### PR TITLE
Fix scoping of temporary variables in Darwin codegen.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/partials/decode_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/decode_value.zapt
@@ -11,21 +11,21 @@
     {{>decode_value target=target source=(concat source ".Value()") cluster=cluster errorCode=errorCode depth=(incrementDepth depth) isNullable=false}}
   }
 {{else if isArray}}
-  auto * array_{{depth}} = [NSMutableArray new];
-  auto iter_{{depth}} = {{source}}.begin();
-  while (iter_{{depth}}.Next()) {
-    auto & entry_{{depth}} = iter_{{depth}}.GetValue();
-    {{asObjectiveCClass type cluster forceNotList=true}} * newElement_{{depth}};
-    {{>decode_value target=(concat "newElement_" depth) source=(concat "entry_" depth) cluster=cluster errorCode=errorCode depth=(incrementDepth depth) isArray=false}}
-    [array_{{depth}} addObject:newElement_{{depth}}];
-  }
-  {  // Scope for the error so we will know what it's named
+  { // Scope for our temporary variables
+    auto * array_{{depth}} = [NSMutableArray new];
+    auto iter_{{depth}} = {{source}}.begin();
+    while (iter_{{depth}}.Next()) {
+      auto & entry_{{depth}} = iter_{{depth}}.GetValue();
+      {{asObjectiveCClass type cluster forceNotList=true}} * newElement_{{depth}};
+      {{>decode_value target=(concat "newElement_" depth) source=(concat "entry_" depth) cluster=cluster errorCode=errorCode depth=(incrementDepth depth) isArray=false}}
+      [array_{{depth}} addObject:newElement_{{depth}}];
+    }
     CHIP_ERROR err = iter_{{depth}}.GetStatus();
     if (err != CHIP_NO_ERROR) {
       {{errorCode}}
     }
+    {{target}} = array_{{depth}};
   }
-  {{target}} = array_{{depth}};
 {{else}}
   {{#if_is_struct type}}
     {{target}} = [{{asObjectiveCClass type cluster forceNotList=true}} new];

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPAttributeTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPAttributeTLVValueDecoder.mm
@@ -45,80 +45,80 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPAccessControlClusterAccessControlEntry * newElement_0;
-                newElement_0 = [CHIPAccessControlClusterAccessControlEntry new];
-                newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
-                newElement_0.privilege = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.privilege)];
-                newElement_0.authMode = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.authMode)];
-                if (entry_0.subjects.IsNull()) {
-                    newElement_0.subjects = nil;
-                } else {
-                    auto * array_3 = [NSMutableArray new];
-                    auto iter_3 = entry_0.subjects.Value().begin();
-                    while (iter_3.Next()) {
-                        auto & entry_3 = iter_3.GetValue();
-                        NSNumber * newElement_3;
-                        newElement_3 = [NSNumber numberWithUnsignedLongLong:entry_3];
-                        [array_3 addObject:newElement_3];
-                    }
-                    { // Scope for the error so we will know what it's named
-                        CHIP_ERROR err = iter_3.GetStatus();
-                        if (err != CHIP_NO_ERROR) {
-                            *aError = err;
-                            return nil;
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPAccessControlClusterAccessControlEntry * newElement_0;
+                    newElement_0 = [CHIPAccessControlClusterAccessControlEntry new];
+                    newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
+                    newElement_0.privilege = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.privilege)];
+                    newElement_0.authMode = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.authMode)];
+                    if (entry_0.subjects.IsNull()) {
+                        newElement_0.subjects = nil;
+                    } else {
+                        { // Scope for our temporary variables
+                            auto * array_3 = [NSMutableArray new];
+                            auto iter_3 = entry_0.subjects.Value().begin();
+                            while (iter_3.Next()) {
+                                auto & entry_3 = iter_3.GetValue();
+                                NSNumber * newElement_3;
+                                newElement_3 = [NSNumber numberWithUnsignedLongLong:entry_3];
+                                [array_3 addObject:newElement_3];
+                            }
+                            CHIP_ERROR err = iter_3.GetStatus();
+                            if (err != CHIP_NO_ERROR) {
+                                *aError = err;
+                                return nil;
+                            }
+                            newElement_0.subjects = array_3;
                         }
                     }
-                    newElement_0.subjects = array_3;
+                    if (entry_0.targets.IsNull()) {
+                        newElement_0.targets = nil;
+                    } else {
+                        { // Scope for our temporary variables
+                            auto * array_3 = [NSMutableArray new];
+                            auto iter_3 = entry_0.targets.Value().begin();
+                            while (iter_3.Next()) {
+                                auto & entry_3 = iter_3.GetValue();
+                                CHIPAccessControlClusterTarget * newElement_3;
+                                newElement_3 = [CHIPAccessControlClusterTarget new];
+                                if (entry_3.cluster.IsNull()) {
+                                    newElement_3.cluster = nil;
+                                } else {
+                                    newElement_3.cluster = [NSNumber numberWithUnsignedInt:entry_3.cluster.Value()];
+                                }
+                                if (entry_3.endpoint.IsNull()) {
+                                    newElement_3.endpoint = nil;
+                                } else {
+                                    newElement_3.endpoint = [NSNumber numberWithUnsignedShort:entry_3.endpoint.Value()];
+                                }
+                                if (entry_3.deviceType.IsNull()) {
+                                    newElement_3.deviceType = nil;
+                                } else {
+                                    newElement_3.deviceType = [NSNumber numberWithUnsignedInt:entry_3.deviceType.Value()];
+                                }
+                                [array_3 addObject:newElement_3];
+                            }
+                            CHIP_ERROR err = iter_3.GetStatus();
+                            if (err != CHIP_NO_ERROR) {
+                                *aError = err;
+                                return nil;
+                            }
+                            newElement_0.targets = array_3;
+                        }
+                    }
+                    [array_0 addObject:newElement_0];
                 }
-                if (entry_0.targets.IsNull()) {
-                    newElement_0.targets = nil;
-                } else {
-                    auto * array_3 = [NSMutableArray new];
-                    auto iter_3 = entry_0.targets.Value().begin();
-                    while (iter_3.Next()) {
-                        auto & entry_3 = iter_3.GetValue();
-                        CHIPAccessControlClusterTarget * newElement_3;
-                        newElement_3 = [CHIPAccessControlClusterTarget new];
-                        if (entry_3.cluster.IsNull()) {
-                            newElement_3.cluster = nil;
-                        } else {
-                            newElement_3.cluster = [NSNumber numberWithUnsignedInt:entry_3.cluster.Value()];
-                        }
-                        if (entry_3.endpoint.IsNull()) {
-                            newElement_3.endpoint = nil;
-                        } else {
-                            newElement_3.endpoint = [NSNumber numberWithUnsignedShort:entry_3.endpoint.Value()];
-                        }
-                        if (entry_3.deviceType.IsNull()) {
-                            newElement_3.deviceType = nil;
-                        } else {
-                            newElement_3.deviceType = [NSNumber numberWithUnsignedInt:entry_3.deviceType.Value()];
-                        }
-                        [array_3 addObject:newElement_3];
-                    }
-                    { // Scope for the error so we will know what it's named
-                        CHIP_ERROR err = iter_3.GetStatus();
-                        if (err != CHIP_NO_ERROR) {
-                            *aError = err;
-                            return nil;
-                        }
-                    }
-                    newElement_0.targets = array_3;
-                }
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::Extension::Id: {
@@ -129,24 +129,24 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPAccessControlClusterExtensionEntry * newElement_0;
-                newElement_0 = [CHIPAccessControlClusterExtensionEntry new];
-                newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
-                newElement_0.data = [NSData dataWithBytes:entry_0.data.data() length:entry_0.data.size()];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPAccessControlClusterExtensionEntry * newElement_0;
+                    newElement_0 = [CHIPAccessControlClusterExtensionEntry new];
+                    newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
+                    newElement_0.data = [NSData dataWithBytes:entry_0.data.data() length:entry_0.data.size()];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {
@@ -157,22 +157,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -183,22 +183,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -209,22 +209,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -255,22 +255,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -281,22 +281,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -307,22 +307,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -386,22 +386,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -412,22 +412,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -438,22 +438,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -565,22 +565,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedShort:chip::to_underlying(entry_0)];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedShort:chip::to_underlying(entry_0)];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {
@@ -591,22 +591,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -617,22 +617,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -643,22 +643,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -689,22 +689,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedShort:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedShort:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ApplicationLauncherApp::Id: {
@@ -740,22 +740,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -766,22 +766,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -792,22 +792,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -838,27 +838,27 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPAudioOutputClusterOutputInfo * newElement_0;
-                newElement_0 = [CHIPAudioOutputClusterOutputInfo new];
-                newElement_0.index = [NSNumber numberWithUnsignedChar:entry_0.index];
-                newElement_0.outputType = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.outputType)];
-                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                             length:entry_0.name.size()
-                                                           encoding:NSUTF8StringEncoding];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPAudioOutputClusterOutputInfo * newElement_0;
+                    newElement_0 = [CHIPAudioOutputClusterOutputInfo new];
+                    newElement_0.index = [NSNumber numberWithUnsignedChar:entry_0.index];
+                    newElement_0.outputType = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.outputType)];
+                    newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
+                                                                 length:entry_0.name.size()
+                                                               encoding:NSUTF8StringEncoding];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::CurrentAudioOutput::Id: {
@@ -880,22 +880,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -906,22 +906,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -932,22 +932,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -1022,22 +1022,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -1048,22 +1048,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -1074,22 +1074,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -1329,22 +1329,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -1355,22 +1355,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -1381,22 +1381,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -1460,22 +1460,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -1486,22 +1486,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -1512,22 +1512,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -1558,22 +1558,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -1584,22 +1584,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -1610,22 +1610,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -1667,22 +1667,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -1693,22 +1693,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -1719,22 +1719,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -1765,30 +1765,30 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPBridgedActionsClusterActionStruct * newElement_0;
-                newElement_0 = [CHIPBridgedActionsClusterActionStruct new];
-                newElement_0.actionID = [NSNumber numberWithUnsignedShort:entry_0.actionID];
-                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                             length:entry_0.name.size()
-                                                           encoding:NSUTF8StringEncoding];
-                newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
-                newElement_0.endpointListID = [NSNumber numberWithUnsignedShort:entry_0.endpointListID];
-                newElement_0.supportedCommands = [NSNumber numberWithUnsignedShort:entry_0.supportedCommands];
-                newElement_0.status = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.status)];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPBridgedActionsClusterActionStruct * newElement_0;
+                    newElement_0 = [CHIPBridgedActionsClusterActionStruct new];
+                    newElement_0.actionID = [NSNumber numberWithUnsignedShort:entry_0.actionID];
+                    newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
+                                                                 length:entry_0.name.size()
+                                                               encoding:NSUTF8StringEncoding];
+                    newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
+                    newElement_0.endpointListID = [NSNumber numberWithUnsignedShort:entry_0.endpointListID];
+                    newElement_0.supportedCommands = [NSNumber numberWithUnsignedShort:entry_0.supportedCommands];
+                    newElement_0.status = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.status)];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::EndpointList::Id: {
@@ -1799,43 +1799,43 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPBridgedActionsClusterEndpointListStruct * newElement_0;
-                newElement_0 = [CHIPBridgedActionsClusterEndpointListStruct new];
-                newElement_0.endpointListID = [NSNumber numberWithUnsignedShort:entry_0.endpointListID];
-                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                             length:entry_0.name.size()
-                                                           encoding:NSUTF8StringEncoding];
-                newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
-                auto * array_2 = [NSMutableArray new];
-                auto iter_2 = entry_0.endpoints.begin();
-                while (iter_2.Next()) {
-                    auto & entry_2 = iter_2.GetValue();
-                    NSNumber * newElement_2;
-                    newElement_2 = [NSNumber numberWithUnsignedShort:entry_2];
-                    [array_2 addObject:newElement_2];
-                }
-                { // Scope for the error so we will know what it's named
-                    CHIP_ERROR err = iter_2.GetStatus();
-                    if (err != CHIP_NO_ERROR) {
-                        *aError = err;
-                        return nil;
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPBridgedActionsClusterEndpointListStruct * newElement_0;
+                    newElement_0 = [CHIPBridgedActionsClusterEndpointListStruct new];
+                    newElement_0.endpointListID = [NSNumber numberWithUnsignedShort:entry_0.endpointListID];
+                    newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
+                                                                 length:entry_0.name.size()
+                                                               encoding:NSUTF8StringEncoding];
+                    newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
+                    { // Scope for our temporary variables
+                        auto * array_2 = [NSMutableArray new];
+                        auto iter_2 = entry_0.endpoints.begin();
+                        while (iter_2.Next()) {
+                            auto & entry_2 = iter_2.GetValue();
+                            NSNumber * newElement_2;
+                            newElement_2 = [NSNumber numberWithUnsignedShort:entry_2];
+                            [array_2 addObject:newElement_2];
+                        }
+                        CHIP_ERROR err = iter_2.GetStatus();
+                        if (err != CHIP_NO_ERROR) {
+                            *aError = err;
+                            return nil;
+                        }
+                        newElement_0.endpoints = array_2;
                     }
+                    [array_0 addObject:newElement_0];
                 }
-                newElement_0.endpoints = array_2;
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::SetupUrl::Id: {
@@ -1857,22 +1857,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -1883,22 +1883,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -1909,22 +1909,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -2109,22 +2109,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -2135,22 +2135,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -2161,22 +2161,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -2207,45 +2207,45 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPChannelClusterChannelInfo * newElement_0;
-                newElement_0 = [CHIPChannelClusterChannelInfo new];
-                newElement_0.majorNumber = [NSNumber numberWithUnsignedShort:entry_0.majorNumber];
-                newElement_0.minorNumber = [NSNumber numberWithUnsignedShort:entry_0.minorNumber];
-                if (entry_0.name.HasValue()) {
-                    newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.Value().data()
-                                                                 length:entry_0.name.Value().size()
-                                                               encoding:NSUTF8StringEncoding];
-                } else {
-                    newElement_0.name = nil;
-                }
-                if (entry_0.callSign.HasValue()) {
-                    newElement_0.callSign = [[NSString alloc] initWithBytes:entry_0.callSign.Value().data()
-                                                                     length:entry_0.callSign.Value().size()
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPChannelClusterChannelInfo * newElement_0;
+                    newElement_0 = [CHIPChannelClusterChannelInfo new];
+                    newElement_0.majorNumber = [NSNumber numberWithUnsignedShort:entry_0.majorNumber];
+                    newElement_0.minorNumber = [NSNumber numberWithUnsignedShort:entry_0.minorNumber];
+                    if (entry_0.name.HasValue()) {
+                        newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.Value().data()
+                                                                     length:entry_0.name.Value().size()
                                                                    encoding:NSUTF8StringEncoding];
-                } else {
-                    newElement_0.callSign = nil;
+                    } else {
+                        newElement_0.name = nil;
+                    }
+                    if (entry_0.callSign.HasValue()) {
+                        newElement_0.callSign = [[NSString alloc] initWithBytes:entry_0.callSign.Value().data()
+                                                                         length:entry_0.callSign.Value().size()
+                                                                       encoding:NSUTF8StringEncoding];
+                    } else {
+                        newElement_0.callSign = nil;
+                    }
+                    if (entry_0.affiliateCallSign.HasValue()) {
+                        newElement_0.affiliateCallSign = [[NSString alloc] initWithBytes:entry_0.affiliateCallSign.Value().data()
+                                                                                  length:entry_0.affiliateCallSign.Value().size()
+                                                                                encoding:NSUTF8StringEncoding];
+                    } else {
+                        newElement_0.affiliateCallSign = nil;
+                    }
+                    [array_0 addObject:newElement_0];
                 }
