### PR TITLE
[YAML] Update some subscriptions maxInterval to be under the timeout for darwin tests

### DIFF
--- a/src/app/tests/suites/TestCluster.yaml
+++ b/src/app/tests/suites/TestCluster.yaml
@@ -2894,7 +2894,7 @@ tests:
       command: "subscribeAttribute"
       attribute: "list_int8u"
       minInterval: 2
-      maxInterval: 10
+      maxInterval: 5
       response:
           value: [1, 2, 3, 4]
 

--- a/src/app/tests/suites/TestSubscribe_OnOff.yaml
+++ b/src/app/tests/suites/TestSubscribe_OnOff.yaml
@@ -35,7 +35,7 @@ tests:
       command: "subscribeAttribute"
       attribute: "OnOff"
       minInterval: 2
-      maxInterval: 10
+      maxInterval: 5
       response:
           value: false
 

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -19,7 +19,7 @@
 const uint16_t kPairingTimeoutInSeconds = 10;
 const uint16_t kAddressResolveTimeoutInSeconds = 10;
 const uint16_t kCASESetupTimeoutInSeconds = 30;
-const uint16_t kTimeoutInSeconds = 5;
+const uint16_t kTimeoutInSeconds = 20;
 const uint64_t nodeId = 0x12344321;
 const uint16_t kDiscriminator = 3840;
 const uint32_t kSetupPINCode = 20202021;

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -36,7 +36,7 @@
 const uint16_t kPairingTimeoutInSeconds = 10;
 const uint16_t kAddressResolveTimeoutInSeconds = 10;
 const uint16_t kCASESetupTimeoutInSeconds = 30;
-const uint16_t kTimeoutInSeconds = 5;
+const uint16_t kTimeoutInSeconds = 20;
 const uint64_t nodeId = 0x12344321;
 const uint16_t kDiscriminator = 3840;
 const uint32_t kSetupPINCode = 20202021;
@@ -36970,7 +36970,7 @@ ResponseHandler test_TestCluster_list_int8u_Reported = nil;
     XCTAssertNotNil(cluster);
 
     uint16_t minIntervalArgument = 2U;
-    uint16_t maxIntervalArgument = 10U;
+    uint16_t maxIntervalArgument = 5U;
     [cluster subscribeAttributeListInt8uWithMinInterval:@(minIntervalArgument)
         maxInterval:@(maxIntervalArgument)
         subscriptionEstablished:^{
@@ -45212,7 +45212,7 @@ ResponseHandler test_TestSubscribe_OnOff_OnOff_Reported = nil;
     XCTAssertNotNil(cluster);
 
     uint16_t minIntervalArgument = 2U;
-    uint16_t maxIntervalArgument = 10U;
+    uint16_t maxIntervalArgument = 5U;
     [cluster subscribeAttributeOnOffWithMinInterval:@(minIntervalArgument)
         maxInterval:@(maxIntervalArgument)
         subscriptionEstablished:^{

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -69895,7 +69895,7 @@ private:
         uint16_t minIntervalArgument;
         minIntervalArgument = 2U;
         uint16_t maxIntervalArgument;
-        maxIntervalArgument = 10U;
+        maxIntervalArgument = 5U;
 
         ReturnErrorOnFailure(cluster.SubscribeAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(
             this, OnSuccessCallback_367, OnFailureCallback_367, minIntervalArgument, maxIntervalArgument,
@@ -81676,7 +81676,7 @@ private:
         uint16_t minIntervalArgument;
         minIntervalArgument = 2U;
         uint16_t maxIntervalArgument;
-        maxIntervalArgument = 10U;
+        maxIntervalArgument = 5U;
 
         ReturnErrorOnFailure(cluster.SubscribeAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(
             this, OnSuccessCallback_3, OnFailureCallback_3, minIntervalArgument, maxIntervalArgument, OnSubscriptionEstablished_3));


### PR DESCRIPTION
#### Problem

The timeout limit for darwin tests is less than the maxInterval of some of the YAML test steps that uses subscriptions. That may triggers some random errors on darwin.

#### Change overview
 * Update the timeouts
