### PR TITLE
[clang-support] Define __SANITIZE_ADDRESS__ if ASAN is enabled

### DIFF
--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -891,6 +891,8 @@ void GroupDataProviderImpl::Finish()
     mGroupKeyIterators.ReleaseAll();
     mEndpointIterators.ReleaseAll();
     mKeySetIterators.ReleaseAll();
+    mGroupSessionsIterator.ReleaseAll();
+    mKeyContexPool.ReleaseAll();
 }
 
 //

--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -499,7 +499,16 @@ static void OnLwIPInitComplete(void * arg)
 
 void ShutdownNetwork()
 {
+    gTCP.ForEachEndPoint([](TCPEndPoint * lEndPoint) -> Loop {
+        gTCP.ReleaseEndPoint(lEndPoint);
+        return Loop::Continue;
+    });
     gTCP.Shutdown();
+
+    gUDP.ForEachEndPoint([](UDPEndPoint * lEndPoint) -> Loop {
+        gUDP.ReleaseEndPoint(lEndPoint);
+        return Loop::Continue;
+    });
     gUDP.Shutdown();
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     ReleaseLwIP();

--- a/src/lib/support/Pool.h
+++ b/src/lib/support/Pool.h
@@ -296,6 +296,13 @@ public:
     HeapObjectPool() {}
     ~HeapObjectPool()
     {
+#ifndef __SANITIZE_ADDRESS__
+#ifdef __clang__
+#if __has_feature(address_sanitizer)
+#define __SANITIZE_ADDRESS__ 1
+#endif
+#endif
+#endif
 #if __SANITIZE_ADDRESS__
         // Free all remaining objects so that ASAN can catch specific use-after-free cases.
         ReleaseAll();

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -75,9 +75,8 @@ CHIP_ERROR LayerImplSelect::Shutdown()
             dispatch_source_cancel(timer->mTimerSource);
             dispatch_release(timer->mTimerSource);
         }
-
-        mTimerPool.Release(timer);
     }
+    mTimerPool.ReleaseAll();
 #else  // CHIP_SYSTEM_CONFIG_USE_DISPATCH
     mTimerList.Clear();
     mTimerPool.ReleaseAll();

--- a/src/transport/raw/tests/NetworkTestHelpers.cpp
+++ b/src/transport/raw/tests/NetworkTestHelpers.cpp
@@ -49,7 +49,7 @@ CHIP_ERROR IOContext::Shutdown()
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     ShutdownNetwork();
-    gSystemLayer.Shutdown();
+    ShutdownSystemLayer();
     Platform::MemoryShutdown();
 
     return err;


### PR DESCRIPTION
#### Problem

Toying with Asan on Darwin I realised that `__SANITIZE_ADDRESS__` is a gcc thing, so the code in `src/lib/support/Pool.h` does not catch `use-after-free` properly.
 
#### Change overview
 * Define `__SANITIZE_ADDRESS__` if asan is turned on with clang
 
#### Testing
I have verified it with some code that triggers a `==4406==ERROR: AddressSanitizer: heap-use-after-free on address 0x608000012c40 at pc 0x000109c58645 bp 0x7ffee626fa60 sp 0x7ffee626fa58` with this patch and just a `VerifyOrDie failure at ../../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/lib/support/Pool.h:304: Allocated() == 0` without