### PR TITLE
Fix name overlaps for lists in chip-tool.

### DIFF
--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -301,6 +301,7 @@ class {{filename}}: public TestCommand
         {{#if isCommand}}
         using RequestType = chip::app::Clusters::{{asUpperCamelCase cluster}}::Commands::{{asUpperCamelCase command}}::Type;
 
+        ListFreer listFreer;
         RequestType request;
         {{#chip_tests_item_parameters}}
         {{>commandValue ns=parent.cluster container=(concat "request." (asLowerCamelCase label)) definedValue=definedValue depth=0}}
@@ -334,6 +335,7 @@ class {{filename}}: public TestCommand
         cluster.Associate({{>device}}, endpoint);
         {{/if}}
 
+        ListFreer listFreer;
         {{#chip_tests_item_parameters}}
         {{zapTypeToEncodableClusterObjectType type ns=parent.cluster}} {{asLowerCamelCase name}}Argument;
         {{>commandValue ns=parent.cluster container=(concat (asLowerCamelCase name) "Argument") definedValue=definedValue depth=0}}

--- a/examples/chip-tool/templates/partials/test_cluster_command_value.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster_command_value.zapt
@@ -14,13 +14,14 @@
       Similarly, forceNotOptional=true and forceNotNullable=true because we
       have accounted for those already. }}
   {{#if definedValue.length}}
-  {{! This should really do heap-allocation with a function-scope-wide
-      auto-free setup, so we could guarantee no name collisions. }}
-  {{zapTypeToEncodableClusterObjectType type ns=ns forceNotList=true forceNotNullable=true forceNotOptional=true}} {{asLowerCamelCase label}}List_{{depth}}[{{definedValue.length}}];
-  {{#each definedValue}}
-  {{>commandValue ns=../ns container=(concat (asLowerCamelCase ../label) "List_" ../depth "[" @index "]") definedValue=. type=../type depth=(incrementDepth ../depth) parent=../parent}}
-  {{/each}}
-  {{container}} = {{asLowerCamelCase label}}List_{{depth}};
+  {
+    auto * listHolder_{{depth}} = new ListHolder<{{zapTypeToEncodableClusterObjectType type ns=ns forceNotList=true forceNotNullable=true forceNotOptional=true}}>({{definedValue.length}});
+    listFreer.add(listHolder_{{depth}});
+    {{#each definedValue}}
+    {{>commandValue ns=../ns container=(concat "listHolder_" ../depth "->mList[" @index "]") definedValue=. type=../type depth=(incrementDepth ../depth) parent=../parent}}
+    {{/each}}
+    {{container}} = chip::app::DataModel::List<{{zapTypeToEncodableClusterObjectType type ns=ns forceNotList=true forceNotNullable=true forceNotOptional=true}}>(listHolder_{{depth}}->mList, {{definedValue.length}});
+  }
   {{else}}
   {{container}} = chip::app::DataModel::List<{{zapTypeToEncodableClusterObjectType type ns=ns forceNotList=true forceNotNullable=true forceNotOptional=true}}>();
   {{/if}}

--- a/examples/chip-tool/templates/tests-commands.zapt
+++ b/examples/chip-tool/templates/tests-commands.zapt
@@ -5,6 +5,7 @@
 #include <commands/tests/TestCommand.h>
 #include <commands/common/CommandInvoker.h>
 #include <lib/core/Optional.h>
+#include <lib/support/CHIPListUtils.h>
 #include <system/SystemClock.h>
 
 #include <math.h> // For INFINITY

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -22,6 +22,7 @@
 #include <commands/common/CommandInvoker.h>
 #include <commands/tests/TestCommand.h>
 #include <lib/core/Optional.h>
+#include <lib/support/CHIPListUtils.h>
 #include <system/SystemClock.h>
 
 #include <math.h> // For INFINITY
@@ -355,6 +356,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -379,6 +382,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -402,6 +407,7 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 1U;
 
@@ -424,6 +430,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -448,6 +456,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::AttributeList::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -697,6 +707,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::OutOfService::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -721,6 +733,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::OutOfService::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -744,6 +758,7 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool outOfServiceArgument;
         outOfServiceArgument = 0;
 
@@ -765,6 +780,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::OutOfService::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -790,6 +807,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::PresentValue::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
@@ -813,6 +832,7 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool presentValueArgument;
         presentValueArgument = 0;
 
@@ -834,6 +854,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::PresentValue::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
@@ -859,6 +881,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::StatusFlags::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
         return CHIP_NO_ERROR;
@@ -882,6 +906,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::StatusFlags::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
@@ -908,6 +934,7 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t statusFlagsArgument;
         statusFlagsArgument = 0;
 
@@ -930,6 +957,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::StatusFlags::TypeInfo>(
             this, OnSuccessCallback_11, OnFailureCallback_11));
@@ -1184,6 +1213,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::PresentValue::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -1207,6 +1238,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::OutOfService::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -1232,6 +1265,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::StatusFlags::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -1255,6 +1290,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::PresentValue::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -1280,6 +1317,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::OutOfService::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
@@ -1303,6 +1342,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::StatusFlags::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -1328,6 +1369,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::StatusFlags::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
         return CHIP_NO_ERROR;
@@ -1351,6 +1394,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::StatusFlags::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
@@ -1522,6 +1567,8 @@ private:
         chip::Controller::BooleanStateClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BooleanState::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -1546,6 +1593,8 @@ private:
         chip::Controller::BooleanStateClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BooleanState::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -1569,6 +1618,7 @@ private:
         chip::Controller::BooleanStateClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 1U;
 
@@ -1591,6 +1641,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::BooleanStateClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BooleanState::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -1615,6 +1667,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::BooleanStateClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BooleanState::Attributes::AttributeList::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -1771,6 +1825,8 @@ private:
         chip::Controller::BooleanStateClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BooleanState::Attributes::StateValue::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -1795,6 +1851,8 @@ private:
         chip::Controller::BooleanStateClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BooleanState::Attributes::StateValue::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -1818,6 +1876,7 @@ private:
         chip::Controller::BooleanStateClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool stateValueArgument;
         stateValueArgument = 1;
 
@@ -1840,6 +1899,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::BooleanStateClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BooleanState::Attributes::StateValue::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -1971,6 +2032,8 @@ private:
         chip::Controller::BridgedActionsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BridgedActions::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -1994,6 +2057,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::BridgedActionsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::BridgedActions::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -2135,6 +2200,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -2158,6 +2225,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 4U;
 
@@ -2180,6 +2248,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::AttributeList::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -4303,6 +4373,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentHue::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -4326,6 +4398,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentHue::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -4352,6 +4426,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t currentHueArgument;
         currentHueArgument = 0;
 
@@ -4374,6 +4449,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentHue::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -4399,6 +4476,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentSaturation::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
@@ -4422,6 +4501,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentSaturation::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -4448,6 +4529,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t currentSaturationArgument;
         currentSaturationArgument = 0;
 
@@ -4470,6 +4552,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentSaturation::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
@@ -4495,6 +4579,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentX::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
         return CHIP_NO_ERROR;
@@ -4518,6 +4604,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentX::TypeInfo>(
             this, OnSuccessCallback_10, OnFailureCallback_10));
@@ -4544,6 +4632,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t currentXArgument;
         currentXArgument = 24939U;
 
@@ -4566,6 +4655,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentX::TypeInfo>(
             this, OnSuccessCallback_12, OnFailureCallback_12));
@@ -4591,6 +4682,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentY::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
         return CHIP_NO_ERROR;
@@ -4614,6 +4707,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentY::TypeInfo>(
             this, OnSuccessCallback_14, OnFailureCallback_14));
@@ -4640,6 +4735,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t currentYArgument;
         currentYArgument = 24701U;
 
@@ -4662,6 +4758,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentY::TypeInfo>(
             this, OnSuccessCallback_16, OnFailureCallback_16));
@@ -4686,6 +4784,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTemperature::TypeInfo>(
             this, OnSuccessCallback_17, OnFailureCallback_17));
@@ -4712,6 +4812,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorMode::TypeInfo>(
             this, OnSuccessCallback_18, OnFailureCallback_18));
         return CHIP_NO_ERROR;
@@ -4737,6 +4839,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorControlOptions::TypeInfo>(
             this, OnSuccessCallback_19, OnFailureCallback_19));
         return CHIP_NO_ERROR;
@@ -4761,6 +4865,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorControlOptions::TypeInfo>(
             this, OnSuccessCallback_20, OnFailureCallback_20));
         return CHIP_NO_ERROR;
@@ -4784,6 +4890,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t colorControlOptionsArgument;
         colorControlOptionsArgument = 0;
 
@@ -4805,6 +4912,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorControlOptions::TypeInfo>(
             this, OnSuccessCallback_22, OnFailureCallback_22));
@@ -4830,6 +4939,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_23, OnFailureCallback_23));
         return CHIP_NO_ERROR;
@@ -4854,6 +4965,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_24, OnFailureCallback_24));
         return CHIP_NO_ERROR;
@@ -4877,6 +4990,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t enhancedCurrentHueArgument;
         enhancedCurrentHueArgument = 0U;
 
@@ -4899,6 +5013,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_26, OnFailureCallback_26));
@@ -4924,6 +5040,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedColorMode::TypeInfo>(
             this, OnSuccessCallback_27, OnFailureCallback_27));
         return CHIP_NO_ERROR;
@@ -4946,6 +5064,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_28, OnFailureCallback_28));
@@ -4971,6 +5091,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_29, OnFailureCallback_29));
         return CHIP_NO_ERROR;
@@ -4994,6 +5116,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t colorLoopActiveArgument;
         colorLoopActiveArgument = 0;
 
@@ -5016,6 +5139,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_31, OnFailureCallback_31));
@@ -5041,6 +5166,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
             this, OnSuccessCallback_32, OnFailureCallback_32));
         return CHIP_NO_ERROR;
@@ -5065,6 +5192,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
             this, OnSuccessCallback_33, OnFailureCallback_33));
         return CHIP_NO_ERROR;
@@ -5088,6 +5217,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t colorLoopDirectionArgument;
         colorLoopDirectionArgument = 0;
 
@@ -5110,6 +5240,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
             this, OnSuccessCallback_35, OnFailureCallback_35));
@@ -5135,6 +5267,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
             this, OnSuccessCallback_36, OnFailureCallback_36));
         return CHIP_NO_ERROR;
@@ -5159,6 +5293,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
             this, OnSuccessCallback_37, OnFailureCallback_37));
         return CHIP_NO_ERROR;
@@ -5182,6 +5318,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t colorLoopTimeArgument;
         colorLoopTimeArgument = 25U;
 
@@ -5204,6 +5341,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
             this, OnSuccessCallback_39, OnFailureCallback_39));
@@ -5228,6 +5367,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStartEnhancedHue::TypeInfo>(
@@ -5254,6 +5395,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStartEnhancedHue::TypeInfo>(
                 this, OnSuccessCallback_41, OnFailureCallback_41));
@@ -5278,6 +5421,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t colorLoopStartEnhancedHueArgument;
         colorLoopStartEnhancedHueArgument = 8960U;
 
@@ -5301,6 +5445,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStartEnhancedHue::TypeInfo>(
@@ -5327,6 +5473,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
                 this, OnSuccessCallback_44, OnFailureCallback_44));
@@ -5352,6 +5500,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
                 this, OnSuccessCallback_45, OnFailureCallback_45));
@@ -5376,6 +5526,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t colorLoopStoredEnhancedHueArgument;
         colorLoopStoredEnhancedHueArgument = 0U;
 
@@ -5399,6 +5550,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
@@ -5425,6 +5578,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorCapabilities::TypeInfo>(
             this, OnSuccessCallback_48, OnFailureCallback_48));
         return CHIP_NO_ERROR;
@@ -5448,6 +5603,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorCapabilities::TypeInfo>(
             this, OnSuccessCallback_49, OnFailureCallback_49));
@@ -5474,6 +5631,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t colorCapabilitiesArgument;
         colorCapabilitiesArgument = 0U;
 
@@ -5496,6 +5654,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorCapabilities::TypeInfo>(
             this, OnSuccessCallback_51, OnFailureCallback_51));
@@ -5521,6 +5681,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTempPhysicalMin::TypeInfo>(
             this, OnSuccessCallback_52, OnFailureCallback_52));
         return CHIP_NO_ERROR;
@@ -5544,6 +5706,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTempPhysicalMin::TypeInfo>(
             this, OnSuccessCallback_53, OnFailureCallback_53));
@@ -5570,6 +5734,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t colorTempPhysicalMinArgument;
         colorTempPhysicalMinArgument = 0U;
 
@@ -5592,6 +5757,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTempPhysicalMin::TypeInfo>(
             this, OnSuccessCallback_55, OnFailureCallback_55));
@@ -5617,6 +5784,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTempPhysicalMax::TypeInfo>(
             this, OnSuccessCallback_56, OnFailureCallback_56));
         return CHIP_NO_ERROR;
@@ -5640,6 +5809,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTempPhysicalMax::TypeInfo>(
             this, OnSuccessCallback_57, OnFailureCallback_57));
@@ -5666,6 +5837,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t colorTempPhysicalMaxArgument;
         colorTempPhysicalMaxArgument = 65279U;
 
@@ -5688,6 +5860,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTempPhysicalMax::TypeInfo>(
             this, OnSuccessCallback_59, OnFailureCallback_59));
@@ -5713,6 +5887,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CoupleColorTempToLevelMinMireds::TypeInfo>(
                 this, OnSuccessCallback_60, OnFailureCallback_60));
@@ -5737,6 +5913,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t coupleColorTempToLevelMinMiredsArgument;
         coupleColorTempToLevelMinMiredsArgument = 0U;
 
@@ -5760,6 +5937,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CoupleColorTempToLevelMinMireds::TypeInfo>(
@@ -5785,6 +5964,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::StartUpColorTemperatureMireds::TypeInfo>(
@@ -5812,6 +5993,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t startUpColorTemperatureMiredsArgument;
         startUpColorTemperatureMiredsArgument = 0U;
 
@@ -5834,6 +6016,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::StartUpColorTemperatureMireds::TypeInfo>(
@@ -5860,6 +6044,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::RemainingTime::TypeInfo>(
             this, OnSuccessCallback_66, OnFailureCallback_66));
         return CHIP_NO_ERROR;
@@ -5883,6 +6069,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::RemainingTime::TypeInfo>(
             this, OnSuccessCallback_67, OnFailureCallback_67));
@@ -5909,6 +6097,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t remainingTimeArgument;
         remainingTimeArgument = 0U;
 
@@ -5931,6 +6120,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::RemainingTime::TypeInfo>(
             this, OnSuccessCallback_69, OnFailureCallback_69));
@@ -5955,6 +6146,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::DriftCompensation::TypeInfo>(
             this, OnSuccessCallback_70, OnFailureCallback_70));
@@ -5981,6 +6174,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t driftCompensationArgument;
         driftCompensationArgument = 0;
 
@@ -6003,6 +6197,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::DriftCompensation::TypeInfo>(
             this, OnSuccessCallback_72, OnFailureCallback_72));
@@ -6028,6 +6224,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CompensationText::TypeInfo>(
             this, OnSuccessCallback_73, OnFailureCallback_73));
         return CHIP_NO_ERROR;
@@ -6052,6 +6250,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan compensationTextArgument;
         compensationTextArgument = chip::Span<const char>("garbage: not in length on purpose", 0);
 
@@ -6074,6 +6273,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CompensationText::TypeInfo>(
             this, OnSuccessCallback_75, OnFailureCallback_75));
@@ -6098,6 +6299,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::NumberOfPrimaries::TypeInfo>(
             this, OnSuccessCallback_76, OnFailureCallback_76));
@@ -6124,6 +6327,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t numberOfPrimariesArgument;
         numberOfPrimariesArgument = 0;
 
@@ -6146,6 +6350,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::NumberOfPrimaries::TypeInfo>(
             this, OnSuccessCallback_78, OnFailureCallback_78));
@@ -6170,6 +6376,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary1X::TypeInfo>(
             this, OnSuccessCallback_79, OnFailureCallback_79));
@@ -6196,6 +6404,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t primary1XArgument;
         primary1XArgument = 0U;
 
@@ -6218,6 +6427,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary1X::TypeInfo>(
             this, OnSuccessCallback_81, OnFailureCallback_81));
@@ -6242,6 +6453,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary1Y::TypeInfo>(
             this, OnSuccessCallback_82, OnFailureCallback_82));
@@ -6268,6 +6481,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t primary1YArgument;
         primary1YArgument = 0U;
 
@@ -6290,6 +6504,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary1Y::TypeInfo>(
             this, OnSuccessCallback_84, OnFailureCallback_84));
@@ -6315,6 +6531,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary1Intensity::TypeInfo>(
             this, OnSuccessCallback_85, OnFailureCallback_85));
         return CHIP_NO_ERROR;
@@ -6337,6 +6555,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary2X::TypeInfo>(
             this, OnSuccessCallback_86, OnFailureCallback_86));
@@ -6363,6 +6583,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t primary2XArgument;
         primary2XArgument = 0U;
 
@@ -6385,6 +6606,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary2X::TypeInfo>(
             this, OnSuccessCallback_88, OnFailureCallback_88));
@@ -6409,6 +6632,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary2Y::TypeInfo>(
             this, OnSuccessCallback_89, OnFailureCallback_89));
@@ -6435,6 +6660,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t primary2YArgument;
         primary2YArgument = 0U;
 
@@ -6457,6 +6683,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary2Y::TypeInfo>(
             this, OnSuccessCallback_91, OnFailureCallback_91));
@@ -6482,6 +6710,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary2Intensity::TypeInfo>(
             this, OnSuccessCallback_92, OnFailureCallback_92));
         return CHIP_NO_ERROR;
@@ -6504,6 +6734,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary3X::TypeInfo>(
             this, OnSuccessCallback_93, OnFailureCallback_93));
@@ -6530,6 +6762,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t primary3XArgument;
         primary3XArgument = 0U;
 
@@ -6552,6 +6785,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary3X::TypeInfo>(
             this, OnSuccessCallback_95, OnFailureCallback_95));
@@ -6576,6 +6811,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary3Y::TypeInfo>(
             this, OnSuccessCallback_96, OnFailureCallback_96));
@@ -6602,6 +6839,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t primary3YArgument;
         primary3YArgument = 0U;
 
@@ -6624,6 +6862,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary3Y::TypeInfo>(
             this, OnSuccessCallback_98, OnFailureCallback_98));
@@ -6649,6 +6889,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary3Intensity::TypeInfo>(
             this, OnSuccessCallback_99, OnFailureCallback_99));
         return CHIP_NO_ERROR;
@@ -6671,6 +6913,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary4X::TypeInfo>(
             this, OnSuccessCallback_100, OnFailureCallback_100));
@@ -6697,6 +6941,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t primary4XArgument;
         primary4XArgument = 0U;
 
@@ -6719,6 +6964,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary4X::TypeInfo>(
             this, OnSuccessCallback_102, OnFailureCallback_102));
@@ -6743,6 +6990,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary4Y::TypeInfo>(
             this, OnSuccessCallback_103, OnFailureCallback_103));
@@ -6769,6 +7018,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t primary4YArgument;
         primary4YArgument = 0U;
 
@@ -6791,6 +7041,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary4Y::TypeInfo>(
             this, OnSuccessCallback_105, OnFailureCallback_105));
@@ -6816,6 +7068,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary4Intensity::TypeInfo>(
             this, OnSuccessCallback_106, OnFailureCallback_106));
         return CHIP_NO_ERROR;
@@ -6838,6 +7092,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary5X::TypeInfo>(
             this, OnSuccessCallback_107, OnFailureCallback_107));
@@ -6864,6 +7120,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t primary5XArgument;
         primary5XArgument = 0U;
 
@@ -6886,6 +7143,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary5X::TypeInfo>(
             this, OnSuccessCallback_109, OnFailureCallback_109));
@@ -6910,6 +7169,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary5Y::TypeInfo>(
             this, OnSuccessCallback_110, OnFailureCallback_110));
@@ -6936,6 +7197,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t primary5YArgument;
         primary5YArgument = 0U;
 
@@ -6958,6 +7220,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary5Y::TypeInfo>(
             this, OnSuccessCallback_112, OnFailureCallback_112));
@@ -6983,6 +7247,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary5Intensity::TypeInfo>(
             this, OnSuccessCallback_113, OnFailureCallback_113));
         return CHIP_NO_ERROR;
@@ -7005,6 +7271,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary6X::TypeInfo>(
             this, OnSuccessCallback_114, OnFailureCallback_114));
@@ -7031,6 +7299,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t primary6XArgument;
         primary6XArgument = 0U;
 
@@ -7053,6 +7322,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary6X::TypeInfo>(
             this, OnSuccessCallback_116, OnFailureCallback_116));
@@ -7077,6 +7348,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary6Y::TypeInfo>(
             this, OnSuccessCallback_117, OnFailureCallback_117));
@@ -7103,6 +7376,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t primary6YArgument;
         primary6YArgument = 0U;
 
@@ -7125,6 +7399,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary6Y::TypeInfo>(
             this, OnSuccessCallback_119, OnFailureCallback_119));
@@ -7150,6 +7426,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary6Intensity::TypeInfo>(
             this, OnSuccessCallback_120, OnFailureCallback_120));
         return CHIP_NO_ERROR;
@@ -7172,6 +7450,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::WhitePointX::TypeInfo>(
             this, OnSuccessCallback_121, OnFailureCallback_121));
@@ -7198,6 +7478,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t whitePointXArgument;
         whitePointXArgument = 0U;
 
@@ -7219,6 +7500,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::WhitePointX::TypeInfo>(
             this, OnSuccessCallback_123, OnFailureCallback_123));
@@ -7243,6 +7526,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::WhitePointY::TypeInfo>(
             this, OnSuccessCallback_124, OnFailureCallback_124));
@@ -7269,6 +7554,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t whitePointYArgument;
         whitePointYArgument = 0U;
 
@@ -7290,6 +7576,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::WhitePointY::TypeInfo>(
             this, OnSuccessCallback_126, OnFailureCallback_126));
@@ -7314,6 +7602,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointRX::TypeInfo>(
             this, OnSuccessCallback_127, OnFailureCallback_127));
@@ -7340,6 +7630,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t colorPointRXArgument;
         colorPointRXArgument = 0U;
 
@@ -7361,6 +7652,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointRX::TypeInfo>(
             this, OnSuccessCallback_129, OnFailureCallback_129));
@@ -7385,6 +7678,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointRY::TypeInfo>(
             this, OnSuccessCallback_130, OnFailureCallback_130));
@@ -7411,6 +7706,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t colorPointRYArgument;
         colorPointRYArgument = 0U;
 
@@ -7432,6 +7728,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointRY::TypeInfo>(
             this, OnSuccessCallback_132, OnFailureCallback_132));
@@ -7457,6 +7755,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointRIntensity::TypeInfo>(
             this, OnSuccessCallback_133, OnFailureCallback_133));
         return CHIP_NO_ERROR;
@@ -7480,6 +7780,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t colorPointRIntensityArgument;
         colorPointRIntensityArgument = 0;
 
@@ -7501,6 +7802,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointRIntensity::TypeInfo>(
             this, OnSuccessCallback_135, OnFailureCallback_135));
@@ -7525,6 +7828,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointGX::TypeInfo>(
             this, OnSuccessCallback_136, OnFailureCallback_136));
@@ -7551,6 +7856,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t colorPointGXArgument;
         colorPointGXArgument = 0U;
 
@@ -7572,6 +7878,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointGX::TypeInfo>(
             this, OnSuccessCallback_138, OnFailureCallback_138));
@@ -7596,6 +7904,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointGY::TypeInfo>(
             this, OnSuccessCallback_139, OnFailureCallback_139));
@@ -7622,6 +7932,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t colorPointGYArgument;
         colorPointGYArgument = 0U;
 
@@ -7643,6 +7954,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointGY::TypeInfo>(
             this, OnSuccessCallback_141, OnFailureCallback_141));
@@ -7668,6 +7981,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointGIntensity::TypeInfo>(
             this, OnSuccessCallback_142, OnFailureCallback_142));
         return CHIP_NO_ERROR;
@@ -7691,6 +8006,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t colorPointGIntensityArgument;
         colorPointGIntensityArgument = 0;
 
@@ -7712,6 +8028,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointGIntensity::TypeInfo>(
             this, OnSuccessCallback_144, OnFailureCallback_144));
@@ -7736,6 +8054,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointBX::TypeInfo>(
             this, OnSuccessCallback_145, OnFailureCallback_145));
@@ -7762,6 +8082,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t colorPointBXArgument;
         colorPointBXArgument = 0U;
 
@@ -7783,6 +8104,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointBX::TypeInfo>(
             this, OnSuccessCallback_147, OnFailureCallback_147));
@@ -7807,6 +8130,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointBY::TypeInfo>(
             this, OnSuccessCallback_148, OnFailureCallback_148));
@@ -7833,6 +8158,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t colorPointBYArgument;
         colorPointBYArgument = 0U;
 
@@ -7854,6 +8180,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointBY::TypeInfo>(
             this, OnSuccessCallback_150, OnFailureCallback_150));
@@ -7879,6 +8207,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointBIntensity::TypeInfo>(
             this, OnSuccessCallback_151, OnFailureCallback_151));
         return CHIP_NO_ERROR;
@@ -7902,6 +8232,7 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t colorPointBIntensityArgument;
         colorPointBIntensityArgument = 0;
 
@@ -7923,6 +8254,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointBIntensity::TypeInfo>(
             this, OnSuccessCallback_153, OnFailureCallback_153));
@@ -8090,6 +8423,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -8118,6 +8452,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -8141,6 +8477,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentHue::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -8166,6 +8504,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveToHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.hue             = 150;
         request.direction       = static_cast<chip::app::Clusters::ColorControl::HueDirection>(0);
@@ -8198,6 +8537,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveToHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.hue             = 200;
         request.direction       = static_cast<chip::app::Clusters::ColorControl::HueDirection>(1);
@@ -8230,6 +8570,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveToHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.hue             = 250;
         request.direction       = static_cast<chip::app::Clusters::ColorControl::HueDirection>(2);
@@ -8262,6 +8603,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveToHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.hue             = 225;
         request.direction       = static_cast<chip::app::Clusters::ColorControl::HueDirection>(3);
@@ -8294,6 +8636,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -8321,6 +8664,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
@@ -8474,6 +8819,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -8502,6 +8848,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -8525,6 +8873,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(1);
         request.rate            = 50;
@@ -8556,6 +8905,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(0);
         request.rate            = 50;
@@ -8587,6 +8937,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(3);
         request.rate            = 50;
@@ -8618,6 +8969,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(0);
         request.rate            = 50;
@@ -8649,6 +9001,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -8676,6 +9029,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
@@ -8821,6 +9176,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -8849,6 +9205,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -8872,6 +9230,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::StepHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.stepMode        = static_cast<chip::app::Clusters::ColorControl::HueStepMode>(1);
         request.stepSize        = 5;
@@ -8904,6 +9263,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::StepHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.stepMode        = static_cast<chip::app::Clusters::ColorControl::HueStepMode>(3);
         request.stepSize        = 5;
@@ -8936,6 +9296,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -8963,6 +9324,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -9104,6 +9467,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -9132,6 +9496,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -9155,6 +9521,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveToSaturation::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.saturation      = 90;
         request.transitionTime  = 10U;
@@ -9186,6 +9553,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -9213,6 +9581,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -9374,6 +9744,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -9402,6 +9773,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -9425,6 +9798,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::SaturationMoveMode>(1);
         request.rate            = 5;
@@ -9456,6 +9830,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::SaturationMoveMode>(3);
         request.rate            = 5;
@@ -9487,6 +9862,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::SaturationMoveMode>(1);
         request.rate            = 5;
@@ -9518,6 +9894,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::SaturationMoveMode>(0);
         request.rate            = 5;
@@ -9549,6 +9926,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::SaturationMoveMode>(3);
         request.rate            = 5;
@@ -9580,6 +9958,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::SaturationMoveMode>(0);
         request.rate            = 5;
@@ -9611,6 +9990,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -9638,6 +10018,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_10, OnFailureCallback_10));
@@ -9783,6 +10165,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -9811,6 +10194,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -9834,6 +10219,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::StepSaturation::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.stepMode        = static_cast<chip::app::Clusters::ColorControl::SaturationStepMode>(1);
         request.stepSize        = 15;
@@ -9866,6 +10252,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::StepSaturation::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.stepMode        = static_cast<chip::app::Clusters::ColorControl::SaturationStepMode>(3);
         request.stepSize        = 20;
@@ -9898,6 +10285,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -9925,6 +10313,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -10066,6 +10456,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -10094,6 +10485,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -10117,6 +10510,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveToHueAndSaturation::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.hue             = 40;
         request.saturation      = 160;
@@ -10149,6 +10543,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -10176,6 +10571,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -10317,6 +10714,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -10345,6 +10743,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -10368,6 +10768,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveToColor::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.colorX          = 200U;
         request.colorY          = 300U;
@@ -10400,6 +10801,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -10427,6 +10829,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -10572,6 +10976,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -10600,6 +11005,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -10623,6 +11030,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveColor::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.rateX           = 15;
         request.rateY           = 20;
@@ -10654,6 +11062,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::StopMoveStep::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
@@ -10683,6 +11092,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -10710,6 +11120,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -10851,6 +11263,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -10879,6 +11292,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -10902,6 +11317,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::StepColor::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.stepX           = 15;
         request.stepY           = 20;
@@ -10934,6 +11350,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -10961,6 +11378,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -11102,6 +11521,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -11130,6 +11550,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -11153,6 +11575,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveToColorTemperature::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.colorTemperature = 100U;
         request.transitionTime   = 10U;
@@ -11184,6 +11607,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -11211,6 +11635,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -11386,6 +11812,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -11414,6 +11841,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -11437,6 +11866,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTemperature::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -11462,6 +11893,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode                = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(1);
         request.rate                    = 10U;
@@ -11495,6 +11927,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode                = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(3);
         request.rate                    = 20U;
@@ -11528,6 +11961,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode                = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(1);
         request.rate                    = 10U;
@@ -11561,6 +11995,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode                = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(0);
         request.rate                    = 10U;
@@ -11594,6 +12029,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode                = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(3);
         request.rate                    = 20U;
@@ -11627,6 +12063,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode                = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(0);
         request.rate                    = 10U;
@@ -11660,6 +12097,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -11687,6 +12125,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_11, OnFailureCallback_11));
@@ -11832,6 +12272,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -11860,6 +12301,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -11883,6 +12326,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::StepColorTemperature::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.stepMode                = static_cast<chip::app::Clusters::ColorControl::HueStepMode>(1);
         request.stepSize                = 5U;
@@ -11917,6 +12361,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::StepColorTemperature::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.stepMode                = static_cast<chip::app::Clusters::ColorControl::HueStepMode>(3);
         request.stepSize                = 5U;
@@ -11951,6 +12396,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -11978,6 +12424,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -12135,6 +12583,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -12163,6 +12612,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -12186,6 +12637,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.enhancedHue     = 1025U;
         request.direction       = static_cast<chip::app::Clusters::ColorControl::HueDirection>(0);
@@ -12218,6 +12670,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.enhancedHue     = 1100U;
         request.direction       = static_cast<chip::app::Clusters::ColorControl::HueDirection>(0);
@@ -12250,6 +12703,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.enhancedHue     = 1150U;
         request.direction       = static_cast<chip::app::Clusters::ColorControl::HueDirection>(1);
@@ -12282,6 +12736,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.enhancedHue     = 1200U;
         request.direction       = static_cast<chip::app::Clusters::ColorControl::HueDirection>(2);
@@ -12314,6 +12769,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.enhancedHue     = 1300U;
         request.direction       = static_cast<chip::app::Clusters::ColorControl::HueDirection>(3);
@@ -12346,6 +12802,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -12373,6 +12830,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
@@ -12540,6 +12999,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -12568,6 +13028,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -12591,6 +13053,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -12616,6 +13080,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(1);
         request.rate            = 50U;
@@ -12647,6 +13112,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(0);
         request.rate            = 0U;
@@ -12678,6 +13144,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(3);
         request.rate            = 5U;
@@ -12709,6 +13176,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(0);
         request.rate            = 0U;
@@ -12740,6 +13208,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -12767,6 +13236,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
@@ -12912,6 +13383,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -12940,6 +13412,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -12963,6 +13437,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::EnhancedStepHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.stepMode        = static_cast<chip::app::Clusters::ColorControl::HueStepMode>(0);
         request.stepSize        = 50U;
@@ -12995,6 +13470,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::EnhancedStepHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.stepMode        = static_cast<chip::app::Clusters::ColorControl::HueStepMode>(1);
         request.stepSize        = 75U;
@@ -13027,6 +13503,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -13054,6 +13531,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -13195,6 +13674,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -13223,6 +13703,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -13246,6 +13728,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHueAndSaturation::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.enhancedHue     = 1200U;
         request.saturation      = 90;
