### PR TITLE
[mac] Turn on TestTCP

### DIFF
--- a/src/inet/TCPEndPointImplSockets.cpp
+++ b/src/inet/TCPEndPointImplSockets.cpp
@@ -1134,7 +1134,12 @@ CHIP_ERROR TCPEndPointImplSockets::CheckConnectionProgress(bool & isProgressing)
 
     // Fetch the bytes pending successful transmission in the TCP out queue.
 
+#ifdef __APPLE__
+    socklen_t len = sizeof(currPendingBytesRaw);
+    if (getsockopt(mSocket, SOL_SOCKET, SO_NWRITE, &currPendingBytesRaw, &len) < 0)
+#else
     if (ioctl(mSocket, TIOCOUTQ, &currPendingBytesRaw) < 0)
+#endif
     {
         return CHIP_ERROR_POSIX(errno);
     }

--- a/src/transport/raw/tests/BUILD.gn
+++ b/src/transport/raw/tests/BUILD.gn
@@ -42,11 +42,8 @@ chip_test_suite("tests") {
   test_sources = [
     "TestMessageHeader.cpp",
     "TestPeerAddress.cpp",
+    "TestTCP.cpp",
   ]
-
-  if (current_os != "mac") {
-    test_sources += [ "TestTCP.cpp" ]
-  }
 
   public_deps = [
     ":helpers",


### PR DESCRIPTION
#### Problem

`TestTCP` is disabled on Mac. While working on #15138 I end up fixing it to validate that it works.
It was failing because the code that fetch the pending bytes uses `TIOCOUTQ` which is not the way to go on Mac.

fix #2721

#### Change overview
 * Update `TCPEndPointImpSockets.cpp` to fetch the pending bytes properly on Mac
 * Activate `TestTCP` on Mac

#### Testing
`TestTCP` is running.