### PR TITLE
[all-clusters-app] Allow more subscriptions opened at the same time (…

### DIFF
--- a/config/standalone/CHIPProjectConfig.h
+++ b/config/standalone/CHIPProjectConfig.h
@@ -73,9 +73,9 @@
 // Default of 8 ECs is not sufficient for some of the unit tests
 // that try to validate multiple simultaneous interactions.
 //
-#define CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS 16
+#define CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS 24
 
-#define CHIP_IM_MAX_NUM_READ_HANDLER 5
+#define CHIP_IM_MAX_NUM_READ_HANDLER 8
 
 #define CONFIG_IM_BUILD_FOR_UNIT_TEST 1
 

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -353,10 +353,7 @@ void TestReadInteraction::TestReadAttributeTimeout(nlTestSuite * apSuite, void *
 
     NL_TEST_ASSERT(apSuite, !onSuccessCbInvoked && onFailureCbInvoked);
 
-    //
-    // TODO: Figure out why I cannot enable this line below.
-    //
-    // NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 1);
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 1);
 
     ctx.DrainAndServiceIO();
     app::InteractionModelEngine::GetInstance()->GetReportingEngine().Run();
@@ -434,10 +431,7 @@ void TestReadInteraction::TestReadHandler_MultipleSubscriptions(nlTestSuite * ap
 
     app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 
-    //
-    // TODO: Figure out why I cannot enable this line below.
-    //
-    // NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
 }
 
 void TestReadInteraction::TestReadHandler_MultipleSubscriptionsWithDataVersionFilter(nlTestSuite * apSuite, void * apContext)
@@ -498,10 +492,7 @@ void TestReadInteraction::TestReadHandler_MultipleSubscriptionsWithDataVersionFi
 
     app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 
-    //
-    // TODO: Figure out why I cannot enable this line below.
-    //
-    // NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
 }
 
 void TestReadInteraction::TestReadHandlerResourceExhaustion_MultipleSubscriptions(nlTestSuite * apSuite, void * apContext)
@@ -565,10 +556,7 @@ void TestReadInteraction::TestReadHandlerResourceExhaustion_MultipleSubscription
     app::InteractionModelEngine::GetInstance()->SetHandlerCapacity(-1);
     app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 
-    //
-    // TODO: Figure out why I cannot enable this line below.
-    //
-    // NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
 }
 
 void TestReadInteraction::TestReadHandlerResourceExhaustion_MultipleReads(nlTestSuite * apSuite, void * apContext)
@@ -618,10 +606,7 @@ void TestReadInteraction::TestReadHandlerResourceExhaustion_MultipleReads(nlTest
     NL_TEST_ASSERT(apSuite, numSuccessCalls == 0);
     NL_TEST_ASSERT(apSuite, numFailureCalls == 1);
 
-    //
-    // TODO: Figure out why I cannot enable this line below.
-    //
-    // NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
 }
 
 void TestReadInteraction::TestReadFabricScopedWithoutFabricFilter(nlTestSuite * apSuite, void * apContext)
@@ -740,11 +725,11 @@ const nlTest sTests[] =
     NL_TEST_DEF("TestReadAttributeError", TestReadInteraction::TestReadAttributeError),
     NL_TEST_DEF("TestReadFabricScopedWithoutFabricFilter", TestReadInteraction::TestReadFabricScopedWithoutFabricFilter),
     NL_TEST_DEF("TestReadFabricScopedWithFabricFilter", TestReadInteraction::TestReadFabricScopedWithFabricFilter),
-    NL_TEST_DEF("TestReadAttributeTimeout", TestReadInteraction::TestReadAttributeTimeout),
     NL_TEST_DEF("TestReadHandler_MultipleSubscriptions", TestReadInteraction::TestReadHandler_MultipleSubscriptions),
     NL_TEST_DEF("TestReadHandler_MultipleSubscriptionsWithDataVersionFilter", TestReadInteraction::TestReadHandler_MultipleSubscriptionsWithDataVersionFilter),
     NL_TEST_DEF("TestReadHandlerResourceExhaustion_MultipleSubscriptions", TestReadInteraction::TestReadHandlerResourceExhaustion_MultipleSubscriptions),
     NL_TEST_DEF("TestReadHandlerResourceExhaustion_MultipleReads", TestReadInteraction::TestReadHandlerResourceExhaustion_MultipleReads),
+    NL_TEST_DEF("TestReadAttributeTimeout", TestReadInteraction::TestReadAttributeTimeout),
     NL_TEST_SENTINEL()
 };
 // clang-format on


### PR DESCRIPTION
…second attempts)

#### Problem
With https://github.com/project-chip/connectedhomeip/pull/15029 I have raised the number of read handlers in order to try to fight a random failure on the `Darwin / Build Darwin` CI task. Apparently I have not be aggressive enough. 
So this is a second attempt at trying to augment the number of available handlers. I have also removed a few TODOs from the tests by just reordering `TestReadAttributeTimeout` which is not cleaning up properly the exchange contexts - one would need to figure out why...

#### Change overview
 * Augment the number of  read handlers and exchange contexts available for the standalone config
 * Remove a few TODOs from `TestRead.cpp`
 