### PR TITLE
Added CASE Authenticated Tag (CAT) Support To the Commissioner APIs.

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2021 Project CHIP Authors
+ *   Copyright (c) 2021-2022 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -218,6 +218,7 @@ CHIP_ERROR CHIPCommand::InitializeCommissioner(std::string key, chip::FabricId f
 
         ReturnLogErrorOnFailure(ephemeralKey.Initialize());
         ReturnLogErrorOnFailure(mCredIssuerCmds->GenerateControllerNOCChain(mCommissionerStorage.GetLocalNodeId(), fabricId,
+                                                                            mCommissionerStorage.GetCommissionerCATs(),
                                                                             ephemeralKey, rcacSpan, icacSpan, nocSpan));
         commissionerParams.operationalKeypair = &ephemeralKey;
         commissionerParams.controllerRCAC     = rcacSpan;

--- a/examples/chip-tool/commands/common/CredentialIssuerCommands.h
+++ b/examples/chip-tool/commands/common/CredentialIssuerCommands.h
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2021 Project CHIP Authors
+ *   Copyright (c) 2021-2022 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,6 +63,7 @@ public:
      *
      * @param[in] nodeId   The desired NodeId for the generated NOC Chain - May be optional/unused in some implementations.
      * @param[in] fabricId The desired FabricId for the generated NOC Chain - May be optional/unused in some implementations.
+     * @param[in] cats     The desired CATs for the generated NOC Chain - May be optional/unused in some implementations.
      * @param[in] keypair  The desired Keypair for the generated NOC Chain - May be optional/unused in some implementations.
      * @param[in,out] rcac  Buffer to hold the Root Certificate of the generated NOC Chain.
      * @param[in,out] icac  Buffer to hold the Intermediate Certificate of the generated NOC Chain.
@@ -70,7 +71,7 @@ public:
      *
      * @return CHIP_ERROR CHIP_NO_ERROR on success, or corresponding error code.
      */
-    virtual CHIP_ERROR GenerateControllerNOCChain(chip::NodeId nodeId, chip::FabricId fabricId, chip::Crypto::P256Keypair & keypair,
-                                                  chip::MutableByteSpan & rcac, chip::MutableByteSpan & icac,
-                                                  chip::MutableByteSpan & noc) = 0;
+    virtual CHIP_ERROR GenerateControllerNOCChain(chip::NodeId nodeId, chip::FabricId fabricId, const chip::CATValues & cats,
+                                                  chip::Crypto::P256Keypair & keypair, chip::MutableByteSpan & rcac,
+                                                  chip::MutableByteSpan & icac, chip::MutableByteSpan & noc) = 0;
 };

--- a/examples/chip-tool/commands/example/ExampleCredentialIssuerCommands.h
+++ b/examples/chip-tool/commands/example/ExampleCredentialIssuerCommands.h
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2021 Project CHIP Authors
+ *   Copyright (c) 2021-2022 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,11 +42,11 @@ public:
         return CHIP_NO_ERROR;
     }
     chip::Controller::OperationalCredentialsDelegate * GetCredentialIssuer() override { return &mOpCredsIssuer; }
-    CHIP_ERROR GenerateControllerNOCChain(chip::NodeId nodeId, chip::FabricId fabricId, chip::Crypto::P256Keypair & keypair,
-                                          chip::MutableByteSpan & rcac, chip::MutableByteSpan & icac,
-                                          chip::MutableByteSpan & noc) override
+    CHIP_ERROR GenerateControllerNOCChain(chip::NodeId nodeId, chip::FabricId fabricId, const chip::CATValues & cats,
+                                          chip::Crypto::P256Keypair & keypair, chip::MutableByteSpan & rcac,
+                                          chip::MutableByteSpan & icac, chip::MutableByteSpan & noc) override
     {
-        return mOpCredsIssuer.GenerateNOCChainAfterValidation(nodeId, fabricId, keypair.Pubkey(), rcac, icac, noc);
+        return mOpCredsIssuer.GenerateNOCChainAfterValidation(nodeId, fabricId, cats, keypair.Pubkey(), rcac, icac, noc);
     }
 
 private:

--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2020 Project CHIP Authors
+ *   Copyright (c) 2020-2022 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,11 +32,12 @@ using namespace ::chip;
 using namespace ::chip::Controller;
 using namespace ::chip::Logging;
 
