### PR TITLE
Thread Scan Network command handling for end devices

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -97,6 +97,8 @@ void initNetworkCommissioningThreadDriver(void)
 #endif
 }
 
+NetworkCommissioning::ThreadScanResponse * scanResult;
+otScanResponseIterator<NetworkCommissioning::ThreadScanResponse> mScanResponseIter(scanResult);
 } // namespace
 // Fully instantiate the generic implementation class in whatever compilation unit includes this file.
 template class GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>;
@@ -359,11 +361,55 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnThreadAttachFinishe
 template <class ImplClass>
 CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_StartThreadScan(ThreadDriver::ScanCallback * callback)
 {
-    // TODO END scan feature + _OnNetworkScanFinished callback for response
-    // There is another ongoing scan request, reject the new one.
+    // If there is another ongoing scan request, reject the new one.
     VerifyOrReturnError(mpScanCallback == nullptr, CHIP_ERROR_INCORRECT_STATE);
     mpScanCallback = callback;
-    return CHIP_NO_ERROR;
+    CHIP_ERROR err = MapOpenThreadError(otLinkActiveScan(mOTInst, 0, /* all channels */
+                                                         0,          /* default value `kScanDurationDefault` = 300 ms. */
+                                                         _OnNetworkScanFinished, this));
+    return err;
+}
+
+template <class ImplClass>
+void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnNetworkScanFinished(otActiveScanResult * aResult, void * aContext)
+{
+    reinterpret_cast<GenericThreadStackManagerImpl_OpenThread *>(aContext)->_OnNetworkScanFinished(aResult);
+}
+
+template <class ImplClass>
+void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnNetworkScanFinished(otActiveScanResult * aResult)
+{
+    if (aResult == nullptr) // scan completed
+    {
+        if (mpScanCallback != nullptr)
+        {
+            DeviceLayer::SystemLayer().ScheduleLambda([this]() {
+                mpScanCallback->OnFinished(NetworkCommissioning::Status::kSuccess, CharSpan(), &mScanResponseIter);
+                mpScanCallback = nullptr;
+            });
+        }
+    }
+    else
+    {
+        ChipLogProgress(
+            DeviceLayer,
+            "Thread Network: %s Panid 0x%" PRIx16 " Channel %" PRIu16 " RSSI %" PRId16 " LQI %" PRIu16 " Version %" PRIu16,
+            aResult->mNetworkName.m8, aResult->mPanId, aResult->mChannel, aResult->mRssi, aResult->mLqi, aResult->mVersion);
+
+        NetworkCommissioning::ThreadScanResponse scanResponse = { 0 };
+
+        scanResponse.panId           = aResult->mPanId;   // why is scanResponse.panID 64b
+        scanResponse.channel         = aResult->mChannel; // why is scanResponse.channel 16b
+        scanResponse.version         = aResult->mVersion;
+        scanResponse.rssi            = aResult->mRssi;
+        scanResponse.lqi             = aResult->mLqi;
+        scanResponse.extendedAddress = Encoding::BigEndian::Get64(aResult->mExtAddress.m8);
+        scanResponse.extendedPanId   = Encoding::BigEndian::Get64(aResult->mExtendedPanId.m8);
+        scanResponse.networkNameLen  = strnlen(aResult->mNetworkName.m8, OT_NETWORK_NAME_MAX_SIZE);
+        memcpy(scanResponse.networkName, aResult->mNetworkName.m8, scanResponse.networkNameLen);
+
+        mScanResponseIter.Add(&scanResponse);
+    }
 }
 
 template <class ImplClass>

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <openthread/instance.h>
+#include <openthread/link.h>
 #include <openthread/netdata.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
@@ -89,6 +90,8 @@ protected:
     ConnectivityManager::ThreadDeviceType _GetThreadDeviceType(void);
     CHIP_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);
     CHIP_ERROR _StartThreadScan(NetworkCommissioning::ThreadDriver::ScanCallback * callback);
