### PR TITLE
[Android] Pass list of attribute paths to read/subscribe

### DIFF
--- a/scripts/idl/generators/java/ChipClustersCpp.jinja
+++ b/scripts/idl/generators/java/ChipClustersCpp.jinja
@@ -26,14 +26,14 @@
     using ListType_{{depth}} = std::remove_reference_t<decltype({{target}})>;
     using ListMemberType_{{depth}} = ListMemberTypeGetter<ListType_{{depth}}>::Type;
     jint {{source}}Size;
-    chip::JniReferences::GetInstance().GetArrayListSize({{source}}, {{source}}Size);
+    chip::JniReferences::GetInstance().GetListSize({{source}}, {{source}}Size);
     if ({{source}}Size != 0) {
       auto * listHolder_{{depth}} = new ListHolder<ListMemberType_{{depth}}>({{source}}Size);
       listFreer.add(listHolder_{{depth}});
 
       for (size_t i_{{depth}} = 0; i_{{depth}} < static_cast<size_t>({{source}}Size); ++i_{{depth}}) {
         jobject element_{{depth}};
-        chip::JniReferences::GetInstance().GetArrayListItem({{source}}, i_{{depth}}, element_{{depth}});
+        chip::JniReferences::GetInstance().GetListItem({{source}}, i_{{depth}}, element_{{depth}});
         {{encode_value(
            "listHolder_{}->mList[i_{}]".format(depth, depth),
            "element_{}".format(depth),

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
@@ -79,7 +79,7 @@ class WildcardFragment : Fragment() {
                                      reportCallback,
                                      ChipClient.getConnectedDevicePointer(requireContext(),
                                                                           addressUpdateFragment.deviceId),
-                                     attributePath,
+                                     listOf(attributePath),
                                      minInterval,
                                      maxInterval)
   }
@@ -93,7 +93,7 @@ class WildcardFragment : Fragment() {
     deviceController.readPath(reportCallback,
                               ChipClient.getConnectedDevicePointer(requireContext(),
                                                                    addressUpdateFragment.deviceId),
-                              attributePath)
+                              listOf(attributePath))
   }
 
   private fun showSubscribeDialog() {

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -22,6 +22,7 @@ import android.util.Log;
 import androidx.annotation.Nullable;
 import chip.devicecontroller.GetConnectedDeviceCallbackJni.GetConnectedDeviceCallback;
 import chip.devicecontroller.model.ChipAttributePath;
+import java.util.List;
 
 /** Controller to interact with the CHIP device. */
 public class ChipDeviceController {
@@ -311,12 +312,15 @@ public class ChipDeviceController {
     return getAttestationChallenge(deviceControllerPtr, devicePtr);
   }
 
-  /** Subscribe to the given attribute path. */
+  /**
+   * Subscribe to the given attribute path. The size of {@code attributePaths} should be less than
+   * or equal to 20 (kMaxAttributePaths), defined in the native code.
+   */
   public void subscribeToPath(
       SubscriptionEstablishedCallback subscriptionEstablishedCallback,
       ReportCallback reportCallback,
       long devicePtr,
-      ChipAttributePath attributePath,
+      List<ChipAttributePath> attributePaths,
       int minInterval,
       int maxInterval) {
     ReportCallbackJni jniCallback =
@@ -325,15 +329,19 @@ public class ChipDeviceController {
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
-        attributePath,
+        attributePaths,
         minInterval,
         maxInterval);
   }
 
-  /** Read the given attribute path. */
-  public void readPath(ReportCallback callback, long devicePtr, ChipAttributePath attributePath) {
+  /**
+   * Read the given attribute path. The size of {@code attributePaths} should be less than or equal
+   * to 20 (kMaxAttributePaths), defined in the native code.
+   */
+  public void readPath(
+      ReportCallback callback, long devicePtr, List<ChipAttributePath> attributePaths) {
     ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback);
-    readPath(deviceControllerPtr, jniCallback.getCallbackHandle(), devicePtr, attributePath);
+    readPath(deviceControllerPtr, jniCallback.getCallbackHandle(), devicePtr, attributePaths);
   }
 
   /**
@@ -356,7 +364,7 @@ public class ChipDeviceController {
       long deviceControllerPtr,
       long callbackHandle,
       long devicePtr,
-      ChipAttributePath attributePath,
+      List<ChipAttributePath> attributePaths,
       int minInterval,
       int maxInterval);
 
@@ -364,7 +372,7 @@ public class ChipDeviceController {
       long deviceControllerPtr,
       long callbackHandle,
       long devicePtr,
-      ChipAttributePath attributePath);
+      List<ChipAttributePath> attributePaths);
 
   private native long newDeviceController();
 

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -312,10 +312,7 @@ public class ChipDeviceController {
     return getAttestationChallenge(deviceControllerPtr, devicePtr);
   }
 
-  /**
-   * Subscribe to the given attribute path. The size of {@code attributePaths} should be less than
-   * or equal to 20 (kMaxAttributePaths), defined in the native code.
-   */
+  /** Subscribe to the given attribute path. */
   public void subscribeToPath(
       SubscriptionEstablishedCallback subscriptionEstablishedCallback,
       ReportCallback reportCallback,
@@ -334,10 +331,7 @@ public class ChipDeviceController {
         maxInterval);
   }
 
-  /**
-   * Read the given attribute path. The size of {@code attributePaths} should be less than or equal
-   * to 20 (kMaxAttributePaths), defined in the native code.
-   */
+  /** Read the given attribute path. */
   public void readPath(
       ReportCallback callback, long devicePtr, List<ChipAttributePath> attributePaths) {
     ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback);

--- a/src/controller/java/templates/partials/decode_value.zapt
+++ b/src/controller/java/templates/partials/decode_value.zapt
@@ -21,7 +21,7 @@ if ({{source}}.IsNull()) {
   {
     auto & entry_{{depth}} = iter_{{target}}_{{depth}}.GetValue();
     {{>decode_value target=(concat "newElement_" depth) source=(concat "entry_" depth) cluster=cluster depth=(incrementDepth depth) isArray=false forceNotList=true omitDeclaration=false earlyReturn=earlyReturn}}
-    chip::JniReferences::GetInstance().AddToArrayList({{target}}, newElement_{{depth}});
+    chip::JniReferences::GetInstance().AddToList({{target}}, newElement_{{depth}});
   }
 {{else}}
   {{#if_is_struct type}}

--- a/src/controller/java/templates/partials/encode_value.zapt
+++ b/src/controller/java/templates/partials/encode_value.zapt
@@ -17,14 +17,14 @@
     using ListType_{{depth}} = std::remove_reference_t<decltype({{target}})>;
     using ListMemberType_{{depth}} = ListMemberTypeGetter<ListType_{{depth}}>::Type;
     jint {{source}}Size;
-    chip::JniReferences::GetInstance().GetArrayListSize({{source}}, {{source}}Size);
+    chip::JniReferences::GetInstance().GetListSize({{source}}, {{source}}Size);
     if ({{source}}Size != 0) {
       auto * listHolder_{{depth}} = new ListHolder<ListMemberType_{{depth}}>({{source}}Size);
       listFreer.add(listHolder_{{depth}});
 
       for (size_t i_{{depth}} = 0; i_{{depth}} < static_cast<size_t>({{source}}Size); ++i_{{depth}}) {
         jobject element_{{depth}};
-        chip::JniReferences::GetInstance().GetArrayListItem({{source}}, i_{{depth}}, element_{{depth}});
+        chip::JniReferences::GetInstance().GetListItem({{source}}, i_{{depth}}, element_{{depth}});
         {{>encode_value target=(concat "listHolder_" depth "->mList[i_" depth "]") source=(concat "element_" depth) cluster=cluster depth=(incrementDepth depth) isArray=false}}
       }
       {{target}} = ListType_{{depth}}(listHolder_{{depth}}->mList, {{source}}Size);

--- a/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
+++ b/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
@@ -93,7 +93,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         std::string newElement_NaNCtorSignature = "(J)V";
                         chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(
                             newElement_NaNClassName.c_str(), newElement_NaNCtorSignature.c_str(), entry_NaN, newElement_NaN);
-                        chip::JniReferences::GetInstance().AddToArrayList(newElement_0_subjects, newElement_NaN);
+                        chip::JniReferences::GetInstance().AddToList(newElement_0_subjects, newElement_NaN);
                     }
                 }
                 jobject newElement_0_targets;
@@ -168,7 +168,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                         newElement_NaN = env->NewObject(targetStructClass, targetStructCtor, newElement_NaN_cluster,
                                                         newElement_NaN_endpoint, newElement_NaN_deviceType);
-                        chip::JniReferences::GetInstance().AddToArrayList(newElement_0_targets, newElement_NaN);
+                        chip::JniReferences::GetInstance().AddToList(newElement_0_targets, newElement_NaN);
                     }
                 }
 
@@ -192,7 +192,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 newElement_0 =
                     env->NewObject(accessControlEntryStructClass, accessControlEntryStructCtor, newElement_0_fabricIndex,
                                    newElement_0_privilege, newElement_0_authMode, newElement_0_subjects, newElement_0_targets);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -242,7 +242,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                 newElement_0 = env->NewObject(extensionEntryStructClass, extensionEntryStructCtor, newElement_0_fabricIndex,
                                               newElement_0_data);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -266,7 +266,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -290,7 +290,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -314,7 +314,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -363,7 +363,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -387,7 +387,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -411,7 +411,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -505,7 +505,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -529,7 +529,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -553,7 +553,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -723,7 +723,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(I)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), static_cast<uint16_t>(entry_0), newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -747,7 +747,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -771,7 +771,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -795,7 +795,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -844,7 +844,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(I)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -948,7 +948,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -972,7 +972,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -996,7 +996,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1074,7 +1074,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                 newElement_0 = env->NewObject(outputInfoStructClass, outputInfoStructCtor, newElement_0_index,
                                               newElement_0_outputType, newElement_0_name);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1113,7 +1113,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1137,7 +1137,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1161,7 +1161,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1270,7 +1270,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1294,7 +1294,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1318,7 +1318,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1616,7 +1616,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1640,7 +1640,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1664,7 +1664,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1758,7 +1758,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1782,7 +1782,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1806,7 +1806,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1855,7 +1855,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1879,7 +1879,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1903,7 +1903,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1967,7 +1967,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -1991,7 +1991,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -2015,7 +2015,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -2114,7 +2114,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 newElement_0 = env->NewObject(actionStructStructClass, actionStructStructCtor, newElement_0_actionID,
                                               newElement_0_name, newElement_0_type, newElement_0_endpointListID,
                                               newElement_0_supportedCommands, newElement_0_status);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -2160,7 +2160,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     std::string newElement_NaNCtorSignature = "(I)V";
                     chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
                         newElement_NaNClassName.c_str(), newElement_NaNCtorSignature.c_str(), entry_NaN, newElement_NaN);
-                    chip::JniReferences::GetInstance().AddToArrayList(newElement_0_endpoints, newElement_NaN);
+                    chip::JniReferences::GetInstance().AddToList(newElement_0_endpoints, newElement_NaN);
                 }
 
                 jclass endpointListStructStructClass;
@@ -2184,7 +2184,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 newElement_0 =
                     env->NewObject(endpointListStructStructClass, endpointListStructStructCtor, newElement_0_endpointListID,
                                    newElement_0_name, newElement_0_type, newElement_0_endpoints);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -2220,7 +2220,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -2244,7 +2244,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -2268,7 +2268,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -2497,7 +2497,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -2521,7 +2521,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -2545,7 +2545,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -2653,7 +2653,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 newElement_0 = env->NewObject(channelInfoStructClass, channelInfoStructCtor, newElement_0_majorNumber,
                                               newElement_0_minorNumber, newElement_0_name, newElement_0_callSign,
                                               newElement_0_affiliateCallSign);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -2827,7 +2827,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -2851,7 +2851,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -2875,7 +2875,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -3701,7 +3701,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -3725,7 +3725,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -3749,7 +3749,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -3795,7 +3795,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 auto & entry_0 = iter_value_0.GetValue();
                 jobject newElement_0;
                 newElement_0 = env->NewStringUTF(std::string(entry_0.data(), entry_0.size()).c_str());
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -3834,7 +3834,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -3858,7 +3858,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -3882,7 +3882,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -3957,7 +3957,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                 newElement_0 =
                     env->NewObject(deviceTypeStructClass, deviceTypeStructCtor, newElement_0_type, newElement_0_revision);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -3981,7 +3981,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -4005,7 +4005,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -4029,7 +4029,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(I)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -4053,7 +4053,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -4077,7 +4077,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -4101,7 +4101,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -4150,7 +4150,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -4174,7 +4174,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -4198,7 +4198,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -4558,7 +4558,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -4582,7 +4582,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -4606,7 +4606,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -4820,7 +4820,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -4844,7 +4844,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -4868,7 +4868,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5073,7 +5073,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5097,7 +5097,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5121,7 +5121,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5204,7 +5204,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                 newElement_0 =
                     env->NewObject(labelStructStructClass, labelStructStructCtor, newElement_0_label, newElement_0_value);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5228,7 +5228,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5252,7 +5252,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5276,7 +5276,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5385,7 +5385,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5409,7 +5409,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5433,7 +5433,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5564,7 +5564,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5588,7 +5588,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5612,7 +5612,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5712,7 +5712,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     env->SetByteArrayRegion(newElement_NaNByteArray, 0, static_cast<jsize>(entry_NaN.size()),
                                             reinterpret_cast<const jbyte *>(entry_NaN.data()));
                     newElement_NaN = newElement_NaNByteArray;
-                    chip::JniReferences::GetInstance().AddToArrayList(newElement_0_IPv4Addresses, newElement_NaN);
+                    chip::JniReferences::GetInstance().AddToList(newElement_0_IPv4Addresses, newElement_NaN);
                 }
                 jobject newElement_0_IPv6Addresses;
                 chip::JniReferences::GetInstance().CreateArrayList(newElement_0_IPv6Addresses);
@@ -5726,7 +5726,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     env->SetByteArrayRegion(newElement_NaNByteArray, 0, static_cast<jsize>(entry_NaN.size()),
                                             reinterpret_cast<const jbyte *>(entry_NaN.data()));
                     newElement_NaN = newElement_NaNByteArray;
-                    chip::JniReferences::GetInstance().AddToArrayList(newElement_0_IPv6Addresses, newElement_NaN);
+                    chip::JniReferences::GetInstance().AddToList(newElement_0_IPv6Addresses, newElement_NaN);
                 }
                 jobject newElement_0_type;
                 std::string newElement_0_typeClassName     = "java/lang/Integer";