-constexpr const char kDefaultSectionName[] = "Default";
-constexpr const char kPortKey[]            = "ListenPort";
-constexpr const char kLoggingKey[]         = "LoggingLevel";
-constexpr const char kLocalNodeIdKey[]     = "LocalNodeId";
-constexpr LogCategory kDefaultLoggingLevel = kLogCategory_Detail;
+constexpr const char kDefaultSectionName[]  = "Default";
+constexpr const char kPortKey[]             = "ListenPort";
+constexpr const char kLoggingKey[]          = "LoggingLevel";
+constexpr const char kLocalNodeIdKey[]      = "LocalNodeId";
+constexpr const char kCommissionerCATsKey[] = "CommissionerCATs";
+constexpr LogCategory kDefaultLoggingLevel  = kLogCategory_Detail;
 
 std::string GetFilename(const char * name)
 {
@@ -238,4 +239,30 @@ CHIP_ERROR PersistentStorage::SetLocalNodeId(NodeId value)
 {
     uint64_t nodeId = Encoding::LittleEndian::HostSwap64(value);
     return SyncSetKeyValue(kLocalNodeIdKey, &nodeId, sizeof(nodeId));
+}
+
+CATValues PersistentStorage::GetCommissionerCATs()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    CATValues cats;
+    chip::CATValues::Serialized serializedCATs;
+    uint16_t size = chip::CATValues::kSerializedLength;
+    err           = SyncGetKeyValue(kCommissionerCATsKey, serializedCATs, size);
+    if (err == CHIP_NO_ERROR && size == chip::CATValues::kSerializedLength)
+    {
+        err = cats.Deserialize(serializedCATs);
+        if (err == CHIP_NO_ERROR)
+        {
+            return cats;
+        }
+    }
+    return chip::kUndefinedCATs;
+}
+
+CHIP_ERROR PersistentStorage::SetCommissionerCATs(const CATValues & cats)
+{
+    chip::CATValues::Serialized serializedCATs;
+    ReturnErrorOnFailure(cats.Serialize(serializedCATs));
+
+    return SyncSetKeyValue(kCommissionerCATsKey, serializedCATs, sizeof(serializedCATs));
 }

--- a/examples/chip-tool/config/PersistentStorage.h
+++ b/examples/chip-tool/config/PersistentStorage.h
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2020 Project CHIP Authors
+ *   Copyright (c) 2020-2022 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,6 +41,12 @@ public:
 
     // Store local node id.
     CHIP_ERROR SetLocalNodeId(chip::NodeId nodeId);
+
+    // Return the stored local device (commissioner) CASE Authenticated Tags (CATs).
+    chip::CATValues GetCommissionerCATs();
+
+    // Store local CATs.
+    CHIP_ERROR SetCommissionerCATs(const chip::CATValues & cats);
 
 private:
     CHIP_ERROR CommitConfig(const char * name);

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -398,8 +398,8 @@ CHIP_ERROR InitCommissioner()
     Crypto::P256Keypair ephemeralKey;
     ReturnErrorOnFailure(ephemeralKey.Initialize());
 
-    ReturnErrorOnFailure(gOpCredsIssuer.GenerateNOCChainAfterValidation(gLocalId, /* fabricId = */ 1, ephemeralKey.Pubkey(),
-                                                                        rcacSpan, icacSpan, nocSpan));
+    ReturnErrorOnFailure(gOpCredsIssuer.GenerateNOCChainAfterValidation(gLocalId, /* fabricId = */ 1, chip::kUndefinedCATs,
+                                                                        ephemeralKey.Pubkey(), rcacSpan, icacSpan, nocSpan));
 
     params.operationalKeypair = &ephemeralKey;
     params.controllerRCAC     = rcacSpan;

--- a/src/controller/ExampleOperationalCredentialsIssuer.h
+++ b/src/controller/ExampleOperationalCredentialsIssuer.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +31,7 @@
 
 #include <controller/OperationalCredentialsDelegate.h>
 #include <crypto/CHIPCryptoPAL.h>
+#include <lib/core/CASEAuthTag.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/support/CodeUtils.h>
@@ -99,8 +100,9 @@ public:
      * This method is expected to be called once all the checks (e.g. device attestation, CSR verification etc)
      * have been completed, or not required (e.g. for self trusted devices such as commissioner apps).
      */