@@ -13278,6 +13761,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -13305,6 +13789,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -13570,6 +14056,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -13598,6 +14085,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -13621,6 +14110,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(14);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -13656,6 +14146,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
@@ -13680,6 +14172,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
@@ -13703,6 +14197,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStartEnhancedHue::TypeInfo>(
@@ -13729,6 +14225,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
         return CHIP_NO_ERROR;
@@ -13752,6 +14250,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(1);
@@ -13787,6 +14286,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
         return CHIP_NO_ERROR;
@@ -13810,6 +14311,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(6);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -13845,6 +14347,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
             this, OnSuccessCallback_11, OnFailureCallback_11));
         return CHIP_NO_ERROR;
@@ -13869,6 +14373,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
             this, OnSuccessCallback_12, OnFailureCallback_12));
         return CHIP_NO_ERROR;
@@ -13892,6 +14398,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(2);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -13927,6 +14434,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
             this, OnSuccessCallback_14, OnFailureCallback_14));
         return CHIP_NO_ERROR;
@@ -13950,6 +14459,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -13977,6 +14487,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_16, OnFailureCallback_16));
@@ -14879,6 +15391,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -14907,6 +15420,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -14930,6 +15445,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -14965,6 +15481,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
@@ -14988,6 +15506,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(2);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -15023,6 +15542,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
         return CHIP_NO_ERROR;
@@ -15046,6 +15567,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(4);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -15081,6 +15603,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
         return CHIP_NO_ERROR;
@@ -15104,6 +15628,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(8);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -15139,6 +15664,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStartEnhancedHue::TypeInfo>(
                 this, OnSuccessCallback_10, OnFailureCallback_10));
@@ -15163,6 +15690,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(1);
@@ -15198,6 +15726,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_12, OnFailureCallback_12));
         return CHIP_NO_ERROR;
@@ -15221,6 +15751,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
@@ -15246,6 +15778,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
                 this, OnSuccessCallback_14, OnFailureCallback_14));
@@ -15270,6 +15804,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -15305,6 +15840,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_16, OnFailureCallback_16));
         return CHIP_NO_ERROR;
@@ -15328,6 +15865,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
@@ -15354,6 +15893,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_18, OnFailureCallback_18));
         return CHIP_NO_ERROR;
@@ -15377,6 +15918,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(2);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -15412,6 +15954,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
             this, OnSuccessCallback_20, OnFailureCallback_20));
         return CHIP_NO_ERROR;
@@ -15435,6 +15979,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(1);
@@ -15470,6 +16015,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_22, OnFailureCallback_22));
         return CHIP_NO_ERROR;
@@ -15493,6 +16040,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_23, OnFailureCallback_23));
@@ -15518,6 +16067,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
                 this, OnSuccessCallback_24, OnFailureCallback_24));
@@ -15542,6 +16093,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -15577,6 +16129,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_26, OnFailureCallback_26));
         return CHIP_NO_ERROR;
@@ -15600,6 +16154,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
@@ -15626,6 +16182,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_28, OnFailureCallback_28));
         return CHIP_NO_ERROR;
@@ -15649,6 +16207,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.enhancedHue     = 40960U;
         request.direction       = static_cast<chip::app::Clusters::ColorControl::HueDirection>(0);
@@ -15688,6 +16247,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_31, OnFailureCallback_31));
         return CHIP_NO_ERROR;
@@ -15711,6 +16272,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(2);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -15746,6 +16308,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
             this, OnSuccessCallback_33, OnFailureCallback_33));
         return CHIP_NO_ERROR;
@@ -15769,6 +16333,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(2);
@@ -15804,6 +16369,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_35, OnFailureCallback_35));
         return CHIP_NO_ERROR;
@@ -15827,6 +16394,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_36, OnFailureCallback_36));
@@ -15852,6 +16421,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
                 this, OnSuccessCallback_37, OnFailureCallback_37));
@@ -15876,6 +16447,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -15911,6 +16483,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_39, OnFailureCallback_39));
         return CHIP_NO_ERROR;
@@ -15934,6 +16508,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
@@ -15960,6 +16536,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_41, OnFailureCallback_41));
         return CHIP_NO_ERROR;
@@ -15983,6 +16561,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(2);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -16018,6 +16597,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
             this, OnSuccessCallback_43, OnFailureCallback_43));
         return CHIP_NO_ERROR;
@@ -16041,6 +16622,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(2);
@@ -16076,6 +16658,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_45, OnFailureCallback_45));
         return CHIP_NO_ERROR;
@@ -16099,6 +16683,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_46, OnFailureCallback_46));
@@ -16124,6 +16710,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
                 this, OnSuccessCallback_47, OnFailureCallback_47));
@@ -16148,6 +16736,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -16183,6 +16772,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_49, OnFailureCallback_49));
         return CHIP_NO_ERROR;
@@ -16206,6 +16797,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
@@ -16232,6 +16825,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_51, OnFailureCallback_51));
         return CHIP_NO_ERROR;
@@ -16255,6 +16850,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -16282,6 +16878,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_53, OnFailureCallback_53));
@@ -16667,6 +17265,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -16695,6 +17294,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -16718,6 +17319,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(15);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -16753,6 +17355,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
@@ -16776,6 +17380,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -16801,6 +17407,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
         return CHIP_NO_ERROR;
@@ -16824,6 +17432,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStartEnhancedHue::TypeInfo>(
@@ -16849,6 +17459,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(1);
@@ -16884,6 +17495,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
         return CHIP_NO_ERROR;
@@ -16907,6 +17520,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_10, OnFailureCallback_10));
@@ -16932,6 +17547,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
                 this, OnSuccessCallback_11, OnFailureCallback_11));
@@ -16956,6 +17573,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(2);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -16991,6 +17609,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
         return CHIP_NO_ERROR;
@@ -17014,6 +17634,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -17049,6 +17670,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_15, OnFailureCallback_15));
         return CHIP_NO_ERROR;
@@ -17072,6 +17695,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
@@ -17098,6 +17723,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_17, OnFailureCallback_17));
         return CHIP_NO_ERROR;
@@ -17121,6 +17748,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -17148,6 +17776,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_19, OnFailureCallback_19));
@@ -17533,6 +18163,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -17561,6 +18192,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -17584,6 +18217,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(15);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -17619,6 +18253,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
@@ -17642,6 +18278,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -17667,6 +18305,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
         return CHIP_NO_ERROR;
@@ -17690,6 +18330,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStartEnhancedHue::TypeInfo>(
@@ -17715,6 +18357,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(1);
@@ -17750,6 +18393,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
         return CHIP_NO_ERROR;
@@ -17773,6 +18418,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_10, OnFailureCallback_10));
@@ -17798,6 +18445,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
                 this, OnSuccessCallback_11, OnFailureCallback_11));
@@ -17822,6 +18471,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(4);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -17857,6 +18507,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
         return CHIP_NO_ERROR;
@@ -17880,6 +18532,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
@@ -17915,6 +18568,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
             this, OnSuccessCallback_15, OnFailureCallback_15));
         return CHIP_NO_ERROR;
@@ -17938,6 +18593,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
@@ -17964,6 +18621,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
             this, OnSuccessCallback_17, OnFailureCallback_17));
         return CHIP_NO_ERROR;
@@ -17987,6 +18646,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -18014,6 +18674,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_19, OnFailureCallback_19));
@@ -18392,6 +19054,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::DataModelRevision::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -18414,6 +19078,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::VendorName::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -18439,6 +19105,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::VendorID::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -18461,6 +19129,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::ProductName::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -18486,6 +19156,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::ProductID::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
@@ -18508,6 +19180,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::NodeLabel::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -18532,6 +19206,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
@@ -18558,6 +19234,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::HardwareVersion::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
         return CHIP_NO_ERROR;
@@ -18580,6 +19258,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::HardwareVersionString::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
@@ -18606,6 +19286,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::SoftwareVersion::TypeInfo>(
             this, OnSuccessCallback_10, OnFailureCallback_10));
         return CHIP_NO_ERROR;
@@ -18628,6 +19310,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::SoftwareVersionString::TypeInfo>(
             this, OnSuccessCallback_11, OnFailureCallback_11));
@@ -18655,6 +19339,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::ManufacturingDate::TypeInfo>(
             this, OnSuccessCallback_12, OnFailureCallback_12));
         return CHIP_NO_ERROR;
@@ -18681,6 +19367,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::PartNumber::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
         return CHIP_NO_ERROR;
@@ -18704,6 +19392,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::ProductURL::TypeInfo>(
             this, OnSuccessCallback_14, OnFailureCallback_14));
@@ -18730,6 +19420,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::ProductLabel::TypeInfo>(
             this, OnSuccessCallback_15, OnFailureCallback_15));
         return CHIP_NO_ERROR;
@@ -18753,6 +19445,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::SerialNumber::TypeInfo>(
             this, OnSuccessCallback_16, OnFailureCallback_16));
@@ -18778,6 +19472,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::LocalConfigDisabled::TypeInfo>(
             this, OnSuccessCallback_17, OnFailureCallback_17));
         return CHIP_NO_ERROR;
@@ -18801,6 +19497,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::Reachable::TypeInfo>(
             this, OnSuccessCallback_18, OnFailureCallback_18));
         return CHIP_NO_ERROR;
@@ -18823,6 +19521,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::UniqueID::TypeInfo>(
             this, OnSuccessCallback_19, OnFailureCallback_19));
@@ -18956,6 +19656,8 @@ private:
         chip::Controller::NetworkCommissioningClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::NetworkCommissioning::Attributes::MaxNetworks::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -18978,6 +19680,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::NetworkCommissioningClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::NetworkCommissioning::Attributes::Networks::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -19141,6 +19845,8 @@ private:
         chip::Controller::OperationalCredentialsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::Fabrics::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -19171,6 +19877,8 @@ private:
         chip::Controller::OperationalCredentialsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::SupportedFabrics::TypeInfo>(
                 this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -19196,6 +19904,8 @@ private:
         chip::Controller::OperationalCredentialsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::CommissionedFabrics::TypeInfo>(
                 this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -19220,6 +19930,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::OperationalCredentialsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::TrustedRootCertificates::TypeInfo>(
@@ -19390,6 +20102,8 @@ private:
         chip::Controller::ElectricalMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::ClusterRevision::TypeInfo>(
                 this, OnSuccessCallback_1, OnFailureCallback_1));
@@ -19415,6 +20129,8 @@ private:
         chip::Controller::ElectricalMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::ClusterRevision::TypeInfo>(
                 this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -19439,6 +20155,7 @@ private:
         chip::Controller::ElectricalMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 1U;
 
@@ -19462,6 +20179,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ElectricalMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::ClusterRevision::TypeInfo>(
@@ -19487,6 +20206,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ElectricalMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::AttributeList::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -19784,6 +20505,8 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -19807,6 +20530,7 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 2U;
 
@@ -19829,6 +20553,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::AttributeList::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -20100,6 +20826,8 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MeasuredValue::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -20122,6 +20850,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -20146,6 +20876,8 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -20169,6 +20901,7 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t measuredValueArgument;
         measuredValueArgument = 0;
 
@@ -20192,6 +20925,7 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t minMeasuredValueArgument;
         minMeasuredValueArgument = 0;
 
@@ -20215,6 +20949,7 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t maxMeasuredValueArgument;
         maxMeasuredValueArgument = 0;
 
@@ -20237,6 +20972,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MeasuredValue::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
@@ -20261,6 +20998,8 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
         return CHIP_NO_ERROR;
@@ -20283,6 +21022,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
@@ -20307,6 +21048,8 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::Tolerance::TypeInfo>(
             this, OnSuccessCallback_10, OnFailureCallback_10));
         return CHIP_NO_ERROR;
@@ -20330,6 +21073,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::Tolerance::TypeInfo>(
             this, OnSuccessCallback_11, OnFailureCallback_11));
@@ -20356,6 +21101,7 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t toleranceArgument;
         toleranceArgument = 0U;
 
@@ -20378,6 +21124,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::Tolerance::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
@@ -20508,6 +21256,8 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MeasuredValue::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -20530,6 +21280,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MeasuredValue::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -20699,6 +21451,8 @@ private:
         chip::Controller::IlluminanceMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::IlluminanceMeasurement::Attributes::ClusterRevision::TypeInfo>(
                 this, OnSuccessCallback_1, OnFailureCallback_1));
@@ -20724,6 +21478,8 @@ private:
         chip::Controller::IlluminanceMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::IlluminanceMeasurement::Attributes::ClusterRevision::TypeInfo>(
                 this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -20748,6 +21504,7 @@ private:
         chip::Controller::IlluminanceMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 1U;
 
@@ -20771,6 +21528,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::IlluminanceMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::IlluminanceMeasurement::Attributes::ClusterRevision::TypeInfo>(
@@ -20796,6 +21555,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::IlluminanceMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::IlluminanceMeasurement::Attributes::AttributeList::TypeInfo>(
@@ -20991,6 +21752,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -21015,6 +21778,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -21038,6 +21803,7 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 4U;
 
@@ -21060,6 +21826,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -21085,6 +21853,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::AttributeList::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
@@ -21107,6 +21877,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::FeatureMap::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -21131,6 +21903,7 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t featureMapArgument;
         featureMapArgument = 0UL;
 
@@ -21420,6 +22193,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.level          = 254;
         request.transitionTime = 0U;
@@ -21458,6 +22232,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -21481,6 +22257,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::RemainingTime::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -21506,6 +22284,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::MinLevel::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
@@ -21530,6 +22310,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::MaxLevel::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
         return CHIP_NO_ERROR;
@@ -21552,6 +22334,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentFrequency::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
@@ -21577,6 +22361,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::MinFrequency::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
         return CHIP_NO_ERROR;
@@ -21600,6 +22386,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::MaxFrequency::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
@@ -21625,6 +22413,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::OnOffTransitionTime::TypeInfo>(
             this, OnSuccessCallback_10, OnFailureCallback_10));
         return CHIP_NO_ERROR;
@@ -21649,6 +22439,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::OnLevel::TypeInfo>(
             this, OnSuccessCallback_11, OnFailureCallback_11));
         return CHIP_NO_ERROR;
@@ -21671,6 +22463,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::OnTransitionTime::TypeInfo>(
             this, OnSuccessCallback_12, OnFailureCallback_12));
@@ -21695,6 +22489,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::OffTransitionTime::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
         return CHIP_NO_ERROR;
@@ -21718,6 +22514,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::DefaultMoveRate::TypeInfo>(
             this, OnSuccessCallback_14, OnFailureCallback_14));
         return CHIP_NO_ERROR;
@@ -21740,6 +22538,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::Options::TypeInfo>(
             this, OnSuccessCallback_15, OnFailureCallback_15));
@@ -22031,6 +22831,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::OnOffTransitionTime::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -22055,6 +22857,7 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t onOffTransitionTimeArgument;
         onOffTransitionTimeArgument = 10U;
 
@@ -22076,6 +22879,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::OnOffTransitionTime::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -22101,6 +22906,7 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t onOffTransitionTimeArgument;
         onOffTransitionTimeArgument = 0U;
 
@@ -22123,6 +22929,7 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> onLevelArgument;
         onLevelArgument.SetNonNull();
         onLevelArgument.Value() = 254;
@@ -22145,6 +22952,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::OnLevel::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -22171,6 +22980,7 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> onTransitionTimeArgument;
         onTransitionTimeArgument.SetNonNull();
         onTransitionTimeArgument.Value() = 100U;
@@ -22193,6 +23003,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::OnTransitionTime::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
@@ -22219,6 +23031,7 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> offTransitionTimeArgument;
         offTransitionTimeArgument.SetNonNull();
         offTransitionTimeArgument.Value() = 100U;
@@ -22241,6 +23054,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::OffTransitionTime::TypeInfo>(
             this, OnSuccessCallback_10, OnFailureCallback_10));
@@ -22267,6 +23082,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::DefaultMoveRate::TypeInfo>(
             this, OnSuccessCallback_11, OnFailureCallback_11));
         return CHIP_NO_ERROR;
@@ -22292,6 +23109,7 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> defaultMoveRateArgument;
         defaultMoveRateArgument.SetNonNull();
         defaultMoveRateArgument.Value() = 100;
@@ -22314,6 +23132,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::DefaultMoveRate::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
@@ -22340,6 +23160,7 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> startUpCurrentLevelArgument;
         startUpCurrentLevelArgument.SetNonNull();
         startUpCurrentLevelArgument.Value() = 254;
@@ -22362,6 +23183,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::StartUpCurrentLevel::TypeInfo>(
             this, OnSuccessCallback_15, OnFailureCallback_15));
@@ -22595,6 +23418,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -22618,6 +23443,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::MinLevel::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -22643,6 +23470,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::MaxLevel::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -22666,6 +23495,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.level          = 64;
         request.transitionTime = 0U;
@@ -22704,6 +23534,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
         return CHIP_NO_ERROR;
@@ -22727,6 +23559,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.level          = 128;
         request.transitionTime = 1U;
@@ -22765,6 +23598,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
         return CHIP_NO_ERROR;
@@ -22789,6 +23624,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::OnOffTransitionTime::TypeInfo>(
             this, OnSuccessCallback_10, OnFailureCallback_10));
         return CHIP_NO_ERROR;
@@ -22812,6 +23649,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.level          = 254;
         request.transitionTime = 65535U;
@@ -22850,6 +23688,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
         return CHIP_NO_ERROR;
@@ -22873,6 +23713,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.level          = 254;
         request.transitionTime = 0U;
@@ -23129,6 +23970,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -23153,6 +23996,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::MaxLevel::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -23176,6 +24021,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::Move::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode       = static_cast<chip::app::Clusters::LevelControl::MoveMode>(0);
         request.rate           = 200;
@@ -23214,6 +24060,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
@@ -23238,6 +24086,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::MinLevel::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
         return CHIP_NO_ERROR;
@@ -23261,6 +24111,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::Move::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode       = static_cast<chip::app::Clusters::LevelControl::MoveMode>(1);
         request.rate           = 250;
@@ -23299,6 +24150,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
         return CHIP_NO_ERROR;
@@ -23323,6 +24176,7 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> defaultMoveRateArgument;
         defaultMoveRateArgument.SetNonNull();
         defaultMoveRateArgument.Value() = 20;
@@ -23345,6 +24199,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::DefaultMoveRate::TypeInfo>(
             this, OnSuccessCallback_11, OnFailureCallback_11));
@@ -23370,6 +24226,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::Move::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode       = static_cast<chip::app::Clusters::LevelControl::MoveMode>(0);
         request.rate           = 255;
@@ -23408,6 +24265,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
             this, OnSuccessCallback_14, OnFailureCallback_14));
         return CHIP_NO_ERROR;
@@ -23431,6 +24290,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.level          = 254;
         request.transitionTime = 0U;
@@ -23627,6 +24487,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -23654,6 +24515,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::Step::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.stepMode       = static_cast<chip::app::Clusters::LevelControl::StepMode>(1);
         request.stepSize       = 126;
@@ -23693,6 +24555,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
@@ -23716,6 +24580,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::Step::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.stepMode       = static_cast<chip::app::Clusters::LevelControl::StepMode>(1);
         request.stepSize       = 64;
@@ -23755,6 +24620,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
         return CHIP_NO_ERROR;
@@ -23778,6 +24645,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::Step::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.stepMode       = static_cast<chip::app::Clusters::LevelControl::StepMode>(0);
         request.stepSize       = 64;
@@ -23817,6 +24685,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
             this, OnSuccessCallback_10, OnFailureCallback_10));
         return CHIP_NO_ERROR;
@@ -23840,6 +24710,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.level          = 254;
         request.transitionTime = 0U;
@@ -23877,6 +24748,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -24045,6 +24917,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -24072,6 +24945,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.level          = 0;
         request.transitionTime = 0U;
@@ -24110,6 +24984,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
@@ -24133,6 +25009,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::Move::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.moveMode       = static_cast<chip::app::Clusters::LevelControl::MoveMode>(0);
         request.rate           = 1;
@@ -24170,6 +25047,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::Stop::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.optionMask     = 0;
         request.optionOverride = 0;
@@ -24200,6 +25078,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
         return CHIP_NO_ERROR;
@@ -24223,6 +25103,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.level          = 254;
         request.transitionTime = 0U;
@@ -24260,6 +25141,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -24433,6 +25315,8 @@ private:
         chip::Controller::MediaInputClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaInput::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -24457,6 +25341,8 @@ private:
         chip::Controller::MediaInputClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaInput::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -24480,6 +25366,7 @@ private:
         chip::Controller::MediaInputClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 1U;
 
@@ -24502,6 +25389,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::MediaInputClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaInput::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -24526,6 +25415,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::MediaInputClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaInput::Attributes::AttributeList::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -24630,6 +25521,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LowPower::Commands::Sleep::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -25598,6 +26490,8 @@ private:
         chip::Controller::ChannelClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Channel::Attributes::ChannelList::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -25915,6 +26809,8 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::CurrentState::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -26081,6 +26977,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::CurrentState::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -26392,6 +27290,8 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::PlaybackSpeed::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -26421,6 +27321,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::CurrentState::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -26457,6 +27359,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::CurrentState::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
@@ -26756,6 +27660,8 @@ private:
         chip::Controller::TargetNavigatorClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TargetNavigator::Attributes::CurrentTarget::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -26778,6 +27684,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TargetNavigatorClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TargetNavigator::Attributes::TargetList::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -26975,6 +27883,8 @@ private:
         chip::Controller::ApplicationBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::VendorName::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -26997,6 +27907,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ApplicationBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::VendorID::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -27022,6 +27934,8 @@ private:
         chip::Controller::ApplicationBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::ApplicationName::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
@@ -27046,6 +27960,8 @@ private:
         chip::Controller::ApplicationBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::ProductID::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
@@ -27068,6 +27984,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ApplicationBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::Status::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -27092,6 +28010,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ApplicationBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::ApplicationVersion::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
@@ -27234,6 +28154,8 @@ private:
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -27257,6 +28179,7 @@ private:
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 3U;
 
@@ -27279,6 +28202,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::AttributeList::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -27501,6 +28426,8 @@ private:
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::Occupancy::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -27526,6 +28453,7 @@ private:
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t occupancyArgument;
         occupancyArgument = 0;
 
@@ -27548,6 +28476,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::Occupancy::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -27572,6 +28502,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::OccupancySensorType::TypeInfo>(
@@ -27599,6 +28531,7 @@ private:
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t occupancySensorTypeArgument;
         occupancySensorTypeArgument = 0;
 
@@ -27622,6 +28555,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::OccupancySensorType::TypeInfo>(
@@ -27647,6 +28582,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::OccupancySensorTypeBitmap::TypeInfo>(
@@ -27674,6 +28611,7 @@ private:
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t occupancySensorTypeBitmapArgument;
         occupancySensorTypeBitmapArgument = 1;
 
@@ -27697,6 +28635,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::OccupancySensorTypeBitmap::TypeInfo>(
@@ -27838,6 +28778,8 @@ private:
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::Occupancy::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -27860,6 +28802,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::Occupancy::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -28082,6 +29026,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -28106,6 +29052,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -28129,6 +29077,7 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 3U;
 
@@ -28151,6 +29100,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -28176,6 +29127,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::AttributeList::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
@@ -28198,6 +29151,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::FeatureMap::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -28223,6 +29178,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::FeatureMap::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
         return CHIP_NO_ERROR;
@@ -28246,6 +29203,7 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t featureMapArgument;
         featureMapArgument = 0UL;
 
@@ -28268,6 +29226,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::FeatureMap::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
@@ -28565,6 +29525,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -28589,6 +29551,7 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool onOffArgument;
         onOffArgument = 0;
 
@@ -28611,6 +29574,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -28636,6 +29601,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::GlobalSceneControl::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
@@ -28659,6 +29626,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -28684,6 +29653,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
         return CHIP_NO_ERROR;
@@ -28707,6 +29678,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::StartUpOnOff::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
@@ -28732,6 +29705,7 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool globalSceneControlArgument;
         globalSceneControlArgument = 0;
 
@@ -28755,6 +29729,7 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t onTimeArgument;
         onTimeArgument = 0U;
 
@@ -28777,6 +29752,7 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t offWaitTimeArgument;
         offWaitTimeArgument = 0U;
 
@@ -28799,6 +29775,7 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t startUpOnOffArgument;
         startUpOnOffArgument = 0;
 
@@ -28820,6 +29797,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::GlobalSceneControl::TypeInfo>(
             this, OnSuccessCallback_12, OnFailureCallback_12));
@@ -28845,6 +29824,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
         return CHIP_NO_ERROR;
@@ -28869,6 +29850,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(
             this, OnSuccessCallback_14, OnFailureCallback_14));
         return CHIP_NO_ERROR;
@@ -28892,6 +29875,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::StartUpOnOff::TypeInfo>(
             this, OnSuccessCallback_15, OnFailureCallback_15));
@@ -29119,6 +30104,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -29147,6 +30133,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -29170,6 +30158,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -29198,6 +30187,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
@@ -29221,6 +30212,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -29249,6 +30241,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
         return CHIP_NO_ERROR;
@@ -29272,6 +30266,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Toggle::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -29300,6 +30295,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
         return CHIP_NO_ERROR;
@@ -29323,6 +30320,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Toggle::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -29351,6 +30349,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_10, OnFailureCallback_10));
         return CHIP_NO_ERROR;
@@ -29374,6 +30374,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -29402,6 +30403,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_12, OnFailureCallback_12));
         return CHIP_NO_ERROR;
@@ -29425,6 +30428,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -29452,6 +30456,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_14, OnFailureCallback_14));
@@ -30282,6 +31288,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -30316,6 +31323,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -30340,6 +31349,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::GlobalSceneControl::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
@@ -30363,6 +31374,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -30397,6 +31409,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
         return CHIP_NO_ERROR;
@@ -30421,6 +31435,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::GlobalSceneControl::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
         return CHIP_NO_ERROR;
@@ -30444,6 +31460,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -30478,6 +31495,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_11, OnFailureCallback_11));
         return CHIP_NO_ERROR;
@@ -30501,6 +31520,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::GlobalSceneControl::TypeInfo>(
             this, OnSuccessCallback_12, OnFailureCallback_12));
@@ -30526,6 +31547,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
         return CHIP_NO_ERROR;
@@ -30550,6 +31573,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(
             this, OnSuccessCallback_14, OnFailureCallback_14));
         return CHIP_NO_ERROR;
@@ -30573,6 +31598,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -30601,6 +31627,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_16, OnFailureCallback_16));
         return CHIP_NO_ERROR;
@@ -30624,6 +31652,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
             this, OnSuccessCallback_17, OnFailureCallback_17));
@@ -30649,6 +31679,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(
             this, OnSuccessCallback_18, OnFailureCallback_18));
         return CHIP_NO_ERROR;
@@ -30672,6 +31704,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -30700,6 +31733,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_20, OnFailureCallback_20));
         return CHIP_NO_ERROR;
@@ -30723,6 +31758,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
             this, OnSuccessCallback_21, OnFailureCallback_21));
@@ -30748,6 +31785,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_22, OnFailureCallback_22));
         return CHIP_NO_ERROR;
@@ -30771,6 +31810,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
             this, OnSuccessCallback_23, OnFailureCallback_23));
@@ -30796,6 +31837,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(
             this, OnSuccessCallback_24, OnFailureCallback_24));
         return CHIP_NO_ERROR;
@@ -30819,6 +31862,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -30847,6 +31891,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
             this, OnSuccessCallback_26, OnFailureCallback_26));
         return CHIP_NO_ERROR;
@@ -30871,6 +31917,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(
             this, OnSuccessCallback_27, OnFailureCallback_27));
         return CHIP_NO_ERROR;
@@ -30894,6 +31942,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -30922,6 +31971,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_29, OnFailureCallback_29));
         return CHIP_NO_ERROR;
@@ -30945,6 +31996,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
             this, OnSuccessCallback_30, OnFailureCallback_30));
@@ -30970,6 +32023,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_31, OnFailureCallback_31));
         return CHIP_NO_ERROR;
@@ -30994,6 +32049,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
             this, OnSuccessCallback_32, OnFailureCallback_32));
         return CHIP_NO_ERROR;
@@ -31017,6 +32074,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -31045,6 +32103,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_34, OnFailureCallback_34));
         return CHIP_NO_ERROR;
@@ -31068,6 +32128,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
             this, OnSuccessCallback_35, OnFailureCallback_35));
@@ -31093,6 +32155,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(
             this, OnSuccessCallback_36, OnFailureCallback_36));
         return CHIP_NO_ERROR;
@@ -31116,6 +32180,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -31144,6 +32209,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_38, OnFailureCallback_38));
         return CHIP_NO_ERROR;
@@ -31167,6 +32234,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
             this, OnSuccessCallback_39, OnFailureCallback_39));
@@ -31192,6 +32261,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_40, OnFailureCallback_40));
         return CHIP_NO_ERROR;
@@ -31215,6 +32286,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
             this, OnSuccessCallback_41, OnFailureCallback_41));
@@ -31240,6 +32313,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(
             this, OnSuccessCallback_42, OnFailureCallback_42));
         return CHIP_NO_ERROR;
@@ -31263,6 +32338,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_43, OnFailureCallback_43));
@@ -31288,6 +32365,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(
             this, OnSuccessCallback_44, OnFailureCallback_44));
         return CHIP_NO_ERROR;
@@ -31312,6 +32391,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(
             this, OnSuccessCallback_45, OnFailureCallback_45));
         return CHIP_NO_ERROR;
@@ -31335,6 +32416,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -31508,6 +32590,8 @@ private:
         chip::Controller::PowerSourceClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PowerSource::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -31532,6 +32616,8 @@ private:
         chip::Controller::PowerSourceClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PowerSource::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -31555,6 +32641,7 @@ private:
         chip::Controller::PowerSourceClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 1U;
 
@@ -31577,6 +32664,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PowerSourceClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PowerSource::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -31601,6 +32690,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PowerSourceClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PowerSource::Attributes::AttributeList::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -31742,6 +32833,8 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -31765,6 +32858,7 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 3U;
 
@@ -31788,6 +32882,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::AttributeList::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -32006,6 +33102,8 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::MeasuredValue::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -32029,6 +33127,7 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t measuredValueArgument;
         measuredValueArgument = 0;
 
@@ -32051,6 +33150,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::MeasuredValue::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -32076,6 +33177,8 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
                 this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -32100,6 +33203,7 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t minMeasuredValueArgument;
         minMeasuredValueArgument = 0;
 
@@ -32123,6 +33227,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
@@ -32149,6 +33255,8 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
                 this, OnSuccessCallback_7, OnFailureCallback_7));
@@ -32173,6 +33281,7 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t maxMeasuredValueArgument;
         maxMeasuredValueArgument = 0;
 
@@ -32196,6 +33305,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
@@ -32353,6 +33464,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::ClusterRevision::TypeInfo>(
                 this, OnSuccessCallback_1, OnFailureCallback_1));
@@ -32377,6 +33490,7 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 3U;
 