@@ -5758,7 +5758,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                               newElement_0_isOperational, newElement_0_offPremiseServicesReachableIPv4,
                                               newElement_0_offPremiseServicesReachableIPv6, newElement_0_hardwareAddress,
                                               newElement_0_IPv4Addresses, newElement_0_IPv6Addresses, newElement_0_type);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5842,7 +5842,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(I)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5866,7 +5866,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(I)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5890,7 +5890,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(I)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5914,7 +5914,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5938,7 +5938,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -5962,7 +5962,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6045,7 +6045,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                 newElement_0 = env->NewObject(groupKeyMapStructStructClass, groupKeyMapStructStructCtor, newElement_0_fabricIndex,
                                               newElement_0_groupId, newElement_0_groupKeySetID);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6089,7 +6089,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     std::string newElement_NaNCtorSignature = "(I)V";
                     chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
                         newElement_NaNClassName.c_str(), newElement_NaNCtorSignature.c_str(), entry_NaN, newElement_NaN);
-                    chip::JniReferences::GetInstance().AddToArrayList(newElement_0_endpoints, newElement_NaN);
+                    chip::JniReferences::GetInstance().AddToList(newElement_0_endpoints, newElement_NaN);
                 }
                 jobject newElement_0_groupName;
                 if (!entry_0.groupName.HasValue())
@@ -6122,7 +6122,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                 newElement_0 = env->NewObject(groupInfoMapStructStructClass, groupInfoMapStructStructCtor, newElement_0_fabricIndex,
                                               newElement_0_groupId, newElement_0_endpoints, newElement_0_groupName);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6176,7 +6176,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6200,7 +6200,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6224,7 +6224,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6288,7 +6288,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6312,7 +6312,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6336,7 +6336,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6415,7 +6415,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6439,7 +6439,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6463,7 +6463,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6615,7 +6615,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6639,7 +6639,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6663,7 +6663,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6712,7 +6712,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6736,7 +6736,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -6760,7 +6760,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7054,7 +7054,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7078,7 +7078,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7102,7 +7102,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7175,7 +7175,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 auto & entry_0 = iter_value_0.GetValue();
                 jobject newElement_0;
                 newElement_0 = env->NewStringUTF(std::string(entry_0.data(), entry_0.size()).c_str());
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7199,7 +7199,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7223,7 +7223,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7272,7 +7272,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7296,7 +7296,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7320,7 +7320,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7402,7 +7402,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                 newElement_0 = env->NewObject(inputInfoStructClass, inputInfoStructCtor, newElement_0_index, newElement_0_inputType,
                                               newElement_0_name, newElement_0_description);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7441,7 +7441,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7465,7 +7465,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7489,7 +7489,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7711,7 +7711,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7735,7 +7735,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7759,7 +7759,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7851,7 +7851,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                 newElement_0 = env->NewObject(modeOptionStructStructClass, modeOptionStructStructCtor, newElement_0_label,
                                               newElement_0_mode, newElement_0_semanticTag);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7917,7 +7917,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7941,7 +7941,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -7965,7 +7965,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -8054,7 +8054,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                 newElement_0 =
                     env->NewObject(networkInfoStructClass, networkInfoStructCtor, newElement_0_networkID, newElement_0_connected);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -8189,7 +8189,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -8213,7 +8213,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -8277,7 +8277,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -8360,7 +8360,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                 newElement_0 = env->NewObject(providerLocationStructClass, providerLocationStructCtor, newElement_0_fabricIndex,
                                               newElement_0_providerNodeID, newElement_0_endpoint);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -8436,7 +8436,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -8530,7 +8530,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -8554,7 +8554,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -8578,7 +8578,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -8702,7 +8702,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -8726,7 +8726,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -8750,7 +8750,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -8844,7 +8844,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -8868,7 +8868,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -8892,7 +8892,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -8978,7 +8978,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                 newElement_0 = env->NewObject(NOCStructStructClass, NOCStructStructCtor, newElement_0_fabricIndex, newElement_0_noc,
                                               newElement_0_icac);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -9052,7 +9052,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 newElement_0 = env->NewObject(fabricDescriptorStructClass, fabricDescriptorStructCtor, newElement_0_fabricIndex,
                                               newElement_0_rootPublicKey, newElement_0_vendorId, newElement_0_fabricId,
                                               newElement_0_nodeId, newElement_0_label);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -9106,7 +9106,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 env->SetByteArrayRegion(newElement_0ByteArray, 0, static_cast<jsize>(entry_0.size()),
                                         reinterpret_cast<const jbyte *>(entry_0.data()));
                 newElement_0 = newElement_0ByteArray;
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -9145,7 +9145,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -9169,7 +9169,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -9193,7 +9193,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -9344,7 +9344,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(I)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -9383,7 +9383,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -9407,7 +9407,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -9431,7 +9431,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -9495,7 +9495,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(I)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -9519,7 +9519,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -9543,7 +9543,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -9567,7 +9567,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -9661,7 +9661,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10084,7 +10084,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10108,7 +10108,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10132,7 +10132,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10256,7 +10256,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10280,7 +10280,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10304,7 +10304,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10428,7 +10428,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10452,7 +10452,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10476,7 +10476,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10566,7 +10566,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                 newElement_0 = env->NewObject(threadMetricsStructClass, threadMetricsStructCtor, newElement_0_id, newElement_0_name,
                                               newElement_0_stackFreeCurrent, newElement_0_stackFreeMinimum, newElement_0_stackSize);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10635,7 +10635,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10659,7 +10659,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10683,7 +10683,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10792,7 +10792,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10816,7 +10816,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10840,7 +10840,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10927,7 +10927,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                 newElement_0 =
                     env->NewObject(targetInfoStructClass, targetInfoStructCtor, newElement_0_identifier, newElement_0_name);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10966,7 +10966,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -10990,7 +10990,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -11014,7 +11014,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -11123,7 +11123,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -11562,7 +11562,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(I)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -11586,7 +11586,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 env->SetByteArrayRegion(newElement_0ByteArray, 0, static_cast<jsize>(entry_0.size()),
                                         reinterpret_cast<const jbyte *>(entry_0.data()));
                 newElement_0 = newElement_0ByteArray;
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -11638,7 +11638,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                 newElement_0 = env->NewObject(testListStructOctetStructClass, testListStructOctetStructCtor,
                                               newElement_0_fabricIndex, newElement_0_operationalCert);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -12099,7 +12099,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
                             newElement_NaNClassName.c_str(), newElement_NaNCtorSignature.c_str(), static_cast<uint8_t>(entry_NaN),
                             newElement_NaN);