-                if (entry_0.affiliateCallSign.HasValue()) {
-                    newElement_0.affiliateCallSign = [[NSString alloc] initWithBytes:entry_0.affiliateCallSign.Value().data()
-                                                                              length:entry_0.affiliateCallSign.Value().size()
-                                                                            encoding:NSUTF8StringEncoding];
-                } else {
-                    newElement_0.affiliateCallSign = nil;
-                }
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ChannelLineup::Id: {
@@ -2327,22 +2327,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -2353,22 +2353,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -2379,22 +2379,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -2997,22 +2997,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -3023,22 +3023,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -3049,22 +3049,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -3095,22 +3095,24 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSString * newElement_0;
-                newElement_0 = [[NSString alloc] initWithBytes:entry_0.data() length:entry_0.size() encoding:NSUTF8StringEncoding];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSString * newElement_0;
+                    newElement_0 = [[NSString alloc] initWithBytes:entry_0.data()
+                                                            length:entry_0.size()
+                                                          encoding:NSUTF8StringEncoding];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::SupportedStreamingProtocols::Id: {
@@ -3132,22 +3134,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -3158,22 +3160,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -3184,22 +3186,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -3230,24 +3232,24 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPDescriptorClusterDeviceType * newElement_0;
-                newElement_0 = [CHIPDescriptorClusterDeviceType new];
-                newElement_0.type = [NSNumber numberWithUnsignedInt:entry_0.type];
-                newElement_0.revision = [NSNumber numberWithUnsignedShort:entry_0.revision];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPDescriptorClusterDeviceType * newElement_0;
+                    newElement_0 = [CHIPDescriptorClusterDeviceType new];
+                    newElement_0.type = [NSNumber numberWithUnsignedInt:entry_0.type];
+                    newElement_0.revision = [NSNumber numberWithUnsignedShort:entry_0.revision];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ServerList::Id: {
@@ -3258,22 +3260,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientList::Id: {
@@ -3284,22 +3286,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::PartsList::Id: {
@@ -3310,22 +3312,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedShort:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedShort:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {
@@ -3336,22 +3338,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -3362,22 +3364,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -3388,22 +3390,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -3434,22 +3436,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -3460,22 +3462,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -3486,22 +3488,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         default:
@@ -3760,22 +3762,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -3786,22 +3788,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -3812,22 +3814,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -3979,22 +3981,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -4005,22 +4007,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -4031,22 +4033,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -4188,22 +4190,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -4214,22 +4216,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -4240,22 +4242,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::FeatureMap::Id: {
@@ -4297,28 +4299,28 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPFixedLabelClusterLabelStruct * newElement_0;
-                newElement_0 = [CHIPFixedLabelClusterLabelStruct new];
-                newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                              length:entry_0.label.size()
-                                                            encoding:NSUTF8StringEncoding];
-                newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
-                                                              length:entry_0.value.size()
-                                                            encoding:NSUTF8StringEncoding];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPFixedLabelClusterLabelStruct * newElement_0;
+                    newElement_0 = [CHIPFixedLabelClusterLabelStruct new];
+                    newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
+                                                                  length:entry_0.label.size()
+                                                                encoding:NSUTF8StringEncoding];
+                    newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
+                                                                  length:entry_0.value.size()
+                                                                encoding:NSUTF8StringEncoding];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {
@@ -4329,22 +4331,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -4355,22 +4357,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -4381,22 +4383,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -4471,22 +4473,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -4497,22 +4499,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -4523,22 +4525,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -4614,22 +4616,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -4640,22 +4642,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -4666,22 +4668,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -4712,41 +4714,41 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPGeneralDiagnosticsClusterNetworkInterfaceType * newElement_0;
-                newElement_0 = [CHIPGeneralDiagnosticsClusterNetworkInterfaceType new];
-                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                             length:entry_0.name.size()
-                                                           encoding:NSUTF8StringEncoding];
-                newElement_0.fabricConnected = [NSNumber numberWithBool:entry_0.fabricConnected];
-                if (entry_0.offPremiseServicesReachableIPv4.IsNull()) {
-                    newElement_0.offPremiseServicesReachableIPv4 = nil;
-                } else {
-                    newElement_0.offPremiseServicesReachableIPv4 =
-                        [NSNumber numberWithBool:entry_0.offPremiseServicesReachableIPv4.Value()];
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPGeneralDiagnosticsClusterNetworkInterfaceType * newElement_0;
+                    newElement_0 = [CHIPGeneralDiagnosticsClusterNetworkInterfaceType new];
+                    newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
+                                                                 length:entry_0.name.size()
+                                                               encoding:NSUTF8StringEncoding];
+                    newElement_0.fabricConnected = [NSNumber numberWithBool:entry_0.fabricConnected];
+                    if (entry_0.offPremiseServicesReachableIPv4.IsNull()) {
+                        newElement_0.offPremiseServicesReachableIPv4 = nil;
+                    } else {
+                        newElement_0.offPremiseServicesReachableIPv4 =
+                            [NSNumber numberWithBool:entry_0.offPremiseServicesReachableIPv4.Value()];
+                    }
+                    if (entry_0.offPremiseServicesReachableIPv6.IsNull()) {
+                        newElement_0.offPremiseServicesReachableIPv6 = nil;
+                    } else {
+                        newElement_0.offPremiseServicesReachableIPv6 =
+                            [NSNumber numberWithBool:entry_0.offPremiseServicesReachableIPv6.Value()];
+                    }
+                    newElement_0.hardwareAddress = [NSData dataWithBytes:entry_0.hardwareAddress.data()
+                                                                  length:entry_0.hardwareAddress.size()];
+                    newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
+                    [array_0 addObject:newElement_0];
                 }
-                if (entry_0.offPremiseServicesReachableIPv6.IsNull()) {
-                    newElement_0.offPremiseServicesReachableIPv6 = nil;
-                } else {
-                    newElement_0.offPremiseServicesReachableIPv6 =
-                        [NSNumber numberWithBool:entry_0.offPremiseServicesReachableIPv6.Value()];
-                }
-                newElement_0.hardwareAddress = [NSData dataWithBytes:entry_0.hardwareAddress.data()
-                                                              length:entry_0.hardwareAddress.size()];
-                newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::RebootCount::Id: {
@@ -4801,22 +4803,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ActiveRadioFaults::Id: {
@@ -4827,22 +4829,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ActiveNetworkFaults::Id: {
@@ -4853,22 +4855,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {
@@ -4879,22 +4881,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -4905,22 +4907,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -4931,22 +4933,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -4977,25 +4979,25 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPGroupKeyManagementClusterGroupKeyMapStruct * newElement_0;
-                newElement_0 = [CHIPGroupKeyManagementClusterGroupKeyMapStruct new];
-                newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
-                newElement_0.groupId = [NSNumber numberWithUnsignedShort:entry_0.groupId];
-                newElement_0.groupKeySetID = [NSNumber numberWithUnsignedShort:entry_0.groupKeySetID];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPGroupKeyManagementClusterGroupKeyMapStruct * newElement_0;
+                    newElement_0 = [CHIPGroupKeyManagementClusterGroupKeyMapStruct new];
+                    newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
+                    newElement_0.groupId = [NSNumber numberWithUnsignedShort:entry_0.groupId];
+                    newElement_0.groupKeySetID = [NSNumber numberWithUnsignedShort:entry_0.groupKeySetID];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::GroupTable::Id: {
@@ -5006,47 +5008,47 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPGroupKeyManagementClusterGroupInfoMapStruct * newElement_0;
-                newElement_0 = [CHIPGroupKeyManagementClusterGroupInfoMapStruct new];
-                newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
-                newElement_0.groupId = [NSNumber numberWithUnsignedShort:entry_0.groupId];
-                auto * array_2 = [NSMutableArray new];
-                auto iter_2 = entry_0.endpoints.begin();
-                while (iter_2.Next()) {
-                    auto & entry_2 = iter_2.GetValue();
-                    NSNumber * newElement_2;
-                    newElement_2 = [NSNumber numberWithUnsignedShort:entry_2];
-                    [array_2 addObject:newElement_2];
-                }
-                { // Scope for the error so we will know what it's named
-                    CHIP_ERROR err = iter_2.GetStatus();
-                    if (err != CHIP_NO_ERROR) {
-                        *aError = err;
-                        return nil;
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPGroupKeyManagementClusterGroupInfoMapStruct * newElement_0;
+                    newElement_0 = [CHIPGroupKeyManagementClusterGroupInfoMapStruct new];
+                    newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
+                    newElement_0.groupId = [NSNumber numberWithUnsignedShort:entry_0.groupId];
+                    { // Scope for our temporary variables
+                        auto * array_2 = [NSMutableArray new];
+                        auto iter_2 = entry_0.endpoints.begin();
+                        while (iter_2.Next()) {
+                            auto & entry_2 = iter_2.GetValue();
+                            NSNumber * newElement_2;
+                            newElement_2 = [NSNumber numberWithUnsignedShort:entry_2];
+                            [array_2 addObject:newElement_2];
+                        }
+                        CHIP_ERROR err = iter_2.GetStatus();
+                        if (err != CHIP_NO_ERROR) {
+                            *aError = err;
+                            return nil;
+                        }
+                        newElement_0.endpoints = array_2;
                     }
+                    if (entry_0.groupName.HasValue()) {
+                        newElement_0.groupName = [[NSString alloc] initWithBytes:entry_0.groupName.Value().data()
+                                                                          length:entry_0.groupName.Value().size()
+                                                                        encoding:NSUTF8StringEncoding];
+                    } else {
+                        newElement_0.groupName = nil;
+                    }
+                    [array_0 addObject:newElement_0];
                 }
-                newElement_0.endpoints = array_2;
-                if (entry_0.groupName.HasValue()) {
-                    newElement_0.groupName = [[NSString alloc] initWithBytes:entry_0.groupName.Value().data()
-                                                                      length:entry_0.groupName.Value().size()
-                                                                    encoding:NSUTF8StringEncoding];
-                } else {
-                    newElement_0.groupName = nil;
-                }
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::MaxGroupsPerFabric::Id: {
@@ -5079,22 +5081,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -5105,22 +5107,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -5131,22 +5133,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -5188,22 +5190,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -5214,22 +5216,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -5240,22 +5242,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -5308,22 +5310,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -5334,22 +5336,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -5360,22 +5362,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -5477,22 +5479,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -5503,22 +5505,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -5529,22 +5531,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -5575,22 +5577,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -5601,22 +5603,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -5627,22 +5629,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -5847,22 +5849,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -5873,22 +5875,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -5899,22 +5901,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::FeatureMap::Id: {
@@ -5967,22 +5969,24 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSString * newElement_0;
-                newElement_0 = [[NSString alloc] initWithBytes:entry_0.data() length:entry_0.size() encoding:NSUTF8StringEncoding];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSString * newElement_0;
+                    newElement_0 = [[NSString alloc] initWithBytes:entry_0.data()
+                                                            length:entry_0.size()
+                                                          encoding:NSUTF8StringEncoding];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {
@@ -5993,22 +5997,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -6019,22 +6023,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -6065,22 +6069,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -6091,22 +6095,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -6117,22 +6121,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -6163,30 +6167,30 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPMediaInputClusterInputInfo * newElement_0;
-                newElement_0 = [CHIPMediaInputClusterInputInfo new];
-                newElement_0.index = [NSNumber numberWithUnsignedChar:entry_0.index];
-                newElement_0.inputType = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.inputType)];
-                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                             length:entry_0.name.size()
-                                                           encoding:NSUTF8StringEncoding];
-                newElement_0.descriptionString = [[NSString alloc] initWithBytes:entry_0.description.data()
-                                                                          length:entry_0.description.size()
-                                                                        encoding:NSUTF8StringEncoding];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPMediaInputClusterInputInfo * newElement_0;
+                    newElement_0 = [CHIPMediaInputClusterInputInfo new];
+                    newElement_0.index = [NSNumber numberWithUnsignedChar:entry_0.index];
+                    newElement_0.inputType = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.inputType)];
+                    newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
+                                                                 length:entry_0.name.size()
+                                                               encoding:NSUTF8StringEncoding];
+                    newElement_0.descriptionString = [[NSString alloc] initWithBytes:entry_0.description.data()
+                                                                              length:entry_0.description.size()
+                                                                            encoding:NSUTF8StringEncoding];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::CurrentMediaInput::Id: {
@@ -6208,22 +6212,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -6234,22 +6238,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -6260,22 +6264,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -6405,22 +6409,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -6431,22 +6435,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -6457,22 +6461,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -6514,27 +6518,27 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPModeSelectClusterModeOptionStruct * newElement_0;
-                newElement_0 = [CHIPModeSelectClusterModeOptionStruct new];
-                newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                              length:entry_0.label.size()
-                                                            encoding:NSUTF8StringEncoding];
-                newElement_0.mode = [NSNumber numberWithUnsignedChar:entry_0.mode];
-                newElement_0.semanticTag = [NSNumber numberWithUnsignedInt:entry_0.semanticTag];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPModeSelectClusterModeOptionStruct * newElement_0;
+                    newElement_0 = [CHIPModeSelectClusterModeOptionStruct new];
+                    newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
+                                                                  length:entry_0.label.size()
+                                                                encoding:NSUTF8StringEncoding];
+                    newElement_0.mode = [NSNumber numberWithUnsignedChar:entry_0.mode];
+                    newElement_0.semanticTag = [NSNumber numberWithUnsignedInt:entry_0.semanticTag];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::OnMode::Id: {
@@ -6578,22 +6582,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -6604,22 +6608,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -6630,22 +6634,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -6687,24 +6691,24 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPNetworkCommissioningClusterNetworkInfo * newElement_0;
-                newElement_0 = [CHIPNetworkCommissioningClusterNetworkInfo new];
-                newElement_0.networkID = [NSData dataWithBytes:entry_0.networkID.data() length:entry_0.networkID.size()];
-                newElement_0.connected = [NSNumber numberWithBool:entry_0.connected];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPNetworkCommissioningClusterNetworkInfo * newElement_0;
+                    newElement_0 = [CHIPNetworkCommissioningClusterNetworkInfo new];
+                    newElement_0.networkID = [NSData dataWithBytes:entry_0.networkID.data() length:entry_0.networkID.size()];
+                    newElement_0.connected = [NSNumber numberWithBool:entry_0.connected];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ScanMaxTimeSeconds::Id: {
@@ -6781,22 +6785,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -6807,22 +6811,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::FeatureMap::Id: {
@@ -6864,22 +6868,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -6910,25 +6914,25 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPOtaSoftwareUpdateRequestorClusterProviderLocation * newElement_0;
-                newElement_0 = [CHIPOtaSoftwareUpdateRequestorClusterProviderLocation new];
-                newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
-                newElement_0.providerNodeID = [NSNumber numberWithUnsignedLongLong:entry_0.providerNodeID];
-                newElement_0.endpoint = [NSNumber numberWithUnsignedShort:entry_0.endpoint];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPOtaSoftwareUpdateRequestorClusterProviderLocation * newElement_0;
+                    newElement_0 = [CHIPOtaSoftwareUpdateRequestorClusterProviderLocation new];
+                    newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
+                    newElement_0.providerNodeID = [NSNumber numberWithUnsignedLongLong:entry_0.providerNodeID];
+                    newElement_0.endpoint = [NSNumber numberWithUnsignedShort:entry_0.endpoint];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::UpdatePossible::Id: {
@@ -6976,22 +6980,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -7055,22 +7059,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -7081,22 +7085,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -7107,22 +7111,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -7208,22 +7212,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -7234,22 +7238,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -7260,22 +7264,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::FeatureMap::Id: {
@@ -7339,22 +7343,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -7365,22 +7369,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -7391,22 +7395,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -7437,29 +7441,29 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPOperationalCredentialsClusterNOCStruct * newElement_0;
-                newElement_0 = [CHIPOperationalCredentialsClusterNOCStruct new];
-                newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
-                newElement_0.noc = [NSData dataWithBytes:entry_0.noc.data() length:entry_0.noc.size()];
-                if (entry_0.icac.IsNull()) {
-                    newElement_0.icac = nil;
-                } else {
-                    newElement_0.icac = [NSData dataWithBytes:entry_0.icac.Value().data() length:entry_0.icac.Value().size()];
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPOperationalCredentialsClusterNOCStruct * newElement_0;
+                    newElement_0 = [CHIPOperationalCredentialsClusterNOCStruct new];
+                    newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
+                    newElement_0.noc = [NSData dataWithBytes:entry_0.noc.data() length:entry_0.noc.size()];
+                    if (entry_0.icac.IsNull()) {
+                        newElement_0.icac = nil;
+                    } else {
+                        newElement_0.icac = [NSData dataWithBytes:entry_0.icac.Value().data() length:entry_0.icac.Value().size()];
+                    }
+                    [array_0 addObject:newElement_0];
                 }
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::FabricsList::Id: {
@@ -7470,31 +7474,31 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPOperationalCredentialsClusterFabricDescriptor * newElement_0;
-                newElement_0 = [CHIPOperationalCredentialsClusterFabricDescriptor new];
-                newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
-                newElement_0.rootPublicKey = [NSData dataWithBytes:entry_0.rootPublicKey.data()
-                                                            length:entry_0.rootPublicKey.size()];
-                newElement_0.vendorId = [NSNumber numberWithUnsignedShort:entry_0.vendorId];
-                newElement_0.fabricId = [NSNumber numberWithUnsignedLongLong:entry_0.fabricId];
-                newElement_0.nodeId = [NSNumber numberWithUnsignedLongLong:entry_0.nodeId];
-                newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                              length:entry_0.label.size()
-                                                            encoding:NSUTF8StringEncoding];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPOperationalCredentialsClusterFabricDescriptor * newElement_0;
+                    newElement_0 = [CHIPOperationalCredentialsClusterFabricDescriptor new];
+                    newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
+                    newElement_0.rootPublicKey = [NSData dataWithBytes:entry_0.rootPublicKey.data()
+                                                                length:entry_0.rootPublicKey.size()];
+                    newElement_0.vendorId = [NSNumber numberWithUnsignedShort:entry_0.vendorId];
+                    newElement_0.fabricId = [NSNumber numberWithUnsignedLongLong:entry_0.fabricId];
+                    newElement_0.nodeId = [NSNumber numberWithUnsignedLongLong:entry_0.nodeId];
+                    newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
+                                                                  length:entry_0.label.size()
+                                                                encoding:NSUTF8StringEncoding];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::SupportedFabrics::Id: {
@@ -7527,22 +7531,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSData * newElement_0;
-                newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSData * newElement_0;
+                    newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::CurrentFabricIndex::Id: {
@@ -7564,22 +7568,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -7590,22 +7594,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -7616,22 +7620,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -7739,22 +7743,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::BatteryChargeState::Id: {
@@ -7776,22 +7780,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -7802,22 +7806,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -7828,22 +7832,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::FeatureMap::Id: {
@@ -7885,22 +7889,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {
@@ -7911,22 +7915,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -7937,22 +7941,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -7963,22 +7967,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -8042,22 +8046,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -8360,22 +8364,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -8386,22 +8390,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -8412,22 +8416,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::FeatureMap::Id: {
@@ -8513,22 +8517,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -8539,22 +8543,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -8565,22 +8569,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -8666,22 +8670,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -8692,22 +8696,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -8718,22 +8722,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -8764,29 +8768,29 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPSoftwareDiagnosticsClusterThreadMetrics * newElement_0;
-                newElement_0 = [CHIPSoftwareDiagnosticsClusterThreadMetrics new];
-                newElement_0.id = [NSNumber numberWithUnsignedLongLong:entry_0.id];
-                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                             length:entry_0.name.size()
-                                                           encoding:NSUTF8StringEncoding];
-                newElement_0.stackFreeCurrent = [NSNumber numberWithUnsignedInt:entry_0.stackFreeCurrent];
-                newElement_0.stackFreeMinimum = [NSNumber numberWithUnsignedInt:entry_0.stackFreeMinimum];
-                newElement_0.stackSize = [NSNumber numberWithUnsignedInt:entry_0.stackSize];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPSoftwareDiagnosticsClusterThreadMetrics * newElement_0;
+                    newElement_0 = [CHIPSoftwareDiagnosticsClusterThreadMetrics new];
+                    newElement_0.id = [NSNumber numberWithUnsignedLongLong:entry_0.id];
+                    newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
+                                                                 length:entry_0.name.size()
+                                                               encoding:NSUTF8StringEncoding];
+                    newElement_0.stackFreeCurrent = [NSNumber numberWithUnsignedInt:entry_0.stackFreeCurrent];
+                    newElement_0.stackFreeMinimum = [NSNumber numberWithUnsignedInt:entry_0.stackFreeMinimum];
+                    newElement_0.stackSize = [NSNumber numberWithUnsignedInt:entry_0.stackSize];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::CurrentHeapFree::Id: {
@@ -8830,22 +8834,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -8856,22 +8860,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -8882,22 +8886,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::FeatureMap::Id: {
@@ -8972,22 +8976,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -8998,22 +9002,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -9024,22 +9028,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::FeatureMap::Id: {
@@ -9081,26 +9085,26 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPTargetNavigatorClusterTargetInfo * newElement_0;
-                newElement_0 = [CHIPTargetNavigatorClusterTargetInfo new];
-                newElement_0.identifier = [NSNumber numberWithUnsignedChar:entry_0.identifier];
-                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                             length:entry_0.name.size()
-                                                           encoding:NSUTF8StringEncoding];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPTargetNavigatorClusterTargetInfo * newElement_0;
+                    newElement_0 = [CHIPTargetNavigatorClusterTargetInfo new];
+                    newElement_0.identifier = [NSNumber numberWithUnsignedChar:entry_0.identifier];
+                    newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
+                                                                 length:entry_0.name.size()
+                                                               encoding:NSUTF8StringEncoding];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::CurrentNavigatorTarget::Id: {
@@ -9122,22 +9126,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -9148,22 +9152,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -9174,22 +9178,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -9264,22 +9268,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -9596,22 +9600,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ListOctetString::Id: {
@@ -9622,22 +9626,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSData * newElement_0;
-                newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSData * newElement_0;
+                    newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ListStructOctetString::Id: {
@@ -9648,25 +9652,25 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPTestClusterClusterTestListStructOctet * newElement_0;
-                newElement_0 = [CHIPTestClusterClusterTestListStructOctet new];
-                newElement_0.fabricIndex = [NSNumber numberWithUnsignedLongLong:entry_0.fabricIndex];
-                newElement_0.operationalCert = [NSData dataWithBytes:entry_0.operationalCert.data()
-                                                              length:entry_0.operationalCert.size()];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPTestClusterClusterTestListStructOctet * newElement_0;
+                    newElement_0 = [CHIPTestClusterClusterTestListStructOctet new];
+                    newElement_0.fabricIndex = [NSNumber numberWithUnsignedLongLong:entry_0.fabricIndex];
+                    newElement_0.operationalCert = [NSData dataWithBytes:entry_0.operationalCert.data()
+                                                                  length:entry_0.operationalCert.size()];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::LongOctetString::Id: {
@@ -9743,194 +9747,194 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPTestClusterClusterNullablesAndOptionalsStruct * newElement_0;
-                newElement_0 = [CHIPTestClusterClusterNullablesAndOptionalsStruct new];
-                if (entry_0.nullableInt.IsNull()) {
-                    newElement_0.nullableInt = nil;
-                } else {
-                    newElement_0.nullableInt = [NSNumber numberWithUnsignedShort:entry_0.nullableInt.Value()];
-                }
-                if (entry_0.optionalInt.HasValue()) {
-                    newElement_0.optionalInt = [NSNumber numberWithUnsignedShort:entry_0.optionalInt.Value()];
-                } else {
-                    newElement_0.optionalInt = nil;
-                }
-                if (entry_0.nullableOptionalInt.HasValue()) {
-                    if (entry_0.nullableOptionalInt.Value().IsNull()) {
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPTestClusterClusterNullablesAndOptionalsStruct * newElement_0;
+                    newElement_0 = [CHIPTestClusterClusterNullablesAndOptionalsStruct new];
+                    if (entry_0.nullableInt.IsNull()) {
+                        newElement_0.nullableInt = nil;
+                    } else {
+                        newElement_0.nullableInt = [NSNumber numberWithUnsignedShort:entry_0.nullableInt.Value()];
+                    }
+                    if (entry_0.optionalInt.HasValue()) {
+                        newElement_0.optionalInt = [NSNumber numberWithUnsignedShort:entry_0.optionalInt.Value()];
+                    } else {
+                        newElement_0.optionalInt = nil;
+                    }
+                    if (entry_0.nullableOptionalInt.HasValue()) {
+                        if (entry_0.nullableOptionalInt.Value().IsNull()) {
+                            newElement_0.nullableOptionalInt = nil;
+                        } else {
+                            newElement_0.nullableOptionalInt =
+                                [NSNumber numberWithUnsignedShort:entry_0.nullableOptionalInt.Value().Value()];
+                        }
+                    } else {
                         newElement_0.nullableOptionalInt = nil;
-                    } else {
-                        newElement_0.nullableOptionalInt =
-                            [NSNumber numberWithUnsignedShort:entry_0.nullableOptionalInt.Value().Value()];
                     }
-                } else {
-                    newElement_0.nullableOptionalInt = nil;
-                }
-                if (entry_0.nullableString.IsNull()) {
-                    newElement_0.nullableString = nil;
-                } else {
-                    newElement_0.nullableString = [[NSString alloc] initWithBytes:entry_0.nullableString.Value().data()
-                                                                           length:entry_0.nullableString.Value().size()
-                                                                         encoding:NSUTF8StringEncoding];
-                }
-                if (entry_0.optionalString.HasValue()) {
-                    newElement_0.optionalString = [[NSString alloc] initWithBytes:entry_0.optionalString.Value().data()
-                                                                           length:entry_0.optionalString.Value().size()
-                                                                         encoding:NSUTF8StringEncoding];
-                } else {
-                    newElement_0.optionalString = nil;
-                }
-                if (entry_0.nullableOptionalString.HasValue()) {
-                    if (entry_0.nullableOptionalString.Value().IsNull()) {
+                    if (entry_0.nullableString.IsNull()) {
+                        newElement_0.nullableString = nil;
+                    } else {
+                        newElement_0.nullableString = [[NSString alloc] initWithBytes:entry_0.nullableString.Value().data()
+                                                                               length:entry_0.nullableString.Value().size()
+                                                                             encoding:NSUTF8StringEncoding];
+                    }
+                    if (entry_0.optionalString.HasValue()) {
+                        newElement_0.optionalString = [[NSString alloc] initWithBytes:entry_0.optionalString.Value().data()
+                                                                               length:entry_0.optionalString.Value().size()
+                                                                             encoding:NSUTF8StringEncoding];
+                    } else {
+                        newElement_0.optionalString = nil;
+                    }
+                    if (entry_0.nullableOptionalString.HasValue()) {
+                        if (entry_0.nullableOptionalString.Value().IsNull()) {
+                            newElement_0.nullableOptionalString = nil;
+                        } else {
+                            newElement_0.nullableOptionalString =
+                                [[NSString alloc] initWithBytes:entry_0.nullableOptionalString.Value().Value().data()
+                                                         length:entry_0.nullableOptionalString.Value().Value().size()
+                                                       encoding:NSUTF8StringEncoding];
+                        }
+                    } else {
                         newElement_0.nullableOptionalString = nil;
-                    } else {
-                        newElement_0.nullableOptionalString =
-                            [[NSString alloc] initWithBytes:entry_0.nullableOptionalString.Value().Value().data()
-                                                     length:entry_0.nullableOptionalString.Value().Value().size()
-                                                   encoding:NSUTF8StringEncoding];
                     }
-                } else {
-                    newElement_0.nullableOptionalString = nil;
-                }
-                if (entry_0.nullableStruct.IsNull()) {
-                    newElement_0.nullableStruct = nil;
-                } else {
-                    newElement_0.nullableStruct = [CHIPTestClusterClusterSimpleStruct new];
-                    newElement_0.nullableStruct.a = [NSNumber numberWithUnsignedChar:entry_0.nullableStruct.Value().a];
-                    newElement_0.nullableStruct.b = [NSNumber numberWithBool:entry_0.nullableStruct.Value().b];
-                    newElement_0.nullableStruct.c =
-                        [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.nullableStruct.Value().c)];
-                    newElement_0.nullableStruct.d = [NSData dataWithBytes:entry_0.nullableStruct.Value().d.data()
-                                                                   length:entry_0.nullableStruct.Value().d.size()];
-                    newElement_0.nullableStruct.e = [[NSString alloc] initWithBytes:entry_0.nullableStruct.Value().e.data()
-                                                                             length:entry_0.nullableStruct.Value().e.size()
-                                                                           encoding:NSUTF8StringEncoding];
-                    newElement_0.nullableStruct.f = [NSNumber numberWithUnsignedChar:entry_0.nullableStruct.Value().f.Raw()];
-                    newElement_0.nullableStruct.g = [NSNumber numberWithFloat:entry_0.nullableStruct.Value().g];
-                    newElement_0.nullableStruct.h = [NSNumber numberWithDouble:entry_0.nullableStruct.Value().h];
-                }
-                if (entry_0.optionalStruct.HasValue()) {
-                    newElement_0.optionalStruct = [CHIPTestClusterClusterSimpleStruct new];
-                    newElement_0.optionalStruct.a = [NSNumber numberWithUnsignedChar:entry_0.optionalStruct.Value().a];
-                    newElement_0.optionalStruct.b = [NSNumber numberWithBool:entry_0.optionalStruct.Value().b];
-                    newElement_0.optionalStruct.c =
-                        [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.optionalStruct.Value().c)];
-                    newElement_0.optionalStruct.d = [NSData dataWithBytes:entry_0.optionalStruct.Value().d.data()
-                                                                   length:entry_0.optionalStruct.Value().d.size()];
-                    newElement_0.optionalStruct.e = [[NSString alloc] initWithBytes:entry_0.optionalStruct.Value().e.data()
-                                                                             length:entry_0.optionalStruct.Value().e.size()
-                                                                           encoding:NSUTF8StringEncoding];
-                    newElement_0.optionalStruct.f = [NSNumber numberWithUnsignedChar:entry_0.optionalStruct.Value().f.Raw()];
-                    newElement_0.optionalStruct.g = [NSNumber numberWithFloat:entry_0.optionalStruct.Value().g];
-                    newElement_0.optionalStruct.h = [NSNumber numberWithDouble:entry_0.optionalStruct.Value().h];
-                } else {
-                    newElement_0.optionalStruct = nil;
-                }
-                if (entry_0.nullableOptionalStruct.HasValue()) {
-                    if (entry_0.nullableOptionalStruct.Value().IsNull()) {
+                    if (entry_0.nullableStruct.IsNull()) {
+                        newElement_0.nullableStruct = nil;
+                    } else {
+                        newElement_0.nullableStruct = [CHIPTestClusterClusterSimpleStruct new];
+                        newElement_0.nullableStruct.a = [NSNumber numberWithUnsignedChar:entry_0.nullableStruct.Value().a];
+                        newElement_0.nullableStruct.b = [NSNumber numberWithBool:entry_0.nullableStruct.Value().b];
+                        newElement_0.nullableStruct.c =
+                            [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.nullableStruct.Value().c)];
+                        newElement_0.nullableStruct.d = [NSData dataWithBytes:entry_0.nullableStruct.Value().d.data()
+                                                                       length:entry_0.nullableStruct.Value().d.size()];
+                        newElement_0.nullableStruct.e = [[NSString alloc] initWithBytes:entry_0.nullableStruct.Value().e.data()
+                                                                                 length:entry_0.nullableStruct.Value().e.size()
+                                                                               encoding:NSUTF8StringEncoding];
+                        newElement_0.nullableStruct.f = [NSNumber numberWithUnsignedChar:entry_0.nullableStruct.Value().f.Raw()];
+                        newElement_0.nullableStruct.g = [NSNumber numberWithFloat:entry_0.nullableStruct.Value().g];
+                        newElement_0.nullableStruct.h = [NSNumber numberWithDouble:entry_0.nullableStruct.Value().h];
+                    }
+                    if (entry_0.optionalStruct.HasValue()) {
+                        newElement_0.optionalStruct = [CHIPTestClusterClusterSimpleStruct new];
+                        newElement_0.optionalStruct.a = [NSNumber numberWithUnsignedChar:entry_0.optionalStruct.Value().a];
+                        newElement_0.optionalStruct.b = [NSNumber numberWithBool:entry_0.optionalStruct.Value().b];
+                        newElement_0.optionalStruct.c =
+                            [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.optionalStruct.Value().c)];
+                        newElement_0.optionalStruct.d = [NSData dataWithBytes:entry_0.optionalStruct.Value().d.data()
+                                                                       length:entry_0.optionalStruct.Value().d.size()];
+                        newElement_0.optionalStruct.e = [[NSString alloc] initWithBytes:entry_0.optionalStruct.Value().e.data()
+                                                                                 length:entry_0.optionalStruct.Value().e.size()
+                                                                               encoding:NSUTF8StringEncoding];
+                        newElement_0.optionalStruct.f = [NSNumber numberWithUnsignedChar:entry_0.optionalStruct.Value().f.Raw()];
+                        newElement_0.optionalStruct.g = [NSNumber numberWithFloat:entry_0.optionalStruct.Value().g];
+                        newElement_0.optionalStruct.h = [NSNumber numberWithDouble:entry_0.optionalStruct.Value().h];
+                    } else {
+                        newElement_0.optionalStruct = nil;
+                    }
+                    if (entry_0.nullableOptionalStruct.HasValue()) {
+                        if (entry_0.nullableOptionalStruct.Value().IsNull()) {
+                            newElement_0.nullableOptionalStruct = nil;
+                        } else {
+                            newElement_0.nullableOptionalStruct = [CHIPTestClusterClusterSimpleStruct new];
+                            newElement_0.nullableOptionalStruct.a =
+                                [NSNumber numberWithUnsignedChar:entry_0.nullableOptionalStruct.Value().Value().a];
+                            newElement_0.nullableOptionalStruct.b =
+                                [NSNumber numberWithBool:entry_0.nullableOptionalStruct.Value().Value().b];
+                            newElement_0.nullableOptionalStruct.c = [NSNumber
+                                numberWithUnsignedChar:chip::to_underlying(entry_0.nullableOptionalStruct.Value().Value().c)];
+                            newElement_0.nullableOptionalStruct.d =
+                                [NSData dataWithBytes:entry_0.nullableOptionalStruct.Value().Value().d.data()
+                                               length:entry_0.nullableOptionalStruct.Value().Value().d.size()];
+                            newElement_0.nullableOptionalStruct.e =
+                                [[NSString alloc] initWithBytes:entry_0.nullableOptionalStruct.Value().Value().e.data()
+                                                         length:entry_0.nullableOptionalStruct.Value().Value().e.size()
+                                                       encoding:NSUTF8StringEncoding];
+                            newElement_0.nullableOptionalStruct.f =
+                                [NSNumber numberWithUnsignedChar:entry_0.nullableOptionalStruct.Value().Value().f.Raw()];
+                            newElement_0.nullableOptionalStruct.g =
+                                [NSNumber numberWithFloat:entry_0.nullableOptionalStruct.Value().Value().g];
+                            newElement_0.nullableOptionalStruct.h =
+                                [NSNumber numberWithDouble:entry_0.nullableOptionalStruct.Value().Value().h];
+                        }
+                    } else {
                         newElement_0.nullableOptionalStruct = nil;
+                    }
+                    if (entry_0.nullableList.IsNull()) {
+                        newElement_0.nullableList = nil;
                     } else {
-                        newElement_0.nullableOptionalStruct = [CHIPTestClusterClusterSimpleStruct new];
-                        newElement_0.nullableOptionalStruct.a =
-                            [NSNumber numberWithUnsignedChar:entry_0.nullableOptionalStruct.Value().Value().a];
-                        newElement_0.nullableOptionalStruct.b =
-                            [NSNumber numberWithBool:entry_0.nullableOptionalStruct.Value().Value().b];
-                        newElement_0.nullableOptionalStruct.c =
-                            [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.nullableOptionalStruct.Value().Value().c)];
-                        newElement_0.nullableOptionalStruct.d =
-                            [NSData dataWithBytes:entry_0.nullableOptionalStruct.Value().Value().d.data()
-                                           length:entry_0.nullableOptionalStruct.Value().Value().d.size()];
-                        newElement_0.nullableOptionalStruct.e =
-                            [[NSString alloc] initWithBytes:entry_0.nullableOptionalStruct.Value().Value().e.data()
-                                                     length:entry_0.nullableOptionalStruct.Value().Value().e.size()
-                                                   encoding:NSUTF8StringEncoding];
-                        newElement_0.nullableOptionalStruct.f =
-                            [NSNumber numberWithUnsignedChar:entry_0.nullableOptionalStruct.Value().Value().f.Raw()];
-                        newElement_0.nullableOptionalStruct.g =
-                            [NSNumber numberWithFloat:entry_0.nullableOptionalStruct.Value().Value().g];
-                        newElement_0.nullableOptionalStruct.h =
-                            [NSNumber numberWithDouble:entry_0.nullableOptionalStruct.Value().Value().h];
-                    }
-                } else {
-                    newElement_0.nullableOptionalStruct = nil;
-                }
-                if (entry_0.nullableList.IsNull()) {
-                    newElement_0.nullableList = nil;
-                } else {
-                    auto * array_3 = [NSMutableArray new];
-                    auto iter_3 = entry_0.nullableList.Value().begin();
-                    while (iter_3.Next()) {
-                        auto & entry_3 = iter_3.GetValue();
-                        NSNumber * newElement_3;
-                        newElement_3 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_3)];
-                        [array_3 addObject:newElement_3];
-                    }
-                    { // Scope for the error so we will know what it's named
-                        CHIP_ERROR err = iter_3.GetStatus();
-                        if (err != CHIP_NO_ERROR) {
-                            *aError = err;
-                            return nil;
-                        }
-                    }
-                    newElement_0.nullableList = array_3;
-                }
-                if (entry_0.optionalList.HasValue()) {
-                    auto * array_3 = [NSMutableArray new];
-                    auto iter_3 = entry_0.optionalList.Value().begin();
-                    while (iter_3.Next()) {
-                        auto & entry_3 = iter_3.GetValue();
-                        NSNumber * newElement_3;
-                        newElement_3 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_3)];
-                        [array_3 addObject:newElement_3];
-                    }
-                    { // Scope for the error so we will know what it's named
-                        CHIP_ERROR err = iter_3.GetStatus();
-                        if (err != CHIP_NO_ERROR) {
-                            *aError = err;
-                            return nil;
-                        }
-                    }
-                    newElement_0.optionalList = array_3;
-                } else {
-                    newElement_0.optionalList = nil;
-                }
-                if (entry_0.nullableOptionalList.HasValue()) {
-                    if (entry_0.nullableOptionalList.Value().IsNull()) {
-                        newElement_0.nullableOptionalList = nil;
-                    } else {
-                        auto * array_4 = [NSMutableArray new];
-                        auto iter_4 = entry_0.nullableOptionalList.Value().Value().begin();
-                        while (iter_4.Next()) {
-                            auto & entry_4 = iter_4.GetValue();
-                            NSNumber * newElement_4;
-                            newElement_4 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_4)];
-                            [array_4 addObject:newElement_4];
-                        }
-                        { // Scope for the error so we will know what it's named
-                            CHIP_ERROR err = iter_4.GetStatus();
+                        { // Scope for our temporary variables
+                            auto * array_3 = [NSMutableArray new];
+                            auto iter_3 = entry_0.nullableList.Value().begin();
+                            while (iter_3.Next()) {
+                                auto & entry_3 = iter_3.GetValue();
+                                NSNumber * newElement_3;
+                                newElement_3 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_3)];
+                                [array_3 addObject:newElement_3];
+                            }
+                            CHIP_ERROR err = iter_3.GetStatus();
                             if (err != CHIP_NO_ERROR) {
                                 *aError = err;
                                 return nil;
                             }
+                            newElement_0.nullableList = array_3;
                         }
-                        newElement_0.nullableOptionalList = array_4;
                     }
-                } else {
-                    newElement_0.nullableOptionalList = nil;
+                    if (entry_0.optionalList.HasValue()) {
+                        { // Scope for our temporary variables
+                            auto * array_3 = [NSMutableArray new];
+                            auto iter_3 = entry_0.optionalList.Value().begin();
+                            while (iter_3.Next()) {
+                                auto & entry_3 = iter_3.GetValue();
+                                NSNumber * newElement_3;
+                                newElement_3 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_3)];
+                                [array_3 addObject:newElement_3];
+                            }
+                            CHIP_ERROR err = iter_3.GetStatus();
+                            if (err != CHIP_NO_ERROR) {
+                                *aError = err;
+                                return nil;
+                            }
+                            newElement_0.optionalList = array_3;
+                        }
+                    } else {
+                        newElement_0.optionalList = nil;
+                    }
+                    if (entry_0.nullableOptionalList.HasValue()) {
+                        if (entry_0.nullableOptionalList.Value().IsNull()) {
+                            newElement_0.nullableOptionalList = nil;
+                        } else {
+                            { // Scope for our temporary variables
+                                auto * array_4 = [NSMutableArray new];
+                                auto iter_4 = entry_0.nullableOptionalList.Value().Value().begin();
+                                while (iter_4.Next()) {
+                                    auto & entry_4 = iter_4.GetValue();
+                                    NSNumber * newElement_4;
+                                    newElement_4 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_4)];
+                                    [array_4 addObject:newElement_4];
+                                }
+                                CHIP_ERROR err = iter_4.GetStatus();
+                                if (err != CHIP_NO_ERROR) {
+                                    *aError = err;
+                                    return nil;
+                                }
+                                newElement_0.nullableOptionalList = array_4;
+                            }
+                        }
+                    } else {
+                        newElement_0.nullableOptionalList = nil;
+                    }
+                    [array_0 addObject:newElement_0];
                 }
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::EnumAttr::Id: {
@@ -10015,22 +10019,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSData * newElement_0;
-                newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSData * newElement_0;
+                    newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::TimedWriteBoolean::Id: {
@@ -10592,22 +10596,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -10618,22 +10622,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -10644,22 +10648,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -10877,22 +10881,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::FeatureMap::Id: {
@@ -10967,22 +10971,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -10993,22 +10997,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -11019,22 +11023,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -11142,36 +11146,36 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPThreadNetworkDiagnosticsClusterNeighborTable * newElement_0;
-                newElement_0 = [CHIPThreadNetworkDiagnosticsClusterNeighborTable new];
-                newElement_0.extAddress = [NSNumber numberWithUnsignedLongLong:entry_0.extAddress];
-                newElement_0.age = [NSNumber numberWithUnsignedInt:entry_0.age];
-                newElement_0.rloc16 = [NSNumber numberWithUnsignedShort:entry_0.rloc16];
-                newElement_0.linkFrameCounter = [NSNumber numberWithUnsignedInt:entry_0.linkFrameCounter];
-                newElement_0.mleFrameCounter = [NSNumber numberWithUnsignedInt:entry_0.mleFrameCounter];
-                newElement_0.lqi = [NSNumber numberWithUnsignedChar:entry_0.lqi];
-                newElement_0.averageRssi = [NSNumber numberWithChar:entry_0.averageRssi];
-                newElement_0.lastRssi = [NSNumber numberWithChar:entry_0.lastRssi];
-                newElement_0.frameErrorRate = [NSNumber numberWithUnsignedChar:entry_0.frameErrorRate];
-                newElement_0.messageErrorRate = [NSNumber numberWithUnsignedChar:entry_0.messageErrorRate];
-                newElement_0.rxOnWhenIdle = [NSNumber numberWithBool:entry_0.rxOnWhenIdle];
-                newElement_0.fullThreadDevice = [NSNumber numberWithBool:entry_0.fullThreadDevice];
-                newElement_0.fullNetworkData = [NSNumber numberWithBool:entry_0.fullNetworkData];
-                newElement_0.isChild = [NSNumber numberWithBool:entry_0.isChild];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPThreadNetworkDiagnosticsClusterNeighborTable * newElement_0;
+                    newElement_0 = [CHIPThreadNetworkDiagnosticsClusterNeighborTable new];
+                    newElement_0.extAddress = [NSNumber numberWithUnsignedLongLong:entry_0.extAddress];
+                    newElement_0.age = [NSNumber numberWithUnsignedInt:entry_0.age];
+                    newElement_0.rloc16 = [NSNumber numberWithUnsignedShort:entry_0.rloc16];
+                    newElement_0.linkFrameCounter = [NSNumber numberWithUnsignedInt:entry_0.linkFrameCounter];
+                    newElement_0.mleFrameCounter = [NSNumber numberWithUnsignedInt:entry_0.mleFrameCounter];
+                    newElement_0.lqi = [NSNumber numberWithUnsignedChar:entry_0.lqi];
+                    newElement_0.averageRssi = [NSNumber numberWithChar:entry_0.averageRssi];
+                    newElement_0.lastRssi = [NSNumber numberWithChar:entry_0.lastRssi];
+                    newElement_0.frameErrorRate = [NSNumber numberWithUnsignedChar:entry_0.frameErrorRate];
+                    newElement_0.messageErrorRate = [NSNumber numberWithUnsignedChar:entry_0.messageErrorRate];
+                    newElement_0.rxOnWhenIdle = [NSNumber numberWithBool:entry_0.rxOnWhenIdle];
+                    newElement_0.fullThreadDevice = [NSNumber numberWithBool:entry_0.fullThreadDevice];
+                    newElement_0.fullNetworkData = [NSNumber numberWithBool:entry_0.fullNetworkData];
+                    newElement_0.isChild = [NSNumber numberWithBool:entry_0.isChild];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::RouteTableList::Id: {
@@ -11182,32 +11186,32 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPThreadNetworkDiagnosticsClusterRouteTable * newElement_0;
-                newElement_0 = [CHIPThreadNetworkDiagnosticsClusterRouteTable new];
-                newElement_0.extAddress = [NSNumber numberWithUnsignedLongLong:entry_0.extAddress];
-                newElement_0.rloc16 = [NSNumber numberWithUnsignedShort:entry_0.rloc16];
-                newElement_0.routerId = [NSNumber numberWithUnsignedChar:entry_0.routerId];
-                newElement_0.nextHop = [NSNumber numberWithUnsignedChar:entry_0.nextHop];
-                newElement_0.pathCost = [NSNumber numberWithUnsignedChar:entry_0.pathCost];
-                newElement_0.lqiIn = [NSNumber numberWithUnsignedChar:entry_0.LQIIn];
-                newElement_0.lqiOut = [NSNumber numberWithUnsignedChar:entry_0.LQIOut];
-                newElement_0.age = [NSNumber numberWithUnsignedChar:entry_0.age];
-                newElement_0.allocated = [NSNumber numberWithBool:entry_0.allocated];
-                newElement_0.linkEstablished = [NSNumber numberWithBool:entry_0.linkEstablished];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPThreadNetworkDiagnosticsClusterRouteTable * newElement_0;
+                    newElement_0 = [CHIPThreadNetworkDiagnosticsClusterRouteTable new];
+                    newElement_0.extAddress = [NSNumber numberWithUnsignedLongLong:entry_0.extAddress];
+                    newElement_0.rloc16 = [NSNumber numberWithUnsignedShort:entry_0.rloc16];
+                    newElement_0.routerId = [NSNumber numberWithUnsignedChar:entry_0.routerId];
+                    newElement_0.nextHop = [NSNumber numberWithUnsignedChar:entry_0.nextHop];
+                    newElement_0.pathCost = [NSNumber numberWithUnsignedChar:entry_0.pathCost];
+                    newElement_0.lqiIn = [NSNumber numberWithUnsignedChar:entry_0.LQIIn];
+                    newElement_0.lqiOut = [NSNumber numberWithUnsignedChar:entry_0.LQIOut];
+                    newElement_0.age = [NSNumber numberWithUnsignedChar:entry_0.age];
+                    newElement_0.allocated = [NSNumber numberWithBool:entry_0.allocated];
+                    newElement_0.linkEstablished = [NSNumber numberWithBool:entry_0.linkEstablished];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::PartitionId::Id: {
@@ -11768,24 +11772,24 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPThreadNetworkDiagnosticsClusterSecurityPolicy * newElement_0;
-                newElement_0 = [CHIPThreadNetworkDiagnosticsClusterSecurityPolicy new];
-                newElement_0.rotationTime = [NSNumber numberWithUnsignedShort:entry_0.rotationTime];
-                newElement_0.flags = [NSNumber numberWithUnsignedShort:entry_0.flags];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPThreadNetworkDiagnosticsClusterSecurityPolicy * newElement_0;
+                    newElement_0 = [CHIPThreadNetworkDiagnosticsClusterSecurityPolicy new];
+                    newElement_0.rotationTime = [NSNumber numberWithUnsignedShort:entry_0.rotationTime];
+                    newElement_0.flags = [NSNumber numberWithUnsignedShort:entry_0.flags];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ChannelMask::Id: {
@@ -11807,34 +11811,34 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents * newElement_0;
-                newElement_0 = [CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents new];
-                newElement_0.activeTimestampPresent = [NSNumber numberWithBool:entry_0.activeTimestampPresent];
-                newElement_0.pendingTimestampPresent = [NSNumber numberWithBool:entry_0.pendingTimestampPresent];
-                newElement_0.masterKeyPresent = [NSNumber numberWithBool:entry_0.masterKeyPresent];
-                newElement_0.networkNamePresent = [NSNumber numberWithBool:entry_0.networkNamePresent];
-                newElement_0.extendedPanIdPresent = [NSNumber numberWithBool:entry_0.extendedPanIdPresent];
-                newElement_0.meshLocalPrefixPresent = [NSNumber numberWithBool:entry_0.meshLocalPrefixPresent];
-                newElement_0.delayPresent = [NSNumber numberWithBool:entry_0.delayPresent];
-                newElement_0.panIdPresent = [NSNumber numberWithBool:entry_0.panIdPresent];
-                newElement_0.channelPresent = [NSNumber numberWithBool:entry_0.channelPresent];
-                newElement_0.pskcPresent = [NSNumber numberWithBool:entry_0.pskcPresent];
-                newElement_0.securityPolicyPresent = [NSNumber numberWithBool:entry_0.securityPolicyPresent];
-                newElement_0.channelMaskPresent = [NSNumber numberWithBool:entry_0.channelMaskPresent];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents * newElement_0;
+                    newElement_0 = [CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents new];
+                    newElement_0.activeTimestampPresent = [NSNumber numberWithBool:entry_0.activeTimestampPresent];
+                    newElement_0.pendingTimestampPresent = [NSNumber numberWithBool:entry_0.pendingTimestampPresent];
+                    newElement_0.masterKeyPresent = [NSNumber numberWithBool:entry_0.masterKeyPresent];
+                    newElement_0.networkNamePresent = [NSNumber numberWithBool:entry_0.networkNamePresent];
+                    newElement_0.extendedPanIdPresent = [NSNumber numberWithBool:entry_0.extendedPanIdPresent];
+                    newElement_0.meshLocalPrefixPresent = [NSNumber numberWithBool:entry_0.meshLocalPrefixPresent];
+                    newElement_0.delayPresent = [NSNumber numberWithBool:entry_0.delayPresent];
+                    newElement_0.panIdPresent = [NSNumber numberWithBool:entry_0.panIdPresent];
+                    newElement_0.channelPresent = [NSNumber numberWithBool:entry_0.channelPresent];
+                    newElement_0.pskcPresent = [NSNumber numberWithBool:entry_0.pskcPresent];
+                    newElement_0.securityPolicyPresent = [NSNumber numberWithBool:entry_0.securityPolicyPresent];
+                    newElement_0.channelMaskPresent = [NSNumber numberWithBool:entry_0.channelMaskPresent];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ActiveNetworkFaultsList::Id: {
@@ -11845,22 +11849,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0)];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0)];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {
@@ -11871,22 +11875,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -11897,22 +11901,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -11923,22 +11927,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::FeatureMap::Id: {
@@ -12002,22 +12006,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0)];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0)];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {
@@ -12028,22 +12032,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -12054,22 +12058,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -12111,22 +12115,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::FeatureMap::Id: {
@@ -12168,28 +12172,28 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                CHIPUserLabelClusterLabelStruct * newElement_0;
-                newElement_0 = [CHIPUserLabelClusterLabelStruct new];
-                newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                              length:entry_0.label.size()
-                                                            encoding:NSUTF8StringEncoding];
-                newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
-                                                              length:entry_0.value.size()
-                                                            encoding:NSUTF8StringEncoding];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    CHIPUserLabelClusterLabelStruct * newElement_0;
+                    newElement_0 = [CHIPUserLabelClusterLabelStruct new];
+                    newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
+                                                                  length:entry_0.label.size()
+                                                                encoding:NSUTF8StringEncoding];
+                    newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
+                                                                  length:entry_0.value.size()
+                                                                encoding:NSUTF8StringEncoding];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ServerGeneratedCommandList::Id: {
@@ -12200,22 +12204,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -12226,22 +12230,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -12283,22 +12287,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -12309,22 +12313,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -12335,22 +12339,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClusterRevision::Id: {
@@ -12544,22 +12548,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -12570,22 +12574,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -12596,22 +12600,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::FeatureMap::Id: {
@@ -12883,22 +12887,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::ClientGeneratedCommandList::Id: {
@@ -12909,22 +12913,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::AttributeList::Id: {
@@ -12935,22 +12939,22 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                 return nil;
             }
             NSArray * _Nonnull value;
-            auto * array_0 = [NSMutableArray new];
-            auto iter_0 = cppValue.begin();
-            while (iter_0.Next()) {
-                auto & entry_0 = iter_0.GetValue();
-                NSNumber * newElement_0;
-                newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-                [array_0 addObject:newElement_0];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_0 = [NSMutableArray new];
+                auto iter_0 = cppValue.begin();
+                while (iter_0.Next()) {
+                    auto & entry_0 = iter_0.GetValue();
+                    NSNumber * newElement_0;
+                    newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+                    [array_0 addObject:newElement_0];
+                }
                 CHIP_ERROR err = iter_0.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     *aError = err;
                     return nil;
                 }
+                value = array_0;
             }
-            value = array_0;
             return value;
         }
         case Attributes::FeatureMap::Id: {

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -738,80 +738,80 @@ void CHIPAccessControlAclListAttributeCallbackBridge::OnSuccessFn(void * context
         value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPAccessControlClusterAccessControlEntry * newElement_0;
-        newElement_0 = [CHIPAccessControlClusterAccessControlEntry new];
-        newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
-        newElement_0.privilege = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.privilege)];
-        newElement_0.authMode = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.authMode)];
-        if (entry_0.subjects.IsNull()) {
-            newElement_0.subjects = nil;
-        } else {
-            auto * array_3 = [NSMutableArray new];
-            auto iter_3 = entry_0.subjects.Value().begin();
-            while (iter_3.Next()) {
-                auto & entry_3 = iter_3.GetValue();
-                NSNumber * newElement_3;
-                newElement_3 = [NSNumber numberWithUnsignedLongLong:entry_3];
-                [array_3 addObject:newElement_3];
-            }
-            { // Scope for the error so we will know what it's named
-                CHIP_ERROR err = iter_3.GetStatus();
-                if (err != CHIP_NO_ERROR) {
-                    OnFailureFn(context, err);
-                    return;
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPAccessControlClusterAccessControlEntry * newElement_0;
+            newElement_0 = [CHIPAccessControlClusterAccessControlEntry new];
+            newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
+            newElement_0.privilege = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.privilege)];
+            newElement_0.authMode = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.authMode)];
+            if (entry_0.subjects.IsNull()) {
+                newElement_0.subjects = nil;
+            } else {
+                { // Scope for our temporary variables
+                    auto * array_3 = [NSMutableArray new];
+                    auto iter_3 = entry_0.subjects.Value().begin();
+                    while (iter_3.Next()) {
+                        auto & entry_3 = iter_3.GetValue();
+                        NSNumber * newElement_3;
+                        newElement_3 = [NSNumber numberWithUnsignedLongLong:entry_3];
+                        [array_3 addObject:newElement_3];
+                    }
+                    CHIP_ERROR err = iter_3.GetStatus();
+                    if (err != CHIP_NO_ERROR) {
+                        OnFailureFn(context, err);
+                        return;
+                    }
+                    newElement_0.subjects = array_3;
                 }
             }
-            newElement_0.subjects = array_3;
+            if (entry_0.targets.IsNull()) {
+                newElement_0.targets = nil;
+            } else {
+                { // Scope for our temporary variables
+                    auto * array_3 = [NSMutableArray new];
+                    auto iter_3 = entry_0.targets.Value().begin();
+                    while (iter_3.Next()) {
+                        auto & entry_3 = iter_3.GetValue();
+                        CHIPAccessControlClusterTarget * newElement_3;
+                        newElement_3 = [CHIPAccessControlClusterTarget new];
+                        if (entry_3.cluster.IsNull()) {
+                            newElement_3.cluster = nil;
+                        } else {
+                            newElement_3.cluster = [NSNumber numberWithUnsignedInt:entry_3.cluster.Value()];
+                        }
+                        if (entry_3.endpoint.IsNull()) {
+                            newElement_3.endpoint = nil;
+                        } else {
+                            newElement_3.endpoint = [NSNumber numberWithUnsignedShort:entry_3.endpoint.Value()];
+                        }
+                        if (entry_3.deviceType.IsNull()) {
+                            newElement_3.deviceType = nil;
+                        } else {
+                            newElement_3.deviceType = [NSNumber numberWithUnsignedInt:entry_3.deviceType.Value()];
+                        }
+                        [array_3 addObject:newElement_3];
+                    }
+                    CHIP_ERROR err = iter_3.GetStatus();
+                    if (err != CHIP_NO_ERROR) {
+                        OnFailureFn(context, err);
+                        return;
+                    }
+                    newElement_0.targets = array_3;
+                }
+            }
+            [array_0 addObject:newElement_0];
         }
-        if (entry_0.targets.IsNull()) {
-            newElement_0.targets = nil;
-        } else {
-            auto * array_3 = [NSMutableArray new];
-            auto iter_3 = entry_0.targets.Value().begin();
-            while (iter_3.Next()) {
-                auto & entry_3 = iter_3.GetValue();
-                CHIPAccessControlClusterTarget * newElement_3;
-                newElement_3 = [CHIPAccessControlClusterTarget new];
-                if (entry_3.cluster.IsNull()) {
-                    newElement_3.cluster = nil;
-                } else {
-                    newElement_3.cluster = [NSNumber numberWithUnsignedInt:entry_3.cluster.Value()];
-                }
-                if (entry_3.endpoint.IsNull()) {
-                    newElement_3.endpoint = nil;
-                } else {
-                    newElement_3.endpoint = [NSNumber numberWithUnsignedShort:entry_3.endpoint.Value()];
-                }
-                if (entry_3.deviceType.IsNull()) {
-                    newElement_3.deviceType = nil;
-                } else {
-                    newElement_3.deviceType = [NSNumber numberWithUnsignedInt:entry_3.deviceType.Value()];
-                }
-                [array_3 addObject:newElement_3];
-            }
-            { // Scope for the error so we will know what it's named
-                CHIP_ERROR err = iter_3.GetStatus();
-                if (err != CHIP_NO_ERROR) {
-                    OnFailureFn(context, err);
-                    return;
-                }
-            }
-            newElement_0.targets = array_3;
-        }
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -835,24 +835,24 @@ void CHIPAccessControlExtensionListAttributeCallbackBridge::OnSuccessFn(void * c
     const chip::app::DataModel::DecodableList<chip::app::Clusters::AccessControl::Structs::ExtensionEntry::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPAccessControlClusterExtensionEntry * newElement_0;
-        newElement_0 = [CHIPAccessControlClusterExtensionEntry new];
-        newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
-        newElement_0.data = [NSData dataWithBytes:entry_0.data.data() length:entry_0.data.size()];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPAccessControlClusterExtensionEntry * newElement_0;
+            newElement_0 = [CHIPAccessControlClusterExtensionEntry new];
+            newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
+            newElement_0.data = [NSData dataWithBytes:entry_0.data.data() length:entry_0.data.size()];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -876,22 +876,22 @@ void CHIPAccessControlServerGeneratedCommandListListAttributeCallbackBridge::OnS
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -915,22 +915,22 @@ void CHIPAccessControlClientGeneratedCommandListListAttributeCallbackBridge::OnS
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -954,22 +954,22 @@ void CHIPAccessControlAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -993,22 +993,22 @@ void CHIPAccountLoginServerGeneratedCommandListListAttributeCallbackBridge::OnSu
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1032,22 +1032,22 @@ void CHIPAccountLoginClientGeneratedCommandListListAttributeCallbackBridge::OnSu
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1071,22 +1071,22 @@ void CHIPAccountLoginAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1110,22 +1110,22 @@ void CHIPAdministratorCommissioningServerGeneratedCommandListListAttributeCallba
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1151,22 +1151,22 @@ void CHIPAdministratorCommissioningClientGeneratedCommandListListAttributeCallba
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1192,22 +1192,22 @@ void CHIPAdministratorCommissioningAttributeListListAttributeCallbackBridge::OnS
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1259,22 +1259,22 @@ void CHIPApplicationBasicAllowedVendorListListAttributeCallbackBridge::OnSuccess
     void * context, const chip::app::DataModel::DecodableList<chip::VendorId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedShort:chip::to_underlying(entry_0)];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedShort:chip::to_underlying(entry_0)];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1298,22 +1298,22 @@ void CHIPApplicationBasicServerGeneratedCommandListListAttributeCallbackBridge::
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1338,22 +1338,22 @@ void CHIPApplicationBasicClientGeneratedCommandListListAttributeCallbackBridge::
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1378,22 +1378,22 @@ void CHIPApplicationBasicAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1417,22 +1417,22 @@ void CHIPApplicationLauncherApplicationLauncherListListAttributeCallbackBridge::
     void * context, const chip::app::DataModel::DecodableList<uint16_t> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedShort:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedShort:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1496,22 +1496,22 @@ void CHIPApplicationLauncherServerGeneratedCommandListListAttributeCallbackBridg
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1536,22 +1536,22 @@ void CHIPApplicationLauncherClientGeneratedCommandListListAttributeCallbackBridg
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1576,22 +1576,22 @@ void CHIPApplicationLauncherAttributeListListAttributeCallbackBridge::OnSuccessF
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1615,27 +1615,27 @@ void CHIPAudioOutputAudioOutputListListAttributeCallbackBridge::OnSuccessFn(void
     const chip::app::DataModel::DecodableList<chip::app::Clusters::AudioOutput::Structs::OutputInfo::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPAudioOutputClusterOutputInfo * newElement_0;
-        newElement_0 = [CHIPAudioOutputClusterOutputInfo new];
-        newElement_0.index = [NSNumber numberWithUnsignedChar:entry_0.index];
-        newElement_0.outputType = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.outputType)];
-        newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                     length:entry_0.name.size()
-                                                   encoding:NSUTF8StringEncoding];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPAudioOutputClusterOutputInfo * newElement_0;
+            newElement_0 = [CHIPAudioOutputClusterOutputInfo new];
+            newElement_0.index = [NSNumber numberWithUnsignedChar:entry_0.index];
+            newElement_0.outputType = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.outputType)];
+            newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
+                                                         length:entry_0.name.size()
+                                                       encoding:NSUTF8StringEncoding];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1659,22 +1659,22 @@ void CHIPAudioOutputServerGeneratedCommandListListAttributeCallbackBridge::OnSuc
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1698,22 +1698,22 @@ void CHIPAudioOutputClientGeneratedCommandListListAttributeCallbackBridge::OnSuc
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1737,22 +1737,22 @@ void CHIPAudioOutputAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1776,22 +1776,22 @@ void CHIPBarrierControlServerGeneratedCommandListListAttributeCallbackBridge::On
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1815,22 +1815,22 @@ void CHIPBarrierControlClientGeneratedCommandListListAttributeCallbackBridge::On
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1854,22 +1854,22 @@ void CHIPBarrierControlAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1893,22 +1893,22 @@ void CHIPBasicServerGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1932,22 +1932,22 @@ void CHIPBasicClientGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -1971,22 +1971,22 @@ void CHIPBasicAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2010,22 +2010,22 @@ void CHIPBinaryInputBasicServerGeneratedCommandListListAttributeCallbackBridge::
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2050,22 +2050,22 @@ void CHIPBinaryInputBasicClientGeneratedCommandListListAttributeCallbackBridge::
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2090,22 +2090,22 @@ void CHIPBinaryInputBasicAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2129,22 +2129,22 @@ void CHIPBindingServerGeneratedCommandListListAttributeCallbackBridge::OnSuccess
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2168,22 +2168,22 @@ void CHIPBindingClientGeneratedCommandListListAttributeCallbackBridge::OnSuccess
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2207,22 +2207,22 @@ void CHIPBindingAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2246,22 +2246,22 @@ void CHIPBooleanStateServerGeneratedCommandListListAttributeCallbackBridge::OnSu
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2285,22 +2285,22 @@ void CHIPBooleanStateClientGeneratedCommandListListAttributeCallbackBridge::OnSu
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2324,22 +2324,22 @@ void CHIPBooleanStateAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2363,30 +2363,30 @@ void CHIPBridgedActionsActionListListAttributeCallbackBridge::OnSuccessFn(void *
     const chip::app::DataModel::DecodableList<chip::app::Clusters::BridgedActions::Structs::ActionStruct::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPBridgedActionsClusterActionStruct * newElement_0;
-        newElement_0 = [CHIPBridgedActionsClusterActionStruct new];
-        newElement_0.actionID = [NSNumber numberWithUnsignedShort:entry_0.actionID];
-        newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                     length:entry_0.name.size()
-                                                   encoding:NSUTF8StringEncoding];
-        newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
-        newElement_0.endpointListID = [NSNumber numberWithUnsignedShort:entry_0.endpointListID];
-        newElement_0.supportedCommands = [NSNumber numberWithUnsignedShort:entry_0.supportedCommands];
-        newElement_0.status = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.status)];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPBridgedActionsClusterActionStruct * newElement_0;
+            newElement_0 = [CHIPBridgedActionsClusterActionStruct new];
+            newElement_0.actionID = [NSNumber numberWithUnsignedShort:entry_0.actionID];
+            newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
+                                                         length:entry_0.name.size()
+                                                       encoding:NSUTF8StringEncoding];
+            newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
+            newElement_0.endpointListID = [NSNumber numberWithUnsignedShort:entry_0.endpointListID];
+            newElement_0.supportedCommands = [NSNumber numberWithUnsignedShort:entry_0.supportedCommands];
+            newElement_0.status = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.status)];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2411,43 +2411,43 @@ void CHIPBridgedActionsEndpointListListAttributeCallbackBridge::OnSuccessFn(void
         value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPBridgedActionsClusterEndpointListStruct * newElement_0;
-        newElement_0 = [CHIPBridgedActionsClusterEndpointListStruct new];
-        newElement_0.endpointListID = [NSNumber numberWithUnsignedShort:entry_0.endpointListID];
-        newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                     length:entry_0.name.size()
-                                                   encoding:NSUTF8StringEncoding];
-        newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
-        auto * array_2 = [NSMutableArray new];
-        auto iter_2 = entry_0.endpoints.begin();
-        while (iter_2.Next()) {
-            auto & entry_2 = iter_2.GetValue();
-            NSNumber * newElement_2;
-            newElement_2 = [NSNumber numberWithUnsignedShort:entry_2];
-            [array_2 addObject:newElement_2];
-        }
-        { // Scope for the error so we will know what it's named
-            CHIP_ERROR err = iter_2.GetStatus();
-            if (err != CHIP_NO_ERROR) {
-                OnFailureFn(context, err);
-                return;
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPBridgedActionsClusterEndpointListStruct * newElement_0;
+            newElement_0 = [CHIPBridgedActionsClusterEndpointListStruct new];
+            newElement_0.endpointListID = [NSNumber numberWithUnsignedShort:entry_0.endpointListID];
+            newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
+                                                         length:entry_0.name.size()
+                                                       encoding:NSUTF8StringEncoding];
+            newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
+            { // Scope for our temporary variables
+                auto * array_2 = [NSMutableArray new];
+                auto iter_2 = entry_0.endpoints.begin();
+                while (iter_2.Next()) {
+                    auto & entry_2 = iter_2.GetValue();
+                    NSNumber * newElement_2;
+                    newElement_2 = [NSNumber numberWithUnsignedShort:entry_2];
+                    [array_2 addObject:newElement_2];
+                }
+                CHIP_ERROR err = iter_2.GetStatus();
+                if (err != CHIP_NO_ERROR) {
+                    OnFailureFn(context, err);
+                    return;
+                }
+                newElement_0.endpoints = array_2;
             }
+            [array_0 addObject:newElement_0];
         }
