### PR TITLE
Minor DAC script update.

### DIFF
--- a/src/tools/chip-cert/dacs.py
+++ b/src/tools/chip-cert/dacs.py
@@ -1,4 +1,7 @@
+#!/usr/bin/env python
+
 import argparse
+import os
 import subprocess
 import sys
 import typing
@@ -112,6 +115,9 @@ class DevCertBuilder:
         self.pid = pid
         self.cert_type = cert_type
         self.chipcert = chip_cert_dir + 'chip-cert'
+
+        if not os.path.exists(self.chipcert):
+            raise Exception('Path not found: %s' % self.chipcert)
 
         paa = Names(CertType.PAA, test_dir, dev_dir, pid)
         pai = Names(CertType.PAI, test_dir, dev_dir, pid)


### PR DESCRIPTION
#### Problem
dacs.py not directly executable.

#### Change overview
make the script executable, add `#!/usr/bin/env python` to the top, make it throw if it cannot find the chip-tool binary (very likely if not knowing how/if to build it).

#### Testing
Ran the tool without error. Could not validate since the output does seem different from what is already in our source code.