@@ -32401,6 +33515,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::AttributeList::TypeInfo>(
                 this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -32424,6 +33540,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::FeatureMap::TypeInfo>(
@@ -33209,6 +34327,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxPressure::TypeInfo>(
                 this, OnSuccessCallback_1, OnFailureCallback_1));
@@ -33232,6 +34352,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxSpeed::TypeInfo>(
@@ -33257,6 +34379,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxFlow::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -33279,6 +34403,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveOperationMode::TypeInfo>(
@@ -33304,6 +34430,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveControlMode::TypeInfo>(
                 this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -33327,6 +34455,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Capacity::TypeInfo>(
@@ -33352,6 +34482,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxPressure::TypeInfo>(
                 this, OnSuccessCallback_7, OnFailureCallback_7));
@@ -33375,6 +34507,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxSpeed::TypeInfo>(
@@ -33400,6 +34534,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxFlow::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
         return CHIP_NO_ERROR;
@@ -33422,6 +34558,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveOperationMode::TypeInfo>(
@@ -33447,6 +34585,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveControlMode::TypeInfo>(
                 this, OnSuccessCallback_11, OnFailureCallback_11));
@@ -33470,6 +34610,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Capacity::TypeInfo>(
@@ -33495,6 +34637,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstPressure::TypeInfo>(
                 this, OnSuccessCallback_13, OnFailureCallback_13));
@@ -33518,6 +34662,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstPressure::TypeInfo>(
@@ -33543,6 +34689,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinCompPressure::TypeInfo>(
                 this, OnSuccessCallback_15, OnFailureCallback_15));
@@ -33566,6 +34714,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxCompPressure::TypeInfo>(
@@ -33591,6 +34741,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstSpeed::TypeInfo>(
                 this, OnSuccessCallback_17, OnFailureCallback_17));
@@ -33614,6 +34766,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstSpeed::TypeInfo>(
@@ -33639,6 +34793,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstFlow::TypeInfo>(
                 this, OnSuccessCallback_19, OnFailureCallback_19));
@@ -33663,6 +34819,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstFlow::TypeInfo>(
                 this, OnSuccessCallback_20, OnFailureCallback_20));
@@ -33686,6 +34844,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstTemp::TypeInfo>(
@@ -33712,6 +34872,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstTemp::TypeInfo>(
                 this, OnSuccessCallback_22, OnFailureCallback_22));
@@ -33736,6 +34898,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::PumpStatus::TypeInfo>(
@@ -33762,6 +34926,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::PumpStatus::TypeInfo>(
                 this, OnSuccessCallback_24, OnFailureCallback_24));
@@ -33786,6 +34952,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Speed::TypeInfo>(
             this, OnSuccessCallback_25, OnFailureCallback_25));
         return CHIP_NO_ERROR;
@@ -33808,6 +34976,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeRunningHours::TypeInfo>(
@@ -33835,6 +35005,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeRunningHours::TypeInfo>(
                 this, OnSuccessCallback_27, OnFailureCallback_27));
@@ -33859,6 +35031,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Power::TypeInfo>(
             this, OnSuccessCallback_28, OnFailureCallback_28));
         return CHIP_NO_ERROR;
@@ -33881,6 +35055,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeEnergyConsumed::TypeInfo>(
@@ -33908,6 +35084,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeEnergyConsumed::TypeInfo>(
                 this, OnSuccessCallback_30, OnFailureCallback_30));
@@ -33932,6 +35110,7 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint32_t> lifetimeEnergyConsumedArgument;
         lifetimeEnergyConsumedArgument.SetNonNull();
         lifetimeEnergyConsumedArgument.Value() = 0UL;
@@ -33955,6 +35134,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstPressure::TypeInfo>(
@@ -33980,6 +35161,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstPressure::TypeInfo>(
                 this, OnSuccessCallback_33, OnFailureCallback_33));
@@ -34003,6 +35186,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinCompPressure::TypeInfo>(
@@ -34028,6 +35213,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxCompPressure::TypeInfo>(
                 this, OnSuccessCallback_35, OnFailureCallback_35));
@@ -34051,6 +35238,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstSpeed::TypeInfo>(
@@ -34076,6 +35265,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstSpeed::TypeInfo>(
                 this, OnSuccessCallback_37, OnFailureCallback_37));
@@ -34099,6 +35290,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstFlow::TypeInfo>(
@@ -34124,6 +35317,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstFlow::TypeInfo>(
                 this, OnSuccessCallback_39, OnFailureCallback_39));
@@ -34147,6 +35342,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MinConstTemp::TypeInfo>(
@@ -34173,6 +35370,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxConstTemp::TypeInfo>(
                 this, OnSuccessCallback_41, OnFailureCallback_41));
@@ -34197,6 +35396,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::PumpStatus::TypeInfo>(
@@ -34223,6 +35424,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::PumpStatus::TypeInfo>(
                 this, OnSuccessCallback_43, OnFailureCallback_43));
@@ -34247,6 +35450,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Speed::TypeInfo>(
             this, OnSuccessCallback_44, OnFailureCallback_44));
         return CHIP_NO_ERROR;
@@ -34269,6 +35474,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeRunningHours::TypeInfo>(
@@ -34296,6 +35503,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeRunningHours::TypeInfo>(
                 this, OnSuccessCallback_46, OnFailureCallback_46));
@@ -34320,6 +35529,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Power::TypeInfo>(
             this, OnSuccessCallback_47, OnFailureCallback_47));
         return CHIP_NO_ERROR;
@@ -34342,6 +35553,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeEnergyConsumed::TypeInfo>(
@@ -34368,6 +35581,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::LifetimeEnergyConsumed::TypeInfo>(
@@ -34518,6 +35733,7 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t operationModeArgument;
         operationModeArgument = 1;
 
@@ -34541,6 +35757,7 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t operationModeArgument;
         operationModeArgument = 2;
 
@@ -34564,6 +35781,7 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t operationModeArgument;
         operationModeArgument = 3;
 
@@ -34814,6 +36032,7 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t operationModeArgument;
         operationModeArgument = 0;
 
@@ -34836,6 +36055,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveOperationMode::TypeInfo>(
@@ -34862,6 +36083,7 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t controlModeArgument;
         controlModeArgument = 0;
 
@@ -34884,6 +36106,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveControlMode::TypeInfo>(
@@ -34910,6 +36134,7 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t controlModeArgument;
         controlModeArgument = 1;
 
@@ -34933,6 +36158,7 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t controlModeArgument;
         controlModeArgument = 2;
 
@@ -34956,6 +36182,7 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t controlModeArgument;
         controlModeArgument = 3;
 
@@ -34979,6 +36206,7 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t controlModeArgument;
         controlModeArgument = 5;
 
@@ -35002,6 +36230,7 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t controlModeArgument;
         controlModeArgument = 7;
 
@@ -35142,6 +36371,8 @@ private:
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::ClusterRevision::TypeInfo>(
                 this, OnSuccessCallback_1, OnFailureCallback_1));
@@ -35166,6 +36397,7 @@ private:
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 1U;
 
@@ -35189,6 +36421,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::AttributeList::TypeInfo>(
@@ -35347,6 +36581,8 @@ private:
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::MeasuredValue::TypeInfo>(
                 this, OnSuccessCallback_1, OnFailureCallback_1));
@@ -35370,6 +36606,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
@@ -35397,6 +36635,8 @@ private:
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::Tolerance::TypeInfo>(
                 this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -35421,6 +36661,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::Tolerance::TypeInfo>(
@@ -35563,6 +36805,8 @@ private:
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::MeasuredValue::TypeInfo>(
                 this, OnSuccessCallback_1, OnFailureCallback_1));
@@ -35586,6 +36830,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::MeasuredValue::TypeInfo>(
@@ -35773,6 +37019,8 @@ private:
         chip::Controller::SwitchClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Switch::Attributes::NumberOfPositions::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -35796,6 +37044,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::SwitchClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Switch::Attributes::NumberOfPositions::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -35821,6 +37071,8 @@ private:
         chip::Controller::SwitchClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Switch::Attributes::CurrentPosition::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -35844,6 +37096,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::SwitchClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Switch::Attributes::CurrentPosition::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -35869,6 +37123,8 @@ private:
         chip::Controller::SwitchClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Switch::Attributes::MultiPressMax::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
@@ -35892,6 +37148,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::SwitchClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Switch::Attributes::MultiPressMax::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -36175,6 +37433,8 @@ private:
         chip::Controller::SwitchClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Switch::Attributes::CurrentPosition::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -36216,6 +37476,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::SwitchClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Switch::Attributes::CurrentPosition::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
@@ -36538,6 +37800,8 @@ private:
         chip::Controller::TemperatureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TemperatureMeasurement::Attributes::ClusterRevision::TypeInfo>(
                 this, OnSuccessCallback_1, OnFailureCallback_1));
@@ -36562,6 +37826,7 @@ private:
         chip::Controller::TemperatureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 4U;
 
@@ -36585,6 +37850,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TemperatureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TemperatureMeasurement::Attributes::AttributeList::TypeInfo>(
@@ -36715,6 +37982,8 @@ private:
         chip::Controller::TemperatureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TemperatureMeasurement::Attributes::MeasuredValue::TypeInfo>(
                 this, OnSuccessCallback_1, OnFailureCallback_1));
@@ -36738,6 +38007,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TemperatureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TemperatureMeasurement::Attributes::Tolerance::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -36879,6 +38150,8 @@ private:
         chip::Controller::TemperatureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TemperatureMeasurement::Attributes::MeasuredValue::TypeInfo>(
                 this, OnSuccessCallback_1, OnFailureCallback_1));
@@ -36902,6 +38175,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TemperatureMeasurementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TemperatureMeasurement::Attributes::MeasuredValue::TypeInfo>(
@@ -37059,6 +38334,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -37082,6 +38359,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 5U;
 
@@ -37105,6 +38383,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AttributeList::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -37127,6 +38407,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::FeatureMap::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -38067,6 +39349,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::LocalTemperature::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -38089,6 +39373,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AbsMinHeatSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -38113,6 +39399,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AbsMinHeatSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -38139,6 +39427,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t absMinHeatSetpointLimitArgument;
         absMinHeatSetpointLimitArgument = 700;
 
@@ -38161,6 +39450,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AbsMinHeatSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -38186,6 +39477,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AbsMaxHeatSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
         return CHIP_NO_ERROR;
@@ -38209,6 +39502,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AbsMaxHeatSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
@@ -38235,6 +39530,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t absMaxHeatSetpointLimitArgument;
         absMaxHeatSetpointLimitArgument = 3000;
 
@@ -38257,6 +39553,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AbsMaxHeatSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
@@ -38282,6 +39580,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AbsMinCoolSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_10, OnFailureCallback_10));
         return CHIP_NO_ERROR;
@@ -38305,6 +39605,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AbsMinCoolSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_11, OnFailureCallback_11));
@@ -38331,6 +39633,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t absMinCoolSetpointLimitArgument;
         absMinCoolSetpointLimitArgument = 1600;
 
@@ -38353,6 +39656,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AbsMinCoolSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
@@ -38378,6 +39683,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AbsMaxCoolSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_14, OnFailureCallback_14));
         return CHIP_NO_ERROR;
@@ -38401,6 +39708,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AbsMaxCoolSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_15, OnFailureCallback_15));
@@ -38427,6 +39736,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t absMaxCoolSetpointLimitArgument;
         absMaxCoolSetpointLimitArgument = 3200;
 
@@ -38449,6 +39759,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::AbsMaxCoolSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_17, OnFailureCallback_17));
@@ -38474,6 +39786,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::OccupiedCoolingSetpoint::TypeInfo>(
             this, OnSuccessCallback_18, OnFailureCallback_18));
         return CHIP_NO_ERROR;
@@ -38497,6 +39811,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::OccupiedCoolingSetpoint::TypeInfo>(
             this, OnSuccessCallback_19, OnFailureCallback_19));
@@ -38523,6 +39839,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t occupiedCoolingSetpointArgument;
         occupiedCoolingSetpointArgument = 2600;
 
@@ -38544,6 +39861,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::OccupiedCoolingSetpoint::TypeInfo>(
             this, OnSuccessCallback_21, OnFailureCallback_21));
@@ -38569,6 +39888,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::OccupiedHeatingSetpoint::TypeInfo>(
             this, OnSuccessCallback_22, OnFailureCallback_22));
         return CHIP_NO_ERROR;
@@ -38592,6 +39913,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::OccupiedHeatingSetpoint::TypeInfo>(
             this, OnSuccessCallback_23, OnFailureCallback_23));
@@ -38618,6 +39941,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t occupiedHeatingSetpointArgument;
         occupiedHeatingSetpointArgument = 2000;
 
@@ -38639,6 +39963,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::OccupiedHeatingSetpoint::TypeInfo>(
             this, OnSuccessCallback_25, OnFailureCallback_25));
@@ -38664,6 +39990,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MinHeatSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_26, OnFailureCallback_26));
         return CHIP_NO_ERROR;
@@ -38687,6 +40015,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MinHeatSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_27, OnFailureCallback_27));
@@ -38713,6 +40043,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t minHeatSetpointLimitArgument;
         minHeatSetpointLimitArgument = 700;
 
@@ -38734,6 +40065,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MinHeatSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_29, OnFailureCallback_29));
@@ -38759,6 +40092,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MaxHeatSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_30, OnFailureCallback_30));
         return CHIP_NO_ERROR;
@@ -38782,6 +40117,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MaxHeatSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_31, OnFailureCallback_31));
@@ -38808,6 +40145,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t maxHeatSetpointLimitArgument;
         maxHeatSetpointLimitArgument = 3000;
 
@@ -38829,6 +40167,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MaxHeatSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_33, OnFailureCallback_33));
@@ -38854,6 +40194,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MinCoolSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_34, OnFailureCallback_34));
         return CHIP_NO_ERROR;
@@ -38877,6 +40219,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MinCoolSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_35, OnFailureCallback_35));
@@ -38903,6 +40247,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t minCoolSetpointLimitArgument;
         minCoolSetpointLimitArgument = 1600;
 
@@ -38924,6 +40269,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MinCoolSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_37, OnFailureCallback_37));
@@ -38949,6 +40296,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MaxCoolSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_38, OnFailureCallback_38));
         return CHIP_NO_ERROR;
@@ -38972,6 +40321,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MaxCoolSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_39, OnFailureCallback_39));
@@ -38998,6 +40349,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t maxCoolSetpointLimitArgument;
         maxCoolSetpointLimitArgument = 3200;
 
@@ -39019,6 +40371,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MaxCoolSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_41, OnFailureCallback_41));
@@ -39044,6 +40398,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::ControlSequenceOfOperation::TypeInfo>(
                 this, OnSuccessCallback_42, OnFailureCallback_42));
@@ -39068,6 +40424,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::ControlSequenceOfOperation::TypeInfo>(
@@ -39095,6 +40453,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t controlSequenceOfOperationArgument;
         controlSequenceOfOperationArgument = 4;
 
@@ -39117,6 +40476,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::ControlSequenceOfOperation::TypeInfo>(
@@ -39143,6 +40504,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::SystemMode::TypeInfo>(
             this, OnSuccessCallback_46, OnFailureCallback_46));
         return CHIP_NO_ERROR;
@@ -39166,6 +40529,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::SystemMode::TypeInfo>(
             this, OnSuccessCallback_47, OnFailureCallback_47));
@@ -39192,6 +40557,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t systemModeArgument;
         systemModeArgument = 1;
 
@@ -39213,6 +40579,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::SystemMode::TypeInfo>(
             this, OnSuccessCallback_49, OnFailureCallback_49));
@@ -39238,6 +40606,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MinSetpointDeadBand::TypeInfo>(
             this, OnSuccessCallback_50, OnFailureCallback_50));
         return CHIP_NO_ERROR;
@@ -39261,6 +40631,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MinSetpointDeadBand::TypeInfo>(
             this, OnSuccessCallback_51, OnFailureCallback_51));
@@ -39287,6 +40659,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int8_t minSetpointDeadBandArgument;
         minSetpointDeadBandArgument = 25;
 
@@ -39308,6 +40681,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MinSetpointDeadBand::TypeInfo>(
             this, OnSuccessCallback_53, OnFailureCallback_53));
@@ -39332,6 +40707,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::StartOfWeek::TypeInfo>(
             this, OnSuccessCallback_54, OnFailureCallback_54));
@@ -39358,6 +40735,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t startOfWeekArgument;
         startOfWeekArgument = 0;
 
@@ -39380,6 +40758,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::StartOfWeek::TypeInfo>(
             this, OnSuccessCallback_56, OnFailureCallback_56));
@@ -39405,6 +40785,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::NumberOfWeeklyTransitions::TypeInfo>(
                 this, OnSuccessCallback_57, OnFailureCallback_57));
@@ -39429,6 +40811,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t numberOfWeeklyTransitionsArgument;
         numberOfWeeklyTransitionsArgument = 0;
 
@@ -39453,6 +40836,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::NumberOfDailyTransitions::TypeInfo>(
             this, OnSuccessCallback_59, OnFailureCallback_59));
         return CHIP_NO_ERROR;
@@ -39476,6 +40861,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t numberOfDailyTransitionsArgument;
         numberOfDailyTransitionsArgument = 0;
 
@@ -40471,6 +41857,8 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::OccupiedCoolingSetpoint::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -40497,6 +41885,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t occupiedCoolingSetpointArgument;
         occupiedCoolingSetpointArgument = 2000;
 
@@ -40518,6 +41907,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::OccupiedCoolingSetpoint::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -40543,6 +41934,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t occupiedCoolingSetpointArgument;
         occupiedCoolingSetpointArgument = 1600;
 
@@ -40565,6 +41957,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t occupiedCoolingSetpointArgument;
         occupiedCoolingSetpointArgument = 2600;
 
@@ -40586,6 +41979,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::OccupiedHeatingSetpoint::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -40613,6 +42008,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t occupiedHeatingSetpointArgument;
         occupiedHeatingSetpointArgument = 2100;
 
@@ -40634,6 +42030,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::OccupiedHeatingSetpoint::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
@@ -40659,6 +42057,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t occupiedHeatingSetpointArgument;
         occupiedHeatingSetpointArgument = 700;
 
@@ -40681,6 +42080,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t occupiedHeatingSetpointArgument;
         occupiedHeatingSetpointArgument = 3000;
 
@@ -40702,6 +42102,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MinHeatSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_11, OnFailureCallback_11));
@@ -40729,6 +42131,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t minHeatSetpointLimitArgument;
         minHeatSetpointLimitArgument = 2000;
 
@@ -40750,6 +42153,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MinHeatSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
@@ -40775,6 +42180,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t minHeatSetpointLimitArgument;
         minHeatSetpointLimitArgument = 700;
 
@@ -40797,6 +42203,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t minHeatSetpointLimitArgument;
         minHeatSetpointLimitArgument = 3000;
 
@@ -40818,6 +42225,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MaxHeatSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_16, OnFailureCallback_16));
@@ -40845,6 +42254,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t maxHeatSetpointLimitArgument;
         maxHeatSetpointLimitArgument = 2000;
 
@@ -40866,6 +42276,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MaxHeatSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_18, OnFailureCallback_18));
@@ -40891,6 +42303,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t maxHeatSetpointLimitArgument;
         maxHeatSetpointLimitArgument = 700;
 
@@ -40913,6 +42326,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t maxHeatSetpointLimitArgument;
         maxHeatSetpointLimitArgument = 3000;
 
@@ -40934,6 +42348,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MinCoolSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_21, OnFailureCallback_21));
@@ -40961,6 +42377,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t minCoolSetpointLimitArgument;
         minCoolSetpointLimitArgument = 2000;
 
@@ -40982,6 +42399,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MinCoolSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_23, OnFailureCallback_23));
@@ -41007,6 +42426,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t minCoolSetpointLimitArgument;
         minCoolSetpointLimitArgument = 1600;
 
@@ -41029,6 +42449,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t minCoolSetpointLimitArgument;
         minCoolSetpointLimitArgument = 3200;
 
@@ -41050,6 +42471,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MaxCoolSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_26, OnFailureCallback_26));
@@ -41077,6 +42500,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t maxCoolSetpointLimitArgument;
         maxCoolSetpointLimitArgument = 2000;
 
@@ -41098,6 +42522,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::MaxCoolSetpointLimit::TypeInfo>(
             this, OnSuccessCallback_28, OnFailureCallback_28));
@@ -41123,6 +42549,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t maxCoolSetpointLimitArgument;
         maxCoolSetpointLimitArgument = 1600;
 
@@ -41145,6 +42572,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t maxCoolSetpointLimitArgument;
         maxCoolSetpointLimitArgument = 3200;
 
@@ -41167,6 +42595,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t minHeatSetpointLimitArgument;
         minHeatSetpointLimitArgument = 700;
 
@@ -41189,6 +42618,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t minHeatSetpointLimitArgument;
         minHeatSetpointLimitArgument = 3000;
 
@@ -41211,6 +42641,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t maxHeatSetpointLimitArgument;
         maxHeatSetpointLimitArgument = 700;
 
@@ -41233,6 +42664,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t maxHeatSetpointLimitArgument;
         maxHeatSetpointLimitArgument = 3000;
 
@@ -41255,6 +42687,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t minCoolSetpointLimitArgument;
         minCoolSetpointLimitArgument = 1600;
 
@@ -41277,6 +42710,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t minCoolSetpointLimitArgument;
         minCoolSetpointLimitArgument = 3200;
 
@@ -41299,6 +42733,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t maxCoolSetpointLimitArgument;
         maxCoolSetpointLimitArgument = 1600;
 
@@ -41321,6 +42756,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t maxCoolSetpointLimitArgument;
         maxCoolSetpointLimitArgument = 3200;
 