-        newElement_0.endpoints = array_2;
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2471,22 +2471,22 @@ void CHIPBridgedActionsServerGeneratedCommandListListAttributeCallbackBridge::On
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2510,22 +2510,22 @@ void CHIPBridgedActionsClientGeneratedCommandListListAttributeCallbackBridge::On
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2549,22 +2549,22 @@ void CHIPBridgedActionsAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2588,22 +2588,22 @@ void CHIPBridgedDeviceBasicServerGeneratedCommandListListAttributeCallbackBridge
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2628,22 +2628,22 @@ void CHIPBridgedDeviceBasicClientGeneratedCommandListListAttributeCallbackBridge
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2668,22 +2668,22 @@ void CHIPBridgedDeviceBasicAttributeListListAttributeCallbackBridge::OnSuccessFn
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2707,45 +2707,45 @@ void CHIPChannelChannelListListAttributeCallbackBridge::OnSuccessFn(void * conte
     const chip::app::DataModel::DecodableList<chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPChannelClusterChannelInfo * newElement_0;
-        newElement_0 = [CHIPChannelClusterChannelInfo new];
-        newElement_0.majorNumber = [NSNumber numberWithUnsignedShort:entry_0.majorNumber];
-        newElement_0.minorNumber = [NSNumber numberWithUnsignedShort:entry_0.minorNumber];
-        if (entry_0.name.HasValue()) {
-            newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.Value().data()
-                                                         length:entry_0.name.Value().size()
-                                                       encoding:NSUTF8StringEncoding];
-        } else {
-            newElement_0.name = nil;
-        }
-        if (entry_0.callSign.HasValue()) {
-            newElement_0.callSign = [[NSString alloc] initWithBytes:entry_0.callSign.Value().data()
-                                                             length:entry_0.callSign.Value().size()
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPChannelClusterChannelInfo * newElement_0;
+            newElement_0 = [CHIPChannelClusterChannelInfo new];
+            newElement_0.majorNumber = [NSNumber numberWithUnsignedShort:entry_0.majorNumber];
+            newElement_0.minorNumber = [NSNumber numberWithUnsignedShort:entry_0.minorNumber];
+            if (entry_0.name.HasValue()) {
+                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.Value().data()
+                                                             length:entry_0.name.Value().size()
                                                            encoding:NSUTF8StringEncoding];
-        } else {
-            newElement_0.callSign = nil;
+            } else {
+                newElement_0.name = nil;
+            }
+            if (entry_0.callSign.HasValue()) {
+                newElement_0.callSign = [[NSString alloc] initWithBytes:entry_0.callSign.Value().data()
+                                                                 length:entry_0.callSign.Value().size()
+                                                               encoding:NSUTF8StringEncoding];
+            } else {
+                newElement_0.callSign = nil;
+            }
+            if (entry_0.affiliateCallSign.HasValue()) {
+                newElement_0.affiliateCallSign = [[NSString alloc] initWithBytes:entry_0.affiliateCallSign.Value().data()
+                                                                          length:entry_0.affiliateCallSign.Value().size()
+                                                                        encoding:NSUTF8StringEncoding];
+            } else {
+                newElement_0.affiliateCallSign = nil;
+            }
+            [array_0 addObject:newElement_0];
         }
