### PR TITLE
Stop using PRI*8 printf formats.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,6 +43,14 @@ jobs:
         run: |
           git grep -n "VerifyOrExit(.*, [A-Za-z]*_ERROR" -- './*' ':(exclude).github/workflows/lint.yml' && exit 1 || exit 0
 
+      # git grep exits with 0 if it finds a match, but we want
+      # to fail (exit nonzero) on match.  And we wasnt to exclude this file,
+      # to avoid our grep regexp matching itself.
+      - name: Check for use of PRI*8, which are not supported on some libcs.
+        if: always()
+        run: |
+          git grep -n "PRI.8" -- './*' ':(exclude).github/workflows/lint.yml' ':(exclude)third_party/lwip/repo/lwip/src/include/lwip/arch.h' && exit 1 || exit 0
+
       # Comments like '{{! ... }}' should be used in zap files
       - name: Do not allow TODO in generated files
         if: always()

--- a/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
@@ -61,7 +61,7 @@ EmberAfStatus StaticSupportedModesManager::getModeOptionByMode(unsigned short en
             return EMBER_ZCL_STATUS_SUCCESS;
         }
     }
-    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "Cannot find the mode %" PRIu8, mode);
+    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "Cannot find the mode %u", mode);
     return EMBER_ZCL_STATUS_INVALID_VALUE;
 }
 

