### PR TITLE
Add control over fabric-filtering of reads to chip-tool.

### DIFF
--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -122,6 +122,11 @@ protected:
         params.mpAttributePathParamsList    = attributePathParams;
         params.mAttributePathParamsListSize = 1;
 
+        if (mFabricFiltered.HasValue())
+        {
+            params.mIsFabricFiltered = mFabricFiltered.Value();
+        }
+
         chip::Optional<chip::app::DataVersionFilter> dataVersionFilter;
         if (aDataVersion.HasValue())
         {
@@ -168,6 +173,10 @@ protected:
 
     std::unique_ptr<chip::app::ReadClient> mReadClient;
     chip::app::BufferedReadCallback mBufferedReadAdapter;
+
+    // mFabricFiltered is really only used by the attribute commands, but we end
+    // up needing it in our class's shared code.
+    chip::Optional<bool> mFabricFiltered;
 };
 
 class ReadAttribute : public ReportCommand
@@ -178,6 +187,7 @@ public:
         AddArgument("cluster-id", 0, UINT32_MAX, &mClusterId);
         AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
         AddArgument("data-version", 0, UINT32_MAX, &mDataVersion);
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
         ReportCommand::AddArguments();
     }
 
@@ -186,6 +196,7 @@ public:
     {
         AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
         AddArgument("data-version", 0, UINT32_MAX, &mDataVersion);
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
         ReportCommand::AddArguments();
     }
 
@@ -196,6 +207,7 @@ public:
     {
         AddArgument("attr-name", attributeName);
         AddArgument("data-version", 0, UINT32_MAX, &mDataVersion);
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
         ReportCommand::AddArguments();
     }
 
@@ -226,6 +238,7 @@ public:
         AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
         AddArgument("data-version", 0, UINT32_MAX, &mDataVersion);
         AddArgument("wait", 0, 1, &mWait);
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
         ReportCommand::AddArguments();
     }
 
@@ -237,6 +250,7 @@ public:
         AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
         AddArgument("data-version", 0, UINT32_MAX, &mDataVersion);
         AddArgument("wait", 0, 1, &mWait);
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
         ReportCommand::AddArguments();
     }
 
@@ -250,6 +264,7 @@ public:
         AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
         AddArgument("data-version", 0, UINT32_MAX, &mDataVersion);
         AddArgument("wait", 0, 1, &mWait);
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
         ReportCommand::AddArguments();
     }
 

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -53,7 +53,7 @@ struct ReadPrepareParams
     uint16_t mMinIntervalFloorSeconds               = 0;
     uint16_t mMaxIntervalCeilingSeconds             = 0;
     bool mKeepSubscriptions                         = true;
-    bool mIsFabricFiltered                          = false;
+    bool mIsFabricFiltered                          = true;
     OnResubscribePolicyCB mResubscribePolicy        = nullptr;
 
     ReadPrepareParams() {}


### PR DESCRIPTION
Two changes:

1) Set mIsFabricFiltered to true by default in ReadPrepareParams, so
   that unwary consumers don't accidentally do unfiltered reads and
   use those to base write operations on.

2) Add an optional flag to chip-tool attribute read/subscribe commands
   to allow turning off fabric filtering (with "--fabric-filtered 0").
   This adds the flag to all reads, not just the ones for attributes
   where it's known to affect behavior, so we can test all the cases.

#### Problem
Can't do a fabric-filtered read via chip-tool command line.

#### Change overview
Fix that to work.

#### Testing
Ran these:
```
chip-tool accesscontrol read acl 17 0
```
```
chip-tool accesscontrol read acl 17 0 --fabric-filtered 1
```
```
chip-tool accesscontrol read acl 17 0 --fabric-filtered 0
```
and verified that the server logs `isFabricFiltered = true`, `isFabricFiltered = true`, `isFabricFiltered = false` respectively.