@@ -41342,6 +42778,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::ControlSequenceOfOperation::TypeInfo>(
@@ -41370,6 +42808,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t controlSequenceOfOperationArgument;
         controlSequenceOfOperationArgument = 2;
 
@@ -41392,6 +42831,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::Thermostat::Attributes::ControlSequenceOfOperation::TypeInfo>(
@@ -41418,6 +42859,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t occupiedHeatingSetpointArgument;
         occupiedHeatingSetpointArgument = 2000;
 
@@ -41440,6 +42882,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t occupiedHeatingSetpointArgument;
         occupiedHeatingSetpointArgument = 2000;
 
@@ -41462,6 +42905,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t occupiedCoolingSetpointArgument;
         occupiedCoolingSetpointArgument = 2600;
 
@@ -41484,6 +42928,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t occupiedCoolingSetpointArgument;
         occupiedCoolingSetpointArgument = 2600;
 
@@ -41506,6 +42951,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t occupiedCoolingSetpointArgument;
         occupiedCoolingSetpointArgument = 2600;
 
@@ -41528,6 +42974,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t occupiedHeatingSetpointArgument;
         occupiedHeatingSetpointArgument = 2000;
 
@@ -41550,6 +42997,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t occupiedCoolingSetpointArgument;
         occupiedCoolingSetpointArgument = 2600;
 
@@ -41572,6 +43020,7 @@ private:
         chip::Controller::ThermostatClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t occupiedHeatingSetpointArgument;
         occupiedHeatingSetpointArgument = 2000;
 
@@ -41712,6 +43161,8 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::ClusterRevision::TypeInfo>(
                 this, OnSuccessCallback_1, OnFailureCallback_1));
@@ -41736,6 +43187,7 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 2U;
 
@@ -41760,6 +43212,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::AttributeList::TypeInfo>(
@@ -42064,6 +43518,8 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<
                 chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::TemperatureDisplayMode::TypeInfo>(
@@ -42090,6 +43546,8 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<
                 chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::TemperatureDisplayMode::TypeInfo>(
@@ -42115,6 +43573,7 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t temperatureDisplayModeArgument;
         temperatureDisplayModeArgument = 0;
 
@@ -42138,6 +43597,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<
@@ -42165,6 +43626,8 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<
                 chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::TemperatureDisplayMode::TypeInfo>(
@@ -42189,6 +43652,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::KeypadLockout::TypeInfo>(
@@ -42215,6 +43680,8 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::KeypadLockout::TypeInfo>(
                 this, OnSuccessCallback_7, OnFailureCallback_7));
@@ -42239,6 +43706,7 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t keypadLockoutArgument;
         keypadLockoutArgument = 0;
 
@@ -42261,6 +43729,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::KeypadLockout::TypeInfo>(
@@ -42287,6 +43757,8 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::KeypadLockout::TypeInfo>(
                 this, OnSuccessCallback_10, OnFailureCallback_10));
@@ -42310,6 +43782,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<
@@ -42337,6 +43811,8 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<
                 chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::ScheduleProgrammingVisibility::TypeInfo>(
@@ -42362,6 +43838,7 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t scheduleProgrammingVisibilityArgument;
         scheduleProgrammingVisibilityArgument = 0;
 
@@ -42385,6 +43862,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<
@@ -42411,6 +43890,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<
@@ -42677,6 +44158,7 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t temperatureDisplayModeArgument;
         temperatureDisplayModeArgument = 0;
 
@@ -42701,6 +44183,7 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t temperatureDisplayModeArgument;
         temperatureDisplayModeArgument = 1;
 
@@ -42725,6 +44208,7 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t keypadLockoutArgument;
         keypadLockoutArgument = 0;
 
@@ -42748,6 +44232,7 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t keypadLockoutArgument;
         keypadLockoutArgument = 1;
 
@@ -42771,6 +44256,7 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t keypadLockoutArgument;
         keypadLockoutArgument = 2;
 
@@ -42794,6 +44280,7 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t keypadLockoutArgument;
         keypadLockoutArgument = 3;
 
@@ -42817,6 +44304,7 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t keypadLockoutArgument;
         keypadLockoutArgument = 4;
 
@@ -42840,6 +44328,7 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t keypadLockoutArgument;
         keypadLockoutArgument = 5;
 
@@ -42863,6 +44352,7 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t scheduleProgrammingVisibilityArgument;
         scheduleProgrammingVisibilityArgument = 0;
 
@@ -42887,6 +44377,7 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t scheduleProgrammingVisibilityArgument;
         scheduleProgrammingVisibilityArgument = 1;
 
@@ -43006,6 +44497,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::ThreadNetworkDiagnostics::Commands::ResetCounts::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -43033,6 +44525,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::ThreadNetworkDiagnosticsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::OverrunCount::TypeInfo>(
@@ -43153,6 +44647,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::GeneralDiagnosticsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::GeneralDiagnostics::Attributes::NetworkInterfaces::TypeInfo>(
@@ -43430,6 +44926,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -43455,6 +44953,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 201U;
 
@@ -43477,6 +44976,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::ClusterRevision::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -43503,6 +45004,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::AttributeList::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
@@ -43525,6 +45028,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::FeatureMap::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -43551,6 +45056,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t featureMapArgument;
         featureMapArgument = 32769UL;
 
@@ -43573,6 +45079,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::FeatureMap::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
@@ -44424,6 +45932,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::Type::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -44449,6 +45959,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t typeArgument;
         typeArgument = 250;
 
@@ -44471,6 +45982,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::Type::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -44497,6 +46010,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::ConfigStatus::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
@@ -44522,6 +46037,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t configStatusArgument;
         configStatusArgument = 128;
 
@@ -44544,6 +46060,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::ConfigStatus::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -44570,6 +46088,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::OperationalStatus::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
         return CHIP_NO_ERROR;
@@ -44595,6 +46115,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t operationalStatusArgument;
         operationalStatusArgument = 128;
 
@@ -44617,6 +46138,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::OperationalStatus::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
@@ -44643,6 +46166,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::EndProductType::TypeInfo>(
             this, OnSuccessCallback_10, OnFailureCallback_10));
         return CHIP_NO_ERROR;
@@ -44668,6 +46193,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t endProductTypeArgument;
         endProductTypeArgument = 250;
 
@@ -44690,6 +46216,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::EndProductType::TypeInfo>(
             this, OnSuccessCallback_12, OnFailureCallback_12));
@@ -44716,6 +46244,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::Mode::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
         return CHIP_NO_ERROR;
@@ -44741,6 +46271,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t modeArgument;
         modeArgument = 8;
 
@@ -44762,6 +46293,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::Mode::TypeInfo>(
             this, OnSuccessCallback_15, OnFailureCallback_15));
@@ -44786,6 +46319,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::TargetPositionLiftPercent100ths::TypeInfo>(
@@ -44815,6 +46350,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<chip::Percent100ths> targetPositionLiftPercent100thsArgument;
         targetPositionLiftPercent100thsArgument.SetNonNull();
         targetPositionLiftPercent100thsArgument.Value() = 20000U;
@@ -44839,6 +46375,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::TargetPositionLiftPercent100ths::TypeInfo>(
@@ -44865,6 +46403,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::TargetPositionTiltPercent100ths::TypeInfo>(
@@ -44894,6 +46434,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<chip::Percent100ths> targetPositionTiltPercent100thsArgument;
         targetPositionTiltPercent100thsArgument.SetNonNull();
         targetPositionTiltPercent100thsArgument.Value() = 20000U;
@@ -44918,6 +46459,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::TargetPositionTiltPercent100ths::TypeInfo>(
@@ -44944,6 +46487,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLiftPercent100ths::TypeInfo>(
@@ -44973,6 +46518,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<chip::Percent100ths> currentPositionLiftPercent100thsArgument;
         currentPositionLiftPercent100thsArgument.SetNonNull();
         currentPositionLiftPercent100thsArgument.Value() = 20000U;
@@ -44997,6 +46543,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLiftPercent100ths::TypeInfo>(
@@ -45023,6 +46571,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTiltPercent100ths::TypeInfo>(
@@ -45052,6 +46602,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<chip::Percent100ths> currentPositionTiltPercent100thsArgument;
         currentPositionTiltPercent100thsArgument.SetNonNull();
         currentPositionTiltPercent100thsArgument.Value() = 20000U;
@@ -45076,6 +46627,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTiltPercent100ths::TypeInfo>(
@@ -45103,6 +46656,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::InstalledOpenLimitLift::TypeInfo>(
                 this, OnSuccessCallback_28, OnFailureCallback_28));
@@ -45129,6 +46684,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t installedOpenLimitLiftArgument;
         installedOpenLimitLiftArgument = 255U;
 
@@ -45152,6 +46708,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::InstalledOpenLimitLift::TypeInfo>(
@@ -45179,6 +46737,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::InstalledClosedLimitLift::TypeInfo>(
                 this, OnSuccessCallback_31, OnFailureCallback_31));
@@ -45205,6 +46765,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t installedClosedLimitLiftArgument;
         installedClosedLimitLiftArgument = 255U;
 
@@ -45228,6 +46789,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::InstalledClosedLimitLift::TypeInfo>(
@@ -45255,6 +46818,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::InstalledOpenLimitTilt::TypeInfo>(
                 this, OnSuccessCallback_34, OnFailureCallback_34));
@@ -45281,6 +46846,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t installedOpenLimitTiltArgument;
         installedOpenLimitTiltArgument = 255U;
 
@@ -45304,6 +46870,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::InstalledOpenLimitTilt::TypeInfo>(
@@ -45331,6 +46899,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::InstalledClosedLimitTilt::TypeInfo>(
                 this, OnSuccessCallback_37, OnFailureCallback_37));
@@ -45357,6 +46927,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t installedClosedLimitTiltArgument;
         installedClosedLimitTiltArgument = 255U;
 
@@ -45380,6 +46951,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::InstalledClosedLimitTilt::TypeInfo>(
@@ -45407,6 +46980,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::SafetyStatus::TypeInfo>(
             this, OnSuccessCallback_40, OnFailureCallback_40));
         return CHIP_NO_ERROR;
@@ -45432,6 +47007,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t safetyStatusArgument;
         safetyStatusArgument = 4096U;
 
@@ -45454,6 +47030,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::SafetyStatus::TypeInfo>(
             this, OnSuccessCallback_42, OnFailureCallback_42));
@@ -45480,6 +47058,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLift::TypeInfo>(
             this, OnSuccessCallback_43, OnFailureCallback_43));
         return CHIP_NO_ERROR;
@@ -45505,6 +47085,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> currentPositionLiftArgument;
         currentPositionLiftArgument.SetNonNull();
         currentPositionLiftArgument.Value() = 255U;
@@ -45528,6 +47109,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLift::TypeInfo>(
             this, OnSuccessCallback_45, OnFailureCallback_45));
@@ -45554,6 +47137,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTilt::TypeInfo>(
             this, OnSuccessCallback_46, OnFailureCallback_46));
         return CHIP_NO_ERROR;
@@ -45579,6 +47164,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> currentPositionTiltArgument;
         currentPositionTiltArgument.SetNonNull();
         currentPositionTiltArgument.Value() = 255U;
@@ -45602,6 +47188,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTilt::TypeInfo>(
             this, OnSuccessCallback_48, OnFailureCallback_48));
@@ -45627,6 +47215,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLiftPercentage::TypeInfo>(
@@ -45654,6 +47244,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<chip::Percent> currentPositionLiftPercentageArgument;
         currentPositionLiftPercentageArgument.SetNonNull();
         currentPositionLiftPercentageArgument.Value() = 200;
@@ -45678,6 +47269,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLiftPercentage::TypeInfo>(
@@ -45705,6 +47298,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTiltPercentage::TypeInfo>(
                 this, OnSuccessCallback_52, OnFailureCallback_52));
@@ -45731,6 +47326,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<chip::Percent> currentPositionTiltPercentageArgument;
         currentPositionTiltPercentageArgument.SetNonNull();
         currentPositionTiltPercentageArgument.Value() = 200;
@@ -45755,6 +47351,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTiltPercentage::TypeInfo>(
@@ -45976,6 +47574,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::Type::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -45999,6 +47599,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::Type::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -46141,6 +47743,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::EndProductType::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -46164,6 +47768,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::EndProductType::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -46611,6 +48217,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::WindowCovering::Commands::DownOrClose::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -46645,6 +48252,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLiftPercent100ths::TypeInfo>(
                 this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -46673,6 +48282,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLiftPercentage::TypeInfo>(
                 this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -46698,6 +48309,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTiltPercent100ths::TypeInfo>(
@@ -46727,6 +48340,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTiltPercentage::TypeInfo>(
                 this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -46753,6 +48368,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         mTest_Test_TC_WNCV_3_1_OperationalStatus_Reported = OnSuccessCallback_7;
         return WaitForMs(0);
     }
@@ -46776,6 +48393,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t minIntervalArgument;
         minIntervalArgument = 4U;
         uint16_t maxIntervalArgument;
@@ -46815,6 +48433,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -46849,6 +48468,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::TargetPositionLiftPercent100ths::TypeInfo>(
                 this, OnSuccessCallback_11, OnFailureCallback_11));
@@ -46880,6 +48501,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         mTest_Test_TC_WNCV_3_1_OperationalStatus_Reported = OnSuccessCallback_13;
         return CHIP_NO_ERROR;
@@ -46913,6 +48536,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLiftPercent100ths::TypeInfo>(
                 this, OnSuccessCallback_15, OnFailureCallback_15));
@@ -46941,6 +48566,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLiftPercentage::TypeInfo>(
                 this, OnSuccessCallback_16, OnFailureCallback_16));
@@ -46966,6 +48593,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTiltPercent100ths::TypeInfo>(
@@ -46995,6 +48624,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTiltPercentage::TypeInfo>(
                 this, OnSuccessCallback_18, OnFailureCallback_18));
@@ -47020,6 +48651,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::WindowCovering::Commands::StopMotion::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -47054,6 +48686,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::OperationalStatus::TypeInfo>(
             this, OnSuccessCallback_21, OnFailureCallback_21));
         return CHIP_NO_ERROR;
@@ -47084,6 +48718,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::TargetPositionLiftPercent100ths::TypeInfo>(
                 this, OnSuccessCallback_23, OnFailureCallback_23));
@@ -47111,6 +48747,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::TargetPositionTiltPercent100ths::TypeInfo>(
@@ -47560,6 +49198,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -47594,6 +49233,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLiftPercent100ths::TypeInfo>(
                 this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -47622,6 +49263,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLiftPercentage::TypeInfo>(
                 this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -47647,6 +49290,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTiltPercent100ths::TypeInfo>(
@@ -47676,6 +49321,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTiltPercentage::TypeInfo>(
                 this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -47702,6 +49349,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         mTest_Test_TC_WNCV_3_2_OperationalStatus_Reported = OnSuccessCallback_7;
         return WaitForMs(0);
     }
@@ -47725,6 +49374,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t minIntervalArgument;
         minIntervalArgument = 4U;
         uint16_t maxIntervalArgument;
@@ -47764,6 +49414,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::WindowCovering::Commands::DownOrClose::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -47798,6 +49449,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::TargetPositionLiftPercent100ths::TypeInfo>(
                 this, OnSuccessCallback_11, OnFailureCallback_11));
@@ -47829,6 +49482,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         mTest_Test_TC_WNCV_3_2_OperationalStatus_Reported = OnSuccessCallback_13;
         return CHIP_NO_ERROR;
@@ -47862,6 +49517,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLiftPercent100ths::TypeInfo>(
                 this, OnSuccessCallback_15, OnFailureCallback_15));
@@ -47890,6 +49547,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLiftPercentage::TypeInfo>(
                 this, OnSuccessCallback_16, OnFailureCallback_16));
@@ -47915,6 +49574,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTiltPercent100ths::TypeInfo>(
@@ -47944,6 +49605,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTiltPercentage::TypeInfo>(
                 this, OnSuccessCallback_18, OnFailureCallback_18));
@@ -47969,6 +49632,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::WindowCovering::Commands::StopMotion::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -48003,6 +49667,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::OperationalStatus::TypeInfo>(
             this, OnSuccessCallback_21, OnFailureCallback_21));
         return CHIP_NO_ERROR;
@@ -48033,6 +49699,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::TargetPositionLiftPercent100ths::TypeInfo>(
                 this, OnSuccessCallback_23, OnFailureCallback_23));
@@ -48060,6 +49728,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::TargetPositionTiltPercent100ths::TypeInfo>(
@@ -48358,6 +50028,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::WindowCovering::Commands::DownOrClose::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -48391,6 +50062,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -48425,6 +50097,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         mTest_Test_TC_WNCV_3_3_OperationalStatus_Reported = OnSuccessCallback_5;
         return WaitForMs(0);
     }
@@ -48448,6 +50122,7 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t minIntervalArgument;
         minIntervalArgument = 4U;
         uint16_t maxIntervalArgument;
@@ -48487,6 +50162,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::WindowCovering::Commands::StopMotion::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -48521,6 +50197,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         mTest_Test_TC_WNCV_3_3_OperationalStatus_Reported = OnSuccessCallback_9;
         return CHIP_NO_ERROR;
     }
@@ -48552,6 +50230,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::OperationalStatus::TypeInfo>(
             this, OnSuccessCallback_11, OnFailureCallback_11));
         return CHIP_NO_ERROR;
@@ -48575,6 +50255,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionLiftPercent100ths::TypeInfo>(
@@ -48604,6 +50286,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::TargetPositionLiftPercent100ths::TypeInfo>(
@@ -48639,6 +50323,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::CurrentPositionTiltPercent100ths::TypeInfo>(
                 this, OnSuccessCallback_14, OnFailureCallback_14));
@@ -48667,6 +50353,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::TargetPositionTiltPercent100ths::TypeInfo>(
@@ -48815,6 +50503,8 @@ private:
         chip::Controller::TargetNavigatorClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TargetNavigator::Attributes::TargetList::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -48850,6 +50540,8 @@ private:
         chip::Controller::TargetNavigatorClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TargetNavigator::Attributes::CurrentTarget::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -48873,6 +50565,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TargetNavigator::Commands::NavigateTarget::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.target = 1;
         request.data.Emplace();
@@ -49029,6 +50722,8 @@ private:
         chip::Controller::AudioOutputClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::AudioOutput::Attributes::OutputList::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -49070,6 +50765,8 @@ private:
         chip::Controller::AudioOutputClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::AudioOutput::Attributes::CurrentOutput::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -49093,6 +50790,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 2;
         using RequestType               = chip::app::Clusters::AudioOutput::Commands::SelectOutput::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.index = 1;
 
@@ -49121,6 +50819,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 2;
         using RequestType               = chip::app::Clusters::AudioOutput::Commands::RenameOutput::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.index = 1;
         request.name  = chip::Span<const char>("exampleNamegarbage: not in length on purpose", 11);
@@ -49255,6 +50954,8 @@ private:
         chip::Controller::ApplicationLauncherClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationLauncher::Attributes::CatalogList::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -49285,6 +50986,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ApplicationLauncher::Commands::LaunchApp::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.application.catalogVendorId = 123U;
@@ -49325,6 +51027,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ApplicationLauncher::Commands::StopApp::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.application.catalogVendorId = 123U;
@@ -49362,6 +51065,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ApplicationLauncher::Commands::HideApp::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.application.catalogVendorId = 123U;
@@ -49481,6 +51185,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::KeypadInput::Commands::SendKey::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.keyCode = static_cast<chip::app::Clusters::KeypadInput::CecKeyCode>(3);
 
@@ -49604,6 +51309,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         using RequestType               = chip::app::Clusters::AccountLogin::Commands::GetSetupPIN::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.tempAccountIdentifier = chip::Span<const char>("asdfgarbage: not in length on purpose", 4);
 
@@ -49638,6 +51344,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         using RequestType               = chip::app::Clusters::AccountLogin::Commands::Login::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.tempAccountIdentifier = chip::Span<const char>("asdfgarbage: not in length on purpose", 4);
         request.setupPIN              = chip::Span<const char>("tempPin123garbage: not in length on purpose", 10);
@@ -49668,6 +51375,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         using RequestType               = chip::app::Clusters::AccountLogin::Commands::Logout::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -49788,6 +51496,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::WakeOnLanClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::WakeOnLan::Attributes::MACAddress::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
@@ -49975,6 +51685,8 @@ private:
         chip::Controller::ApplicationBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::VendorName::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -49998,6 +51710,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         chip::Controller::ApplicationBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::VendorID::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -50023,6 +51737,8 @@ private:
         chip::Controller::ApplicationBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::ApplicationName::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -50046,6 +51762,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         chip::Controller::ApplicationBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::ProductID::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -50071,6 +51789,8 @@ private:
         chip::Controller::ApplicationBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::Status::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
@@ -50094,6 +51814,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         chip::Controller::ApplicationBasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::ApplicationVersion::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -50325,6 +52047,8 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::CurrentState::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -50348,6 +52072,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::StartTime::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -50374,6 +52100,8 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::Duration::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -50399,6 +52127,8 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::PlaybackSpeed::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
@@ -50422,6 +52152,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::SeekRangeEnd::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -50448,6 +52180,8 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::SeekRangeStart::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
         return CHIP_NO_ERROR;
@@ -50472,6 +52206,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Play::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -50504,6 +52239,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Pause::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -50536,6 +52272,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         using RequestType               = chip::app::Clusters::MediaPlayback::Commands::StopPlayback::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -50568,6 +52305,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         using RequestType               = chip::app::Clusters::MediaPlayback::Commands::StartOver::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -50600,6 +52338,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Previous::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -50632,6 +52371,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Next::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -50664,6 +52404,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Rewind::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -50696,6 +52437,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         using RequestType               = chip::app::Clusters::MediaPlayback::Commands::FastForward::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -50728,6 +52470,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         using RequestType               = chip::app::Clusters::MediaPlayback::Commands::SkipForward::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.deltaPositionMilliseconds = 100ULL;
 
@@ -50761,6 +52504,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         using RequestType               = chip::app::Clusters::MediaPlayback::Commands::SkipBackward::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.deltaPositionMilliseconds = 100ULL;
 
@@ -50794,6 +52538,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Seek::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.position = 100ULL;
 
@@ -50934,6 +52679,8 @@ private:
         chip::Controller::ChannelClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Channel::Attributes::ChannelList::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -50985,6 +52732,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Channel::Commands::ChangeChannel::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.match = chip::Span<const char>("CNNgarbage: not in length on purpose", 3);
 
@@ -51030,6 +52778,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Channel::Commands::ChangeChannelByNumber::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.majorNumber = 1U;
         request.minorNumber = 2U;
@@ -51059,6 +52808,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Channel::Commands::SkipChannel::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.count = 1U;
 
@@ -51169,6 +52919,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::LowPower::Commands::Sleep::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -51311,6 +53062,8 @@ private:
         chip::Controller::ContentLauncherClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ContentLauncher::Attributes::AcceptHeader::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -51342,6 +53095,8 @@ private:
         chip::Controller::ContentLauncherClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::ContentLauncher::Attributes::SupportedStreamingProtocols::TypeInfo>(
                 this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -51366,22 +53121,32 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ContentLauncher::Commands::LaunchContent::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
-        chip::app::Clusters::ContentLauncher::Structs::Parameter::Type parameterListList_1[1];
+        {
+            auto * listHolder_1 = new ListHolder<chip::app::Clusters::ContentLauncher::Structs::Parameter::Type>(1);
+            listFreer.add(listHolder_1);
 
-        parameterListList_1[0].type  = static_cast<chip::app::Clusters::ContentLauncher::ParameterEnum>(1);
-        parameterListList_1[0].value = chip::Span<const char>("exampleValuegarbage: not in length on purpose", 12);
-        parameterListList_1[0].externalIDList.Emplace();
+            listHolder_1->mList[0].type  = static_cast<chip::app::Clusters::ContentLauncher::ParameterEnum>(1);
+            listHolder_1->mList[0].value = chip::Span<const char>("exampleValuegarbage: not in length on purpose", 12);
+            listHolder_1->mList[0].externalIDList.Emplace();
 
-        chip::app::Clusters::ContentLauncher::Structs::AdditionalInfo::Type externalIDListList_4[1];
+            {
+                auto * listHolder_4 = new ListHolder<chip::app::Clusters::ContentLauncher::Structs::AdditionalInfo::Type>(1);
+                listFreer.add(listHolder_4);
 
-        externalIDListList_4[0].name  = chip::Span<const char>("namegarbage: not in length on purpose", 4);
-        externalIDListList_4[0].value = chip::Span<const char>("valuegarbage: not in length on purpose", 5);
+                listHolder_4->mList[0].name  = chip::Span<const char>("namegarbage: not in length on purpose", 4);
+                listHolder_4->mList[0].value = chip::Span<const char>("valuegarbage: not in length on purpose", 5);
 
-        parameterListList_1[0].externalIDList.Value() = externalIDListList_4;
+                listHolder_1->mList[0].externalIDList.Value() =
+                    chip::app::DataModel::List<chip::app::Clusters::ContentLauncher::Structs::AdditionalInfo::Type>(
+                        listHolder_4->mList, 1);
+            }
 
-        request.search.parameterList = parameterListList_1;
+            request.search.parameterList =
+                chip::app::DataModel::List<chip::app::Clusters::ContentLauncher::Structs::Parameter::Type>(listHolder_1->mList, 1);
+        }
 
         request.autoPlay = true;
         request.data.Emplace();
@@ -51420,6 +53185,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ContentLauncher::Commands::LaunchURL::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.contentURL = chip::Span<const char>("exampleUrlgarbage: not in length on purpose", 10);
         request.displayString.Emplace();
@@ -51661,6 +53427,8 @@ private:
         chip::Controller::MediaInputClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaInput::Attributes::InputList::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -51701,6 +53469,8 @@ private:
         chip::Controller::MediaInputClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaInput::Attributes::CurrentInput::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -51724,6 +53494,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::MediaInput::Commands::SelectInput::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.index = 1;
 
@@ -51752,6 +53523,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::MediaInput::Commands::HideInputStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -51779,6 +53551,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::MediaInput::Commands::ShowInputStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -51806,6 +53579,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::MediaInput::Commands::RenameInput::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.index = 1;
         request.name  = chip::Span<const char>("newNamegarbage: not in length on purpose", 7);
@@ -57909,6 +59683,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::Test::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -57934,6 +59709,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestNotHandled::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -57960,6 +59736,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestSpecific::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -57990,6 +59767,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.arg1 = 3;
         request.arg2 = 17;
@@ -58022,6 +59800,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.arg1 = 250;
         request.arg2 = 6;
@@ -58051,6 +59830,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
         return CHIP_NO_ERROR;
@@ -58075,6 +59856,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool booleanArgument;
         booleanArgument = 1;
 
@@ -58096,6 +59878,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
@@ -58121,6 +59905,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool booleanArgument;
         booleanArgument = 0;
 
@@ -58142,6 +59927,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(
             this, OnSuccessCallback_10, OnFailureCallback_10));
@@ -58167,6 +59954,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap8::TypeInfo>(
             this, OnSuccessCallback_11, OnFailureCallback_11));
         return CHIP_NO_ERROR;
@@ -58191,6 +59980,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t bitmap8Argument;
         bitmap8Argument = 255;
 
@@ -58212,6 +60002,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap8::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
@@ -58237,6 +60029,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t bitmap8Argument;
         bitmap8Argument = 0;
 
@@ -58258,6 +60051,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap8::TypeInfo>(
             this, OnSuccessCallback_15, OnFailureCallback_15));
@@ -58283,6 +60078,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap16::TypeInfo>(
             this, OnSuccessCallback_16, OnFailureCallback_16));
         return CHIP_NO_ERROR;
@@ -58307,6 +60104,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t bitmap16Argument;
         bitmap16Argument = 65535U;
 
@@ -58328,6 +60126,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap16::TypeInfo>(
             this, OnSuccessCallback_18, OnFailureCallback_18));
@@ -58353,6 +60153,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t bitmap16Argument;
         bitmap16Argument = 0U;
 
@@ -58374,6 +60175,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap16::TypeInfo>(
             this, OnSuccessCallback_20, OnFailureCallback_20));
@@ -58399,6 +60202,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap32::TypeInfo>(
             this, OnSuccessCallback_21, OnFailureCallback_21));
         return CHIP_NO_ERROR;
@@ -58423,6 +60228,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t bitmap32Argument;
         bitmap32Argument = 4294967295UL;
 
@@ -58444,6 +60250,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap32::TypeInfo>(
             this, OnSuccessCallback_23, OnFailureCallback_23));
@@ -58469,6 +60277,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t bitmap32Argument;
         bitmap32Argument = 0UL;
 
@@ -58490,6 +60299,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap32::TypeInfo>(
             this, OnSuccessCallback_25, OnFailureCallback_25));
@@ -58515,6 +60326,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap64::TypeInfo>(
             this, OnSuccessCallback_26, OnFailureCallback_26));
         return CHIP_NO_ERROR;
@@ -58539,6 +60352,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint64_t bitmap64Argument;
         bitmap64Argument = 18446744073709551615ULL;
 
@@ -58560,6 +60374,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap64::TypeInfo>(
             this, OnSuccessCallback_28, OnFailureCallback_28));
@@ -58585,6 +60401,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint64_t bitmap64Argument;
         bitmap64Argument = 0ULL;
 
@@ -58606,6 +60423,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap64::TypeInfo>(
             this, OnSuccessCallback_30, OnFailureCallback_30));
@@ -58631,6 +60450,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8u::TypeInfo>(
             this, OnSuccessCallback_31, OnFailureCallback_31));
         return CHIP_NO_ERROR;
@@ -58655,6 +60476,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t int8uArgument;
         int8uArgument = 255;
 
@@ -58676,6 +60498,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8u::TypeInfo>(
             this, OnSuccessCallback_33, OnFailureCallback_33));
@@ -58701,6 +60525,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t int8uArgument;
         int8uArgument = 0;
 
@@ -58722,6 +60547,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8u::TypeInfo>(
             this, OnSuccessCallback_35, OnFailureCallback_35));
@@ -58747,6 +60574,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16u::TypeInfo>(
             this, OnSuccessCallback_36, OnFailureCallback_36));
         return CHIP_NO_ERROR;
@@ -58771,6 +60600,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t int16uArgument;
         int16uArgument = 65535U;
 
@@ -58792,6 +60622,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16u::TypeInfo>(
             this, OnSuccessCallback_38, OnFailureCallback_38));
@@ -58817,6 +60649,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t int16uArgument;
         int16uArgument = 0U;
 
@@ -58838,6 +60671,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16u::TypeInfo>(
             this, OnSuccessCallback_40, OnFailureCallback_40));
@@ -58863,6 +60698,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(
             this, OnSuccessCallback_41, OnFailureCallback_41));
         return CHIP_NO_ERROR;
@@ -58887,6 +60724,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t int32uArgument;
         int32uArgument = 4294967295UL;
 
@@ -58908,6 +60746,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(
             this, OnSuccessCallback_43, OnFailureCallback_43));
@@ -58933,6 +60773,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t int32uArgument;
         int32uArgument = 0UL;
 
@@ -58954,6 +60795,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(
             this, OnSuccessCallback_45, OnFailureCallback_45));
@@ -58979,6 +60822,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64u::TypeInfo>(
             this, OnSuccessCallback_46, OnFailureCallback_46));
         return CHIP_NO_ERROR;
@@ -59003,6 +60848,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint64_t int64uArgument;
         int64uArgument = 18446744073709551615ULL;
 
@@ -59024,6 +60870,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64u::TypeInfo>(
             this, OnSuccessCallback_48, OnFailureCallback_48));
@@ -59049,6 +60897,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint64_t int64uArgument;
         int64uArgument = 0ULL;
 
@@ -59070,6 +60919,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64u::TypeInfo>(
             this, OnSuccessCallback_50, OnFailureCallback_50));
@@ -59095,6 +60946,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(
             this, OnSuccessCallback_51, OnFailureCallback_51));
         return CHIP_NO_ERROR;
@@ -59119,6 +60972,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int8_t int8sArgument;
         int8sArgument = 127;
 
@@ -59140,6 +60994,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(
             this, OnSuccessCallback_53, OnFailureCallback_53));
@@ -59165,6 +61021,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int8_t int8sArgument;
         int8sArgument = -128;
 
@@ -59186,6 +61043,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(
             this, OnSuccessCallback_55, OnFailureCallback_55));
@@ -59211,6 +61070,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int8_t int8sArgument;
         int8sArgument = 0;
 
@@ -59232,6 +61092,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(
             this, OnSuccessCallback_57, OnFailureCallback_57));
@@ -59257,6 +61119,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(
             this, OnSuccessCallback_58, OnFailureCallback_58));
         return CHIP_NO_ERROR;
@@ -59281,6 +61145,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t int16sArgument;
         int16sArgument = 32767;
 
@@ -59302,6 +61167,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(
             this, OnSuccessCallback_60, OnFailureCallback_60));
@@ -59327,6 +61194,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t int16sArgument;
         int16sArgument = -32768;
 
@@ -59348,6 +61216,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(
             this, OnSuccessCallback_62, OnFailureCallback_62));
@@ -59373,6 +61243,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t int16sArgument;
         int16sArgument = 0;
 
@@ -59394,6 +61265,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(
             this, OnSuccessCallback_64, OnFailureCallback_64));
@@ -59419,6 +61292,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(
             this, OnSuccessCallback_65, OnFailureCallback_65));
         return CHIP_NO_ERROR;
@@ -59443,6 +61318,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int32_t int32sArgument;
         int32sArgument = 2147483647L;
 
@@ -59464,6 +61340,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(
             this, OnSuccessCallback_67, OnFailureCallback_67));
@@ -59489,6 +61367,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int32_t int32sArgument;
         int32sArgument = -2147483648L;
 
@@ -59510,6 +61389,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(
             this, OnSuccessCallback_69, OnFailureCallback_69));
@@ -59535,6 +61416,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int32_t int32sArgument;
         int32sArgument = 0L;
 
@@ -59556,6 +61438,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(
             this, OnSuccessCallback_71, OnFailureCallback_71));
@@ -59581,6 +61465,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(
             this, OnSuccessCallback_72, OnFailureCallback_72));
         return CHIP_NO_ERROR;
@@ -59605,6 +61491,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int64_t int64sArgument;
         int64sArgument = 9223372036854775807LL;
 
@@ -59626,6 +61513,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(
             this, OnSuccessCallback_74, OnFailureCallback_74));
@@ -59651,6 +61540,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int64_t int64sArgument;
         int64sArgument = -9223372036854775807LL;
 
@@ -59672,6 +61562,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(
             this, OnSuccessCallback_76, OnFailureCallback_76));
@@ -59697,6 +61589,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int64_t int64sArgument;
         int64sArgument = 0LL;
 
@@ -59718,6 +61611,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(
             this, OnSuccessCallback_78, OnFailureCallback_78));
@@ -59743,6 +61638,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::FloatSingle::TypeInfo>(
             this, OnSuccessCallback_79, OnFailureCallback_79));
         return CHIP_NO_ERROR;
@@ -59767,6 +61664,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         float floatSingleArgument;
         floatSingleArgument = 0.1f;
 
@@ -59788,6 +61686,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::FloatSingle::TypeInfo>(
             this, OnSuccessCallback_81, OnFailureCallback_81));
@@ -59813,6 +61713,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         float floatSingleArgument;
         floatSingleArgument = 17000000000.0f;
 
@@ -59834,6 +61735,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::FloatSingle::TypeInfo>(
             this, OnSuccessCallback_83, OnFailureCallback_83));
@@ -59859,6 +61762,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         float floatSingleArgument;
         floatSingleArgument = 1.7e-10f;
 
@@ -59880,6 +61784,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::FloatSingle::TypeInfo>(
             this, OnSuccessCallback_85, OnFailureCallback_85));
@@ -59905,6 +61811,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         float floatSingleArgument;
         floatSingleArgument = 0.0f;
 
@@ -59926,6 +61833,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::FloatSingle::TypeInfo>(
             this, OnSuccessCallback_87, OnFailureCallback_87));
@@ -59951,6 +61860,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::FloatDouble::TypeInfo>(
             this, OnSuccessCallback_88, OnFailureCallback_88));
         return CHIP_NO_ERROR;
@@ -59975,6 +61886,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         double floatDoubleArgument;
         floatDoubleArgument = 0.1234567890123;
 
@@ -59996,6 +61908,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::FloatDouble::TypeInfo>(
             this, OnSuccessCallback_90, OnFailureCallback_90));
@@ -60021,6 +61935,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         double floatDoubleArgument;
         floatDoubleArgument = 1.7e+200;
 
@@ -60042,6 +61957,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::FloatDouble::TypeInfo>(
             this, OnSuccessCallback_92, OnFailureCallback_92));
@@ -60067,6 +61984,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         double floatDoubleArgument;
         floatDoubleArgument = 1.7e-200;
 
@@ -60088,6 +62006,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::FloatDouble::TypeInfo>(
             this, OnSuccessCallback_94, OnFailureCallback_94));
@@ -60113,6 +62033,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         double floatDoubleArgument;
         floatDoubleArgument = 0;
 
@@ -60134,6 +62055,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::FloatDouble::TypeInfo>(
             this, OnSuccessCallback_96, OnFailureCallback_96));
@@ -60159,6 +62082,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum8::TypeInfo>(
             this, OnSuccessCallback_97, OnFailureCallback_97));
         return CHIP_NO_ERROR;
@@ -60183,6 +62108,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t enum8Argument;
         enum8Argument = 255;
 
@@ -60204,6 +62130,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum8::TypeInfo>(
             this, OnSuccessCallback_99, OnFailureCallback_99));
@@ -60229,6 +62157,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t enum8Argument;
         enum8Argument = 0;
 
@@ -60250,6 +62179,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum8::TypeInfo>(
             this, OnSuccessCallback_101, OnFailureCallback_101));
@@ -60275,6 +62206,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum16::TypeInfo>(
             this, OnSuccessCallback_102, OnFailureCallback_102));
         return CHIP_NO_ERROR;
@@ -60299,6 +62232,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t enum16Argument;
         enum16Argument = 65535U;
 
@@ -60320,6 +62254,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum16::TypeInfo>(
             this, OnSuccessCallback_104, OnFailureCallback_104));
@@ -60345,6 +62281,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t enum16Argument;
         enum16Argument = 0U;
 
@@ -60366,6 +62303,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum16::TypeInfo>(
             this, OnSuccessCallback_106, OnFailureCallback_106));
@@ -60391,6 +62330,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
             this, OnSuccessCallback_107, OnFailureCallback_107));
         return CHIP_NO_ERROR;
@@ -60415,6 +62356,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::ByteSpan octetStringArgument;
         octetStringArgument = chip::ByteSpan(chip::Uint8::from_const_char("Tes\x00ti\x00nggarbage: not in length on purpose"), 9);
 
@@ -60436,6 +62378,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
             this, OnSuccessCallback_109, OnFailureCallback_109));
@@ -60462,6 +62406,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::ByteSpan octetStringArgument;
         octetStringArgument =
             chip::ByteSpan(chip::Uint8::from_const_char("\x0d\x0a\xff\x22\xa0garbage: not in length on purpose"), 5);
@@ -60484,6 +62429,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
             this, OnSuccessCallback_111, OnFailureCallback_111));
@@ -60510,6 +62457,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::ByteSpan octetStringArgument;
         octetStringArgument = chip::ByteSpan(chip::Uint8::from_const_char("TestValuegarbage: not in length on purpose"), 9);
 
@@ -60531,6 +62479,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
             this, OnSuccessCallback_113, OnFailureCallback_113));
@@ -60557,6 +62507,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::ByteSpan octetStringArgument;
         octetStringArgument =
             chip::ByteSpan(chip::Uint8::from_const_char("TestValueLongerThan10garbage: not in length on purpose"), 21);
@@ -60580,6 +62531,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
             this, OnSuccessCallback_115, OnFailureCallback_115));
@@ -60606,6 +62559,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::ByteSpan octetStringArgument;
         octetStringArgument = chip::ByteSpan(chip::Uint8::from_const_char("garbage: not in length on purpose"), 0);
 
@@ -60627,6 +62581,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::LongOctetString::TypeInfo>(
             this, OnSuccessCallback_117, OnFailureCallback_117));
@@ -60652,6 +62608,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::ByteSpan longOctetStringArgument;
         longOctetStringArgument = chip::ByteSpan(
             chip::Uint8::from_const_char(
@@ -60678,6 +62635,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::LongOctetString::TypeInfo>(
             this, OnSuccessCallback_119, OnFailureCallback_119));
@@ -60710,6 +62669,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::ByteSpan longOctetStringArgument;
         longOctetStringArgument = chip::ByteSpan(chip::Uint8::from_const_char("garbage: not in length on purpose"), 0);
 
@@ -60731,6 +62691,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_121, OnFailureCallback_121));
@@ -60756,6 +62718,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan charStringArgument;
         charStringArgument = chip::Span<const char>("☉T☉garbage: not in length on purpose", 7);
 
@@ -60777,6 +62740,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_123, OnFailureCallback_123));
@@ -60802,6 +62767,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan charStringArgument;
         charStringArgument = chip::Span<const char>("☉TestValueLongerThan10☉garbage: not in length on purpose", 27);
 
@@ -60824,6 +62790,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_125, OnFailureCallback_125));
@@ -60849,6 +62817,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan charStringArgument;
         charStringArgument = chip::Span<const char>("garbage: not in length on purpose", 0);
 
@@ -60870,6 +62839,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::LongCharString::TypeInfo>(
             this, OnSuccessCallback_127, OnFailureCallback_127));
@@ -60895,6 +62866,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan longCharStringArgument;
         longCharStringArgument = chip::Span<const char>(
             "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
@@ -60920,6 +62892,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::LongCharString::TypeInfo>(
             this, OnSuccessCallback_129, OnFailureCallback_129));
@@ -60950,6 +62924,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan longCharStringArgument;
         longCharStringArgument = chip::Span<const char>("garbage: not in length on purpose", 0);
 
@@ -60971,6 +62946,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListLongOctetString::TypeInfo>(
             this, OnSuccessCallback_131, OnFailureCallback_131));
@@ -61043,50 +63020,54 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::List<const chip::ByteSpan> listLongOctetStringArgument;
 
-        chip::ByteSpan listLongOctetStringList_0[5];
-        listLongOctetStringList_0[0] = chip::ByteSpan(
-            chip::Uint8::from_const_char(
-                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01"
-                "23456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123"
-                "456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef012345"
-                "6789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
-                "89abcdef0123456789abcdef0123456789abcdef0123456789abcdefgarbage: not in length on purpose"),
-            512);
-        listLongOctetStringList_0[1] = chip::ByteSpan(
-            chip::Uint8::from_const_char(
-                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01"
-                "23456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123"
-                "456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef012345"
-                "6789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
-                "89abcdef0123456789abcdef0123456789abcdef0123456789abcdefgarbage: not in length on purpose"),
-            512);
-        listLongOctetStringList_0[2] = chip::ByteSpan(
-            chip::Uint8::from_const_char(
-                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01"
-                "23456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123"
-                "456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef012345"
-                "6789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
-                "89abcdef0123456789abcdef0123456789abcdef0123456789abcdefgarbage: not in length on purpose"),
-            512);
-        listLongOctetStringList_0[3] = chip::ByteSpan(
-            chip::Uint8::from_const_char(
-                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01"
-                "23456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123"
-                "456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef012345"
-                "6789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
-                "89abcdef0123456789abcdef0123456789abcdef0123456789abcdefgarbage: not in length on purpose"),
-            512);
-        listLongOctetStringList_0[4] = chip::ByteSpan(
-            chip::Uint8::from_const_char(
-                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01"
-                "23456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123"
-                "456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef012345"
-                "6789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
-                "89abcdef0123456789abcdef0123456789abcdef0123456789abcdefgarbage: not in length on purpose"),
-            512);
-        listLongOctetStringArgument = listLongOctetStringList_0;
+        {
+            auto * listHolder_0 = new ListHolder<chip::ByteSpan>(5);
+            listFreer.add(listHolder_0);
+            listHolder_0->mList[0] = chip::ByteSpan(
+                chip::Uint8::from_const_char(
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd"
+                    "ef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab"
+                    "cdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+                    "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
+                    "89abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdefgarbage: not in length on purpose"),
+                512);
+            listHolder_0->mList[1] = chip::ByteSpan(
+                chip::Uint8::from_const_char(
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd"
+                    "ef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab"
+                    "cdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+                    "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
+                    "89abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdefgarbage: not in length on purpose"),
+                512);
+            listHolder_0->mList[2] = chip::ByteSpan(
+                chip::Uint8::from_const_char(
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd"
+                    "ef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab"
+                    "cdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+                    "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
+                    "89abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdefgarbage: not in length on purpose"),
+                512);
+            listHolder_0->mList[3] = chip::ByteSpan(
+                chip::Uint8::from_const_char(
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd"
+                    "ef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab"
+                    "cdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+                    "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
+                    "89abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdefgarbage: not in length on purpose"),
+                512);
+            listHolder_0->mList[4] = chip::ByteSpan(
+                chip::Uint8::from_const_char(
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd"
+                    "ef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab"
+                    "cdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+                    "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
+                    "89abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdefgarbage: not in length on purpose"),
+                512);
+            listLongOctetStringArgument = chip::app::DataModel::List<chip::ByteSpan>(listHolder_0->mList, 5);
+        }
 
         ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::ListLongOctetString::TypeInfo>(
             listLongOctetStringArgument, this, OnSuccessCallback_132, OnFailureCallback_132));
@@ -61106,6 +63087,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListLongOctetString::TypeInfo>(
             this, OnSuccessCallback_133, OnFailureCallback_133));
@@ -61189,6 +63172,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(
             this, OnSuccessCallback_134, OnFailureCallback_134));
         return CHIP_NO_ERROR;
@@ -61213,6 +63198,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint64_t epochUsArgument;
         epochUsArgument = 18446744073709551615ULL;
 
@@ -61234,6 +63220,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(
             this, OnSuccessCallback_136, OnFailureCallback_136));
@@ -61259,6 +63247,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint64_t epochUsArgument;
         epochUsArgument = 0ULL;
 
@@ -61280,6 +63269,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(
             this, OnSuccessCallback_138, OnFailureCallback_138));
@@ -61305,6 +63296,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(
             this, OnSuccessCallback_139, OnFailureCallback_139));
         return CHIP_NO_ERROR;
