### PR TITLE
[ESP32]: Fix initialization order of ota-requestor and ota-provider apps

### DIFF
--- a/examples/ota-requestor-app/esp32/main/main.cpp
+++ b/examples/ota-requestor-app/esp32/main/main.cpp
@@ -69,6 +69,12 @@ static void InitServer(intptr_t context)
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 
     sWiFiNetworkCommissioningInstance.Init();
+
+    SetRequestorInstance(&gRequestorCore);
+    gRequestorCore.Init(&(Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gImageProcessor.SetOTADownloader(&gDownloader);
+    gDownloader.SetImageProcessorDelegate(&gImageProcessor);
+    gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 }
 
 } // namespace
@@ -106,10 +112,4 @@ extern "C" void app_main()
     }
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
-
-    SetRequestorInstance(&gRequestorCore);
-    gRequestorCore.Init(&(Server::GetInstance()), &gRequestorUser, &gDownloader);
-    gImageProcessor.SetOTADownloader(&gDownloader);
-    gDownloader.SetImageProcessorDelegate(&gImageProcessor);
-    gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 }

--- a/src/platform/ESP32/OTAImageProcessorImpl.cpp
+++ b/src/platform/ESP32/OTAImageProcessorImpl.cpp
@@ -160,7 +160,7 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
 
     ByteSpan block = ByteSpan(imageProcessor->mBlock.data(), imageProcessor->mBlock.size());
 
-    CHIP_ERROR error = imageProcessor->ProcessBlock(block);
+    CHIP_ERROR error = imageProcessor->ProcessHeader(block);
     if (error != CHIP_NO_ERROR)
     {
         ESP_LOGE(TAG, "Failed to process OTA image header");


### PR DESCRIPTION
#### Problem
This is the regression introduces in #14946 while fixing the network commissioning.

* Fixes #15153
* Fixes #15154

#### Change overview
* Changed the initialization order in ESP32 ota-requestor and ota-provider app.
* Fixed the wrong API being called in ESP32 OTA image processor implementation

#### Testing
Tested manually
* ESP32 ota-requestor and Linux ota-provider
* ESP32 ota-provider and Linux ota-requestor