-        if (entry_0.affiliateCallSign.HasValue()) {
-            newElement_0.affiliateCallSign = [[NSString alloc] initWithBytes:entry_0.affiliateCallSign.Value().data()
-                                                                      length:entry_0.affiliateCallSign.Value().size()
-                                                                    encoding:NSUTF8StringEncoding];
-        } else {
-            newElement_0.affiliateCallSign = nil;
-        }
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2866,22 +2866,22 @@ void CHIPChannelServerGeneratedCommandListListAttributeCallbackBridge::OnSuccess
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2905,22 +2905,22 @@ void CHIPChannelClientGeneratedCommandListListAttributeCallbackBridge::OnSuccess
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2944,22 +2944,22 @@ void CHIPChannelAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -2983,22 +2983,22 @@ void CHIPColorControlServerGeneratedCommandListListAttributeCallbackBridge::OnSu
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3022,22 +3022,22 @@ void CHIPColorControlClientGeneratedCommandListListAttributeCallbackBridge::OnSu
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3061,22 +3061,22 @@ void CHIPColorControlAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3100,22 +3100,22 @@ void CHIPContentLauncherAcceptHeaderListListAttributeCallbackBridge::OnSuccessFn
     void * context, const chip::app::DataModel::DecodableList<chip::CharSpan> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSString * newElement_0;
