### PR TITLE
Prevent ExchangeMgr::Shutdown to be called twice

### DIFF
--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -94,6 +94,8 @@ CHIP_ERROR ExchangeManager::Init(SessionManager * sessionManager)
 
 CHIP_ERROR ExchangeManager::Shutdown()
 {
+    VerifyOrReturnError(mState == State::kState_Initialized, CHIP_ERROR_INCORRECT_STATE);
+
     mReliableMessageMgr.Shutdown();
 
     if (mSessionManager != nullptr)


### PR DESCRIPTION
#### Problem

While playing with signal handlers, I accidentally tried to call two times `ExchangeManager::Shutdown`, hopefully Asan told me it was bad...

#### Change overview
 * returns a `CHIP_ERROR_INCORRECT_STATE` if the exchange mgr is not initialized already
 