### PR TITLE
[Fix] Add missing return cause after AddStatus

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -279,6 +279,7 @@ void Instance::HandleConnectNetwork(HandlerContext & ctx, const Commands::Connec
     if (req.networkID.size() > DeviceLayer::NetworkCommissioning::kMaxNetworkIDLen)
     {
         ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::InvalidValue);
+        return;
     }
 
     mConnectingNetworkIDLen = static_cast<uint8_t>(req.networkID.size());

--- a/src/controller/python/test/test_scripts/network_commissioning.py
+++ b/src/controller/python/test/test_scripts/network_commissioning.py
@@ -82,7 +82,7 @@ class NetworkCommissioningTests:
             res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req)
             raise AssertionError(f"Failure expected but got response {res}")
         except chip.interaction_model.InteractionModelError as ex:
-            logger.info(f"Recevied {ex} from server.")
+            logger.info(f"Received {ex} from server.")
 
         logger.info(f"Finished negative test cases.")
 

--- a/src/controller/python/test/test_scripts/network_commissioning.py
+++ b/src/controller/python/test/test_scripts/network_commissioning.py
@@ -70,6 +70,22 @@ class NetworkCommissioningTests:
         logger.info(f"Got values: {values}")
         return values
 
+    async def test_negative(self, endpointId):
+        logger.info(
+            f"Running negative test cases for NetworkCommissioning cluster on endpoint {endpointId}")
+
+        try:
+            logger.info(
+                f"1. Send ConnectNetwork command with a illegal network id")
+            req = Clusters.NetworkCommissioning.Commands.ConnectNetwork(
+                networkID=b'0' * 254, breadcrumb=0)
+            res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req)
+            raise AssertionError(f"Failure expected but got response {res}")
+        except chip.interaction_model.InteractionModelError as ex:
+            logger.info(f"Recevied {ex} from server.")
+
+        logger.info(f"Finished negative test cases.")
+
     async def test_wifi(self, endpointId):
         logger.info(f"Get basic information of the endpoint")
         res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[
@@ -290,10 +306,12 @@ class NetworkCommissioningTests:
                 if clus.featureMap == WIFI_NETWORK_FEATURE_MAP:
                     logger.info(
                         f"Endpoint {endpoint} is configured as WiFi network, run WiFi commissioning test.")
+                    await self.test_negative(endpoint)
                     await self.test_wifi(endpoint)
                 elif clus.featureMap == THREAD_NETWORK_FEATURE_MAP:
                     logger.info(
                         f"Endpoint {endpoint} is configured as Thread network, run Thread commissioning test.")
+                    await self.test_negative(endpoint)
                     await self.test_thread(endpoint)
                 else:
                     logger.info(


### PR DESCRIPTION
#### Problem
The code added in PR https://github.com/project-chip/connectedhomeip/pull/15125 will happily do:

mConnectingNetworkIDLen = static_cast<uint8_t>(req.networkID.size());
memcpy(mConnectingNetworkID, req.networkID.data(), mConnectingNetworkIDLen);
even if mConnectingNetworkIDLen (which is provided on the wire here) is larger than the size of the mConnectingNetworkID buffer.

#### Change overview
- Adds the missing `return`

#### Testing
- Adds a simple negative test case in cirque since we need a real network driver here.