-        newElement_0 = [[NSString alloc] initWithBytes:entry_0.data() length:entry_0.size() encoding:NSUTF8StringEncoding];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSString * newElement_0;
+            newElement_0 = [[NSString alloc] initWithBytes:entry_0.data() length:entry_0.size() encoding:NSUTF8StringEncoding];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3139,22 +3139,22 @@ void CHIPContentLauncherServerGeneratedCommandListListAttributeCallbackBridge::O
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3178,22 +3178,22 @@ void CHIPContentLauncherClientGeneratedCommandListListAttributeCallbackBridge::O
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3217,22 +3217,22 @@ void CHIPContentLauncherAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3256,24 +3256,24 @@ void CHIPDescriptorDeviceListListAttributeCallbackBridge::OnSuccessFn(void * con
     const chip::app::DataModel::DecodableList<chip::app::Clusters::Descriptor::Structs::DeviceType::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPDescriptorClusterDeviceType * newElement_0;
-        newElement_0 = [CHIPDescriptorClusterDeviceType new];
-        newElement_0.type = [NSNumber numberWithUnsignedInt:entry_0.type];
-        newElement_0.revision = [NSNumber numberWithUnsignedShort:entry_0.revision];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPDescriptorClusterDeviceType * newElement_0;
+            newElement_0 = [CHIPDescriptorClusterDeviceType new];
+            newElement_0.type = [NSNumber numberWithUnsignedInt:entry_0.type];
+            newElement_0.revision = [NSNumber numberWithUnsignedShort:entry_0.revision];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3297,22 +3297,22 @@ void CHIPDescriptorServerListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::ClusterId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3336,22 +3336,22 @@ void CHIPDescriptorClientListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::ClusterId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3375,22 +3375,22 @@ void CHIPDescriptorPartsListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::EndpointId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedShort:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedShort:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3414,22 +3414,22 @@ void CHIPDescriptorServerGeneratedCommandListListAttributeCallbackBridge::OnSucc
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3453,22 +3453,22 @@ void CHIPDescriptorClientGeneratedCommandListListAttributeCallbackBridge::OnSucc
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3492,22 +3492,22 @@ void CHIPDescriptorAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3531,22 +3531,22 @@ void CHIPDiagnosticLogsServerGeneratedCommandListListAttributeCallbackBridge::On
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3570,22 +3570,22 @@ void CHIPDiagnosticLogsClientGeneratedCommandListListAttributeCallbackBridge::On
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3609,22 +3609,22 @@ void CHIPDiagnosticLogsAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3648,22 +3648,22 @@ void CHIPDoorLockServerGeneratedCommandListListAttributeCallbackBridge::OnSucces
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3687,22 +3687,22 @@ void CHIPDoorLockClientGeneratedCommandListListAttributeCallbackBridge::OnSucces
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3726,22 +3726,22 @@ void CHIPDoorLockAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3765,22 +3765,22 @@ void CHIPElectricalMeasurementServerGeneratedCommandListListAttributeCallbackBri
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3806,22 +3806,22 @@ void CHIPElectricalMeasurementClientGeneratedCommandListListAttributeCallbackBri
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3847,22 +3847,22 @@ void CHIPElectricalMeasurementAttributeListListAttributeCallbackBridge::OnSucces
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3886,22 +3886,22 @@ void CHIPEthernetNetworkDiagnosticsServerGeneratedCommandListListAttributeCallba
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3927,22 +3927,22 @@ void CHIPEthernetNetworkDiagnosticsClientGeneratedCommandListListAttributeCallba
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -3968,22 +3968,22 @@ void CHIPEthernetNetworkDiagnosticsAttributeListListAttributeCallbackBridge::OnS
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4007,28 +4007,28 @@ void CHIPFixedLabelLabelListListAttributeCallbackBridge::OnSuccessFn(void * cont
     const chip::app::DataModel::DecodableList<chip::app::Clusters::FixedLabel::Structs::LabelStruct::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPFixedLabelClusterLabelStruct * newElement_0;
-        newElement_0 = [CHIPFixedLabelClusterLabelStruct new];
-        newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                      length:entry_0.label.size()
-                                                    encoding:NSUTF8StringEncoding];
-        newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
-                                                      length:entry_0.value.size()
-                                                    encoding:NSUTF8StringEncoding];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPFixedLabelClusterLabelStruct * newElement_0;
+            newElement_0 = [CHIPFixedLabelClusterLabelStruct new];
+            newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
+                                                          length:entry_0.label.size()
+                                                        encoding:NSUTF8StringEncoding];
+            newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
+                                                          length:entry_0.value.size()
+                                                        encoding:NSUTF8StringEncoding];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4052,22 +4052,22 @@ void CHIPFixedLabelServerGeneratedCommandListListAttributeCallbackBridge::OnSucc
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4091,22 +4091,22 @@ void CHIPFixedLabelClientGeneratedCommandListListAttributeCallbackBridge::OnSucc
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4130,22 +4130,22 @@ void CHIPFixedLabelAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4169,22 +4169,22 @@ void CHIPFlowMeasurementServerGeneratedCommandListListAttributeCallbackBridge::O
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4208,22 +4208,22 @@ void CHIPFlowMeasurementClientGeneratedCommandListListAttributeCallbackBridge::O
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4247,22 +4247,22 @@ void CHIPFlowMeasurementAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4312,22 +4312,22 @@ void CHIPGeneralCommissioningServerGeneratedCommandListListAttributeCallbackBrid
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4352,22 +4352,22 @@ void CHIPGeneralCommissioningClientGeneratedCommandListListAttributeCallbackBrid
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4392,22 +4392,22 @@ void CHIPGeneralCommissioningAttributeListListAttributeCallbackBridge::OnSuccess
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4432,40 +4432,41 @@ void CHIPGeneralDiagnosticsNetworkInterfacesListAttributeCallbackBridge::OnSucce
         chip::app::Clusters::GeneralDiagnostics::Structs::NetworkInterfaceType::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPGeneralDiagnosticsClusterNetworkInterfaceType * newElement_0;
-        newElement_0 = [CHIPGeneralDiagnosticsClusterNetworkInterfaceType new];
-        newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                     length:entry_0.name.size()
-                                                   encoding:NSUTF8StringEncoding];
-        newElement_0.fabricConnected = [NSNumber numberWithBool:entry_0.fabricConnected];
-        if (entry_0.offPremiseServicesReachableIPv4.IsNull()) {
-            newElement_0.offPremiseServicesReachableIPv4 = nil;
-        } else {
-            newElement_0.offPremiseServicesReachableIPv4 =
-                [NSNumber numberWithBool:entry_0.offPremiseServicesReachableIPv4.Value()];
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPGeneralDiagnosticsClusterNetworkInterfaceType * newElement_0;
+            newElement_0 = [CHIPGeneralDiagnosticsClusterNetworkInterfaceType new];
+            newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
+                                                         length:entry_0.name.size()
+                                                       encoding:NSUTF8StringEncoding];
+            newElement_0.fabricConnected = [NSNumber numberWithBool:entry_0.fabricConnected];
+            if (entry_0.offPremiseServicesReachableIPv4.IsNull()) {
+                newElement_0.offPremiseServicesReachableIPv4 = nil;
+            } else {
+                newElement_0.offPremiseServicesReachableIPv4 =
+                    [NSNumber numberWithBool:entry_0.offPremiseServicesReachableIPv4.Value()];
+            }
+            if (entry_0.offPremiseServicesReachableIPv6.IsNull()) {
+                newElement_0.offPremiseServicesReachableIPv6 = nil;
+            } else {
+                newElement_0.offPremiseServicesReachableIPv6 =
+                    [NSNumber numberWithBool:entry_0.offPremiseServicesReachableIPv6.Value()];
+            }
+            newElement_0.hardwareAddress = [NSData dataWithBytes:entry_0.hardwareAddress.data()
+                                                          length:entry_0.hardwareAddress.size()];
+            newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
+            [array_0 addObject:newElement_0];
         }
-        if (entry_0.offPremiseServicesReachableIPv6.IsNull()) {
-            newElement_0.offPremiseServicesReachableIPv6 = nil;
-        } else {
-            newElement_0.offPremiseServicesReachableIPv6 =
-                [NSNumber numberWithBool:entry_0.offPremiseServicesReachableIPv6.Value()];
-        }
-        newElement_0.hardwareAddress = [NSData dataWithBytes:entry_0.hardwareAddress.data() length:entry_0.hardwareAddress.size()];
-        newElement_0.type = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.type)];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4489,22 +4490,22 @@ void CHIPGeneralDiagnosticsActiveHardwareFaultsListAttributeCallbackBridge::OnSu
     void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4528,22 +4529,22 @@ void CHIPGeneralDiagnosticsActiveRadioFaultsListAttributeCallbackBridge::OnSucce
     void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4567,22 +4568,22 @@ void CHIPGeneralDiagnosticsActiveNetworkFaultsListAttributeCallbackBridge::OnSuc
     void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4606,22 +4607,22 @@ void CHIPGeneralDiagnosticsServerGeneratedCommandListListAttributeCallbackBridge
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4646,22 +4647,22 @@ void CHIPGeneralDiagnosticsClientGeneratedCommandListListAttributeCallbackBridge
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4686,22 +4687,22 @@ void CHIPGeneralDiagnosticsAttributeListListAttributeCallbackBridge::OnSuccessFn
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4726,25 +4727,25 @@ void CHIPGroupKeyManagementGroupKeyMapListAttributeCallbackBridge::OnSuccessFn(v
         value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPGroupKeyManagementClusterGroupKeyMapStruct * newElement_0;
-        newElement_0 = [CHIPGroupKeyManagementClusterGroupKeyMapStruct new];
-        newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
-        newElement_0.groupId = [NSNumber numberWithUnsignedShort:entry_0.groupId];
-        newElement_0.groupKeySetID = [NSNumber numberWithUnsignedShort:entry_0.groupKeySetID];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPGroupKeyManagementClusterGroupKeyMapStruct * newElement_0;
+            newElement_0 = [CHIPGroupKeyManagementClusterGroupKeyMapStruct new];
+            newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
+            newElement_0.groupId = [NSNumber numberWithUnsignedShort:entry_0.groupId];
+            newElement_0.groupKeySetID = [NSNumber numberWithUnsignedShort:entry_0.groupKeySetID];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4769,47 +4770,47 @@ void CHIPGroupKeyManagementGroupTableListAttributeCallbackBridge::OnSuccessFn(vo
         value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPGroupKeyManagementClusterGroupInfoMapStruct * newElement_0;
-        newElement_0 = [CHIPGroupKeyManagementClusterGroupInfoMapStruct new];
-        newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
-        newElement_0.groupId = [NSNumber numberWithUnsignedShort:entry_0.groupId];
-        auto * array_2 = [NSMutableArray new];
-        auto iter_2 = entry_0.endpoints.begin();
-        while (iter_2.Next()) {
-            auto & entry_2 = iter_2.GetValue();
-            NSNumber * newElement_2;
-            newElement_2 = [NSNumber numberWithUnsignedShort:entry_2];
-            [array_2 addObject:newElement_2];
-        }
-        { // Scope for the error so we will know what it's named
-            CHIP_ERROR err = iter_2.GetStatus();
-            if (err != CHIP_NO_ERROR) {
-                OnFailureFn(context, err);
-                return;
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPGroupKeyManagementClusterGroupInfoMapStruct * newElement_0;
+            newElement_0 = [CHIPGroupKeyManagementClusterGroupInfoMapStruct new];
+            newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
+            newElement_0.groupId = [NSNumber numberWithUnsignedShort:entry_0.groupId];
+            { // Scope for our temporary variables
+                auto * array_2 = [NSMutableArray new];
+                auto iter_2 = entry_0.endpoints.begin();
+                while (iter_2.Next()) {
+                    auto & entry_2 = iter_2.GetValue();
+                    NSNumber * newElement_2;
+                    newElement_2 = [NSNumber numberWithUnsignedShort:entry_2];
+                    [array_2 addObject:newElement_2];
+                }
+                CHIP_ERROR err = iter_2.GetStatus();
+                if (err != CHIP_NO_ERROR) {
+                    OnFailureFn(context, err);
+                    return;
+                }
+                newElement_0.endpoints = array_2;
             }
+            if (entry_0.groupName.HasValue()) {
+                newElement_0.groupName = [[NSString alloc] initWithBytes:entry_0.groupName.Value().data()
+                                                                  length:entry_0.groupName.Value().size()
+                                                                encoding:NSUTF8StringEncoding];
+            } else {
+                newElement_0.groupName = nil;
+            }
+            [array_0 addObject:newElement_0];
         }
-        newElement_0.endpoints = array_2;
-        if (entry_0.groupName.HasValue()) {
-            newElement_0.groupName = [[NSString alloc] initWithBytes:entry_0.groupName.Value().data()
-                                                              length:entry_0.groupName.Value().size()
-                                                            encoding:NSUTF8StringEncoding];
-        } else {
-            newElement_0.groupName = nil;
-        }
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4833,22 +4834,22 @@ void CHIPGroupKeyManagementServerGeneratedCommandListListAttributeCallbackBridge
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4873,22 +4874,22 @@ void CHIPGroupKeyManagementClientGeneratedCommandListListAttributeCallbackBridge
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4913,22 +4914,22 @@ void CHIPGroupKeyManagementAttributeListListAttributeCallbackBridge::OnSuccessFn
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4952,22 +4953,22 @@ void CHIPGroupsServerGeneratedCommandListListAttributeCallbackBridge::OnSuccessF
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -4991,22 +4992,22 @@ void CHIPGroupsClientGeneratedCommandListListAttributeCallbackBridge::OnSuccessF
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5030,22 +5031,22 @@ void CHIPGroupsAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5069,22 +5070,22 @@ void CHIPIdentifyServerGeneratedCommandListListAttributeCallbackBridge::OnSucces
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5108,22 +5109,22 @@ void CHIPIdentifyClientGeneratedCommandListListAttributeCallbackBridge::OnSucces
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5147,22 +5148,22 @@ void CHIPIdentifyAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5186,22 +5187,22 @@ void CHIPIlluminanceMeasurementServerGeneratedCommandListListAttributeCallbackBr
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5227,22 +5228,22 @@ void CHIPIlluminanceMeasurementClientGeneratedCommandListListAttributeCallbackBr
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5268,22 +5269,22 @@ void CHIPIlluminanceMeasurementAttributeListListAttributeCallbackBridge::OnSucce
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5307,22 +5308,22 @@ void CHIPKeypadInputServerGeneratedCommandListListAttributeCallbackBridge::OnSuc
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5346,22 +5347,22 @@ void CHIPKeypadInputClientGeneratedCommandListListAttributeCallbackBridge::OnSuc
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5385,22 +5386,22 @@ void CHIPKeypadInputAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5424,22 +5425,22 @@ void CHIPLevelControlServerGeneratedCommandListListAttributeCallbackBridge::OnSu
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5463,22 +5464,22 @@ void CHIPLevelControlClientGeneratedCommandListListAttributeCallbackBridge::OnSu
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5502,22 +5503,22 @@ void CHIPLevelControlAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5541,22 +5542,22 @@ void CHIPLocalizationConfigurationSupportedLocalesListAttributeCallbackBridge::O
     void * context, const chip::app::DataModel::DecodableList<chip::CharSpan> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSString * newElement_0;
-        newElement_0 = [[NSString alloc] initWithBytes:entry_0.data() length:entry_0.size() encoding:NSUTF8StringEncoding];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSString * newElement_0;
+            newElement_0 = [[NSString alloc] initWithBytes:entry_0.data() length:entry_0.size() encoding:NSUTF8StringEncoding];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5580,22 +5581,22 @@ void CHIPLocalizationConfigurationServerGeneratedCommandListListAttributeCallbac
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5621,22 +5622,22 @@ void CHIPLocalizationConfigurationClientGeneratedCommandListListAttributeCallbac
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5662,22 +5663,22 @@ void CHIPLowPowerServerGeneratedCommandListListAttributeCallbackBridge::OnSucces
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5701,22 +5702,22 @@ void CHIPLowPowerClientGeneratedCommandListListAttributeCallbackBridge::OnSucces
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5740,22 +5741,22 @@ void CHIPLowPowerAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5779,30 +5780,30 @@ void CHIPMediaInputMediaInputListListAttributeCallbackBridge::OnSuccessFn(void *
     const chip::app::DataModel::DecodableList<chip::app::Clusters::MediaInput::Structs::InputInfo::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPMediaInputClusterInputInfo * newElement_0;
-        newElement_0 = [CHIPMediaInputClusterInputInfo new];
-        newElement_0.index = [NSNumber numberWithUnsignedChar:entry_0.index];
-        newElement_0.inputType = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.inputType)];
-        newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                     length:entry_0.name.size()
-                                                   encoding:NSUTF8StringEncoding];
-        newElement_0.descriptionString = [[NSString alloc] initWithBytes:entry_0.description.data()
-                                                                  length:entry_0.description.size()
-                                                                encoding:NSUTF8StringEncoding];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPMediaInputClusterInputInfo * newElement_0;
+            newElement_0 = [CHIPMediaInputClusterInputInfo new];
+            newElement_0.index = [NSNumber numberWithUnsignedChar:entry_0.index];
+            newElement_0.inputType = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.inputType)];
+            newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
+                                                         length:entry_0.name.size()
+                                                       encoding:NSUTF8StringEncoding];
+            newElement_0.descriptionString = [[NSString alloc] initWithBytes:entry_0.description.data()
+                                                                      length:entry_0.description.size()
+                                                                    encoding:NSUTF8StringEncoding];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5826,22 +5827,22 @@ void CHIPMediaInputServerGeneratedCommandListListAttributeCallbackBridge::OnSucc
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5865,22 +5866,22 @@ void CHIPMediaInputClientGeneratedCommandListListAttributeCallbackBridge::OnSucc
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5904,22 +5905,22 @@ void CHIPMediaInputAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -5973,22 +5974,22 @@ void CHIPMediaPlaybackServerGeneratedCommandListListAttributeCallbackBridge::OnS
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6012,22 +6013,22 @@ void CHIPMediaPlaybackClientGeneratedCommandListListAttributeCallbackBridge::OnS
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6051,22 +6052,22 @@ void CHIPMediaPlaybackAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6090,27 +6091,27 @@ void CHIPModeSelectSupportedModesListAttributeCallbackBridge::OnSuccessFn(void *
     const chip::app::DataModel::DecodableList<chip::app::Clusters::ModeSelect::Structs::ModeOptionStruct::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPModeSelectClusterModeOptionStruct * newElement_0;
-        newElement_0 = [CHIPModeSelectClusterModeOptionStruct new];
-        newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                      length:entry_0.label.size()
-                                                    encoding:NSUTF8StringEncoding];
-        newElement_0.mode = [NSNumber numberWithUnsignedChar:entry_0.mode];
-        newElement_0.semanticTag = [NSNumber numberWithUnsignedInt:entry_0.semanticTag];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPModeSelectClusterModeOptionStruct * newElement_0;
+            newElement_0 = [CHIPModeSelectClusterModeOptionStruct new];
+            newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
+                                                          length:entry_0.label.size()
+                                                        encoding:NSUTF8StringEncoding];
+            newElement_0.mode = [NSNumber numberWithUnsignedChar:entry_0.mode];
+            newElement_0.semanticTag = [NSNumber numberWithUnsignedInt:entry_0.semanticTag];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6134,22 +6135,22 @@ void CHIPModeSelectServerGeneratedCommandListListAttributeCallbackBridge::OnSucc
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6173,22 +6174,22 @@ void CHIPModeSelectClientGeneratedCommandListListAttributeCallbackBridge::OnSucc
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6212,22 +6213,22 @@ void CHIPModeSelectAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6252,24 +6253,24 @@ void CHIPNetworkCommissioningNetworksListAttributeCallbackBridge::OnSuccessFn(vo
         value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPNetworkCommissioningClusterNetworkInfo * newElement_0;
-        newElement_0 = [CHIPNetworkCommissioningClusterNetworkInfo new];
-        newElement_0.networkID = [NSData dataWithBytes:entry_0.networkID.data() length:entry_0.networkID.size()];
-        newElement_0.connected = [NSNumber numberWithBool:entry_0.connected];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPNetworkCommissioningClusterNetworkInfo * newElement_0;
+            newElement_0 = [CHIPNetworkCommissioningClusterNetworkInfo new];
+            newElement_0.networkID = [NSData dataWithBytes:entry_0.networkID.data() length:entry_0.networkID.size()];
+            newElement_0.connected = [NSNumber numberWithBool:entry_0.connected];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6293,22 +6294,22 @@ void CHIPNetworkCommissioningServerGeneratedCommandListListAttributeCallbackBrid
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6333,22 +6334,22 @@ void CHIPNetworkCommissioningClientGeneratedCommandListListAttributeCallbackBrid
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6373,22 +6374,22 @@ void CHIPOtaSoftwareUpdateProviderAttributeListListAttributeCallbackBridge::OnSu
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6413,25 +6414,25 @@ void CHIPOtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridg
         chip::app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPOtaSoftwareUpdateRequestorClusterProviderLocation * newElement_0;
-        newElement_0 = [CHIPOtaSoftwareUpdateRequestorClusterProviderLocation new];
-        newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
-        newElement_0.providerNodeID = [NSNumber numberWithUnsignedLongLong:entry_0.providerNodeID];
-        newElement_0.endpoint = [NSNumber numberWithUnsignedShort:entry_0.endpoint];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPOtaSoftwareUpdateRequestorClusterProviderLocation * newElement_0;
+            newElement_0 = [CHIPOtaSoftwareUpdateRequestorClusterProviderLocation new];
+            newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
+            newElement_0.providerNodeID = [NSNumber numberWithUnsignedLongLong:entry_0.providerNodeID];
+            newElement_0.endpoint = [NSNumber numberWithUnsignedShort:entry_0.endpoint];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6456,22 +6457,22 @@ void CHIPOtaSoftwareUpdateRequestorAttributeListListAttributeCallbackBridge::OnS
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6495,22 +6496,22 @@ void CHIPOccupancySensingServerGeneratedCommandListListAttributeCallbackBridge::
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6535,22 +6536,22 @@ void CHIPOccupancySensingClientGeneratedCommandListListAttributeCallbackBridge::
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6575,22 +6576,22 @@ void CHIPOccupancySensingAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6614,22 +6615,22 @@ void CHIPOnOffServerGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6653,22 +6654,22 @@ void CHIPOnOffClientGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6692,22 +6693,22 @@ void CHIPOnOffAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6731,22 +6732,22 @@ void CHIPOnOffSwitchConfigurationServerGeneratedCommandListListAttributeCallback
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6772,22 +6773,22 @@ void CHIPOnOffSwitchConfigurationClientGeneratedCommandListListAttributeCallback
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6813,22 +6814,22 @@ void CHIPOnOffSwitchConfigurationAttributeListListAttributeCallbackBridge::OnSuc
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6853,29 +6854,29 @@ void CHIPOperationalCredentialsNOCsListAttributeCallbackBridge::OnSuccessFn(void
         value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPOperationalCredentialsClusterNOCStruct * newElement_0;
-        newElement_0 = [CHIPOperationalCredentialsClusterNOCStruct new];
-        newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
-        newElement_0.noc = [NSData dataWithBytes:entry_0.noc.data() length:entry_0.noc.size()];
-        if (entry_0.icac.IsNull()) {
-            newElement_0.icac = nil;
-        } else {
-            newElement_0.icac = [NSData dataWithBytes:entry_0.icac.Value().data() length:entry_0.icac.Value().size()];
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPOperationalCredentialsClusterNOCStruct * newElement_0;
+            newElement_0 = [CHIPOperationalCredentialsClusterNOCStruct new];
+            newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
+            newElement_0.noc = [NSData dataWithBytes:entry_0.noc.data() length:entry_0.noc.size()];
+            if (entry_0.icac.IsNull()) {
+                newElement_0.icac = nil;
+            } else {
+                newElement_0.icac = [NSData dataWithBytes:entry_0.icac.Value().data() length:entry_0.icac.Value().size()];
+            }
+            [array_0 addObject:newElement_0];
         }
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6900,30 +6901,30 @@ void CHIPOperationalCredentialsFabricsListListAttributeCallbackBridge::OnSuccess
         chip::app::Clusters::OperationalCredentials::Structs::FabricDescriptor::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPOperationalCredentialsClusterFabricDescriptor * newElement_0;
-        newElement_0 = [CHIPOperationalCredentialsClusterFabricDescriptor new];
-        newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
-        newElement_0.rootPublicKey = [NSData dataWithBytes:entry_0.rootPublicKey.data() length:entry_0.rootPublicKey.size()];
-        newElement_0.vendorId = [NSNumber numberWithUnsignedShort:entry_0.vendorId];
-        newElement_0.fabricId = [NSNumber numberWithUnsignedLongLong:entry_0.fabricId];
-        newElement_0.nodeId = [NSNumber numberWithUnsignedLongLong:entry_0.nodeId];
-        newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                      length:entry_0.label.size()
-                                                    encoding:NSUTF8StringEncoding];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPOperationalCredentialsClusterFabricDescriptor * newElement_0;
+            newElement_0 = [CHIPOperationalCredentialsClusterFabricDescriptor new];
+            newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
+            newElement_0.rootPublicKey = [NSData dataWithBytes:entry_0.rootPublicKey.data() length:entry_0.rootPublicKey.size()];
+            newElement_0.vendorId = [NSNumber numberWithUnsignedShort:entry_0.vendorId];
+            newElement_0.fabricId = [NSNumber numberWithUnsignedLongLong:entry_0.fabricId];
+            newElement_0.nodeId = [NSNumber numberWithUnsignedLongLong:entry_0.nodeId];
+            newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
+                                                          length:entry_0.label.size()
+                                                        encoding:NSUTF8StringEncoding];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6947,22 +6948,22 @@ void CHIPOperationalCredentialsTrustedRootCertificatesListAttributeCallbackBridg
     void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSData * newElement_0;