@@ -61329,6 +63322,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t epochSArgument;
         epochSArgument = 4294967295UL;
 
@@ -61350,6 +63344,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(
             this, OnSuccessCallback_141, OnFailureCallback_141));
@@ -61375,6 +63371,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t epochSArgument;
         epochSArgument = 0UL;
 
@@ -61396,6 +63393,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(
             this, OnSuccessCallback_143, OnFailureCallback_143));
@@ -61421,6 +63420,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Unsupported::TypeInfo>(
             this, OnSuccessCallback_144, OnFailureCallback_144));
         return CHIP_NO_ERROR;
@@ -61445,6 +63446,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool unsupportedArgument;
         unsupportedArgument = 0;
 
@@ -61466,6 +63468,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 200;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::Test::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -61494,6 +63497,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::Test::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -61523,6 +63527,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(
             this, OnSuccessCallback_148, OnFailureCallback_148));
         return CHIP_NO_ERROR;
@@ -61547,6 +63553,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::VendorId vendorIdArgument;
         vendorIdArgument = static_cast<chip::VendorId>(17);
 
@@ -61568,6 +63575,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(
             this, OnSuccessCallback_150, OnFailureCallback_150));
@@ -61593,6 +63602,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::VendorId vendorIdArgument;
         vendorIdArgument = static_cast<chip::VendorId>(0);
 
@@ -61614,6 +63624,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestEnumsRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.arg1 = static_cast<chip::VendorId>(20003);
         request.arg2 = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(101);
@@ -61650,6 +63661,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.arg1.a = 0;
@@ -61691,6 +63703,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.arg1.a = 0;
@@ -61732,6 +63745,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestNestedStructArgumentRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.arg1.a = 0;
@@ -61776,6 +63790,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestNestedStructArgumentRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.arg1.a = 0;
@@ -61820,6 +63835,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestNestedStructListArgumentRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.arg1.a = 0;
@@ -61834,44 +63850,62 @@ private:
         request.arg1.c.g = 0.0f;
         request.arg1.c.h = 0;
 
-        chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type dList_1[2];
+        {
+            auto * listHolder_1 = new ListHolder<chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type>(2);
+            listFreer.add(listHolder_1);
 
-        dList_1[0].a = 1;
-        dList_1[0].b = true;
-        dList_1[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
-        dList_1[0].d = chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
-        dList_1[0].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
-        dList_1[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
-        dList_1[0].g = 0.0f;
-        dList_1[0].h = 0;
+            listHolder_1->mList[0].a = 1;
+            listHolder_1->mList[0].b = true;
+            listHolder_1->mList[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+            listHolder_1->mList[0].d =
+                chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
+            listHolder_1->mList[0].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
+            listHolder_1->mList[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+            listHolder_1->mList[0].g = 0.0f;
+            listHolder_1->mList[0].h = 0;
 
-        dList_1[1].a = 2;
-        dList_1[1].b = true;
-        dList_1[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
-        dList_1[1].d = chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
-        dList_1[1].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
-        dList_1[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
-        dList_1[1].g = 0.0f;
-        dList_1[1].h = 0;
+            listHolder_1->mList[1].a = 2;
+            listHolder_1->mList[1].b = true;
+            listHolder_1->mList[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+            listHolder_1->mList[1].d =
+                chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
+            listHolder_1->mList[1].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
+            listHolder_1->mList[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+            listHolder_1->mList[1].g = 0.0f;
+            listHolder_1->mList[1].h = 0;
 
-        request.arg1.d = dList_1;
+            request.arg1.d =
+                chip::app::DataModel::List<chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type>(listHolder_1->mList, 2);
+        }
 
-        uint32_t eList_1[3];
-        eList_1[0]     = 1UL;
-        eList_1[1]     = 2UL;
-        eList_1[2]     = 3UL;
-        request.arg1.e = eList_1;
+        {
+            auto * listHolder_1 = new ListHolder<uint32_t>(3);
+            listFreer.add(listHolder_1);
+            listHolder_1->mList[0] = 1UL;
+            listHolder_1->mList[1] = 2UL;
+            listHolder_1->mList[2] = 3UL;
+            request.arg1.e         = chip::app::DataModel::List<uint32_t>(listHolder_1->mList, 3);
+        }
 
-        chip::ByteSpan fList_1[3];
-        fList_1[0]     = chip::ByteSpan(chip::Uint8::from_const_char("octet_string_1garbage: not in length on purpose"), 14);
-        fList_1[1]     = chip::ByteSpan(chip::Uint8::from_const_char("octect_string_2garbage: not in length on purpose"), 15);
-        fList_1[2]     = chip::ByteSpan(chip::Uint8::from_const_char("octet_string_3garbage: not in length on purpose"), 14);
-        request.arg1.f = fList_1;
+        {
+            auto * listHolder_1 = new ListHolder<chip::ByteSpan>(3);
+            listFreer.add(listHolder_1);
+            listHolder_1->mList[0] =
+                chip::ByteSpan(chip::Uint8::from_const_char("octet_string_1garbage: not in length on purpose"), 14);
+            listHolder_1->mList[1] =
+                chip::ByteSpan(chip::Uint8::from_const_char("octect_string_2garbage: not in length on purpose"), 15);
+            listHolder_1->mList[2] =
+                chip::ByteSpan(chip::Uint8::from_const_char("octet_string_3garbage: not in length on purpose"), 14);
+            request.arg1.f = chip::app::DataModel::List<chip::ByteSpan>(listHolder_1->mList, 3);
+        }
 
-        uint8_t gList_1[2];
-        gList_1[0]     = 0;
-        gList_1[1]     = 255;
-        request.arg1.g = gList_1;
+        {
+            auto * listHolder_1 = new ListHolder<uint8_t>(2);
+            listFreer.add(listHolder_1);
+            listHolder_1->mList[0] = 0;
+            listHolder_1->mList[1] = 255;
+            request.arg1.g         = chip::app::DataModel::List<uint8_t>(listHolder_1->mList, 2);
+        }
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))->OnSuccessResponse_157(data.value);
@@ -61903,6 +63937,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestNestedStructListArgumentRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.arg1.a = 0;
@@ -61917,44 +63952,62 @@ private:
         request.arg1.c.g = 0.0f;
         request.arg1.c.h = 0;
 
-        chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type dList_1[2];
+        {
+            auto * listHolder_1 = new ListHolder<chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type>(2);
+            listFreer.add(listHolder_1);
 
-        dList_1[0].a = 1;
-        dList_1[0].b = true;
-        dList_1[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
-        dList_1[0].d = chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
-        dList_1[0].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
-        dList_1[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
-        dList_1[0].g = 0.0f;
-        dList_1[0].h = 0;
+            listHolder_1->mList[0].a = 1;
+            listHolder_1->mList[0].b = true;
+            listHolder_1->mList[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+            listHolder_1->mList[0].d =
+                chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
+            listHolder_1->mList[0].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
+            listHolder_1->mList[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+            listHolder_1->mList[0].g = 0.0f;
+            listHolder_1->mList[0].h = 0;
 
-        dList_1[1].a = 2;
-        dList_1[1].b = false;
-        dList_1[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
-        dList_1[1].d = chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
-        dList_1[1].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
-        dList_1[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
-        dList_1[1].g = 0.0f;
-        dList_1[1].h = 0;
+            listHolder_1->mList[1].a = 2;
+            listHolder_1->mList[1].b = false;
+            listHolder_1->mList[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+            listHolder_1->mList[1].d =
+                chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
+            listHolder_1->mList[1].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
+            listHolder_1->mList[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+            listHolder_1->mList[1].g = 0.0f;
+            listHolder_1->mList[1].h = 0;
 
-        request.arg1.d = dList_1;
+            request.arg1.d =
+                chip::app::DataModel::List<chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type>(listHolder_1->mList, 2);
+        }
 
-        uint32_t eList_1[3];
-        eList_1[0]     = 1UL;
-        eList_1[1]     = 2UL;
-        eList_1[2]     = 3UL;
-        request.arg1.e = eList_1;
+        {
+            auto * listHolder_1 = new ListHolder<uint32_t>(3);
+            listFreer.add(listHolder_1);
+            listHolder_1->mList[0] = 1UL;
+            listHolder_1->mList[1] = 2UL;
+            listHolder_1->mList[2] = 3UL;
+            request.arg1.e         = chip::app::DataModel::List<uint32_t>(listHolder_1->mList, 3);
+        }
 
-        chip::ByteSpan fList_1[3];
-        fList_1[0]     = chip::ByteSpan(chip::Uint8::from_const_char("octet_string_1garbage: not in length on purpose"), 14);
-        fList_1[1]     = chip::ByteSpan(chip::Uint8::from_const_char("octect_string_2garbage: not in length on purpose"), 15);
-        fList_1[2]     = chip::ByteSpan(chip::Uint8::from_const_char("octet_string_3garbage: not in length on purpose"), 14);
-        request.arg1.f = fList_1;
+        {
+            auto * listHolder_1 = new ListHolder<chip::ByteSpan>(3);
+            listFreer.add(listHolder_1);
+            listHolder_1->mList[0] =
+                chip::ByteSpan(chip::Uint8::from_const_char("octet_string_1garbage: not in length on purpose"), 14);
+            listHolder_1->mList[1] =
+                chip::ByteSpan(chip::Uint8::from_const_char("octect_string_2garbage: not in length on purpose"), 15);
+            listHolder_1->mList[2] =
+                chip::ByteSpan(chip::Uint8::from_const_char("octet_string_3garbage: not in length on purpose"), 14);
+            request.arg1.f = chip::app::DataModel::List<chip::ByteSpan>(listHolder_1->mList, 3);
+        }
 
-        uint8_t gList_1[2];
-        gList_1[0]     = 0;
-        gList_1[1]     = 255;
-        request.arg1.g = gList_1;
+        {
+            auto * listHolder_1 = new ListHolder<uint8_t>(2);
+            listFreer.add(listHolder_1);
+            listHolder_1->mList[0] = 0;
+            listHolder_1->mList[1] = 255;
+            request.arg1.g         = chip::app::DataModel::List<uint8_t>(listHolder_1->mList, 2);
+        }
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))->OnSuccessResponse_158(data.value);
@@ -61986,6 +64039,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::SimpleStructEchoRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.arg1.a = 17;
@@ -62034,19 +64088,23 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
-        uint8_t arg1List_0[9];
-        arg1List_0[0] = 1;
-        arg1List_0[1] = 2;
-        arg1List_0[2] = 3;
-        arg1List_0[3] = 4;
-        arg1List_0[4] = 5;
-        arg1List_0[5] = 6;
-        arg1List_0[6] = 7;
-        arg1List_0[7] = 8;
-        arg1List_0[8] = 9;
-        request.arg1  = arg1List_0;
+        {
+            auto * listHolder_0 = new ListHolder<uint8_t>(9);
+            listFreer.add(listHolder_0);
+            listHolder_0->mList[0] = 1;
+            listHolder_0->mList[1] = 2;
+            listHolder_0->mList[2] = 3;
+            listHolder_0->mList[3] = 4;
+            listHolder_0->mList[4] = 5;
+            listHolder_0->mList[5] = 6;
+            listHolder_0->mList[6] = 7;
+            listHolder_0->mList[7] = 8;
+            listHolder_0->mList[8] = 9;
+            request.arg1           = chip::app::DataModel::List<uint8_t>(listHolder_0->mList, 9);
+        }
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))->OnSuccessResponse_160(data.value);
@@ -62078,20 +64136,24 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
-        uint8_t arg1List_0[10];
-        arg1List_0[0] = 1;
-        arg1List_0[1] = 2;
-        arg1List_0[2] = 3;
-        arg1List_0[3] = 4;
-        arg1List_0[4] = 5;
-        arg1List_0[5] = 6;
-        arg1List_0[6] = 7;
-        arg1List_0[7] = 8;
-        arg1List_0[8] = 9;
-        arg1List_0[9] = 0;
-        request.arg1  = arg1List_0;
+        {
+            auto * listHolder_0 = new ListHolder<uint8_t>(10);
+            listFreer.add(listHolder_0);
+            listHolder_0->mList[0] = 1;
+            listHolder_0->mList[1] = 2;
+            listHolder_0->mList[2] = 3;
+            listHolder_0->mList[3] = 4;
+            listHolder_0->mList[4] = 5;
+            listHolder_0->mList[5] = 6;
+            listHolder_0->mList[6] = 7;
+            listHolder_0->mList[7] = 8;
+            listHolder_0->mList[8] = 9;
+            listHolder_0->mList[9] = 0;
+            request.arg1           = chip::app::DataModel::List<uint8_t>(listHolder_0->mList, 10);
+        }
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))->OnSuccessResponse_161(data.value);
@@ -62123,19 +64185,23 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
-        uint8_t arg1List_0[9];
-        arg1List_0[0] = 1;
-        arg1List_0[1] = 2;
-        arg1List_0[2] = 3;
-        arg1List_0[3] = 4;
-        arg1List_0[4] = 5;
-        arg1List_0[5] = 6;
-        arg1List_0[6] = 7;
-        arg1List_0[7] = 8;
-        arg1List_0[8] = 9;
-        request.arg1  = arg1List_0;
+        {
+            auto * listHolder_0 = new ListHolder<uint8_t>(9);
+            listFreer.add(listHolder_0);
+            listHolder_0->mList[0] = 1;
+            listHolder_0->mList[1] = 2;
+            listHolder_0->mList[2] = 3;
+            listHolder_0->mList[3] = 4;
+            listHolder_0->mList[4] = 5;
+            listHolder_0->mList[5] = 6;
+            listHolder_0->mList[6] = 7;
+            listHolder_0->mList[7] = 8;
+            listHolder_0->mList[8] = 9;
+            request.arg1           = chip::app::DataModel::List<uint8_t>(listHolder_0->mList, 9);
+        }
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))->OnSuccessResponse_162(data.arg1);
@@ -62188,6 +64254,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.arg1 = chip::app::DataModel::List<uint8_t>();
@@ -62225,29 +64292,36 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
-        chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type arg1List_0[2];
+        {
+            auto * listHolder_0 = new ListHolder<chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type>(2);
+            listFreer.add(listHolder_0);
 
-        arg1List_0[0].a = 0;
-        arg1List_0[0].b = true;
-        arg1List_0[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
-        arg1List_0[0].d = chip::ByteSpan(chip::Uint8::from_const_char("first_octet_stringgarbage: not in length on purpose"), 18);
-        arg1List_0[0].e = chip::Span<const char>("first_char_stringgarbage: not in length on purpose", 17);
-        arg1List_0[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
-        arg1List_0[0].g = 0.0f;
-        arg1List_0[0].h = 0;
+            listHolder_0->mList[0].a = 0;
+            listHolder_0->mList[0].b = true;
+            listHolder_0->mList[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
+            listHolder_0->mList[0].d =
+                chip::ByteSpan(chip::Uint8::from_const_char("first_octet_stringgarbage: not in length on purpose"), 18);
+            listHolder_0->mList[0].e = chip::Span<const char>("first_char_stringgarbage: not in length on purpose", 17);
+            listHolder_0->mList[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+            listHolder_0->mList[0].g = 0.0f;
+            listHolder_0->mList[0].h = 0;
 
-        arg1List_0[1].a = 1;
-        arg1List_0[1].b = true;
-        arg1List_0[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
-        arg1List_0[1].d = chip::ByteSpan(chip::Uint8::from_const_char("second_octet_stringgarbage: not in length on purpose"), 19);
-        arg1List_0[1].e = chip::Span<const char>("second_char_stringgarbage: not in length on purpose", 18);
-        arg1List_0[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
-        arg1List_0[1].g = 0.0f;
-        arg1List_0[1].h = 0;
+            listHolder_0->mList[1].a = 1;
+            listHolder_0->mList[1].b = true;
+            listHolder_0->mList[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+            listHolder_0->mList[1].d =
+                chip::ByteSpan(chip::Uint8::from_const_char("second_octet_stringgarbage: not in length on purpose"), 19);
+            listHolder_0->mList[1].e = chip::Span<const char>("second_char_stringgarbage: not in length on purpose", 18);
+            listHolder_0->mList[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+            listHolder_0->mList[1].g = 0.0f;
+            listHolder_0->mList[1].h = 0;
 
-        request.arg1 = arg1List_0;
+            request.arg1 =
+                chip::app::DataModel::List<chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type>(listHolder_0->mList, 2);
+        }
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))->OnSuccessResponse_164(data.value);
@@ -62279,29 +64353,36 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
-        chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type arg1List_0[2];
+        {
+            auto * listHolder_0 = new ListHolder<chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type>(2);
+            listFreer.add(listHolder_0);
 
-        arg1List_0[0].a = 1;
-        arg1List_0[0].b = true;
-        arg1List_0[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
-        arg1List_0[0].d = chip::ByteSpan(chip::Uint8::from_const_char("second_octet_stringgarbage: not in length on purpose"), 19);
-        arg1List_0[0].e = chip::Span<const char>("second_char_stringgarbage: not in length on purpose", 18);
-        arg1List_0[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
-        arg1List_0[0].g = 0.0f;
-        arg1List_0[0].h = 0;
+            listHolder_0->mList[0].a = 1;
+            listHolder_0->mList[0].b = true;
+            listHolder_0->mList[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+            listHolder_0->mList[0].d =
+                chip::ByteSpan(chip::Uint8::from_const_char("second_octet_stringgarbage: not in length on purpose"), 19);
+            listHolder_0->mList[0].e = chip::Span<const char>("second_char_stringgarbage: not in length on purpose", 18);
+            listHolder_0->mList[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+            listHolder_0->mList[0].g = 0.0f;
+            listHolder_0->mList[0].h = 0;
 
-        arg1List_0[1].a = 0;
-        arg1List_0[1].b = false;
-        arg1List_0[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
-        arg1List_0[1].d = chip::ByteSpan(chip::Uint8::from_const_char("first_octet_stringgarbage: not in length on purpose"), 18);
-        arg1List_0[1].e = chip::Span<const char>("first_char_stringgarbage: not in length on purpose", 17);
-        arg1List_0[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
-        arg1List_0[1].g = 0.0f;
-        arg1List_0[1].h = 0;
+            listHolder_0->mList[1].a = 0;
+            listHolder_0->mList[1].b = false;
+            listHolder_0->mList[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
+            listHolder_0->mList[1].d =
+                chip::ByteSpan(chip::Uint8::from_const_char("first_octet_stringgarbage: not in length on purpose"), 18);
+            listHolder_0->mList[1].e = chip::Span<const char>("first_char_stringgarbage: not in length on purpose", 17);
+            listHolder_0->mList[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+            listHolder_0->mList[1].g = 0.0f;
+            listHolder_0->mList[1].h = 0;
 
-        request.arg1 = arg1List_0;
+            request.arg1 =
+                chip::app::DataModel::List<chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type>(listHolder_0->mList, 2);
+        }
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))->OnSuccessResponse_165(data.value);
@@ -62333,62 +64414,87 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestListNestedStructListArgumentRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
-        chip::app::Clusters::TestCluster::Structs::NestedStructList::Type arg1List_0[1];
+        {
+            auto * listHolder_0 = new ListHolder<chip::app::Clusters::TestCluster::Structs::NestedStructList::Type>(1);
+            listFreer.add(listHolder_0);
 
-        arg1List_0[0].a = 0;
-        arg1List_0[0].b = true;
+            listHolder_0->mList[0].a = 0;
+            listHolder_0->mList[0].b = true;
 
-        arg1List_0[0].c.a = 0;
-        arg1List_0[0].c.b = true;
-        arg1List_0[0].c.c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
-        arg1List_0[0].c.d = chip::ByteSpan(chip::Uint8::from_const_char("octet_stringgarbage: not in length on purpose"), 12);
-        arg1List_0[0].c.e = chip::Span<const char>("char_stringgarbage: not in length on purpose", 11);
-        arg1List_0[0].c.f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
-        arg1List_0[0].c.g = 0.0f;
-        arg1List_0[0].c.h = 0;
+            listHolder_0->mList[0].c.a = 0;
+            listHolder_0->mList[0].c.b = true;
+            listHolder_0->mList[0].c.c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
+            listHolder_0->mList[0].c.d =
+                chip::ByteSpan(chip::Uint8::from_const_char("octet_stringgarbage: not in length on purpose"), 12);
+            listHolder_0->mList[0].c.e = chip::Span<const char>("char_stringgarbage: not in length on purpose", 11);
+            listHolder_0->mList[0].c.f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+            listHolder_0->mList[0].c.g = 0.0f;
+            listHolder_0->mList[0].c.h = 0;
 
-        chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type dList_2[2];
+            {
+                auto * listHolder_2 = new ListHolder<chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type>(2);
+                listFreer.add(listHolder_2);
 
-        dList_2[0].a = 1;
-        dList_2[0].b = true;
-        dList_2[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
-        dList_2[0].d = chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
-        dList_2[0].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
-        dList_2[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
-        dList_2[0].g = 0.0f;
-        dList_2[0].h = 0;
+                listHolder_2->mList[0].a = 1;
+                listHolder_2->mList[0].b = true;
+                listHolder_2->mList[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+                listHolder_2->mList[0].d =
+                    chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
+                listHolder_2->mList[0].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
+                listHolder_2->mList[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+                listHolder_2->mList[0].g = 0.0f;
+                listHolder_2->mList[0].h = 0;
 
-        dList_2[1].a = 2;
-        dList_2[1].b = true;
-        dList_2[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
-        dList_2[1].d = chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
-        dList_2[1].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
-        dList_2[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
-        dList_2[1].g = 0.0f;
-        dList_2[1].h = 0;
+                listHolder_2->mList[1].a = 2;
+                listHolder_2->mList[1].b = true;
+                listHolder_2->mList[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+                listHolder_2->mList[1].d =
+                    chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
+                listHolder_2->mList[1].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
+                listHolder_2->mList[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+                listHolder_2->mList[1].g = 0.0f;
+                listHolder_2->mList[1].h = 0;
 
-        arg1List_0[0].d = dList_2;
+                listHolder_0->mList[0].d =
+                    chip::app::DataModel::List<chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type>(listHolder_2->mList,
+                                                                                                              2);
+            }
 
-        uint32_t eList_2[3];
-        eList_2[0]      = 1UL;
-        eList_2[1]      = 2UL;
-        eList_2[2]      = 3UL;
-        arg1List_0[0].e = eList_2;
+            {
+                auto * listHolder_2 = new ListHolder<uint32_t>(3);
+                listFreer.add(listHolder_2);
+                listHolder_2->mList[0]   = 1UL;
+                listHolder_2->mList[1]   = 2UL;
+                listHolder_2->mList[2]   = 3UL;
+                listHolder_0->mList[0].e = chip::app::DataModel::List<uint32_t>(listHolder_2->mList, 3);
+            }
 
-        chip::ByteSpan fList_2[3];
-        fList_2[0]      = chip::ByteSpan(chip::Uint8::from_const_char("octet_string_1garbage: not in length on purpose"), 14);
-        fList_2[1]      = chip::ByteSpan(chip::Uint8::from_const_char("octect_string_2garbage: not in length on purpose"), 15);
-        fList_2[2]      = chip::ByteSpan(chip::Uint8::from_const_char("octet_string_3garbage: not in length on purpose"), 14);
-        arg1List_0[0].f = fList_2;
+            {
+                auto * listHolder_2 = new ListHolder<chip::ByteSpan>(3);
+                listFreer.add(listHolder_2);
+                listHolder_2->mList[0] =
+                    chip::ByteSpan(chip::Uint8::from_const_char("octet_string_1garbage: not in length on purpose"), 14);
+                listHolder_2->mList[1] =
+                    chip::ByteSpan(chip::Uint8::from_const_char("octect_string_2garbage: not in length on purpose"), 15);
+                listHolder_2->mList[2] =
+                    chip::ByteSpan(chip::Uint8::from_const_char("octet_string_3garbage: not in length on purpose"), 14);
+                listHolder_0->mList[0].f = chip::app::DataModel::List<chip::ByteSpan>(listHolder_2->mList, 3);
+            }
 
-        uint8_t gList_2[2];
-        gList_2[0]      = 0;
-        gList_2[1]      = 255;
-        arg1List_0[0].g = gList_2;
+            {
+                auto * listHolder_2 = new ListHolder<uint8_t>(2);
+                listFreer.add(listHolder_2);
+                listHolder_2->mList[0]   = 0;
+                listHolder_2->mList[1]   = 255;
+                listHolder_0->mList[0].g = chip::app::DataModel::List<uint8_t>(listHolder_2->mList, 2);
+            }
 
-        request.arg1 = arg1List_0;
+            request.arg1 = chip::app::DataModel::List<chip::app::Clusters::TestCluster::Structs::NestedStructList::Type>(
+                listHolder_0->mList, 1);
+        }
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))->OnSuccessResponse_166(data.value);
@@ -62420,62 +64526,87 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestListNestedStructListArgumentRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
-        chip::app::Clusters::TestCluster::Structs::NestedStructList::Type arg1List_0[1];
+        {
+            auto * listHolder_0 = new ListHolder<chip::app::Clusters::TestCluster::Structs::NestedStructList::Type>(1);
+            listFreer.add(listHolder_0);
 
-        arg1List_0[0].a = 0;
-        arg1List_0[0].b = true;
+            listHolder_0->mList[0].a = 0;
+            listHolder_0->mList[0].b = true;
 
-        arg1List_0[0].c.a = 0;
-        arg1List_0[0].c.b = true;
-        arg1List_0[0].c.c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
-        arg1List_0[0].c.d = chip::ByteSpan(chip::Uint8::from_const_char("octet_stringgarbage: not in length on purpose"), 12);
-        arg1List_0[0].c.e = chip::Span<const char>("char_stringgarbage: not in length on purpose", 11);
-        arg1List_0[0].c.f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
-        arg1List_0[0].c.g = 0.0f;
-        arg1List_0[0].c.h = 0;
+            listHolder_0->mList[0].c.a = 0;
+            listHolder_0->mList[0].c.b = true;
+            listHolder_0->mList[0].c.c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
+            listHolder_0->mList[0].c.d =
+                chip::ByteSpan(chip::Uint8::from_const_char("octet_stringgarbage: not in length on purpose"), 12);
+            listHolder_0->mList[0].c.e = chip::Span<const char>("char_stringgarbage: not in length on purpose", 11);
+            listHolder_0->mList[0].c.f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+            listHolder_0->mList[0].c.g = 0.0f;
+            listHolder_0->mList[0].c.h = 0;
 
-        chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type dList_2[2];
+            {
+                auto * listHolder_2 = new ListHolder<chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type>(2);
+                listFreer.add(listHolder_2);
 
-        dList_2[0].a = 1;
-        dList_2[0].b = true;
-        dList_2[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
-        dList_2[0].d = chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
-        dList_2[0].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
-        dList_2[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
-        dList_2[0].g = 0.0f;
-        dList_2[0].h = 0;
+                listHolder_2->mList[0].a = 1;
+                listHolder_2->mList[0].b = true;
+                listHolder_2->mList[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+                listHolder_2->mList[0].d =
+                    chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
+                listHolder_2->mList[0].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
+                listHolder_2->mList[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+                listHolder_2->mList[0].g = 0.0f;
+                listHolder_2->mList[0].h = 0;
 
-        dList_2[1].a = 2;
-        dList_2[1].b = false;
-        dList_2[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
-        dList_2[1].d = chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
-        dList_2[1].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
-        dList_2[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
-        dList_2[1].g = 0.0f;
-        dList_2[1].h = 0;
+                listHolder_2->mList[1].a = 2;
+                listHolder_2->mList[1].b = false;
+                listHolder_2->mList[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+                listHolder_2->mList[1].d =
+                    chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
+                listHolder_2->mList[1].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
+                listHolder_2->mList[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+                listHolder_2->mList[1].g = 0.0f;
+                listHolder_2->mList[1].h = 0;
 
-        arg1List_0[0].d = dList_2;
+                listHolder_0->mList[0].d =
+                    chip::app::DataModel::List<chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type>(listHolder_2->mList,
+                                                                                                              2);
+            }
 
-        uint32_t eList_2[3];
-        eList_2[0]      = 1UL;
-        eList_2[1]      = 2UL;
-        eList_2[2]      = 3UL;
-        arg1List_0[0].e = eList_2;
+            {
+                auto * listHolder_2 = new ListHolder<uint32_t>(3);
+                listFreer.add(listHolder_2);
+                listHolder_2->mList[0]   = 1UL;
+                listHolder_2->mList[1]   = 2UL;
+                listHolder_2->mList[2]   = 3UL;
+                listHolder_0->mList[0].e = chip::app::DataModel::List<uint32_t>(listHolder_2->mList, 3);
+            }
 
-        chip::ByteSpan fList_2[3];
-        fList_2[0]      = chip::ByteSpan(chip::Uint8::from_const_char("octet_string_1garbage: not in length on purpose"), 14);
-        fList_2[1]      = chip::ByteSpan(chip::Uint8::from_const_char("octect_string_2garbage: not in length on purpose"), 15);
-        fList_2[2]      = chip::ByteSpan(chip::Uint8::from_const_char("octet_string_3garbage: not in length on purpose"), 14);
-        arg1List_0[0].f = fList_2;
+            {
+                auto * listHolder_2 = new ListHolder<chip::ByteSpan>(3);
+                listFreer.add(listHolder_2);
+                listHolder_2->mList[0] =
+                    chip::ByteSpan(chip::Uint8::from_const_char("octet_string_1garbage: not in length on purpose"), 14);
+                listHolder_2->mList[1] =
+                    chip::ByteSpan(chip::Uint8::from_const_char("octect_string_2garbage: not in length on purpose"), 15);
+                listHolder_2->mList[2] =
+                    chip::ByteSpan(chip::Uint8::from_const_char("octet_string_3garbage: not in length on purpose"), 14);
+                listHolder_0->mList[0].f = chip::app::DataModel::List<chip::ByteSpan>(listHolder_2->mList, 3);
+            }
 
-        uint8_t gList_2[2];
-        gList_2[0]      = 0;
-        gList_2[1]      = 255;
-        arg1List_0[0].g = gList_2;
+            {
+                auto * listHolder_2 = new ListHolder<uint8_t>(2);
+                listFreer.add(listHolder_2);
+                listHolder_2->mList[0]   = 0;
+                listHolder_2->mList[1]   = 255;
+                listHolder_0->mList[0].g = chip::app::DataModel::List<uint8_t>(listHolder_2->mList, 2);
+            }
 
-        request.arg1 = arg1List_0;
+            request.arg1 = chip::app::DataModel::List<chip::app::Clusters::TestCluster::Structs::NestedStructList::Type>(
+                listHolder_0->mList, 1);
+        }
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))->OnSuccessResponse_167(data.value);
@@ -62508,14 +64639,18 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::List<const uint8_t> listInt8uArgument;
 
-        uint8_t listInt8uList_0[4];
-        listInt8uList_0[0] = 1;
-        listInt8uList_0[1] = 2;
-        listInt8uList_0[2] = 3;
-        listInt8uList_0[3] = 4;
-        listInt8uArgument  = listInt8uList_0;
+        {
+            auto * listHolder_0 = new ListHolder<uint8_t>(4);
+            listFreer.add(listHolder_0);
+            listHolder_0->mList[0] = 1;
+            listHolder_0->mList[1] = 2;
+            listHolder_0->mList[2] = 3;
+            listHolder_0->mList[3] = 4;
+            listInt8uArgument      = chip::app::DataModel::List<uint8_t>(listHolder_0->mList, 4);
+        }
 
         ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(
             listInt8uArgument, this, OnSuccessCallback_168, OnFailureCallback_168));
@@ -62535,6 +64670,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(
             this, OnSuccessCallback_169, OnFailureCallback_169));
@@ -62571,14 +64708,18 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::List<const chip::ByteSpan> listOctetStringArgument;
 
-        chip::ByteSpan listOctetStringList_0[4];
-        listOctetStringList_0[0] = chip::ByteSpan(chip::Uint8::from_const_char("Test0garbage: not in length on purpose"), 5);
-        listOctetStringList_0[1] = chip::ByteSpan(chip::Uint8::from_const_char("Test1garbage: not in length on purpose"), 5);
-        listOctetStringList_0[2] = chip::ByteSpan(chip::Uint8::from_const_char("Test2garbage: not in length on purpose"), 5);
-        listOctetStringList_0[3] = chip::ByteSpan(chip::Uint8::from_const_char("Test3garbage: not in length on purpose"), 5);
-        listOctetStringArgument  = listOctetStringList_0;
+        {
+            auto * listHolder_0 = new ListHolder<chip::ByteSpan>(4);
+            listFreer.add(listHolder_0);
+            listHolder_0->mList[0]  = chip::ByteSpan(chip::Uint8::from_const_char("Test0garbage: not in length on purpose"), 5);
+            listHolder_0->mList[1]  = chip::ByteSpan(chip::Uint8::from_const_char("Test1garbage: not in length on purpose"), 5);
+            listHolder_0->mList[2]  = chip::ByteSpan(chip::Uint8::from_const_char("Test2garbage: not in length on purpose"), 5);
+            listHolder_0->mList[3]  = chip::ByteSpan(chip::Uint8::from_const_char("Test3garbage: not in length on purpose"), 5);
+            listOctetStringArgument = chip::app::DataModel::List<chip::ByteSpan>(listHolder_0->mList, 4);
+        }
 
         ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::ListOctetString::TypeInfo>(
             listOctetStringArgument, this, OnSuccessCallback_170, OnFailureCallback_170));
@@ -62598,6 +64739,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListOctetString::TypeInfo>(
             this, OnSuccessCallback_171, OnFailureCallback_171));
@@ -62638,28 +64781,34 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::List<const chip::app::Clusters::TestCluster::Structs::TestListStructOctet::Type>
             listStructOctetStringArgument;
 
-        chip::app::Clusters::TestCluster::Structs::TestListStructOctet::Type listStructOctetStringList_0[4];
+        {
+            auto * listHolder_0 = new ListHolder<chip::app::Clusters::TestCluster::Structs::TestListStructOctet::Type>(4);
+            listFreer.add(listHolder_0);
 
-        listStructOctetStringList_0[0].fabricIndex = 0ULL;
-        listStructOctetStringList_0[0].operationalCert =
-            chip::ByteSpan(chip::Uint8::from_const_char("Test0garbage: not in length on purpose"), 5);
+            listHolder_0->mList[0].fabricIndex = 0ULL;
+            listHolder_0->mList[0].operationalCert =
+                chip::ByteSpan(chip::Uint8::from_const_char("Test0garbage: not in length on purpose"), 5);
 
-        listStructOctetStringList_0[1].fabricIndex = 1ULL;
-        listStructOctetStringList_0[1].operationalCert =
-            chip::ByteSpan(chip::Uint8::from_const_char("Test1garbage: not in length on purpose"), 5);
+            listHolder_0->mList[1].fabricIndex = 1ULL;
+            listHolder_0->mList[1].operationalCert =
+                chip::ByteSpan(chip::Uint8::from_const_char("Test1garbage: not in length on purpose"), 5);
 
-        listStructOctetStringList_0[2].fabricIndex = 2ULL;
-        listStructOctetStringList_0[2].operationalCert =
-            chip::ByteSpan(chip::Uint8::from_const_char("Test2garbage: not in length on purpose"), 5);
+            listHolder_0->mList[2].fabricIndex = 2ULL;
+            listHolder_0->mList[2].operationalCert =
+                chip::ByteSpan(chip::Uint8::from_const_char("Test2garbage: not in length on purpose"), 5);
 
-        listStructOctetStringList_0[3].fabricIndex = 3ULL;
-        listStructOctetStringList_0[3].operationalCert =
-            chip::ByteSpan(chip::Uint8::from_const_char("Test3garbage: not in length on purpose"), 5);
+            listHolder_0->mList[3].fabricIndex = 3ULL;
+            listHolder_0->mList[3].operationalCert =
+                chip::ByteSpan(chip::Uint8::from_const_char("Test3garbage: not in length on purpose"), 5);
 
-        listStructOctetStringArgument = listStructOctetStringList_0;
+            listStructOctetStringArgument =
+                chip::app::DataModel::List<chip::app::Clusters::TestCluster::Structs::TestListStructOctet::Type>(
+                    listHolder_0->mList, 4);
+        }
 
         ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::ListStructOctetString::TypeInfo>(
             listStructOctetStringArgument, this, OnSuccessCallback_172, OnFailureCallback_172));
@@ -62679,6 +64828,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListStructOctetString::TypeInfo>(
             this, OnSuccessCallback_173, OnFailureCallback_173));
@@ -62724,6 +64875,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.arg1.Emplace();
         request.arg1.Value().SetNonNull();
@@ -62771,6 +64923,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -62805,6 +64958,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListNullablesAndOptionalsStruct::TypeInfo>(
@@ -62843,22 +64998,32 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::List<const chip::app::Clusters::TestCluster::Structs::NullablesAndOptionalsStruct::Type>
             listNullablesAndOptionalsStructArgument;
 
-        chip::app::Clusters::TestCluster::Structs::NullablesAndOptionalsStruct::Type listNullablesAndOptionalsStructList_0[1];
+        {
+            auto * listHolder_0 = new ListHolder<chip::app::Clusters::TestCluster::Structs::NullablesAndOptionalsStruct::Type>(1);
+            listFreer.add(listHolder_0);
 
-        listNullablesAndOptionalsStructList_0[0].nullableInt.SetNull();
-        listNullablesAndOptionalsStructList_0[0].nullableString.SetNull();
-        listNullablesAndOptionalsStructList_0[0].nullableStruct.SetNull();
-        listNullablesAndOptionalsStructList_0[0].nullableList.SetNonNull();
+            listHolder_0->mList[0].nullableInt.SetNull();
+            listHolder_0->mList[0].nullableString.SetNull();
+            listHolder_0->mList[0].nullableStruct.SetNull();
+            listHolder_0->mList[0].nullableList.SetNonNull();
 
-        chip::app::Clusters::TestCluster::SimpleEnum nullableListList_3[2];
-        nullableListList_3[0] = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(1);
-        nullableListList_3[1] = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
-        listNullablesAndOptionalsStructList_0[0].nullableList.Value() = nullableListList_3;
+            {
+                auto * listHolder_3 = new ListHolder<chip::app::Clusters::TestCluster::SimpleEnum>(2);
+                listFreer.add(listHolder_3);
+                listHolder_3->mList[0] = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(1);
+                listHolder_3->mList[1] = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
+                listHolder_0->mList[0].nullableList.Value() =
+                    chip::app::DataModel::List<chip::app::Clusters::TestCluster::SimpleEnum>(listHolder_3->mList, 2);
+            }
 
-        listNullablesAndOptionalsStructArgument = listNullablesAndOptionalsStructList_0;
+            listNullablesAndOptionalsStructArgument =
+                chip::app::DataModel::List<chip::app::Clusters::TestCluster::Structs::NullablesAndOptionalsStruct::Type>(
+                    listHolder_0->mList, 1);
+        }
 
         ReturnErrorOnFailure(
             cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::ListNullablesAndOptionalsStruct::TypeInfo>(
@@ -62879,6 +65044,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListNullablesAndOptionalsStruct::TypeInfo>(
@@ -62928,6 +65095,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<bool> nullableBooleanArgument;
         nullableBooleanArgument.SetNull();
 
@@ -62949,6 +65117,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBoolean::TypeInfo>(
             this, OnSuccessCallback_180, OnFailureCallback_180));
@@ -62974,6 +65144,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<bool> nullableBooleanArgument;
         nullableBooleanArgument.SetNonNull();
         nullableBooleanArgument.Value() = true;
@@ -62996,6 +65167,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBoolean::TypeInfo>(
             this, OnSuccessCallback_182, OnFailureCallback_182));
@@ -63022,6 +65195,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableBitmap8Argument;
         nullableBitmap8Argument.SetNonNull();
         nullableBitmap8Argument.Value() = 254;
@@ -63044,6 +65218,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap8::TypeInfo>(
             this, OnSuccessCallback_184, OnFailureCallback_184));
@@ -63070,6 +65246,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableBitmap8Argument;
         nullableBitmap8Argument.SetNonNull();
         nullableBitmap8Argument.Value() = 255;
@@ -63093,6 +65270,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap8::TypeInfo>(
             this, OnSuccessCallback_186, OnFailureCallback_186));
@@ -63119,6 +65298,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableBitmap8Argument;
         nullableBitmap8Argument.SetNull();
 
@@ -63140,6 +65320,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap8::TypeInfo>(
             this, OnSuccessCallback_188, OnFailureCallback_188));
@@ -63165,6 +65347,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableBitmap16Argument;
         nullableBitmap16Argument.SetNonNull();
         nullableBitmap16Argument.Value() = 65534U;
@@ -63187,6 +65370,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap16::TypeInfo>(
             this, OnSuccessCallback_190, OnFailureCallback_190));
@@ -63213,6 +65398,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableBitmap16Argument;
         nullableBitmap16Argument.SetNonNull();
         nullableBitmap16Argument.Value() = 65535U;
@@ -63236,6 +65422,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap16::TypeInfo>(
             this, OnSuccessCallback_192, OnFailureCallback_192));
@@ -63262,6 +65450,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableBitmap16Argument;
         nullableBitmap16Argument.SetNull();
 
@@ -63283,6 +65472,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap16::TypeInfo>(
             this, OnSuccessCallback_194, OnFailureCallback_194));
@@ -63308,6 +65499,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint32_t> nullableBitmap32Argument;
         nullableBitmap32Argument.SetNonNull();
         nullableBitmap32Argument.Value() = 4294967294UL;
@@ -63330,6 +65522,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap32::TypeInfo>(
             this, OnSuccessCallback_196, OnFailureCallback_196));
@@ -63356,6 +65550,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint32_t> nullableBitmap32Argument;
         nullableBitmap32Argument.SetNonNull();
         nullableBitmap32Argument.Value() = 4294967295UL;
@@ -63379,6 +65574,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap32::TypeInfo>(
             this, OnSuccessCallback_198, OnFailureCallback_198));
@@ -63405,6 +65602,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint32_t> nullableBitmap32Argument;
         nullableBitmap32Argument.SetNull();
 
@@ -63426,6 +65624,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap32::TypeInfo>(
             this, OnSuccessCallback_200, OnFailureCallback_200));
@@ -63451,6 +65651,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint64_t> nullableBitmap64Argument;
         nullableBitmap64Argument.SetNonNull();
         nullableBitmap64Argument.Value() = 18446744073709551614ULL;
@@ -63473,6 +65674,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap64::TypeInfo>(
             this, OnSuccessCallback_202, OnFailureCallback_202));
@@ -63499,6 +65702,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint64_t> nullableBitmap64Argument;
         nullableBitmap64Argument.SetNonNull();
         nullableBitmap64Argument.Value() = 18446744073709551615ULL;
@@ -63522,6 +65726,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap64::TypeInfo>(
             this, OnSuccessCallback_204, OnFailureCallback_204));
@@ -63548,6 +65754,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint64_t> nullableBitmap64Argument;
         nullableBitmap64Argument.SetNull();
 
@@ -63569,6 +65776,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap64::TypeInfo>(
             this, OnSuccessCallback_206, OnFailureCallback_206));
@@ -63594,6 +65803,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableInt8uArgument;
         nullableInt8uArgument.SetNonNull();
         nullableInt8uArgument.Value() = 0;
@@ -63616,6 +65826,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
             this, OnSuccessCallback_208, OnFailureCallback_208));
@@ -63642,6 +65854,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableInt8uArgument;
         nullableInt8uArgument.SetNonNull();
         nullableInt8uArgument.Value() = 254;
@@ -63664,6 +65877,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
             this, OnSuccessCallback_210, OnFailureCallback_210));
@@ -63690,6 +65905,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableInt8uArgument;
         nullableInt8uArgument.SetNonNull();
         nullableInt8uArgument.Value() = 255;
@@ -63713,6 +65929,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
             this, OnSuccessCallback_212, OnFailureCallback_212));
@@ -63739,6 +65957,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
             this, OnSuccessCallback_213, OnFailureCallback_213));
         return CHIP_NO_ERROR;
@@ -63763,6 +65983,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableInt8uArgument;
         nullableInt8uArgument.SetNull();
 
@@ -63784,6 +66005,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
             this, OnSuccessCallback_215, OnFailureCallback_215));
@@ -63809,6 +66032,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
             this, OnSuccessCallback_216, OnFailureCallback_216));
         return CHIP_NO_ERROR;
@@ -63832,6 +66057,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
             this, OnSuccessCallback_217, OnFailureCallback_217));