--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
@@ -46,7 +46,7 @@ CHIP_ERROR SetupPayloadParseCommand::Parse(std::string codeString, chip::SetupPa
 
 CHIP_ERROR SetupPayloadParseCommand::Print(chip::SetupPayload payload)
 {
-    ChipLogProgress(SetupPayload, "CommissioningFlow: %" PRIu8, to_underlying(payload.commissioningFlow));
+    ChipLogProgress(SetupPayload, "CommissioningFlow: %u", to_underlying(payload.commissioningFlow));
     ChipLogProgress(SetupPayload, "VendorID: %u", payload.vendorID);
     ChipLogProgress(SetupPayload, "Version: %u", payload.version);
     ChipLogProgress(SetupPayload, "ProductID: %u", payload.productID);

--- a/examples/door-lock-app/linux/src/LockEndpoint.cpp
+++ b/examples/door-lock-app/linux/src/LockEndpoint.cpp
@@ -58,13 +58,13 @@ bool LockEndpoint::GetUser(uint16_t userIndex, EmberAfPluginDoorLockUserInfo & u
     user.createdBy      = userInDb.createdBy;
     user.lastModifiedBy = userInDb.lastModifiedBy;
 
-    ChipLogDetail(
-        Zcl,
-        "Found occupied user "
-        "[endpoint=%d,adjustedIndex=%hu,name=\"%*.s\",credentialsCount=%zu,uniqueId=%x,type=%" PRIu8 ",credentialRule=%" PRIu8 ","
-        "createdBy=%d,lastModifiedBy=%d]",
-        mEndpointId, adjustedUserIndex, static_cast<int>(user.userName.size()), user.userName.data(), user.credentials.size(),
-        user.userUniqueId, to_underlying(user.userType), to_underlying(user.credentialRule), user.createdBy, user.lastModifiedBy);
+    ChipLogDetail(Zcl,
+                  "Found occupied user "
+                  "[endpoint=%d,adjustedIndex=%hu,name=\"%*.s\",credentialsCount=%zu,uniqueId=%x,type=%u,credentialRule=%u,"
+                  "createdBy=%d,lastModifiedBy=%d]",
+                  mEndpointId, adjustedUserIndex, static_cast<int>(user.userName.size()), user.userName.data(),
+                  user.credentials.size(), user.userUniqueId, to_underlying(user.userType), to_underlying(user.credentialRule),
+                  user.createdBy, user.lastModifiedBy);
 
     return true;
 }
@@ -76,8 +76,8 @@ bool LockEndpoint::SetUser(uint16_t userIndex, chip::FabricIndex creator, chip::
     ChipLogProgress(Zcl,
                     "Door Lock App: LockEndpoint::SetUser "
                     "[endpoint=%d,userIndex=%" PRIu16 ",creator=%d,modifier=%d,userName=\"%*.s\",uniqueId=%" PRIx32
-                    ",userStatus=%" PRIu8 ",userType=%" PRIu8 ","
-                    "credentialRule=%" PRIu8 ",credentials=%p,totalCredentials=%zu]",
+                    ",userStatus=%u,userType=%u,"
+                    "credentialRule=%u,credentials=%p,totalCredentials=%zu]",
                     mEndpointId, userIndex, creator, modifier, static_cast<int>(userName.size()), userName.data(), uniqueId,
                     to_underlying(userStatus), to_underlying(usertype), to_underlying(credentialRule), credentials,
                     totalCredentials);
@@ -132,9 +132,8 @@ bool LockEndpoint::SetUser(uint16_t userIndex, chip::FabricIndex creator, chip::
 bool LockEndpoint::GetCredential(uint16_t credentialIndex, DlCredentialType credentialType,
                                  EmberAfPluginDoorLockCredentialInfo & credential) const
 {
-    ChipLogProgress(
-        Zcl, "Door Lock App: LockEndpoint::GetCredential [endpoint=%d,credentialIndex=%" PRIu16 ",credentialType=%" PRIu8 "]",
-        mEndpointId, credentialIndex, to_underlying(credentialType));
+    ChipLogProgress(Zcl, "Door Lock App: LockEndpoint::GetCredential [endpoint=%d,credentialIndex=%" PRIu16 ",credentialType=%u]",
+                    mEndpointId, credentialIndex, to_underlying(credentialType));
 
     if (credentialIndex >= mLockCredentials.size() || (0 == credentialIndex && DlCredentialType::kProgrammingPIN != credentialType))
     {
@@ -153,7 +152,7 @@ bool LockEndpoint::GetCredential(uint16_t credentialIndex, DlCredentialType cred
     credential.credentialType = credentialInStorage.credentialType;
     credential.credentialData = chip::ByteSpan(credentialInStorage.credentialData, credentialInStorage.credentialDataSize);
 
-    ChipLogDetail(Zcl, "Found occupied credential [endpoint=%d,index=%" PRIu16 ",type=%" PRIu8 ",dataSize=%zu]", mEndpointId,
+    ChipLogDetail(Zcl, "Found occupied credential [endpoint=%d,index=%" PRIu16 ",type=%u,dataSize=%zu]", mEndpointId,
                   credentialIndex, to_underlying(credential.credentialType), credential.credentialData.size());
 
     return true;
@@ -162,11 +161,11 @@ bool LockEndpoint::GetCredential(uint16_t credentialIndex, DlCredentialType cred
 bool LockEndpoint::SetCredential(uint16_t credentialIndex, DlCredentialStatus credentialStatus, DlCredentialType credentialType,
                                  const chip::ByteSpan & credentialData)
 {
-    ChipLogProgress(
-        Zcl,
-        "Door Lock App: LockEndpoint::SetCredential "
-        "[endpoint=%d,credentialIndex=%" PRIu16 ",credentialStatus=%" PRIu8 ",credentialType=%" PRIu8 ",credentialDataSize=%zu]",
-        mEndpointId, credentialIndex, to_underlying(credentialStatus), to_underlying(credentialType), credentialData.size());
+    ChipLogProgress(Zcl,
+                    "Door Lock App: LockEndpoint::SetCredential "
+                    "[endpoint=%d,credentialIndex=%" PRIu16 ",credentialStatus=%u,credentialType=%u,credentialDataSize=%zu]",
+                    mEndpointId, credentialIndex, to_underlying(credentialStatus), to_underlying(credentialType),
+                    credentialData.size());
 
     if (credentialIndex >= mLockCredentials.size() || (0 == credentialIndex && DlCredentialType::kProgrammingPIN != credentialType))
     {
@@ -188,7 +187,7 @@ bool LockEndpoint::SetCredential(uint16_t credentialIndex, DlCredentialStatus cr
     std::memcpy(credentialInStorage.credentialData, credentialData.data(), credentialData.size());
     credentialInStorage.credentialDataSize = credentialData.size();
 
-    ChipLogProgress(Zcl, "Successfully set the credential [mEndpointId=%d,index=%d,credentialType=%" PRIu8 "]", mEndpointId,
+    ChipLogProgress(Zcl, "Successfully set the credential [mEndpointId=%d,index=%d,credentialType=%u]", mEndpointId,
                     credentialIndex, to_underlying(credentialType));
 
     return true;

--- a/examples/light-switch-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/light-switch-app/efr32/src/ZclCallbacks.cpp
@@ -40,16 +40,15 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 
     if (clusterId == OnOffSwitchConfiguration::Id)
     {
-        ChipLogProgress(Zcl,
-                        "OnOff Switch Configuration attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16
-                        ", length %" PRIu16,
-                        ChipLogValueMEI(attributeId), type, *value, size);
+        ChipLogProgress(
+            Zcl, "OnOff Switch Configuration attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
+            ChipLogValueMEI(attributeId), type, *value, size);
 
         // WIP Apply attribute change to Light
     }
     else if (clusterId == Identify::Id)
     {
-        ChipLogProgress(Zcl, "Identify attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
+        ChipLogProgress(Zcl, "Identify attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
                         ChipLogValueMEI(attributeId), type, *value, size);
     }
 }

--- a/examples/lighting-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/efr32/src/ZclCallbacks.cpp
@@ -44,32 +44,29 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
     }
     else if (clusterId == LevelControl::Id)
     {
-        ChipLogProgress(Zcl,
-                        "Level Control attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
+        ChipLogProgress(Zcl, "Level Control attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
                         ChipLogValueMEI(attributeId), type, *value, size);
 
         // WIP Apply attribute change to Light
     }
     else if (clusterId == ColorControl::Id)
     {
-        ChipLogProgress(Zcl,
-                        "Color Control attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
+        ChipLogProgress(Zcl, "Color Control attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
                         ChipLogValueMEI(attributeId), type, *value, size);
 
         // WIP Apply attribute change to Light
     }
     else if (clusterId == OnOffSwitchConfiguration::Id)
     {
-        ChipLogProgress(Zcl,
-                        "OnOff Switch Configuration attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16
-                        ", length %" PRIu16,
-                        ChipLogValueMEI(attributeId), type, *value, size);
+        ChipLogProgress(
+            Zcl, "OnOff Switch Configuration attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
+            ChipLogValueMEI(attributeId), type, *value, size);
 
         // WIP Apply attribute change to Light
     }
     else if (clusterId == Identify::Id)
     {
-        ChipLogProgress(Zcl, "Identify attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
+        ChipLogProgress(Zcl, "Identify attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
                         ChipLogValueMEI(attributeId), type, *value, size);
     }
 }

--- a/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
@@ -35,13 +35,13 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 
     if (clusterId == OnOff::Id && attributeId == OnOff::Attributes::OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Cluster OnOff: attribute OnOff set to %" PRIu8, *value);
+        ChipLogProgress(Zcl, "Cluster OnOff: attribute OnOff set to %u", *value);
         LightingMgr().InitiateAction(*value ? LightingManager::ON_ACTION : LightingManager::OFF_ACTION,
                                      AppEvent::kEventType_Lighting, size, value);
     }
     else if (clusterId == LevelControl::Id && attributeId == LevelControl::Attributes::CurrentLevel::Id)
     {
-        ChipLogProgress(Zcl, "Cluster LevelControl: attribute CurrentLevel set to %" PRIu8, *value);
+        ChipLogProgress(Zcl, "Cluster LevelControl: attribute CurrentLevel set to %u", *value);
         LightingMgr().InitiateAction(LightingManager::LEVEL_ACTION, AppEvent::kEventType_Lighting, size, value);
     }
 }

--- a/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -676,6 +676,6 @@ void AppTask::UpdateClusterState(void)
                                                  (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: updating on/off %x", status);
     }
 }

--- a/examples/lighting-app/nxp/k32w/k32w0/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/ZclCallbacks.cpp
@@ -45,26 +45,23 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
     }
     else if (path.mClusterId == LevelControl::Id)
     {
-        ChipLogProgress(Zcl,
-                        "Level Control attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
+        ChipLogProgress(Zcl, "Level Control attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
                         ChipLogValueMEI(path.mAttributeId), type, *value, size);
 
         // WIP Apply attribute change to Light
     }
     else if (path.mClusterId == ColorControl::Id)
     {
-        ChipLogProgress(Zcl,
-                        "Color Control attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
+        ChipLogProgress(Zcl, "Color Control attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
                         ChipLogValueMEI(path.mAttributeId), type, *value, size);
 
         // WIP Apply attribute change to Light
     }
     else if (path.mClusterId == OnOffSwitchConfiguration::Id)
     {
-        ChipLogProgress(Zcl,
-                        "OnOff Switch Configuration attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16
-                        ", length %" PRIu16,
-                        ChipLogValueMEI(path.mAttributeId), type, *value, size);
+        ChipLogProgress(
+            Zcl, "OnOff Switch Configuration attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
+            ChipLogValueMEI(path.mAttributeId), type, *value, size);
 
         // WIP Apply attribute change to Light
     }

--- a/examples/lighting-app/p6/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/p6/src/ZclCallbacks.cpp
@@ -44,32 +44,29 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
     }
     else if (clusterId == LevelControl::Id)
     {
-        ChipLogProgress(Zcl,
-                        "Level Control attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
+        ChipLogProgress(Zcl, "Level Control attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
                         ChipLogValueMEI(attributeId), type, *value, size);
 
         // WIP Apply attribute change to Light
     }
     else if (clusterId == ColorControl::Id)
     {
-        ChipLogProgress(Zcl,
-                        "Color Control attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
+        ChipLogProgress(Zcl, "Color Control attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
                         ChipLogValueMEI(attributeId), type, *value, size);
 
         // WIP Apply attribute change to Light
     }
     else if (clusterId == OnOffSwitchConfiguration::Id)
     {
-        ChipLogProgress(Zcl,
-                        "OnOff Switch Configuration attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16
-                        ", length %" PRIu16,
-                        ChipLogValueMEI(attributeId), type, *value, size);
+        ChipLogProgress(
+            Zcl, "OnOff Switch Configuration attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
+            ChipLogValueMEI(attributeId), type, *value, size);
 
         // WIP Apply attribute change to Light
     }
     else if (clusterId == Identify::Id)
     {
-        ChipLogProgress(Zcl, "Identify attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
+        ChipLogProgress(Zcl, "Identify attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
                         ChipLogValueMEI(attributeId), type, *value, size);
     }
 }

--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -459,7 +459,7 @@ void AppTask::UpdateClusterState(void)
                                                  (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: updating on/off %x", status);
     }
 
     newValue = LightingMgr().GetLevel();
@@ -468,6 +468,6 @@ void AppTask::UpdateClusterState(void)
 
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: updating level %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: updating level %x", status);
     }
 }

--- a/examples/lock-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lock-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -709,6 +709,6 @@ void AppTask::UpdateClusterState(void)
                                                  (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: updating on/off %x", status);
     }
 }

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -520,6 +520,6 @@ void AppTask::UpdateClusterState(void)
                                                  (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: updating on/off %x", status);
     }
 }

--- a/examples/ota-provider-app/ota-provider-common/DefaultUserConsentProvider.cpp
+++ b/examples/ota-provider-app/ota-provider-common/DefaultUserConsentProvider.cpp
@@ -24,7 +24,7 @@ namespace ota {
 void DefaultUserConsentProvider::LogUserConsentSubject(const UserConsentSubject & subject)
 {
     ChipLogDetail(SoftwareUpdate, "User consent request for:");
-    ChipLogDetail(SoftwareUpdate, ":  FabricIndex: %" PRIu8, subject.fabricIndex);
+    ChipLogDetail(SoftwareUpdate, ":  FabricIndex: %u", subject.fabricIndex);
     ChipLogDetail(SoftwareUpdate, ":  RequestorNodeId: " ChipLogFormatX64, ChipLogValueX64(subject.requestorNodeId));
     ChipLogDetail(SoftwareUpdate, ":  ProviderEndpointId: %" PRIu16, subject.providerEndpointId);
     ChipLogDetail(SoftwareUpdate, ":  RequestorVendorId: %" PRIu16, subject.requestorVendorId);

--- a/examples/ota-requestor-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/ota-requestor-app/efr32/src/ZclCallbacks.cpp
@@ -44,32 +44,29 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
     }
     else if (clusterId == LevelControl::Id)
     {
-        ChipLogProgress(Zcl,
-                        "Level Control attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
+        ChipLogProgress(Zcl, "Level Control attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
                         ChipLogValueMEI(attributeId), type, *value, size);
 
         // WIP Apply attribute change to Light
     }
     else if (clusterId == ColorControl::Id)
     {
-        ChipLogProgress(Zcl,
-                        "Color Control attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
+        ChipLogProgress(Zcl, "Color Control attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
                         ChipLogValueMEI(attributeId), type, *value, size);
 
         // WIP Apply attribute change to Light
     }
     else if (clusterId == OnOffSwitchConfiguration::Id)
     {
-        ChipLogProgress(Zcl,
-                        "OnOff Switch Configuration attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16
-                        ", length %" PRIu16,
-                        ChipLogValueMEI(attributeId), type, *value, size);
+        ChipLogProgress(
+            Zcl, "OnOff Switch Configuration attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
+            ChipLogValueMEI(attributeId), type, *value, size);
 
         // WIP Apply attribute change to Light
     }
     else if (clusterId == Identify::Id)
     {
-        ChipLogProgress(Zcl, "Identify attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
+        ChipLogProgress(Zcl, "Identify attribute ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
                         ChipLogValueMEI(attributeId), type, *value, size);
     }
 }

--- a/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -380,7 +380,7 @@ void AppTask::InitOnOffClusterState()
     status = OnOff::Attributes::OnOff::Set(ONOFF_CLUSTER_ENDPOINT, false);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Init On/Off state  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Init On/Off state  %x", status);
     }
 }
 
@@ -397,98 +397,98 @@ void AppTask::UpdateClusterState()
     status          = OnOff::Attributes::OnOff::Set(ONOFF_CLUSTER_ENDPOINT, onOffState);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating On/Off state  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating On/Off state  %x", status);
     }
 
     int16_t maxPressure = PumpMgr().GetMaxPressure();
     status              = PumpConfigurationAndControl::Attributes::MaxPressure::Set(PCC_CLUSTER_ENDPOINT, maxPressure);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MaxPressure  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MaxPressure  %x", status);
     }
 
     uint16_t maxSpeed = PumpMgr().GetMaxSpeed();
     status            = PumpConfigurationAndControl::Attributes::MaxSpeed::Set(PCC_CLUSTER_ENDPOINT, maxSpeed);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MaxSpeed  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MaxSpeed  %x", status);
     }
 
     uint16_t maxFlow = PumpMgr().GetMaxFlow();
     status           = PumpConfigurationAndControl::Attributes::MaxFlow::Set(PCC_CLUSTER_ENDPOINT, maxFlow);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MaxFlow  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MaxFlow  %x", status);
     }
 
     int16_t minConstPress = PumpMgr().GetMinConstPressure();
     status                = PumpConfigurationAndControl::Attributes::MinConstPressure::Set(PCC_CLUSTER_ENDPOINT, minConstPress);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MinConstPressure  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MinConstPressure  %x", status);
     }
 
     int16_t maxConstPress = PumpMgr().GetMaxConstPressure();
     status                = PumpConfigurationAndControl::Attributes::MaxConstPressure::Set(PCC_CLUSTER_ENDPOINT, maxConstPress);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MaxConstPressure  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MaxConstPressure  %x", status);
     }
 
     int16_t minCompPress = PumpMgr().GetMinCompPressure();
     status               = PumpConfigurationAndControl::Attributes::MinCompPressure::Set(PCC_CLUSTER_ENDPOINT, minCompPress);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MinCompPressure  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MinCompPressure  %x", status);
     }
 
     int16_t maxCompPress = PumpMgr().GetMaxCompPressure();
     status               = PumpConfigurationAndControl::Attributes::MaxCompPressure::Set(PCC_CLUSTER_ENDPOINT, maxCompPress);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MaxCompPressure  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MaxCompPressure  %x", status);
     }
 
     uint16_t minConstSpeed = PumpMgr().GetMinConstSpeed();
     status                 = PumpConfigurationAndControl::Attributes::MinConstSpeed::Set(PCC_CLUSTER_ENDPOINT, minConstSpeed);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MinConstSpeed  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MinConstSpeed  %x", status);
     }
 
     uint16_t maxConstSpeed = PumpMgr().GetMaxConstSpeed();
     status                 = PumpConfigurationAndControl::Attributes::MaxConstSpeed::Set(PCC_CLUSTER_ENDPOINT, maxConstSpeed);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MaxConstSpeed  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MaxConstSpeed  %x", status);
     }
 
     uint16_t minConstFlow = PumpMgr().GetMinConstFlow();
     status                = PumpConfigurationAndControl::Attributes::MinConstFlow::Set(PCC_CLUSTER_ENDPOINT, minConstFlow);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MinConstFlow  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MinConstFlow  %x", status);
     }
 
     uint16_t maxConstFlow = PumpMgr().GetMaxConstFlow();
     status                = PumpConfigurationAndControl::Attributes::MaxConstFlow::Set(PCC_CLUSTER_ENDPOINT, maxConstFlow);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MaxConstFlow  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MaxConstFlow  %x", status);
     }
 
     int16_t minConstTemp = PumpMgr().GetMinConstTemp();
     status               = PumpConfigurationAndControl::Attributes::MinConstTemp::Set(PCC_CLUSTER_ENDPOINT, minConstTemp);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MinConstTemp  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MinConstTemp  %x", status);
     }
 
     int16_t maxConstTemp = PumpMgr().GetMaxConstTemp();
     status               = PumpConfigurationAndControl::Attributes::MaxConstTemp::Set(PCC_CLUSTER_ENDPOINT, maxConstTemp);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MaxConstTemp  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MaxConstTemp  %x", status);
     }
 }
 