-        newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSData * newElement_0;
+            newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -6987,22 +6988,22 @@ void CHIPOperationalCredentialsServerGeneratedCommandListListAttributeCallbackBr
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7028,22 +7029,22 @@ void CHIPOperationalCredentialsClientGeneratedCommandListListAttributeCallbackBr
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7069,22 +7070,22 @@ void CHIPOperationalCredentialsAttributeListListAttributeCallbackBridge::OnSucce
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7108,22 +7109,22 @@ void CHIPPowerSourceActiveBatteryFaultsListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7147,22 +7148,22 @@ void CHIPPowerSourceServerGeneratedCommandListListAttributeCallbackBridge::OnSuc
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7186,22 +7187,22 @@ void CHIPPowerSourceClientGeneratedCommandListListAttributeCallbackBridge::OnSuc
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7225,22 +7226,22 @@ void CHIPPowerSourceAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7264,22 +7265,22 @@ void CHIPPowerSourceConfigurationSourcesListAttributeCallbackBridge::OnSuccessFn
     void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7303,22 +7304,22 @@ void CHIPPowerSourceConfigurationServerGeneratedCommandListListAttributeCallback
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7344,22 +7345,22 @@ void CHIPPowerSourceConfigurationClientGeneratedCommandListListAttributeCallback
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7385,22 +7386,22 @@ void CHIPPowerSourceConfigurationAttributeListListAttributeCallbackBridge::OnSuc
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7424,22 +7425,22 @@ void CHIPPressureMeasurementAttributeListListAttributeCallbackBridge::OnSuccessF
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7463,22 +7464,22 @@ void CHIPPumpConfigurationAndControlServerGeneratedCommandListListAttributeCallb
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7504,22 +7505,22 @@ void CHIPPumpConfigurationAndControlClientGeneratedCommandListListAttributeCallb
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7545,22 +7546,22 @@ void CHIPPumpConfigurationAndControlAttributeListListAttributeCallbackBridge::On
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7584,22 +7585,22 @@ void CHIPRelativeHumidityMeasurementServerGeneratedCommandListListAttributeCallb
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7625,22 +7626,22 @@ void CHIPRelativeHumidityMeasurementClientGeneratedCommandListListAttributeCallb
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7666,22 +7667,22 @@ void CHIPRelativeHumidityMeasurementAttributeListListAttributeCallbackBridge::On
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7705,22 +7706,22 @@ void CHIPScenesServerGeneratedCommandListListAttributeCallbackBridge::OnSuccessF
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7744,22 +7745,22 @@ void CHIPScenesClientGeneratedCommandListListAttributeCallbackBridge::OnSuccessF
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7783,22 +7784,22 @@ void CHIPScenesAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7823,29 +7824,29 @@ void CHIPSoftwareDiagnosticsThreadMetricsListAttributeCallbackBridge::OnSuccessF
         value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPSoftwareDiagnosticsClusterThreadMetrics * newElement_0;
-        newElement_0 = [CHIPSoftwareDiagnosticsClusterThreadMetrics new];
-        newElement_0.id = [NSNumber numberWithUnsignedLongLong:entry_0.id];
-        newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                     length:entry_0.name.size()
-                                                   encoding:NSUTF8StringEncoding];
-        newElement_0.stackFreeCurrent = [NSNumber numberWithUnsignedInt:entry_0.stackFreeCurrent];
-        newElement_0.stackFreeMinimum = [NSNumber numberWithUnsignedInt:entry_0.stackFreeMinimum];
-        newElement_0.stackSize = [NSNumber numberWithUnsignedInt:entry_0.stackSize];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPSoftwareDiagnosticsClusterThreadMetrics * newElement_0;
+            newElement_0 = [CHIPSoftwareDiagnosticsClusterThreadMetrics new];
+            newElement_0.id = [NSNumber numberWithUnsignedLongLong:entry_0.id];
+            newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
+                                                         length:entry_0.name.size()
+                                                       encoding:NSUTF8StringEncoding];
+            newElement_0.stackFreeCurrent = [NSNumber numberWithUnsignedInt:entry_0.stackFreeCurrent];
+            newElement_0.stackFreeMinimum = [NSNumber numberWithUnsignedInt:entry_0.stackFreeMinimum];
+            newElement_0.stackSize = [NSNumber numberWithUnsignedInt:entry_0.stackSize];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7869,22 +7870,22 @@ void CHIPSoftwareDiagnosticsServerGeneratedCommandListListAttributeCallbackBridg
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7909,22 +7910,22 @@ void CHIPSoftwareDiagnosticsClientGeneratedCommandListListAttributeCallbackBridg
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7949,22 +7950,22 @@ void CHIPSoftwareDiagnosticsAttributeListListAttributeCallbackBridge::OnSuccessF
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -7988,22 +7989,22 @@ void CHIPSwitchServerGeneratedCommandListListAttributeCallbackBridge::OnSuccessF
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8027,22 +8028,22 @@ void CHIPSwitchClientGeneratedCommandListListAttributeCallbackBridge::OnSuccessF
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8066,22 +8067,22 @@ void CHIPSwitchAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8105,26 +8106,26 @@ void CHIPTargetNavigatorTargetNavigatorListListAttributeCallbackBridge::OnSucces
     const chip::app::DataModel::DecodableList<chip::app::Clusters::TargetNavigator::Structs::TargetInfo::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPTargetNavigatorClusterTargetInfo * newElement_0;
-        newElement_0 = [CHIPTargetNavigatorClusterTargetInfo new];
-        newElement_0.identifier = [NSNumber numberWithUnsignedChar:entry_0.identifier];
-        newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                     length:entry_0.name.size()
-                                                   encoding:NSUTF8StringEncoding];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPTargetNavigatorClusterTargetInfo * newElement_0;
+            newElement_0 = [CHIPTargetNavigatorClusterTargetInfo new];
+            newElement_0.identifier = [NSNumber numberWithUnsignedChar:entry_0.identifier];
+            newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
+                                                         length:entry_0.name.size()
+                                                       encoding:NSUTF8StringEncoding];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8148,22 +8149,22 @@ void CHIPTargetNavigatorServerGeneratedCommandListListAttributeCallbackBridge::O
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8187,22 +8188,22 @@ void CHIPTargetNavigatorClientGeneratedCommandListListAttributeCallbackBridge::O
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8226,22 +8227,22 @@ void CHIPTargetNavigatorAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8265,22 +8266,22 @@ void CHIPTemperatureMeasurementAttributeListListAttributeCallbackBridge::OnSucce
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8304,22 +8305,22 @@ void CHIPTestClusterListInt8uListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<uint8_t> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8343,22 +8344,22 @@ void CHIPTestClusterListOctetStringListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSData * newElement_0;
-        newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSData * newElement_0;
+            newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8383,24 +8384,25 @@ void CHIPTestClusterListStructOctetStringListAttributeCallbackBridge::OnSuccessF
         value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPTestClusterClusterTestListStructOctet * newElement_0;
-        newElement_0 = [CHIPTestClusterClusterTestListStructOctet new];
-        newElement_0.fabricIndex = [NSNumber numberWithUnsignedLongLong:entry_0.fabricIndex];
-        newElement_0.operationalCert = [NSData dataWithBytes:entry_0.operationalCert.data() length:entry_0.operationalCert.size()];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPTestClusterClusterTestListStructOctet * newElement_0;
+            newElement_0 = [CHIPTestClusterClusterTestListStructOctet new];
+            newElement_0.fabricIndex = [NSNumber numberWithUnsignedLongLong:entry_0.fabricIndex];
+            newElement_0.operationalCert = [NSData dataWithBytes:entry_0.operationalCert.data()
+                                                          length:entry_0.operationalCert.size()];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8425,189 +8427,194 @@ void CHIPTestClusterListNullablesAndOptionalsStructListAttributeCallbackBridge::
         chip::app::Clusters::TestCluster::Structs::NullablesAndOptionalsStruct::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPTestClusterClusterNullablesAndOptionalsStruct * newElement_0;