@@ -63857,6 +66084,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableInt8uArgument;
         nullableInt8uArgument.SetNonNull();
         nullableInt8uArgument.Value() = 128;
@@ -63879,6 +66107,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
             this, OnSuccessCallback_219, OnFailureCallback_219));
@@ -63904,6 +66134,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
             this, OnSuccessCallback_220, OnFailureCallback_220));
         return CHIP_NO_ERROR;
@@ -63928,6 +66160,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableInt16uArgument;
         nullableInt16uArgument.SetNonNull();
         nullableInt16uArgument.Value() = 0U;
@@ -63950,6 +66183,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
             this, OnSuccessCallback_222, OnFailureCallback_222));
@@ -63976,6 +66211,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableInt16uArgument;
         nullableInt16uArgument.SetNonNull();
         nullableInt16uArgument.Value() = 65534U;
@@ -63998,6 +66234,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
             this, OnSuccessCallback_224, OnFailureCallback_224));
@@ -64024,6 +66262,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableInt16uArgument;
         nullableInt16uArgument.SetNonNull();
         nullableInt16uArgument.Value() = 65535U;
@@ -64047,6 +66286,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
             this, OnSuccessCallback_226, OnFailureCallback_226));
@@ -64073,6 +66314,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableInt16uArgument;
         nullableInt16uArgument.SetNull();
 
@@ -64094,6 +66336,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
             this, OnSuccessCallback_228, OnFailureCallback_228));
@@ -64119,6 +66363,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
             this, OnSuccessCallback_229, OnFailureCallback_229));
         return CHIP_NO_ERROR;
@@ -64142,6 +66388,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
             this, OnSuccessCallback_230, OnFailureCallback_230));
@@ -64167,6 +66415,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableInt16uArgument;
         nullableInt16uArgument.SetNonNull();
         nullableInt16uArgument.Value() = 32000U;
@@ -64189,6 +66438,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
             this, OnSuccessCallback_232, OnFailureCallback_232));
@@ -64214,6 +66465,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
             this, OnSuccessCallback_233, OnFailureCallback_233));
         return CHIP_NO_ERROR;
@@ -64238,6 +66491,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint32_t> nullableInt32uArgument;
         nullableInt32uArgument.SetNonNull();
         nullableInt32uArgument.Value() = 0UL;
@@ -64260,6 +66514,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
             this, OnSuccessCallback_235, OnFailureCallback_235));
@@ -64286,6 +66542,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint32_t> nullableInt32uArgument;
         nullableInt32uArgument.SetNonNull();
         nullableInt32uArgument.Value() = 4294967294UL;
@@ -64308,6 +66565,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
             this, OnSuccessCallback_237, OnFailureCallback_237));
@@ -64334,6 +66593,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint32_t> nullableInt32uArgument;
         nullableInt32uArgument.SetNonNull();
         nullableInt32uArgument.Value() = 4294967295UL;
@@ -64357,6 +66617,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
             this, OnSuccessCallback_239, OnFailureCallback_239));
@@ -64383,6 +66645,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint32_t> nullableInt32uArgument;
         nullableInt32uArgument.SetNull();
 
@@ -64404,6 +66667,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
             this, OnSuccessCallback_241, OnFailureCallback_241));
@@ -64429,6 +66694,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
             this, OnSuccessCallback_242, OnFailureCallback_242));
         return CHIP_NO_ERROR;
@@ -64452,6 +66719,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
             this, OnSuccessCallback_243, OnFailureCallback_243));
@@ -64477,6 +66746,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint32_t> nullableInt32uArgument;
         nullableInt32uArgument.SetNonNull();
         nullableInt32uArgument.Value() = 2147483647UL;
@@ -64499,6 +66769,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
             this, OnSuccessCallback_245, OnFailureCallback_245));
@@ -64524,6 +66796,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
             this, OnSuccessCallback_246, OnFailureCallback_246));
         return CHIP_NO_ERROR;
@@ -64548,6 +66822,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint64_t> nullableInt64uArgument;
         nullableInt64uArgument.SetNonNull();
         nullableInt64uArgument.Value() = 0ULL;
@@ -64570,6 +66845,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
             this, OnSuccessCallback_248, OnFailureCallback_248));
@@ -64596,6 +66873,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint64_t> nullableInt64uArgument;
         nullableInt64uArgument.SetNonNull();
         nullableInt64uArgument.Value() = 18446744073709551614ULL;
@@ -64618,6 +66896,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
             this, OnSuccessCallback_250, OnFailureCallback_250));
@@ -64644,6 +66924,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint64_t> nullableInt64uArgument;
         nullableInt64uArgument.SetNonNull();
         nullableInt64uArgument.Value() = 18446744073709551615ULL;
@@ -64667,6 +66948,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
             this, OnSuccessCallback_252, OnFailureCallback_252));
@@ -64693,6 +66976,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint64_t> nullableInt64uArgument;
         nullableInt64uArgument.SetNull();
 
@@ -64714,6 +66998,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
             this, OnSuccessCallback_254, OnFailureCallback_254));
@@ -64739,6 +67025,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
             this, OnSuccessCallback_255, OnFailureCallback_255));
         return CHIP_NO_ERROR;
@@ -64762,6 +67050,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
             this, OnSuccessCallback_256, OnFailureCallback_256));
@@ -64787,6 +67077,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint64_t> nullableInt64uArgument;
         nullableInt64uArgument.SetNonNull();
         nullableInt64uArgument.Value() = 18000000000000000000ULL;
@@ -64809,6 +67100,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
             this, OnSuccessCallback_258, OnFailureCallback_258));
@@ -64834,6 +67127,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
             this, OnSuccessCallback_259, OnFailureCallback_259));
         return CHIP_NO_ERROR;
@@ -64858,6 +67153,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int8_t> nullableInt8sArgument;
         nullableInt8sArgument.SetNonNull();
         nullableInt8sArgument.Value() = -127;
@@ -64880,6 +67176,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
             this, OnSuccessCallback_261, OnFailureCallback_261));
@@ -64906,6 +67204,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int8_t> nullableInt8sArgument;
         nullableInt8sArgument.SetNonNull();
         nullableInt8sArgument.Value() = -128;
@@ -64929,6 +67228,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
             this, OnSuccessCallback_263, OnFailureCallback_263));
@@ -64955,6 +67256,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int8_t> nullableInt8sArgument;
         nullableInt8sArgument.SetNull();
 
@@ -64976,6 +67278,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
             this, OnSuccessCallback_265, OnFailureCallback_265));
@@ -65001,6 +67305,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
             this, OnSuccessCallback_266, OnFailureCallback_266));
         return CHIP_NO_ERROR;
@@ -65024,6 +67330,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
             this, OnSuccessCallback_267, OnFailureCallback_267));
@@ -65049,6 +67357,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int8_t> nullableInt8sArgument;
         nullableInt8sArgument.SetNonNull();
         nullableInt8sArgument.Value() = -127;
@@ -65071,6 +67380,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
             this, OnSuccessCallback_269, OnFailureCallback_269));
@@ -65096,6 +67407,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
             this, OnSuccessCallback_270, OnFailureCallback_270));
         return CHIP_NO_ERROR;
@@ -65120,6 +67433,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int16_t> nullableInt16sArgument;
         nullableInt16sArgument.SetNonNull();
         nullableInt16sArgument.Value() = -32767;
@@ -65142,6 +67456,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
             this, OnSuccessCallback_272, OnFailureCallback_272));
@@ -65168,6 +67484,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int16_t> nullableInt16sArgument;
         nullableInt16sArgument.SetNonNull();
         nullableInt16sArgument.Value() = -32768;
@@ -65191,6 +67508,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
             this, OnSuccessCallback_274, OnFailureCallback_274));
@@ -65217,6 +67536,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int16_t> nullableInt16sArgument;
         nullableInt16sArgument.SetNull();
 
@@ -65238,6 +67558,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
             this, OnSuccessCallback_276, OnFailureCallback_276));
@@ -65263,6 +67585,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
             this, OnSuccessCallback_277, OnFailureCallback_277));
         return CHIP_NO_ERROR;
@@ -65286,6 +67610,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
             this, OnSuccessCallback_278, OnFailureCallback_278));
@@ -65311,6 +67637,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int16_t> nullableInt16sArgument;
         nullableInt16sArgument.SetNonNull();
         nullableInt16sArgument.Value() = -32767;
@@ -65333,6 +67660,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
             this, OnSuccessCallback_280, OnFailureCallback_280));
@@ -65358,6 +67687,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
             this, OnSuccessCallback_281, OnFailureCallback_281));
         return CHIP_NO_ERROR;
@@ -65382,6 +67713,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int32_t> nullableInt32sArgument;
         nullableInt32sArgument.SetNonNull();
         nullableInt32sArgument.Value() = -2147483647L;
@@ -65404,6 +67736,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
             this, OnSuccessCallback_283, OnFailureCallback_283));
@@ -65430,6 +67764,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int32_t> nullableInt32sArgument;
         nullableInt32sArgument.SetNonNull();
         nullableInt32sArgument.Value() = -2147483648L;
@@ -65453,6 +67788,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
             this, OnSuccessCallback_285, OnFailureCallback_285));
@@ -65479,6 +67816,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int32_t> nullableInt32sArgument;
         nullableInt32sArgument.SetNull();
 
@@ -65500,6 +67838,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
             this, OnSuccessCallback_287, OnFailureCallback_287));
@@ -65525,6 +67865,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
             this, OnSuccessCallback_288, OnFailureCallback_288));
         return CHIP_NO_ERROR;
@@ -65548,6 +67890,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
             this, OnSuccessCallback_289, OnFailureCallback_289));
@@ -65573,6 +67917,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int32_t> nullableInt32sArgument;
         nullableInt32sArgument.SetNonNull();
         nullableInt32sArgument.Value() = -2147483647L;
@@ -65595,6 +67940,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
             this, OnSuccessCallback_291, OnFailureCallback_291));
@@ -65620,6 +67967,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
             this, OnSuccessCallback_292, OnFailureCallback_292));
         return CHIP_NO_ERROR;
@@ -65644,6 +67993,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int64_t> nullableInt64sArgument;
         nullableInt64sArgument.SetNonNull();
         nullableInt64sArgument.Value() = -9223372036854775807LL;
@@ -65666,6 +68016,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
             this, OnSuccessCallback_294, OnFailureCallback_294));
@@ -65692,6 +68044,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int64_t> nullableInt64sArgument;
         nullableInt64sArgument.SetNonNull();
         nullableInt64sArgument.Value() = -9223372036854775807LL - 1;
@@ -65715,6 +68068,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
             this, OnSuccessCallback_296, OnFailureCallback_296));
@@ -65741,6 +68096,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int64_t> nullableInt64sArgument;
         nullableInt64sArgument.SetNull();
 
@@ -65762,6 +68118,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
             this, OnSuccessCallback_298, OnFailureCallback_298));
@@ -65787,6 +68145,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
             this, OnSuccessCallback_299, OnFailureCallback_299));
         return CHIP_NO_ERROR;
@@ -65810,6 +68170,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
             this, OnSuccessCallback_300, OnFailureCallback_300));
@@ -65835,6 +68197,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int64_t> nullableInt64sArgument;
         nullableInt64sArgument.SetNonNull();
         nullableInt64sArgument.Value() = -9223372036854775807LL;
@@ -65857,6 +68220,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
             this, OnSuccessCallback_302, OnFailureCallback_302));
@@ -65882,6 +68247,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
             this, OnSuccessCallback_303, OnFailureCallback_303));
         return CHIP_NO_ERROR;
@@ -65906,6 +68273,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<float> nullableFloatSingleArgument;
         nullableFloatSingleArgument.SetNonNull();
         nullableFloatSingleArgument.Value() = 0.1f;
@@ -65928,6 +68296,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableFloatSingle::TypeInfo>(
             this, OnSuccessCallback_305, OnFailureCallback_305));
@@ -65954,6 +68324,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<float> nullableFloatSingleArgument;
         nullableFloatSingleArgument.SetNonNull();
         nullableFloatSingleArgument.Value() = INFINITY;
@@ -65976,6 +68347,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableFloatSingle::TypeInfo>(
             this, OnSuccessCallback_307, OnFailureCallback_307));
@@ -66002,6 +68375,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<float> nullableFloatSingleArgument;
         nullableFloatSingleArgument.SetNonNull();
         nullableFloatSingleArgument.Value() = -INFINITY;
@@ -66024,6 +68398,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableFloatSingle::TypeInfo>(
             this, OnSuccessCallback_309, OnFailureCallback_309));
@@ -66050,6 +68426,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<float> nullableFloatSingleArgument;
         nullableFloatSingleArgument.SetNull();
 
@@ -66071,6 +68448,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableFloatSingle::TypeInfo>(
             this, OnSuccessCallback_311, OnFailureCallback_311));
@@ -66096,6 +68475,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<float> nullableFloatSingleArgument;
         nullableFloatSingleArgument.SetNonNull();
         nullableFloatSingleArgument.Value() = 0.0f;
@@ -66118,6 +68498,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableFloatSingle::TypeInfo>(
             this, OnSuccessCallback_313, OnFailureCallback_313));
@@ -66144,6 +68526,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<double> nullableFloatDoubleArgument;
         nullableFloatDoubleArgument.SetNonNull();
         nullableFloatDoubleArgument.Value() = 0.1234567890123;
@@ -66166,6 +68549,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableFloatDouble::TypeInfo>(
             this, OnSuccessCallback_315, OnFailureCallback_315));
@@ -66192,6 +68577,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<double> nullableFloatDoubleArgument;
         nullableFloatDoubleArgument.SetNonNull();
         nullableFloatDoubleArgument.Value() = INFINITY;
@@ -66214,6 +68600,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableFloatDouble::TypeInfo>(
             this, OnSuccessCallback_317, OnFailureCallback_317));
@@ -66240,6 +68628,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<double> nullableFloatDoubleArgument;
         nullableFloatDoubleArgument.SetNonNull();
         nullableFloatDoubleArgument.Value() = -INFINITY;
@@ -66262,6 +68651,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableFloatDouble::TypeInfo>(
             this, OnSuccessCallback_319, OnFailureCallback_319));
@@ -66288,6 +68679,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<double> nullableFloatDoubleArgument;
         nullableFloatDoubleArgument.SetNull();
 
@@ -66309,6 +68701,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableFloatDouble::TypeInfo>(
             this, OnSuccessCallback_321, OnFailureCallback_321));
@@ -66334,6 +68728,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<double> nullableFloatDoubleArgument;
         nullableFloatDoubleArgument.SetNonNull();
         nullableFloatDoubleArgument.Value() = 0;
@@ -66356,6 +68751,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableFloatDouble::TypeInfo>(
             this, OnSuccessCallback_323, OnFailureCallback_323));
@@ -66382,6 +68779,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableEnum8Argument;
         nullableEnum8Argument.SetNonNull();
         nullableEnum8Argument.Value() = 0;
@@ -66404,6 +68802,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum8::TypeInfo>(
             this, OnSuccessCallback_325, OnFailureCallback_325));
@@ -66430,6 +68830,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableEnum8Argument;
         nullableEnum8Argument.SetNonNull();
         nullableEnum8Argument.Value() = 254;
@@ -66452,6 +68853,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum8::TypeInfo>(
             this, OnSuccessCallback_327, OnFailureCallback_327));
@@ -66478,6 +68881,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableEnum8Argument;
         nullableEnum8Argument.SetNonNull();
         nullableEnum8Argument.Value() = 255;
@@ -66501,6 +68905,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum8::TypeInfo>(
             this, OnSuccessCallback_329, OnFailureCallback_329));
@@ -66527,6 +68933,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableEnum8Argument;
         nullableEnum8Argument.SetNull();
 
@@ -66548,6 +68955,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum8::TypeInfo>(
             this, OnSuccessCallback_331, OnFailureCallback_331));
@@ -66573,6 +68982,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableEnum16Argument;
         nullableEnum16Argument.SetNonNull();
         nullableEnum16Argument.Value() = 0U;
@@ -66595,6 +69005,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum16::TypeInfo>(
             this, OnSuccessCallback_333, OnFailureCallback_333));
@@ -66621,6 +69033,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableEnum16Argument;
         nullableEnum16Argument.SetNonNull();
         nullableEnum16Argument.Value() = 65534U;
@@ -66643,6 +69056,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum16::TypeInfo>(
             this, OnSuccessCallback_335, OnFailureCallback_335));
@@ -66669,6 +69084,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableEnum16Argument;
         nullableEnum16Argument.SetNonNull();
         nullableEnum16Argument.Value() = 65535U;
@@ -66692,6 +69108,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum16::TypeInfo>(
             this, OnSuccessCallback_337, OnFailureCallback_337));
@@ -66718,6 +69136,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableEnum16Argument;
         nullableEnum16Argument.SetNull();
 
@@ -66739,6 +69158,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum16::TypeInfo>(
             this, OnSuccessCallback_339, OnFailureCallback_339));
@@ -66764,6 +69185,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::SimpleEnum> nullableEnumAttrArgument;
         nullableEnumAttrArgument.SetNonNull();
         nullableEnumAttrArgument.Value() = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(0);
@@ -66786,6 +69208,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnumAttr::TypeInfo>(
             this, OnSuccessCallback_341, OnFailureCallback_341));
@@ -66813,6 +69237,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::SimpleEnum> nullableEnumAttrArgument;
         nullableEnumAttrArgument.SetNonNull();
         nullableEnumAttrArgument.Value() = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(254);
@@ -66835,6 +69260,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnumAttr::TypeInfo>(
             this, OnSuccessCallback_343, OnFailureCallback_343));
@@ -66862,6 +69289,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::SimpleEnum> nullableEnumAttrArgument;
         nullableEnumAttrArgument.SetNonNull();
         nullableEnumAttrArgument.Value() = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(255);
@@ -66885,6 +69313,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnumAttr::TypeInfo>(
             this, OnSuccessCallback_345, OnFailureCallback_345));
@@ -66912,6 +69342,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::SimpleEnum> nullableEnumAttrArgument;
         nullableEnumAttrArgument.SetNull();
 
@@ -66933,6 +69364,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnumAttr::TypeInfo>(
             this, OnSuccessCallback_347, OnFailureCallback_347));
@@ -66958,6 +69391,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
             this, OnSuccessCallback_348, OnFailureCallback_348));
@@ -66985,6 +69420,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<chip::ByteSpan> nullableOctetStringArgument;
         nullableOctetStringArgument.SetNonNull();
         nullableOctetStringArgument.Value() =
@@ -67008,6 +69444,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
             this, OnSuccessCallback_350, OnFailureCallback_350));
@@ -67035,6 +69473,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<chip::ByteSpan> nullableOctetStringArgument;
         nullableOctetStringArgument.SetNull();
 
@@ -67056,6 +69495,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
             this, OnSuccessCallback_352, OnFailureCallback_352));
@@ -67081,6 +69522,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<chip::ByteSpan> nullableOctetStringArgument;
         nullableOctetStringArgument.SetNonNull();
         nullableOctetStringArgument.Value() = chip::ByteSpan(chip::Uint8::from_const_char("garbage: not in length on purpose"), 0);
@@ -67103,6 +69545,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
             this, OnSuccessCallback_354, OnFailureCallback_354));
@@ -67130,6 +69574,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableCharString::TypeInfo>(
             this, OnSuccessCallback_355, OnFailureCallback_355));
         return CHIP_NO_ERROR;
@@ -67155,6 +69601,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<chip::CharSpan> nullableCharStringArgument;
         nullableCharStringArgument.SetNonNull();
         nullableCharStringArgument.Value() = chip::Span<const char>("☉T☉garbage: not in length on purpose", 7);
@@ -67177,6 +69624,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableCharString::TypeInfo>(
             this, OnSuccessCallback_357, OnFailureCallback_357));
@@ -67203,6 +69652,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<chip::CharSpan> nullableCharStringArgument;
         nullableCharStringArgument.SetNull();
 
@@ -67224,6 +69674,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableCharString::TypeInfo>(
             this, OnSuccessCallback_359, OnFailureCallback_359));
@@ -67249,6 +69701,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<chip::CharSpan> nullableCharStringArgument;
         nullableCharStringArgument.SetNonNull();
         nullableCharStringArgument.Value() = chip::Span<const char>("garbage: not in length on purpose", 0);
@@ -67271,6 +69724,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableCharString::TypeInfo>(
             this, OnSuccessCallback_361, OnFailureCallback_361));
@@ -67297,6 +69752,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(
             this, OnSuccessCallback_362, OnFailureCallback_362));
         return CHIP_NO_ERROR;
@@ -67317,6 +69774,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(
             this, OnSuccessCallback_363, OnFailureCallback_363));
         return CHIP_NO_ERROR;
@@ -67336,6 +69795,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestSimpleOptionalArgumentRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -67364,6 +69824,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestSimpleOptionalArgumentRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.arg1.Emplace();
         request.arg1.Value() = 1;
@@ -67393,6 +69854,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         mTest_TestCluster_list_int8u_Reported = OnSuccessCallback_366;
         return WaitForMs(0);
@@ -67428,6 +69891,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t minIntervalArgument;
         minIntervalArgument = 2U;
         uint16_t maxIntervalArgument;
@@ -67467,14 +69931,18 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::List<const uint8_t> listInt8uArgument;
 
