### PR TITLE
Replace delegate/state table size macro with constexpr

### DIFF
--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -42,15 +42,15 @@ using namespace chip::AppPlatform;
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 using chip::app::Clusters::AccountLogin::Delegate;
 
-#define ACCOUNT_LOGIN_DELEGATE_TABLE_SIZE                                                                                          \
-    (EMBER_AF_ACCOUNT_LOGIN_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+static constexpr size_t kAccountLoginDeletageTableSize =
+    EMBER_AF_ACCOUNT_LOGIN_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 // -----------------------------------------------------------------------------
 // Delegate Implementation
 
 namespace {
 
-Delegate * gDelegateTable[ACCOUNT_LOGIN_DELEGATE_TABLE_SIZE] = { nullptr };
+Delegate * gDelegateTable[kAccountLoginDeletageTableSize] = { nullptr };
 
 Delegate * GetDelegate(EndpointId endpoint)
 {

--- a/src/app/clusters/application-basic-server/application-basic-server.cpp
+++ b/src/app/clusters/application-basic-server/application-basic-server.cpp
@@ -42,8 +42,8 @@ using namespace chip::app::Clusters::ApplicationBasic;
 using namespace chip::AppPlatform;
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
-#define APPLICATION_BASIC_DELEGATE_TABLE_SIZE                                                                                      \
-    (EMBER_AF_APPLICATION_BASIC_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+static constexpr size_t kApplicationBasicDelegateTableSize =
+    EMBER_AF_APPLICATION_BASIC_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 // -----------------------------------------------------------------------------
 // Delegate Implementation
@@ -52,7 +52,7 @@ using chip::app::Clusters::ApplicationBasic::Delegate;
 
 namespace {
 
-Delegate * gDelegateTable[APPLICATION_BASIC_DELEGATE_TABLE_SIZE] = { nullptr };
+Delegate * gDelegateTable[kApplicationBasicDelegateTableSize] = { nullptr };
 
 Delegate * GetDelegate(EndpointId endpoint)
 {

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -45,8 +45,8 @@ using namespace chip::AppPlatform;
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 using namespace chip::Uint8;
 
-#define APPLICATION_LAUNCHER_DELEGATE_TABLE_SIZE                                                                                   \
-    (EMBER_AF_APPLICATION_LAUNCHER_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+static constexpr size_t kApplicationLauncherDelegateTableSize =
+    EMBER_AF_APPLICATION_LAUNCHER_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 // -----------------------------------------------------------------------------
 // Delegate Implementation
@@ -57,7 +57,7 @@ using ApplicationStatusEnum = app::Clusters::ApplicationBasic::ApplicationStatus
 
 namespace {
 
-Delegate * gDelegateTable[APPLICATION_LAUNCHER_DELEGATE_TABLE_SIZE] = { nullptr };
+Delegate * gDelegateTable[kApplicationLauncherDelegateTableSize] = { nullptr };
 
 Delegate * GetDelegate(EndpointId endpoint)
 {

--- a/src/app/clusters/audio-output-server/audio-output-server.cpp
+++ b/src/app/clusters/audio-output-server/audio-output-server.cpp
@@ -35,8 +35,8 @@
 using namespace chip;
 using namespace chip::app::Clusters::AudioOutput;
 
-#define AUDIO_OUTPUT_DELEGATE_TABLE_SIZE                                                                                           \
-    (EMBER_AF_AUDIO_OUTPUT_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+static constexpr size_t kAudioOutputDelegateTableSize =
+    EMBER_AF_AUDIO_OUTPUT_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 // -----------------------------------------------------------------------------
 // Delegate Implementation
@@ -45,7 +45,7 @@ using chip::app::Clusters::AudioOutput::Delegate;
 
 namespace {
 
-Delegate * gDelegateTable[AUDIO_OUTPUT_DELEGATE_TABLE_SIZE] = { nullptr };
+Delegate * gDelegateTable[kAudioOutputDelegateTableSize] = { nullptr };
 
 Delegate * GetDelegate(EndpointId endpoint)
 {

--- a/src/app/clusters/channel-server/channel-server.cpp
+++ b/src/app/clusters/channel-server/channel-server.cpp
@@ -57,7 +57,8 @@ using namespace chip::app::Clusters::Channel;
 using namespace chip::AppPlatform;
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
-#define CHANNEL_DELEGATE_TABLE_SIZE (EMBER_AF_CHANNEL_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+static constexpr size_t kChannelDelegateTableSize =
+    EMBER_AF_CHANNEL_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 // -----------------------------------------------------------------------------
 // Delegate Implementation
@@ -66,7 +67,7 @@ using chip::app::Clusters::Channel::Delegate;
 
 namespace {
 
-Delegate * gDelegateTable[CHANNEL_DELEGATE_TABLE_SIZE] = { nullptr };
+Delegate * gDelegateTable[kChannelDelegateTableSize] = { nullptr };
 
 Delegate * GetDelegate(EndpointId endpoint)
 {

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -62,8 +62,8 @@ using namespace chip::app::Clusters::ContentLauncher;
 using namespace chip::AppPlatform;
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
-#define CONTENT_LAUNCH_DELEGATE_TABLE_SIZE                                                                                         \
-    (EMBER_AF_CONTENT_LAUNCH_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+static constexpr size_t kContentLaunchDelegateTableSize =
+    EMBER_AF_CONTENT_LAUNCH_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 // -----------------------------------------------------------------------------
 // Delegate Implementation
@@ -72,7 +72,7 @@ using chip::app::Clusters::ContentLauncher::Delegate;
 
 namespace {
 
-Delegate * gDelegateTable[EMBER_AF_CONTENT_LAUNCH_CLUSTER_SERVER_ENDPOINT_COUNT] = { nullptr };
+Delegate * gDelegateTable[kContentLaunchDelegateTableSize] = { nullptr };
 
 Delegate * GetDelegate(EndpointId endpoint)
 {

--- a/src/app/clusters/keypad-input-server/keypad-input-server.cpp
+++ b/src/app/clusters/keypad-input-server/keypad-input-server.cpp
@@ -39,8 +39,8 @@ using namespace chip::app::Clusters::KeypadInput;
 using namespace chip::AppPlatform;
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
-#define KEYPAD_INPUT_DELEGATE_TABLE_SIZE                                                                                           \
-    (EMBER_AF_KEYPAD_INPUT_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+static constexpr size_t kKeypadInputDelegateTableSize =
+    EMBER_AF_KEYPAD_INPUT_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 // -----------------------------------------------------------------------------
 // Delegate Implementation
@@ -49,7 +49,7 @@ using chip::app::Clusters::KeypadInput::Delegate;
 
 namespace {
 
-Delegate * gDelegateTable[KEYPAD_INPUT_DELEGATE_TABLE_SIZE] = { nullptr };
+Delegate * gDelegateTable[kKeypadInputDelegateTableSize] = { nullptr };
 
 Delegate * GetDelegate(EndpointId endpoint)
 {

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -89,8 +89,8 @@ static bool areStartUpLevelControlServerAttributesNonVolatile(EndpointId endpoin
 #define STARTUP_CURRENT_LEVEL_USE_DEVICE_MINIMUM 0x00
 #define STARTUP_CURRENT_LEVEL_USE_PREVIOUS_LEVEL 0xFF
 
-#define LEVEL_CONTROL_STATE_TABLE_SIZE                                                                                             \
-    (EMBER_AF_LEVEL_CONTROL_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+static constexpr size_t kLevelControlStateTableSize =
+    EMBER_AF_LEVEL_CONTROL_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 typedef struct
 {
@@ -107,7 +107,7 @@ typedef struct
     uint32_t elapsedTimeMs;
 } EmberAfLevelControlState;
 
-static EmberAfLevelControlState stateTable[LEVEL_CONTROL_STATE_TABLE_SIZE];
+static EmberAfLevelControlState stateTable[kLevelControlStateTableSize];
 
 static EmberAfLevelControlState * getState(EndpointId endpoint);
 

--- a/src/app/clusters/low-power-server/low-power-server.cpp
+++ b/src/app/clusters/low-power-server/low-power-server.cpp
@@ -33,7 +33,8 @@
 using namespace chip;
 using namespace chip::app::Clusters::LowPower;
 
-#define LOW_POWER_DELEGATE_TABLE_SIZE (EMBER_AF_LOW_POWER_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+static constexpr size_t kLowPowerDelegateTableSize =
+    EMBER_AF_LOW_POWER_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 // -----------------------------------------------------------------------------
 // Delegate Implementation
@@ -42,7 +43,7 @@ using chip::app::Clusters::LowPower::Delegate;
 
 namespace {
 
-Delegate * gDelegateTable[LOW_POWER_DELEGATE_TABLE_SIZE] = { nullptr };
+Delegate * gDelegateTable[kLowPowerDelegateTableSize] = { nullptr };
 
 Delegate * GetDelegate(EndpointId endpoint)
 {

--- a/src/app/clusters/media-input-server/media-input-server.cpp
+++ b/src/app/clusters/media-input-server/media-input-server.cpp
@@ -35,8 +35,8 @@ using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::MediaInput;
 
-#define MEDIA_INPUT_DELEGATE_TABLE_SIZE                                                                                            \
-    (EMBER_AF_MEDIA_INPUT_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+static constexpr size_t kMediaInputDelegateTableSize =
+    EMBER_AF_MEDIA_INPUT_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 // -----------------------------------------------------------------------------
 // Delegate Implementation
@@ -45,7 +45,7 @@ using chip::app::Clusters::MediaInput::Delegate;
 
 namespace {
 
-Delegate * gDelegateTable[MEDIA_INPUT_DELEGATE_TABLE_SIZE] = { nullptr };
+Delegate * gDelegateTable[kMediaInputDelegateTableSize] = { nullptr };
 
 Delegate * GetDelegate(EndpointId endpoint)
 {

--- a/src/app/clusters/media-playback-server/media-playback-server.cpp
+++ b/src/app/clusters/media-playback-server/media-playback-server.cpp
@@ -42,8 +42,8 @@ using namespace chip::app::Clusters::MediaPlayback;
 using namespace chip::AppPlatform;
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
-#define MEDIA_PLAYBACK_DELEGATE_TABLE_SIZE                                                                                         \
-    (EMBER_AF_MEDIA_PLAYBACK_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+static constexpr size_t kMediaPlaybackDelegateTableSize =
+    EMBER_AF_MEDIA_PLAYBACK_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 // -----------------------------------------------------------------------------
 // Delegate Implementation
@@ -52,7 +52,7 @@ using chip::app::Clusters::MediaPlayback::Delegate;
 
 namespace {
 
-Delegate * gDelegateTable[MEDIA_PLAYBACK_DELEGATE_TABLE_SIZE] = { nullptr };
+Delegate * gDelegateTable[kMediaPlaybackDelegateTableSize] = { nullptr };
 
 Delegate * GetDelegate(EndpointId endpoint)
 {

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -33,8 +33,8 @@ using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::OtaSoftwareUpdateProvider;
 using chip::app::Clusters::OTAProviderDelegate;
 
-#define OTA_PROVIDER_DELEGATE_TABLE_SIZE                                                                                           \
-    (EMBER_AF_OTA_PROVIDER_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+static constexpr size_t kOtaProviderDelegateTableSize =
+    EMBER_AF_OTA_PROVIDER_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 namespace {
 constexpr size_t kLocationLen          = 2;   // The expected length of the location parameter in QueryImage
@@ -42,7 +42,7 @@ constexpr size_t kMaxMetadataLen       = 512; // The maximum length of Metadata 
 constexpr size_t kUpdateTokenMaxLength = 32;  // The expected length of the Update Token parameter used in multiple commands
 constexpr size_t kUpdateTokenMinLength = 8;   // The expected length of the Update Token parameter used in multiple commands
 
-OTAProviderDelegate * gDelegateTable[OTA_PROVIDER_DELEGATE_TABLE_SIZE] = { nullptr };
+OTAProviderDelegate * gDelegateTable[kOtaProviderDelegateTableSize] = { nullptr };
 
 OTAProviderDelegate * GetDelegate(EndpointId endpoint)
 {

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -42,8 +42,8 @@ using namespace chip::app::Clusters::TargetNavigator;
 using namespace chip::AppPlatform;
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
-#define TARGET_NAVIGATOR_DELEGATE_TABLE_SIZE                                                                                       \
-    (EMBER_AF_TARGET_NAVIGATOR_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+static constexpr size_t kTargetNavigatorDelegateTableSize =
+    EMBER_AF_TARGET_NAVIGATOR_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 // -----------------------------------------------------------------------------
 // Delegate Implementation
@@ -52,7 +52,7 @@ using chip::app::Clusters::TargetNavigator::Delegate;
 
 namespace {
 
-Delegate * gDelegateTable[TARGET_NAVIGATOR_DELEGATE_TABLE_SIZE] = { nullptr };
+Delegate * gDelegateTable[kTargetNavigatorDelegateTableSize] = { nullptr };
 
 Delegate * GetDelegate(EndpointId endpoint)
 {

--- a/src/app/clusters/wake-on-lan-server/wake-on-lan-server.cpp
+++ b/src/app/clusters/wake-on-lan-server/wake-on-lan-server.cpp
@@ -36,8 +36,8 @@ using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::WakeOnLan;
 
-#define WAKE_ON_LAN_DELEGATE_TABLE_SIZE                                                                                            \
-    (EMBER_AF_WAKE_ON_LAN_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+static constexpr size_t kWakeOnLanDelegateTableSize =
+    EMBER_AF_WAKE_ON_LAN_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 // -----------------------------------------------------------------------------
 // Delegate Implementation
@@ -46,7 +46,7 @@ using chip::app::Clusters::WakeOnLan::Delegate;
 
 namespace {
 
-Delegate * gDelegateTable[WAKE_ON_LAN_DELEGATE_TABLE_SIZE] = { nullptr };
+Delegate * gDelegateTable[kWakeOnLanDelegateTableSize] = { nullptr };
 
 Delegate * GetDelegate(EndpointId endpoint)
 {


### PR DESCRIPTION
#### Problem
Need to replace the in delegate/state table size marco with C++ style constexpr.

#### Change overview
Using `constexpr` in the clusters file for delegate/state table size.

#### Testing
Format changes, no additional test required.