### PR TITLE
[Darwin] Get the ShutDown event to work

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -66,6 +66,21 @@ constexpr bool isRendezvousBypassed()
 #endif
 }
 
+void StopEventLoop(intptr_t arg)
+{
+    LogErrorOnFailure(chip::DeviceLayer::PlatformMgr().StopEventLoopTask());
+}
+
+void DispatchShutDownEvent(intptr_t arg)
+{
+    // The ShutDown event SHOULD be emitted on a best-effort basis by a Node prior to any orderly shutdown sequence.
+    chip::DeviceLayer::PlatformManagerDelegate * platformManagerDelegate = chip::DeviceLayer::PlatformMgr().GetDelegate();
+    if (platformManagerDelegate != nullptr)
+    {
+        platformManagerDelegate->OnShutDown();
+    }
+}
+
 } // namespace
 
 namespace chip {
@@ -277,11 +292,17 @@ exit:
     return err;
 }
 
+void Server::DispatchShutDownAndStopEventLoop()
+{
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(DispatchShutDownEvent);
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(StopEventLoop);
+}
+
 void Server::Shutdown()
 {
     chip::Dnssd::ServiceAdvertiser::Instance().Shutdown();
     chip::app::InteractionModelEngine::GetInstance()->Shutdown();
-    mExchangeMgr.Shutdown();
+    LogErrorOnFailure(mExchangeMgr.Shutdown());
     mSessions.Shutdown();
     mTransports.Close();
     mCommissioningWindowManager.Shutdown();

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -87,6 +87,12 @@ public:
 
     CommissioningWindowManager & GetCommissioningWindowManager() { return mCommissioningWindowManager; }
 
+    /**
+     * This function send the ShutDown event before stopping
+     * the event loop.
+     */
+    void DispatchShutDownAndStopEventLoop();
+
     void Shutdown();
 
     static Server & GetInstance() { return sServer; }

--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -132,17 +132,8 @@ exit:
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_Shutdown()
 {
-    CHIP_ERROR err;
-    PlatformManagerDelegate * platformManagerDelegate = PlatformMgr().GetDelegate();
-
-    // The ShutDown event SHOULD be emitted by a Node prior to any orderly shutdown sequence.
-    if (platformManagerDelegate != nullptr)
-    {
-        platformManagerDelegate->OnShutDown();
-    }
-
     ChipLogError(DeviceLayer, "Inet Layer shutdown");
-    err = UDPEndPointManager()->Shutdown();
+    CHIP_ERROR err = UDPEndPointManager()->Shutdown();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
     ChipLogError(DeviceLayer, "BLE shutdown");

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -61,39 +61,10 @@ namespace {
 
 void SignalHandler(int signum)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
     ChipLogDetail(DeviceLayer, "Caught signal %d", signum);
 
-    // The BootReason attribute SHALL indicate the reason for the Node’s most recent boot, the real usecase
-    // for this attribute is embedded system. In Linux simulation, we use different signals to tell the current
-    // running process to terminate with different reasons.
     switch (signum)
     {
-    case SIGINT:
-        ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::SoftwareReset);
-        err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
-        break;
-    case SIGALRM:
-        ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::BrownOutReset);
-        err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
-        break;
-    case SIGVTALRM:
-        ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::PowerOnReboot);
-        err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
-        break;
-    case SIGTRAP:
-        ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::HardwareWatchdogReset);
-        err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
-        break;
-    case SIGILL:
-        ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::SoftwareWatchdogReset);
-        err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
-        break;
-    case SIGIO:
-        ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::SoftwareUpdateCompleted);
-        err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
-        break;
     case SIGUSR1:
         PlatformMgrImpl().HandleSoftwareFault(SoftwareDiagnostics::Events::SoftwareFault::Id);
         break;
@@ -111,12 +82,6 @@ void SignalHandler(int signum)
         break;
     default:
         break;
-    }
-
-    if (err == CHIP_ERROR_REBOOT_SIGNAL_RECEIVED)
-    {
-        PlatformMgr().Shutdown();
-        exit(EXIT_FAILURE);
     }
 }
 
@@ -213,7 +178,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 
     memset(&action, 0, sizeof(action));
     action.sa_handler = SignalHandler;
-    sigaction(SIGINT, &action, NULL);
     sigaction(SIGHUP, &action, NULL);
     sigaction(SIGTERM, &action, NULL);
     sigaction(SIGUSR1, &action, NULL);


### PR DESCRIPTION
#### Problem

In #15103 I was trying to get the `ShutDown` event to work on Darwin. But there was a few different issues. 

 1. Tsan builds and sigactions are not working as expected on darwin, the signal handlers not beeing dispatched.
 2. Calling `PlatformManager::Shutdown` ends up into a `heap-use-after-free` with Asan, basically because `Server::Shutdown` was not called properly
 3. Dispatch of the `ShutDown` event has been moved into `src/include/platform/internal/GenericPlatformManager.cpp` in https://github.com/project-chip/connectedhomeip/pull/14731 but I just don't understand how it is supposed to be effectively dispatched so I moved it back into a method in `Server.h`
    The reason why I do not understand how it is supposed to be dispatched is because the event goes through `LogEvent` which eventually call `ScheduleWork`. But right after the rest of the platform is turned off, which results into tsan/asan complaining...

#### Change overview
 * Move back the code that dispatch the `ShutDown` event from `internal` to `Server.h`
 * Move some signal handlers from `src/platform/Linux` to `examples/platform/Linux` so both Darwin/Linux benefits from them (sadly I add to replace `sigaction` by signal because of Tsan signal interceptors not playing nicely with darwin)
 * Update `Server` code to shutdown properly