-        uint8_t listInt8uList_0[4];
-        listInt8uList_0[0] = 5;
-        listInt8uList_0[1] = 6;
-        listInt8uList_0[2] = 7;
-        listInt8uList_0[3] = 8;
-        listInt8uArgument  = listInt8uList_0;
+        {
+            auto * listHolder_0 = new ListHolder<uint8_t>(4);
+            listFreer.add(listHolder_0);
+            listHolder_0->mList[0] = 5;
+            listHolder_0->mList[1] = 6;
+            listHolder_0->mList[2] = 7;
+            listHolder_0->mList[3] = 8;
+            listInt8uArgument      = chip::app::DataModel::List<uint8_t>(listHolder_0->mList, 4);
+        }
 
         ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(
             listInt8uArgument, this, OnSuccessCallback_368, OnFailureCallback_368));
@@ -67494,6 +69962,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         mTest_TestCluster_list_int8u_Reported = OnSuccessCallback_369;
         return CHIP_NO_ERROR;
@@ -67531,6 +70001,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt8u::TypeInfo>(
             this, OnSuccessCallback_370, OnFailureCallback_370));
         return CHIP_NO_ERROR;
@@ -67555,6 +70027,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t rangeRestrictedInt8uArgument;
         rangeRestrictedInt8uArgument = 0;
 
@@ -67578,6 +70051,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t rangeRestrictedInt8uArgument;
         rangeRestrictedInt8uArgument = 19;
 
@@ -67601,6 +70075,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t rangeRestrictedInt8uArgument;
         rangeRestrictedInt8uArgument = 101;
 
@@ -67624,6 +70099,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t rangeRestrictedInt8uArgument;
         rangeRestrictedInt8uArgument = 255;
 
@@ -67646,6 +70122,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt8u::TypeInfo>(
             this, OnSuccessCallback_375, OnFailureCallback_375));
@@ -67671,6 +70149,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t rangeRestrictedInt8uArgument;
         rangeRestrictedInt8uArgument = 20;
 
@@ -67692,6 +70171,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt8u::TypeInfo>(
             this, OnSuccessCallback_377, OnFailureCallback_377));
@@ -67717,6 +70198,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t rangeRestrictedInt8uArgument;
         rangeRestrictedInt8uArgument = 100;
 
@@ -67738,6 +70220,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt8u::TypeInfo>(
             this, OnSuccessCallback_379, OnFailureCallback_379));
@@ -67763,6 +70247,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t rangeRestrictedInt8uArgument;
         rangeRestrictedInt8uArgument = 50;
 
@@ -67784,6 +70269,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt8u::TypeInfo>(
             this, OnSuccessCallback_381, OnFailureCallback_381));
@@ -67809,6 +70296,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt16u::TypeInfo>(
             this, OnSuccessCallback_382, OnFailureCallback_382));
         return CHIP_NO_ERROR;
@@ -67833,6 +70322,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t rangeRestrictedInt16uArgument;
         rangeRestrictedInt16uArgument = 0U;
 
@@ -67856,6 +70346,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t rangeRestrictedInt16uArgument;
         rangeRestrictedInt16uArgument = 99U;
 
@@ -67879,6 +70370,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t rangeRestrictedInt16uArgument;
         rangeRestrictedInt16uArgument = 1001U;
 
@@ -67902,6 +70394,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t rangeRestrictedInt16uArgument;
         rangeRestrictedInt16uArgument = 65535U;
 
@@ -67924,6 +70417,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt16u::TypeInfo>(
             this, OnSuccessCallback_387, OnFailureCallback_387));
@@ -67949,6 +70444,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t rangeRestrictedInt16uArgument;
         rangeRestrictedInt16uArgument = 100U;
 
@@ -67970,6 +70466,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt16u::TypeInfo>(
             this, OnSuccessCallback_389, OnFailureCallback_389));
@@ -67995,6 +70493,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t rangeRestrictedInt16uArgument;
         rangeRestrictedInt16uArgument = 1000U;
 
@@ -68016,6 +70515,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt16u::TypeInfo>(
             this, OnSuccessCallback_391, OnFailureCallback_391));
@@ -68041,6 +70542,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t rangeRestrictedInt16uArgument;
         rangeRestrictedInt16uArgument = 500U;
 
@@ -68062,6 +70564,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt16u::TypeInfo>(
             this, OnSuccessCallback_393, OnFailureCallback_393));
@@ -68087,6 +70591,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt8s::TypeInfo>(
             this, OnSuccessCallback_394, OnFailureCallback_394));
         return CHIP_NO_ERROR;
@@ -68111,6 +70617,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int8_t rangeRestrictedInt8sArgument;
         rangeRestrictedInt8sArgument = -128;
 
@@ -68134,6 +70641,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int8_t rangeRestrictedInt8sArgument;
         rangeRestrictedInt8sArgument = -41;
 
@@ -68157,6 +70665,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int8_t rangeRestrictedInt8sArgument;
         rangeRestrictedInt8sArgument = 51;
 
@@ -68180,6 +70689,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int8_t rangeRestrictedInt8sArgument;
         rangeRestrictedInt8sArgument = 127;
 
@@ -68202,6 +70712,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt8s::TypeInfo>(
             this, OnSuccessCallback_399, OnFailureCallback_399));
@@ -68227,6 +70739,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int8_t rangeRestrictedInt8sArgument;
         rangeRestrictedInt8sArgument = -40;
 
@@ -68248,6 +70761,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt8s::TypeInfo>(
             this, OnSuccessCallback_401, OnFailureCallback_401));
@@ -68273,6 +70788,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int8_t rangeRestrictedInt8sArgument;
         rangeRestrictedInt8sArgument = 50;
 
@@ -68294,6 +70810,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt8s::TypeInfo>(
             this, OnSuccessCallback_403, OnFailureCallback_403));
@@ -68319,6 +70837,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int8_t rangeRestrictedInt8sArgument;
         rangeRestrictedInt8sArgument = 6;
 
@@ -68340,6 +70859,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt8s::TypeInfo>(
             this, OnSuccessCallback_405, OnFailureCallback_405));
@@ -68365,6 +70886,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt16s::TypeInfo>(
             this, OnSuccessCallback_406, OnFailureCallback_406));
         return CHIP_NO_ERROR;
@@ -68389,6 +70912,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t rangeRestrictedInt16sArgument;
         rangeRestrictedInt16sArgument = -32768;
 
@@ -68412,6 +70936,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t rangeRestrictedInt16sArgument;
         rangeRestrictedInt16sArgument = -151;
 
@@ -68435,6 +70960,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t rangeRestrictedInt16sArgument;
         rangeRestrictedInt16sArgument = 201;
 
@@ -68458,6 +70984,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t rangeRestrictedInt16sArgument;
         rangeRestrictedInt16sArgument = 32767;
 
@@ -68480,6 +71007,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt16s::TypeInfo>(
             this, OnSuccessCallback_411, OnFailureCallback_411));
@@ -68505,6 +71034,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t rangeRestrictedInt16sArgument;
         rangeRestrictedInt16sArgument = -150;
 
@@ -68526,6 +71056,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt16s::TypeInfo>(
             this, OnSuccessCallback_413, OnFailureCallback_413));
@@ -68551,6 +71083,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t rangeRestrictedInt16sArgument;
         rangeRestrictedInt16sArgument = 200;
 
@@ -68572,6 +71105,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt16s::TypeInfo>(
             this, OnSuccessCallback_415, OnFailureCallback_415));
@@ -68597,6 +71132,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t rangeRestrictedInt16sArgument;
         rangeRestrictedInt16sArgument = 7;
 
@@ -68618,6 +71154,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::RangeRestrictedInt16s::TypeInfo>(
             this, OnSuccessCallback_417, OnFailureCallback_417));
@@ -68642,6 +71180,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt8u::TypeInfo>(
@@ -68669,6 +71209,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableRangeRestrictedInt8uArgument;
         nullableRangeRestrictedInt8uArgument.SetNonNull();
         nullableRangeRestrictedInt8uArgument.Value() = 0;
@@ -68694,6 +71235,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableRangeRestrictedInt8uArgument;
         nullableRangeRestrictedInt8uArgument.SetNonNull();
         nullableRangeRestrictedInt8uArgument.Value() = 19;
@@ -68719,6 +71261,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableRangeRestrictedInt8uArgument;
         nullableRangeRestrictedInt8uArgument.SetNonNull();
         nullableRangeRestrictedInt8uArgument.Value() = 101;
@@ -68744,6 +71287,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableRangeRestrictedInt8uArgument;
         nullableRangeRestrictedInt8uArgument.SetNonNull();
         nullableRangeRestrictedInt8uArgument.Value() = 254;
@@ -68768,6 +71312,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt8u::TypeInfo>(
@@ -68795,6 +71341,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableRangeRestrictedInt8uArgument;
         nullableRangeRestrictedInt8uArgument.SetNonNull();
         nullableRangeRestrictedInt8uArgument.Value() = 20;
@@ -68818,6 +71365,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt8u::TypeInfo>(
@@ -68845,6 +71394,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableRangeRestrictedInt8uArgument;
         nullableRangeRestrictedInt8uArgument.SetNonNull();
         nullableRangeRestrictedInt8uArgument.Value() = 100;
@@ -68868,6 +71418,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt8u::TypeInfo>(
@@ -68895,6 +71447,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableRangeRestrictedInt8uArgument;
         nullableRangeRestrictedInt8uArgument.SetNonNull();
         nullableRangeRestrictedInt8uArgument.Value() = 50;
@@ -68918,6 +71471,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt8u::TypeInfo>(
@@ -68945,6 +71500,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint8_t> nullableRangeRestrictedInt8uArgument;
         nullableRangeRestrictedInt8uArgument.SetNull();
 
@@ -68967,6 +71523,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt8u::TypeInfo>(
@@ -68992,6 +71550,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt16u::TypeInfo>(
@@ -69019,6 +71579,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableRangeRestrictedInt16uArgument;
         nullableRangeRestrictedInt16uArgument.SetNonNull();
         nullableRangeRestrictedInt16uArgument.Value() = 0U;
@@ -69044,6 +71605,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableRangeRestrictedInt16uArgument;
         nullableRangeRestrictedInt16uArgument.SetNonNull();
         nullableRangeRestrictedInt16uArgument.Value() = 99U;
@@ -69069,6 +71631,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableRangeRestrictedInt16uArgument;
         nullableRangeRestrictedInt16uArgument.SetNonNull();
         nullableRangeRestrictedInt16uArgument.Value() = 1001U;
@@ -69094,6 +71657,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableRangeRestrictedInt16uArgument;
         nullableRangeRestrictedInt16uArgument.SetNonNull();
         nullableRangeRestrictedInt16uArgument.Value() = 65534U;
@@ -69118,6 +71682,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt16u::TypeInfo>(
@@ -69145,6 +71711,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableRangeRestrictedInt16uArgument;
         nullableRangeRestrictedInt16uArgument.SetNonNull();
         nullableRangeRestrictedInt16uArgument.Value() = 100U;
@@ -69168,6 +71735,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt16u::TypeInfo>(
@@ -69195,6 +71764,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableRangeRestrictedInt16uArgument;
         nullableRangeRestrictedInt16uArgument.SetNonNull();
         nullableRangeRestrictedInt16uArgument.Value() = 1000U;
@@ -69218,6 +71788,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt16u::TypeInfo>(
@@ -69245,6 +71817,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableRangeRestrictedInt16uArgument;
         nullableRangeRestrictedInt16uArgument.SetNonNull();
         nullableRangeRestrictedInt16uArgument.Value() = 500U;
@@ -69268,6 +71841,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt16u::TypeInfo>(
@@ -69295,6 +71870,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<uint16_t> nullableRangeRestrictedInt16uArgument;
         nullableRangeRestrictedInt16uArgument.SetNull();
 
@@ -69317,6 +71893,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt16u::TypeInfo>(
@@ -69342,6 +71920,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt8s::TypeInfo>(
@@ -69369,6 +71949,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int8_t> nullableRangeRestrictedInt8sArgument;
         nullableRangeRestrictedInt8sArgument.SetNonNull();
         nullableRangeRestrictedInt8sArgument.Value() = -127;
@@ -69394,6 +71975,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int8_t> nullableRangeRestrictedInt8sArgument;
         nullableRangeRestrictedInt8sArgument.SetNonNull();
         nullableRangeRestrictedInt8sArgument.Value() = -41;
@@ -69419,6 +72001,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int8_t> nullableRangeRestrictedInt8sArgument;
         nullableRangeRestrictedInt8sArgument.SetNonNull();
         nullableRangeRestrictedInt8sArgument.Value() = 51;
@@ -69444,6 +72027,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int8_t> nullableRangeRestrictedInt8sArgument;
         nullableRangeRestrictedInt8sArgument.SetNonNull();
         nullableRangeRestrictedInt8sArgument.Value() = 127;
@@ -69468,6 +72052,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt8s::TypeInfo>(
@@ -69495,6 +72081,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int8_t> nullableRangeRestrictedInt8sArgument;
         nullableRangeRestrictedInt8sArgument.SetNonNull();
         nullableRangeRestrictedInt8sArgument.Value() = -40;
@@ -69518,6 +72105,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt8s::TypeInfo>(
@@ -69545,6 +72134,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int8_t> nullableRangeRestrictedInt8sArgument;
         nullableRangeRestrictedInt8sArgument.SetNonNull();
         nullableRangeRestrictedInt8sArgument.Value() = 50;
@@ -69568,6 +72158,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt8s::TypeInfo>(
@@ -69595,6 +72187,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int8_t> nullableRangeRestrictedInt8sArgument;
         nullableRangeRestrictedInt8sArgument.SetNonNull();
         nullableRangeRestrictedInt8sArgument.Value() = 6;
@@ -69618,6 +72211,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt8s::TypeInfo>(
@@ -69645,6 +72240,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int8_t> nullableRangeRestrictedInt8sArgument;
         nullableRangeRestrictedInt8sArgument.SetNull();
 
@@ -69667,6 +72263,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt8s::TypeInfo>(
@@ -69692,6 +72290,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt16s::TypeInfo>(
@@ -69719,6 +72319,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int16_t> nullableRangeRestrictedInt16sArgument;
         nullableRangeRestrictedInt16sArgument.SetNonNull();
         nullableRangeRestrictedInt16sArgument.Value() = -32767;
@@ -69744,6 +72345,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int16_t> nullableRangeRestrictedInt16sArgument;
         nullableRangeRestrictedInt16sArgument.SetNonNull();
         nullableRangeRestrictedInt16sArgument.Value() = -151;
@@ -69769,6 +72371,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int16_t> nullableRangeRestrictedInt16sArgument;
         nullableRangeRestrictedInt16sArgument.SetNonNull();
         nullableRangeRestrictedInt16sArgument.Value() = 201;
@@ -69794,6 +72397,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int16_t> nullableRangeRestrictedInt16sArgument;
         nullableRangeRestrictedInt16sArgument.SetNonNull();
         nullableRangeRestrictedInt16sArgument.Value() = 32767;
@@ -69818,6 +72422,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt16s::TypeInfo>(
@@ -69845,6 +72451,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int16_t> nullableRangeRestrictedInt16sArgument;
         nullableRangeRestrictedInt16sArgument.SetNonNull();
         nullableRangeRestrictedInt16sArgument.Value() = -150;
@@ -69868,6 +72475,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt16s::TypeInfo>(
@@ -69895,6 +72504,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int16_t> nullableRangeRestrictedInt16sArgument;
         nullableRangeRestrictedInt16sArgument.SetNonNull();
         nullableRangeRestrictedInt16sArgument.Value() = 200;
@@ -69918,6 +72528,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt16s::TypeInfo>(
@@ -69945,6 +72557,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int16_t> nullableRangeRestrictedInt16sArgument;
         nullableRangeRestrictedInt16sArgument.SetNonNull();
         nullableRangeRestrictedInt16sArgument.Value() = 7;
@@ -69968,6 +72581,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt16s::TypeInfo>(
@@ -69995,6 +72610,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::Nullable<int16_t> nullableRangeRestrictedInt16sArgument;
         nullableRangeRestrictedInt16sArgument.SetNull();
 
@@ -70017,6 +72633,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableRangeRestrictedInt16s::TypeInfo>(
@@ -70043,6 +72661,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool generalErrorBooleanArgument;
         generalErrorBooleanArgument = false;
 
@@ -70066,6 +72685,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool clusterErrorBooleanArgument;
         clusterErrorBooleanArgument = false;
 
@@ -70089,6 +72709,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::GeneralErrorBoolean::TypeInfo>(
             this, OnSuccessCallback_476, OnFailureCallback_476));
         return CHIP_NO_ERROR;
@@ -70109,6 +72731,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ClusterErrorBoolean::TypeInfo>(
             this, OnSuccessCallback_477, OnFailureCallback_477));
         return CHIP_NO_ERROR;
@@ -70128,6 +72752,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ClientGeneratedCommandList::TypeInfo>(
@@ -70201,6 +72827,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ServerGeneratedCommandList::TypeInfo>(
                 this, OnSuccessCallback_479, OnFailureCallback_479));
@@ -70245,6 +72873,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type structAttrArgument;
 
         structAttrArgument.a = 5;
@@ -70274,6 +72903,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::StructAttr::TypeInfo>(
             this, OnSuccessCallback_481, OnFailureCallback_481));
@@ -70587,6 +73218,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.arg1.Emplace();
         request.arg1.Value().SetNull();
@@ -70629,6 +73261,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TimedInvokeRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -70658,6 +73291,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TimedInvokeRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -70686,6 +73320,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TimedInvokeRequest::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -70723,6 +73358,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::Test::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -70751,6 +73387,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::Test::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -70789,6 +73426,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::TimedWriteBoolean::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
         return CHIP_NO_ERROR;
@@ -70813,6 +73452,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool timedWriteBooleanArgument;
         timedWriteBooleanArgument = true;
 
@@ -70835,6 +73475,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::TimedWriteBoolean::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
@@ -70860,6 +73502,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool timedWriteBooleanArgument;
         timedWriteBooleanArgument = true;
 
@@ -70891,6 +73534,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::TimedWriteBoolean::TypeInfo>(
             this, OnSuccessCallback_11, OnFailureCallback_11));
         return CHIP_NO_ERROR;
@@ -70915,6 +73560,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool timedWriteBooleanArgument;
         timedWriteBooleanArgument = true;
 
@@ -70936,6 +73582,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::TimedWriteBoolean::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
@@ -70961,6 +73609,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool timedWriteBooleanArgument;
         timedWriteBooleanArgument = false;
 
@@ -70982,6 +73631,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(
             this, OnSuccessCallback_15, OnFailureCallback_15));
@@ -71007,6 +73658,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool booleanArgument;
         booleanArgument = true;
 
@@ -71038,6 +73690,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(
             this, OnSuccessCallback_17, OnFailureCallback_17));
         return CHIP_NO_ERROR;
@@ -71062,6 +73716,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool booleanArgument;
         booleanArgument = true;
 
@@ -71083,6 +73738,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(
             this, OnSuccessCallback_19, OnFailureCallback_19));
@@ -71108,6 +73765,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool booleanArgument;
         booleanArgument = false;
 
@@ -71477,6 +74135,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t int32uArgument;
         int32uArgument = 5UL;
 
@@ -71498,6 +74157,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -71522,6 +74183,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -71544,6 +74207,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -71569,6 +74234,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t int32uArgument;
         int32uArgument = 0UL;
 
@@ -71591,6 +74257,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan charStringArgument;
         charStringArgument = chip::Span<const char>("** Test **garbage: not in length on purpose", 10);
 
@@ -71612,6 +74279,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
@@ -71636,6 +74305,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
         return CHIP_NO_ERROR;
@@ -71658,6 +74329,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
@@ -71682,6 +74355,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_10, OnFailureCallback_10));
         return CHIP_NO_ERROR;
@@ -71705,6 +74380,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan charStringArgument;
         charStringArgument = chip::Span<const char>("lowercasegarbage: not in length on purpose", 9);
 
@@ -71726,6 +74402,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_12, OnFailureCallback_12));
@@ -71751,6 +74429,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan charStringArgument;
         charStringArgument = chip::Span<const char>("UPPERCASEgarbage: not in length on purpose", 9);
 
@@ -71772,6 +74451,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_14, OnFailureCallback_14));
@@ -71797,6 +74478,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan charStringArgument;
         charStringArgument = chip::Span<const char>("lowUPPERgarbage: not in length on purpose", 8);
 
@@ -71818,6 +74500,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_16, OnFailureCallback_16));
@@ -71843,6 +74527,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan charStringArgument;
         charStringArgument = chip::Span<const char>("ABCDEF012Vgarbage: not in length on purpose", 10);
 
@@ -71864,6 +74549,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_18, OnFailureCallback_18));
@@ -71888,6 +74575,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan charStringArgument;
         charStringArgument = chip::Span<const char>("ABCDEF0123garbage: not in length on purpose", 10);
 
@@ -71909,6 +74597,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_20, OnFailureCallback_20));
@@ -71933,6 +74623,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan charStringArgument;
         charStringArgument = chip::Span<const char>("garbage: not in length on purpose", 0);
 
@@ -73642,6 +76333,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.arg1 = 3;
         request.arg2 = 17;
@@ -73675,6 +76367,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.arg1 = 3;
         request.arg2 = 17;
@@ -73707,6 +76400,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.arg1 = 3;
         request.arg2 = TestAddArgumentDefaultValue;
@@ -73740,6 +76434,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
@@ -73765,6 +76461,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool booleanArgument;
         booleanArgument = 1;
 
@@ -73786,6 +76483,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6));
@@ -73811,6 +76510,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         bool booleanArgument;
         booleanArgument = readAttributeBooleanDefaultValue;
 
@@ -73832,6 +76532,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(
             this, OnSuccessCallback_8, OnFailureCallback_8));
@@ -73856,6 +76558,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap8::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
@@ -73882,6 +76586,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t bitmap8Argument;
         bitmap8Argument = 1;
 
@@ -73903,6 +76608,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap8::TypeInfo>(
             this, OnSuccessCallback_11, OnFailureCallback_11));
@@ -73928,6 +76635,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t bitmap8Argument;
         bitmap8Argument = readAttributeBitmap8DefaultValue;
 
@@ -73949,6 +76657,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap8::TypeInfo>(
             this, OnSuccessCallback_13, OnFailureCallback_13));
@@ -73973,6 +76683,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap16::TypeInfo>(
             this, OnSuccessCallback_14, OnFailureCallback_14));
@@ -73999,6 +76711,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t bitmap16Argument;
         bitmap16Argument = 1U;
 
@@ -74020,6 +76733,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap16::TypeInfo>(
             this, OnSuccessCallback_16, OnFailureCallback_16));
@@ -74045,6 +76760,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t bitmap16Argument;
         bitmap16Argument = readAttributeBitmap16DefaultValue;
 
@@ -74066,6 +76782,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap16::TypeInfo>(
             this, OnSuccessCallback_18, OnFailureCallback_18));
@@ -74090,6 +76808,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap32::TypeInfo>(
             this, OnSuccessCallback_19, OnFailureCallback_19));
@@ -74116,6 +76836,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t bitmap32Argument;
         bitmap32Argument = 1UL;
 
@@ -74137,6 +76858,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap32::TypeInfo>(
             this, OnSuccessCallback_21, OnFailureCallback_21));
@@ -74162,6 +76885,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t bitmap32Argument;
         bitmap32Argument = readAttributeBitmap32DefaultValue;
 
@@ -74183,6 +76907,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap32::TypeInfo>(
             this, OnSuccessCallback_23, OnFailureCallback_23));
@@ -74207,6 +76933,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap64::TypeInfo>(
             this, OnSuccessCallback_24, OnFailureCallback_24));
@@ -74233,6 +76961,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint64_t bitmap64Argument;
         bitmap64Argument = 1ULL;
 
@@ -74254,6 +76983,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap64::TypeInfo>(
             this, OnSuccessCallback_26, OnFailureCallback_26));
@@ -74279,6 +77010,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint64_t bitmap64Argument;
         bitmap64Argument = readAttributeBitmap64DefaultValue;
 
@@ -74300,6 +77032,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap64::TypeInfo>(
             this, OnSuccessCallback_28, OnFailureCallback_28));
@@ -74324,6 +77058,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8u::TypeInfo>(
             this, OnSuccessCallback_29, OnFailureCallback_29));
@@ -74350,6 +77086,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t int8uArgument;
         int8uArgument = 1;
 
@@ -74371,6 +77108,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8u::TypeInfo>(
             this, OnSuccessCallback_31, OnFailureCallback_31));
@@ -74396,6 +77135,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t int8uArgument;
         int8uArgument = readAttributeInt8uDefaultValue;
 
@@ -74417,6 +77157,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8u::TypeInfo>(
             this, OnSuccessCallback_33, OnFailureCallback_33));
@@ -74441,6 +77183,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16u::TypeInfo>(
             this, OnSuccessCallback_34, OnFailureCallback_34));
@@ -74467,6 +77211,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t int16uArgument;
         int16uArgument = 1U;
 
@@ -74488,6 +77233,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16u::TypeInfo>(
             this, OnSuccessCallback_36, OnFailureCallback_36));
@@ -74513,6 +77260,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t int16uArgument;
         int16uArgument = readAttributeInt16uDefaultValue;
 
@@ -74534,6 +77282,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16u::TypeInfo>(
             this, OnSuccessCallback_38, OnFailureCallback_38));
@@ -74558,6 +77308,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(
             this, OnSuccessCallback_39, OnFailureCallback_39));
@@ -74584,6 +77336,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t int32uArgument;
         int32uArgument = 1UL;
 
@@ -74605,6 +77358,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(
             this, OnSuccessCallback_41, OnFailureCallback_41));
@@ -74630,6 +77385,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t int32uArgument;
         int32uArgument = readAttributeInt32uDefaultValue;
 
@@ -74651,6 +77407,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(
             this, OnSuccessCallback_43, OnFailureCallback_43));
@@ -74675,6 +77433,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64u::TypeInfo>(
             this, OnSuccessCallback_44, OnFailureCallback_44));
@@ -74701,6 +77461,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint64_t int64uArgument;
         int64uArgument = 1ULL;
 
@@ -74722,6 +77483,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64u::TypeInfo>(
             this, OnSuccessCallback_46, OnFailureCallback_46));
@@ -74747,6 +77510,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint64_t int64uArgument;
         int64uArgument = readAttributeInt64uDefaultValue;
 
@@ -74768,6 +77532,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64u::TypeInfo>(
             this, OnSuccessCallback_48, OnFailureCallback_48));
@@ -74792,6 +77558,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(
             this, OnSuccessCallback_49, OnFailureCallback_49));
@@ -74818,6 +77586,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int8_t int8sArgument;
         int8sArgument = 1;
 
@@ -74839,6 +77608,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(
             this, OnSuccessCallback_51, OnFailureCallback_51));
@@ -74864,6 +77635,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int8_t int8sArgument;
         int8sArgument = readAttributeInt8sDefaultValue;
 
@@ -74885,6 +77657,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(
             this, OnSuccessCallback_53, OnFailureCallback_53));
@@ -74909,6 +77683,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(
             this, OnSuccessCallback_54, OnFailureCallback_54));
@@ -74935,6 +77711,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t int16sArgument;
         int16sArgument = 1;
 
@@ -74956,6 +77733,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(
             this, OnSuccessCallback_56, OnFailureCallback_56));
@@ -74981,6 +77760,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int16_t int16sArgument;
         int16sArgument = readAttributeInt16sDefaultValue;
 
@@ -75002,6 +77782,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(
             this, OnSuccessCallback_58, OnFailureCallback_58));
@@ -75026,6 +77808,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(
             this, OnSuccessCallback_59, OnFailureCallback_59));
@@ -75052,6 +77836,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int32_t int32sArgument;
         int32sArgument = 1L;
 
@@ -75073,6 +77858,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(
             this, OnSuccessCallback_61, OnFailureCallback_61));
@@ -75098,6 +77885,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int32_t int32sArgument;
         int32sArgument = readAttributeInt32sDefaultValue;
 
@@ -75119,6 +77907,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(
             this, OnSuccessCallback_63, OnFailureCallback_63));
@@ -75143,6 +77933,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(
             this, OnSuccessCallback_64, OnFailureCallback_64));
@@ -75169,6 +77961,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int64_t int64sArgument;
         int64sArgument = 1LL;
 
@@ -75190,6 +77983,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(
             this, OnSuccessCallback_66, OnFailureCallback_66));
@@ -75215,6 +78010,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         int64_t int64sArgument;
         int64sArgument = readAttributeInt64sDefaultValue;
 
@@ -75236,6 +78032,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(
             this, OnSuccessCallback_68, OnFailureCallback_68));
@@ -75260,6 +78058,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum8::TypeInfo>(
             this, OnSuccessCallback_69, OnFailureCallback_69));
@@ -75286,6 +78086,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t enum8Argument;
         enum8Argument = 1;
 
@@ -75307,6 +78108,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum8::TypeInfo>(
             this, OnSuccessCallback_71, OnFailureCallback_71));
@@ -75332,6 +78135,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint8_t enum8Argument;
         enum8Argument = readAttributeEnum8DefaultValue;
 
@@ -75353,6 +78157,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum8::TypeInfo>(
             this, OnSuccessCallback_73, OnFailureCallback_73));
@@ -75377,6 +78183,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum16::TypeInfo>(
             this, OnSuccessCallback_74, OnFailureCallback_74));
@@ -75403,6 +78211,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t enum16Argument;
         enum16Argument = 1U;
 
@@ -75424,6 +78233,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum16::TypeInfo>(
             this, OnSuccessCallback_76, OnFailureCallback_76));
@@ -75449,6 +78260,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t enum16Argument;
         enum16Argument = readAttributeEnum16DefaultValue;
 
@@ -75470,6 +78282,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum16::TypeInfo>(
             this, OnSuccessCallback_78, OnFailureCallback_78));
@@ -75494,6 +78308,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(
             this, OnSuccessCallback_79, OnFailureCallback_79));
@@ -75520,6 +78336,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint64_t epochUsArgument;
         epochUsArgument = 1ULL;
 
@@ -75541,6 +78358,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(
             this, OnSuccessCallback_81, OnFailureCallback_81));
@@ -75566,6 +78385,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint64_t epochUsArgument;
         epochUsArgument = readAttributeEpochUSDefaultValue;
 
@@ -75587,6 +78407,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(
             this, OnSuccessCallback_83, OnFailureCallback_83));
@@ -75611,6 +78433,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(
             this, OnSuccessCallback_84, OnFailureCallback_84));
@@ -75637,6 +78461,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t epochSArgument;
         epochSArgument = 1UL;
 
@@ -75658,6 +78483,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(
             this, OnSuccessCallback_86, OnFailureCallback_86));
@@ -75683,6 +78510,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint32_t epochSArgument;
         epochSArgument = readAttributeEpochSDefaultValue;
 
@@ -75704,6 +78532,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(
             this, OnSuccessCallback_88, OnFailureCallback_88));
@@ -75728,6 +78558,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(
             this, OnSuccessCallback_89, OnFailureCallback_89));
@@ -75754,6 +78586,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::VendorId vendorIdArgument;
         vendorIdArgument = static_cast<chip::VendorId>(1);
 
@@ -75775,6 +78608,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(
             this, OnSuccessCallback_91, OnFailureCallback_91));
@@ -75800,6 +78635,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::VendorId vendorIdArgument;
         vendorIdArgument = readAttributeVendorIdDefaultValue;
 
@@ -75821,6 +78657,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(
             this, OnSuccessCallback_93, OnFailureCallback_93));
@@ -75845,6 +78683,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_94, OnFailureCallback_94));
@@ -75877,6 +78717,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_95, OnFailureCallback_95));
         return CHIP_NO_ERROR;
@@ -75901,6 +78743,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan charStringArgument;
         charStringArgument = chip::Span<const char>("NotDefaultgarbage: not in length on purpose", 10);
 
@@ -75922,6 +78765,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_97, OnFailureCallback_97));
@@ -75955,6 +78800,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_98, OnFailureCallback_98));
         return CHIP_NO_ERROR;
@@ -75980,6 +78827,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan charStringArgument;
         charStringArgument = readAttributeCharStringNotDefaultValue;
 
@@ -76001,6 +78849,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             this, OnSuccessCallback_100, OnFailureCallback_100));
@@ -76026,6 +78876,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan charStringArgument;
         charStringArgument = readAttributeCharStringDefaultValue;
 
@@ -76047,6 +78898,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
             this, OnSuccessCallback_102, OnFailureCallback_102));
@@ -76079,6 +78932,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
             this, OnSuccessCallback_103, OnFailureCallback_103));
         return CHIP_NO_ERROR;
@@ -76103,6 +78958,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::ByteSpan octetStringArgument;
         octetStringArgument = chip::ByteSpan(chip::Uint8::from_const_char("NotDefaultgarbage: not in length on purpose"), 10);
 
@@ -76124,6 +78980,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
             this, OnSuccessCallback_105, OnFailureCallback_105));
@@ -76158,6 +79016,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
             this, OnSuccessCallback_106, OnFailureCallback_106));
         return CHIP_NO_ERROR;