-                        chip::JniReferences::GetInstance().AddToArrayList(newElement_0_nullableList, newElement_NaN);
+                        chip::JniReferences::GetInstance().AddToList(newElement_0_nullableList, newElement_NaN);
                     }
                 }
                 jobject newElement_0_optionalList;
@@ -12121,7 +12121,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
                             newElement_NaNClassName.c_str(), newElement_NaNCtorSignature.c_str(), static_cast<uint8_t>(entry_NaN),
                             newElement_NaN);
-                        chip::JniReferences::GetInstance().AddToArrayList(newElement_0_optionalList, newElement_NaN);
+                        chip::JniReferences::GetInstance().AddToList(newElement_0_optionalList, newElement_NaN);
                     }
                 }
                 jobject newElement_0_nullableOptionalList;
@@ -12149,7 +12149,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
                                 newElement_NaNClassName.c_str(), newElement_NaNCtorSignature.c_str(),
                                 static_cast<uint8_t>(entry_NaN), newElement_NaN);
-                            chip::JniReferences::GetInstance().AddToArrayList(newElement_0_nullableOptionalList, newElement_NaN);
+                            chip::JniReferences::GetInstance().AddToList(newElement_0_nullableOptionalList, newElement_NaN);
                         }
                     }
                 }
@@ -12180,7 +12180,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                    newElement_0_nullableString, newElement_0_optionalString, newElement_0_nullableOptionalString,
                                    newElement_0_nullableStruct, newElement_0_optionalStruct, newElement_0_nullableOptionalStruct,
                                    newElement_0_nullableList, newElement_0_optionalList, newElement_0_nullableOptionalList);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -12348,7 +12348,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 env->SetByteArrayRegion(newElement_0ByteArray, 0, static_cast<jsize>(entry_0.size()),
                                         reinterpret_cast<const jbyte *>(entry_0.data()));
                 newElement_0 = newElement_0ByteArray;
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -13209,7 +13209,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -13233,7 +13233,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -13257,7 +13257,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -13561,7 +13561,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -13670,7 +13670,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -13694,7 +13694,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -13718,7 +13718,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -13973,7 +13973,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     newElement_0_rloc16, newElement_0_linkFrameCounter, newElement_0_mleFrameCounter, newElement_0_lqi,
                     newElement_0_averageRssi, newElement_0_lastRssi, newElement_0_frameErrorRate, newElement_0_messageErrorRate,
                     newElement_0_rxOnWhenIdle, newElement_0_fullThreadDevice, newElement_0_fullNetworkData, newElement_0_isChild);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -14075,7 +14075,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     env->NewObject(routeTableStructClass, routeTableStructCtor, newElement_0_extAddress, newElement_0_rloc16,
                                    newElement_0_routerId, newElement_0_nextHop, newElement_0_pathCost, newElement_0_LQIIn,
                                    newElement_0_LQIOut, newElement_0_age, newElement_0_allocated, newElement_0_linkEstablished);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -14877,7 +14877,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                 newElement_0 = env->NewObject(securityPolicyStructClass, securityPolicyStructCtor, newElement_0_rotationTime,
                                               newElement_0_flags);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15014,7 +15014,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     newElement_0_networkNamePresent, newElement_0_extendedPanIdPresent, newElement_0_meshLocalPrefixPresent,
                     newElement_0_delayPresent, newElement_0_panIdPresent, newElement_0_channelPresent, newElement_0_pskcPresent,
                     newElement_0_securityPolicyPresent, newElement_0_channelMaskPresent);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15038,7 +15038,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(I)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), static_cast<uint8_t>(entry_0), newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15062,7 +15062,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15086,7 +15086,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15110,7 +15110,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15204,7 +15204,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(I)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), static_cast<uint8_t>(entry_0), newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15228,7 +15228,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15252,7 +15252,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15316,7 +15316,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15399,7 +15399,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
 
                 newElement_0 =
                     env->NewObject(labelStructStructClass, labelStructStructCtor, newElement_0_label, newElement_0_value);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15423,7 +15423,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15447,7 +15447,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15508,7 +15508,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15532,7 +15532,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15556,7 +15556,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15835,7 +15835,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15859,7 +15859,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -15883,7 +15883,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -16273,7 +16273,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -16297,7 +16297,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }
@@ -16321,7 +16321,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 std::string newElement_0CtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
                     newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-                chip::JniReferences::GetInstance().AddToArrayList(value, newElement_0);
+                chip::JniReferences::GetInstance().AddToList(value, newElement_0);
             }
             return value;
         }

--- a/src/controller/java/zap-generated/CHIPClustersWrite-JNI.cpp
+++ b/src/controller/java/zap-generated/CHIPClustersWrite-JNI.cpp
@@ -57,7 +57,7 @@ JNI_METHOD(void, AccessControlCluster, writeAclAttribute)
         using ListType_0       = std::remove_reference_t<decltype(cppValue)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         jint valueSize;
