### PR TITLE
Set DiscoveredNodeData have a single interfaceId.

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -205,7 +205,7 @@ void PairingCommand::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & 
     // Stop Mdns discovery. Is it the right method ?
     CurrentCommissioner().RegisterDeviceDiscoveryDelegate(nullptr);
 
-    Inet::InterfaceId interfaceId = nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId[0] : Inet::InterfaceId::Null();
+    Inet::InterfaceId interfaceId = nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId : Inet::InterfaceId::Null();
     PeerAddress peerAddress       = PeerAddress::UDP(nodeData.ipAddress[0], port, interfaceId);
     CHIP_ERROR err                = Pair(mNodeId, peerAddress);
     if (CHIP_NO_ERROR != err)

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -138,7 +138,7 @@ void PrepareForCommissioning(const Dnssd::DiscoveredNodeData * selectedCommissio
 
         // Send User Directed commissioning request
         ReturnOnFailure(Server::GetInstance().SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress::UDP(
-            selectedCommissioner->ipAddress[0], selectedCommissioner->port, selectedCommissioner->interfaceId[0])));
+            selectedCommissioner->ipAddress[0], selectedCommissioner->port, selectedCommissioner->interfaceId)));
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 }

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -194,7 +194,7 @@ void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::Discover
     LogErrorOnFailure(StopConnectOverIP());
     LogErrorOnFailure(StopConnectOverSoftAP());
 
-    Inet::InterfaceId interfaceId = nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId[0] : Inet::InterfaceId::Null();
+    Inet::InterfaceId interfaceId      = nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId : Inet::InterfaceId::Null();
     Transport::PeerAddress peerAddress = Transport::PeerAddress::UDP(nodeData.ipAddress[0], nodeData.port, interfaceId);
     RendezvousParameters params        = RendezvousParameters().SetPeerAddress(peerAddress);
     OnDeviceDiscovered(params);

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -53,14 +53,19 @@ static void HandleNodeResolve(void * context, DnssdService * result, CHIP_ERROR 
     }
 
     DiscoveredNodeData nodeData;
+
     Platform::CopyString(nodeData.hostName, result->mHostName);
     Platform::CopyString(nodeData.instanceName, result->mName);
 
-    if (result->mAddress.HasValue() && nodeData.numIPs < DiscoveredNodeData::kMaxIPAddresses)
+    if (result->mAddress.HasValue())
     {
-        nodeData.ipAddress[nodeData.numIPs]   = result->mAddress.Value();
-        nodeData.interfaceId[nodeData.numIPs] = result->mInterface;
-        nodeData.numIPs++;
+        nodeData.ipAddress[0] = result->mAddress.Value();
+        nodeData.interfaceId  = result->mInterface;
+        nodeData.numIPs       = 1;
+    }
+    else
+    {
+        nodeData.numIPs = 0;
     }
 
     nodeData.port = result->mPort;

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -161,7 +161,7 @@ struct DiscoveredNodeData
     Optional<System::Clock::Milliseconds32> mrpRetryIntervalActive;
     uint16_t port;
     unsigned numIPs;
-    Inet::InterfaceId interfaceId[kMaxIPAddresses];
+    Inet::InterfaceId interfaceId; // interface ID for the packet processed
     Inet::IPAddress ipAddress[kMaxIPAddresses];
 
     void Reset()

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -193,8 +193,8 @@ void PacketDataReporter::OnDiscoveredNodeIPAddress(const chip::Inet::IPAddress &
     {
         return;
     }
-    mDiscoveredNodeData.ipAddress[mDiscoveredNodeData.numIPs]   = addr;
-    mDiscoveredNodeData.interfaceId[mDiscoveredNodeData.numIPs] = mInterfaceId;
+    mDiscoveredNodeData.ipAddress[mDiscoveredNodeData.numIPs] = addr;
+    mDiscoveredNodeData.interfaceId                           = mInterfaceId;
     mDiscoveredNodeData.numIPs++;
 }
 


### PR DESCRIPTION
Previous implementation was assuming every IP address has its own
interface, however resolved nodes generally are only on one interface:
  - Platform MDNS will resolve nodes one by one (one IP only)
  - MinMDNS will process packets one by one, so all addresses belong
    to a single interface

This should have a slight RAM improvement and will make future logic
for processing MDNS entries for figuring out the 'best IP address to
use' simpler.

#### Problem
Extra RAM usage and complexity due to seemingly extra information in resolved node data.

#### Change overview
Have a single interfaceId instead of a list for resolvednodedata.

#### Testing
Compile and CI.