### PR TITLE
Fix backwards string check in ESP32 all-clustes-app CHIPDeviceManager.

### DIFF
--- a/examples/all-clusters-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/all-clusters-app/esp32/main/CHIPDeviceManager.cpp
@@ -32,6 +32,8 @@
 #include <lib/support/ErrorStr.h>
 #include <setup_payload/SetupPayload.h>
 
+#include "esp_log.h"
+
 using namespace ::chip;
 
 namespace chip {
@@ -101,7 +103,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 {
     TaskHandle_t task = xTaskGetCurrentTaskHandle();
     const char * name = pcTaskGetName(task);
-    if (!strcmp(name, "CHIP"))
+    if (strcmp(name, "CHIP"))
     {
         ESP_LOGE("all-clusters-app", "Attribute changed on non-Matter task '%s'\n", name);
     }


### PR DESCRIPTION
Rookie mistake, getting confused about strcmp return value truthiness.

#### Problem
We want to enter the `if` if the string is _not_ "CHIP".  But we are entering if it _is_ "CHIP".

#### Change overview
Fix the condition.

#### Testing
Ran esp32 all-clusters-app, verified the log does not normally show up.