-        chip::JniReferences::GetInstance().GetArrayListSize(value, valueSize);
+        chip::JniReferences::GetInstance().GetListSize(value, valueSize);
         if (valueSize != 0)
         {
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
@@ -66,7 +66,7 @@ JNI_METHOD(void, AccessControlCluster, writeAclAttribute)
             for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
             {
                 jobject element_0;
-                chip::JniReferences::GetInstance().GetArrayListItem(value, i_0, element_0);
+                chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
                 jobject element_0_fabricIndexItem_1;
                 chip::JniReferences::GetInstance().GetObjectField(element_0, "fabricIndex", "Ljava/lang/Integer;",
                                                                   element_0_fabricIndexItem_1);
@@ -99,7 +99,7 @@ JNI_METHOD(void, AccessControlCluster, writeAclAttribute)
                         using ListType_3       = std::remove_reference_t<decltype(nonNullValue_2)>;
                         using ListMemberType_3 = ListMemberTypeGetter<ListType_3>::Type;
                         jint element_0_subjectsItem_1Size;
-                        chip::JniReferences::GetInstance().GetArrayListSize(element_0_subjectsItem_1, element_0_subjectsItem_1Size);
+                        chip::JniReferences::GetInstance().GetListSize(element_0_subjectsItem_1, element_0_subjectsItem_1Size);
                         if (element_0_subjectsItem_1Size != 0)
                         {
                             auto * listHolder_3 = new ListHolder<ListMemberType_3>(element_0_subjectsItem_1Size);
@@ -108,7 +108,7 @@ JNI_METHOD(void, AccessControlCluster, writeAclAttribute)
                             for (size_t i_3 = 0; i_3 < static_cast<size_t>(element_0_subjectsItem_1Size); ++i_3)
                             {
                                 jobject element_3;
-                                chip::JniReferences::GetInstance().GetArrayListItem(element_0_subjectsItem_1, i_3, element_3);
+                                chip::JniReferences::GetInstance().GetListItem(element_0_subjectsItem_1, i_3, element_3);
                                 listHolder_3->mList[i_3] = static_cast<std::remove_reference_t<decltype(listHolder_3->mList[i_3])>>(
                                     chip::JniReferences::GetInstance().LongToPrimitive(element_3));
                             }
@@ -134,7 +134,7 @@ JNI_METHOD(void, AccessControlCluster, writeAclAttribute)
                         using ListType_3       = std::remove_reference_t<decltype(nonNullValue_2)>;
                         using ListMemberType_3 = ListMemberTypeGetter<ListType_3>::Type;
                         jint element_0_targetsItem_1Size;
-                        chip::JniReferences::GetInstance().GetArrayListSize(element_0_targetsItem_1, element_0_targetsItem_1Size);
+                        chip::JniReferences::GetInstance().GetListSize(element_0_targetsItem_1, element_0_targetsItem_1Size);
                         if (element_0_targetsItem_1Size != 0)
                         {
                             auto * listHolder_3 = new ListHolder<ListMemberType_3>(element_0_targetsItem_1Size);
@@ -143,7 +143,7 @@ JNI_METHOD(void, AccessControlCluster, writeAclAttribute)
                             for (size_t i_3 = 0; i_3 < static_cast<size_t>(element_0_targetsItem_1Size); ++i_3)
                             {
                                 jobject element_3;
-                                chip::JniReferences::GetInstance().GetArrayListItem(element_0_targetsItem_1, i_3, element_3);
+                                chip::JniReferences::GetInstance().GetListItem(element_0_targetsItem_1, i_3, element_3);
                                 jobject element_3_clusterItem_4;
                                 chip::JniReferences::GetInstance().GetObjectField(element_3, "cluster", "Ljava/lang/Long;",
                                                                                   element_3_clusterItem_4);
@@ -254,7 +254,7 @@ JNI_METHOD(void, AccessControlCluster, writeExtensionAttribute)
         using ListType_0       = std::remove_reference_t<decltype(cppValue)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         jint valueSize;
-        chip::JniReferences::GetInstance().GetArrayListSize(value, valueSize);
+        chip::JniReferences::GetInstance().GetListSize(value, valueSize);
         if (valueSize != 0)
         {
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
@@ -263,7 +263,7 @@ JNI_METHOD(void, AccessControlCluster, writeExtensionAttribute)
             for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
             {
                 jobject element_0;
-                chip::JniReferences::GetInstance().GetArrayListItem(value, i_0, element_0);
+                chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
                 jobject element_0_fabricIndexItem_1;
                 chip::JniReferences::GetInstance().GetObjectField(element_0, "fabricIndex", "Ljava/lang/Integer;",
                                                                   element_0_fabricIndexItem_1);
@@ -1790,7 +1790,7 @@ JNI_METHOD(void, GroupKeyManagementCluster, writeGroupKeyMapAttribute)
         using ListType_0       = std::remove_reference_t<decltype(cppValue)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         jint valueSize;
-        chip::JniReferences::GetInstance().GetArrayListSize(value, valueSize);
+        chip::JniReferences::GetInstance().GetListSize(value, valueSize);
         if (valueSize != 0)
         {
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
@@ -1799,7 +1799,7 @@ JNI_METHOD(void, GroupKeyManagementCluster, writeGroupKeyMapAttribute)
             for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
             {
                 jobject element_0;
-                chip::JniReferences::GetInstance().GetArrayListItem(value, i_0, element_0);
+                chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
                 jobject element_0_fabricIndexItem_1;
                 chip::JniReferences::GetInstance().GetObjectField(element_0, "fabricIndex", "Ljava/lang/Integer;",
                                                                   element_0_fabricIndexItem_1);
@@ -2491,7 +2491,7 @@ JNI_METHOD(void, OtaSoftwareUpdateRequestorCluster, writeDefaultOtaProvidersAttr
         using ListType_0       = std::remove_reference_t<decltype(cppValue)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         jint valueSize;
-        chip::JniReferences::GetInstance().GetArrayListSize(value, valueSize);
+        chip::JniReferences::GetInstance().GetListSize(value, valueSize);
         if (valueSize != 0)
         {
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
@@ -2500,7 +2500,7 @@ JNI_METHOD(void, OtaSoftwareUpdateRequestorCluster, writeDefaultOtaProvidersAttr
             for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
             {
                 jobject element_0;
-                chip::JniReferences::GetInstance().GetArrayListItem(value, i_0, element_0);
+                chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
                 jobject element_0_fabricIndexItem_1;
                 chip::JniReferences::GetInstance().GetObjectField(element_0, "fabricIndex", "Ljava/lang/Integer;",
                                                                   element_0_fabricIndexItem_1);
@@ -4350,7 +4350,7 @@ JNI_METHOD(void, TestClusterCluster, writeListInt8uAttribute)
         using ListType_0       = std::remove_reference_t<decltype(cppValue)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         jint valueSize;
-        chip::JniReferences::GetInstance().GetArrayListSize(value, valueSize);
+        chip::JniReferences::GetInstance().GetListSize(value, valueSize);
         if (valueSize != 0)
         {
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
@@ -4359,7 +4359,7 @@ JNI_METHOD(void, TestClusterCluster, writeListInt8uAttribute)
             for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
             {
                 jobject element_0;
-                chip::JniReferences::GetInstance().GetArrayListItem(value, i_0, element_0);
+                chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
                 listHolder_0->mList[i_0] = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0])>>(
                     chip::JniReferences::GetInstance().IntegerToPrimitive(element_0));
             }
@@ -4424,7 +4424,7 @@ JNI_METHOD(void, TestClusterCluster, writeListOctetStringAttribute)
         using ListType_0       = std::remove_reference_t<decltype(cppValue)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         jint valueSize;
-        chip::JniReferences::GetInstance().GetArrayListSize(value, valueSize);
+        chip::JniReferences::GetInstance().GetListSize(value, valueSize);
         if (valueSize != 0)
         {
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
@@ -4433,7 +4433,7 @@ JNI_METHOD(void, TestClusterCluster, writeListOctetStringAttribute)
             for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
             {
                 jobject element_0;
-                chip::JniReferences::GetInstance().GetArrayListItem(value, i_0, element_0);
+                chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
                 cleanupByteArrays.push_back(
                     chip::Platform::MakeUnique<chip::JniByteArray>(env, static_cast<jbyteArray>(element_0)));
                 listHolder_0->mList[i_0] = cleanupByteArrays.back()->byteSpan();
@@ -4499,7 +4499,7 @@ JNI_METHOD(void, TestClusterCluster, writeListStructOctetStringAttribute)
         using ListType_0       = std::remove_reference_t<decltype(cppValue)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         jint valueSize;
-        chip::JniReferences::GetInstance().GetArrayListSize(value, valueSize);
+        chip::JniReferences::GetInstance().GetListSize(value, valueSize);
         if (valueSize != 0)
         {
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
@@ -4508,7 +4508,7 @@ JNI_METHOD(void, TestClusterCluster, writeListStructOctetStringAttribute)
             for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
             {
                 jobject element_0;
-                chip::JniReferences::GetInstance().GetArrayListItem(value, i_0, element_0);
+                chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
                 jobject element_0_fabricIndexItem_1;
                 chip::JniReferences::GetInstance().GetObjectField(element_0, "fabricIndex", "Ljava/lang/Long;",
                                                                   element_0_fabricIndexItem_1);
@@ -4893,7 +4893,7 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
         using ListType_0       = std::remove_reference_t<decltype(cppValue)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         jint valueSize;
-        chip::JniReferences::GetInstance().GetArrayListSize(value, valueSize);
+        chip::JniReferences::GetInstance().GetListSize(value, valueSize);
         if (valueSize != 0)
         {
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
@@ -4902,7 +4902,7 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
             for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
             {
                 jobject element_0;
-                chip::JniReferences::GetInstance().GetArrayListItem(value, i_0, element_0);
+                chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
                 jobject element_0_nullableIntItem_1;
                 chip::JniReferences::GetInstance().GetObjectField(element_0, "nullableInt", "Ljava/lang/Integer;",
                                                                   element_0_nullableIntItem_1);
@@ -5168,8 +5168,8 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                         using ListType_3       = std::remove_reference_t<decltype(nonNullValue_2)>;
                         using ListMemberType_3 = ListMemberTypeGetter<ListType_3>::Type;
                         jint element_0_nullableListItem_1Size;
-                        chip::JniReferences::GetInstance().GetArrayListSize(element_0_nullableListItem_1,
-                                                                            element_0_nullableListItem_1Size);
+                        chip::JniReferences::GetInstance().GetListSize(element_0_nullableListItem_1,
+                                                                       element_0_nullableListItem_1Size);
                         if (element_0_nullableListItem_1Size != 0)
                         {
                             auto * listHolder_3 = new ListHolder<ListMemberType_3>(element_0_nullableListItem_1Size);
@@ -5178,7 +5178,7 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                             for (size_t i_3 = 0; i_3 < static_cast<size_t>(element_0_nullableListItem_1Size); ++i_3)
                             {
                                 jobject element_3;
-                                chip::JniReferences::GetInstance().GetArrayListItem(element_0_nullableListItem_1, i_3, element_3);
+                                chip::JniReferences::GetInstance().GetListItem(element_0_nullableListItem_1, i_3, element_3);
                                 listHolder_3->mList[i_3] = static_cast<std::remove_reference_t<decltype(listHolder_3->mList[i_3])>>(
                                     chip::JniReferences::GetInstance().IntegerToPrimitive(element_3));
                             }
@@ -5202,7 +5202,7 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                         using ListType_3       = std::remove_reference_t<decltype(definedValue_2)>;
                         using ListMemberType_3 = ListMemberTypeGetter<ListType_3>::Type;
                         jint optionalValue_2Size;
-                        chip::JniReferences::GetInstance().GetArrayListSize(optionalValue_2, optionalValue_2Size);
+                        chip::JniReferences::GetInstance().GetListSize(optionalValue_2, optionalValue_2Size);
                         if (optionalValue_2Size != 0)
                         {
                             auto * listHolder_3 = new ListHolder<ListMemberType_3>(optionalValue_2Size);
@@ -5211,7 +5211,7 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                             for (size_t i_3 = 0; i_3 < static_cast<size_t>(optionalValue_2Size); ++i_3)
                             {
                                 jobject element_3;
-                                chip::JniReferences::GetInstance().GetArrayListItem(optionalValue_2, i_3, element_3);
+                                chip::JniReferences::GetInstance().GetListItem(optionalValue_2, i_3, element_3);
                                 listHolder_3->mList[i_3] = static_cast<std::remove_reference_t<decltype(listHolder_3->mList[i_3])>>(
                                     chip::JniReferences::GetInstance().IntegerToPrimitive(element_3));
                             }
@@ -5242,7 +5242,7 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                             using ListType_4       = std::remove_reference_t<decltype(nonNullValue_3)>;
                             using ListMemberType_4 = ListMemberTypeGetter<ListType_4>::Type;
                             jint optionalValue_2Size;
-                            chip::JniReferences::GetInstance().GetArrayListSize(optionalValue_2, optionalValue_2Size);
+                            chip::JniReferences::GetInstance().GetListSize(optionalValue_2, optionalValue_2Size);
                             if (optionalValue_2Size != 0)
                             {
                                 auto * listHolder_4 = new ListHolder<ListMemberType_4>(optionalValue_2Size);
@@ -5251,7 +5251,7 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                                 for (size_t i_4 = 0; i_4 < static_cast<size_t>(optionalValue_2Size); ++i_4)
                                 {
                                     jobject element_4;
-                                    chip::JniReferences::GetInstance().GetArrayListItem(optionalValue_2, i_4, element_4);
+                                    chip::JniReferences::GetInstance().GetListItem(optionalValue_2, i_4, element_4);
                                     listHolder_4->mList[i_4] =
                                         static_cast<std::remove_reference_t<decltype(listHolder_4->mList[i_4])>>(
                                             chip::JniReferences::GetInstance().IntegerToPrimitive(element_4));
@@ -5587,7 +5587,7 @@ JNI_METHOD(void, TestClusterCluster, writeListLongOctetStringAttribute)
         using ListType_0       = std::remove_reference_t<decltype(cppValue)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         jint valueSize;
-        chip::JniReferences::GetInstance().GetArrayListSize(value, valueSize);
+        chip::JniReferences::GetInstance().GetListSize(value, valueSize);
         if (valueSize != 0)
         {
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
@@ -5596,7 +5596,7 @@ JNI_METHOD(void, TestClusterCluster, writeListLongOctetStringAttribute)
             for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
             {
                 jobject element_0;
-                chip::JniReferences::GetInstance().GetArrayListItem(value, i_0, element_0);
+                chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
                 cleanupByteArrays.push_back(
                     chip::Platform::MakeUnique<chip::JniByteArray>(env, static_cast<jbyteArray>(element_0)));
                 listHolder_0->mList[i_0] = cleanupByteArrays.back()->byteSpan();
@@ -8566,7 +8566,7 @@ JNI_METHOD(void, UserLabelCluster, writeLabelListAttribute)
         using ListType_0       = std::remove_reference_t<decltype(cppValue)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         jint valueSize;
-        chip::JniReferences::GetInstance().GetArrayListSize(value, valueSize);
+        chip::JniReferences::GetInstance().GetListSize(value, valueSize);
         if (valueSize != 0)
         {
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
@@ -8575,7 +8575,7 @@ JNI_METHOD(void, UserLabelCluster, writeLabelListAttribute)
             for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
             {
                 jobject element_0;
-                chip::JniReferences::GetInstance().GetArrayListItem(value, i_0, element_0);
+                chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
                 jobject element_0_labelItem_1;
                 chip::JniReferences::GetInstance().GetObjectField(element_0, "label", "Ljava/lang/String;", element_0_labelItem_1);
                 cleanupStrings.push_back(

--- a/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
@@ -676,7 +676,7 @@ void CHIPDoorLockClusterGetUserResponseCallback::CallbackFn(
 
             newElement_1 = env->NewObject(dlCredentialStructClass, dlCredentialStructCtor, newElement_1_credentialType,
                                           newElement_1_credentialIndex);
-            chip::JniReferences::GetInstance().AddToArrayList(credentials, newElement_1);
+            chip::JniReferences::GetInstance().AddToList(credentials, newElement_1);
         }
     }
     jobject creatorFabricIndex;
@@ -1301,7 +1301,7 @@ void CHIPGroupKeyManagementClusterKeySetReadAllIndicesResponseCallback::Callback
         std::string newElement_0CtorSignature = "(I)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(GroupKeySetIDs, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(GroupKeySetIDs, newElement_0);
     }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, GroupKeySetIDs);
@@ -1615,7 +1615,7 @@ void CHIPGroupsClusterGetGroupMembershipResponseCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(I)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(groupList, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(groupList, newElement_0);
     }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, capacity, groupList);
@@ -2196,7 +2196,7 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallback::CallbackFn(
             newElement_1 = env->NewObject(wiFiInterfaceScanResultStructClass, wiFiInterfaceScanResultStructCtor,
                                           newElement_1_security, newElement_1_ssid, newElement_1_bssid, newElement_1_channel,
                                           newElement_1_wiFiBand, newElement_1_rssi);
-            chip::JniReferences::GetInstance().AddToArrayList(WiFiScanResults, newElement_1);
+            chip::JniReferences::GetInstance().AddToList(WiFiScanResults, newElement_1);
         }
     }
     jobject ThreadScanResults;
@@ -2279,7 +2279,7 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallback::CallbackFn(
                 env->NewObject(threadInterfaceScanResultStructClass, threadInterfaceScanResultStructCtor, newElement_1_panId,
                                newElement_1_extendedPanId, newElement_1_networkName, newElement_1_channel, newElement_1_version,
                                newElement_1_extendedAddress, newElement_1_rssi, newElement_1_lqi);
-            chip::JniReferences::GetInstance().AddToArrayList(ThreadScanResults, newElement_1);
+            chip::JniReferences::GetInstance().AddToList(ThreadScanResults, newElement_1);
         }
     }
 
@@ -2940,7 +2940,7 @@ void CHIPScenesClusterGetSceneMembershipResponseCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(I)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(newElement_0ClassName.c_str(),
                                                                       newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(sceneList, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(sceneList, newElement_0);
     }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, status, capacity, groupId, sceneCount, sceneList);
@@ -3269,7 +3269,7 @@ void CHIPScenesClusterViewSceneResponseCallback::CallbackFn(
 
         newElement_0 = env->NewObject(sceneExtensionFieldSetStructClass, sceneExtensionFieldSetStructCtor, newElement_0_clusterId,
                                       newElement_0_length, newElement_0_value);
-        chip::JniReferences::GetInstance().AddToArrayList(extensionFieldSets, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(extensionFieldSets, newElement_0);
     }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, status, groupId, sceneId, transitionTime, sceneName, extensionFieldSets);
@@ -3770,7 +3770,7 @@ void CHIPTestClusterClusterTestListInt8UReverseResponseCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(I)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(newElement_0ClassName.c_str(),
                                                                       newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arg1, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arg1, newElement_0);
     }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, arg1);
@@ -4118,7 +4118,7 @@ void CHIPThermostatClusterGetWeeklyScheduleResponseCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(I)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(newElement_0ClassName.c_str(),
                                                                       newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(payload, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(payload, newElement_0);
     }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, numberOfTransitionsForSequence, dayOfWeekForSequence, modeForSequence,

--- a/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
@@ -768,7 +768,7 @@ void CHIPAccessControlAclAttributeCallback::CallbackFn(
                 std::string newElement_NaNCtorSignature = "(J)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(
                     newElement_NaNClassName.c_str(), newElement_NaNCtorSignature.c_str(), entry_NaN, newElement_NaN);
-                chip::JniReferences::GetInstance().AddToArrayList(newElement_0_subjects, newElement_NaN);
+                chip::JniReferences::GetInstance().AddToList(newElement_0_subjects, newElement_NaN);
             }
         }
         jobject newElement_0_targets;
@@ -843,7 +843,7 @@ void CHIPAccessControlAclAttributeCallback::CallbackFn(
 
                 newElement_NaN = env->NewObject(targetStructClass, targetStructCtor, newElement_NaN_cluster,
                                                 newElement_NaN_endpoint, newElement_NaN_deviceType);
-                chip::JniReferences::GetInstance().AddToArrayList(newElement_0_targets, newElement_NaN);
+                chip::JniReferences::GetInstance().AddToList(newElement_0_targets, newElement_NaN);
             }
         }
 
@@ -866,7 +866,7 @@ void CHIPAccessControlAclAttributeCallback::CallbackFn(
 
         newElement_0 = env->NewObject(accessControlEntryStructClass, accessControlEntryStructCtor, newElement_0_fabricIndex,
                                       newElement_0_privilege, newElement_0_authMode, newElement_0_subjects, newElement_0_targets);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -961,7 +961,7 @@ void CHIPAccessControlExtensionAttributeCallback::CallbackFn(
 
         newElement_0 =
             env->NewObject(extensionEntryStructClass, extensionEntryStructCtor, newElement_0_fabricIndex, newElement_0_data);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -1032,7 +1032,7 @@ void CHIPAccessControlServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -1103,7 +1103,7 @@ void CHIPAccessControlClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -1174,7 +1174,7 @@ void CHIPAccessControlAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -1245,7 +1245,7 @@ void CHIPAccountLoginServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -1316,7 +1316,7 @@ void CHIPAccountLoginClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -1387,7 +1387,7 @@ void CHIPAccountLoginAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -1519,7 +1519,7 @@ void CHIPAdministratorCommissioningServerGeneratedCommandListAttributeCallback::
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -1592,7 +1592,7 @@ void CHIPAdministratorCommissioningClientGeneratedCommandListAttributeCallback::
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -1663,7 +1663,7 @@ void CHIPAdministratorCommissioningAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -1734,7 +1734,7 @@ void CHIPApplicationBasicAllowedVendorListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(I)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
             newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), static_cast<uint16_t>(entry_0), newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -1805,7 +1805,7 @@ void CHIPApplicationBasicServerGeneratedCommandListAttributeCallback::CallbackFn
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -1876,7 +1876,7 @@ void CHIPApplicationBasicClientGeneratedCommandListAttributeCallback::CallbackFn
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -1947,7 +1947,7 @@ void CHIPApplicationBasicAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -2018,7 +2018,7 @@ void CHIPApplicationLauncherCatalogListAttributeCallback::CallbackFn(void * cont
         std::string newElement_0CtorSignature = "(I)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -2090,7 +2090,7 @@ void CHIPApplicationLauncherServerGeneratedCommandListAttributeCallback::Callbac
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -2162,7 +2162,7 @@ void CHIPApplicationLauncherClientGeneratedCommandListAttributeCallback::Callbac
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -2233,7 +2233,7 @@ void CHIPApplicationLauncherAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -2331,7 +2331,7 @@ void CHIPAudioOutputOutputListAttributeCallback::CallbackFn(
 
         newElement_0 = env->NewObject(outputInfoStructClass, outputInfoStructCtor, newElement_0_index, newElement_0_outputType,
                                       newElement_0_name);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -2402,7 +2402,7 @@ void CHIPAudioOutputServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -2473,7 +2473,7 @@ void CHIPAudioOutputClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -2542,7 +2542,7 @@ void CHIPAudioOutputAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -2613,7 +2613,7 @@ void CHIPBarrierControlServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -2684,7 +2684,7 @@ void CHIPBarrierControlClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -2755,7 +2755,7 @@ void CHIPBarrierControlAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -2883,7 +2883,7 @@ void CHIPBasicServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -2954,7 +2954,7 @@ void CHIPBasicClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -3023,7 +3023,7 @@ void CHIPBasicAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -3094,7 +3094,7 @@ void CHIPBinaryInputBasicServerGeneratedCommandListAttributeCallback::CallbackFn
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -3165,7 +3165,7 @@ void CHIPBinaryInputBasicClientGeneratedCommandListAttributeCallback::CallbackFn
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -3236,7 +3236,7 @@ void CHIPBinaryInputBasicAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -3307,7 +3307,7 @@ void CHIPBindingServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -3378,7 +3378,7 @@ void CHIPBindingClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -3447,7 +3447,7 @@ void CHIPBindingAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -3518,7 +3518,7 @@ void CHIPBooleanStateServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -3589,7 +3589,7 @@ void CHIPBooleanStateClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -3660,7 +3660,7 @@ void CHIPBooleanStateAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -3779,7 +3779,7 @@ void CHIPBridgedActionsActionListAttributeCallback::CallbackFn(
         newElement_0 =
             env->NewObject(actionStructStructClass, actionStructStructCtor, newElement_0_actionID, newElement_0_name,
                            newElement_0_type, newElement_0_endpointListID, newElement_0_supportedCommands, newElement_0_status);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -3874,7 +3874,7 @@ void CHIPBridgedActionsEndpointListAttributeCallback::CallbackFn(
             std::string newElement_NaNCtorSignature = "(I)V";
             chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
                 newElement_NaNClassName.c_str(), newElement_NaNCtorSignature.c_str(), entry_NaN, newElement_NaN);
-            chip::JniReferences::GetInstance().AddToArrayList(newElement_0_endpoints, newElement_NaN);
+            chip::JniReferences::GetInstance().AddToList(newElement_0_endpoints, newElement_NaN);
         }
 
         jclass endpointListStructStructClass;
@@ -3896,7 +3896,7 @@ void CHIPBridgedActionsEndpointListAttributeCallback::CallbackFn(
 
         newElement_0 = env->NewObject(endpointListStructStructClass, endpointListStructStructCtor, newElement_0_endpointListID,
                                       newElement_0_name, newElement_0_type, newElement_0_endpoints);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -3967,7 +3967,7 @@ void CHIPBridgedActionsServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -4038,7 +4038,7 @@ void CHIPBridgedActionsClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -4109,7 +4109,7 @@ void CHIPBridgedActionsAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -4181,7 +4181,7 @@ void CHIPBridgedDeviceBasicServerGeneratedCommandListAttributeCallback::Callback
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -4253,7 +4253,7 @@ void CHIPBridgedDeviceBasicClientGeneratedCommandListAttributeCallback::Callback
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -4324,7 +4324,7 @@ void CHIPBridgedDeviceBasicAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -4452,7 +4452,7 @@ void CHIPChannelChannelListAttributeCallback::CallbackFn(
         newElement_0 =
             env->NewObject(channelInfoStructClass, channelInfoStructCtor, newElement_0_majorNumber, newElement_0_minorNumber,
                            newElement_0_name, newElement_0_callSign, newElement_0_affiliateCallSign);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -4523,7 +4523,7 @@ void CHIPChannelServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -4594,7 +4594,7 @@ void CHIPChannelClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -4663,7 +4663,7 @@ void CHIPChannelAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -4734,7 +4734,7 @@ void CHIPColorControlServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -4805,7 +4805,7 @@ void CHIPColorControlClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -4876,7 +4876,7 @@ void CHIPColorControlAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -4944,7 +4944,7 @@ void CHIPContentLauncherAcceptHeaderAttributeCallback::CallbackFn(void * context
         auto & entry_0 = iter_arrayListObj_0.GetValue();
         jobject newElement_0;
         newElement_0 = env->NewStringUTF(std::string(entry_0.data(), entry_0.size()).c_str());
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -5015,7 +5015,7 @@ void CHIPContentLauncherServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -5086,7 +5086,7 @@ void CHIPContentLauncherClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -5157,7 +5157,7 @@ void CHIPContentLauncherAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -5252,7 +5252,7 @@ void CHIPDescriptorDeviceListAttributeCallback::CallbackFn(
         }
 
         newElement_0 = env->NewObject(deviceTypeStructClass, deviceTypeStructCtor, newElement_0_type, newElement_0_revision);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -5321,7 +5321,7 @@ void CHIPDescriptorServerListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -5390,7 +5390,7 @@ void CHIPDescriptorClientListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -5459,7 +5459,7 @@ void CHIPDescriptorPartsListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(I)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -5530,7 +5530,7 @@ void CHIPDescriptorServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -5601,7 +5601,7 @@ void CHIPDescriptorClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -5670,7 +5670,7 @@ void CHIPDescriptorAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -5741,7 +5741,7 @@ void CHIPDiagnosticLogsServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -5812,7 +5812,7 @@ void CHIPDiagnosticLogsClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -5883,7 +5883,7 @@ void CHIPDiagnosticLogsAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -6084,7 +6084,7 @@ void CHIPDoorLockServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -6155,7 +6155,7 @@ void CHIPDoorLockClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -6224,7 +6224,7 @@ void CHIPDoorLockAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -6296,7 +6296,7 @@ void CHIPElectricalMeasurementServerGeneratedCommandListAttributeCallback::Callb
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -6368,7 +6368,7 @@ void CHIPElectricalMeasurementClientGeneratedCommandListAttributeCallback::Callb
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -6439,7 +6439,7 @@ void CHIPElectricalMeasurementAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -6713,7 +6713,7 @@ void CHIPEthernetNetworkDiagnosticsServerGeneratedCommandListAttributeCallback::
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -6786,7 +6786,7 @@ void CHIPEthernetNetworkDiagnosticsClientGeneratedCommandListAttributeCallback::
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -6857,7 +6857,7 @@ void CHIPEthernetNetworkDiagnosticsAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -6945,7 +6945,7 @@ void CHIPFixedLabelLabelListAttributeCallback::CallbackFn(
         }
 
         newElement_0 = env->NewObject(labelStructStructClass, labelStructStructCtor, newElement_0_label, newElement_0_value);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -7016,7 +7016,7 @@ void CHIPFixedLabelServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -7087,7 +7087,7 @@ void CHIPFixedLabelClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -7156,7 +7156,7 @@ void CHIPFixedLabelAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -7227,7 +7227,7 @@ void CHIPFlowMeasurementServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -7298,7 +7298,7 @@ void CHIPFlowMeasurementClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -7369,7 +7369,7 @@ void CHIPFlowMeasurementAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -7441,7 +7441,7 @@ void CHIPGeneralCommissioningServerGeneratedCommandListAttributeCallback::Callba
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -7513,7 +7513,7 @@ void CHIPGeneralCommissioningClientGeneratedCommandListAttributeCallback::Callba
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -7584,7 +7584,7 @@ void CHIPGeneralCommissioningAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -7706,7 +7706,7 @@ void CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback::CallbackFn(
             env->SetByteArrayRegion(newElement_NaNByteArray, 0, static_cast<jsize>(entry_NaN.size()),
                                     reinterpret_cast<const jbyte *>(entry_NaN.data()));
             newElement_NaN = newElement_NaNByteArray;
-            chip::JniReferences::GetInstance().AddToArrayList(newElement_0_IPv4Addresses, newElement_NaN);
+            chip::JniReferences::GetInstance().AddToList(newElement_0_IPv4Addresses, newElement_NaN);
         }
         jobject newElement_0_IPv6Addresses;
         chip::JniReferences::GetInstance().CreateArrayList(newElement_0_IPv6Addresses);
@@ -7720,7 +7720,7 @@ void CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback::CallbackFn(
             env->SetByteArrayRegion(newElement_NaNByteArray, 0, static_cast<jsize>(entry_NaN.size()),
                                     reinterpret_cast<const jbyte *>(entry_NaN.data()));
             newElement_NaN = newElement_NaNByteArray;
-            chip::JniReferences::GetInstance().AddToArrayList(newElement_0_IPv6Addresses, newElement_NaN);
+            chip::JniReferences::GetInstance().AddToList(newElement_0_IPv6Addresses, newElement_NaN);
         }
         jobject newElement_0_type;
         std::string newElement_0_typeClassName     = "java/lang/Integer";
@@ -7752,7 +7752,7 @@ void CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback::CallbackFn(
                                       newElement_0_isOperational, newElement_0_offPremiseServicesReachableIPv4,
                                       newElement_0_offPremiseServicesReachableIPv6, newElement_0_hardwareAddress,
                                       newElement_0_IPv4Addresses, newElement_0_IPv6Addresses, newElement_0_type);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -7823,7 +7823,7 @@ void CHIPGeneralDiagnosticsActiveHardwareFaultsAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(I)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(newElement_0ClassName.c_str(),
                                                                       newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -7894,7 +7894,7 @@ void CHIPGeneralDiagnosticsActiveRadioFaultsAttributeCallback::CallbackFn(void *
         std::string newElement_0CtorSignature = "(I)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(newElement_0ClassName.c_str(),
                                                                       newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -7965,7 +7965,7 @@ void CHIPGeneralDiagnosticsActiveNetworkFaultsAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(I)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(newElement_0ClassName.c_str(),
                                                                       newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -8037,7 +8037,7 @@ void CHIPGeneralDiagnosticsServerGeneratedCommandListAttributeCallback::Callback
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -8109,7 +8109,7 @@ void CHIPGeneralDiagnosticsClientGeneratedCommandListAttributeCallback::Callback
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -8180,7 +8180,7 @@ void CHIPGeneralDiagnosticsAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -8286,7 +8286,7 @@ void CHIPGroupKeyManagementGroupKeyMapAttributeCallback::CallbackFn(
 
         newElement_0 = env->NewObject(groupKeyMapStructStructClass, groupKeyMapStructStructCtor, newElement_0_fabricIndex,
                                       newElement_0_groupId, newElement_0_groupKeySetID);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -8379,7 +8379,7 @@ void CHIPGroupKeyManagementGroupTableAttributeCallback::CallbackFn(
             std::string newElement_NaNCtorSignature = "(I)V";
             chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
                 newElement_NaNClassName.c_str(), newElement_NaNCtorSignature.c_str(), entry_NaN, newElement_NaN);
-            chip::JniReferences::GetInstance().AddToArrayList(newElement_0_endpoints, newElement_NaN);
+            chip::JniReferences::GetInstance().AddToList(newElement_0_endpoints, newElement_NaN);
         }
         jobject newElement_0_groupName;
         if (!entry_0.groupName.HasValue())
@@ -8411,7 +8411,7 @@ void CHIPGroupKeyManagementGroupTableAttributeCallback::CallbackFn(
 
         newElement_0 = env->NewObject(groupInfoMapStructStructClass, groupInfoMapStructStructCtor, newElement_0_fabricIndex,
                                       newElement_0_groupId, newElement_0_endpoints, newElement_0_groupName);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -8483,7 +8483,7 @@ void CHIPGroupKeyManagementServerGeneratedCommandListAttributeCallback::Callback
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -8555,7 +8555,7 @@ void CHIPGroupKeyManagementClientGeneratedCommandListAttributeCallback::Callback
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -8626,7 +8626,7 @@ void CHIPGroupKeyManagementAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -8697,7 +8697,7 @@ void CHIPGroupsServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -8768,7 +8768,7 @@ void CHIPGroupsClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -8837,7 +8837,7 @@ void CHIPGroupsAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -8908,7 +8908,7 @@ void CHIPIdentifyServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -8979,7 +8979,7 @@ void CHIPIdentifyClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -9048,7 +9048,7 @@ void CHIPIdentifyAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -9388,7 +9388,7 @@ void CHIPIlluminanceMeasurementServerGeneratedCommandListAttributeCallback::Call
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -9460,7 +9460,7 @@ void CHIPIlluminanceMeasurementClientGeneratedCommandListAttributeCallback::Call
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -9531,7 +9531,7 @@ void CHIPIlluminanceMeasurementAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -9602,7 +9602,7 @@ void CHIPKeypadInputServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -9673,7 +9673,7 @@ void CHIPKeypadInputClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -9742,7 +9742,7 @@ void CHIPKeypadInputAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -10145,7 +10145,7 @@ void CHIPLevelControlServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -10216,7 +10216,7 @@ void CHIPLevelControlClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -10287,7 +10287,7 @@ void CHIPLevelControlAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -10355,7 +10355,7 @@ void CHIPLocalizationConfigurationSupportedLocalesAttributeCallback::CallbackFn(
         auto & entry_0 = iter_arrayListObj_0.GetValue();
         jobject newElement_0;
         newElement_0 = env->NewStringUTF(std::string(entry_0.data(), entry_0.size()).c_str());
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -10427,7 +10427,7 @@ void CHIPLocalizationConfigurationServerGeneratedCommandListAttributeCallback::C
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -10499,7 +10499,7 @@ void CHIPLocalizationConfigurationClientGeneratedCommandListAttributeCallback::C
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -10570,7 +10570,7 @@ void CHIPLowPowerServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -10641,7 +10641,7 @@ void CHIPLowPowerClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -10710,7 +10710,7 @@ void CHIPLowPowerAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -10810,7 +10810,7 @@ void CHIPMediaInputInputListAttributeCallback::CallbackFn(
 
         newElement_0 = env->NewObject(inputInfoStructClass, inputInfoStructCtor, newElement_0_index, newElement_0_inputType,
                                       newElement_0_name, newElement_0_description);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -10881,7 +10881,7 @@ void CHIPMediaInputServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -10952,7 +10952,7 @@ void CHIPMediaInputClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -11021,7 +11021,7 @@ void CHIPMediaInputAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -11354,7 +11354,7 @@ void CHIPMediaPlaybackServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -11425,7 +11425,7 @@ void CHIPMediaPlaybackClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -11496,7 +11496,7 @@ void CHIPMediaPlaybackAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -11594,7 +11594,7 @@ void CHIPModeSelectSupportedModesAttributeCallback::CallbackFn(
 
         newElement_0 = env->NewObject(modeOptionStructStructClass, modeOptionStructStructCtor, newElement_0_label,
                                       newElement_0_mode, newElement_0_semanticTag);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -11665,7 +11665,7 @@ void CHIPModeSelectServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -11736,7 +11736,7 @@ void CHIPModeSelectClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -11805,7 +11805,7 @@ void CHIPModeSelectAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -11903,7 +11903,7 @@ void CHIPNetworkCommissioningNetworksAttributeCallback::CallbackFn(
 
         newElement_0 =
             env->NewObject(networkInfoStructClass, networkInfoStructCtor, newElement_0_networkID, newElement_0_connected);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -12177,7 +12177,7 @@ void CHIPNetworkCommissioningServerGeneratedCommandListAttributeCallback::Callba
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -12249,7 +12249,7 @@ void CHIPNetworkCommissioningClientGeneratedCommandListAttributeCallback::Callba
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -12320,7 +12320,7 @@ void CHIPOtaSoftwareUpdateProviderAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -12428,7 +12428,7 @@ void CHIPOtaSoftwareUpdateRequestorDefaultOtaProvidersAttributeCallback::Callbac
 
         newElement_0 = env->NewObject(providerLocationStructClass, providerLocationStructCtor, newElement_0_fabricIndex,
                                       newElement_0_providerNodeID, newElement_0_endpoint);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -12567,7 +12567,7 @@ void CHIPOtaSoftwareUpdateRequestorAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -12638,7 +12638,7 @@ void CHIPOccupancySensingServerGeneratedCommandListAttributeCallback::CallbackFn
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -12709,7 +12709,7 @@ void CHIPOccupancySensingClientGeneratedCommandListAttributeCallback::CallbackFn
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -12780,7 +12780,7 @@ void CHIPOccupancySensingAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -12851,7 +12851,7 @@ void CHIPOnOffServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -12922,7 +12922,7 @@ void CHIPOnOffClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -12991,7 +12991,7 @@ void CHIPOnOffAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -13063,7 +13063,7 @@ void CHIPOnOffSwitchConfigurationServerGeneratedCommandListAttributeCallback::Ca
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -13135,7 +13135,7 @@ void CHIPOnOffSwitchConfigurationClientGeneratedCommandListAttributeCallback::Ca
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -13206,7 +13206,7 @@ void CHIPOnOffSwitchConfigurationAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -13316,7 +13316,7 @@ void CHIPOperationalCredentialsNOCsAttributeCallback::CallbackFn(
 
         newElement_0 = env->NewObject(NOCStructStructClass, NOCStructStructCtor, newElement_0_fabricIndex, newElement_0_noc,
                                       newElement_0_icac);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -13436,7 +13436,7 @@ void CHIPOperationalCredentialsFabricsAttributeCallback::CallbackFn(
         newElement_0 = env->NewObject(fabricDescriptorStructClass, fabricDescriptorStructCtor, newElement_0_fabricIndex,
                                       newElement_0_rootPublicKey, newElement_0_vendorId, newElement_0_fabricId, newElement_0_nodeId,
                                       newElement_0_label);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -13508,7 +13508,7 @@ void CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback::Callbac
         env->SetByteArrayRegion(newElement_0ByteArray, 0, static_cast<jsize>(entry_0.size()),
                                 reinterpret_cast<const jbyte *>(entry_0.data()));
         newElement_0 = newElement_0ByteArray;
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -13639,7 +13639,7 @@ void CHIPOperationalCredentialsServerGeneratedCommandListAttributeCallback::Call
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -13711,7 +13711,7 @@ void CHIPOperationalCredentialsClientGeneratedCommandListAttributeCallback::Call
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -13782,7 +13782,7 @@ void CHIPOperationalCredentialsAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -13853,7 +13853,7 @@ void CHIPPowerSourceActiveBatteryFaultsAttributeCallback::CallbackFn(void * cont
         std::string newElement_0CtorSignature = "(I)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(newElement_0ClassName.c_str(),
                                                                       newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -13924,7 +13924,7 @@ void CHIPPowerSourceServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -13995,7 +13995,7 @@ void CHIPPowerSourceClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -14064,7 +14064,7 @@ void CHIPPowerSourceAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -14135,7 +14135,7 @@ void CHIPPowerSourceConfigurationSourcesAttributeCallback::CallbackFn(void * con
         std::string newElement_0CtorSignature = "(I)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(newElement_0ClassName.c_str(),
                                                                       newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -14207,7 +14207,7 @@ void CHIPPowerSourceConfigurationServerGeneratedCommandListAttributeCallback::Ca
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -14279,7 +14279,7 @@ void CHIPPowerSourceConfigurationClientGeneratedCommandListAttributeCallback::Ca
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -14350,7 +14350,7 @@ void CHIPPowerSourceConfigurationAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -14421,7 +14421,7 @@ void CHIPPressureMeasurementAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -14631,7 +14631,7 @@ void CHIPPumpConfigurationAndControlServerGeneratedCommandListAttributeCallback:
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -14705,7 +14705,7 @@ void CHIPPumpConfigurationAndControlClientGeneratedCommandListAttributeCallback:
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -14776,7 +14776,7 @@ void CHIPPumpConfigurationAndControlAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -14850,7 +14850,7 @@ void CHIPRelativeHumidityMeasurementServerGeneratedCommandListAttributeCallback:
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -14924,7 +14924,7 @@ void CHIPRelativeHumidityMeasurementClientGeneratedCommandListAttributeCallback:
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -14995,7 +14995,7 @@ void CHIPRelativeHumidityMeasurementAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -15066,7 +15066,7 @@ void CHIPScenesServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -15137,7 +15137,7 @@ void CHIPScenesClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -15206,7 +15206,7 @@ void CHIPScenesAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -15320,7 +15320,7 @@ void CHIPSoftwareDiagnosticsThreadMetricsAttributeCallback::CallbackFn(
 
         newElement_0 = env->NewObject(threadMetricsStructClass, threadMetricsStructCtor, newElement_0_id, newElement_0_name,
                                       newElement_0_stackFreeCurrent, newElement_0_stackFreeMinimum, newElement_0_stackSize);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -15392,7 +15392,7 @@ void CHIPSoftwareDiagnosticsServerGeneratedCommandListAttributeCallback::Callbac
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -15464,7 +15464,7 @@ void CHIPSoftwareDiagnosticsClientGeneratedCommandListAttributeCallback::Callbac
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -15535,7 +15535,7 @@ void CHIPSoftwareDiagnosticsAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -15606,7 +15606,7 @@ void CHIPSwitchServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -15677,7 +15677,7 @@ void CHIPSwitchClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -15746,7 +15746,7 @@ void CHIPSwitchAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -15840,7 +15840,7 @@ void CHIPTargetNavigatorTargetListAttributeCallback::CallbackFn(
         }
 
         newElement_0 = env->NewObject(targetInfoStructClass, targetInfoStructCtor, newElement_0_identifier, newElement_0_name);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -15911,7 +15911,7 @@ void CHIPTargetNavigatorServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -15982,7 +15982,7 @@ void CHIPTargetNavigatorClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -16053,7 +16053,7 @@ void CHIPTargetNavigatorAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -16124,7 +16124,7 @@ void CHIPTemperatureMeasurementAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -16193,7 +16193,7 @@ void CHIPTestClusterListInt8uAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(I)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(newElement_0ClassName.c_str(),
                                                                       newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -16264,7 +16264,7 @@ void CHIPTestClusterListOctetStringAttributeCallback::CallbackFn(void * context,
         env->SetByteArrayRegion(newElement_0ByteArray, 0, static_cast<jsize>(entry_0.size()),
                                 reinterpret_cast<const jbyte *>(entry_0.data()));
         newElement_0 = newElement_0ByteArray;
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -16362,7 +16362,7 @@ void CHIPTestClusterListStructOctetStringAttributeCallback::CallbackFn(
 
         newElement_0 = env->NewObject(testListStructOctetStructClass, testListStructOctetStructCtor, newElement_0_fabricIndex,
                                       newElement_0_operationalCert);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -16840,7 +16840,7 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(newElement_NaNClassName.c_str(),
                                                                               newElement_NaNCtorSignature.c_str(),
                                                                               static_cast<uint8_t>(entry_NaN), newElement_NaN);
-                chip::JniReferences::GetInstance().AddToArrayList(newElement_0_nullableList, newElement_NaN);
+                chip::JniReferences::GetInstance().AddToList(newElement_0_nullableList, newElement_NaN);
             }
         }
         jobject newElement_0_optionalList;
@@ -16862,7 +16862,7 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(newElement_NaNClassName.c_str(),
                                                                               newElement_NaNCtorSignature.c_str(),
                                                                               static_cast<uint8_t>(entry_NaN), newElement_NaN);
-                chip::JniReferences::GetInstance().AddToArrayList(newElement_0_optionalList, newElement_NaN);
+                chip::JniReferences::GetInstance().AddToList(newElement_0_optionalList, newElement_NaN);
             }
         }
         jobject newElement_0_nullableOptionalList;
@@ -16890,7 +16890,7 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
                     chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(newElement_NaNClassName.c_str(),
                                                                                   newElement_NaNCtorSignature.c_str(),
                                                                                   static_cast<uint8_t>(entry_NaN), newElement_NaN);
-                    chip::JniReferences::GetInstance().AddToArrayList(newElement_0_nullableOptionalList, newElement_NaN);
+                    chip::JniReferences::GetInstance().AddToList(newElement_0_nullableOptionalList, newElement_NaN);
                 }
             }
         }
@@ -16920,7 +16920,7 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
                                       newElement_0_nullableString, newElement_0_optionalString, newElement_0_nullableOptionalString,
                                       newElement_0_nullableStruct, newElement_0_optionalStruct, newElement_0_nullableOptionalStruct,
                                       newElement_0_nullableList, newElement_0_optionalList, newElement_0_nullableOptionalList);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -16991,7 +16991,7 @@ void CHIPTestClusterListLongOctetStringAttributeCallback::CallbackFn(
         env->SetByteArrayRegion(newElement_0ByteArray, 0, static_cast<jsize>(entry_0.size()),
                                 reinterpret_cast<const jbyte *>(entry_0.data()));
         newElement_0 = newElement_0ByteArray;
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -19195,7 +19195,7 @@ void CHIPTestClusterServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -19266,7 +19266,7 @@ void CHIPTestClusterClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -19335,7 +19335,7 @@ void CHIPTestClusterAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -19404,7 +19404,7 @@ void CHIPThermostatAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -19479,7 +19479,7 @@ void CHIPThermostatUserInterfaceConfigurationServerGeneratedCommandListAttribute
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -19554,7 +19554,7 @@ void CHIPThermostatUserInterfaceConfigurationClientGeneratedCommandListAttribute
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -19626,7 +19626,7 @@ void CHIPThermostatUserInterfaceConfigurationAttributeListAttributeCallback::Cal
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -19801,7 +19801,7 @@ void CHIPThreadNetworkDiagnosticsNeighborTableListAttributeCallback::CallbackFn(
                                       newElement_0_lqi, newElement_0_averageRssi, newElement_0_lastRssi,
                                       newElement_0_frameErrorRate, newElement_0_messageErrorRate, newElement_0_rxOnWhenIdle,
                                       newElement_0_fullThreadDevice, newElement_0_fullNetworkData, newElement_0_isChild);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -19948,7 +19948,7 @@ void CHIPThreadNetworkDiagnosticsRouteTableListAttributeCallback::CallbackFn(
         newElement_0 = env->NewObject(routeTableStructClass, routeTableStructCtor, newElement_0_extAddress, newElement_0_rloc16,
                                       newElement_0_routerId, newElement_0_nextHop, newElement_0_pathCost, newElement_0_LQIIn,
                                       newElement_0_LQIOut, newElement_0_age, newElement_0_allocated, newElement_0_linkEstablished);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -20047,7 +20047,7 @@ void CHIPThreadNetworkDiagnosticsSecurityPolicyAttributeCallback::CallbackFn(
 
         newElement_0 =
             env->NewObject(securityPolicyStructClass, securityPolicyStructCtor, newElement_0_rotationTime, newElement_0_flags);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -20217,7 +20217,7 @@ void CHIPThreadNetworkDiagnosticsOperationalDatasetComponentsAttributeCallback::
                            newElement_0_networkNamePresent, newElement_0_extendedPanIdPresent, newElement_0_meshLocalPrefixPresent,
                            newElement_0_delayPresent, newElement_0_panIdPresent, newElement_0_channelPresent,
                            newElement_0_pskcPresent, newElement_0_securityPolicyPresent, newElement_0_channelMaskPresent);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -20289,7 +20289,7 @@ void CHIPThreadNetworkDiagnosticsActiveNetworkFaultsListAttributeCallback::Callb
         std::string newElement_0CtorSignature = "(I)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
             newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), static_cast<uint8_t>(entry_0), newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -20361,7 +20361,7 @@ void CHIPThreadNetworkDiagnosticsServerGeneratedCommandListAttributeCallback::Ca
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -20433,7 +20433,7 @@ void CHIPThreadNetworkDiagnosticsClientGeneratedCommandListAttributeCallback::Ca
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -20504,7 +20504,7 @@ void CHIPThreadNetworkDiagnosticsAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -20576,7 +20576,7 @@ void CHIPTimeFormatLocalizationSupportedCalendarTypesAttributeCallback::Callback
         std::string newElement_0CtorSignature = "(I)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
             newElement_0ClassName.c_str(), newElement_0CtorSignature.c_str(), static_cast<uint8_t>(entry_0), newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -20648,7 +20648,7 @@ void CHIPTimeFormatLocalizationServerGeneratedCommandListAttributeCallback::Call
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -20720,7 +20720,7 @@ void CHIPTimeFormatLocalizationClientGeneratedCommandListAttributeCallback::Call
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -20791,7 +20791,7 @@ void CHIPUnitLocalizationAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -20879,7 +20879,7 @@ void CHIPUserLabelLabelListAttributeCallback::CallbackFn(
         }
 
         newElement_0 = env->NewObject(labelStructStructClass, labelStructStructCtor, newElement_0_label, newElement_0_value);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -20950,7 +20950,7 @@ void CHIPUserLabelServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -21021,7 +21021,7 @@ void CHIPUserLabelClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -21092,7 +21092,7 @@ void CHIPWakeOnLanServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -21163,7 +21163,7 @@ void CHIPWakeOnLanClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -21232,7 +21232,7 @@ void CHIPWakeOnLanAttributeListAttributeCallback::CallbackFn(void * context,
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -21639,7 +21639,7 @@ void CHIPWiFiNetworkDiagnosticsServerGeneratedCommandListAttributeCallback::Call
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -21711,7 +21711,7 @@ void CHIPWiFiNetworkDiagnosticsClientGeneratedCommandListAttributeCallback::Call
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -21782,7 +21782,7 @@ void CHIPWiFiNetworkDiagnosticsAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -22395,7 +22395,7 @@ void CHIPWindowCoveringServerGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -22466,7 +22466,7 @@ void CHIPWindowCoveringClientGeneratedCommandListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();
@@ -22537,7 +22537,7 @@ void CHIPWindowCoveringAttributeListAttributeCallback::CallbackFn(
         std::string newElement_0CtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0ClassName.c_str(),
                                                                        newElement_0CtorSignature.c_str(), entry_0, newElement_0);
-        chip::JniReferences::GetInstance().AddToArrayList(arrayListObj, newElement_0);
+        chip::JniReferences::GetInstance().AddToList(arrayListObj, newElement_0);
     }
 
     env->ExceptionClear();

--- a/src/lib/support/JniReferences.cpp
+++ b/src/lib/support/JniReferences.cpp
@@ -43,6 +43,7 @@ void JniReferences::SetJavaVm(JavaVM * jvm, const char * clsType)
     mClassLoader     = env->NewGlobalRef(env->CallObjectMethod(chipClass, getClassLoaderMethod));
     mFindClassMethod = env->GetMethodID(classLoaderClass, "findClass", "(Ljava/lang/String;)Ljava/lang/Class;");
 
+    chip::JniReferences::GetInstance().GetClassRef(env, "java/util/List", mListClass);
     chip::JniReferences::GetInstance().GetClassRef(env, "java/util/ArrayList", mArrayListClass);
     chip::JniReferences::GetInstance().GetClassRef(env, "java/util/HashMap", mHashMapClass);
 }
@@ -307,12 +308,12 @@ CHIP_ERROR JniReferences::CreateArrayList(jobject & outList)
     return err;
 }
 
-CHIP_ERROR JniReferences::AddToArrayList(jobject list, jobject objectToAdd)
+CHIP_ERROR JniReferences::AddToList(jobject list, jobject objectToAdd)
 {
     JNIEnv * env   = GetEnvForCurrentThread();
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    jmethodID addMethod = env->GetMethodID(mArrayListClass, "add", "(Ljava/lang/Object;)Z");
+    jmethodID addMethod = env->GetMethodID(mListClass, "add", "(Ljava/lang/Object;)Z");
     VerifyOrReturnError(addMethod != nullptr, CHIP_JNI_ERROR_METHOD_NOT_FOUND);
 
     env->CallBooleanMethod(list, addMethod, objectToAdd);
@@ -346,12 +347,12 @@ CHIP_ERROR JniReferences::PutInMap(jobject map, jobject key, jobject value)
     return err;
 }
 
-CHIP_ERROR JniReferences::GetArrayListSize(jobject list, jint & size)
+CHIP_ERROR JniReferences::GetListSize(jobject list, jint & size)
 {
     JNIEnv * env   = GetEnvForCurrentThread();
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    jmethodID sizeMethod = env->GetMethodID(mArrayListClass, "size", "()I");
+    jmethodID sizeMethod = env->GetMethodID(mListClass, "size", "()I");
     VerifyOrReturnError(sizeMethod != nullptr, CHIP_JNI_ERROR_METHOD_NOT_FOUND);
 
     size = env->CallIntMethod(list, sizeMethod);
@@ -359,12 +360,12 @@ CHIP_ERROR JniReferences::GetArrayListSize(jobject list, jint & size)
     return err;
 }
 
-CHIP_ERROR JniReferences::GetArrayListItem(jobject list, jint index, jobject & outItem)
+CHIP_ERROR JniReferences::GetListItem(jobject list, jint index, jobject & outItem)
 {
     JNIEnv * env   = GetEnvForCurrentThread();
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    jmethodID getMethod = env->GetMethodID(mArrayListClass, "get", "(I)Ljava/lang/Object;");
+    jmethodID getMethod = env->GetMethodID(mListClass, "get", "(I)Ljava/lang/Object;");
     VerifyOrReturnError(getMethod != nullptr, CHIP_JNI_ERROR_METHOD_NOT_FOUND);
 
     outItem = env->CallObjectMethod(list, getMethod, index);

--- a/src/lib/support/JniReferences.h
+++ b/src/lib/support/JniReferences.h
@@ -114,11 +114,11 @@ public:
 
     CHIP_ERROR CreateArrayList(jobject & outList);
 
-    CHIP_ERROR AddToArrayList(jobject list, jobject objectToAdd);
+    CHIP_ERROR AddToList(jobject list, jobject objectToAdd);
 
-    CHIP_ERROR GetArrayListSize(jobject list, jint & size);
+    CHIP_ERROR GetListSize(jobject list, jint & size);
 
-    CHIP_ERROR GetArrayListItem(jobject list, jint index, jobject & outItem);
+    CHIP_ERROR GetListItem(jobject list, jint index, jobject & outItem);
 
     CHIP_ERROR CreateHashMap(jobject & outMap);
 
@@ -168,6 +168,7 @@ private:
     jmethodID mFindClassMethod = nullptr;
 
     jclass mHashMapClass   = nullptr;
+    jclass mListClass      = nullptr;
     jclass mArrayListClass = nullptr;
 };
 } // namespace chip


### PR DESCRIPTION
#### Problem
`readPath()` and `subscribeToPath()` are only capable of setting one item in `mpAttributePathParamsList`.

#### Change overview
* Allow multiple attribute paths to be passed through
* Make methods in `JniReferences` use `List` instead of `ArrayList` where possible
* Fix bug where we directly treat `strncmp` as bool instead of checking the integer return value

#### Testing
Wildcard read single/multiple paths
