### PR TITLE
Fix PRIu8 in log statement

### DIFF
--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -185,8 +185,7 @@ CHIP_ERROR AccessControl::Check(const SubjectDescriptor & subjectDescriptor, con
     {
         char buf[6 * kCharsPerCatForLogging];
         ChipLogDetail(DataManagement,
-                      "AccessControl: checking f=%" PRIu8 " a=%c s=0x" ChipLogFormatX64 " t=%s c=" ChipLogFormatMEI " e=%" PRIu16
-                      " p=%c",
+                      "AccessControl: checking f=%u a=%c s=0x" ChipLogFormatX64 " t=%s c=" ChipLogFormatMEI " e=%" PRIu16 " p=%c",
                       subjectDescriptor.fabricIndex, GetAuthModeStringForLogging(subjectDescriptor.authMode),
                       ChipLogValueX64(subjectDescriptor.subject), GetCatStringForLogging(buf, sizeof(buf), subjectDescriptor.cats),
                       ChipLogValueMEI(requestPath.cluster), requestPath.endpoint, GetPrivilegeStringForLogging(requestPrivilege));


### PR DESCRIPTION
#### Problem
PRIu8 format specifier is causing a crash on P6 hardware, due to this GCC issue:

https://answers.launchpad.net/gcc-arm-embedded/+question/269083

#### Change overview
%u is safe and appropriate so long as the arg is unsigned and not
larger than unsigned int, because the arg promotes to unsigned int.

#### Testing
- Run on Linux