@@ -76183,6 +79043,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::ByteSpan octetStringArgument;
         octetStringArgument = readAttributeOctetStringNotDefaultValue;
 
@@ -76204,6 +79065,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
             this, OnSuccessCallback_108, OnFailureCallback_108));
@@ -76230,6 +79093,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::ByteSpan octetStringArgument;
         octetStringArgument = readAttributeOctetStringDefaultValue;
 
@@ -76343,6 +79207,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.arg1 = 3;
         request.arg2 = 17;
@@ -76378,6 +79243,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.arg1 = mArg1.HasValue() ? mArg1.Value() : 5;
         request.arg2 = TestAddArgumentDefaultValue;
@@ -76549,6 +79415,8 @@ private:
         chip::Controller::DescriptorClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Descriptor::Attributes::DeviceList::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -76579,6 +79447,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::DescriptorClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Descriptor::Attributes::ServerList::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -76657,6 +79527,8 @@ private:
         chip::Controller::DescriptorClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Descriptor::Attributes::ClientList::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -76685,6 +79557,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::DescriptorClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Descriptor::Attributes::PartsList::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -76859,6 +79733,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -76883,6 +79759,7 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan locationArgument;
         locationArgument = chip::Span<const char>("USgarbage: not in length on purpose", 2);
 
@@ -76904,6 +79781,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -76929,6 +79808,7 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::CharSpan locationArgument;
         locationArgument = chip::Span<const char>("XXgarbage: not in length on purpose", 2);
 
@@ -76950,6 +79830,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::AttributeList::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -77101,6 +79983,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::Identify::Commands::Identify::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.identifyTime = 0U;
 
@@ -77294,6 +80177,8 @@ private:
         chip::Controller::OperationalCredentialsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::SupportedFabrics::TypeInfo>(
                 this, OnSuccessCallback_1, OnFailureCallback_1));
@@ -77318,6 +80203,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::OperationalCredentialsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::CommissionedFabrics::TypeInfo>(
@@ -77344,6 +80231,8 @@ private:
         chip::Controller::OperationalCredentialsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::CurrentFabricIndex::TypeInfo>(
                 this, OnSuccessCallback_3, OnFailureCallback_3));
@@ -77369,6 +80258,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::OperationalCredentials::Commands::RemoveFabric::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.fabricIndex = 243;
 
@@ -77406,6 +80296,8 @@ private:
         chip::Controller::OperationalCredentialsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::Fabrics::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
@@ -77436,6 +80328,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.label = chip::Span<const char>("Batcavegarbage: not in length on purpose", 7);
 
@@ -77475,6 +80368,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::OperationalCredentialsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::Fabrics::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
@@ -77680,6 +80575,8 @@ private:
         chip::Controller::ModeSelectClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::CurrentMode::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -77703,6 +80600,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ModeSelectClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::OnMode::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -77728,6 +80627,8 @@ private:
         chip::Controller::ModeSelectClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::StartUpMode::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -77752,6 +80653,8 @@ private:
         chip::Controller::ModeSelectClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::Description::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4));
         return CHIP_NO_ERROR;
@@ -77775,6 +80678,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::ModeSelectClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::SupportedModes::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -77817,6 +80722,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ModeSelect::Commands::ChangeToMode::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.newMode = 4;
 
@@ -77846,6 +80752,8 @@ private:
         chip::Controller::ModeSelectClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::CurrentMode::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
         return CHIP_NO_ERROR;
@@ -77869,6 +80777,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ModeSelect::Commands::ChangeToMode::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.newMode = 2;
 
@@ -78169,6 +81078,8 @@ private:
         chip::Controller::SoftwareDiagnosticsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::SoftwareDiagnostics::Attributes::ThreadMetrics::TypeInfo>(
             this, OnSuccessCallback_1, OnFailureCallback_1));
         return CHIP_NO_ERROR;
@@ -78194,6 +81105,8 @@ private:
         chip::Controller::SoftwareDiagnosticsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::SoftwareDiagnostics::Attributes::CurrentHeapFree::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -78217,6 +81130,8 @@ private:
         chip::Controller::SoftwareDiagnosticsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::SoftwareDiagnostics::Attributes::CurrentHeapUsed::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -78239,6 +81154,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::SoftwareDiagnosticsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::SoftwareDiagnostics::Attributes::CurrentHeapHighWatermark::TypeInfo>(
@@ -78456,6 +81373,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::SoftwareDiagnostics::Commands::ResetWatermarks::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -78484,6 +81402,8 @@ private:
         chip::Controller::SoftwareDiagnosticsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::SoftwareDiagnostics::Attributes::CurrentHeapUsed::TypeInfo>(
             this, OnSuccessCallback_2, OnFailureCallback_2));
         return CHIP_NO_ERROR;
@@ -78507,6 +81427,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::SoftwareDiagnosticsClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::SoftwareDiagnostics::Attributes::CurrentHeapHighWatermark::TypeInfo>(
@@ -78692,6 +81614,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -78720,6 +81643,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         mTest_TestSubscribe_OnOff_OnOff_Reported = OnSuccessCallback_2;
         return WaitForMs(0);
     }
@@ -78743,6 +81668,7 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         uint16_t minIntervalArgument;
         minIntervalArgument = 2U;
         uint16_t maxIntervalArgument;
@@ -78780,6 +81706,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -78808,6 +81735,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         mTest_TestSubscribe_OnOff_OnOff_Reported = OnSuccessCallback_5;
         return CHIP_NO_ERROR;
     }
@@ -78832,6 +81761,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -78859,6 +81789,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         mTest_TestSubscribe_OnOff_OnOff_Reported = OnSuccessCallback_7;
         return CHIP_NO_ERROR;
@@ -79408,6 +82340,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -79474,6 +82407,8 @@ private:
         chip::Controller::DoorLockClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::DoorLock::Attributes::NumberOfTotalUsersSupported::TypeInfo>(
                 this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -79499,6 +82434,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 0U;
 
@@ -79544,6 +82480,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = static_cast<uint16_t>(NumberOfTotalUsersSupported + 1);
 
@@ -79589,6 +82526,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
         request.userIndex     = 1U;
@@ -79624,6 +82562,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -79695,6 +82634,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
         request.userIndex     = 1U;
@@ -79731,6 +82671,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(2);
         request.userIndex     = 1U;
@@ -79767,6 +82708,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -79838,6 +82780,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(2);
         request.userIndex     = 1U;
@@ -79874,6 +82817,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -79946,6 +82890,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(2);
         request.userIndex     = 1U;
@@ -79982,6 +82927,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -80054,6 +83000,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(2);
         request.userIndex     = 1U;
@@ -80090,6 +83037,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -80162,6 +83110,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(2);
         request.userIndex     = 1U;
@@ -80198,6 +83147,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -80270,6 +83220,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(2);
         request.userIndex     = 1U;
@@ -80310,6 +83261,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -80382,6 +83334,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
         request.userIndex     = 2U;
@@ -80422,6 +83375,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 2U;
 
@@ -80494,6 +83448,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
         request.userIndex     = NumberOfTotalUsersSupported;
@@ -80530,6 +83485,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = NumberOfTotalUsersSupported;
 
@@ -80600,6 +83556,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
         request.userIndex     = 0U;
@@ -80636,6 +83593,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
         request.userIndex     = static_cast<uint16_t>(NumberOfTotalUsersSupported + 1);
@@ -80672,6 +83630,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -80701,6 +83660,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -80766,6 +83726,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
         request.userIndex     = 1U;
@@ -80801,6 +83762,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -80872,6 +83834,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 0U;
 
@@ -80902,6 +83865,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = static_cast<uint16_t>(NumberOfTotalUsersSupported + 1);
 
@@ -80932,6 +83896,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 65534U;
 
@@ -80961,6 +83926,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 2U;
 
@@ -81026,6 +83992,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = NumberOfTotalUsersSupported;
 
@@ -81091,6 +84058,8 @@ private:
         chip::Controller::DoorLockClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::DoorLock::Attributes::NumberOfPINUsersSupported::TypeInfo>(
             this, OnSuccessCallback_35, OnFailureCallback_35));
         return CHIP_NO_ERROR;
@@ -81115,6 +84084,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(1);
@@ -81157,6 +84127,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(1);
@@ -81193,6 +84164,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(1);
@@ -81229,6 +84201,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -81280,6 +84253,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -81358,6 +84332,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(1);
@@ -81401,6 +84376,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -81451,6 +84427,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -81501,6 +84478,8 @@ private:
         chip::Controller::DoorLockClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::DoorLock::Attributes::NumberOfRFIDUsersSupported::TypeInfo>(
             this, OnSuccessCallback_44, OnFailureCallback_44));
         return CHIP_NO_ERROR;
@@ -81525,6 +84504,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(2);
@@ -81561,6 +84541,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(2);
@@ -81597,6 +84578,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(2);
@@ -81639,6 +84621,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -81691,6 +84674,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -81772,6 +84756,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(2);
@@ -81815,6 +84800,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -81866,6 +84852,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -81916,6 +84903,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -81967,6 +84955,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -82018,6 +85007,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -82069,6 +85059,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -82120,6 +85111,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -82171,6 +85163,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -82222,6 +85215,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -82274,6 +85268,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -82326,6 +85321,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -82376,6 +85372,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -82427,6 +85424,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(2);
 
@@ -82478,6 +85476,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -82529,6 +85528,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -82579,6 +85579,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.credential.SetNonNull();
 
@@ -82611,6 +85612,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(1);
@@ -82653,6 +85655,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -82731,6 +85734,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.credential.SetNonNull();
 
@@ -82763,6 +85767,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(1);
@@ -82805,6 +85810,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 2U;
 
@@ -82870,6 +85876,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -82922,6 +85929,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.credential.SetNonNull();
 
@@ -82954,6 +85962,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(2);
@@ -82996,6 +86005,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(2);
@@ -83038,6 +86048,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -83103,6 +86114,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 2U;
 
@@ -83168,6 +86180,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -83219,6 +86232,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -83271,6 +86285,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -83323,6 +86338,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.credential.SetNull();
 
@@ -83352,6 +86368,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(1);
@@ -83394,6 +86411,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(2);
@@ -83436,6 +86454,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(1);
@@ -83478,6 +86497,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -83543,6 +86563,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 2U;
 
@@ -83608,6 +86629,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 3U;
 
@@ -83673,6 +86695,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -83722,6 +86745,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -83772,6 +86796,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -83850,6 +86875,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(0);
@@ -83892,6 +86918,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(2);
 
@@ -83941,6 +86968,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.credential.SetNonNull();
 
@@ -83974,6 +87002,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.credential.SetNonNull();
 
@@ -84007,6 +87036,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.credential.SetNonNull();
 
@@ -84040,6 +87070,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.credential.SetNonNull();
 
@@ -84073,6 +87104,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.credential.SetNonNull();
 
@@ -84106,6 +87138,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.credential.SetNonNull();
 
@@ -84139,6 +87172,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -84168,6 +87202,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 1U;
 
@@ -84233,6 +87268,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.credential.credentialType  = static_cast<chip::app::Clusters::DoorLock::DlCredentialType>(0);
@@ -84435,6 +87471,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -84485,6 +87522,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::UnlockDoor::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.pinCode.Emplace();
         request.pinCode.Value() = chip::ByteSpan(chip::Uint8::from_const_char("000000garbage: not in length on purpose"), 6);
@@ -84517,6 +87555,8 @@ private:
         chip::Controller::DoorLockClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::DoorLock::Attributes::LockState::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3));
         return CHIP_NO_ERROR;
@@ -84541,6 +87581,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::UnlockDoor::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.pinCode.Emplace();
         request.pinCode.Value() = chip::ByteSpan(chip::Uint8::from_const_char("123456garbage: not in length on purpose"), 6);
@@ -84572,6 +87613,8 @@ private:
         chip::Controller::DoorLockClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::DoorLock::Attributes::LockState::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5));
         return CHIP_NO_ERROR;
@@ -84596,6 +87639,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::LockDoor::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.pinCode.Emplace();
         request.pinCode.Value() = chip::ByteSpan(chip::Uint8::from_const_char("000000garbage: not in length on purpose"), 6);
@@ -84628,6 +87672,8 @@ private:
         chip::Controller::DoorLockClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::DoorLock::Attributes::LockState::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
         return CHIP_NO_ERROR;
@@ -84652,6 +87698,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::LockDoor::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.pinCode.Emplace();
         request.pinCode.Value() = chip::ByteSpan(chip::Uint8::from_const_char("123456garbage: not in length on purpose"), 6);
@@ -84683,6 +87730,8 @@ private:
         chip::Controller::DoorLockClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::DoorLock::Attributes::LockState::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
         return CHIP_NO_ERROR;
@@ -84707,6 +87756,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.credential.SetNonNull();
 
@@ -85187,6 +88237,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetCredential::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
 
@@ -85236,6 +88287,8 @@ private:
         chip::Controller::DoorLockClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::DoorLock::Attributes::NumberOfTotalUsersSupported::TypeInfo>(
                 this, OnSuccessCallback_2, OnFailureCallback_2));
@@ -85261,6 +88314,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::DoorLockClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::DoorLock::Attributes::NumberOfWeekDaySchedulesSupportedPerUser::TypeInfo>(
@@ -85288,6 +88343,8 @@ private:
         chip::Controller::DoorLockClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::DoorLock::Attributes::NumberOfYearDaySchedulesSupportedPerUser::TypeInfo>(
                 this, OnSuccessCallback_4, OnFailureCallback_4));
@@ -85313,6 +88370,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 0;
         request.userIndex    = 1U;
@@ -85346,6 +88404,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = static_cast<uint8_t>(NumberOfWeekDaySchedulesSupportedPerUser + 1);
         request.userIndex    = 1U;
@@ -85379,6 +88438,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 0U;
@@ -85412,6 +88472,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = static_cast<uint8_t>(NumberOfTotalUsersSupported + 1);
@@ -85445,6 +88506,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 2U;
@@ -85478,6 +88540,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -85513,6 +88576,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -85548,6 +88612,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -85583,6 +88648,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -85618,6 +88684,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -85653,6 +88720,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -85688,6 +88756,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -85723,6 +88792,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -85758,6 +88828,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -85793,6 +88864,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -85836,6 +88908,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 0;
         request.userIndex    = 1U;
@@ -85879,6 +88952,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = static_cast<uint8_t>(NumberOfWeekDaySchedulesSupportedPerUser + 1);
         request.userIndex    = 1U;
@@ -85923,6 +88997,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 0U;
@@ -85966,6 +89041,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = static_cast<uint8_t>(NumberOfTotalUsersSupported + 1);
@@ -86009,6 +89085,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 2U;
@@ -86052,6 +89129,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex   = 0;
         request.userIndex      = 1U;
@@ -86084,6 +89162,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex   = static_cast<uint8_t>(NumberOfYearDaySchedulesSupportedPerUser + 1);
         request.userIndex      = 1U;
@@ -86116,6 +89195,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex   = 1;
         request.userIndex      = 0U;
@@ -86148,6 +89228,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex   = 1;
         request.userIndex      = static_cast<uint8_t>(NumberOfTotalUsersSupported + 1);
@@ -86180,6 +89261,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex   = 1;
         request.userIndex      = 2U;
@@ -86212,6 +89294,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex   = 1;
         request.userIndex      = 1U;
@@ -86244,6 +89327,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 1;
         request.userIndex    = 1U;
@@ -86284,6 +89368,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 0;
         request.userIndex    = 1U;
@@ -86324,6 +89409,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = static_cast<uint8_t>(NumberOfYearDaySchedulesSupportedPerUser + 1);
         request.userIndex    = 1U;
@@ -86365,6 +89451,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 1;
         request.userIndex    = 0U;
@@ -86405,6 +89492,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 1;
         request.userIndex    = static_cast<uint8_t>(NumberOfTotalUsersSupported + 1);
@@ -86445,6 +89533,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 1;
         request.userIndex    = 2U;
@@ -86485,6 +89574,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -86519,6 +89609,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -86577,6 +89668,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex   = 1;
         request.userIndex      = 1U;
@@ -86608,6 +89700,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 1;
         request.userIndex    = 1U;
@@ -86654,6 +89747,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 0;
         request.userIndex    = 1U;
@@ -86684,6 +89778,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = static_cast<uint8_t>(NumberOfWeekDaySchedulesSupportedPerUser + 1);
         request.userIndex    = 1U;
@@ -86714,6 +89809,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 0U;
@@ -86744,6 +89840,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = static_cast<uint8_t>(NumberOfTotalUsersSupported + 1);
@@ -86774,6 +89871,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 2U;
@@ -86804,6 +89902,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 0;
         request.userIndex    = 1U;
@@ -86834,6 +89933,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = static_cast<uint8_t>(NumberOfYearDaySchedulesSupportedPerUser + 1);
         request.userIndex    = 1U;
@@ -86864,6 +89964,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 1;
         request.userIndex    = 0U;
@@ -86894,6 +89995,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 1;
         request.userIndex    = static_cast<uint8_t>(NumberOfTotalUsersSupported + 1);
@@ -86924,6 +90026,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 1;
         request.userIndex    = 2U;
@@ -86954,6 +90057,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -87012,6 +90116,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 1;
         request.userIndex    = 1U;
@@ -87058,6 +90163,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 2;
         request.userIndex    = 1U;
@@ -87092,6 +90198,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 2;
         request.userIndex    = 1U;
@@ -87150,6 +90257,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex   = 2;
         request.userIndex      = 1U;
@@ -87181,6 +90289,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 2;
         request.userIndex    = 1U;
@@ -87227,6 +90336,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -87256,6 +90366,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -87299,6 +90410,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 254;
         request.userIndex    = 1U;
@@ -87328,6 +90440,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 2;
         request.userIndex    = 1U;
@@ -87371,6 +90484,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 1;
         request.userIndex    = 1U;
@@ -87417,6 +90531,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 2;
         request.userIndex    = 1U;
@@ -87463,6 +90578,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -87497,6 +90613,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 1;
         request.userIndex    = 1U;
@@ -87526,6 +90643,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 1;
         request.userIndex    = 1U;
@@ -87566,6 +90684,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 254;
         request.userIndex    = 1U;
@@ -87595,6 +90714,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 2;
         request.userIndex    = 1U;
@@ -87635,6 +90755,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -87693,6 +90814,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 254;
         request.userIndex    = 1U;
@@ -87722,6 +90844,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.operationType = static_cast<chip::app::Clusters::DoorLock::DlDataOperationType>(0);
         request.userIndex     = 2U;
@@ -87757,6 +90880,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -87791,6 +90915,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -87849,6 +90974,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex   = 4;
         request.userIndex      = 1U;
@@ -87880,6 +91006,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 4;
         request.userIndex    = 1U;
@@ -87926,6 +91053,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 4;
         request.userIndex    = 2U;
@@ -87960,6 +91088,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 4;
         request.userIndex    = 2U;
@@ -88018,6 +91147,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex   = 1;
         request.userIndex      = 1U;
@@ -88049,6 +91179,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 1;
         request.userIndex    = 1U;
@@ -88095,6 +91226,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::ClearUser::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.userIndex = 65534U;
 
@@ -88124,6 +91256,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 1;
         request.userIndex    = 1U;
@@ -88167,6 +91300,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 4;
         request.userIndex    = 1U;
@@ -88207,6 +91341,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.weekDayIndex = 4;
         request.userIndex    = 2U;
@@ -88250,6 +91385,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.yearDayIndex = 1;
         request.userIndex    = 2U;
@@ -88468,6 +91604,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::AddGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId   = 257U;
         request.groupName = chip::Span<const char>("Group #1garbage: not in length on purpose", 8);
@@ -88504,6 +91641,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::Groups::Commands::AddGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId   = 258U;
         request.groupName = chip::Span<const char>("Group #2garbage: not in length on purpose", 8);
@@ -88540,6 +91678,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::GroupKeyManagement::Commands::KeySetWrite::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.groupKeySet.groupKeySetID = 417U;
@@ -88592,6 +91731,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::GroupKeyManagement::Commands::KeySetWrite::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.groupKeySet.groupKeySetID = 418U;
@@ -88645,20 +91785,26 @@ private:
         chip::Controller::GroupKeyManagementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::List<const chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type>
             groupKeyMapArgument;
 
-        chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type groupKeyMapList_0[2];
+        {
+            auto * listHolder_0 = new ListHolder<chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(2);
+            listFreer.add(listHolder_0);
 
-        groupKeyMapList_0[0].fabricIndex   = 1;
-        groupKeyMapList_0[0].groupId       = 257U;
-        groupKeyMapList_0[0].groupKeySetID = 417U;
+            listHolder_0->mList[0].fabricIndex   = 1;
+            listHolder_0->mList[0].groupId       = 257U;
+            listHolder_0->mList[0].groupKeySetID = 417U;
 
-        groupKeyMapList_0[1].fabricIndex   = 1;
-        groupKeyMapList_0[1].groupId       = 258U;
-        groupKeyMapList_0[1].groupKeySetID = 418U;
+            listHolder_0->mList[1].fabricIndex   = 1;
+            listHolder_0->mList[1].groupId       = 258U;
+            listHolder_0->mList[1].groupKeySetID = 418U;
 
-        groupKeyMapArgument = groupKeyMapList_0;
+            groupKeyMapArgument =
+                chip::app::DataModel::List<chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(
+                    listHolder_0->mList, 2);
+        }
 
         ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::GroupKeyManagement::Attributes::GroupKeyMap::TypeInfo>(
             groupKeyMapArgument, this, OnSuccessCallback_5, OnFailureCallback_5));
@@ -88679,6 +91825,7 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.AssociateWithGroup(mDevices[kIdentityAlpha], groupId);
 
+        ListFreer listFreer;
         chip::CharSpan locationArgument;
         locationArgument = chip::Span<const char>("USgarbage: not in length on purpose", 2);
 
@@ -88702,6 +91849,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(
             this, OnSuccessCallback_7, OnFailureCallback_7));
@@ -88727,6 +91876,7 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.AssociateWithGroup(mDevices[kIdentityAlpha], groupId);
 
+        ListFreer listFreer;
         chip::CharSpan locationArgument;
         locationArgument = chip::Span<const char>("XXgarbage: not in length on purpose", 2);
 
@@ -88751,6 +91901,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
         return CHIP_NO_ERROR;
@@ -88774,6 +91926,7 @@ private:
         const chip::GroupId groupId = 257;
         using RequestType           = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -88806,6 +91959,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_11, OnFailureCallback_11));
@@ -88980,6 +92135,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::ViewGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId = 0U;
 
@@ -89015,6 +92171,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::ViewGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId = 1U;
 
@@ -89050,6 +92207,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::AddGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId   = 1U;
         request.groupName = chip::Span<const char>("Group #1garbage: not in length on purpose", 8);
@@ -89086,6 +92244,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::ViewGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId = 1U;
 
@@ -89123,6 +92282,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::ViewGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId = 4369U;
 
@@ -89158,6 +92318,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::GetGroupMembership::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.groupList = chip::app::DataModel::List<uint16_t>();
@@ -89199,6 +92360,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::ViewGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId = 32767U;
 
@@ -89234,6 +92396,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::ViewGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId = 1U;
 
@@ -89271,6 +92434,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::RemoveGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId = 0U;
 
@@ -89306,6 +92470,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::RemoveGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId = 4U;
 
@@ -89341,6 +92506,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::ViewGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId = 1U;
 
@@ -89378,6 +92544,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::ViewGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId = 4369U;
 
@@ -89413,14 +92580,18 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::GetGroupMembership::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
-        uint16_t groupListList_0[4];
-        groupListList_0[0] = 1U;
-        groupListList_0[1] = 2U;
-        groupListList_0[2] = 4369U;
-        groupListList_0[3] = 3U;
-        request.groupList  = groupListList_0;
+        {
+            auto * listHolder_0 = new ListHolder<uint16_t>(4);
+            listFreer.add(listHolder_0);
+            listHolder_0->mList[0] = 1U;
+            listHolder_0->mList[1] = 2U;
+            listHolder_0->mList[2] = 4369U;
+            listHolder_0->mList[3] = 3U;
+            request.groupList      = chip::app::DataModel::List<uint16_t>(listHolder_0->mList, 4);
+        }
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestGroupsCluster *>(context))->OnSuccessResponse_13(data.capacity, data.groupList);
@@ -89459,6 +92630,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::RemoveAllGroups::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -89486,6 +92658,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::ViewGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId = 1U;
 
@@ -89521,6 +92694,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::ViewGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId = 4369U;
 
@@ -89556,6 +92730,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::ViewGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId = 32767U;
 
@@ -89591,15 +92766,19 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::GetGroupMembership::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
-        uint16_t groupListList_0[5];
-        groupListList_0[0] = 1U;
-        groupListList_0[1] = 2U;
-        groupListList_0[2] = 4369U;
-        groupListList_0[3] = 3U;
-        groupListList_0[4] = 32767U;
-        request.groupList  = groupListList_0;
+        {
+            auto * listHolder_0 = new ListHolder<uint16_t>(5);
+            listFreer.add(listHolder_0);
+            listHolder_0->mList[0] = 1U;
+            listHolder_0->mList[1] = 2U;
+            listHolder_0->mList[2] = 4369U;
+            listHolder_0->mList[3] = 3U;
+            listHolder_0->mList[4] = 32767U;
+            request.groupList      = chip::app::DataModel::List<uint16_t>(listHolder_0->mList, 5);
+        }
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestGroupsCluster *>(context))->OnSuccessResponse_18(data.capacity, data.groupList);
@@ -89835,6 +93014,8 @@ private:
         chip::Controller::GroupKeyManagementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
+
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::GroupKeyManagement::Attributes::MaxGroupsPerFabric::TypeInfo>(
                 this, OnSuccessCallback_1, OnFailureCallback_1));
@@ -89858,6 +93039,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::GroupKeyManagementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(
             cluster.ReadAttribute<chip::app::Clusters::GroupKeyManagement::Attributes::MaxGroupKeysPerFabric::TypeInfo>(
@@ -89883,6 +93066,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::AddGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId   = 257U;
         request.groupName = chip::Span<const char>("Group #1garbage: not in length on purpose", 8);
@@ -89919,6 +93103,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::AddGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId   = 258U;
         request.groupName = chip::Span<const char>("Group #2garbage: not in length on purpose", 8);
@@ -89955,6 +93140,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::GroupKeyManagement::Commands::KeySetWrite::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.groupKeySet.groupKeySetID = 417U;
@@ -90007,6 +93193,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::GroupKeyManagement::Commands::KeySetWrite::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.groupKeySet.groupKeySetID = 418U;
@@ -90059,6 +93246,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::GroupKeyManagement::Commands::KeySetRead::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupKeySetID = 417U;
 
@@ -90103,20 +93291,26 @@ private:
         chip::Controller::GroupKeyManagementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::List<const chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type>
             groupKeyMapArgument;
 
-        chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type groupKeyMapList_0[2];
+        {
+            auto * listHolder_0 = new ListHolder<chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(2);
+            listFreer.add(listHolder_0);
 
-        groupKeyMapList_0[0].fabricIndex   = 1;
-        groupKeyMapList_0[0].groupId       = 257U;
-        groupKeyMapList_0[0].groupKeySetID = 417U;
+            listHolder_0->mList[0].fabricIndex   = 1;
+            listHolder_0->mList[0].groupId       = 257U;
+            listHolder_0->mList[0].groupKeySetID = 417U;
 
-        groupKeyMapList_0[1].fabricIndex   = 1;
-        groupKeyMapList_0[1].groupId       = 258U;
-        groupKeyMapList_0[1].groupKeySetID = 418U;
+            listHolder_0->mList[1].fabricIndex   = 1;
+            listHolder_0->mList[1].groupId       = 258U;
+            listHolder_0->mList[1].groupKeySetID = 418U;
 
-        groupKeyMapArgument = groupKeyMapList_0;
+            groupKeyMapArgument =
+                chip::app::DataModel::List<chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(
+                    listHolder_0->mList, 2);
+        }
 
         ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::GroupKeyManagement::Attributes::GroupKeyMap::TypeInfo>(
             groupKeyMapArgument, this, OnSuccessCallback_8, OnFailureCallback_8));
@@ -90136,6 +93330,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::GroupKeyManagementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::GroupKeyManagement::Attributes::GroupKeyMap::TypeInfo>(
             this, OnSuccessCallback_9, OnFailureCallback_9));
@@ -90172,6 +93368,8 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         chip::Controller::GroupKeyManagementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
 
         ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::GroupKeyManagement::Attributes::GroupTable::TypeInfo>(
             this, OnSuccessCallback_10, OnFailureCallback_10));
@@ -90212,6 +93410,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::GroupKeyManagement::Commands::KeySetRemove::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupKeySetID = 417U;
 
@@ -90240,6 +93439,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::GroupKeyManagement::Commands::KeySetRead::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupKeySetID = 417U;
 
@@ -90273,6 +93473,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::GroupKeyManagement::Commands::KeySetRead::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupKeySetID = 418U;
 
@@ -90317,6 +93518,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::RemoveAllGroups::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -90344,6 +93546,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::GroupKeyManagement::Commands::KeySetRemove::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupKeySetID = 418U;
 
@@ -90372,6 +93575,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::GroupKeyManagement::Commands::KeySetRead::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupKeySetID = 418U;
 
@@ -90759,6 +93963,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType = chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.commissioningTimeout = 120U;
 
@@ -90903,6 +94108,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType = chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.commissioningTimeout = 120U;
 
@@ -91619,6 +94825,7 @@ private:
         const chip::GroupId groupId = 257;
         using RequestType           = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -91657,6 +94864,7 @@ private:
         const chip::GroupId groupId = 257;
         using RequestType           = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -91695,6 +94903,7 @@ private:
         const chip::GroupId groupId = 257;
         using RequestType           = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -91733,6 +94942,7 @@ private:
         const chip::GroupId groupId = 257;
         using RequestType           = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -91771,6 +94981,7 @@ private:
         const chip::GroupId groupId = 257;
         using RequestType           = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -91809,6 +95020,7 @@ private:
         const chip::GroupId groupId = 257;
         using RequestType           = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -91847,6 +95059,7 @@ private:
         const chip::GroupId groupId = 257;
         using RequestType           = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -91885,6 +95098,7 @@ private:
         const chip::GroupId groupId = 257;
         using RequestType           = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -91923,6 +95137,7 @@ private:
         const chip::GroupId groupId = 257;
         using RequestType           = chip::app::Clusters::OnOff::Commands::On::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -91961,6 +95176,7 @@ private:
         const chip::GroupId groupId = 257;
         using RequestType           = chip::app::Clusters::OnOff::Commands::Off::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -92096,6 +95312,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::Groups::Commands::AddGroup::Type;
 
+        ListFreer listFreer;
         RequestType request;
         request.groupId   = 257U;
         request.groupName = chip::Span<const char>("Group #1garbage: not in length on purpose", 8);
@@ -92132,6 +95349,7 @@ private:
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
         using RequestType               = chip::app::Clusters::GroupKeyManagement::Commands::KeySetWrite::Type;
 
+        ListFreer listFreer;
         RequestType request;
 
         request.groupKeySet.groupKeySetID = 417U;
@@ -92185,16 +95403,22 @@ private:
         chip::Controller::GroupKeyManagementClusterTest cluster;
         cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
+        ListFreer listFreer;
         chip::app::DataModel::List<const chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type>
             groupKeyMapArgument;
 
-        chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type groupKeyMapList_0[1];
+        {
+            auto * listHolder_0 = new ListHolder<chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(1);
+            listFreer.add(listHolder_0);
 
-        groupKeyMapList_0[0].fabricIndex   = 1;
-        groupKeyMapList_0[0].groupId       = 257U;
-        groupKeyMapList_0[0].groupKeySetID = 417U;
+            listHolder_0->mList[0].fabricIndex   = 1;
+            listHolder_0->mList[0].groupId       = 257U;
+            listHolder_0->mList[0].groupKeySetID = 417U;
 
-        groupKeyMapArgument = groupKeyMapList_0;
+            groupKeyMapArgument =
+                chip::app::DataModel::List<chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(
+                    listHolder_0->mList, 1);
+        }
 
         ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::GroupKeyManagement::Attributes::GroupKeyMap::TypeInfo>(
             groupKeyMapArgument, this, OnSuccessCallback_3, OnFailureCallback_3));


### PR DESCRIPTION
Before this change, chip-tool's codegen just puts all the list buffers
on the stack and they all have to survive until we use them, so they
can't be in nested scopes.  They are suffixed with a nesting depth,
but if you have a list of structs that contain lists, the names for
the non-toplevel lists collide with each other.

This change switches over to the setup Darwin and Android already use:
heap-allocate the lists, hand the buffers to an RAII object higher up
on the stack that will free them when we are done, and then we can
scope each allocation and filling of a list in its own scope to limit
the visibility of the individual lists' names and avoid them colliding
with each other.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Manual generated code inspection (search for listHolder in the generated diff), plus the testcase that @mlepage-google ran into this problem with generates code that compiles.  I assume he will be adding that YAML test soon, once this merges.