### PR TITLE
Hook up GetSubjectDescriptor in GroupSession

### DIFF
--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -40,10 +40,11 @@ public:
 
     Access::SubjectDescriptor GetSubjectDescriptor() const override
     {
-        Access::SubjectDescriptor isd;
-        isd.authMode = Access::AuthMode::kGroup;
-        // TODO: fill other group subjects fields
-        return isd; // return an empty ISD for unauthenticated session.
+        Access::SubjectDescriptor subjectDescriptor;
+        subjectDescriptor.authMode    = Access::AuthMode::kGroup;
+        subjectDescriptor.subject     = NodeIdFromGroupId(mGroupId);
+        subjectDescriptor.fabricIndex = GetFabricIndex();
+        return subjectDescriptor;
     }
 
     bool RequireMRP() const override { return false; }


### PR DESCRIPTION
#### Problem
Hookup inside GroupSession::GetSubjectDescriptor
still TODO

#### Change overview
Hook it up now that we can verify its function

Progress toward #14541

#### Testing
- Ran TestGroupMessaging YAML tests on Linux
- Verified correct subject descriptor in logs
