### PR TITLE
Fix detached thread resource leak if Matter stack is stopped and then…

### DIFF
--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -33,8 +33,6 @@
 #include <platform/PlatformManager.h>
 #include <platform/internal/GenericPlatformManagerImpl_POSIX.cpp>
 
-#include <thread>
-
 #include <arpa/inet.h>
 #include <dirent.h>
 #include <errno.h>
@@ -175,6 +173,9 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 {
     CHIP_ERROR err;
     struct sigaction action;
+#if CHIP_WITH_GIO
+    GError * error = nullptr;
+#endif
 
     memset(&action, 0, sizeof(action));
     action.sa_handler = SignalHandler;
@@ -183,20 +184,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     sigaction(SIGUSR1, &action, NULL);
     sigaction(SIGUSR2, &action, NULL);
     sigaction(SIGTSTP, &action, NULL);
-
-#if CHIP_WITH_GIO
-    GError * error = nullptr;
-
-    this->mpGDBusConnection = UniqueGDBusConnection(g_bus_get_sync(G_BUS_TYPE_SYSTEM, nullptr, &error));
-
-    std::thread gdbusThread(GDBus_Thread);
-    gdbusThread.detach();
-#endif
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    std::thread wifiIPThread(WiFIIPChangeListener);
-    wifiIPThread.detach();
-#endif
 
     // Initialize the configuration system.
     err = Internal::PosixConfig::Init();
@@ -210,6 +197,15 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     SuccessOrExit(err);
 
     mStartTime = System::SystemClock().GetMonotonicTimestamp();
+
+#if CHIP_WITH_GIO
+    this->mpGDBusConnection = UniqueGDBusConnection(g_bus_get_sync(G_BUS_TYPE_SYSTEM, nullptr, &error));
+    mGdbusThread            = std::thread(GDBus_Thread);
+#endif
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    mWifiIPThread = std::thread(WiFIIPChangeListener);
+#endif
 
 exit:
     return err;
@@ -236,6 +232,22 @@ CHIP_ERROR PlatformManagerImpl::_Shutdown()
     {
         ChipLogError(DeviceLayer, "Failed to get current uptime since the Node’s last reboot");
     }
+
+#if CHIP_WITH_GIO
+    if (mGdbusThread.joinable())
+    {
+        pthread_cancel(mGdbusThread.native_handle());
+        mGdbusThread.join();
+    }
+#endif
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    if (mWifiIPThread.joinable())
+    {
+        pthread_cancel(mWifiIPThread.native_handle());
+        mWifiIPThread.join();
+    }
+#endif
 
     return Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>::_Shutdown();
 }

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -217,6 +217,7 @@ exit:
 
 CHIP_ERROR PlatformManagerImpl::_Shutdown()
 {
+    CHIP_ERROR err;
     uint64_t upTime = 0;
 
     if (GetDiagnosticDataProvider().GetUpTime(upTime) == CHIP_NO_ERROR)
@@ -237,6 +238,8 @@ CHIP_ERROR PlatformManagerImpl::_Shutdown()
         ChipLogError(DeviceLayer, "Failed to get current uptime since the Node’s last reboot");
     }
 
+    err = Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>::_Shutdown();
+
 #if CHIP_WITH_GIO
     if (pthread_cancel(mGdbusThreadHandle) != 0)
     {
@@ -251,7 +254,7 @@ CHIP_ERROR PlatformManagerImpl::_Shutdown()
     }
 #endif
 
-    return Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>::_Shutdown();
+    return err;
 }
 
 CHIP_ERROR PlatformManagerImpl::_GetFixedLabelList(

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -30,6 +30,8 @@
 #include <gio/gio.h>
 #endif
 
+#include <thread>
+
 namespace chip {
 namespace DeviceLayer {
 
@@ -97,6 +99,12 @@ private:
     };
     using UniqueGDBusConnection = std::unique_ptr<GDBusConnection, GDBusConnectionDeleter>;
     UniqueGDBusConnection mpGDBusConnection;
+
+    std::thread mGdbusThread;
+#endif
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    std::thread mWifiIPThread;
 #endif
 };
 

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -100,11 +100,11 @@ private:
     using UniqueGDBusConnection = std::unique_ptr<GDBusConnection, GDBusConnectionDeleter>;
     UniqueGDBusConnection mpGDBusConnection;
 
-    std::thread mGdbusThread;
+    std::thread::native_handle_type mGdbusThreadHandle;
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    std::thread mWifiIPThread;
+    std::thread::native_handle_type mWifiIPThreadHandle;
 #endif
 };
 


### PR DESCRIPTION
… restarted

#### Problem
What is being fixed?  Examples:
* Currently, we don't maintain a reference to a working thread after the thread has been detached, this causes the thread resource is leaked when the Matter stack is stopped and then restarted.
* Fixes #9212

#### Change overview
Linux platform retain a reference to the spawned working threads
The _Shutdown method signal to the the spawned working threads and then join them

#### Testing
How was this tested? (at least one bullet point required)
* Start the stop chip-lighting-app and confirm thread 'GDBus_Thread' and 'WiFIIPChangeListener' are cleaned during shutdown process