-        newElement_0 = [CHIPTestClusterClusterNullablesAndOptionalsStruct new];
-        if (entry_0.nullableInt.IsNull()) {
-            newElement_0.nullableInt = nil;
-        } else {
-            newElement_0.nullableInt = [NSNumber numberWithUnsignedShort:entry_0.nullableInt.Value()];
-        }
-        if (entry_0.optionalInt.HasValue()) {
-            newElement_0.optionalInt = [NSNumber numberWithUnsignedShort:entry_0.optionalInt.Value()];
-        } else {
-            newElement_0.optionalInt = nil;
-        }
-        if (entry_0.nullableOptionalInt.HasValue()) {
-            if (entry_0.nullableOptionalInt.Value().IsNull()) {
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPTestClusterClusterNullablesAndOptionalsStruct * newElement_0;
+            newElement_0 = [CHIPTestClusterClusterNullablesAndOptionalsStruct new];
+            if (entry_0.nullableInt.IsNull()) {
+                newElement_0.nullableInt = nil;
+            } else {
+                newElement_0.nullableInt = [NSNumber numberWithUnsignedShort:entry_0.nullableInt.Value()];
+            }
+            if (entry_0.optionalInt.HasValue()) {
+                newElement_0.optionalInt = [NSNumber numberWithUnsignedShort:entry_0.optionalInt.Value()];
+            } else {
+                newElement_0.optionalInt = nil;
+            }
+            if (entry_0.nullableOptionalInt.HasValue()) {
+                if (entry_0.nullableOptionalInt.Value().IsNull()) {
+                    newElement_0.nullableOptionalInt = nil;
+                } else {
+                    newElement_0.nullableOptionalInt =
+                        [NSNumber numberWithUnsignedShort:entry_0.nullableOptionalInt.Value().Value()];
+                }
+            } else {
                 newElement_0.nullableOptionalInt = nil;
-            } else {
-                newElement_0.nullableOptionalInt = [NSNumber numberWithUnsignedShort:entry_0.nullableOptionalInt.Value().Value()];
             }
-        } else {
-            newElement_0.nullableOptionalInt = nil;
-        }
-        if (entry_0.nullableString.IsNull()) {
-            newElement_0.nullableString = nil;
-        } else {
-            newElement_0.nullableString = [[NSString alloc] initWithBytes:entry_0.nullableString.Value().data()
-                                                                   length:entry_0.nullableString.Value().size()
-                                                                 encoding:NSUTF8StringEncoding];
-        }
-        if (entry_0.optionalString.HasValue()) {
-            newElement_0.optionalString = [[NSString alloc] initWithBytes:entry_0.optionalString.Value().data()
-                                                                   length:entry_0.optionalString.Value().size()
-                                                                 encoding:NSUTF8StringEncoding];
-        } else {
-            newElement_0.optionalString = nil;
-        }
-        if (entry_0.nullableOptionalString.HasValue()) {
-            if (entry_0.nullableOptionalString.Value().IsNull()) {
+            if (entry_0.nullableString.IsNull()) {
+                newElement_0.nullableString = nil;
+            } else {
+                newElement_0.nullableString = [[NSString alloc] initWithBytes:entry_0.nullableString.Value().data()
+                                                                       length:entry_0.nullableString.Value().size()
+                                                                     encoding:NSUTF8StringEncoding];
+            }
+            if (entry_0.optionalString.HasValue()) {
+                newElement_0.optionalString = [[NSString alloc] initWithBytes:entry_0.optionalString.Value().data()
+                                                                       length:entry_0.optionalString.Value().size()
+                                                                     encoding:NSUTF8StringEncoding];
+            } else {
+                newElement_0.optionalString = nil;
+            }
+            if (entry_0.nullableOptionalString.HasValue()) {
+                if (entry_0.nullableOptionalString.Value().IsNull()) {
+                    newElement_0.nullableOptionalString = nil;
+                } else {
+                    newElement_0.nullableOptionalString =
+                        [[NSString alloc] initWithBytes:entry_0.nullableOptionalString.Value().Value().data()
+                                                 length:entry_0.nullableOptionalString.Value().Value().size()
+                                               encoding:NSUTF8StringEncoding];
+                }
+            } else {
                 newElement_0.nullableOptionalString = nil;
-            } else {
-                newElement_0.nullableOptionalString =
-                    [[NSString alloc] initWithBytes:entry_0.nullableOptionalString.Value().Value().data()
-                                             length:entry_0.nullableOptionalString.Value().Value().size()
-                                           encoding:NSUTF8StringEncoding];
             }
-        } else {
-            newElement_0.nullableOptionalString = nil;
-        }
-        if (entry_0.nullableStruct.IsNull()) {
-            newElement_0.nullableStruct = nil;
-        } else {
-            newElement_0.nullableStruct = [CHIPTestClusterClusterSimpleStruct new];
-            newElement_0.nullableStruct.a = [NSNumber numberWithUnsignedChar:entry_0.nullableStruct.Value().a];
-            newElement_0.nullableStruct.b = [NSNumber numberWithBool:entry_0.nullableStruct.Value().b];
-            newElement_0.nullableStruct.c = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.nullableStruct.Value().c)];
-            newElement_0.nullableStruct.d = [NSData dataWithBytes:entry_0.nullableStruct.Value().d.data()
-                                                           length:entry_0.nullableStruct.Value().d.size()];
-            newElement_0.nullableStruct.e = [[NSString alloc] initWithBytes:entry_0.nullableStruct.Value().e.data()
-                                                                     length:entry_0.nullableStruct.Value().e.size()
-                                                                   encoding:NSUTF8StringEncoding];
-            newElement_0.nullableStruct.f = [NSNumber numberWithUnsignedChar:entry_0.nullableStruct.Value().f.Raw()];
-            newElement_0.nullableStruct.g = [NSNumber numberWithFloat:entry_0.nullableStruct.Value().g];
-            newElement_0.nullableStruct.h = [NSNumber numberWithDouble:entry_0.nullableStruct.Value().h];
-        }
-        if (entry_0.optionalStruct.HasValue()) {
-            newElement_0.optionalStruct = [CHIPTestClusterClusterSimpleStruct new];
-            newElement_0.optionalStruct.a = [NSNumber numberWithUnsignedChar:entry_0.optionalStruct.Value().a];
-            newElement_0.optionalStruct.b = [NSNumber numberWithBool:entry_0.optionalStruct.Value().b];
-            newElement_0.optionalStruct.c = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.optionalStruct.Value().c)];
-            newElement_0.optionalStruct.d = [NSData dataWithBytes:entry_0.optionalStruct.Value().d.data()
-                                                           length:entry_0.optionalStruct.Value().d.size()];
-            newElement_0.optionalStruct.e = [[NSString alloc] initWithBytes:entry_0.optionalStruct.Value().e.data()
-                                                                     length:entry_0.optionalStruct.Value().e.size()
-                                                                   encoding:NSUTF8StringEncoding];
-            newElement_0.optionalStruct.f = [NSNumber numberWithUnsignedChar:entry_0.optionalStruct.Value().f.Raw()];
-            newElement_0.optionalStruct.g = [NSNumber numberWithFloat:entry_0.optionalStruct.Value().g];
-            newElement_0.optionalStruct.h = [NSNumber numberWithDouble:entry_0.optionalStruct.Value().h];
-        } else {
-            newElement_0.optionalStruct = nil;
-        }
-        if (entry_0.nullableOptionalStruct.HasValue()) {
-            if (entry_0.nullableOptionalStruct.Value().IsNull()) {
+            if (entry_0.nullableStruct.IsNull()) {
+                newElement_0.nullableStruct = nil;
+            } else {
+                newElement_0.nullableStruct = [CHIPTestClusterClusterSimpleStruct new];
+                newElement_0.nullableStruct.a = [NSNumber numberWithUnsignedChar:entry_0.nullableStruct.Value().a];
+                newElement_0.nullableStruct.b = [NSNumber numberWithBool:entry_0.nullableStruct.Value().b];
+                newElement_0.nullableStruct.c =
+                    [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.nullableStruct.Value().c)];
+                newElement_0.nullableStruct.d = [NSData dataWithBytes:entry_0.nullableStruct.Value().d.data()
+                                                               length:entry_0.nullableStruct.Value().d.size()];
+                newElement_0.nullableStruct.e = [[NSString alloc] initWithBytes:entry_0.nullableStruct.Value().e.data()
+                                                                         length:entry_0.nullableStruct.Value().e.size()
+                                                                       encoding:NSUTF8StringEncoding];
+                newElement_0.nullableStruct.f = [NSNumber numberWithUnsignedChar:entry_0.nullableStruct.Value().f.Raw()];
+                newElement_0.nullableStruct.g = [NSNumber numberWithFloat:entry_0.nullableStruct.Value().g];
+                newElement_0.nullableStruct.h = [NSNumber numberWithDouble:entry_0.nullableStruct.Value().h];
+            }
+            if (entry_0.optionalStruct.HasValue()) {
+                newElement_0.optionalStruct = [CHIPTestClusterClusterSimpleStruct new];
+                newElement_0.optionalStruct.a = [NSNumber numberWithUnsignedChar:entry_0.optionalStruct.Value().a];
+                newElement_0.optionalStruct.b = [NSNumber numberWithBool:entry_0.optionalStruct.Value().b];
+                newElement_0.optionalStruct.c =
+                    [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.optionalStruct.Value().c)];
+                newElement_0.optionalStruct.d = [NSData dataWithBytes:entry_0.optionalStruct.Value().d.data()
+                                                               length:entry_0.optionalStruct.Value().d.size()];
+                newElement_0.optionalStruct.e = [[NSString alloc] initWithBytes:entry_0.optionalStruct.Value().e.data()
+                                                                         length:entry_0.optionalStruct.Value().e.size()
+                                                                       encoding:NSUTF8StringEncoding];
+                newElement_0.optionalStruct.f = [NSNumber numberWithUnsignedChar:entry_0.optionalStruct.Value().f.Raw()];
+                newElement_0.optionalStruct.g = [NSNumber numberWithFloat:entry_0.optionalStruct.Value().g];
+                newElement_0.optionalStruct.h = [NSNumber numberWithDouble:entry_0.optionalStruct.Value().h];
+            } else {
+                newElement_0.optionalStruct = nil;
+            }
+            if (entry_0.nullableOptionalStruct.HasValue()) {
+                if (entry_0.nullableOptionalStruct.Value().IsNull()) {
+                    newElement_0.nullableOptionalStruct = nil;
+                } else {
+                    newElement_0.nullableOptionalStruct = [CHIPTestClusterClusterSimpleStruct new];
+                    newElement_0.nullableOptionalStruct.a =
+                        [NSNumber numberWithUnsignedChar:entry_0.nullableOptionalStruct.Value().Value().a];
+                    newElement_0.nullableOptionalStruct.b =
+                        [NSNumber numberWithBool:entry_0.nullableOptionalStruct.Value().Value().b];
+                    newElement_0.nullableOptionalStruct.c =
+                        [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.nullableOptionalStruct.Value().Value().c)];
+                    newElement_0.nullableOptionalStruct.d =
+                        [NSData dataWithBytes:entry_0.nullableOptionalStruct.Value().Value().d.data()
+                                       length:entry_0.nullableOptionalStruct.Value().Value().d.size()];
+                    newElement_0.nullableOptionalStruct.e =
+                        [[NSString alloc] initWithBytes:entry_0.nullableOptionalStruct.Value().Value().e.data()
+                                                 length:entry_0.nullableOptionalStruct.Value().Value().e.size()
+                                               encoding:NSUTF8StringEncoding];
+                    newElement_0.nullableOptionalStruct.f =
+                        [NSNumber numberWithUnsignedChar:entry_0.nullableOptionalStruct.Value().Value().f.Raw()];
+                    newElement_0.nullableOptionalStruct.g =
+                        [NSNumber numberWithFloat:entry_0.nullableOptionalStruct.Value().Value().g];
+                    newElement_0.nullableOptionalStruct.h =
+                        [NSNumber numberWithDouble:entry_0.nullableOptionalStruct.Value().Value().h];
+                }
+            } else {
                 newElement_0.nullableOptionalStruct = nil;
+            }
+            if (entry_0.nullableList.IsNull()) {
+                newElement_0.nullableList = nil;
             } else {
-                newElement_0.nullableOptionalStruct = [CHIPTestClusterClusterSimpleStruct new];
-                newElement_0.nullableOptionalStruct.a =
-                    [NSNumber numberWithUnsignedChar:entry_0.nullableOptionalStruct.Value().Value().a];
-                newElement_0.nullableOptionalStruct.b = [NSNumber numberWithBool:entry_0.nullableOptionalStruct.Value().Value().b];
-                newElement_0.nullableOptionalStruct.c =
-                    [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0.nullableOptionalStruct.Value().Value().c)];
-                newElement_0.nullableOptionalStruct.d =
-                    [NSData dataWithBytes:entry_0.nullableOptionalStruct.Value().Value().d.data()
-                                   length:entry_0.nullableOptionalStruct.Value().Value().d.size()];
-                newElement_0.nullableOptionalStruct.e =
-                    [[NSString alloc] initWithBytes:entry_0.nullableOptionalStruct.Value().Value().e.data()
-                                             length:entry_0.nullableOptionalStruct.Value().Value().e.size()
-                                           encoding:NSUTF8StringEncoding];
-                newElement_0.nullableOptionalStruct.f =
-                    [NSNumber numberWithUnsignedChar:entry_0.nullableOptionalStruct.Value().Value().f.Raw()];
-                newElement_0.nullableOptionalStruct.g = [NSNumber numberWithFloat:entry_0.nullableOptionalStruct.Value().Value().g];
-                newElement_0.nullableOptionalStruct.h =
-                    [NSNumber numberWithDouble:entry_0.nullableOptionalStruct.Value().Value().h];
-            }
-        } else {
-            newElement_0.nullableOptionalStruct = nil;
-        }
-        if (entry_0.nullableList.IsNull()) {
-            newElement_0.nullableList = nil;
-        } else {
-            auto * array_3 = [NSMutableArray new];
-            auto iter_3 = entry_0.nullableList.Value().begin();
-            while (iter_3.Next()) {
-                auto & entry_3 = iter_3.GetValue();
-                NSNumber * newElement_3;
-                newElement_3 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_3)];
-                [array_3 addObject:newElement_3];
-            }
-            { // Scope for the error so we will know what it's named
-                CHIP_ERROR err = iter_3.GetStatus();
-                if (err != CHIP_NO_ERROR) {
-                    OnFailureFn(context, err);
-                    return;
-                }
-            }
-            newElement_0.nullableList = array_3;
-        }
-        if (entry_0.optionalList.HasValue()) {
-            auto * array_3 = [NSMutableArray new];
-            auto iter_3 = entry_0.optionalList.Value().begin();
-            while (iter_3.Next()) {
-                auto & entry_3 = iter_3.GetValue();
-                NSNumber * newElement_3;
-                newElement_3 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_3)];
-                [array_3 addObject:newElement_3];
-            }
-            { // Scope for the error so we will know what it's named
-                CHIP_ERROR err = iter_3.GetStatus();
-                if (err != CHIP_NO_ERROR) {
-                    OnFailureFn(context, err);
-                    return;
-                }
-            }
-            newElement_0.optionalList = array_3;
-        } else {
-            newElement_0.optionalList = nil;
-        }
-        if (entry_0.nullableOptionalList.HasValue()) {
-            if (entry_0.nullableOptionalList.Value().IsNull()) {
-                newElement_0.nullableOptionalList = nil;
-            } else {
-                auto * array_4 = [NSMutableArray new];
-                auto iter_4 = entry_0.nullableOptionalList.Value().Value().begin();
-                while (iter_4.Next()) {
-                    auto & entry_4 = iter_4.GetValue();
-                    NSNumber * newElement_4;
-                    newElement_4 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_4)];
-                    [array_4 addObject:newElement_4];
-                }
-                { // Scope for the error so we will know what it's named
-                    CHIP_ERROR err = iter_4.GetStatus();
+                { // Scope for our temporary variables
+                    auto * array_3 = [NSMutableArray new];
+                    auto iter_3 = entry_0.nullableList.Value().begin();
+                    while (iter_3.Next()) {
+                        auto & entry_3 = iter_3.GetValue();
+                        NSNumber * newElement_3;
+                        newElement_3 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_3)];
+                        [array_3 addObject:newElement_3];
+                    }
+                    CHIP_ERROR err = iter_3.GetStatus();
                     if (err != CHIP_NO_ERROR) {
                         OnFailureFn(context, err);
                         return;
                     }
+                    newElement_0.nullableList = array_3;
                 }
-                newElement_0.nullableOptionalList = array_4;
             }
-        } else {
-            newElement_0.nullableOptionalList = nil;
+            if (entry_0.optionalList.HasValue()) {
+                { // Scope for our temporary variables
+                    auto * array_3 = [NSMutableArray new];
+                    auto iter_3 = entry_0.optionalList.Value().begin();
+                    while (iter_3.Next()) {
+                        auto & entry_3 = iter_3.GetValue();
+                        NSNumber * newElement_3;
+                        newElement_3 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_3)];
+                        [array_3 addObject:newElement_3];
+                    }
+                    CHIP_ERROR err = iter_3.GetStatus();
+                    if (err != CHIP_NO_ERROR) {
+                        OnFailureFn(context, err);
+                        return;
+                    }
+                    newElement_0.optionalList = array_3;
+                }
+            } else {
+                newElement_0.optionalList = nil;
+            }
+            if (entry_0.nullableOptionalList.HasValue()) {
+                if (entry_0.nullableOptionalList.Value().IsNull()) {
+                    newElement_0.nullableOptionalList = nil;
+                } else {
+                    { // Scope for our temporary variables
+                        auto * array_4 = [NSMutableArray new];
+                        auto iter_4 = entry_0.nullableOptionalList.Value().Value().begin();
+                        while (iter_4.Next()) {
+                            auto & entry_4 = iter_4.GetValue();
+                            NSNumber * newElement_4;
+                            newElement_4 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_4)];
+                            [array_4 addObject:newElement_4];
+                        }
+                        CHIP_ERROR err = iter_4.GetStatus();
+                        if (err != CHIP_NO_ERROR) {
+                            OnFailureFn(context, err);
+                            return;
+                        }
+                        newElement_0.nullableOptionalList = array_4;
+                    }
+                }
+            } else {
+                newElement_0.nullableOptionalList = nil;
+            }
+            [array_0 addObject:newElement_0];
         }
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8664,22 +8671,22 @@ void CHIPTestClusterListLongOctetStringListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSData * newElement_0;
-        newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSData * newElement_0;
+            newElement_0 = [NSData dataWithBytes:entry_0.data() length:entry_0.size()];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8741,22 +8748,22 @@ void CHIPTestClusterServerGeneratedCommandListListAttributeCallbackBridge::OnSuc
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8780,22 +8787,22 @@ void CHIPTestClusterClientGeneratedCommandListListAttributeCallbackBridge::OnSuc
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8819,22 +8826,22 @@ void CHIPTestClusterAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8858,22 +8865,22 @@ void CHIPThermostatAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8897,22 +8904,22 @@ void CHIPThermostatUserInterfaceConfigurationServerGeneratedCommandListListAttri
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8939,22 +8946,22 @@ void CHIPThermostatUserInterfaceConfigurationClientGeneratedCommandListListAttri
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -8981,22 +8988,22 @@ void CHIPThermostatUserInterfaceConfigurationAttributeListListAttributeCallbackB
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9023,36 +9030,36 @@ void CHIPThreadNetworkDiagnosticsNeighborTableListListAttributeCallbackBridge::O
         chip::app::Clusters::ThreadNetworkDiagnostics::Structs::NeighborTable::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPThreadNetworkDiagnosticsClusterNeighborTable * newElement_0;
-        newElement_0 = [CHIPThreadNetworkDiagnosticsClusterNeighborTable new];
-        newElement_0.extAddress = [NSNumber numberWithUnsignedLongLong:entry_0.extAddress];
-        newElement_0.age = [NSNumber numberWithUnsignedInt:entry_0.age];
-        newElement_0.rloc16 = [NSNumber numberWithUnsignedShort:entry_0.rloc16];
-        newElement_0.linkFrameCounter = [NSNumber numberWithUnsignedInt:entry_0.linkFrameCounter];
-        newElement_0.mleFrameCounter = [NSNumber numberWithUnsignedInt:entry_0.mleFrameCounter];
-        newElement_0.lqi = [NSNumber numberWithUnsignedChar:entry_0.lqi];
-        newElement_0.averageRssi = [NSNumber numberWithChar:entry_0.averageRssi];
-        newElement_0.lastRssi = [NSNumber numberWithChar:entry_0.lastRssi];
-        newElement_0.frameErrorRate = [NSNumber numberWithUnsignedChar:entry_0.frameErrorRate];
-        newElement_0.messageErrorRate = [NSNumber numberWithUnsignedChar:entry_0.messageErrorRate];
-        newElement_0.rxOnWhenIdle = [NSNumber numberWithBool:entry_0.rxOnWhenIdle];
-        newElement_0.fullThreadDevice = [NSNumber numberWithBool:entry_0.fullThreadDevice];
-        newElement_0.fullNetworkData = [NSNumber numberWithBool:entry_0.fullNetworkData];
-        newElement_0.isChild = [NSNumber numberWithBool:entry_0.isChild];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPThreadNetworkDiagnosticsClusterNeighborTable * newElement_0;
+            newElement_0 = [CHIPThreadNetworkDiagnosticsClusterNeighborTable new];
+            newElement_0.extAddress = [NSNumber numberWithUnsignedLongLong:entry_0.extAddress];
+            newElement_0.age = [NSNumber numberWithUnsignedInt:entry_0.age];
+            newElement_0.rloc16 = [NSNumber numberWithUnsignedShort:entry_0.rloc16];
+            newElement_0.linkFrameCounter = [NSNumber numberWithUnsignedInt:entry_0.linkFrameCounter];
+            newElement_0.mleFrameCounter = [NSNumber numberWithUnsignedInt:entry_0.mleFrameCounter];
+            newElement_0.lqi = [NSNumber numberWithUnsignedChar:entry_0.lqi];
+            newElement_0.averageRssi = [NSNumber numberWithChar:entry_0.averageRssi];
+            newElement_0.lastRssi = [NSNumber numberWithChar:entry_0.lastRssi];
+            newElement_0.frameErrorRate = [NSNumber numberWithUnsignedChar:entry_0.frameErrorRate];
+            newElement_0.messageErrorRate = [NSNumber numberWithUnsignedChar:entry_0.messageErrorRate];
+            newElement_0.rxOnWhenIdle = [NSNumber numberWithBool:entry_0.rxOnWhenIdle];
+            newElement_0.fullThreadDevice = [NSNumber numberWithBool:entry_0.fullThreadDevice];
+            newElement_0.fullNetworkData = [NSNumber numberWithBool:entry_0.fullNetworkData];
+            newElement_0.isChild = [NSNumber numberWithBool:entry_0.isChild];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9077,32 +9084,32 @@ void CHIPThreadNetworkDiagnosticsRouteTableListListAttributeCallbackBridge::OnSu
         value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPThreadNetworkDiagnosticsClusterRouteTable * newElement_0;
-        newElement_0 = [CHIPThreadNetworkDiagnosticsClusterRouteTable new];
-        newElement_0.extAddress = [NSNumber numberWithUnsignedLongLong:entry_0.extAddress];
-        newElement_0.rloc16 = [NSNumber numberWithUnsignedShort:entry_0.rloc16];
-        newElement_0.routerId = [NSNumber numberWithUnsignedChar:entry_0.routerId];
-        newElement_0.nextHop = [NSNumber numberWithUnsignedChar:entry_0.nextHop];
-        newElement_0.pathCost = [NSNumber numberWithUnsignedChar:entry_0.pathCost];
-        newElement_0.lqiIn = [NSNumber numberWithUnsignedChar:entry_0.LQIIn];
-        newElement_0.lqiOut = [NSNumber numberWithUnsignedChar:entry_0.LQIOut];
-        newElement_0.age = [NSNumber numberWithUnsignedChar:entry_0.age];
-        newElement_0.allocated = [NSNumber numberWithBool:entry_0.allocated];
-        newElement_0.linkEstablished = [NSNumber numberWithBool:entry_0.linkEstablished];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPThreadNetworkDiagnosticsClusterRouteTable * newElement_0;
+            newElement_0 = [CHIPThreadNetworkDiagnosticsClusterRouteTable new];
+            newElement_0.extAddress = [NSNumber numberWithUnsignedLongLong:entry_0.extAddress];
+            newElement_0.rloc16 = [NSNumber numberWithUnsignedShort:entry_0.rloc16];
+            newElement_0.routerId = [NSNumber numberWithUnsignedChar:entry_0.routerId];
+            newElement_0.nextHop = [NSNumber numberWithUnsignedChar:entry_0.nextHop];
+            newElement_0.pathCost = [NSNumber numberWithUnsignedChar:entry_0.pathCost];
+            newElement_0.lqiIn = [NSNumber numberWithUnsignedChar:entry_0.LQIIn];
+            newElement_0.lqiOut = [NSNumber numberWithUnsignedChar:entry_0.LQIOut];
+            newElement_0.age = [NSNumber numberWithUnsignedChar:entry_0.age];
+            newElement_0.allocated = [NSNumber numberWithBool:entry_0.allocated];
+            newElement_0.linkEstablished = [NSNumber numberWithBool:entry_0.linkEstablished];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9127,24 +9134,24 @@ void CHIPThreadNetworkDiagnosticsSecurityPolicyListAttributeCallbackBridge::OnSu
         chip::app::Clusters::ThreadNetworkDiagnostics::Structs::SecurityPolicy::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPThreadNetworkDiagnosticsClusterSecurityPolicy * newElement_0;
-        newElement_0 = [CHIPThreadNetworkDiagnosticsClusterSecurityPolicy new];
-        newElement_0.rotationTime = [NSNumber numberWithUnsignedShort:entry_0.rotationTime];
-        newElement_0.flags = [NSNumber numberWithUnsignedShort:entry_0.flags];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPThreadNetworkDiagnosticsClusterSecurityPolicy * newElement_0;
+            newElement_0 = [CHIPThreadNetworkDiagnosticsClusterSecurityPolicy new];
+            newElement_0.rotationTime = [NSNumber numberWithUnsignedShort:entry_0.rotationTime];
+            newElement_0.flags = [NSNumber numberWithUnsignedShort:entry_0.flags];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9169,34 +9176,34 @@ void CHIPThreadNetworkDiagnosticsOperationalDatasetComponentsListAttributeCallba
         chip::app::Clusters::ThreadNetworkDiagnostics::Structs::OperationalDatasetComponents::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents * newElement_0;
