### PR TITLE
Fix ACL Delete LogEvent Logic

### DIFF
--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -486,10 +486,13 @@ CHIP_ERROR AccessControlAttribute::WriteAcl(const ConcreteDataAttributePath & aP
 
         while (i < oldCount)
         {
+            AccessControl::Entry entry;
+
             --oldCount;
+            ReturnErrorOnFailure(GetAccessControl().ReadEntry(oldCount, entry, &accessingFabricIndex));
+            ReturnErrorOnFailure(
+                LogAccessControlEvent(entry, aDecoder.GetSubjectDescriptor(), AccessControlCluster::ChangeTypeEnum::kRemoved));
             ReturnErrorOnFailure(GetAccessControl().DeleteEntry(oldCount, &accessingFabricIndex));
-            ReturnErrorOnFailure(LogAccessControlEvent(iterator.GetValue().entry, aDecoder.GetSubjectDescriptor(),
-                                                       AccessControlCluster::ChangeTypeEnum::kRemoved));
         }
     }
     else if (aPath.mListOp == ConcreteDataAttributePath::ListOperation::AppendItem)


### PR DESCRIPTION
### Problem:

When deleting existing ACLs as part of processing a Write Request
containing a 'replace all' list operation, the existing logic was
incorrectly passing a pointer to the last entry that we had processed in
the newly provided list when calling `LogEvent()`.

Not only is this logging the wrong entry beyond the first iteration of the delete loop, it also does not work if the new list being provided to the caller is actually empty (causing `iterator.GetValue()` to actually have incorrect data).

This caused it to send an error back to the client during processing of that invalid entry.

### Fix:

Correctly read out the i-th entry from the existing ACL list and log
that before deleting that entry.

### Testing:

Validated by using reproducing the original error in the REPL, and
validating that it succeeds after.