### PR TITLE
Track Matter operation times for the Darwin layer

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPCallbackBridgeBase_internal.h
+++ b/src/darwin/Framework/CHIP/CHIPCallbackBridgeBase_internal.h
@@ -85,7 +85,8 @@ private:
         }
 
         dispatch_async(callbackBridge->mQueue, ^{
-            ChipLogDetail(Controller, "%s %f seconds", callbackBridge->mCookie.UTF8String, -[callbackBridge->mResponseTime timeIntervalSinceNow]);
+            ChipLogDetail(Controller, "%s %f seconds", callbackBridge->mCookie.UTF8String,
+                -[callbackBridge->mResponseTime timeIntervalSinceNow]);
             callbackBridge->mHandler(value, error);
 
             if (!callbackBridge->mKeepAlive) {
@@ -101,6 +102,6 @@ private:
     chip::Callback::Callback<CHIPDefaultFailureCallbackType> mFailure;
 
     // Measure the time it took for the callback to trigger
-    NSDate *mResponseTime;
-    NSString *mCookie;
+    NSDate * mResponseTime;
+    NSString * mCookie;
 };

--- a/src/darwin/Framework/CHIP/CHIPCallbackBridgeBase_internal.h
+++ b/src/darwin/Framework/CHIP/CHIPCallbackBridgeBase_internal.h
@@ -36,6 +36,10 @@ public:
         , mSuccess(OnSuccessFn, this)
         , mFailure(OnFailureFn, this)
     {
+        mResponseTime = [NSDate date];
+        // Generate a unique cookie to track this operation
+        mCookie = [NSString stringWithFormat:@"Response Time: %s+%u", typeid(T).name(), arc4random()];
+        ChipLogDetail(Controller, "%s", mCookie.UTF8String);
         __block CHIP_ERROR err = CHIP_NO_ERROR;
         dispatch_sync(chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue(), ^{
             err = action(mSuccess.Cancel(), mFailure.Cancel());
@@ -81,6 +85,7 @@ private:
         }
 
         dispatch_async(callbackBridge->mQueue, ^{
+            ChipLogDetail(Controller, "%s %f seconds", callbackBridge->mCookie.UTF8String, -[callbackBridge->mResponseTime timeIntervalSinceNow]);
             callbackBridge->mHandler(value, error);
 
             if (!callbackBridge->mKeepAlive) {
@@ -94,4 +99,8 @@ private:
 
     chip::Callback::Callback<T> mSuccess;
     chip::Callback::Callback<CHIPDefaultFailureCallbackType> mFailure;
+
+    // Measure the time it took for the callback to trigger
+    NSDate *mResponseTime;
+    NSString *mCookie;
 };

--- a/src/darwin/Framework/CHIP/CHIPCallbackBridgeBase_internal.h
+++ b/src/darwin/Framework/CHIP/CHIPCallbackBridgeBase_internal.h
@@ -36,7 +36,7 @@ public:
         , mSuccess(OnSuccessFn, this)
         , mFailure(OnFailureFn, this)
     {
-        mResponseTime = [NSDate date];
+        mRequestTime = [NSDate date];
         // Generate a unique cookie to track this operation
         mCookie = [NSString stringWithFormat:@"Response Time: %s+%u", typeid(T).name(), arc4random()];
         ChipLogDetail(Controller, "%s", mCookie.UTF8String);
@@ -86,7 +86,7 @@ private:
 
         dispatch_async(callbackBridge->mQueue, ^{
             ChipLogDetail(Controller, "%s %f seconds", callbackBridge->mCookie.UTF8String,
-                -[callbackBridge->mResponseTime timeIntervalSinceNow]);
+                -[callbackBridge->mRequestTime timeIntervalSinceNow]);
             callbackBridge->mHandler(value, error);
 
             if (!callbackBridge->mKeepAlive) {
@@ -102,6 +102,6 @@ private:
     chip::Callback::Callback<CHIPDefaultFailureCallbackType> mFailure;
 
     // Measure the time it took for the callback to trigger
-    NSDate * mResponseTime;
+    NSDate * mRequestTime;
     NSString * mCookie;
 };


### PR DESCRIPTION
#### Problem
No metrics available to track the time it takes for operations. 

#### Change overview
Added a simple log to track how long some operations take. 

#### Testing
* If manually tested, what platforms controller and device platforms were manually tested, and how?
Tested with CHIPTool iOS 
All command with callbacks will now report the time they took in logs. 
```
2022-02-11 14:55:37.033563-0800 CHIPTool[6578:3196599] [all] 🟢 [1644620137033] [6578:3196599] CHIP: [CTL] Response Time: PFvPvRKN4chip3app9DataModel14NullObjectTypeEE+1282435869 0.012232 seconds
```