-        newElement_0 = [CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents new];
-        newElement_0.activeTimestampPresent = [NSNumber numberWithBool:entry_0.activeTimestampPresent];
-        newElement_0.pendingTimestampPresent = [NSNumber numberWithBool:entry_0.pendingTimestampPresent];
-        newElement_0.masterKeyPresent = [NSNumber numberWithBool:entry_0.masterKeyPresent];
-        newElement_0.networkNamePresent = [NSNumber numberWithBool:entry_0.networkNamePresent];
-        newElement_0.extendedPanIdPresent = [NSNumber numberWithBool:entry_0.extendedPanIdPresent];
-        newElement_0.meshLocalPrefixPresent = [NSNumber numberWithBool:entry_0.meshLocalPrefixPresent];
-        newElement_0.delayPresent = [NSNumber numberWithBool:entry_0.delayPresent];
-        newElement_0.panIdPresent = [NSNumber numberWithBool:entry_0.panIdPresent];
-        newElement_0.channelPresent = [NSNumber numberWithBool:entry_0.channelPresent];
-        newElement_0.pskcPresent = [NSNumber numberWithBool:entry_0.pskcPresent];
-        newElement_0.securityPolicyPresent = [NSNumber numberWithBool:entry_0.securityPolicyPresent];
-        newElement_0.channelMaskPresent = [NSNumber numberWithBool:entry_0.channelMaskPresent];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents * newElement_0;
+            newElement_0 = [CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents new];
+            newElement_0.activeTimestampPresent = [NSNumber numberWithBool:entry_0.activeTimestampPresent];
+            newElement_0.pendingTimestampPresent = [NSNumber numberWithBool:entry_0.pendingTimestampPresent];
+            newElement_0.masterKeyPresent = [NSNumber numberWithBool:entry_0.masterKeyPresent];
+            newElement_0.networkNamePresent = [NSNumber numberWithBool:entry_0.networkNamePresent];
+            newElement_0.extendedPanIdPresent = [NSNumber numberWithBool:entry_0.extendedPanIdPresent];
+            newElement_0.meshLocalPrefixPresent = [NSNumber numberWithBool:entry_0.meshLocalPrefixPresent];
+            newElement_0.delayPresent = [NSNumber numberWithBool:entry_0.delayPresent];
+            newElement_0.panIdPresent = [NSNumber numberWithBool:entry_0.panIdPresent];
+            newElement_0.channelPresent = [NSNumber numberWithBool:entry_0.channelPresent];
+            newElement_0.pskcPresent = [NSNumber numberWithBool:entry_0.pskcPresent];
+            newElement_0.securityPolicyPresent = [NSNumber numberWithBool:entry_0.securityPolicyPresent];
+            newElement_0.channelMaskPresent = [NSNumber numberWithBool:entry_0.channelMaskPresent];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9222,22 +9229,22 @@ void CHIPThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeCallbackBri
     void * context, const chip::app::DataModel::DecodableList<chip::app::Clusters::ThreadNetworkDiagnostics::NetworkFault> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0)];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0)];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9263,22 +9270,22 @@ void CHIPThreadNetworkDiagnosticsServerGeneratedCommandListListAttributeCallback
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9304,22 +9311,22 @@ void CHIPThreadNetworkDiagnosticsClientGeneratedCommandListListAttributeCallback
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9345,22 +9352,22 @@ void CHIPThreadNetworkDiagnosticsAttributeListListAttributeCallbackBridge::OnSuc
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9384,22 +9391,22 @@ void CHIPTimeFormatLocalizationSupportedCalendarTypesListAttributeCallbackBridge
     void * context, const chip::app::DataModel::DecodableList<chip::app::Clusters::TimeFormatLocalization::CalendarType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0)];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_0)];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9424,22 +9431,22 @@ void CHIPTimeFormatLocalizationServerGeneratedCommandListListAttributeCallbackBr
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9465,22 +9472,22 @@ void CHIPTimeFormatLocalizationClientGeneratedCommandListListAttributeCallbackBr
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9506,22 +9513,22 @@ void CHIPUnitLocalizationAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9545,28 +9552,28 @@ void CHIPUserLabelLabelListListAttributeCallbackBridge::OnSuccessFn(void * conte
     const chip::app::DataModel::DecodableList<chip::app::Clusters::UserLabel::Structs::LabelStruct::DecodableType> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        CHIPUserLabelClusterLabelStruct * newElement_0;
-        newElement_0 = [CHIPUserLabelClusterLabelStruct new];
-        newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
-                                                      length:entry_0.label.size()
-                                                    encoding:NSUTF8StringEncoding];
-        newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
-                                                      length:entry_0.value.size()
-                                                    encoding:NSUTF8StringEncoding];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            CHIPUserLabelClusterLabelStruct * newElement_0;
+            newElement_0 = [CHIPUserLabelClusterLabelStruct new];
+            newElement_0.label = [[NSString alloc] initWithBytes:entry_0.label.data()
+                                                          length:entry_0.label.size()
+                                                        encoding:NSUTF8StringEncoding];
+            newElement_0.value = [[NSString alloc] initWithBytes:entry_0.value.data()
+                                                          length:entry_0.value.size()
+                                                        encoding:NSUTF8StringEncoding];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9590,22 +9597,22 @@ void CHIPUserLabelServerGeneratedCommandListListAttributeCallbackBridge::OnSucce
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9629,22 +9636,22 @@ void CHIPUserLabelClientGeneratedCommandListListAttributeCallbackBridge::OnSucce
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9668,22 +9675,22 @@ void CHIPWakeOnLanServerGeneratedCommandListListAttributeCallbackBridge::OnSucce
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9707,22 +9714,22 @@ void CHIPWakeOnLanClientGeneratedCommandListListAttributeCallbackBridge::OnSucce
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9746,22 +9753,22 @@ void CHIPWakeOnLanAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9785,22 +9792,22 @@ void CHIPWiFiNetworkDiagnosticsServerGeneratedCommandListListAttributeCallbackBr
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9826,22 +9833,22 @@ void CHIPWiFiNetworkDiagnosticsClientGeneratedCommandListListAttributeCallbackBr
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9867,22 +9874,22 @@ void CHIPWiFiNetworkDiagnosticsAttributeListListAttributeCallbackBridge::OnSucce
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9906,22 +9913,22 @@ void CHIPWindowCoveringServerGeneratedCommandListListAttributeCallbackBridge::On
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9945,22 +9952,22 @@ void CHIPWindowCoveringClientGeneratedCommandListListAttributeCallbackBridge::On
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -9984,22 +9991,22 @@ void CHIPWindowCoveringAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
-    auto * array_0 = [NSMutableArray new];
-    auto iter_0 = value.begin();
-    while (iter_0.Next()) {
-        auto & entry_0 = iter_0.GetValue();
-        NSNumber * newElement_0;
-        newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
-        [array_0 addObject:newElement_0];
-    }
-    { // Scope for the error so we will know what it's named
+    { // Scope for our temporary variables
+        auto * array_0 = [NSMutableArray new];
+        auto iter_0 = value.begin();
+        while (iter_0.Next()) {
+            auto & entry_0 = iter_0.GetValue();
+            NSNumber * newElement_0;
+            newElement_0 = [NSNumber numberWithUnsignedInt:entry_0];
+            [array_0 addObject:newElement_0];
+        }
         CHIP_ERROR err = iter_0.GetStatus();
         if (err != CHIP_NO_ERROR) {
             OnFailureFn(context, err);
             return;
         }
+        objCValue = array_0;
     }
-    objCValue = array_0;
     DispatchSuccess(context, objCValue);
 };
 
@@ -10191,24 +10198,24 @@ void CHIPDoorLockClusterGetUserResponseCallbackBridge::OnSuccessFn(
         if (data.credentials.IsNull()) {
             response.credentials = nil;
         } else {
-            auto * array_1 = [NSMutableArray new];
-            auto iter_1 = data.credentials.Value().begin();
-            while (iter_1.Next()) {
-                auto & entry_1 = iter_1.GetValue();
-                CHIPDoorLockClusterDlCredential * newElement_1;
-                newElement_1 = [CHIPDoorLockClusterDlCredential new];
-                newElement_1.credentialType = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_1.credentialType)];
-                newElement_1.credentialIndex = [NSNumber numberWithUnsignedShort:entry_1.credentialIndex];
-                [array_1 addObject:newElement_1];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_1 = [NSMutableArray new];
+                auto iter_1 = data.credentials.Value().begin();
+                while (iter_1.Next()) {
+                    auto & entry_1 = iter_1.GetValue();
+                    CHIPDoorLockClusterDlCredential * newElement_1;
+                    newElement_1 = [CHIPDoorLockClusterDlCredential new];
+                    newElement_1.credentialType = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_1.credentialType)];
+                    newElement_1.credentialIndex = [NSNumber numberWithUnsignedShort:entry_1.credentialIndex];
+                    [array_1 addObject:newElement_1];
+                }
                 CHIP_ERROR err = iter_1.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     OnFailureFn(context, err);
                     return;
                 }
+                response.credentials = array_1;
             }
-            response.credentials = array_1;
         }
     }
     {
@@ -10390,22 +10397,22 @@ void CHIPGroupKeyManagementClusterKeySetReadAllIndicesResponseCallbackBridge::On
 {
     auto * response = [CHIPGroupKeyManagementClusterKeySetReadAllIndicesResponseParams new];
     {
-        auto * array_0 = [NSMutableArray new];
-        auto iter_0 = data.groupKeySetIDs.begin();
-        while (iter_0.Next()) {
-            auto & entry_0 = iter_0.GetValue();
-            NSNumber * newElement_0;
-            newElement_0 = [NSNumber numberWithUnsignedShort:entry_0];
-            [array_0 addObject:newElement_0];
-        }
-        { // Scope for the error so we will know what it's named
+        { // Scope for our temporary variables
+            auto * array_0 = [NSMutableArray new];
+            auto iter_0 = data.groupKeySetIDs.begin();
+            while (iter_0.Next()) {
+                auto & entry_0 = iter_0.GetValue();
+                NSNumber * newElement_0;
+                newElement_0 = [NSNumber numberWithUnsignedShort:entry_0];
+                [array_0 addObject:newElement_0];
+            }
             CHIP_ERROR err = iter_0.GetStatus();
             if (err != CHIP_NO_ERROR) {
                 OnFailureFn(context, err);
                 return;
             }
+            response.groupKeySetIDs = array_0;
         }
-        response.groupKeySetIDs = array_0;
     }
     DispatchSuccess(context, response);
 };
@@ -10477,22 +10484,22 @@ void CHIPGroupsClusterGetGroupMembershipResponseCallbackBridge::OnSuccessFn(
         response.capacity = [NSNumber numberWithUnsignedChar:data.capacity];
     }
     {
-        auto * array_0 = [NSMutableArray new];
-        auto iter_0 = data.groupList.begin();
-        while (iter_0.Next()) {
-            auto & entry_0 = iter_0.GetValue();
-            NSNumber * newElement_0;
-            newElement_0 = [NSNumber numberWithUnsignedShort:entry_0];
-            [array_0 addObject:newElement_0];
-        }
-        { // Scope for the error so we will know what it's named
+        { // Scope for our temporary variables
+            auto * array_0 = [NSMutableArray new];
+            auto iter_0 = data.groupList.begin();
+            while (iter_0.Next()) {
+                auto & entry_0 = iter_0.GetValue();
+                NSNumber * newElement_0;
+                newElement_0 = [NSNumber numberWithUnsignedShort:entry_0];
+                [array_0 addObject:newElement_0];
+            }
             CHIP_ERROR err = iter_0.GetStatus();
             if (err != CHIP_NO_ERROR) {
                 OnFailureFn(context, err);
                 return;
             }
+            response.groupList = array_0;
         }
-        response.groupList = array_0;
     }
     DispatchSuccess(context, response);
 };
@@ -10605,60 +10612,60 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge::OnSucces
     }
     {
         if (data.wiFiScanResults.HasValue()) {
-            auto * array_1 = [NSMutableArray new];
-            auto iter_1 = data.wiFiScanResults.Value().begin();
-            while (iter_1.Next()) {
-                auto & entry_1 = iter_1.GetValue();
-                CHIPNetworkCommissioningClusterWiFiInterfaceScanResult * newElement_1;
-                newElement_1 = [CHIPNetworkCommissioningClusterWiFiInterfaceScanResult new];
-                newElement_1.security = [NSNumber numberWithUnsignedChar:entry_1.security];
-                newElement_1.ssid = [NSData dataWithBytes:entry_1.ssid.data() length:entry_1.ssid.size()];
-                newElement_1.bssid = [NSData dataWithBytes:entry_1.bssid.data() length:entry_1.bssid.size()];
-                newElement_1.channel = [NSNumber numberWithUnsignedShort:entry_1.channel];
-                newElement_1.wiFiBand = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_1.wiFiBand)];
-                newElement_1.rssi = [NSNumber numberWithChar:entry_1.rssi];
-                [array_1 addObject:newElement_1];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_1 = [NSMutableArray new];
+                auto iter_1 = data.wiFiScanResults.Value().begin();
+                while (iter_1.Next()) {
+                    auto & entry_1 = iter_1.GetValue();
+                    CHIPNetworkCommissioningClusterWiFiInterfaceScanResult * newElement_1;
+                    newElement_1 = [CHIPNetworkCommissioningClusterWiFiInterfaceScanResult new];
+                    newElement_1.security = [NSNumber numberWithUnsignedChar:entry_1.security];
+                    newElement_1.ssid = [NSData dataWithBytes:entry_1.ssid.data() length:entry_1.ssid.size()];
+                    newElement_1.bssid = [NSData dataWithBytes:entry_1.bssid.data() length:entry_1.bssid.size()];
+                    newElement_1.channel = [NSNumber numberWithUnsignedShort:entry_1.channel];
+                    newElement_1.wiFiBand = [NSNumber numberWithUnsignedChar:chip::to_underlying(entry_1.wiFiBand)];
+                    newElement_1.rssi = [NSNumber numberWithChar:entry_1.rssi];
+                    [array_1 addObject:newElement_1];
+                }
                 CHIP_ERROR err = iter_1.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     OnFailureFn(context, err);
                     return;
                 }
+                response.wiFiScanResults = array_1;
             }
-            response.wiFiScanResults = array_1;
         } else {
             response.wiFiScanResults = nil;
         }
     }
     {
         if (data.threadScanResults.HasValue()) {
-            auto * array_1 = [NSMutableArray new];
-            auto iter_1 = data.threadScanResults.Value().begin();
-            while (iter_1.Next()) {
-                auto & entry_1 = iter_1.GetValue();
-                CHIPNetworkCommissioningClusterThreadInterfaceScanResult * newElement_1;
-                newElement_1 = [CHIPNetworkCommissioningClusterThreadInterfaceScanResult new];
-                newElement_1.panId = [NSNumber numberWithUnsignedLongLong:entry_1.panId];
-                newElement_1.extendedPanId = [NSNumber numberWithUnsignedLongLong:entry_1.extendedPanId];
-                newElement_1.networkName = [[NSString alloc] initWithBytes:entry_1.networkName.data()
-                                                                    length:entry_1.networkName.size()
-                                                                  encoding:NSUTF8StringEncoding];
-                newElement_1.channel = [NSNumber numberWithUnsignedShort:entry_1.channel];
-                newElement_1.version = [NSNumber numberWithUnsignedChar:entry_1.version];
-                newElement_1.extendedAddress = [NSNumber numberWithUnsignedLongLong:entry_1.extendedAddress];
-                newElement_1.rssi = [NSNumber numberWithChar:entry_1.rssi];
-                newElement_1.lqi = [NSNumber numberWithUnsignedChar:entry_1.lqi];
-                [array_1 addObject:newElement_1];
-            }
-            { // Scope for the error so we will know what it's named
+            { // Scope for our temporary variables
+                auto * array_1 = [NSMutableArray new];
+                auto iter_1 = data.threadScanResults.Value().begin();
+                while (iter_1.Next()) {
+                    auto & entry_1 = iter_1.GetValue();
+                    CHIPNetworkCommissioningClusterThreadInterfaceScanResult * newElement_1;
+                    newElement_1 = [CHIPNetworkCommissioningClusterThreadInterfaceScanResult new];
+                    newElement_1.panId = [NSNumber numberWithUnsignedLongLong:entry_1.panId];
+                    newElement_1.extendedPanId = [NSNumber numberWithUnsignedLongLong:entry_1.extendedPanId];
+                    newElement_1.networkName = [[NSString alloc] initWithBytes:entry_1.networkName.data()
+                                                                        length:entry_1.networkName.size()
+                                                                      encoding:NSUTF8StringEncoding];
+                    newElement_1.channel = [NSNumber numberWithUnsignedShort:entry_1.channel];
+                    newElement_1.version = [NSNumber numberWithUnsignedChar:entry_1.version];
+                    newElement_1.extendedAddress = [NSNumber numberWithUnsignedLongLong:entry_1.extendedAddress];
+                    newElement_1.rssi = [NSNumber numberWithChar:entry_1.rssi];
+                    newElement_1.lqi = [NSNumber numberWithUnsignedChar:entry_1.lqi];
+                    [array_1 addObject:newElement_1];
+                }
                 CHIP_ERROR err = iter_1.GetStatus();
                 if (err != CHIP_NO_ERROR) {
                     OnFailureFn(context, err);
                     return;
                 }
+                response.threadScanResults = array_1;
             }
-            response.threadScanResults = array_1;
         } else {
             response.threadScanResults = nil;
         }
@@ -10840,22 +10847,22 @@ void CHIPScenesClusterGetSceneMembershipResponseCallbackBridge::OnSuccessFn(
         response.sceneCount = [NSNumber numberWithUnsignedChar:data.sceneCount];
     }
     {
-        auto * array_0 = [NSMutableArray new];
-        auto iter_0 = data.sceneList.begin();
-        while (iter_0.Next()) {
-            auto & entry_0 = iter_0.GetValue();
-            NSNumber * newElement_0;
-            newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
-            [array_0 addObject:newElement_0];
-        }
-        { // Scope for the error so we will know what it's named
+        { // Scope for our temporary variables
+            auto * array_0 = [NSMutableArray new];
+            auto iter_0 = data.sceneList.begin();
+            while (iter_0.Next()) {
+                auto & entry_0 = iter_0.GetValue();
+                NSNumber * newElement_0;
+                newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
+                [array_0 addObject:newElement_0];
+            }
             CHIP_ERROR err = iter_0.GetStatus();
             if (err != CHIP_NO_ERROR) {
                 OnFailureFn(context, err);
                 return;
             }
+            response.sceneList = array_0;
         }
-        response.sceneList = array_0;
     }
     DispatchSuccess(context, response);
 };
@@ -10927,25 +10934,25 @@ void CHIPScenesClusterViewSceneResponseCallbackBridge::OnSuccessFn(
                                                     encoding:NSUTF8StringEncoding];
     }
     {
-        auto * array_0 = [NSMutableArray new];
-        auto iter_0 = data.extensionFieldSets.begin();
-        while (iter_0.Next()) {
-            auto & entry_0 = iter_0.GetValue();
-            CHIPScenesClusterSceneExtensionFieldSet * newElement_0;
-            newElement_0 = [CHIPScenesClusterSceneExtensionFieldSet new];
-            newElement_0.clusterId = [NSNumber numberWithUnsignedInt:entry_0.clusterId];
-            newElement_0.length = [NSNumber numberWithUnsignedChar:entry_0.length];
-            newElement_0.value = [NSNumber numberWithUnsignedChar:entry_0.value];
-            [array_0 addObject:newElement_0];
-        }
-        { // Scope for the error so we will know what it's named
+        { // Scope for our temporary variables
+            auto * array_0 = [NSMutableArray new];
+            auto iter_0 = data.extensionFieldSets.begin();
+            while (iter_0.Next()) {
+                auto & entry_0 = iter_0.GetValue();
+                CHIPScenesClusterSceneExtensionFieldSet * newElement_0;
+                newElement_0 = [CHIPScenesClusterSceneExtensionFieldSet new];
+                newElement_0.clusterId = [NSNumber numberWithUnsignedInt:entry_0.clusterId];
+                newElement_0.length = [NSNumber numberWithUnsignedChar:entry_0.length];
+                newElement_0.value = [NSNumber numberWithUnsignedChar:entry_0.value];
+                [array_0 addObject:newElement_0];
+            }
             CHIP_ERROR err = iter_0.GetStatus();
             if (err != CHIP_NO_ERROR) {
                 OnFailureFn(context, err);
                 return;
             }
+            response.extensionFieldSets = array_0;
         }
-        response.extensionFieldSets = array_0;
     }
     DispatchSuccess(context, response);
 };
@@ -11037,22 +11044,22 @@ void CHIPTestClusterClusterTestListInt8UReverseResponseCallbackBridge::OnSuccess
 {
     auto * response = [CHIPTestClusterClusterTestListInt8UReverseResponseParams new];
     {
-        auto * array_0 = [NSMutableArray new];
-        auto iter_0 = data.arg1.begin();
-        while (iter_0.Next()) {
-            auto & entry_0 = iter_0.GetValue();
-            NSNumber * newElement_0;
-            newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
-            [array_0 addObject:newElement_0];
-        }
-        { // Scope for the error so we will know what it's named
+        { // Scope for our temporary variables
+            auto * array_0 = [NSMutableArray new];
+            auto iter_0 = data.arg1.begin();
+            while (iter_0.Next()) {
+                auto & entry_0 = iter_0.GetValue();
+                NSNumber * newElement_0;
+                newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
+                [array_0 addObject:newElement_0];
+            }
             CHIP_ERROR err = iter_0.GetStatus();
             if (err != CHIP_NO_ERROR) {
                 OnFailureFn(context, err);
                 return;
             }
+            response.arg1 = array_0;
         }
-        response.arg1 = array_0;
     }
     DispatchSuccess(context, response);
 };
@@ -11141,22 +11148,22 @@ void CHIPThermostatClusterGetWeeklyScheduleResponseCallbackBridge::OnSuccessFn(
         response.modeForSequence = [NSNumber numberWithUnsignedChar:data.modeForSequence.Raw()];
     }
     {
-        auto * array_0 = [NSMutableArray new];
-        auto iter_0 = data.payload.begin();
-        while (iter_0.Next()) {
-            auto & entry_0 = iter_0.GetValue();
-            NSNumber * newElement_0;
-            newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
-            [array_0 addObject:newElement_0];
-        }
-        { // Scope for the error so we will know what it's named
+        { // Scope for our temporary variables
+            auto * array_0 = [NSMutableArray new];
+            auto iter_0 = data.payload.begin();
+            while (iter_0.Next()) {
+                auto & entry_0 = iter_0.GetValue();
+                NSNumber * newElement_0;
+                newElement_0 = [NSNumber numberWithUnsignedChar:entry_0];
+                [array_0 addObject:newElement_0];
+            }
             CHIP_ERROR err = iter_0.GetStatus();
             if (err != CHIP_NO_ERROR) {
                 OnFailureFn(context, err);
                 return;
             }
+            response.payload = array_0;
         }
-        response.payload = array_0;
     }
     DispatchSuccess(context, response);
 };


### PR DESCRIPTION
When converting a C++ DecodableList into an Objective C NSArray, we
declare some temporary variables.  These were not scoped in their own
scope, so if multiple lists were decoded at the same nesting level
(e.g. two list-typed members of the same struct), the names would
collide and produce compile errors.

The fix is to just scope the entire conversion.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Compiled #15025 successfully with this fix applied on top of it.