### PR TITLE
Error out if large (not-exactly-representable) integers are used in YAML

### DIFF
--- a/src/app/tests/suites/TestCluster.yaml
+++ b/src/app/tests/suites/TestCluster.yaml
@@ -606,13 +606,13 @@ tests:
       command: "writeAttribute"
       attribute: "float_double"
       arguments:
-          value: 1.7e200
+          value: "1.7e+200"
 
     - label: "Read attribute DOUBLE large Value"
       command: "readAttribute"
       attribute: "float_double"
       response:
-          value: 1.7e200
+          value: "1.7e+200"
 
     - label: "Write attribute DOUBLE small Value"
       command: "writeAttribute"


### PR DESCRIPTION
Otherwise we get silent value corruption.

#### Problem
64-bit ints do not go through JS very well.

#### Change overview
Make sure people use strings for them.

#### Testing
Tried putting large int values in various places in yaml and made sure they all failed.