--- a/examples/pump-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
@@ -39,7 +39,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
     else if (attributePath.mClusterId == LevelControl::Id &&
              attributePath.mAttributeId == LevelControl::Attributes::CurrentLevel::Id)
     {
-        ChipLogProgress(Zcl, "[pump-app] Cluster LevelControl: attribute CurrentLevel set to %" PRIu8, *value);
+        ChipLogProgress(Zcl, "[pump-app] Cluster LevelControl: attribute CurrentLevel set to %u", *value);
     }
     else
     {

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -521,97 +521,97 @@ void AppTask::UpdateClusterState()
     status = OnOff::Attributes::OnOff::Set(ONOFF_CLUSTER_ENDPOINT, onOffState);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating On/Off state  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating On/Off state  %x", status);
     }
 
     int16_t maxPressure = PumpMgr().GetMaxPressure();
     status              = PumpConfigurationAndControl::Attributes::MaxPressure::Set(PCC_CLUSTER_ENDPOINT, maxPressure);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MaxPressure  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MaxPressure  %x", status);
     }
 
     uint16_t maxSpeed = PumpMgr().GetMaxSpeed();
     status            = PumpConfigurationAndControl::Attributes::MaxSpeed::Set(PCC_CLUSTER_ENDPOINT, maxSpeed);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MaxSpeed  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MaxSpeed  %x", status);
     }
 
     uint16_t maxFlow = PumpMgr().GetMaxFlow();
     status           = PumpConfigurationAndControl::Attributes::MaxFlow::Set(PCC_CLUSTER_ENDPOINT, maxFlow);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MaxFlow  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MaxFlow  %x", status);
     }
 
     int16_t minConstPress = PumpMgr().GetMinConstPressure();
     status                = PumpConfigurationAndControl::Attributes::MinConstPressure::Set(PCC_CLUSTER_ENDPOINT, minConstPress);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MinConstPressure  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MinConstPressure  %x", status);
     }
 
     int16_t maxConstPress = PumpMgr().GetMaxConstPressure();
     status                = PumpConfigurationAndControl::Attributes::MaxConstPressure::Set(PCC_CLUSTER_ENDPOINT, maxConstPress);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MaxConstPressure  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MaxConstPressure  %x", status);
     }
 
     int16_t minCompPress = PumpMgr().GetMinCompPressure();
     status               = PumpConfigurationAndControl::Attributes::MinCompPressure::Set(PCC_CLUSTER_ENDPOINT, minCompPress);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MinCompPressure  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MinCompPressure  %x", status);
     }
 
     int16_t maxCompPress = PumpMgr().GetMaxCompPressure();
     status               = PumpConfigurationAndControl::Attributes::MaxCompPressure::Set(PCC_CLUSTER_ENDPOINT, maxCompPress);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MaxCompPressure  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MaxCompPressure  %x", status);
     }
 
     uint16_t minConstSpeed = PumpMgr().GetMinConstSpeed();
     status                 = PumpConfigurationAndControl::Attributes::MinConstSpeed::Set(PCC_CLUSTER_ENDPOINT, minConstSpeed);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MinConstSpeed  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MinConstSpeed  %x", status);
     }
 
     uint16_t maxConstSpeed = PumpMgr().GetMaxConstSpeed();
     status                 = PumpConfigurationAndControl::Attributes::MaxConstSpeed::Set(PCC_CLUSTER_ENDPOINT, maxConstSpeed);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MaxConstSpeed  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MaxConstSpeed  %x", status);
     }
 
     uint16_t minConstFlow = PumpMgr().GetMinConstFlow();
     status                = PumpConfigurationAndControl::Attributes::MinConstFlow::Set(PCC_CLUSTER_ENDPOINT, minConstFlow);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MinConstFlow  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MinConstFlow  %x", status);
     }
 
     uint16_t maxConstFlow = PumpMgr().GetMaxConstFlow();
     status                = PumpConfigurationAndControl::Attributes::MaxConstFlow::Set(PCC_CLUSTER_ENDPOINT, maxConstFlow);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MaxConstFlow  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MaxConstFlow  %x", status);
     }
 
     int16_t minConstTemp = PumpMgr().GetMinConstTemp();
     status               = PumpConfigurationAndControl::Attributes::MinConstTemp::Set(PCC_CLUSTER_ENDPOINT, minConstTemp);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MinConstTemp  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MinConstTemp  %x", status);
     }
 
     int16_t maxConstTemp = PumpMgr().GetMaxConstTemp();
     status               = PumpConfigurationAndControl::Attributes::MaxConstTemp::Set(PCC_CLUSTER_ENDPOINT, maxConstTemp);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: Updating MaxConstTemp  %" PRIx8, status);
+        ChipLogError(NotSpecified, "ERR: Updating MaxConstTemp  %x", status);
     }
 }

