### PR TITLE
[YAML] Add TestMultiAdmin.yaml

### DIFF
--- a/examples/chip-tool/templates/tests/tests.js
+++ b/examples/chip-tool/templates/tests/tests.js
@@ -480,6 +480,10 @@ function getTests()
     'TestBinding',
   ];
 
+  const MultiAdmin = [
+    'TestMultiAdmin',
+  ];
+
   const SoftwareDiagnostics = [
     'Test_TC_SWDIAG_1_1',
     'Test_TC_SWDIAG_2_1',
@@ -531,6 +535,7 @@ function getTests()
     WindowCovering, //
     TV, //
     Others, //
+    MultiAdmin, //
     SoftwareDiagnostics, //
     Subscriptions, //
     DoorLock, //

--- a/src/app/tests/suites/TestMultiAdmin.yaml
+++ b/src/app/tests/suites/TestMultiAdmin.yaml
@@ -1,0 +1,141 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Test Multi Admin
+
+config:
+    nodeId: 0x12344321
+    nodeId2:
+        type: NODE_ID
+        defaultValue: 0xCAFE
+    nodeId3:
+        type: NODE_ID
+        defaultValue: 0xC00FEE
+    endpoint: 0
+    discriminator:
+        type: INT16U
+        defaultValue: 3840
+    payload:
+        type: CHAR_STRING
+        defaultValue: "MT:-24J0AFN00KA0648G00" # This value needs to be generated automatically
+
+tests:
+    - label: "Reboot target device"
+      cluster: "SystemCommands"
+      command: "Reboot"
+      arguments:
+          values:
+              - name: "discriminator"
+                value: discriminator
+
+    - label: "Wait for the commissioned device to be retrieved for alpha"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
+
+    - label: "Open Commissioning Window from alpha"
+      cluster: "AdministratorCommissioning"
+      command: "OpenBasicCommissioningWindow"
+      timedInteractionTimeoutMs: 10000
+      arguments:
+          values:
+              - name: "CommissioningTimeout"
+                value: 120
+
+    - label: "Commission from beta"
+      identity: "beta"
+      cluster: "CommissionerCommands"
+      command: "PairWithQRCode"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId2
+              - name: "payload"
+                value: payload
+
+    - label: "Wait for the commissioned device to be retrieved for beta"
+      identity: "beta"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId2
+
+    - label: "Open Commissioning Window from beta"
+      identity: "beta"
+      cluster: "AdministratorCommissioning"
+      command: "OpenBasicCommissioningWindow"
+      timedInteractionTimeoutMs: 10000
+      arguments:
+          values:
+              - name: "CommissioningTimeout"
+                value: 120
+
+    - label: "Commission from gamma"
+      identity: "gamma"
+      cluster: "CommissionerCommands"
+      command: "PairWithQRCode"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId3
+              - name: "payload"
+                value: payload
+
+    - label: "Wait for the commissioned device to be retrieved for gamma"
+      identity: "gamma"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId3
+
+    - label: "read the mandatory attribute: NodeLabel from alpha"
+      identity: "alpha"
+      cluster: "Basic"
+      command: "readAttribute"
+      attribute: "NodeLabel"
+      response:
+          value: ""
+          saveAs: readFromAlpha
+
+    - label: "write the mandatory attribute NodeLabel from beta"
+      identity: "beta"
+      cluster: "Basic"
+      command: "writeAttribute"
+      attribute: "NodeLabel"
+      arguments:
+          value: "written from beta"
+
+    - label: "read the mandatory attribute: NodeLabel from gamma"
+      identity: "gamma"
+      cluster: "Basic"
+      command: "readAttribute"
+      attribute: "NodeLabel"
+      response:
+          constraints:
+              notValue: readFromAlpha
+
+    - label: "write the mandatory attribute NodeLabel back to default"
+      identity: "alpha"
+      cluster: "Basic"
+      command: "writeAttribute"
+      attribute: "NodeLabel"
+      arguments:
+          value: readFromAlpha


### PR DESCRIPTION
#### Problem

This PR adds a test that makes uses of multiple controllers/fabrics to control a device.
I was hoping to add it to CI directly, but since it seems that there is still some flakiness on Darwin with the mdns advertisement I am just adding to it the manual section at the moment. So that may show to others how to use multiple fabrics from a single test.

#### Change overview
 * Add `TestMultiAdmin.yaml`
 * Update generated code

#### Testing
The test has been ran manually multiple times.