### PR TITLE
Add chip-cert to build_examples.py

### DIFF
--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -61,6 +61,11 @@ jobs:
                   path: |
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
+            - name: Build Standalone cert tool
+              timeout-minutes: 5
+              run: |
+                 ./scripts/run_in_build_env.sh \
+                 "./scripts/build/build_examples.py --no-log-timestamps --target-glob '*-chip-cert' build"
             - name: Build example Standalone Echo Client
               timeout-minutes: 5
               run: |

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -145,6 +145,8 @@ def HostTargets():
         targets[0].Extend('rpc-console', app=HostApp.RPC_CONSOLE))
     app_targets.append(
         targets[0].Extend('tv-app', app=HostApp.TV_APP))
+    app_targets.append(
+        targets[0].Extend('chip-cert', app=HostApp.CERT_TOOL))
 
     for target in targets:
         app_targets.append(target.Extend(

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -30,6 +30,7 @@ class HostApp(Enum):
     LOCK = auto()
     TESTS = auto()
     SHELL = auto()
+    CERT_TOOL = auto()
 
     def ExamplePath(self):
         if self == HostApp.ALL_CLUSTERS:
@@ -50,6 +51,8 @@ class HostApp(Enum):
             return '../'
         elif self == HostApp.SHELL:
             return 'shell/standalone'
+        elif self == HostApp.CERT_TOOL:
+            return '..'
         else:
             raise Exception('Unknown app type: %r' % self)
 
@@ -83,6 +86,9 @@ class HostApp(Enum):
         elif self == HostApp.SHELL:
             yield 'chip-shell'
             yield 'chip-shell.map'
+        elif self == HostApp.CERT_TOOL:
+            yield 'cert-tool'
+            yield 'cert-tool.map'
         else:
             raise Exception('Unknown app type: %r' % self)
 
@@ -168,6 +174,14 @@ class HostBuilder(GnBuilder):
         if app == HostApp.TESTS:
             self.extra_gn_options.append('chip_build_tests=true')
             self.build_command = 'check'
+
+        if app == HostApp.CERT_TOOL:
+            # Certification only built for openssl
+            if self.board == HostBoard.ARM64:
+                # OpenSSL and MBEDTLS conflict. We only cross compile with mbedtls
+                raise Exception("Cannot cross compile CERT TOOL: ssl library conflict")
+            self.extra_gn_options.append('chip_crypto="openssl"')
+            self.build_command = 'src/tools/chip-cert'
 
     def GnBuildArgs(self):
         if self.board == HostBoard.NATIVE:

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -179,7 +179,8 @@ class HostBuilder(GnBuilder):
             # Certification only built for openssl
             if self.board == HostBoard.ARM64:
                 # OpenSSL and MBEDTLS conflict. We only cross compile with mbedtls
-                raise Exception("Cannot cross compile CERT TOOL: ssl library conflict")
+                raise Exception(
+                    "Cannot cross compile CERT TOOL: ssl library conflict")
             self.extra_gn_options.append('chip_crypto="openssl"')
             self.build_command = 'src/tools/chip-cert'
 

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -70,6 +70,12 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Generating linux-x64-all-clusters-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-all-clusters-ipv6only
 
+# Generating linux-x64-chip-cert
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--args=chip_crypto="openssl"' {out}/linux-x64-chip-cert
+
+# Generating linux-x64-chip-cert-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--args=chip_inet_config_enable_ipv4=false chip_crypto="openssl"' {out}/linux-x64-chip-cert-ipv6only
+
 # Generating linux-x64-chip-tool
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool {out}/linux-x64-chip-tool
 
@@ -156,6 +162,12 @@ ninja -C {out}/linux-x64-all-clusters
 
 # Building linux-x64-all-clusters-ipv6only
 ninja -C {out}/linux-x64-all-clusters-ipv6only
+
+# Building linux-x64-chip-cert
+ninja -C {out}/linux-x64-chip-cert src/tools/chip-cert
+
+# Building linux-x64-chip-cert-ipv6only
+ninja -C {out}/linux-x64-chip-cert-ipv6only src/tools/chip-cert
 
 # Building linux-x64-chip-tool
 ninja -C {out}/linux-x64-chip-tool


### PR DESCRIPTION
#### Problem
chip-cert tool does not seem to be built by any CI. Also local path seemed to be assumed out/standalone/debug in our python scripts, however that let me to try to use gn_build.sh to generate it and got k32w errors.

#### Change overview
Make build_examples.py be capable to build the chip-cert tool. Added CI step for this.

#### Testing
Manually compiled with `./scripts/build/build_examples.py --target-glob '*-chip-cert' build` on my linux machine.
CI will also validate.