-    CHIP_ERROR GenerateNOCChainAfterValidation(NodeId nodeId, FabricId fabricId, const Crypto::P256PublicKey & pubkey,
-                                               MutableByteSpan & rcac, MutableByteSpan & icac, MutableByteSpan & noc);
+    CHIP_ERROR GenerateNOCChainAfterValidation(NodeId nodeId, FabricId fabricId, const CATValues & cats,
+                                               const Crypto::P256PublicKey & pubkey, MutableByteSpan & rcac, MutableByteSpan & icac,
+                                               MutableByteSpan & noc);
 
 private:
     Crypto::P256Keypair mIssuer;

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -62,7 +62,7 @@ void AndroidDeviceControllerWrapper::CallJavaMethod(const char * methodName, jin
 
 AndroidDeviceControllerWrapper *
 AndroidDeviceControllerWrapper::AllocateNew(JavaVM * vm, jobject deviceControllerObj, chip::NodeId nodeId,
-                                            chip::System::Layer * systemLayer,
+                                            const chip::CATValues & cats, chip::System::Layer * systemLayer,
                                             chip::Inet::EndPointManager<Inet::TCPEndPoint> * tcpEndPointManager,
                                             chip::Inet::EndPointManager<Inet::UDPEndPoint> * udpEndPointManager,
                                             AndroidOperationalCredentialsIssuerPtr opCredsIssuerPtr, CHIP_ERROR * errInfoOnFailure)
@@ -163,8 +163,8 @@ AndroidDeviceControllerWrapper::AllocateNew(JavaVM * vm, jobject deviceControlle
         return nullptr;
     }
 
-    *errInfoOnFailure = opCredsIssuer->GenerateNOCChainAfterValidation(nodeId, /* fabricId = */ 1, ephemeralKey.Pubkey(), rcacSpan,
-                                                                       icacSpan, nocSpan);
+    *errInfoOnFailure = opCredsIssuer->GenerateNOCChainAfterValidation(nodeId, /* fabricId = */ 1, cats, ephemeralKey.Pubkey(),
+                                                                       rcacSpan, icacSpan, nocSpan);
     if (*errInfoOnFailure != CHIP_NO_ERROR)
     {
         return nullptr;

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2020-2021 Project CHIP Authors
+ *   Copyright (c) 2020-2022 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,7 +72,7 @@ public:
     using AndroidOperationalCredentialsIssuerPtr = std::unique_ptr<chip::Controller::AndroidOperationalCredentialsIssuer>;
 
     static AndroidDeviceControllerWrapper * AllocateNew(JavaVM * vm, jobject deviceControllerObj, chip::NodeId nodeId,
-                                                        chip::System::Layer * systemLayer,
+                                                        const chip::CATValues & cats, chip::System::Layer * systemLayer,
                                                         chip::Inet::EndPointManager<chip::Inet::TCPEndPoint> * tcpEndPointManager,
                                                         chip::Inet::EndPointManager<chip::Inet::UDPEndPoint> * udpEndPointManager,
                                                         AndroidOperationalCredentialsIssuerPtr opCredsIssuer,

--- a/src/controller/java/AndroidOperationalCredentialsIssuer.h
+++ b/src/controller/java/AndroidOperationalCredentialsIssuer.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +31,7 @@
 
 #include <controller/OperationalCredentialsDelegate.h>
 #include <crypto/CHIPCryptoPAL.h>
+#include <lib/core/CASEAuthTag.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/support/CodeUtils.h>
@@ -81,8 +82,9 @@ public:
      * This method is expected to be called once all the checks (e.g. device attestation, CSR verification etc)
      * have been completed, or not required (e.g. for self trusted devices such as commissioner apps).
      */
-    CHIP_ERROR GenerateNOCChainAfterValidation(NodeId nodeId, FabricId fabricId, const Crypto::P256PublicKey & pubkey,
-                                               MutableByteSpan & rcac, MutableByteSpan & icac, MutableByteSpan & noc);
+    CHIP_ERROR GenerateNOCChainAfterValidation(NodeId nodeId, FabricId fabricId, const CATValues & cats,
+                                               const Crypto::P256PublicKey & pubkey, MutableByteSpan & rcac, MutableByteSpan & icac,
+                                               MutableByteSpan & noc);
 
 private:
     Crypto::P256Keypair mIssuer;

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -159,9 +159,9 @@ JNI_METHOD(jlong, newDeviceController)(JNIEnv * env, jobject self)
     ChipLogProgress(Controller, "newDeviceController() called");
     std::unique_ptr<chip::Controller::AndroidOperationalCredentialsIssuer> opCredsIssuer(
         new chip::Controller::AndroidOperationalCredentialsIssuer());
-    wrapper = AndroidDeviceControllerWrapper::AllocateNew(sJVM, self, kLocalDeviceId, &DeviceLayer::SystemLayer(),
-                                                          DeviceLayer::TCPEndPointManager(), DeviceLayer::UDPEndPointManager(),
-                                                          std::move(opCredsIssuer), &err);
+    wrapper = AndroidDeviceControllerWrapper::AllocateNew(sJVM, self, kLocalDeviceId, chip::kUndefinedCATs,
+                                                          &DeviceLayer::SystemLayer(), DeviceLayer::TCPEndPointManager(),
+                                                          DeviceLayer::UDPEndPointManager(), std::move(opCredsIssuer), &err);
     SuccessOrExit(err);
 
     // Create and start the IO thread. Must be called after Controller()->Init

--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *    Copyright (c) 2019-2020 Google LLC.
  *    Copyright (c) 2013-2018 Nest Labs, Inc.
  *    All rights reserved.
@@ -59,10 +59,10 @@ public:
 
     CHIP_ERROR Initialize(PersistentStorageDelegate & storageDelegate) { return mExampleOpCredsIssuer.Initialize(storageDelegate); }
 
-    CHIP_ERROR GenerateNOCChain(NodeId nodeId, FabricId fabricId, const Crypto::P256PublicKey & pubKey, MutableByteSpan & rcac,
-                                MutableByteSpan & icac, MutableByteSpan & noc)
+    CHIP_ERROR GenerateNOCChain(NodeId nodeId, FabricId fabricId, const CATValues & cats, const Crypto::P256PublicKey & pubKey,
+                                MutableByteSpan & rcac, MutableByteSpan & icac, MutableByteSpan & noc)
     {
-        return mExampleOpCredsIssuer.GenerateNOCChainAfterValidation(nodeId, fabricId, pubKey, rcac, icac, noc);
+        return mExampleOpCredsIssuer.GenerateNOCChainAfterValidation(nodeId, fabricId, cats, pubKey, rcac, icac, noc);
     }
 
 private:
@@ -159,7 +159,8 @@ ChipError::StorageType pychip_OpCreds_AllocateController(OpCredsContext * contex
     ReturnErrorCodeIf(!rcac.Alloc(Controller::kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY.AsInteger());
     MutableByteSpan rcacSpan(rcac.Get(), Controller::kMaxCHIPDERCertLength);
 
-    err = context->mAdapter->GenerateNOCChain(nodeId, fabricId, ephemeralKey.Pubkey(), rcacSpan, icacSpan, nocSpan);
+    err = context->mAdapter->GenerateNOCChain(nodeId, fabricId, chip::kUndefinedCATs, ephemeralKey.Pubkey(), rcacSpan, icacSpan,
+                                              nocSpan);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err.AsInteger());
 
     Controller::SetupParams initParams;

--- a/src/controller/python/chip/configuration/__init__.py
+++ b/src/controller/python/chip/configuration/__init__.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2021 Project CHIP Authors
+#    Copyright (c) 2021-2022 Project CHIP Authors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -19,8 +19,10 @@ from typing import Optional
 # Represents the node ID that is to be used when creating device
 # controllers/commissioning devices
 _local_node_id: Optional[int] = None
+_local_cat: Optional[int] = None
 
 DEFAULT_LOCAL_NODE_ID = 12345
+DEFAULT_COMMISSIONER_CAT = 0xABCD0010
 
 
 def SetLocalNodeId(node_id: int):
@@ -44,3 +46,26 @@ def GetLocalNodeId() -> int:
         SetLocalNodeId(DEFAULT_LOCAL_NODE_ID)
 
     return _local_node_id
+
+
+def SetCommissionerCAT(cat: int):
+    """Local (controllers/commissioning) device CASE Authenticated Tag (CAT).
+       Can be set at the start of scripts, however once set it cannot be reassigned.
+    """
+    global _local_cat
+
+    if _local_cat is not None:
+        raise Exception('Local CAT is already set.')
+
+    _local_cat = cat
+
+
+def GetCommissionerCAT() -> int:
+ """Returns the current local (controllers/commissioning) device CAT. If none has been set,
+    a default is set and used."""
+  global _local_cat
+
+   if _local_cat is None:
+        SetCommissionerCAT(DEFAULT_COMMISSIONER_CAT)
+
+    return _local_cat

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -93,7 +93,8 @@ pychip_internal_PairingDelegate_SetPairingCompleteCallback(ScriptDevicePairingDe
     gPairingDelegate.SetPairingCompleteCallback(callback);
 }
 
-extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_New(uint64_t localDeviceId)
+extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_New(uint64_t localDeviceId,
+                                                                                   uint32_t localCommissionerCAT)
 {
     std::unique_ptr<chip::Controller::DeviceCommissioner> result;
     CHIP_ERROR err;
@@ -138,8 +139,9 @@ extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_N
             chip::MutableByteSpan nocSpan(noc.Get(), chip::Controller::kMaxCHIPDERCertLength);
             chip::MutableByteSpan icacSpan(icac.Get(), chip::Controller::kMaxCHIPDERCertLength);
             chip::MutableByteSpan rcacSpan(rcac.Get(), chip::Controller::kMaxCHIPDERCertLength);
-            err = gOperationalCredentialsIssuer.GenerateNOCChainAfterValidation(localDeviceId, /* fabricId = */ 1,
-                                                                                ephemeralKey.Pubkey(), rcacSpan, icacSpan, nocSpan);
+            err = gOperationalCredentialsIssuer.GenerateNOCChainAfterValidation(
+                localDeviceId, /* fabricId = */ 1, { { localCommissionerCAT, chip::kUndefinedCAT, chip::kUndefinedCAT } },
+                ephemeralKey.Pubkey(), rcacSpan, icacSpan, nocSpan);
             SuccessOrExit(err);
 
             commissionerParams.operationalCredentialsDelegate = &gOperationalCredentialsIssuer;

--- a/src/controller/python/chip/internal/commissioner.py
+++ b/src/controller/python/chip/internal/commissioner.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2021 Project CHIP Authors
+#    Copyright (c) 2021-2022 Project CHIP Authors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 #    limitations under the License.
 #
 from chip.configuration import GetLocalNodeId
+from chip.configuration import GetCommissionerCAT
 from chip.native import NativeLibraryHandleMethodArguments, GetLibraryHandle
 from enum import Enum
 from typing import Optional
@@ -103,7 +104,7 @@ def _SetNativeCallSignatues(handle: ctypes.CDLL):
     setter = NativeLibraryHandleMethodArguments(handle)
 
     setter.Set('pychip_internal_Commissioner_New',
-               Commissioner_p, [ctypes.c_uint64])
+               Commissioner_p, [ctypes.c_uint64, ctypes.c_uint32])
     setter.Set('pychip_internal_Commissioner_Unpair',
                ctypes.c_uint32, [Commissioner_p, ctypes.c_uint64])
     setter.Set('pychip_internal_Commissioner_BleConnectForPairing',
@@ -119,7 +120,7 @@ commissionerSingleton: Optional[Commissioner] = None
 def GetCommissioner() -> Commissioner:
     """Gets a reference to the global commissioner singleton.
 
-    Uses the configuration GetLocalNodeId().
+    Uses the configuration GetLocalNodeId() and GetCommissionerCAT().
     """
 
     global commissionerSingleton
@@ -128,7 +129,8 @@ def GetCommissioner() -> Commissioner:
         handle = GetLibraryHandle()
         _SetNativeCallSignatues(handle)
 
-        native = handle.pychip_internal_Commissioner_New(GetLocalNodeId())
+        native = handle.pychip_internal_Commissioner_New(
+            GetLocalNodeId(), GetCommissionerCAT())
         if not native:
             raise Exception('Failed to create commissioner object.')
 

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -576,6 +576,19 @@ CHIP_ERROR ChipDN::AddAttribute(chip::ASN1::OID oid, uint64_t val)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ChipDN::AddCATs(const chip::CATValues & cats)
+{
+    for (auto & cat : cats.values)
+    {
+        if (cat != kUndefinedCAT)
+        {
+            ReturnErrorOnFailure(AddAttribute(chip::ASN1::kOID_AttributeType_ChipCASEAuthenticatedTag, cat));
+        }
+    }
+
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR ChipDN::AddAttribute(chip::ASN1::OID oid, CharSpan val, bool isPrintableString)
 {
     uint8_t rdnCount = RDNCount();

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -231,6 +231,15 @@ public:
     CHIP_ERROR AddAttribute(chip::ASN1::OID oid, uint64_t val);
 
     /**
+     * @brief Add CASE Authenticated Tags (CATs) attributes to the DN.
+     *
+     * @param cats    Array of CAT values.
+     *
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR AddCATs(const chip::CATValues & cats);
+
+    /**
      * @brief Add string attribute to the DN.
      *
      * @param oid     String OID for DN attribute.

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -214,7 +214,7 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
         chip::MutableByteSpan icac;
 
         errorCode = _operationalCredentialsDelegate->GenerateNOCChainAfterValidation(
-            _localDeviceId, /* fabricId = */ 1, ephemeralKey.Pubkey(), rcac, icac, noc);
+            _localDeviceId, /* fabricId = */ 1, chip::kUndefinedCATs, ephemeralKey.Pubkey(), rcac, icac, noc);
         if ([self checkForStartError:(CHIP_NO_ERROR == errorCode) logMsg:kErrorCommissionerInit]) {
             return;
         }

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 #import "CHIPPersistentStorageDelegateBridge.h"
 
 #include <controller/OperationalCredentialsDelegate.h>
+#include <lib/core/CASEAuthTag.h>
 #include <platform/Darwin/CHIPP256KeypairNativeBridge.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -52,7 +53,7 @@ public:
     void SetDeviceID(chip::NodeId deviceId) { mDeviceBeingPaired = deviceId; }
     void ResetDeviceID() { mDeviceBeingPaired = chip::kUndefinedNodeId; }
 
-    CHIP_ERROR GenerateNOCChainAfterValidation(chip::NodeId nodeId, chip::FabricId fabricId,
+    CHIP_ERROR GenerateNOCChainAfterValidation(chip::NodeId nodeId, chip::FabricId fabricId, const chip::CATValues & cats,
         const chip::Crypto::P256PublicKey & pubkey, chip::MutableByteSpan & rcac, chip::MutableByteSpan & icac,
         chip::MutableByteSpan & noc);
 

--- a/src/lib/core/CASEAuthTag.h
+++ b/src/lib/core/CASEAuthTag.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <lib/core/CHIPConfig.h>
+#include <lib/core/CHIPEncoding.h>
 #include <lib/core/NodeId.h>
 #include <lib/support/CodeUtils.h>
 
@@ -55,6 +56,29 @@ struct CATValues
             }
         }
         return false;
+    }
+
+    static constexpr size_t kSerializedLength = kMaxSubjectCATAttributeCount * sizeof(CASEAuthTag);
+    typedef uint8_t Serialized[kSerializedLength];
+
+    CHIP_ERROR Serialize(Serialized & outSerialized) const
+    {
+        uint8_t * p = outSerialized;
+        for (size_t i = 0; i < kMaxSubjectCATAttributeCount; i++)
+        {
+            Encoding::LittleEndian::Write32(p, values[i]);
+        }
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR Deserialize(const Serialized & inSerialized)
+    {
+        const uint8_t * p = inSerialized;
+        for (size_t i = 0; i < kMaxSubjectCATAttributeCount; i++)
+        {
+            values[i] = Encoding::LittleEndian::Read32(p);
+        }
+        return CHIP_NO_ERROR;
     }
 };
 

--- a/src/lib/core/CHIPVendorIdentifiers.hpp
+++ b/src/lib/core/CHIPVendorIdentifiers.hpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *    Copyright (c) 2014-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,5 +49,10 @@ enum VendorId : uint16_t
     TestVendor4  = 0xFFF4u,
     NotSpecified = 0xFFFFu
 };
+
+constexpr bool IsTestVendorId(VendorId vid)
+{
+    return (vid >= TestVendor1 && vid <= TestVendor4);
+}
 
 } // namespace chip


### PR DESCRIPTION
#### Problem
Current code doesn't support CASE Authenticated Tags in the Operation Certificates generation logic.

#### Change overview
Added CAT support

#### Testing
existing tests