+    static void _OnNetworkScanFinished(otActiveScanResult * aResult, void * aContext);
+    void _OnNetworkScanFinished(otActiveScanResult * aResult);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
     CHIP_ERROR _GetSEDPollingConfig(ConnectivityManager::SEDPollingConfig & pollingConfig);


### PR DESCRIPTION
#### Problem
Thread Scan Network command isn't supported 

#### Change overview
- Use openthread scan network api on command reception.  Call back is received for every network scanned and at completion with a null response.
- Add a thread Scan response iterator without the use of vectors
- On completion call `_OnNetworkScanFinished` and pass the iterator



#### Testing
Built on efr32 ligth-app
send command with chip-tool ` ./out/standalone/chip-tool networkcommissioning scan-networks 0 0 <nodeid> 0`
Validate response received and compared with `ot-cli scan` command

```
[1644614351.867048][4675:4680] CHIP:DMG: Received Command Response Data, Endpoint=0 Cluster=0x0000_0031 Command=0x0000_0001
[1644614351.867107][4675:4680] CHIP:TOO: Endpoint: 0 Cluster: 0x0000_0031 Command 0x0000_0001
[1644614351.867206][4675:4680] CHIP:TOO:   ScanNetworksResponse: {
[1644614351.867240][4675:4680] CHIP:TOO:     networkingStatus: 0
[1644614351.867269][4675:4680] CHIP:TOO:     debugText:
[1644614351.867318][4675:4680] CHIP:TOO:     threadScanResults: 3 entries
[1644614351.867412][4675:4680] CHIP:TOO:       [1]: {
[1644614351.867442][4675:4680] CHIP:TOO:         PanId: 48538
[1644614351.867470][4675:4680] CHIP:TOO:         ExtendedPanId: 0
[1644614351.867498][4675:4680] CHIP:TOO:         NetworkName:
[1644614351.867526][4675:4680] CHIP:TOO:         Channel: 11
[1644614351.867553][4675:4680] CHIP:TOO:         Version: 0
[1644614351.867580][4675:4680] CHIP:TOO:         ExtendedAddress: 2497762197471250902
[1644614351.867608][4675:4680] CHIP:TOO:         Rssi: -32
[1644614351.867636][4675:4680] CHIP:TOO:         Lqi: 255
[1644614351.867665][4675:4680] CHIP:TOO:        }
[1644614351.867706][4675:4680] CHIP:TOO:       [2]: {
[1644614351.867736][4675:4680] CHIP:TOO:         PanId: 16384
[1644614351.867763][4675:4680] CHIP:TOO:         ExtendedPanId: 16045481867444538110
[1644614351.867791][4675:4680] CHIP:TOO:         NetworkName: OpenThread
[1644614351.867818][4675:4680] CHIP:TOO:         Channel: 11
[1644614351.867845][4675:4680] CHIP:TOO:         Version: 2
[1644614351.867873][4675:4680] CHIP:TOO:         ExtendedAddress: 14332622412298900794
[1644614351.867901][4675:4680] CHIP:TOO:         Rssi: -48
[1644614351.867928][4675:4680] CHIP:TOO:         Lqi: 255
[1644614351.867955][4675:4680] CHIP:TOO:        }
[1644614351.867994][4675:4680] CHIP:TOO:       [3]: {
[1644614351.868022][4675:4680] CHIP:TOO:         PanId: 15571
[1644614351.868050][4675:4680] CHIP:TOO:         ExtendedPanId: 5524919397427458830
[1644614351.868078][4675:4680] CHIP:TOO:         NetworkName: NEST-PAN-304C
[1644614351.868106][4675:4680] CHIP:TOO:         Channel: 22
[1644614351.868132][4675:4680] CHIP:TOO:         Version: 2
[1644614351.868160][4675:4680] CHIP:TOO:         ExtendedAddress: 4203091419839563401
[1644614351.868188][4675:4680] CHIP:TOO:         Rssi: -38
[1644614351.868215][4675:4680] CHIP:TOO:         Lqi: 255
[1644614351.868241][4675:4680] CHIP:TOO:        }
[1644614351.868271][4675:4680] CHIP:TOO:    }
```