### PR TITLE
Update persistent storage app for P6 platform

### DIFF
--- a/examples/persistent-storage/p6/main.cpp
+++ b/examples/persistent-storage/p6/main.cpp
@@ -19,37 +19,53 @@
 #include "AppConfig.h"
 #include "KeyValueStorageTest.h"
 #include "init_p6Platform.h"
+#include <FreeRTOS.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/KeyValueStoreManager.h>
+#include <task.h>
 
 using namespace chip;
 
-int main(int argc, char * argv[])
+static TaskHandle_t sTestTaskHandle;
+void TestTask(void * pvParameter)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    err            = chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init();
+    if (err != CHIP_NO_ERROR)
+    {
+        P6_LOG("PersistedStorage::KeyValueStoreMgrImpl().Init() failed");
+        return;
+    }
+    while (1)
+    {
+        P6_LOG("Running Tests:");
+        chip::RunKvsTest();
+        vTaskDelay(60000); // Run every minute
+    }
+}
+
+extern "C" void vApplicationDaemonTaskStartupHook()
+{
+    // Init Chip memory management before the stack
+    chip::Platform::MemoryInit();
+
+    // Run tests
+    xTaskCreate(TestTask, "Test", 2048, NULL, 1, &sTestTaskHandle);
+}
+
+int main(int argc, char * argv[])
+{
     init_p6Platform();
-
-    err = chip::Platform::MemoryInit();
-    SuccessOrExit(err);
-
-    err = chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init();
-    SuccessOrExit(err);
 
     P6_LOG("=============================================\n");
     P6_LOG("chip-p6-persistent-storage-example starting\n");
     P6_LOG("=============================================\n");
 
-    while (1)
-    {
-        P6_LOG("Running Tests:\n");
-        chip::RunKvsTest();
-        cyhal_system_delay_ms(60000); // Run every minute
-    }
+    P6_LOG("Starting FreeRTOS scheduler");
 
-exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return 1;
-    }
-    return 0;
+    vTaskStartScheduler();
+
+    // Should never get here.
+    P6_LOG("vTaskStartScheduler() failed");
+    return -1;
 }


### PR DESCRIPTION
#### Problem
Persistent storage app for P6 needs to be updated to support new keymanagement support

#### Change overview
Persistent storage app changes 

#### Testing
Verified manually

**Logs:**
CHIP:P6: =============================================
CHIP:P6: chip-p6-persistent-storage-example starting
CHIP:P6: =============================================

CHIP:P6: Starting FreeRTOS scheduler
CHIP:P6: Running Tests:
CHIP:-: TestEmptyString(): PASSED
CHIP:-: TestString(): PASSED
CHIP:-: TestUint32(): PASSED
CHIP:-: TestArray(): PASSED
CHIP:-: TestStruct(): PASSED
CHIP:-: TestUpdateValue(): PASSED
CHIP:-: TestMultiRead(): PASSED
CHIP:P6: Running Tests:
CHIP:-: TestEmptyString(): PASSED
CHIP:-: TestString(): PASSED
CHIP:-: TestUint32(): PASSED
CHIP:-: TestArray(): PASSED
CHIP:-: TestStruct(): PASSED
CHIP:-: TestUpdateValue(): PASSED
CHIP:-: TestMultiRead(): PASSED
