### PR TITLE
fix ot-cli shell commissioning issue

### DIFF
--- a/examples/shell/shell_common/cmd_otcli.cpp
+++ b/examples/shell/shell_common/cmd_otcli.cpp
@@ -40,13 +40,13 @@
 #include <openthread/link.h>
 #include <openthread/thread.h>
 #if OPENTHREAD_API_VERSION >= 85
-#if defined(__ZEPHYR__)
+#if !defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
 #ifndef SHELL_OTCLI_TX_BUFFER_SIZE
 #define SHELL_OTCLI_TX_BUFFER_SIZE 1024
 #endif
 static char sTxBuffer[SHELL_OTCLI_TX_BUFFER_SIZE];
 static constexpr uint16_t sTxLength = SHELL_OTCLI_TX_BUFFER_SIZE;
-#endif // defined(__ZEPHYR__)
+#endif // !defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
 #endif
 #else
 #include <sys/types.h>
@@ -165,7 +165,7 @@ static const shell_command_t cmds_otcli_root = { &cmd_otcli_dispatch, "otcli", "
 
 #if CHIP_TARGET_STYLE_EMBEDDED
 #if OPENTHREAD_API_VERSION >= 85
-#if defined(__ZEPHYR__)
+#if !defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
 static int OnOtCliOutput(void * aContext, const char * aFormat, va_list aArguments)
 {
     int rval = vsnprintf(sTxBuffer, sTxLength, aFormat, aArguments);
@@ -174,7 +174,7 @@ static int OnOtCliOutput(void * aContext, const char * aFormat, va_list aArgumen
 exit:
     return rval;
 }
-#endif // __ZEPHYR__
+#endif // !defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
 #else
 
 static int OnOtCliOutput(const char * aBuf, uint16_t aBufLength, void * aContext)
@@ -190,13 +190,13 @@ void cmd_otcli_init()
 {
 #if CHIP_ENABLE_OPENTHREAD
 #if CHIP_TARGET_STYLE_EMBEDDED
-#if defined(__ZEPHYR__)
+#if !defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
 #if OPENTHREAD_API_VERSION >= 85
     otCliInit(otInstanceInitSingle(), &OnOtCliOutput, NULL);
 #else
     otCliConsoleInit(otInstanceInitSingle(), &OnOtCliOutput, NULL);
 #endif // OPENTHREAD_API_VERSION >= 85
-#endif // __ZEPHYR__
+#endif // !defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
 #endif // CHIP_TARGET_STYLE_EMBEDDED
 
     // Register the root otcli command with the top-level shell.

--- a/examples/shell/shell_common/cmd_otcli.cpp
+++ b/examples/shell/shell_common/cmd_otcli.cpp
@@ -40,13 +40,13 @@
 #include <openthread/link.h>
 #include <openthread/thread.h>
 #if OPENTHREAD_API_VERSION >= 85
-#if !defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
+#if !CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 #ifndef SHELL_OTCLI_TX_BUFFER_SIZE
 #define SHELL_OTCLI_TX_BUFFER_SIZE 1024
 #endif
 static char sTxBuffer[SHELL_OTCLI_TX_BUFFER_SIZE];
 static constexpr uint16_t sTxLength = SHELL_OTCLI_TX_BUFFER_SIZE;
-#endif // !defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
+#endif // !CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
 #endif
 #else
 #include <sys/types.h>
@@ -165,7 +165,7 @@ static const shell_command_t cmds_otcli_root = { &cmd_otcli_dispatch, "otcli", "
 
 #if CHIP_TARGET_STYLE_EMBEDDED
 #if OPENTHREAD_API_VERSION >= 85
-#if !defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
+#if !CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 static int OnOtCliOutput(void * aContext, const char * aFormat, va_list aArguments)
 {
     int rval = vsnprintf(sTxBuffer, sTxLength, aFormat, aArguments);
@@ -174,7 +174,7 @@ static int OnOtCliOutput(void * aContext, const char * aFormat, va_list aArgumen
 exit:
     return rval;
 }
-#endif // !defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
+#endif // !CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 #else
 
 static int OnOtCliOutput(const char * aBuf, uint16_t aBufLength, void * aContext)
@@ -190,13 +190,13 @@ void cmd_otcli_init()
 {
 #if CHIP_ENABLE_OPENTHREAD
 #if CHIP_TARGET_STYLE_EMBEDDED
-#if !defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
+#if !CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 #if OPENTHREAD_API_VERSION >= 85
     otCliInit(otInstanceInitSingle(), &OnOtCliOutput, NULL);
 #else
     otCliConsoleInit(otInstanceInitSingle(), &OnOtCliOutput, NULL);
 #endif // OPENTHREAD_API_VERSION >= 85
-#endif // !defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
+#endif // !CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 #endif // CHIP_TARGET_STYLE_EMBEDDED
 
     // Register the root otcli command with the top-level shell.

--- a/examples/shell/shell_common/cmd_otcli.cpp
+++ b/examples/shell/shell_common/cmd_otcli.cpp
@@ -40,11 +40,13 @@
 #include <openthread/link.h>
 #include <openthread/thread.h>
 #if OPENTHREAD_API_VERSION >= 85
+#if defined(__ZEPHYR__)
 #ifndef SHELL_OTCLI_TX_BUFFER_SIZE
 #define SHELL_OTCLI_TX_BUFFER_SIZE 1024
 #endif
 static char sTxBuffer[SHELL_OTCLI_TX_BUFFER_SIZE];
 static constexpr uint16_t sTxLength = SHELL_OTCLI_TX_BUFFER_SIZE;
+#endif // defined(__ZEPHYR__)
 #endif
 #else
 #include <sys/types.h>
@@ -163,6 +165,7 @@ static const shell_command_t cmds_otcli_root = { &cmd_otcli_dispatch, "otcli", "
 
 #if CHIP_TARGET_STYLE_EMBEDDED
 #if OPENTHREAD_API_VERSION >= 85
+#if defined(__ZEPHYR__)
 static int OnOtCliOutput(void * aContext, const char * aFormat, va_list aArguments)
 {
     int rval = vsnprintf(sTxBuffer, sTxLength, aFormat, aArguments);
@@ -171,7 +174,9 @@ static int OnOtCliOutput(void * aContext, const char * aFormat, va_list aArgumen
 exit:
     return rval;
 }
+#endif // __ZEPHYR__
 #else
+
 static int OnOtCliOutput(const char * aBuf, uint16_t aBufLength, void * aContext)
 {
     return streamer_write(streamer_get(), aBuf, aBufLength);
@@ -185,12 +190,14 @@ void cmd_otcli_init()
 {
 #if CHIP_ENABLE_OPENTHREAD
 #if CHIP_TARGET_STYLE_EMBEDDED
+#if defined(__ZEPHYR__)
 #if OPENTHREAD_API_VERSION >= 85
     otCliInit(otInstanceInitSingle(), &OnOtCliOutput, NULL);
 #else
     otCliConsoleInit(otInstanceInitSingle(), &OnOtCliOutput, NULL);
-#endif
-#endif
+#endif // OPENTHREAD_API_VERSION >= 85
+#endif // __ZEPHYR__
+#endif // CHIP_TARGET_STYLE_EMBEDDED
 
     // Register the root otcli command with the top-level shell.
     Engine::Root().RegisterCommands(&cmds_otcli_root, 1);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1582,7 +1582,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstanc
         VerifyOrExit(otInst != NULL, err = MapOpenThreadError(OT_ERROR_FAILED));
     }
 
-#if !defined(__ZEPHYR__) && !defined(PW_RPC_ENABLED) && (defined(ENABLE_CHIP_SHELL) || CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
+#if !defined(PW_RPC_ENABLED) && defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
     otAppCliInit(otInst);
 #endif
 

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -68,7 +68,7 @@
 
 extern "C" void otSysProcessDrivers(otInstance * aInstance);
 
-#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
+#if CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
 extern "C" void otAppCliInit(otInstance * aInstance);
 #endif
 
@@ -1582,7 +1582,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstanc
         VerifyOrExit(otInst != NULL, err = MapOpenThreadError(OT_ERROR_FAILED));
     }
 
-#if !defined(PW_RPC_ENABLED) && defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
+#if !defined(PW_RPC_ENABLED) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     otAppCliInit(otInst);
 #endif
 

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1582,7 +1582,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstanc
         VerifyOrExit(otInst != NULL, err = MapOpenThreadError(OT_ERROR_FAILED));
     }
 
-#if !defined(__ZEPHYR__) && !defined(ENABLE_CHIP_SHELL) && !defined(PW_RPC_ENABLED) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
+#if !defined(__ZEPHYR__) && !defined(PW_RPC_ENABLED) && (defined(ENABLE_CHIP_SHELL) || CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
     otAppCliInit(otInst);
 #endif
 

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -68,7 +68,7 @@
 
 extern "C" void otSysProcessDrivers(otInstance * aInstance);
 
-#if CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
+#if defined(CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
 extern "C" void otAppCliInit(otInstance * aInstance);
 #endif
 


### PR DESCRIPTION
#### Problem
When the ot-cli was enabled within the matter shell, devices would not register their SRP service with the OTBR and the commisionning woudl fail

#### Change overview
For non zephyr devices, enable the ot-cli inside the openthread init function

#### Testing
Manual tests with efr32 MG12 and MG24 to validate the commissioning works with and without the matter shell
