### PR TITLE
[Logging] Log the error message when the StartUp and ShutDown event a…

### DIFF
--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -344,9 +344,10 @@ class PlatformMgrDelegate : public DeviceLayer::PlatformManagerDelegate
             Events::StartUp::Type event{ softwareVersion };
             EventNumber eventNumber;
 
-            if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber, EventOptions::Type::kUrgent))
+            CHIP_ERROR err = LogEvent(event, endpoint, eventNumber, EventOptions::Type::kUrgent);
+            if (CHIP_NO_ERROR != err)
             {
-                ChipLogError(Zcl, "PlatformMgrDelegate: Failed to record StartUp event");
+                ChipLogError(Zcl, "PlatformMgrDelegate: Failed to record StartUp event: %" CHIP_ERROR_FORMAT, err.Format());
             }
         }
     }
@@ -362,9 +363,10 @@ class PlatformMgrDelegate : public DeviceLayer::PlatformManagerDelegate
             Events::ShutDown::Type event;
             EventNumber eventNumber;
 
-            if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber, EventOptions::Type::kUrgent))
+            CHIP_ERROR err = LogEvent(event, endpoint, eventNumber, EventOptions::Type::kUrgent);
+            if (CHIP_NO_ERROR != err)
             {
-                ChipLogError(Zcl, "PlatformMgrDelegate: Failed to record ShutDown event");
+                ChipLogError(Zcl, "PlatformMgrDelegate: Failed to record ShutDown event: %" CHIP_ERROR_FORMAT, err.Format());
             }
         }
     }


### PR DESCRIPTION
…re not dispatched in the basic cluster

#### Problem

When the `StartUp` event or the `ShutDown` event fails to be dispatched in `Basic.cpp` the specific reason is not logged. I'm trying to debug some failures to launch the `ShutDown` event on Darwin and this is not helping at first sight.

#### Change overview
 * Log the error message.

#### Testing
Tried by running some code where the `ShutDown` event is not dispatch for "some" reason. With this patch I can clearly identify where the failures comes from, which is that the session manager is off...