--- a/examples/pump-controller-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
+++ b/examples/pump-controller-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
@@ -39,7 +39,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
     else if (attributePath.mClusterId == LevelControl::Id &&
              attributePath.mAttributeId == LevelControl::Attributes::CurrentLevel::Id)
     {
-        ChipLogProgress(Zcl, "[pump-app] Cluster LevelControl: attribute CurrentLevel set to %" PRIu8, *value);
+        ChipLogProgress(Zcl, "[pump-app] Cluster LevelControl: attribute CurrentLevel set to %u", *value);
     }
     else
     {

--- a/examples/window-app/common/src/ZclCallbacks.cpp
+++ b/examples/window-app/common/src/ZclCallbacks.cpp
@@ -43,7 +43,7 @@ void MatterPostAttributeChangeCallback(const app::ConcreteAttributePath & attrib
     switch (attributePath.mClusterId)
     {
     case app::Clusters::Identify::Id:
-        ChipLogProgress(Zcl, "Identify cluster ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
+        ChipLogProgress(Zcl, "Identify cluster ID: " ChipLogFormatMEI " Type: %u Value: %" PRIu16 ", length %" PRIu16,
                         ChipLogValueMEI(attributePath.mAttributeId), type, *value, size);
         break;
     default:

--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -185,8 +185,7 @@ CHIP_ERROR AccessControl::Check(const SubjectDescriptor & subjectDescriptor, con
     {
         char buf[6 * kCharsPerCatForLogging];
         ChipLogDetail(DataManagement,
-                      "AccessControl: checking f=%" PRIu8 " a=%c s=0x" ChipLogFormatX64 " t=%s c=" ChipLogFormatMEI " e=%" PRIu16
-                      " p=%c",
+                      "AccessControl: checking f=%u a=%c s=0x" ChipLogFormatX64 " t=%s c=" ChipLogFormatMEI " e=%" PRIu16 " p=%c",
                       subjectDescriptor.fabricIndex, GetAuthModeStringForLogging(subjectDescriptor.authMode),
                       ChipLogValueX64(subjectDescriptor.subject), GetCatStringForLogging(buf, sizeof(buf), subjectDescriptor.cats),
                       ChipLogValueMEI(requestPath.cluster), requestPath.endpoint, GetPrivilegeStringForLogging(requestPrivilege));

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -296,7 +296,7 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
             {
                 ChipLogProgress(DataManagement,
                                 "Received Command Response Status for Endpoint=%" PRIu16 " Cluster=" ChipLogFormatMEI
-                                " Command=" ChipLogFormatMEI " Status=0x%" PRIx8,
+                                " Command=" ChipLogFormatMEI " Status=0x%x",
                                 endpointId, ChipLogValueMEI(clusterId), ChipLogValueMEI(commandId),
                                 to_underlying(statusIB.mStatus));
             }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -274,7 +274,7 @@ CHIP_ERROR InteractionModelEngine::OnReadInitialRequest(Messaging::ExchangeConte
                 if (handler->IsFromSubscriber(*apExchangeContext))
                 {
                     ChipLogProgress(InteractionModel,
-                                    "Deleting previous subscription from NodeId: " ChipLogFormatX64 ", FabricIndex: %" PRIu8,
+                                    "Deleting previous subscription from NodeId: " ChipLogFormatX64 ", FabricIndex: %u",
                                     ChipLogValueX64(apExchangeContext->GetSessionHandle()->AsSecureSession()->GetPeerNodeId()),
                                     apExchangeContext->GetSessionHandle()->GetFabricIndex());
                     mReadHandlers.ReleaseObject(handler);

--- a/src/app/MessageDef/AttributeDataIB.cpp
+++ b/src/app/MessageDef/AttributeDataIB.cpp
@@ -139,7 +139,7 @@ AttributeDataIB::Parser::ParseData(TLV::TLVReader & aReader, int aDepth) const
         {
             for (size_t i = 0; i < len; i++)
             {
-                PRETTY_PRINT_SAMELINE("0x%" PRIx8 ", ", value_b[i]);
+                PRETTY_PRINT_SAMELINE("0x%x, ", value_b[i]);
             }
         }
 

--- a/src/app/MessageDef/CommandDataIB.cpp
+++ b/src/app/MessageDef/CommandDataIB.cpp
@@ -151,7 +151,7 @@ CommandDataIB::Parser::ParseData(TLV::TLVReader & aReader, int aDepth) const
         {
             for (size_t i = 0; i < len; i++)
             {
-                PRETTY_PRINT_SAMELINE("0x%" PRIx8 ", ", value_b[i]);
+                PRETTY_PRINT_SAMELINE("0x%x, ", value_b[i]);
             }
         }
 

--- a/src/app/MessageDef/EventDataIB.cpp
+++ b/src/app/MessageDef/EventDataIB.cpp
@@ -138,7 +138,7 @@ EventDataIB::Parser::ParseData(TLV::TLVReader & aReader, int aDepth) const
         {
             for (size_t i = 0; i < len; i++)
             {
-                PRETTY_PRINT_SAMELINE("0x%" PRIx8 ", ", value_b[i]);
+                PRETTY_PRINT_SAMELINE("0x%x, ", value_b[i]);
             }
         }
 

--- a/src/app/MessageDef/StatusIB.cpp
+++ b/src/app/MessageDef/StatusIB.cpp
@@ -96,7 +96,7 @@ CHIP_ERROR StatusIB::Parser::CheckSchemaValidity() const
             {
                 ClusterStatus clusterStatus;
                 ReturnErrorOnFailure(reader.Get(clusterStatus));
-                PRETTY_PRINT("\tcluster-status = 0x%" PRIx8 ",", clusterStatus);
+                PRETTY_PRINT("\tcluster-status = 0x%x,", clusterStatus);
             }
 #endif // CHIP_DETAIL_LOGGING
         }
@@ -195,12 +195,12 @@ bool FormatStatusIBError(char * buf, uint16_t bufSize, CHIP_ERROR err)
 
     const char * desc = nullptr;
 #if !CHIP_CONFIG_SHORT_ERROR_STR
-    constexpr char generalFormat[] = "General error: 0x%02" PRIx8;
-    constexpr char clusterFormat[] = "Cluster-specific error: 0x%02" PRIx8;
+    constexpr char generalFormat[] = "General error: 0x%02x";
+    constexpr char clusterFormat[] = "Cluster-specific error: 0x%02x";
 
-    // Formatting an 8-bit int will take at most 2 chars, and replace the '%'
-    // and the format letter(s) for PRIx8, so a buffer big enough to hold our
-    // format string will also hold our formatted string.
+    // Formatting an 8-bit int will take at most 2 chars, and replace the '%02x'
+    // so a buffer big enough to hold our format string will also hold our
+    // formatted string.
     constexpr size_t formattedSize = max(sizeof(generalFormat), sizeof(clusterFormat));
     char formattedString[formattedSize];
 

--- a/src/app/MessageDef/TimedRequestMessage.cpp
+++ b/src/app/MessageDef/TimedRequestMessage.cpp
@@ -45,7 +45,7 @@ CHIP_ERROR TimedRequestMessage::Parser::CheckSchemaValidity() const
             {
                 uint16_t timeout;
                 ReturnErrorOnFailure(reader.Get(timeout));
-                PRETTY_PRINT("\tTimeoutMs = 0x%" PRIx8 ",", timeout);
+                PRETTY_PRINT("\tTimeoutMs = 0x%x,", timeout);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;

--- a/src/app/StatusResponse.cpp
+++ b/src/app/StatusResponse.cpp
@@ -54,7 +54,7 @@ CHIP_ERROR StatusResponse::ProcessStatusResponse(System::PacketBufferHandle && a
 #endif
     StatusIB status;
     ReturnErrorOnFailure(response.GetStatus(status.mStatus));
-    ChipLogProgress(InteractionModel, "Received status response, status is %" PRIu8, to_underlying(status.mStatus));
+    ChipLogProgress(InteractionModel, "Received status response, status is %u", to_underlying(status.mStatus));
 
     if (status.mStatus == Protocols::InteractionModel::Status::Success)
     {

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -178,8 +178,8 @@ CHIP_ERROR BasicAttrAccess::Read(const ConcreteReadAttributePath & aPath, Attrib
         if (status == CHIP_NO_ERROR)
         {
             // Format is YYYYMMDD
-            snprintf(manufacturingDateString, sizeof(manufacturingDateString), "%04" PRIu16 "%02" PRIu8 "%02" PRIu8,
-                     manufacturingYear, manufacturingMonth, manufacturingDayOfMonth);
+            snprintf(manufacturingDateString, sizeof(manufacturingDateString), "%04" PRIu16 "%02u%02u", manufacturingYear,
+                     manufacturingMonth, manufacturingDayOfMonth);
             status = aEncoder.Encode(chip::CharSpan(manufacturingDateString, strnlen(manufacturingDateString, kMaxLen)));
         }
         break;

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -308,8 +308,8 @@ void DoorLockServer::GetUserCommandHandler(chip::app::CommandHandler * commandOb
         if (DlUserStatus::kAvailable != user.userStatus)
         {
             emberAfDoorLockClusterPrintln("Found user in storage: "
-                                          "[userIndex=%d,userName=\"%s\",userStatus=%" PRIu8 ",userType=%" PRIu8
-                                          ",credentialRule=%" PRIu8 ",createdBy=%" PRIu8 ",modifiedBy=%" PRIu8 "]",
+                                          "[userIndex=%d,userName=\"%s\",userStatus=%u,userType=%u"
+                                          ",credentialRule=%u,createdBy=%u,modifiedBy=%u]",
                                           userIndex, user.userName.data(), to_underlying(user.userStatus),
                                           to_underlying(user.userType), to_underlying(user.credentialRule), user.createdBy,
                                           user.lastModifiedBy);
@@ -469,7 +469,7 @@ void DoorLockServer::SetCredentialCommandHandler(
 
     if (!credentialTypeSupported(commandPath.mEndpointId, credentialType))
     {
-        emberAfDoorLockClusterPrintln("[SetCredential] Credential type is not supported [endpointId=%d,credentialType=%" PRIu8 "]",
+        emberAfDoorLockClusterPrintln("[SetCredential] Credential type is not supported [endpointId=%d,credentialType=%u]",
                                       commandPath.mEndpointId, to_underlying(credentialType));
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_UNSUPPORTED_COMMAND);
         return;
@@ -483,7 +483,7 @@ void DoorLockServer::SetCredentialCommandHandler(
     uint16_t maxNumberOfCredentials = 0;
     if (!credentialIndexValid(commandPath.mEndpointId, credentialType, credentialIndex, maxNumberOfCredentials))
     {
-        emberAfDoorLockClusterPrintln("[SetCredential] Credential index is out of range [endpointId=%d,credentialType=%" PRIu8
+        emberAfDoorLockClusterPrintln("[SetCredential] Credential index is out of range [endpointId=%d,credentialType=%u"
                                       ",credentialIndex=%d]",
                                       commandPath.mEndpointId, to_underlying(credentialType), credentialIndex);
         sendSetCredentialResponse(commandObj, DlStatus::kInvalidField, 0, nextAvailableCredentialSlot);
@@ -503,7 +503,7 @@ void DoorLockServer::SetCredentialCommandHandler(
     if (credentialData.size() < minSize || credentialData.size() > maxSize)
     {
         emberAfDoorLockClusterPrintln("[SetCredential] Credential data size is out of range "
-                                      "[endpointId=%d,credentialType=%" PRIu8 ",minLength=%zu,maxLength=%zu,length=%zu]",
+                                      "[endpointId=%d,credentialType=%u,minLength=%zu,maxLength=%zu,length=%zu]",
                                       commandPath.mEndpointId, to_underlying(credentialType), minSize, maxSize,
                                       credentialData.size());
         sendSetCredentialResponse(commandObj, DlStatus::kInvalidField, 0, nextAvailableCredentialSlot);
@@ -517,7 +517,7 @@ void DoorLockServer::SetCredentialCommandHandler(
         if (!emberAfPluginDoorLockGetCredential(commandPath.mEndpointId, i, credentialType, currentCredential))
         {
             emberAfDoorLockClusterPrintln("[SetCredential] Unable to get the credential to exclude duplicated entry "
-                                          "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d]",
+                                          "[endpointId=%d,credentialType=%u,credentialIndex=%d]",
                                           commandPath.mEndpointId, to_underlying(credentialType), i);
             sendSetCredentialResponse(commandObj, DlStatus::kFailure, 0, nextAvailableCredentialSlot);
             return;
@@ -527,7 +527,7 @@ void DoorLockServer::SetCredentialCommandHandler(
         {
             emberAfDoorLockClusterPrintln(
                 "[SetCredential] Credential with the same data and type already exist "
-                "[endpointId=%d,credentialType=%" PRIu8 ",dataLength=%zu,existingCredentialIndex=%d,credentialIndex=%d]",
+                "[endpointId=%d,credentialType=%u,dataLength=%zu,existingCredentialIndex=%d,credentialIndex=%d]",
                 commandPath.mEndpointId, to_underlying(credentialType), credentialData.size(), i, credentialIndex);
             sendSetCredentialResponse(commandObj, DlStatus::kDuplicate, 0, nextAvailableCredentialSlot);
             return;
@@ -601,7 +601,7 @@ void DoorLockServer::GetCredentialStatusCommandHandler(
 
     if (!credentialTypeSupported(commandPath.mEndpointId, credentialType))
     {
-        emberAfDoorLockClusterPrintln("[GetCredentialStatus] Credential type is not supported [endpointId=%d,credentialType=%" PRIu8
+        emberAfDoorLockClusterPrintln("[GetCredentialStatus] Credential type is not supported [endpointId=%d,credentialType=%u"
                                       "]",
                                       commandPath.mEndpointId, to_underlying(credentialType));
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_UNSUPPORTED_COMMAND);
@@ -612,7 +612,7 @@ void DoorLockServer::GetCredentialStatusCommandHandler(
     if (!credentialIndexValid(commandPath.mEndpointId, credentialType, credentialIndex, maxNumberOfCredentials))
     {
         emberAfDoorLockClusterPrintln("[GetCredentialStatus] Credential index is out of range "
-                                      "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,maxNumberOfCredentials=%d]",
+                                      "[endpointId=%d,credentialType=%u,credentialIndex=%d,maxNumberOfCredentials=%d]",
                                       commandPath.mEndpointId, to_underlying(credentialType), credentialIndex,
                                       maxNumberOfCredentials);
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
@@ -623,7 +623,7 @@ void DoorLockServer::GetCredentialStatusCommandHandler(
     if (!emberAfPluginDoorLockGetCredential(commandPath.mEndpointId, credentialIndex, credentialType, credentialInfo))
     {
         emberAfDoorLockClusterPrintln("[GetCredentialStatus] Unable to get the credential: app error "
-                                      "[endpointId=%d,credentialIndex=%d,credentialType=%" PRIu8 "]",
+                                      "[endpointId=%d,credentialIndex=%d,credentialType=%u]",
                                       commandPath.mEndpointId, credentialIndex, to_underlying(credentialType));
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
@@ -639,7 +639,7 @@ void DoorLockServer::GetCredentialStatusCommandHandler(
             // to handle that properly other than panic in the log.
             ChipLogError(Zcl,
                          "[GetCredentialStatus] Database possibly corrupted - credential exists without user assigned "
-                         "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d]",
+                         "[endpointId=%d,credentialType=%u,credentialIndex=%d]",
                          commandPath.mEndpointId, to_underlying(credentialType), credentialIndex);
             emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
             return;
@@ -666,17 +666,17 @@ void DoorLockServer::GetCredentialStatusCommandHandler(
     }
     SuccessOrExit(err = commandObj->FinishCommand());
 
-    emberAfDoorLockClusterPrintln(
-        "[GetCredentialStatus] Prepared credential status "
-        "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,userIndex=%d,nextCredentialIndex=%d]",
-        commandPath.mEndpointId, to_underlying(credentialType), credentialIndex, userIndexWithCredential, nextCredentialIndex);
+    emberAfDoorLockClusterPrintln("[GetCredentialStatus] Prepared credential status "
+                                  "[endpointId=%d,credentialType=%u,credentialIndex=%d,userIndex=%d,nextCredentialIndex=%d]",
+                                  commandPath.mEndpointId, to_underlying(credentialType), credentialIndex, userIndexWithCredential,
+                                  nextCredentialIndex);
 
 exit:
     if (CHIP_NO_ERROR != err)
     {
         ChipLogError(Zcl,
                      "[GetCredentialStatus] Error occurred when preparing response: %s "
-                     "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,userIndex=%d,nextCredentialIndex=%d]",
+                     "[endpointId=%d,credentialType=%u,credentialIndex=%d,userIndex=%d,nextCredentialIndex=%d]",
                      err.AsString(), commandPath.mEndpointId, to_underlying(credentialType), credentialIndex,
                      userIndexWithCredential, nextCredentialIndex);
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
@@ -823,7 +823,7 @@ void DoorLockServer::SetWeekDayScheduleCommandHandler(
     {
         ChipLogError(Zcl,
                      "[SetWeekDaySchedule] Unable to add schedule - internal error "
-                     "[endpointId=%d,weekDayIndex=%d,userIndex=%d,status=%" PRIu8 "]",
+                     "[endpointId=%d,weekDayIndex=%d,userIndex=%d,status=%u]",
                      endpointId, weekDayIndex, userIndex, to_underlying(status));
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
@@ -953,7 +953,7 @@ void DoorLockServer::ClearWeekDayScheduleCommandHandler(
     if (DlStatus::kSuccess != clearStatus)
     {
         emberAfDoorLockClusterPrintln(
-            "[ClearWeekDaySchedule] Unable to clear the user schedules - app error [endpointId=%d,userIndex=%d,status=%" PRIu8 "]",
+            "[ClearWeekDaySchedule] Unable to clear the user schedules - app error [endpointId=%d,userIndex=%d,status=%u]",
             endpointId, userIndex, to_underlying(clearStatus));
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
@@ -1034,7 +1034,7 @@ void DoorLockServer::SetYearDayScheduleCommandHandler(
     {
         ChipLogError(Zcl,
                      "[SetYearDaySchedule] Unable to add schedule - internal error "
-                     "[endpointId=%d,yearDayIndex=%d,userIndex=%d,status=%" PRIu8 "]",
+                     "[endpointId=%d,yearDayIndex=%d,userIndex=%d,status=%u]",
                      endpointId, yearDayIndex, userIndex, to_underlying(status));
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
@@ -1162,7 +1162,7 @@ void DoorLockServer::ClearYearDayScheduleCommandHandler(
     if (DlStatus::kSuccess != clearStatus)
     {
         emberAfDoorLockClusterPrintln(
-            "[ClearYearDaySchedule] Unable to clear the user schedules - app error [endpointId=%d,userIndex=%d,status=%" PRIu8 "]",
+            "[ClearYearDaySchedule] Unable to clear the user schedules - app error [endpointId=%d,userIndex=%d,status=%u]",
             endpointId, userIndex, to_underlying(clearStatus));
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
@@ -1297,8 +1297,7 @@ bool DoorLockServer::getCredentialRange(chip::EndpointId endpointId, DlCredentia
 
     if (!statusMin || !statusMax)
     {
-        ChipLogError(Zcl,
-                     "Unable to read attributes to get min/max length for credentials [endpointId=%d,credentialType=%" PRIu8 "]",
+        ChipLogError(Zcl, "Unable to read attributes to get min/max length for credentials [endpointId=%d,credentialType=%u]",
                      endpointId, to_underlying(type));
         return false;
     }
@@ -1384,7 +1383,7 @@ bool DoorLockServer::findUnoccupiedCredentialSlot(chip::EndpointId endpointId, D
         EmberAfPluginDoorLockCredentialInfo info;
         if (!emberAfPluginDoorLockGetCredential(endpointId, i, credentialType, info))
         {
-            ChipLogError(Zcl, "Unable to get credential: app error [endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d]",
+            ChipLogError(Zcl, "Unable to get credential: app error [endpointId=%d,credentialType=%u,credentialIndex=%d]",
                          endpointId, to_underlying(credentialType), i);
             return false;
         }
@@ -1473,7 +1472,7 @@ bool DoorLockServer::findUserIndexByCredential(chip::EndpointId endpointId, DlCr
             {
                 ChipLogError(Zcl,
                              "[findUserIndexByCredential] Unable to get credential: app error "
-                             "[userIndex=%d,credentialIndex=%d,credentialType=%" PRIu8 "]",
+                             "[userIndex=%d,credentialIndex=%d,credentialType=%u]",
                              i, credential.CredentialIndex, to_underlying(credentialType));
                 emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
                 return false;
@@ -1484,7 +1483,7 @@ bool DoorLockServer::findUserIndexByCredential(chip::EndpointId endpointId, DlCr
                 ChipLogError(Zcl,
                              "[findUserIndexByCredential] Users/Credentials database error: credential index attached to user is "
                              "not occupied "
-                             "[userIndex=%d,credentialIndex=%d,credentialType=%" PRIu8 "]",
+                             "[userIndex=%d,credentialIndex=%d,credentialType=%u]",
                              i, credential.CredentialIndex, to_underlying(credentialType));
                 emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
                 return false;
@@ -1543,7 +1542,7 @@ EmberAfStatus DoorLockServer::createUser(chip::EndpointId endpointId, chip::Fabr
         emberAfDoorLockClusterPrintln(
             "[createUser] Unable to create user: app error "
             "[endpointId=%d,creatorFabricId=%d,userIndex=%d,userName=\"%s\",userUniqueId=0x%" PRIx32 ",userStatus="
-            "%" PRIu8 ",userType=%" PRIu8 ",credentialRule=%" PRIu8 ",totalCredentials=%zu]",
+            "%u,userType=%u,credentialRule=%u,totalCredentials=%zu]",
             endpointId, creatorFabricIdx, userIndex, newUserName.data(), newUserUniqueId, to_underlying(newUserStatus),
             to_underlying(newUserType), to_underlying(newCredentialRule), newTotalCredentials);
         return EMBER_ZCL_STATUS_FAILURE;
@@ -1552,7 +1551,7 @@ EmberAfStatus DoorLockServer::createUser(chip::EndpointId endpointId, chip::Fabr
     emberAfDoorLockClusterPrintln(
         "[createUser] User created "
         "[endpointId=%d,creatorFabricId=%d,userIndex=%d,userName=\"%s\",userUniqueId=0x%" PRIx32 ",userStatus=%"
-        "" PRIu8 ",userType=%" PRIu8 ",credentialRule=%" PRIu8 ",totalCredentials=%zu]",
+        "u,userType=%u,credentialRule=%u,totalCredentials=%zu]",
         endpointId, creatorFabricIdx, userIndex, newUserName.data(), newUserUniqueId, to_underlying(newUserStatus),
         to_underlying(newUserType), to_underlying(newCredentialRule), newTotalCredentials);
 
@@ -1613,8 +1612,8 @@ EmberAfStatus DoorLockServer::modifyUser(chip::EndpointId endpointId, chip::Fabr
     {
         ChipLogError(Zcl,
                      "[modifyUser] Unable to modify the user: app error "
-                     "[endpointId=%d,modifierFabric=%d,userIndex=%d,userName=\"%s\",userUniqueId=0x%" PRIx32 ",userStatus=%" PRIu8
-                     ",userType=%" PRIu8 ",credentialRule=%" PRIu8 "]",
+                     "[endpointId=%d,modifierFabric=%d,userIndex=%d,userName=\"%s\",userUniqueId=0x%" PRIx32 ",userStatus=%u"
+                     ",userType=%u,credentialRule=%u]",
                      endpointId, modifierFabricIndex, userIndex, newUserName.data(), newUserUniqueId, to_underlying(newUserStatus),
                      to_underlying(newUserType), to_underlying(newCredentialRule));
         return EMBER_ZCL_STATUS_FAILURE;
@@ -1622,8 +1621,8 @@ EmberAfStatus DoorLockServer::modifyUser(chip::EndpointId endpointId, chip::Fabr
 
     emberAfDoorLockClusterPrintln("[modifyUser] User modified "
                                   "[endpointId=%d,modifierFabric=%d,userIndex=%d,userName=\"%s\",userUniqueId=0x%" PRIx32
-                                  ",userStatus=%" PRIu8 ","
-                                  "userType=%" PRIu8 ",credentialRule=%" PRIu8 "]",
+                                  ",userStatus=%u,"
+                                  "userType=%u,credentialRule=%u]",
                                   endpointId, modifierFabricIndex, userIndex, newUserName.data(), newUserUniqueId,
                                   to_underlying(newUserStatus), to_underlying(newUserType), to_underlying(newCredentialRule));
 
@@ -1652,7 +1651,7 @@ EmberAfStatus DoorLockServer::clearUser(chip::EndpointId endpointId, chip::Fabri
     for (const auto & credential : user.credentials)
     {
         emberAfDoorLockClusterPrintln(
-            "[ClearUser] Clearing associated credential [endpointId=%d,userIndex=%d,credentialType=%" PRIu8 ",credentialIndex=%d]",
+            "[ClearUser] Clearing associated credential [endpointId=%d,userIndex=%d,credentialType=%u,credentialIndex=%d]",
             endpointId, userIndex, credential.CredentialType, credential.CredentialIndex);
 
         if (!emberAfPluginDoorLockSetCredential(endpointId, credential.CredentialIndex, DlCredentialStatus::kAvailable,
@@ -1660,7 +1659,7 @@ EmberAfStatus DoorLockServer::clearUser(chip::EndpointId endpointId, chip::Fabri
         {
             ChipLogError(Zcl,
                          "[ClearUser] Unable to remove credentials associated with user - internal error "
-                         "[endpointId=%d,userIndex=%d,credentialIndex=%d,credentialType=%" PRIu8 "]",
+                         "[endpointId=%d,userIndex=%d,credentialIndex=%d,credentialType=%u]",
                          endpointId, userIndex, credential.CredentialIndex, credential.CredentialType);
             return EMBER_ZCL_STATUS_FAILURE;
         }
@@ -1719,13 +1718,13 @@ DlStatus DoorLockServer::createNewCredentialAndUser(chip::EndpointId endpointId,
                                             static_cast<DlCredentialType>(credential.CredentialType), credentialData))
     {
         emberAfDoorLockClusterPrintln("[SetCredential] Unable to set the credential: app error "
-                                      "[endpointId=%d,credentialIndex=%d,credentialType=%" PRIu8 ",dataLength=%zu]",
+                                      "[endpointId=%d,credentialIndex=%d,credentialType=%u,dataLength=%zu]",
                                       endpointId, credential.CredentialIndex, credential.CredentialType, credentialData.size());
         return DlStatus::kFailure;
     }
 
     emberAfDoorLockClusterPrintln("[SetCredential] Credential and user were created "
-                                  "[endpointId=%d,credentialIndex=%d,credentialType=%" PRIu8 ",dataLength=%zu,userIndex=%d]",
+                                  "[endpointId=%d,credentialIndex=%d,credentialType=%u,dataLength=%zu,userIndex=%d]",
                                   endpointId, credential.CredentialIndex, credential.CredentialType, credentialData.size(),
                                   availableUserIndex);
     createdUserIndex = availableUserIndex;
@@ -1769,7 +1768,7 @@ DlStatus DoorLockServer::createNewCredentialAndAddItToUser(chip::EndpointId endp
     if (DlStatus::kSuccess != status)
     {
         emberAfDoorLockClusterPrintln("[SetCredential] Unable to add credential to a user: internal error "
-                                      "[endpointId=%d,credentialIndex=%d,userIndex=%d,status=%" PRIu8 "]",
+                                      "[endpointId=%d,credentialIndex=%d,userIndex=%d,status=%u]",
                                       endpointId, credential.CredentialIndex, userIndex, to_underlying(status));
         return status;
     }
@@ -1778,7 +1777,7 @@ DlStatus DoorLockServer::createNewCredentialAndAddItToUser(chip::EndpointId endp
                                             static_cast<DlCredentialType>(credential.CredentialType), credentialData))
     {
         emberAfDoorLockClusterPrintln("[SetCredential] Unable to set the credential: app error "
-                                      "[endpointId=%d,credentialIndex=%d,credentialType=%" PRIu8 ",dataLength=%zu]",
+                                      "[endpointId=%d,credentialIndex=%d,credentialType=%u,dataLength=%zu]",
                                       endpointId, credential.CredentialIndex, credential.CredentialType, credentialData.size());
         return DlStatus::kFailure;
     }
@@ -1932,7 +1931,7 @@ DlStatus DoorLockServer::createCredential(chip::EndpointId endpointId, chip::Fab
     if (!userType.IsNull() && DlUserType::kProgrammingUser == userType.Value())
     {
         emberAfDoorLockClusterPrintln("[SetCredential] Unable to set the credential: user type is invalid "
-                                      "[endpointId=%d,credentialIndex=%d,userType=%" PRIu8 "]",
+                                      "[endpointId=%d,credentialIndex=%d,userType=%u]",
                                       endpointId, credentialIndex, to_underlying(userType.Value()));
 
         return DlStatus::kInvalidField;
@@ -1993,14 +1992,14 @@ DlStatus DoorLockServer::modifyProgrammingPIN(chip::EndpointId endpointId, chip:
                                             existingCredential.credentialType, credentialData))
     {
         emberAfDoorLockClusterPrintln("[SetCredential] Unable to modify the credential: app error "
-                                      "[endpointId=%d,credentialIndex=%d,credentialType=%" PRIu8 ",credentialDataSize=%zu]",
+                                      "[endpointId=%d,credentialIndex=%d,credentialType=%u,credentialDataSize=%zu]",
                                       endpointId, credentialIndex, to_underlying(credentialType), credentialData.size());
         return DlStatus::kFailure;
     }
     else
     {
         emberAfDoorLockClusterPrintln("[SetCredential] Successfully modified the credential "
-                                      "[endpointId=%d,credentialIndex=%d,credentialType=%" PRIu8 ",credentialDataSize=%zu]",
+                                      "[endpointId=%d,credentialIndex=%d,credentialType=%u,credentialDataSize=%zu]",
                                       endpointId, credentialIndex, to_underlying(credentialType), credentialData.size());
 
         sendRemoteLockUserChange(endpointId, credentialTypeToLockDataType(credentialType), DlDataOperationType::kModify,
@@ -2021,7 +2020,7 @@ DlStatus DoorLockServer::modifyCredential(chip::EndpointId endpointId, chip::Fab
     if (!userStatus.IsNull() || (!userType.IsNull() && DlUserType::kProgrammingUser != userType.Value()))
     {
         emberAfDoorLockClusterPrintln("[SetCredential] Unable to modify the credential: invalid arguments "
-                                      "[endpointId=%d,credentialIndex=%d,credentialType=%" PRIu8 "]",
+                                      "[endpointId=%d,credentialIndex=%d,credentialType=%u]",
                                       endpointId, credentialIndex, to_underlying(credentialType));
         return DlStatus::kInvalidField;
     }
@@ -2035,14 +2034,14 @@ DlStatus DoorLockServer::modifyCredential(chip::EndpointId endpointId, chip::Fab
                                                 existingCredential.credentialType, credentialData))
         {
             emberAfDoorLockClusterPrintln("[SetCredential] Unable to modify the credential: app error "
-                                          "[endpointId=%d,credentialIndex=%d,credentialType=%" PRIu8 ",credentialDataSize=%zu]",
+                                          "[endpointId=%d,credentialIndex=%d,credentialType=%u,credentialDataSize=%zu]",
                                           endpointId, credentialIndex, to_underlying(credentialType), credentialData.size());
 
             return DlStatus::kFailure;
         }
 
         emberAfDoorLockClusterPrintln("[SetCredential] Successfully modified the credential "
-                                      "[endpointId=%d,credentialIndex=%d,credentialType=%" PRIu8 ",credentialDataSize=%zu]",
+                                      "[endpointId=%d,credentialIndex=%d,credentialType=%u,credentialDataSize=%zu]",
                                       endpointId, credentialIndex, to_underlying(credentialType), credentialData.size());
 
         sendRemoteLockUserChange(endpointId, credentialTypeToLockDataType(credentialType), DlDataOperationType::kModify,
@@ -2118,7 +2117,7 @@ DlStatus DoorLockServer::clearWeekDaySchedule(chip::EndpointId endpointId, uint1
     {
         ChipLogError(Zcl,
                      "[ClearWeekDaySchedule] Unable to clear the schedule - internal error "
-                     "[endpointId=%d,userIndex=%d,scheduleIndex=%d,status=%" PRIu8 "]",
+                     "[endpointId=%d,userIndex=%d,scheduleIndex=%d,status=%u]",
                      endpointId, userIndex, weekDayIndex, to_underlying(status));
         return status;
     }
@@ -2151,7 +2150,7 @@ DlStatus DoorLockServer::clearSchedules(chip::EndpointId endpointId, uint16_t us
     {
         ChipLogError(Zcl,
                      "[CleaAllSchedules] Unable to clear week day schedules for user - internal error "
-                     "[endpointId=%d,userIndex=%d,status=%" PRIu8 "]",
+                     "[endpointId=%d,userIndex=%d,status=%u]",
                      endpointId, userIndex, to_underlying(status));
         return status;
     }
@@ -2161,7 +2160,7 @@ DlStatus DoorLockServer::clearSchedules(chip::EndpointId endpointId, uint16_t us
     {
         ChipLogError(Zcl,
                      "[CleaAllSchedules] Unable to clear year day schedules for user - internal error "
-                     "[endpointId=%d,userIndex=%d,status=%" PRIu8 "]",
+                     "[endpointId=%d,userIndex=%d,status=%u]",
                      endpointId, userIndex, to_underlying(status));
         return status;
     }
@@ -2217,7 +2216,7 @@ DlStatus DoorLockServer::clearYearDaySchedule(chip::EndpointId endpointId, uint1
     {
         ChipLogError(Zcl,
                      "[ClearYearDaySchedule] Unable to clear the schedule - internal error "
-                     "[endpointId=%d,userIndex=%d,scheduleIndex=%d,status=%" PRIu8 "]",
+                     "[endpointId=%d,userIndex=%d,scheduleIndex=%d,status=%u]",
                      endpointId, userIndex, yearDayIndex, to_underlying(status));
         return status;
     }
@@ -2269,7 +2268,7 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
     if (DlCredentialType::kProgrammingPIN == credentialType)
     {
         emberAfDoorLockClusterPrintln("[clearCredential] Cannot clear programming PIN credentials "
-                                      "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,modifier=%d]",
+                                      "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d]",
                                       endpointId, to_underlying(credentialType), credentialIndex, modifier);
         return EMBER_ZCL_STATUS_INVALID_COMMAND;
     }
@@ -2277,7 +2276,7 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
     if (!credentialIndexValid(endpointId, credentialType, credentialIndex))
     {
         emberAfDoorLockClusterPrintln("[clearCredential] Cannot clear credential - index out of bounds "
-                                      "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,modifier=%d]",
+                                      "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d]",
                                       endpointId, to_underlying(credentialType), credentialIndex, modifier);
         return EMBER_ZCL_STATUS_INVALID_COMMAND;
     }
@@ -2288,7 +2287,7 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
     {
         ChipLogError(Zcl,
                      "[clearCredential] Unable to clear credential - couldn't read credential from database "
-                     "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,modifier=%d]",
+                     "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d]",
                      endpointId, to_underlying(credentialType), credentialIndex, modifier);
         return EMBER_ZCL_STATUS_FAILURE;
     }
@@ -2296,17 +2295,17 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
     if (DlCredentialStatus::kAvailable == credential.status)
     {
         emberAfDoorLockClusterPrintln("[clearCredential] Ignored attempt to clear unoccupied credential slot "
-                                      "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,modifier=%d]",
+                                      "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d]",
                                       endpointId, to_underlying(credentialType), credentialIndex, modifier);
         return EMBER_ZCL_STATUS_SUCCESS;
     }
 
     if (credentialType != credential.credentialType)
     {
-        emberAfDoorLockClusterPrintln(
-            "[clearCredential] Ignored attempt to clear credential of different type "
-            "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,modifier=%d,actualCredentialType=%" PRIu8 "]",
-            endpointId, to_underlying(credentialType), credentialIndex, modifier, to_underlying(credential.credentialType));
+        emberAfDoorLockClusterPrintln("[clearCredential] Ignored attempt to clear credential of different type "
+                                      "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d,actualCredentialType=%u]",
+                                      endpointId, to_underlying(credentialType), credentialIndex, modifier,
+                                      to_underlying(credential.credentialType));
         return EMBER_ZCL_STATUS_SUCCESS;
     }
 
@@ -2317,7 +2316,7 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
     {
         ChipLogError(Zcl,
                      "[clearCredential] Unable to clear related credential user - couldn't find index of related user "
-                     "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,modifier=%d]",
+                     "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d]",
                      endpointId, to_underlying(credentialType), credentialIndex, modifier);
         return EMBER_ZCL_STATUS_FAILURE;
     }
@@ -2326,7 +2325,7 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
     {
         ChipLogError(Zcl,
                      "[clearCredential] Unable to clear credential for related user - couldn't get user from database "
-                     "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,modifier=%d,userIndex=%d]",
+                     "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d,userIndex=%d]",
                      endpointId, to_underlying(credentialType), credentialIndex, modifier, relatedUserIndex);
 
         return EMBER_ZCL_STATUS_FAILURE;
@@ -2334,20 +2333,20 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
     if (1 == relatedUser.credentials.size())
     {
         emberAfDoorLockClusterPrintln("[clearCredential] Clearing related user - no credentials left "
-                                      "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,modifier=%d,userIndex=%d]",
+                                      "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d,userIndex=%d]",
                                       endpointId, to_underlying(credentialType), credentialIndex, modifier, relatedUserIndex);
         auto clearStatus = clearUser(endpointId, modifier, sourceNodeId, relatedUserIndex, relatedUser, true);
         if (EMBER_ZCL_STATUS_SUCCESS != clearStatus)
         {
             ChipLogError(Zcl,
                          "[clearCredential] Unable to clear related credential user - internal error "
-                         "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,modifier=%d,userIndex=%d,status=%d]",
+                         "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d,userIndex=%d,status=%d]",
                          endpointId, to_underlying(credentialType), credentialIndex, modifier, relatedUserIndex, clearStatus);
 
             return EMBER_ZCL_STATUS_FAILURE;
         }
         emberAfDoorLockClusterPrintln("[clearCredential] Successfully clear credential and related user "
-                                      "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,modifier=%d,userIndex=%d]",
+                                      "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d,userIndex=%d]",
                                       endpointId, to_underlying(credentialType), credentialIndex, modifier, relatedUserIndex);
         return EMBER_ZCL_STATUS_SUCCESS;
     }
@@ -2358,7 +2357,7 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
     {
         ChipLogError(Zcl,
                      "[clearCredential] Unable to clear credential - couldn't write new credential to database "
-                     "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,modifier=%d]",
+                     "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d]",
                      endpointId, to_underlying(credentialType), credentialIndex, modifier);
         return EMBER_ZCL_STATUS_FAILURE;
     }
@@ -2368,7 +2367,7 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
     {
         ChipLogError(Zcl,
                      "[clearCredential] Unable to clear credential for related user - user has too many credentials associated"
-                     "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,modifier=%d,userIndex=%d,credentialsCount=%zu]",
+                     "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d,userIndex=%d,credentialsCount=%zu]",
                      endpointId, to_underlying(credentialType), credentialIndex, modifier, relatedUserIndex,
                      relatedUser.credentials.size());
 
@@ -2392,7 +2391,7 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
     {
         ChipLogError(Zcl,
                      "[clearCredential] Unable to clear credential for related user - unable to update database "
-                     "[endpointId=%d,credentialType=%" PRIu8
+                     "[endpointId=%d,credentialType=%u"
                      ",credentialIndex=%d,modifier=%d,userIndex=%d,newCredentialsCount=%zu]",
                      endpointId, to_underlying(credentialType), credentialIndex, modifier, relatedUserIndex, newCredentialsCount);
         return EMBER_ZCL_STATUS_FAILURE;
@@ -2400,7 +2399,7 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
 
     emberAfDoorLockClusterPrintln(
         "[clearCredential] Successfully clear credential and related user "
-        "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,modifier=%d,userIndex=%d,newCredentialsCount=%zu]",
+        "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d,userIndex=%d,newCredentialsCount=%zu]",
         endpointId, to_underlying(credentialType), credentialIndex, modifier, relatedUserIndex, newCredentialsCount);
 
     if (sendUserChangeEvent)
@@ -2483,7 +2482,7 @@ EmberAfStatus DoorLockServer::clearCredentials(chip::EndpointId endpointId, chip
     {
         ChipLogError(Zcl,
                      "[clearCredentials] Unable to get max number of credentials to clear - can't get max number of credentials "
-                     "[endpointId=%d,credentialType=%" PRIu8 "]",
+                     "[endpointId=%d,credentialType=%u]",
                      endpointId, to_underlying(credentialType));
         return EMBER_ZCL_STATUS_FAILURE;
     }
@@ -2495,7 +2494,7 @@ EmberAfStatus DoorLockServer::clearCredentials(chip::EndpointId endpointId, chip
         {
             ChipLogError(Zcl,
                          "[clearCredentials] Unable to clear the credential - internal error "
-                         "[endpointId=%d,credentialType=%" PRIu8 ",credentialIndex=%d,status=%d]",
+                         "[endpointId=%d,credentialType=%u,credentialIndex=%d,status=%d]",
                          endpointId, to_underlying(credentialType), i, status);
             return status;
         }
@@ -2535,7 +2534,7 @@ bool DoorLockServer::sendRemoteLockUserChange(chip::EndpointId endpointId, DlLoc
         return false;
     }
     emberAfDoorLockClusterPrintln("[RemoteLockUserChange] Sent lock user change event "
-                                  "[endpointId=%d,eventNumber=%" PRIu64 ",dataType=%" PRIu8 ",operation=%" PRIu8 ",nodeId=%" PRIu64
+                                  "[endpointId=%d,eventNumber=%" PRIu64 ",dataType=%u,operation=%u,nodeId=%" PRIu64
                                   ",fabricIndex=%d]",
                                   endpointId, eventNumber, to_underlying(dataType), to_underlying(operation), nodeId, fabricIndex);
     return true;
@@ -2701,7 +2700,7 @@ void DoorLockServer::ScheduleAutoRelock(chip::EndpointId endpointId, uint32_t ti
 
     if (EMBER_SUCCESS != err)
     {
-        ChipLogError(Zcl, "Failed to schedule autorelock: timeout=%" PRIu32 ", status=0x%" PRIx8, timeoutSec, err);
+        ChipLogError(Zcl, "Failed to schedule autorelock: timeout=%" PRIu32 ", status=0x%x", timeoutSec, err);
     }
 }
 
@@ -2726,7 +2725,7 @@ bool DoorLockServer::GetAttribute(chip::EndpointId endpointId, chip::AttributeId
 
     if (!success)
     {
-        ChipLogError(Zcl, "Failed to read DoorLock attribute: attribute=0x%" PRIx32 ", status=0x%" PRIx8, attributeId,
+        ChipLogError(Zcl, "Failed to read DoorLock attribute: attribute=0x%" PRIx32 ", status=0x%x", attributeId,
                      to_underlying(status));
     }
     return success;
@@ -2741,7 +2740,7 @@ bool DoorLockServer::SetAttribute(chip::EndpointId endpointId, chip::AttributeId
 
     if (!success)
     {
-        ChipLogError(Zcl, "Failed to write DoorLock attribute: attribute=0x%" PRIx32 ", status=0x%" PRIx8, attributeId,
+        ChipLogError(Zcl, "Failed to write DoorLock attribute: attribute=0x%" PRIx32 ", status=0x%x", attributeId,
                      to_underlying(status));
     }
     return success;

--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -91,7 +91,7 @@ bool emberAfModeSelectClusterChangeToModeCallback(CommandHandler * commandHandle
         ModeSelect::getSupportedModesManager()->getModeOptionByMode(endpointId, newMode, &modeOptionPtr);
     if (EMBER_ZCL_STATUS_SUCCESS != checkSupportedModeStatus)
     {
-        emberAfPrintln(EMBER_AF_PRINT_DEBUG, "ModeSelect: Failed to find the option with mode %" PRIu8, newMode);
+        emberAfPrintln(EMBER_AF_PRINT_DEBUG, "ModeSelect: Failed to find the option with mode %u", newMode);
         emberAfSendImmediateDefaultResponse(checkSupportedModeStatus);
         return false;
     }

--- a/src/app/clusters/network-commissioning-old/network-commissioning-old.cpp
+++ b/src/app/clusters/network-commissioning-old/network-commissioning-old.cpp
@@ -149,7 +149,7 @@ void OnAddOrUpdateThreadNetworkCommandCallbackInternal(app::CommandHandler * apC
 exit:
     // TODO: We should encode response command here.
 
-    ChipLogDetail(Zcl, "AddOrUpdateThreadNetwork: %" PRIu8, to_underlying(err));
+    ChipLogDetail(Zcl, "AddOrUpdateThreadNetwork: %u", to_underlying(err));
     response.networkingStatus = err;
 #else
     // The target does not supports ThreadNetwork. We should not add AddOrUpdateThreadNetwork command in that case then the upper
@@ -207,7 +207,7 @@ void OnAddOrUpdateWiFiNetworkCommandCallbackInternal(app::CommandHandler * apCom
 exit:
     // TODO: We should encode response command here.
 
-    ChipLogDetail(Zcl, "AddOrUpdateWiFiNetwork: %" PRIu8, to_underlying(err));
+    ChipLogDetail(Zcl, "AddOrUpdateWiFiNetwork: %u", to_underlying(err));
     response.networkingStatus = err;
 #else
     // The target does not supports WiFiNetwork.

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -74,7 +74,7 @@ CHIP_ERROR CreateAccessControlEntryForNewFabricAdministrator(FabricIndex fabricI
     ReturnErrorOnFailure(entry.AddSubject(nullptr, subject));
     ReturnErrorOnFailure(Access::GetAccessControl().CreateEntry(nullptr, entry));
 
-    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: ACL entry created for Fabric %" PRIX8 " CASE Admin NodeId 0x" ChipLogFormatX64,
+    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: ACL entry created for Fabric %X CASE Admin NodeId 0x" ChipLogFormatX64,
                    fabricIndex, ChipLogValueX64(subject));
 
     // TODO: event notification for newly created ACL entry
@@ -288,7 +288,7 @@ class OpCredsFabricTableDelegate : public FabricTableDelegate
     void OnFabricDeletedFromStorage(CompressedFabricId compressedFabricId, FabricIndex fabricId) override
     {
         printf("OpCredsFabricTableDelegate::OnFabricDeletedFromStorage\n");
-        emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Fabric 0x%" PRIu8 " was deleted from fabric storage.", fabricId);
+        emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Fabric 0x%u was deleted from fabric storage.", fabricId);
         fabricListChanged();
 
         // The Leave event SHOULD be emitted by a Node prior to permanently
@@ -310,7 +310,7 @@ class OpCredsFabricTableDelegate : public FabricTableDelegate
     void OnFabricRetrievedFromStorage(FabricInfo * fabric) override
     {
         emberAfPrintln(EMBER_AF_PRINT_DEBUG,
-                       "OpCreds: Fabric 0x%" PRIu8 " was retrieved from storage. FabricId 0x" ChipLogFormatX64
+                       "OpCreds: Fabric 0x%u was retrieved from storage. FabricId 0x" ChipLogFormatX64
                        ", NodeId 0x" ChipLogFormatX64 ", VendorId 0x%04" PRIX16,
                        fabric->GetFabricIndex(), ChipLogValueX64(fabric->GetFabricId()),
                        ChipLogValueX64(fabric->GetPeerId().GetNodeId()), fabric->GetVendorId());
@@ -321,8 +321,8 @@ class OpCredsFabricTableDelegate : public FabricTableDelegate
     void OnFabricPersistedToStorage(FabricInfo * fabric) override
     {
         emberAfPrintln(EMBER_AF_PRINT_DEBUG,
-                       "OpCreds: Fabric %" PRIX8 " was persisted to storage. FabricId " ChipLogFormatX64
-                       ", NodeId " ChipLogFormatX64 ", VendorId 0x%04" PRIX16,
+                       "OpCreds: Fabric %X was persisted to storage. FabricId " ChipLogFormatX64 ", NodeId " ChipLogFormatX64
+                       ", VendorId 0x%04" PRIX16,
                        fabric->GetFabricIndex(), ChipLogValueX64(fabric->GetFabricId()),
                        ChipLogValueX64(fabric->GetPeerId().GetNodeId()), fabric->GetVendorId());
         fabricListChanged();

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -200,7 +200,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(app::CommandHandl
     auto protocolIter = protocolsSupported.begin();
     while (protocolIter.Next())
     {
-        ChipLogDetail(Zcl, "    %" PRIu8, to_underlying(protocolIter.GetValue()));
+        ChipLogDetail(Zcl, "    %u", to_underlying(protocolIter.GetValue()));
     }
     ChipLogDetail(Zcl, "  ]");
     if (hardwareVersion.HasValue())
@@ -213,7 +213,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(app::CommandHandl
     }
     if (requestorCanConsent.HasValue())
     {
-        ChipLogDetail(Zcl, "  RequestorCanConsent: %" PRIu8, requestorCanConsent.Value());
+        ChipLogDetail(Zcl, "  RequestorCanConsent: %u", requestorCanConsent.Value());
     }
     if (metadataForProvider.HasValue())
     {

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -47,7 +47,7 @@ constexpr uint32_t kImmediateStartDelayMs = 1; // Start the timer with this valu
 static void LogQueryImageResponse(const QueryImageResponse::DecodableType & response)
 {
     ChipLogDetail(SoftwareUpdate, "QueryImageResponse:");
-    ChipLogDetail(SoftwareUpdate, "  status: %" PRIu8 "", to_underlying(response.status));
+    ChipLogDetail(SoftwareUpdate, "  status: %u", to_underlying(response.status));
     if (response.delayedActionTime.HasValue())
     {
         ChipLogDetail(SoftwareUpdate, "  delayedActionTime: %" PRIu32 " seconds", response.delayedActionTime.Value());
@@ -84,7 +84,7 @@ static void LogQueryImageResponse(const QueryImageResponse::DecodableType & resp
 static void LogApplyUpdateResponse(const ApplyUpdateResponse::DecodableType & response)
 {
     ChipLogDetail(SoftwareUpdate, "ApplyUpdateResponse:");
-    ChipLogDetail(SoftwareUpdate, "  action: %" PRIu8 "", to_underlying(response.action));
+    ChipLogDetail(SoftwareUpdate, "  action: %u", to_underlying(response.action));
     ChipLogDetail(SoftwareUpdate, "  delayedActionTime: %" PRIu32 " seconds", response.delayedActionTime);
 }
 
@@ -240,10 +240,10 @@ EmberAfStatus OTARequestor::HandleAnnounceOTAProvider(app::CommandHandler * comm
     mProviderEndpointId  = providerEndpoint;
 
     ChipLogProgress(SoftwareUpdate, "OTA Requestor received AnnounceOTAProvider");
-    ChipLogDetail(SoftwareUpdate, "  FabricIndex: %" PRIu8, mProviderFabricIndex);
+    ChipLogDetail(SoftwareUpdate, "  FabricIndex: %u", mProviderFabricIndex);
     ChipLogDetail(SoftwareUpdate, "  ProviderNodeID: 0x" ChipLogFormatX64, ChipLogValueX64(mProviderNodeId));
     ChipLogDetail(SoftwareUpdate, "  VendorID: 0x%" PRIx16, commandData.vendorId);
-    ChipLogDetail(SoftwareUpdate, "  AnnouncementReason: %" PRIu8, to_underlying(announcementReason));
+    ChipLogDetail(SoftwareUpdate, "  AnnouncementReason: %u", to_underlying(announcementReason));
     if (commandData.metadataForNode.HasValue())
     {
         ChipLogDetail(SoftwareUpdate, "  MetadataForNode: %zu", commandData.metadataForNode.Value().size());
@@ -263,7 +263,7 @@ EmberAfStatus OTARequestor::HandleAnnounceOTAProvider(app::CommandHandler * comm
         msToStart = kImmediateStartDelayMs;
         break;
     default:
-        ChipLogError(SoftwareUpdate, "Unexpected announcementReason: %" PRIu8, static_cast<uint8_t>(announcementReason));
+        ChipLogError(SoftwareUpdate, "Unexpected announcementReason: %u", static_cast<uint8_t>(announcementReason));
         return EMBER_ZCL_STATUS_FAILURE;
     }
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -254,8 +254,8 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
                     Transport::PeerAddress::Multicast(fabric.GetFabricIndex(), groupInfo.group_id), true);
                 if (err != CHIP_NO_ERROR)
                 {
-                    ChipLogError(AppServer, "Error when trying to join Group %" PRIu16 " of fabric index %" PRIu8,
-                                 groupInfo.group_id, fabric.GetFabricIndex());
+                    ChipLogError(AppServer, "Error when trying to join Group %" PRIu16 " of fabric index %u", groupInfo.group_id,
+                                 fabric.GetFabricIndex());
                     break;
                 }
             }

--- a/src/app/tests/TestAttributeValueEncoder.cpp
+++ b/src/app/tests/TestAttributeValueEncoder.cpp
@@ -84,13 +84,13 @@ using TestSetup = LimitedTestSetup<1024>;
             printf("Encoded: \n");                                                                                                 \
             for (size_t i = 0; i < aSetup.writer.GetLengthWritten(); i++)                                                          \
             {                                                                                                                      \
-                printf("0x%02" PRIx8 ",", aSetup.buf[i]);                                                                          \
+                printf("0x%02x,", aSetup.buf[i]);                                                                                  \
             }                                                                                                                      \
             printf("\n");                                                                                                          \
             printf("Expected: \n");                                                                                                \
             for (size_t i = 0; i < sizeof(aExpected); i++)                                                                         \
             {                                                                                                                      \
-                printf("0x%02" PRIx8 ",", aExpected[i]);                                                                           \
+                printf("0x%02x,", aExpected[i]);                                                                                   \
             }                                                                                                                      \
             printf("\n");                                                                                                          \
         }                                                                                                                          \

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -332,9 +332,9 @@ function asPrintFormat(type)
       case 'bool':
         return '%d';
       case 'int8_t':
-        return '%" PRId8 "';
+        return '%d';
       case 'uint8_t':
-        return '%" PRIu8 "';
+        return '%u';
       case 'int16_t':
         return '%" PRId16 "';
       case 'uint16_t':

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -702,7 +702,7 @@ void GenericConfigurationManagerImpl<ConfigClass>::LogDeviceConfig()
         err = GetManufacturingDate(year, month, dayOfMonth);
         if (err == CHIP_NO_ERROR)
         {
-            ChipLogProgress(DeviceLayer, "  Manufacturing Date: %04" PRIu16 "/%02" PRIu8 "/%02" PRIu8, year, month, dayOfMonth);
+            ChipLogProgress(DeviceLayer, "  Manufacturing Date: %04" PRIu16 "/%02u/%02u", year, month, dayOfMonth);
         }
         else
         {

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -376,7 +376,7 @@ bool IsCategoryEnabled(uint8_t category);
 /**
  * Logging helpers for message types, so we format them consistently.
  */
-#define ChipLogFormatMessageType "0x%" PRIx8
+#define ChipLogFormatMessageType "0x%x"
 
 } // namespace Logging
 } // namespace chip

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -132,7 +132,7 @@ void ReliableMessageMgr::ExecuteActions()
         {
             ChipLogError(ExchangeManager,
                          "Failed to Send CHIP MessageCounter:" ChipLogFormatMessageCounter " on exchange " ChipLogFormatExchange
-                         " sendCount: %" PRIu8 " max retries: %d",
+                         " sendCount: %u max retries: %d",
                          messageCounter, ChipLogValueExchange(&entry->ec.Get()), sendCount, CHIP_CONFIG_RMP_DEFAULT_MAX_RETRANS);
 
             // Do not StartTimer, we will schedule the timer at the end of the timer handler.

--- a/src/platform/ESP32/SystemTimeSupport.cpp
+++ b/src/platform/ESP32/SystemTimeSupport.cpp
@@ -103,10 +103,8 @@ CHIP_ERROR ClockImpl::SetClock_RealTime(Clock::Microseconds64 aNewCurTime)
         const time_t timep = tv.tv_sec;
         struct tm calendar;
         localtime_r(&timep, &calendar);
-        ChipLogProgress(
-            DeviceLayer,
-            "Real time clock set to %ld (%04" PRId16 "/%02" PRId8 "/%02" PRId8 " %02" PRId8 ":%02" PRId8 ":%02" PRId8 " UTC)",
-            tv.tv_sec, calendar.tm_year, calendar.tm_mon, calendar.tm_mday, calendar.tm_hour, calendar.tm_min, calendar.tm_sec);
+        ChipLogProgress(DeviceLayer, "Real time clock set to %ld (%04" PRId16 "/%02d/%02d %02d:%02d:%02d UTC)", tv.tv_sec,
+                        calendar.tm_year, calendar.tm_mon, calendar.tm_mday, calendar.tm_hour, calendar.tm_min, calendar.tm_sec);
     }
 #endif // CHIP_PROGRESS_LOGGING
     return CHIP_NO_ERROR;

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -913,7 +913,7 @@ exit:
 
 CHIP_ERROR BLEManagerImpl::HandleGAPDisconnect(struct ble_gap_event * gapEvent)
 {
-    ChipLogProgress(DeviceLayer, "BLE GAP connection terminated (con %" PRIu16 " reason 0x%02" PRIx8 ")",
+    ChipLogProgress(DeviceLayer, "BLE GAP connection terminated (con %" PRIu16 " reason 0x%02x)",
                     gapEvent->disconnect.conn.conn_handle, gapEvent->disconnect.reason);
 
     // Update the number of GAP connections.

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -571,8 +571,8 @@ void ThreadStackManagerImpl::_OnNetworkScanFinished(GAsyncResult * res)
                                    &joiner_udp_port, &channel, &rssi, &lqi, &version, &is_native, &is_joinable))
         {
             ChipLogProgress(DeviceLayer,
-                            "Thread Network: %s (%016" PRIx64 ") ExtPanId(%016" PRIx64 ") RSSI %" PRIu16 " LQI %" PRIu8
-                            " Version %" PRIu8,
+                            "Thread Network: %s (%016" PRIx64 ") ExtPanId(%016" PRIx64 ") RSSI %" PRIu16 " LQI %u"
+                            " Version %u",
                             network_name, ext_address, ext_panid, rssi, lqi, version);
             NetworkCommissioning::ThreadScanResponse networkScanned;
             networkScanned.panId         = panid;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -792,7 +792,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetAndLogThread
             otErr               = otThreadGetChildInfoById(mOTInst, neighbor->mRloc16, child);
             VerifyOrExit(otErr == OT_ERROR_NONE, err = MapOpenThreadError(otErr));
 
-            snprintf(printBuf, TELEM_PRINT_BUFFER_SIZE, ", Timeout: %10" PRIu32 " NetworkDataVersion: %3" PRIu8, child->mTimeout,
+            snprintf(printBuf, TELEM_PRINT_BUFFER_SIZE, ", Timeout: %10" PRIu32 " NetworkDataVersion: %3u", child->mTimeout,
                      child->mNetworkDataVersion);
         }
         else

--- a/src/platform/OpenThread/OpenThreadUtils.cpp
+++ b/src/platform/OpenThread/OpenThreadUtils.cpp
@@ -223,12 +223,12 @@ void LogOpenThreadPacket(const char * titleStr, otMessage * pkt)
             }
             else
             {
-                snprintf(typeBuf, sizeof(typeBuf), "ICMPv6 %" PRIu8 ",%" PRIu8, ICMPv6_Type, ICMPv6_Code);
+                snprintf(typeBuf, sizeof(typeBuf), "ICMPv6 %u,%u", ICMPv6_Type, ICMPv6_Code);
             }
         }
         else
         {
-            snprintf(typeBuf, sizeof(typeBuf), "IP proto %" PRIu8, IPv6_NextHeader);
+            snprintf(typeBuf, sizeof(typeBuf), "IP proto %u", IPv6_NextHeader);
         }
 
         if (IPv6_NextHeader == kIPProto_UDP || IPv6_NextHeader == kIPProto_TCP)

--- a/src/platform/Tizen/SystemTimeSupport.cpp
+++ b/src/platform/Tizen/SystemTimeSupport.cpp
@@ -114,10 +114,8 @@ CHIP_ERROR SetClock_RealTime(uint64_t newCurTime)
         const time_t timep = tv.tv_sec;
         struct tm calendar;
         localtime_r(&timep, &calendar);
-        ChipLogProgress(
-            DeviceLayer,
-            "Real time clock set to %ld (%04" PRId16 "/%02" PRId8 "/%02" PRId8 " %02" PRId8 ":%02" PRId8 ":%02" PRId8 " UTC)",
-            tv.tv_sec, calendar.tm_year, calendar.tm_mon, calendar.tm_mday, calendar.tm_hour, calendar.tm_min, calendar.tm_sec);
+        ChipLogProgress(DeviceLayer, "Real time clock set to %ld (%04" PRId16 "/%02d/%02d %02d:%02d:%02d UTC)", tv.tv_sec,
+                        calendar.tm_year, calendar.tm_mon, calendar.tm_mday, calendar.tm_hour, calendar.tm_min, calendar.tm_sec);
     }
 #endif // CHIP_PROGRESS_LOGGING
     return CHIP_NO_ERROR;

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -264,8 +264,7 @@ void CASESession::OnResponseTimeout(ExchangeContext * ec)
 {
     VerifyOrReturn(ec != nullptr, ChipLogError(SecureChannel, "CASESession::OnResponseTimeout was called by null exchange"));
     VerifyOrReturn(mExchangeCtxt == ec, ChipLogError(SecureChannel, "CASESession::OnResponseTimeout exchange doesn't match"));
-    ChipLogError(SecureChannel, "CASESession timed out while waiting for a response from the peer. Current state was %" PRIu8,
-                 mState);
+    ChipLogError(SecureChannel, "CASESession timed out while waiting for a response from the peer. Current state was %u", mState);
     // Discard the exchange so that Clear() doesn't try closing it.  The
     // exchange will handle that.
     DiscardExchange();

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -344,8 +344,7 @@ void PASESession::OnResponseTimeout(ExchangeContext * ec)
     VerifyOrReturn(ec != nullptr, ChipLogError(SecureChannel, "PASESession::OnResponseTimeout was called by null exchange"));
     VerifyOrReturn(mExchangeCtxt == nullptr || mExchangeCtxt == ec,
                    ChipLogError(SecureChannel, "PASESession::OnResponseTimeout exchange doesn't match"));
-    ChipLogError(SecureChannel,
-                 "PASESession timed out while waiting for a response from the peer. Expected message type was %" PRIu8,
+    ChipLogError(SecureChannel, "PASESession timed out while waiting for a response from the peer. Expected message type was %u",
                  to_underlying(mNextExpectedMsg));
     // Discard the exchange so that Clear() doesn't try closing it.  The
     // exchange will handle that.

--- a/src/system/SystemStats.h
+++ b/src/system/SystemStats.h
@@ -74,7 +74,6 @@ enum
 };
 
 typedef int8_t count_t;
-#define PRI_CHIP_SYS_STATS_COUNT PRId8
 #define CHIP_SYS_STATS_COUNT_MAX INT8_MAX
 
 extern count_t ResourcesInUse[kNumEntries];

--- a/src/tools/chip-cert/Cmd_PrintCert.cpp
+++ b/src/tools/chip-cert/Cmd_PrintCert.cpp
@@ -156,8 +156,8 @@ void PrintEpochTime(FILE * file, const char * name, int indent, uint32_t epochTi
     Indent(file, indent);
     fprintf(file, "%s: ", name);
 
-    fprintf(file, "0x%08" PRIX32 "  ( %04" PRId16 "/%02" PRId8 "/%02" PRId8 " %02" PRId8 ":%02" PRId8 ":%02" PRId8 " )\n",
-            epochTime, asn1Time.Year, asn1Time.Month, asn1Time.Day, asn1Time.Hour, asn1Time.Minute, asn1Time.Second);
+    fprintf(file, "0x%08" PRIX32 "  ( %04" PRId16 "/%02d/%02d %02d:%02d:%02d )\n", epochTime, asn1Time.Year, asn1Time.Month,
+            asn1Time.Day, asn1Time.Hour, asn1Time.Minute, asn1Time.Second);
 }
 
 void PrintDN(FILE * file, const char * name, int indent, const ChipDN * dn)


### PR DESCRIPTION
These are not supported on some embedded/minimal libcs.  Use %u/%d/%x
instead, since [u]int8_t will get promoted to int anyway when passed
via varargs.

This commit was generated by installing the git-extras package and running:

    git sed -f g '" PRIu8 "' 'u'
    git sed -f g '" PRIu8' 'u"'
    git sed -f g '" PRIx8 "' 'x'
    git sed -f g '" PRIx8' 'x"'
    git sed -f g '" PRIX8 "' 'X'
    git sed -f g '" PRIX8' 'X"'
    git sed -f g '" PRId8 "' 'd'
    git sed -f g '" PRId8' 'd"'

followed by the following manual fixups:

1) Fixing a comment in src/app/MessageDef/StatusIB.cpp
2) Deleting an unused macro in src/system/SystemStats.h
3) Reverting the change the above git sed commands caused in
   third_party/lwip/repo/lwip/src/include/lwip/arch.h
4) Adding a lint.
5) Running restyle.

#### Problem
Log statements can print garbage or even crash, due to libcs ignoring these and ending up with format/args mismatches.

#### Change overview
See above.

#### Testing
Ideally no behavior changes in our CI, and fewer logging problems on devices.