### PR TITLE
Add GetPeerOperationalId API to session interface

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -189,12 +189,11 @@ CHIP_ERROR InteractionModelEngine::ShutdownSubscription(uint64_t aSubscriptionId
     return CHIP_ERROR_KEY_NOT_FOUND;
 }
 
-CHIP_ERROR InteractionModelEngine::ShutdownSubscriptions(FabricIndex aFabricIndex, NodeId aPeerNodeId)
+CHIP_ERROR InteractionModelEngine::ShutdownSubscriptions(OperationalId aPeerOperationalId)
 {
     for (auto * readClient = mpActiveReadClientList; readClient != nullptr; readClient = readClient->GetNextClient())
     {
-        if (readClient->IsSubscriptionType() && readClient->GetFabricIndex() == aFabricIndex &&
-            readClient->GetPeerNodeId() == aPeerNodeId)
+        if (readClient->IsSubscriptionType() && readClient->GetPeerOperationalId() == aPeerOperationalId)
         {
             readClient->Close(CHIP_NO_ERROR);
         }
@@ -273,10 +272,8 @@ CHIP_ERROR InteractionModelEngine::OnReadInitialRequest(Messaging::ExchangeConte
             mReadHandlers.ForEachActiveObject([this, apExchangeContext](ReadHandler * handler) {
                 if (handler->IsFromSubscriber(*apExchangeContext))
                 {
-                    ChipLogProgress(InteractionModel,
-                                    "Deleting previous subscription from NodeId: " ChipLogFormatX64 ", FabricIndex: %u",
-                                    ChipLogValueX64(apExchangeContext->GetSessionHandle()->AsSecureSession()->GetPeerNodeId()),
-                                    apExchangeContext->GetSessionHandle()->GetFabricIndex());
+                    ChipLogProgress(InteractionModel, "Deleting previous subscription from peer: " ChipLogFormatOperationalId,
+                                    ChipLogValueOperationalId(apExchangeContext->GetSessionHandle()->GetPeerOperationalId()));
                     mReadHandlers.ReleaseObject(handler);
                 }
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -108,7 +108,7 @@ public:
      * @retval #CHIP_ERROR_KEY_NOT_FOUND If no active subscription is found.
      * @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR ShutdownSubscriptions(FabricIndex aFabricIndex, NodeId aPeerNodeId);
+    CHIP_ERROR ShutdownSubscriptions(OperationalId aPeerOperationalId);
 
     uint32_t GetNumActiveReadHandlers() const;
     uint32_t GetNumActiveReadHandlers(ReadHandler::InteractionType type) const;

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -299,7 +299,8 @@ void OperationalDeviceProxy::OnSessionReleased()
 
 CHIP_ERROR OperationalDeviceProxy::ShutdownSubscriptions()
 {
-    return app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(mFabricInfo->GetFabricIndex(), GetDeviceId());
+    return app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(
+        OperationalId(GetDeviceId(), mFabricInfo->GetFabricIndex()));
 }
 
 OperationalDeviceProxy::~OperationalDeviceProxy() {}

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -265,8 +265,7 @@ CHIP_ERROR ReadClient::SendReadRequest(ReadPrepareParams & aReadPrepareParams)
     ReturnErrorOnFailure(mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReadRequest, std::move(msgBuf),
                                                     Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse)));
 
-    mPeerNodeId  = aReadPrepareParams.mSessionHolder->AsSecureSession()->GetPeerNodeId();
-    mFabricIndex = aReadPrepareParams.mSessionHolder->GetFabricIndex();
+    mPeerOperationalId = aReadPrepareParams.mSessionHolder->GetPeerOperationalId();
 
     MoveToState(ClientState::AwaitingInitialReport);
 
@@ -705,8 +704,9 @@ void ReadClient::OnLivenessTimeoutCallback(System::Layer * apSystemLayer, void *
     //
     VerifyOrDie(_this->mpImEngine->InActiveReadClientList(_this));
 
-    ChipLogError(DataManagement, "Subscription Liveness timeout with subscription id 0x%" PRIx64 " peer node 0x%" PRIx64,
-                 _this->mSubscriptionId, _this->mPeerNodeId);
+    ChipLogError(DataManagement,
+                 "Subscription Liveness timeout with subscription id 0x%" PRIx64 " peer " ChipLogFormatOperationalId,
+                 _this->mSubscriptionId, ChipLogValueOperationalId(_this->mPeerOperationalId));
 
     // TODO: add a more specific error here for liveness timeout failure to distinguish between other classes of timeouts (i.e
     // response timeouts).
@@ -828,8 +828,7 @@ CHIP_ERROR ReadClient::SendSubscribeRequest(ReadPrepareParams & aReadPreparePara
     ReturnErrorOnFailure(mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::SubscribeRequest, std::move(msgBuf),
                                                     Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse)));
 
-    mPeerNodeId  = aReadPrepareParams.mSessionHolder->AsSecureSession()->GetPeerNodeId();
-    mFabricIndex = aReadPrepareParams.mSessionHolder->GetFabricIndex();
+    mPeerOperationalId = aReadPrepareParams.mSessionHolder->GetPeerOperationalId();
 
     MoveToState(ClientState::AwaitingInitialReport);
 

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -233,8 +233,7 @@ public:
         return mInteractionType == InteractionType::Subscribe ? returnType(mSubscriptionId) : returnType::Missing();
     }
 
-    FabricIndex GetFabricIndex() const { return mFabricIndex; }
-    NodeId GetPeerNodeId() const { return mPeerNodeId; }
+    OperationalId GetPeerOperationalId() const { return mPeerOperationalId; }
     bool IsReadType() { return mInteractionType == InteractionType::Read; }
     bool IsSubscriptionType() const { return mInteractionType == InteractionType::Subscribe; };
 
@@ -335,8 +334,7 @@ private:
     uint16_t mMinIntervalFloorSeconds   = 0;
     uint16_t mMaxIntervalCeilingSeconds = 0;
     uint64_t mSubscriptionId            = 0;
-    NodeId mPeerNodeId                  = kUndefinedNodeId;
-    FabricIndex mFabricIndex            = kUndefinedFabricIndex;
+    OperationalId mPeerOperationalId    = OperationalId::UndefinedOperationalId();
     InteractionType mInteractionType    = InteractionType::Read;
     Timestamp mEventTimestamp;
     EventNumber mEventMin = 0;

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -42,7 +42,7 @@ ReadHandler::ReadHandler(Callback & apCallback, Messaging::ExchangeContext * apE
     mpExchangeMgr           = apExchangeContext->GetExchangeMgr();
     mpExchangeCtx           = apExchangeContext;
     mInteractionType        = aInteractionType;
-    mInitiatorNodeId        = apExchangeContext->GetSessionHandle()->AsSecureSession()->GetPeerNodeId();
+    mInitiatorOperationalId = apExchangeContext->GetSessionHandle()->GetPeerOperationalId();
     mSubjectDescriptor      = apExchangeContext->GetSessionHandle()->GetSubjectDescriptor();
     mLastWrittenEventsBytes = 0;
     if (apExchangeContext != nullptr)
@@ -261,8 +261,7 @@ CHIP_ERROR ReadHandler::OnMessageReceived(Messaging::ExchangeContext * apExchang
 bool ReadHandler::IsFromSubscriber(Messaging::ExchangeContext & apExchangeContext)
 {
     return (IsType(InteractionType::Subscribe) &&
-            GetInitiatorNodeId() == apExchangeContext.GetSessionHandle()->AsSecureSession()->GetPeerNodeId() &&
-            GetAccessingFabricIndex() == apExchangeContext.GetSessionHandle()->GetFabricIndex());
+            mInitiatorOperationalId == apExchangeContext.GetSessionHandle()->GetPeerOperationalId());
 }
 
 CHIP_ERROR ReadHandler::OnUnknownMsgType(Messaging::ExchangeContext * apExchangeContext, const PayloadHeader & aPayloadHeader,

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -162,7 +162,6 @@ public:
     }
     void ClearDirty() { mDirty = false; }
     bool IsDirty() { return mDirty; }
-    NodeId GetInitiatorNodeId() const { return mInitiatorNodeId; }
     FabricIndex GetAccessingFabricIndex() const { return mSubjectDescriptor.fabricIndex; }
 
     const SubjectDescriptor & GetSubjectDescriptor() const { return mSubjectDescriptor; }
@@ -272,7 +271,7 @@ private:
     // The flag indicating we are in the middle of a series of chunked report messages, this flag will be cleared during sending
     // last chunked message.
     bool mIsChunkedReport                                    = false;
-    NodeId mInitiatorNodeId                                  = kUndefinedNodeId;
+    OperationalId mInitiatorOperationalId                    = OperationalId::UndefinedOperationalId();
     AttributePathExpandIterator mAttributePathExpandIterator = AttributePathExpandIterator(nullptr);
     bool mIsFabricFiltered                                   = false;
     // mHoldSync is used to prevent subscription empty report delivery while we

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -204,19 +204,10 @@ void DoorLockServer::SetUserCommandHandler(chip::app::CommandHandler * commandOb
         return;
     }
 
-    auto fabricIdx = getFabricIndex(commandObj);
-    if (chip::kUndefinedFabricIndex == fabricIdx)
+    auto operationalId = getOperationalId(commandObj);
+    if (operationalId == OperationalId::UndefinedOperationalId())
     {
-        ChipLogError(Zcl, "[SetUser] Unable to get the fabric IDX [endpointId=%d,userIndex=%d]", commandPath.mEndpointId,
-                     userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
-        return;
-    }
-
-    auto sourceNodeId = getNodeId(commandObj);
-    if (chip::kUndefinedNodeId == sourceNodeId)
-    {
-        ChipLogError(Zcl, "[SetUser] Unable to get the source node index [endpointId=%d,userIndex=%d]", commandPath.mEndpointId,
+        ChipLogError(Zcl, "[SetUser] Unable to get the operationalId [endpointId=%d,userIndex=%d]", commandPath.mEndpointId,
                      userIndex);
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
@@ -251,12 +242,12 @@ void DoorLockServer::SetUserCommandHandler(chip::app::CommandHandler * commandOb
     switch (operationType)
     {
     case DlDataOperationType::kAdd:
-        status = createUser(commandPath.mEndpointId, fabricIdx, sourceNodeId, userIndex, userName, userUniqueId, userStatus,
-                            userType, credentialRule);
+        status = createUser(commandPath.mEndpointId, operationalId, userIndex, userName, userUniqueId, userStatus, userType,
+                            credentialRule);
         break;
     case DlDataOperationType::kModify:
-        status = modifyUser(commandPath.mEndpointId, fabricIdx, sourceNodeId, userIndex, userName, userUniqueId, userStatus,
-                            userType, credentialRule);
+        status = modifyUser(commandPath.mEndpointId, operationalId, userIndex, userName, userUniqueId, userStatus, userType,
+                            credentialRule);
         break;
     case DlDataOperationType::kClear:
         // appclusters, 5.2.4.34: SetUser command allow only kAdd/kModify, we should respond with INVALID_COMMAND if we got kClear
@@ -378,19 +369,10 @@ void DoorLockServer::ClearUserCommandHandler(chip::app::CommandHandler * command
         return;
     }
 
-    auto fabricIdx = getFabricIndex(commandObj);
-    if (chip::kUndefinedFabricIndex == fabricIdx)
+    auto operationalId = getOperationalId(commandObj);
+    if (operationalId == OperationalId::UndefinedOperationalId())
     {
-        ChipLogError(Zcl, "[ClearUser] Unable to get the fabric IDX [endpointId=%d,userIndex=%d]", commandPath.mEndpointId,
-                     userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
-        return;
-    }
-
-    auto sourceNodeId = getNodeId(commandObj);
-    if (chip::kUndefinedNodeId == sourceNodeId)
-    {
-        ChipLogError(Zcl, "[ClearUser] Unable to get the source node index [endpointId=%d,userIndex=%d]", commandPath.mEndpointId,
+        ChipLogError(Zcl, "[ClearUser] Unable to get the operationalId [endpointId=%d,userIndex=%d]", commandPath.mEndpointId,
                      userIndex);
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
@@ -407,7 +389,7 @@ void DoorLockServer::ClearUserCommandHandler(chip::app::CommandHandler * command
 
     if (0xFFFE != userIndex)
     {
-        auto status = clearUser(commandPath.mEndpointId, fabricIdx, sourceNodeId, userIndex, true);
+        auto status = clearUser(commandPath.mEndpointId, operationalId, userIndex, true);
         if (EMBER_ZCL_STATUS_SUCCESS != status)
         {
             ChipLogError(Zcl, "[ClearUser] App reported failure when resetting the user [userIndex=%d,status=0x%x]", userIndex,
@@ -420,7 +402,7 @@ void DoorLockServer::ClearUserCommandHandler(chip::app::CommandHandler * command
     emberAfDoorLockClusterPrintln("[ClearUser] Removing all users from storage");
     for (uint16_t i = 1; i <= maxNumberOfUsers; ++i)
     {
-        auto status = clearUser(commandPath.mEndpointId, fabricIdx, sourceNodeId, i, false);
+        auto status = clearUser(commandPath.mEndpointId, operationalId, i, false);
         if (EMBER_ZCL_STATUS_SUCCESS != status)
         {
             ChipLogError(Zcl, "[ClearUser] App reported failure when resetting the user [userIndex=%d,status=0x%x]", i, status);
@@ -431,8 +413,8 @@ void DoorLockServer::ClearUserCommandHandler(chip::app::CommandHandler * command
     }
     emberAfDoorLockClusterPrintln("[ClearUser] Removed all users from storage [users=%d]", maxNumberOfUsers);
 
-    sendRemoteLockUserChange(commandPath.mEndpointId, DlLockDataType::kUserIndex, DlDataOperationType::kClear, sourceNodeId,
-                             fabricIdx, 0xFFFE, 0xFFFE);
+    sendRemoteLockUserChange(commandPath.mEndpointId, DlLockDataType::kUserIndex, DlDataOperationType::kClear, operationalId,
+                             0xFFFE, 0xFFFE);
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
 }
@@ -443,18 +425,10 @@ void DoorLockServer::SetCredentialCommandHandler(
 {
     emberAfDoorLockClusterPrintln("[SetCredential] Incoming command [endpointId=%d]", commandPath.mEndpointId);
 
-    auto fabricIdx = getFabricIndex(commandObj);
-    if (kUndefinedFabricIndex == fabricIdx)
+    auto operationalId = getOperationalId(commandObj);
+    if (operationalId == OperationalId::UndefinedOperationalId())
     {
-        ChipLogError(Zcl, "[SetCredential] Unable to get the fabric IDX [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
-        return;
-    }
-
-    auto sourceNodeId = getNodeId(commandObj);
-    if (chip::kUndefinedNodeId == sourceNodeId)
-    {
-        ChipLogError(Zcl, "[SetCredential] Unable to get the source node index [endpointId=%d]", commandPath.mEndpointId);
+        ChipLogError(Zcl, "[SetCredential] Unable to get the operationalId [endpointId=%d]", commandPath.mEndpointId);
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
     }
@@ -550,7 +524,7 @@ void DoorLockServer::SetCredentialCommandHandler(
     case DlDataOperationType::kAdd: {
         uint16_t createdUserIndex = 0;
 
-        DlStatus status = createCredential(commandPath.mEndpointId, fabricIdx, sourceNodeId, credentialIndex, credentialType,
+        DlStatus status = createCredential(commandPath.mEndpointId, operationalId, credentialIndex, credentialType,
                                            existingCredential, credentialData, userIndex, userStatus, userType, createdUserIndex);
         sendSetCredentialResponse(commandObj, status, createdUserIndex, nextAvailableCredentialSlot);
         return;
@@ -570,14 +544,14 @@ void DoorLockServer::SetCredentialCommandHandler(
         // if userIndex is NULL then we're changing the programming user PIN
         if (userIndex.IsNull())
         {
-            auto status = modifyProgrammingPIN(commandPath.mEndpointId, fabricIdx, sourceNodeId, credentialIndex, credentialType,
+            auto status = modifyProgrammingPIN(commandPath.mEndpointId, operationalId, credentialIndex, credentialType,
                                                existingCredential, credentialData);
             sendSetCredentialResponse(commandObj, status, 0, nextAvailableCredentialSlot);
             return;
         }
 
-        auto status = modifyCredential(commandPath.mEndpointId, fabricIdx, sourceNodeId, credentialIndex, credentialType,
-                                       existingCredential, credentialData, userIndex.Value(), userStatus, userType);
+        auto status = modifyCredential(commandPath.mEndpointId, operationalId, credentialIndex, credentialType, existingCredential,
+                                       credentialData, userIndex.Value(), userStatus, userType);
         sendSetCredentialResponse(commandObj, status, 0, nextAvailableCredentialSlot);
         return;
     }
@@ -689,15 +663,8 @@ void DoorLockServer::ClearCredentialCommandHandler(
 {
     emberAfDoorLockClusterPrintln("[ClearCredential] Incoming command [endpointId=%d]", commandPath.mEndpointId);
 
-    auto modifier = getFabricIndex(commandObj);
-    if (kUndefinedFabricIndex == modifier)
-    {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
-        return;
-    }
-
-    auto sourceNodeId = getNodeId(commandObj);
-    if (chip::kUndefinedNodeId == sourceNodeId)
+    auto operationalId = getOperationalId(commandObj);
+    if (operationalId == OperationalId::UndefinedOperationalId())
     {
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
@@ -707,7 +674,7 @@ void DoorLockServer::ClearCredentialCommandHandler(
     if (credential.IsNull())
     {
         emberAfDoorLockClusterPrintln("[ClearCredential] Clearing all credentials [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(clearCredentials(commandPath.mEndpointId, modifier, sourceNodeId));
+        emberAfSendImmediateDefaultResponse(clearCredentials(commandPath.mEndpointId, operationalId));
         return;
     }
 
@@ -716,12 +683,12 @@ void DoorLockServer::ClearCredentialCommandHandler(
     auto credentialIndex = credential.Value().credentialIndex;
     if (0xFFFE == credentialIndex)
     {
-        emberAfSendImmediateDefaultResponse(clearCredentials(commandPath.mEndpointId, modifier, sourceNodeId, credentialType));
+        emberAfSendImmediateDefaultResponse(clearCredentials(commandPath.mEndpointId, operationalId, credentialType));
         return;
     }
 
     emberAfSendImmediateDefaultResponse(
-        clearCredential(commandPath.mEndpointId, modifier, sourceNodeId, credentialType, credentialIndex, false));
+        clearCredential(commandPath.mEndpointId, operationalId, credentialType, credentialIndex, false));
 }
 
 void DoorLockServer::SetWeekDayScheduleCommandHandler(
@@ -738,18 +705,10 @@ void DoorLockServer::SetWeekDayScheduleCommandHandler(
 
     emberAfDoorLockClusterPrintln("[SetWeekDaySchedule] Incoming command [endpointId=%d]", endpointId);
 
-    auto fabricIdx = getFabricIndex(commandObj);
-    if (kUndefinedFabricIndex == fabricIdx)
+    auto operationalId = getOperationalId(commandObj);
+    if (operationalId == OperationalId::UndefinedOperationalId())
     {
-        ChipLogError(Zcl, "[SetWeekDaySchedule] Unable to get the fabric IDX [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
-        return;
-    }
-
-    auto sourceNodeId = getNodeId(commandObj);
-    if (chip::kUndefinedNodeId == sourceNodeId)
-    {
-        ChipLogError(Zcl, "[SetWeekDaySchedule] Unable to get the source node index [endpointId=%d]", commandPath.mEndpointId);
+        ChipLogError(Zcl, "[SetWeekDaySchedule] Unable to get the operationalId [endpointId=%d]", commandPath.mEndpointId);
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
     }
@@ -833,8 +792,8 @@ void DoorLockServer::SetWeekDayScheduleCommandHandler(
                                   "[endpointId=%d,weekDayIndex=%d,userIndex=%d,daysMask=%d,startTime=\"%d:%d\",endTime=\"%d:%d\"]",
                                   endpointId, weekDayIndex, userIndex, daysMask.Raw(), startHour, startMinute, endHour, endMinute);
 
-    sendRemoteLockUserChange(endpointId, DlLockDataType::kWeekDaySchedule, DlDataOperationType::kAdd, sourceNodeId, fabricIdx,
-                             userIndex, static_cast<uint16_t>(weekDayIndex));
+    sendRemoteLockUserChange(endpointId, DlLockDataType::kWeekDaySchedule, DlDataOperationType::kAdd, operationalId, userIndex,
+                             static_cast<uint16_t>(weekDayIndex));
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
 }
@@ -899,18 +858,10 @@ void DoorLockServer::ClearWeekDayScheduleCommandHandler(
 
     emberAfDoorLockClusterPrintln("[ClearWeekDaySchedule] Incoming command [endpointId=%d]", endpointId);
 
-    auto fabricIdx = getFabricIndex(commandObj);
-    if (kUndefinedFabricIndex == fabricIdx)
+    auto operationalId = getOperationalId(commandObj);
+    if (operationalId == OperationalId::UndefinedOperationalId())
     {
-        ChipLogError(Zcl, "[ClearWeekDaySchedule] Unable to get the fabric IDX [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
-        return;
-    }
-
-    auto sourceNodeId = getNodeId(commandObj);
-    if (chip::kUndefinedNodeId == sourceNodeId)
-    {
-        ChipLogError(Zcl, "[ClearWeekDaySchedule] Unable to get the source node index [endpointId=%d]", commandPath.mEndpointId);
+        ChipLogError(Zcl, "[ClearWeekDaySchedule] Unable to get the operationalId [endpointId=%d]", commandPath.mEndpointId);
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
     }
@@ -959,8 +910,8 @@ void DoorLockServer::ClearWeekDayScheduleCommandHandler(
         return;
     }
 
-    sendRemoteLockUserChange(endpointId, DlLockDataType::kWeekDaySchedule, DlDataOperationType::kClear, sourceNodeId, fabricIdx,
-                             userIndex, static_cast<uint16_t>(weekDayIndex));
+    sendRemoteLockUserChange(endpointId, DlLockDataType::kWeekDaySchedule, DlDataOperationType::kClear, operationalId, userIndex,
+                             static_cast<uint16_t>(weekDayIndex));
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
 }
@@ -979,18 +930,10 @@ void DoorLockServer::SetYearDayScheduleCommandHandler(
 
     emberAfDoorLockClusterPrintln("[SetYearDaySchedule] incoming command [endpointId=%d]", endpointId);
 
-    auto fabricIdx = getFabricIndex(commandObj);
-    if (kUndefinedFabricIndex == fabricIdx)
+    auto operationalId = getOperationalId(commandObj);
+    if (operationalId == OperationalId::UndefinedOperationalId())
     {
-        ChipLogError(Zcl, "[SetYearDaySchedule] Unable to get the fabric IDX [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
-        return;
-    }
-
-    auto sourceNodeId = getNodeId(commandObj);
-    if (chip::kUndefinedNodeId == sourceNodeId)
-    {
-        ChipLogError(Zcl, "[SetYearDaySchedule] Unable to get the source node index [endpointId=%d]", commandPath.mEndpointId);
+        ChipLogError(Zcl, "[SetYearDaySchedule] Unable to get the operationalId [endpointId=%d]", commandPath.mEndpointId);
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
     }
@@ -1044,8 +987,8 @@ void DoorLockServer::SetYearDayScheduleCommandHandler(
                                   "[endpointId=%d,yearDayIndex=%d,userIndex=%d,localStartTime=%" PRIu32 ",endTime=%" PRIu32 "]",
                                   endpointId, yearDayIndex, userIndex, localStarTime, localEndTime);
 
-    sendRemoteLockUserChange(endpointId, DlLockDataType::kYearDaySchedule, DlDataOperationType::kAdd, sourceNodeId, fabricIdx,
-                             userIndex, static_cast<uint16_t>(yearDayIndex));
+    sendRemoteLockUserChange(endpointId, DlLockDataType::kYearDaySchedule, DlDataOperationType::kAdd, operationalId, userIndex,
+                             static_cast<uint16_t>(yearDayIndex));
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
 }
@@ -1108,18 +1051,10 @@ void DoorLockServer::ClearYearDayScheduleCommandHandler(
     }
     emberAfDoorLockClusterPrintln("[ClearYearDaySchedule] incoming command [endpointId=%d]", endpointId);
 
-    auto fabricIdx = getFabricIndex(commandObj);
-    if (kUndefinedFabricIndex == fabricIdx)
+    auto operationalId = getOperationalId(commandObj);
+    if (operationalId == OperationalId::UndefinedOperationalId())
     {
-        ChipLogError(Zcl, "[ClearYearDaySchedule] Unable to get the fabric IDX [endpointId=%d]", commandPath.mEndpointId);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
-        return;
-    }
-
-    auto sourceNodeId = getNodeId(commandObj);
-    if (chip::kUndefinedNodeId == sourceNodeId)
-    {
-        ChipLogError(Zcl, "[ClearYearDaySchedule] Unable to get the source node index [endpointId=%d]", commandPath.mEndpointId);
+        ChipLogError(Zcl, "[ClearYearDaySchedule] Unable to get the operationalId [endpointId=%d]", commandPath.mEndpointId);
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
     }
@@ -1168,8 +1103,8 @@ void DoorLockServer::ClearYearDayScheduleCommandHandler(
         return;
     }
 
-    sendRemoteLockUserChange(endpointId, DlLockDataType::kYearDaySchedule, DlDataOperationType::kClear, sourceNodeId, fabricIdx,
-                             userIndex, static_cast<uint16_t>(yearDayIndex));
+    sendRemoteLockUserChange(endpointId, DlLockDataType::kYearDaySchedule, DlDataOperationType::kClear, operationalId, userIndex,
+                             static_cast<uint16_t>(yearDayIndex));
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
 }
@@ -1186,31 +1121,15 @@ bool DoorLockServer::HasFeature(chip::EndpointId endpointId, DoorLockFeature fea
  * DoorLockServer private methods
  *********************************************************/
 
-chip::FabricIndex DoorLockServer::getFabricIndex(const chip::app::CommandHandler * commandObj)
-{
-    if (nullptr == commandObj || nullptr == commandObj->GetExchangeContext())
-    {
-        ChipLogError(Zcl, "Cannot access ExchangeContext of Command Object for Fabric Index");
-        return kUndefinedFabricIndex;
-    }
-
-    return commandObj->GetAccessingFabricIndex();
-}
-
-chip::NodeId DoorLockServer::getNodeId(const chip::app::CommandHandler * commandObj)
+chip::OperationalId DoorLockServer::getOperationalId(const chip::app::CommandHandler * commandObj)
 {
     if (nullptr == commandObj || nullptr == commandObj->GetExchangeContext())
     {
         ChipLogError(Zcl, "Cannot access ExchangeContext of Command Object for Node ID");
-        return kUndefinedNodeId;
+        return OperationalId::UndefinedOperationalId();
     }
 
-    auto secureSession = commandObj->GetExchangeContext()->GetSessionHandle()->AsSecureSession();
-    if (nullptr == secureSession)
-    {
-        ChipLogError(Zcl, "Cannot access Secure session handle of Command Object for Node ID");
-    }
-    return secureSession->GetPeerNodeId();
+    return commandObj->GetExchangeContext()->GetSessionHandle()->GetPeerOperationalId();
 }
 
 bool DoorLockServer::userIndexValid(chip::EndpointId endpointId, uint16_t userIndex)
@@ -1501,10 +1420,10 @@ bool DoorLockServer::findUserIndexByCredential(chip::EndpointId endpointId, DlCr
     return false;
 }
 
-EmberAfStatus DoorLockServer::createUser(chip::EndpointId endpointId, chip::FabricIndex creatorFabricIdx, chip::NodeId sourceNodeId,
-                                         uint16_t userIndex, const Nullable<chip::CharSpan> & userName,
-                                         const Nullable<uint32_t> & userUniqueId, const Nullable<DlUserStatus> & userStatus,
-                                         const Nullable<DlUserType> & userType, const Nullable<DlCredentialRule> & credentialRule,
+EmberAfStatus DoorLockServer::createUser(chip::EndpointId endpointId, chip::OperationalId operationalId, uint16_t userIndex,
+                                         const Nullable<chip::CharSpan> & userName, const Nullable<uint32_t> & userUniqueId,
+                                         const Nullable<DlUserStatus> & userStatus, const Nullable<DlUserType> & userType,
+                                         const Nullable<DlCredentialRule> & credentialRule,
                                          const Nullable<DlCredential> & credential)
 {
     EmberAfPluginDoorLockUserInfo user;
@@ -1536,35 +1455,37 @@ EmberAfStatus DoorLockServer::createUser(chip::EndpointId endpointId, chip::Fabr
         newTotalCredentials = 1;
     }
 
-    if (!emberAfPluginDoorLockSetUser(endpointId, userIndex, creatorFabricIdx, creatorFabricIdx, newUserName, newUserUniqueId,
-                                      newUserStatus, newUserType, newCredentialRule, newCredentials, newTotalCredentials))
+    if (!emberAfPluginDoorLockSetUser(endpointId, userIndex, operationalId.GetFabricIndex(), operationalId.GetFabricIndex(),
+                                      newUserName, newUserUniqueId, newUserStatus, newUserType, newCredentialRule, newCredentials,
+                                      newTotalCredentials))
     {
-        emberAfDoorLockClusterPrintln(
-            "[createUser] Unable to create user: app error "
-            "[endpointId=%d,creatorFabricId=%d,userIndex=%d,userName=\"%s\",userUniqueId=0x%" PRIx32 ",userStatus="
-            "%u,userType=%u,credentialRule=%u,totalCredentials=%zu]",
-            endpointId, creatorFabricIdx, userIndex, newUserName.data(), newUserUniqueId, to_underlying(newUserStatus),
-            to_underlying(newUserType), to_underlying(newCredentialRule), newTotalCredentials);
+        emberAfDoorLockClusterPrintln("[createUser] Unable to create user: app error "
+                                      "[endpointId=%d,creator=" ChipLogFormatOperationalId
+                                      ",userIndex=%d,userName=\"%s\",userUniqueId=0x%" PRIx32 ",userStatus="
+                                      "%u,userType=%u,credentialRule=%u,totalCredentials=%zu]",
+                                      endpointId, ChipLogValueOperationalId(operationalId), userIndex, newUserName.data(),
+                                      newUserUniqueId, to_underlying(newUserStatus), to_underlying(newUserType),
+                                      to_underlying(newCredentialRule), newTotalCredentials);
         return EMBER_ZCL_STATUS_FAILURE;
     }
 
     emberAfDoorLockClusterPrintln(
         "[createUser] User created "
-        "[endpointId=%d,creatorFabricId=%d,userIndex=%d,userName=\"%s\",userUniqueId=0x%" PRIx32 ",userStatus=%"
+        "[endpointId=%d,creator=" ChipLogFormatOperationalId ",userIndex=%d,userName=\"%s\",userUniqueId=0x%" PRIx32 ",userStatus=%"
         "u,userType=%u,credentialRule=%u,totalCredentials=%zu]",
-        endpointId, creatorFabricIdx, userIndex, newUserName.data(), newUserUniqueId, to_underlying(newUserStatus),
-        to_underlying(newUserType), to_underlying(newCredentialRule), newTotalCredentials);
+        endpointId, ChipLogValueOperationalId(operationalId), userIndex, newUserName.data(), newUserUniqueId,
+        to_underlying(newUserStatus), to_underlying(newUserType), to_underlying(newCredentialRule), newTotalCredentials);
 
-    sendRemoteLockUserChange(endpointId, DlLockDataType::kUserIndex, DlDataOperationType::kAdd, sourceNodeId, creatorFabricIdx,
-                             userIndex, userIndex);
+    sendRemoteLockUserChange(endpointId, DlLockDataType::kUserIndex, DlDataOperationType::kAdd, operationalId, userIndex,
+                             userIndex);
 
     return EMBER_ZCL_STATUS_SUCCESS;
 }
 
-EmberAfStatus DoorLockServer::modifyUser(chip::EndpointId endpointId, chip::FabricIndex modifierFabricIndex,
-                                         chip::NodeId sourceNodeId, uint16_t userIndex, const Nullable<chip::CharSpan> & userName,
-                                         const Nullable<uint32_t> & userUniqueId, const Nullable<DlUserStatus> & userStatus,
-                                         const Nullable<DlUserType> & userType, const Nullable<DlCredentialRule> & credentialRule)
+EmberAfStatus DoorLockServer::modifyUser(chip::EndpointId endpointId, chip::OperationalId operationalId, uint16_t userIndex,
+                                         const Nullable<chip::CharSpan> & userName, const Nullable<uint32_t> & userUniqueId,
+                                         const Nullable<DlUserStatus> & userStatus, const Nullable<DlUserType> & userType,
+                                         const Nullable<DlCredentialRule> & credentialRule)
 {
     // We should get the user by that index first
     EmberAfPluginDoorLockUserInfo user;
@@ -1583,20 +1504,20 @@ EmberAfStatus DoorLockServer::modifyUser(chip::EndpointId endpointId, chip::Fabr
     }
 
     // appclusters, 5.2.4.34: UserName SHALL be null if modifying a user record that was not created by the accessing fabric
-    if (user.createdBy != modifierFabricIndex && !userName.IsNull())
+    if (user.createdBy != operationalId.GetFabricIndex() && !userName.IsNull())
     {
         emberAfDoorLockClusterPrintln("[modifyUser] Unable to modify name of user created by different fabric "
-                                      "[endpointId=%d,userIndex=%d,creatorIdx=%d,modifierIdx=%d]",
-                                      endpointId, userIndex, user.createdBy, modifierFabricIndex);
+                                      "[endpointId=%d,userIndex=%d,creatorIdx=%d,modifier=" ChipLogFormatOperationalId "]",
+                                      endpointId, userIndex, user.createdBy, ChipLogValueOperationalId(operationalId));
         return EMBER_ZCL_STATUS_INVALID_COMMAND;
     }
 
     // appclusters, 5.2.4.34: UserUniqueID SHALL be null if modifying the user record that was not created by the accessing fabric.
-    if (user.createdBy != modifierFabricIndex && !userUniqueId.IsNull())
+    if (user.createdBy != operationalId.GetFabricIndex() && !userUniqueId.IsNull())
     {
         emberAfDoorLockClusterPrintln("[modifyUser] Unable to modify UUID of user created by different fabric "
-                                      "[endpointId=%d,userIndex=%d,creatorIdx=%d,modifierIdx=%d]",
-                                      endpointId, userIndex, user.createdBy, modifierFabricIndex);
+                                      "[endpointId=%d,userIndex=%d,creatorIdx=%d,modifier=" ChipLogFormatOperationalId "]",
+                                      endpointId, userIndex, user.createdBy, ChipLogValueOperationalId(operationalId));
         return EMBER_ZCL_STATUS_INVALID_COMMAND;
     }
 
@@ -1606,34 +1527,36 @@ EmberAfStatus DoorLockServer::modifyUser(chip::EndpointId endpointId, chip::Fabr
     auto newUserType         = userType.IsNull() ? user.userType : userType.Value();
     auto newCredentialRule   = credentialRule.IsNull() ? user.credentialRule : credentialRule.Value();
 
-    if (!emberAfPluginDoorLockSetUser(endpointId, userIndex, user.createdBy, modifierFabricIndex, newUserName, newUserUniqueId,
-                                      newUserStatus, newUserType, newCredentialRule, user.credentials.data(),
+    if (!emberAfPluginDoorLockSetUser(endpointId, userIndex, user.createdBy, operationalId.GetFabricIndex(), newUserName,
+                                      newUserUniqueId, newUserStatus, newUserType, newCredentialRule, user.credentials.data(),
                                       user.credentials.size()))
     {
         ChipLogError(Zcl,
                      "[modifyUser] Unable to modify the user: app error "
-                     "[endpointId=%d,modifierFabric=%d,userIndex=%d,userName=\"%s\",userUniqueId=0x%" PRIx32 ",userStatus=%u"
+                     "[endpointId=%d,modifier=" ChipLogFormatOperationalId ",userIndex=%d,userName=\"%s\",userUniqueId=0x%" PRIx32
+                     ",userStatus=%u"
                      ",userType=%u,credentialRule=%u]",
-                     endpointId, modifierFabricIndex, userIndex, newUserName.data(), newUserUniqueId, to_underlying(newUserStatus),
-                     to_underlying(newUserType), to_underlying(newCredentialRule));
+                     endpointId, ChipLogValueOperationalId(operationalId), userIndex, newUserName.data(), newUserUniqueId,
+                     to_underlying(newUserStatus), to_underlying(newUserType), to_underlying(newCredentialRule));
         return EMBER_ZCL_STATUS_FAILURE;
     }
 
     emberAfDoorLockClusterPrintln("[modifyUser] User modified "
-                                  "[endpointId=%d,modifierFabric=%d,userIndex=%d,userName=\"%s\",userUniqueId=0x%" PRIx32
-                                  ",userStatus=%u,"
+                                  "[endpointId=%d,modifier=" ChipLogFormatOperationalId
+                                  ",userIndex=%d,userName=\"%s\",userUniqueId=0x%" PRIx32 ",userStatus=%u,"
                                   "userType=%u,credentialRule=%u]",
-                                  endpointId, modifierFabricIndex, userIndex, newUserName.data(), newUserUniqueId,
-                                  to_underlying(newUserStatus), to_underlying(newUserType), to_underlying(newCredentialRule));
+                                  endpointId, ChipLogValueOperationalId(operationalId), userIndex, newUserName.data(),
+                                  newUserUniqueId, to_underlying(newUserStatus), to_underlying(newUserType),
+                                  to_underlying(newCredentialRule));
 
-    sendRemoteLockUserChange(endpointId, DlLockDataType::kUserIndex, DlDataOperationType::kModify, sourceNodeId,
-                             modifierFabricIndex, userIndex, userIndex);
+    sendRemoteLockUserChange(endpointId, DlLockDataType::kUserIndex, DlDataOperationType::kModify, operationalId, userIndex,
+                             userIndex);
 
     return EMBER_ZCL_STATUS_SUCCESS;
 }
 
-EmberAfStatus DoorLockServer::clearUser(chip::EndpointId endpointId, chip::FabricIndex modifierFabricId, chip::NodeId sourceNodeId,
-                                        uint16_t userIndex, bool sendUserChangeEvent)
+EmberAfStatus DoorLockServer::clearUser(chip::EndpointId endpointId, chip::OperationalId operationalId, uint16_t userIndex,
+                                        bool sendUserChangeEvent)
 {
     EmberAfPluginDoorLockUserInfo user;
     if (!emberAfPluginDoorLockGetUser(endpointId, userIndex, user))
@@ -1641,11 +1564,11 @@ EmberAfStatus DoorLockServer::clearUser(chip::EndpointId endpointId, chip::Fabri
         return EMBER_ZCL_STATUS_FAILURE;
     }
 
-    return clearUser(endpointId, modifierFabricId, sourceNodeId, userIndex, user, sendUserChangeEvent);
+    return clearUser(endpointId, operationalId, userIndex, user, sendUserChangeEvent);
 }
 
-EmberAfStatus DoorLockServer::clearUser(chip::EndpointId endpointId, chip::FabricIndex modifierFabricId, chip::NodeId sourceNodeId,
-                                        uint16_t userIndex, const EmberAfPluginDoorLockUserInfo & user, bool sendUserChangeEvent)
+EmberAfStatus DoorLockServer::clearUser(chip::EndpointId endpointId, chip::OperationalId operationalId, uint16_t userIndex,
+                                        const EmberAfPluginDoorLockUserInfo & user, bool sendUserChangeEvent)
 {
     // appclusters, 5.2.4.37: all the credentials associated with user should be cleared when clearing the user
     for (const auto & credential : user.credentials)
@@ -1683,14 +1606,14 @@ EmberAfStatus DoorLockServer::clearUser(chip::EndpointId endpointId, chip::Fabri
 
     if (sendUserChangeEvent)
     {
-        sendRemoteLockUserChange(endpointId, DlLockDataType::kUserIndex, DlDataOperationType::kClear, sourceNodeId,
-                                 modifierFabricId, userIndex, userIndex);
+        sendRemoteLockUserChange(endpointId, DlLockDataType::kUserIndex, DlDataOperationType::kClear, operationalId, userIndex,
+                                 userIndex);
     }
     return EMBER_ZCL_STATUS_SUCCESS;
 }
 
-DlStatus DoorLockServer::createNewCredentialAndUser(chip::EndpointId endpointId, chip::FabricIndex creatorFabricIdx,
-                                                    chip::NodeId sourceNodeId, const Nullable<DlUserStatus> & userStatus,
+DlStatus DoorLockServer::createNewCredentialAndUser(chip::EndpointId endpointId, chip::OperationalId operationalId,
+                                                    const Nullable<DlUserStatus> & userStatus,
                                                     const Nullable<DlUserType> & userType, const DlCredential & credential,
                                                     const chip::ByteSpan & credentialData, uint16_t & createdUserIndex)
 {
@@ -1703,9 +1626,8 @@ DlStatus DoorLockServer::createNewCredentialAndUser(chip::EndpointId endpointId,
         return DlStatus::kOccupied;
     }
 
-    auto status =
-        createUser(endpointId, creatorFabricIdx, sourceNodeId, availableUserIndex, Nullable<CharSpan>(), Nullable<uint32_t>(),
-                   userStatus, userType, Nullable<DlCredentialRule>(), Nullable<DlCredential>(credential));
+    auto status = createUser(endpointId, operationalId, availableUserIndex, Nullable<CharSpan>(), Nullable<uint32_t>(), userStatus,
+                             userType, Nullable<DlCredentialRule>(), Nullable<DlCredential>(credential));
     if (EMBER_ZCL_STATUS_SUCCESS != status)
     {
         emberAfDoorLockClusterPrintln("[SetCredential] Unable to create new user for credential: internal error "
@@ -1911,8 +1833,8 @@ DlStatus DoorLockServer::modifyCredentialForUser(chip::EndpointId endpointId, ch
     return DlStatus::kInvalidField;
 }
 
-DlStatus DoorLockServer::createCredential(chip::EndpointId endpointId, chip::FabricIndex creatorFabricIdx,
-                                          chip::NodeId sourceNodeId, uint16_t credentialIndex, DlCredentialType credentialType,
+DlStatus DoorLockServer::createCredential(chip::EndpointId endpointId, chip::OperationalId operationalId, uint16_t credentialIndex,
+                                          DlCredentialType credentialType,
                                           const EmberAfPluginDoorLockCredentialInfo & existingCredential,
                                           const chip::ByteSpan & credentialData, Nullable<uint16_t> userIndex,
                                           Nullable<DlUserStatus> userStatus, Nullable<DlUserType> userType,
@@ -1945,26 +1867,27 @@ DlStatus DoorLockServer::createCredential(chip::EndpointId endpointId, chip::Fab
         emberAfDoorLockClusterPrintln("[SetCredential] UserIndex is not set, creating new user [endpointId=%d,credentialIndex=%d]",
                                       endpointId, credentialIndex);
 
-        status = createNewCredentialAndUser(endpointId, creatorFabricIdx, sourceNodeId, userStatus, userType, credential,
-                                            credentialData, createdUserIndex);
+        status = createNewCredentialAndUser(endpointId, operationalId, userStatus, userType, credential, credentialData,
+                                            createdUserIndex);
     }
     else
     {
         // appclusters, 5.2.4.40: if user index is NULL, we should try to modify the existing user
-        status = createNewCredentialAndAddItToUser(endpointId, creatorFabricIdx, userIndex.Value(), credential, credentialData);
+        status = createNewCredentialAndAddItToUser(endpointId, operationalId.GetFabricIndex(), userIndex.Value(), credential,
+                                                   credentialData);
     }
 
     if (DlStatus::kSuccess == status)
     {
-        sendRemoteLockUserChange(endpointId, credentialTypeToLockDataType(credentialType), DlDataOperationType::kAdd, sourceNodeId,
-                                 creatorFabricIdx, createdUserIndex == 0 ? userIndex.Value() : createdUserIndex, credentialIndex);
+        sendRemoteLockUserChange(endpointId, credentialTypeToLockDataType(credentialType), DlDataOperationType::kAdd, operationalId,
+                                 createdUserIndex == 0 ? userIndex.Value() : createdUserIndex, credentialIndex);
     }
 
     return status;
 }
 
-DlStatus DoorLockServer::modifyProgrammingPIN(chip::EndpointId endpointId, chip::FabricIndex modifierFabricIndex,
-                                              chip::NodeId sourceNodeId, uint16_t credentialIndex, DlCredentialType credentialType,
+DlStatus DoorLockServer::modifyProgrammingPIN(chip::EndpointId endpointId, chip::OperationalId operationalId,
+                                              uint16_t credentialIndex, DlCredentialType credentialType,
                                               const EmberAfPluginDoorLockCredentialInfo & existingCredential,
                                               const chip::ByteSpan & credentialData)
 {
@@ -2003,14 +1926,14 @@ DlStatus DoorLockServer::modifyProgrammingPIN(chip::EndpointId endpointId, chip:
                                       endpointId, credentialIndex, to_underlying(credentialType), credentialData.size());
 
         sendRemoteLockUserChange(endpointId, credentialTypeToLockDataType(credentialType), DlDataOperationType::kModify,
-                                 sourceNodeId, modifierFabricIndex, relatedUserIndex, credentialIndex);
+                                 operationalId, relatedUserIndex, credentialIndex);
     }
 
     return DlStatus::kSuccess;
 }
 
-DlStatus DoorLockServer::modifyCredential(chip::EndpointId endpointId, chip::FabricIndex modifierFabricIndex,
-                                          chip::NodeId sourceNodeId, uint16_t credentialIndex, DlCredentialType credentialType,
+DlStatus DoorLockServer::modifyCredential(chip::EndpointId endpointId, chip::OperationalId operationalId, uint16_t credentialIndex,
+                                          DlCredentialType credentialType,
                                           const EmberAfPluginDoorLockCredentialInfo & existingCredential,
                                           const chip::ByteSpan & credentialData, uint16_t userIndex,
                                           Nullable<DlUserStatus> userStatus, Nullable<DlUserType> userType)
@@ -2026,7 +1949,7 @@ DlStatus DoorLockServer::modifyCredential(chip::EndpointId endpointId, chip::Fab
     }
 
     DlCredential credential{ to_underlying(credentialType), credentialIndex };
-    auto status = modifyCredentialForUser(endpointId, modifierFabricIndex, userIndex, credential);
+    auto status = modifyCredentialForUser(endpointId, operationalId.GetFabricIndex(), userIndex, credential);
 
     if (DlStatus::kSuccess == status)
     {
@@ -2045,7 +1968,7 @@ DlStatus DoorLockServer::modifyCredential(chip::EndpointId endpointId, chip::Fab
                                       endpointId, credentialIndex, to_underlying(credentialType), credentialData.size());
 
         sendRemoteLockUserChange(endpointId, credentialTypeToLockDataType(credentialType), DlDataOperationType::kModify,
-                                 sourceNodeId, modifierFabricIndex, userIndex, credentialIndex);
+                                 operationalId, userIndex, credentialIndex);
     }
     return status;
 }
@@ -2262,22 +2185,24 @@ CHIP_ERROR DoorLockServer::sendGetYearDayScheduleResponse(chip::app::CommandHand
     return commandObj->AddResponseData(commandPath, response);
 }
 
-EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip::FabricIndex modifier, chip::NodeId sourceNodeId,
+EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip::OperationalId operationalId,
                                               DlCredentialType credentialType, uint16_t credentialIndex, bool sendUserChangeEvent)
 {
     if (DlCredentialType::kProgrammingPIN == credentialType)
     {
-        emberAfDoorLockClusterPrintln("[clearCredential] Cannot clear programming PIN credentials "
-                                      "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d]",
-                                      endpointId, to_underlying(credentialType), credentialIndex, modifier);
+        emberAfDoorLockClusterPrintln(
+            "[clearCredential] Cannot clear programming PIN credentials "
+            "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=" ChipLogFormatOperationalId "]",
+            endpointId, to_underlying(credentialType), credentialIndex, ChipLogValueOperationalId(operationalId));
         return EMBER_ZCL_STATUS_INVALID_COMMAND;
     }
 
     if (!credentialIndexValid(endpointId, credentialType, credentialIndex))
     {
-        emberAfDoorLockClusterPrintln("[clearCredential] Cannot clear credential - index out of bounds "
-                                      "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d]",
-                                      endpointId, to_underlying(credentialType), credentialIndex, modifier);
+        emberAfDoorLockClusterPrintln(
+            "[clearCredential] Cannot clear credential - index out of bounds "
+            "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=" ChipLogFormatOperationalId "]",
+            endpointId, to_underlying(credentialType), credentialIndex, ChipLogValueOperationalId(operationalId));
         return EMBER_ZCL_STATUS_INVALID_COMMAND;
     }
 
@@ -2287,25 +2212,27 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
     {
         ChipLogError(Zcl,
                      "[clearCredential] Unable to clear credential - couldn't read credential from database "
-                     "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d]",
-                     endpointId, to_underlying(credentialType), credentialIndex, modifier);
+                     "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=" ChipLogFormatOperationalId "]",
+                     endpointId, to_underlying(credentialType), credentialIndex, ChipLogValueOperationalId(operationalId));
         return EMBER_ZCL_STATUS_FAILURE;
     }
 
     if (DlCredentialStatus::kAvailable == credential.status)
     {
-        emberAfDoorLockClusterPrintln("[clearCredential] Ignored attempt to clear unoccupied credential slot "
-                                      "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d]",
-                                      endpointId, to_underlying(credentialType), credentialIndex, modifier);
+        emberAfDoorLockClusterPrintln(
+            "[clearCredential] Ignored attempt to clear unoccupied credential slot "
+            "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=" ChipLogFormatOperationalId "]",
+            endpointId, to_underlying(credentialType), credentialIndex, ChipLogValueOperationalId(operationalId));
         return EMBER_ZCL_STATUS_SUCCESS;
     }
 
     if (credentialType != credential.credentialType)
     {
         emberAfDoorLockClusterPrintln("[clearCredential] Ignored attempt to clear credential of different type "
-                                      "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d,actualCredentialType=%u]",
-                                      endpointId, to_underlying(credentialType), credentialIndex, modifier,
-                                      to_underlying(credential.credentialType));
+                                      "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=" ChipLogFormatOperationalId
+                                      ",actualCredentialType=%u]",
+                                      endpointId, to_underlying(credentialType), credentialIndex,
+                                      ChipLogValueOperationalId(operationalId), to_underlying(credential.credentialType));
         return EMBER_ZCL_STATUS_SUCCESS;
     }
 
@@ -2316,8 +2243,8 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
     {
         ChipLogError(Zcl,
                      "[clearCredential] Unable to clear related credential user - couldn't find index of related user "
-                     "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d]",
-                     endpointId, to_underlying(credentialType), credentialIndex, modifier);
+                     "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=" ChipLogFormatOperationalId "]",
+                     endpointId, to_underlying(credentialType), credentialIndex, ChipLogValueOperationalId(operationalId));
         return EMBER_ZCL_STATUS_FAILURE;
     }
     EmberAfPluginDoorLockUserInfo relatedUser;
@@ -2325,29 +2252,34 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
     {
         ChipLogError(Zcl,
                      "[clearCredential] Unable to clear credential for related user - couldn't get user from database "
-                     "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d,userIndex=%d]",
-                     endpointId, to_underlying(credentialType), credentialIndex, modifier, relatedUserIndex);
+                     "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=" ChipLogFormatOperationalId ",userIndex=%d]",
+                     endpointId, to_underlying(credentialType), credentialIndex, ChipLogValueOperationalId(operationalId),
+                     relatedUserIndex);
 
         return EMBER_ZCL_STATUS_FAILURE;
     }
     if (1 == relatedUser.credentials.size())
     {
-        emberAfDoorLockClusterPrintln("[clearCredential] Clearing related user - no credentials left "
-                                      "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d,userIndex=%d]",
-                                      endpointId, to_underlying(credentialType), credentialIndex, modifier, relatedUserIndex);
-        auto clearStatus = clearUser(endpointId, modifier, sourceNodeId, relatedUserIndex, relatedUser, true);
+        emberAfDoorLockClusterPrintln(
+            "[clearCredential] Clearing related user - no credentials left "
+            "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=" ChipLogFormatOperationalId ",userIndex=%d]",
+            endpointId, to_underlying(credentialType), credentialIndex, ChipLogValueOperationalId(operationalId), relatedUserIndex);
+        auto clearStatus = clearUser(endpointId, operationalId, relatedUserIndex, relatedUser, true);
         if (EMBER_ZCL_STATUS_SUCCESS != clearStatus)
         {
             ChipLogError(Zcl,
                          "[clearCredential] Unable to clear related credential user - internal error "
-                         "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d,userIndex=%d,status=%d]",
-                         endpointId, to_underlying(credentialType), credentialIndex, modifier, relatedUserIndex, clearStatus);
+                         "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=" ChipLogFormatOperationalId
+                         ",userIndex=%d,status=%d]",
+                         endpointId, to_underlying(credentialType), credentialIndex, ChipLogValueOperationalId(operationalId),
+                         relatedUserIndex, clearStatus);
 
             return EMBER_ZCL_STATUS_FAILURE;
         }
-        emberAfDoorLockClusterPrintln("[clearCredential] Successfully clear credential and related user "
-                                      "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d,userIndex=%d]",
-                                      endpointId, to_underlying(credentialType), credentialIndex, modifier, relatedUserIndex);
+        emberAfDoorLockClusterPrintln(
+            "[clearCredential] Successfully clear credential and related user "
+            "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=" ChipLogFormatOperationalId ",userIndex=%d]",
+            endpointId, to_underlying(credentialType), credentialIndex, ChipLogValueOperationalId(operationalId), relatedUserIndex);
         return EMBER_ZCL_STATUS_SUCCESS;
     }
 
@@ -2357,8 +2289,8 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
     {
         ChipLogError(Zcl,
                      "[clearCredential] Unable to clear credential - couldn't write new credential to database "
-                     "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d]",
-                     endpointId, to_underlying(credentialType), credentialIndex, modifier);
+                     "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=" ChipLogFormatOperationalId "]",
+                     endpointId, to_underlying(credentialType), credentialIndex, ChipLogValueOperationalId(operationalId));
         return EMBER_ZCL_STATUS_FAILURE;
     }
 
@@ -2367,9 +2299,10 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
     {
         ChipLogError(Zcl,
                      "[clearCredential] Unable to clear credential for related user - user has too many credentials associated"
-                     "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d,userIndex=%d,credentialsCount=%zu]",
-                     endpointId, to_underlying(credentialType), credentialIndex, modifier, relatedUserIndex,
-                     relatedUser.credentials.size());
+                     "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=" ChipLogFormatOperationalId
+                     ",userIndex=%d,credentialsCount=%zu]",
+                     endpointId, to_underlying(credentialType), credentialIndex, ChipLogValueOperationalId(operationalId),
+                     relatedUserIndex, relatedUser.credentials.size());
 
         return EMBER_ZCL_STATUS_FAILURE;
     }
@@ -2385,37 +2318,39 @@ EmberAfStatus DoorLockServer::clearCredential(chip::EndpointId endpointId, chip:
         newCredentials[newCredentialsCount++] = c;
     }
 
-    if (!emberAfPluginDoorLockSetUser(endpointId, relatedUserIndex, relatedUser.createdBy, modifier, relatedUser.userName,
-                                      relatedUser.userUniqueId, relatedUser.userStatus, relatedUser.userType,
+    if (!emberAfPluginDoorLockSetUser(endpointId, relatedUserIndex, relatedUser.createdBy, operationalId.GetFabricIndex(),
+                                      relatedUser.userName, relatedUser.userUniqueId, relatedUser.userStatus, relatedUser.userType,
                                       relatedUser.credentialRule, newCredentials, newCredentialsCount))
     {
         ChipLogError(Zcl,
                      "[clearCredential] Unable to clear credential for related user - unable to update database "
                      "[endpointId=%d,credentialType=%u"
-                     ",credentialIndex=%d,modifier=%d,userIndex=%d,newCredentialsCount=%zu]",
-                     endpointId, to_underlying(credentialType), credentialIndex, modifier, relatedUserIndex, newCredentialsCount);
+                     ",credentialIndex=%d,modifier=" ChipLogFormatOperationalId ",userIndex=%d,newCredentialsCount=%zu]",
+                     endpointId, to_underlying(credentialType), credentialIndex, ChipLogValueOperationalId(operationalId),
+                     relatedUserIndex, newCredentialsCount);
         return EMBER_ZCL_STATUS_FAILURE;
     }
 
-    emberAfDoorLockClusterPrintln(
-        "[clearCredential] Successfully clear credential and related user "
-        "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=%d,userIndex=%d,newCredentialsCount=%zu]",
-        endpointId, to_underlying(credentialType), credentialIndex, modifier, relatedUserIndex, newCredentialsCount);
+    emberAfDoorLockClusterPrintln("[clearCredential] Successfully clear credential and related user "
+                                  "[endpointId=%d,credentialType=%u,credentialIndex=%d,modifier=" ChipLogFormatOperationalId
+                                  ",userIndex=%d,newCredentialsCount=%zu]",
+                                  endpointId, to_underlying(credentialType), credentialIndex,
+                                  ChipLogValueOperationalId(operationalId), relatedUserIndex, newCredentialsCount);
 
     if (sendUserChangeEvent)
     {
         sendRemoteLockUserChange(endpointId, credentialTypeToLockDataType(credentialType), DlDataOperationType::kClear,
-                                 sourceNodeId, modifier, relatedUserIndex, credentialIndex);
+                                 operationalId, relatedUserIndex, credentialIndex);
     }
 
     return EMBER_ZCL_STATUS_SUCCESS;
 }
 
-EmberAfStatus DoorLockServer::clearCredentials(chip::EndpointId endpointId, chip::FabricIndex modifier, chip::NodeId sourceNodeId)
+EmberAfStatus DoorLockServer::clearCredentials(chip::EndpointId endpointId, chip::OperationalId operationalId)
 {
     if (SupportsPIN(endpointId))
     {
-        auto status = clearCredentials(endpointId, modifier, sourceNodeId, DlCredentialType::kPin);
+        auto status = clearCredentials(endpointId, operationalId, DlCredentialType::kPin);
         if (EMBER_ZCL_STATUS_SUCCESS != status)
         {
             ChipLogError(Zcl, "[clearCredentials] Unable to clear all PIN credentials [endpointId=%d,status=%d]", endpointId,
@@ -2428,7 +2363,7 @@ EmberAfStatus DoorLockServer::clearCredentials(chip::EndpointId endpointId, chip
 
     if (SupportsPFID(endpointId))
     {
-        auto status = clearCredentials(endpointId, modifier, sourceNodeId, DlCredentialType::kRfid);
+        auto status = clearCredentials(endpointId, operationalId, DlCredentialType::kRfid);
         if (EMBER_ZCL_STATUS_SUCCESS != status)
         {
             ChipLogError(Zcl, "[clearCredentials] Unable to clear all RFID credentials [endpointId=%d,status=%d]", endpointId,
@@ -2440,7 +2375,7 @@ EmberAfStatus DoorLockServer::clearCredentials(chip::EndpointId endpointId, chip
 
     if (SupportsFingers(endpointId))
     {
-        auto status = clearCredentials(endpointId, modifier, sourceNodeId, DlCredentialType::kFingerprint);
+        auto status = clearCredentials(endpointId, operationalId, DlCredentialType::kFingerprint);
         if (EMBER_ZCL_STATUS_SUCCESS != status)
         {
             ChipLogError(Zcl, "[clearCredentials] Unable to clear all Fingerprint credentials [endpointId=%d,status=%d]",
@@ -2448,7 +2383,7 @@ EmberAfStatus DoorLockServer::clearCredentials(chip::EndpointId endpointId, chip
             return status;
         }
 
-        status = clearCredentials(endpointId, modifier, sourceNodeId, DlCredentialType::kFingerVein);
+        status = clearCredentials(endpointId, operationalId, DlCredentialType::kFingerVein);
         if (EMBER_ZCL_STATUS_SUCCESS != status)
         {
             ChipLogError(Zcl, "[clearCredentials] Unable to clear all Finger Vein credentials [endpointId=%d,status=%d]",
@@ -2461,7 +2396,7 @@ EmberAfStatus DoorLockServer::clearCredentials(chip::EndpointId endpointId, chip
 
     if (SupportsFace(endpointId))
     {
-        auto status = clearCredentials(endpointId, modifier, sourceNodeId, DlCredentialType::kFace);
+        auto status = clearCredentials(endpointId, operationalId, DlCredentialType::kFace);
         if (EMBER_ZCL_STATUS_SUCCESS != status)
         {
             ChipLogError(Zcl, "[clearCredentials] Unable to clear all face credentials [endpointId=%d,status=%d]", endpointId,
@@ -2474,7 +2409,7 @@ EmberAfStatus DoorLockServer::clearCredentials(chip::EndpointId endpointId, chip
     return EMBER_ZCL_STATUS_SUCCESS;
 }
 
-EmberAfStatus DoorLockServer::clearCredentials(chip::EndpointId endpointId, chip::FabricIndex modifier, chip::NodeId sourceNodeId,
+EmberAfStatus DoorLockServer::clearCredentials(chip::EndpointId endpointId, chip::OperationalId operationalId,
                                                DlCredentialType credentialType)
 {
     uint16_t maxNumberOfCredentials = 0;
@@ -2489,7 +2424,7 @@ EmberAfStatus DoorLockServer::clearCredentials(chip::EndpointId endpointId, chip
 
     for (uint16_t i = 1; i < maxNumberOfCredentials; ++i)
     {
-        auto status = clearCredential(endpointId, modifier, sourceNodeId, credentialType, i, false);
+        auto status = clearCredential(endpointId, operationalId, credentialType, i, false);
         if (EMBER_ZCL_STATUS_SUCCESS != status)
         {
             ChipLogError(Zcl,
@@ -2500,15 +2435,14 @@ EmberAfStatus DoorLockServer::clearCredentials(chip::EndpointId endpointId, chip
         }
     }
 
-    sendRemoteLockUserChange(endpointId, credentialTypeToLockDataType(credentialType), DlDataOperationType::kClear, sourceNodeId,
-                             modifier, 0xFFFE, 0xFFFE);
+    sendRemoteLockUserChange(endpointId, credentialTypeToLockDataType(credentialType), DlDataOperationType::kClear, operationalId,
+                             0xFFFE, 0xFFFE);
 
     return EMBER_ZCL_STATUS_SUCCESS;
 }
 
 bool DoorLockServer::sendRemoteLockUserChange(chip::EndpointId endpointId, DlLockDataType dataType, DlDataOperationType operation,
-                                              chip::NodeId nodeId, chip::FabricIndex fabricIndex, uint16_t userIndex,
-                                              uint16_t dataIndex)
+                                              chip::OperationalId operationalId, uint16_t userIndex, uint16_t dataIndex)
 {
     Events::LockUserChange::Type event;
     event.lockDataType      = dataType;
@@ -2518,8 +2452,8 @@ bool DoorLockServer::sendRemoteLockUserChange(chip::EndpointId endpointId, DlLoc
     {
         event.userIndex = Nullable<uint16_t>(userIndex);
     }
-    event.fabricIndex = Nullable<chip::FabricIndex>(fabricIndex);
-    event.sourceNode  = Nullable<chip::NodeId>(nodeId);
+    event.fabricIndex = Nullable<chip::FabricIndex>(operationalId.GetFabricIndex());
+    event.sourceNode  = Nullable<chip::NodeId>(operationalId.GetNodeId());
     if (0 != dataIndex)
     {
         event.dataIndex = Nullable<uint16_t>(dataIndex);
@@ -2534,9 +2468,9 @@ bool DoorLockServer::sendRemoteLockUserChange(chip::EndpointId endpointId, DlLoc
         return false;
     }
     emberAfDoorLockClusterPrintln("[RemoteLockUserChange] Sent lock user change event "
-                                  "[endpointId=%d,eventNumber=%" PRIu64 ",dataType=%u,operation=%u,nodeId=%" PRIu64
-                                  ",fabricIndex=%d]",
-                                  endpointId, eventNumber, to_underlying(dataType), to_underlying(operation), nodeId, fabricIndex);
+                                  "[endpointId=%d,eventNumber=%" PRIu64 ",dataType=%u,operation=%u," ChipLogFormatOperationalId "]",
+                                  endpointId, eventNumber, to_underlying(dataType), to_underlying(operation),
+                                  ChipLogValueOperationalId(operationalId));
     return true;
 }
 
@@ -2648,9 +2582,10 @@ exit:
         credListSize = 1;
     }
 
+    auto operationalId = getOperationalId(commandObj);
     SendLockOperationEvent(endpoint, opType, DlOperationSource::kRemote, reason, Nullable<uint16_t>(pinUserIdx),
-                           Nullable<chip::FabricIndex>(getFabricIndex(commandObj)), Nullable<chip::NodeId>(getNodeId(commandObj)),
-                           credList, credListSize, success);
+                           Nullable<chip::FabricIndex>(operationalId.GetFabricIndex()),
+                           Nullable<chip::NodeId>(operationalId.GetNodeId()), credList, credListSize, success);
     return success;
 }
 

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -155,8 +155,7 @@ public:
     }
 
 private:
-    chip::FabricIndex getFabricIndex(const chip::app::CommandHandler * commandObj);
-    chip::NodeId getNodeId(const chip::app::CommandHandler * commandObj);
+    chip::OperationalId getOperationalId(const chip::app::CommandHandler * commandObj);
 
     bool userIndexValid(chip::EndpointId endpointId, uint16_t userIndex);
     bool userIndexValid(chip::EndpointId endpointId, uint16_t userIndex, uint16_t & maxNumberOfUser);
@@ -180,21 +179,21 @@ private:
     bool findUserIndexByCredential(chip::EndpointId endpointId, DlCredentialType credentialType, chip::ByteSpan credentialData,
                                    uint16_t & userIndex, uint16_t & credentialIndex);
 
-    EmberAfStatus createUser(chip::EndpointId endpointId, chip::FabricIndex creatorFabricIdx, chip::NodeId sourceNodeId,
-                             uint16_t userIndex, const Nullable<chip::CharSpan> & userName, const Nullable<uint32_t> & userUniqueId,
+    EmberAfStatus createUser(chip::EndpointId endpointId, chip::OperationalId operationalId, uint16_t userIndex,
+                             const Nullable<chip::CharSpan> & userName, const Nullable<uint32_t> & userUniqueId,
                              const Nullable<DlUserStatus> & userStatus, const Nullable<DlUserType> & userType,
                              const Nullable<DlCredentialRule> & credentialRule,
                              const Nullable<DlCredential> & credential = Nullable<DlCredential>());
-    EmberAfStatus modifyUser(chip::EndpointId endpointId, chip::FabricIndex modifierFabricIndex, chip::NodeId sourceNodeId,
-                             uint16_t userIndex, const Nullable<chip::CharSpan> & userName, const Nullable<uint32_t> & userUniqueId,
+    EmberAfStatus modifyUser(chip::EndpointId endpointId, chip::OperationalId operationalId, uint16_t userIndex,
+                             const Nullable<chip::CharSpan> & userName, const Nullable<uint32_t> & userUniqueId,
                              const Nullable<DlUserStatus> & userStatus, const Nullable<DlUserType> & userType,
                              const Nullable<DlCredentialRule> & credentialRule);
-    EmberAfStatus clearUser(chip::EndpointId endpointId, chip::FabricIndex modifierFabricId, chip::NodeId sourceNodeId,
-                            uint16_t userIndex, bool sendUserChangeEvent);
-    EmberAfStatus clearUser(chip::EndpointId endpointId, chip::FabricIndex modifierFabricId, chip::NodeId sourceNodeId,
-                            uint16_t userIndex, const EmberAfPluginDoorLockUserInfo & user, bool sendUserChangeEvent);
+    EmberAfStatus clearUser(chip::EndpointId endpointId, chip::OperationalId operationalId, uint16_t userIndex,
+                            bool sendUserChangeEvent);
+    EmberAfStatus clearUser(chip::EndpointId endpointId, chip::OperationalId operationalId, uint16_t userIndex,
+                            const EmberAfPluginDoorLockUserInfo & user, bool sendUserChangeEvent);
 
-    DlStatus createNewCredentialAndUser(chip::EndpointId endpointId, chip::FabricIndex creatorFabricIdx, chip::NodeId sourceNodeId,
+    DlStatus createNewCredentialAndUser(chip::EndpointId endpointId, chip::OperationalId operationalId,
                                         const Nullable<DlUserStatus> & userStatus, const Nullable<DlUserType> & userType,
                                         const DlCredential & credential, const chip::ByteSpan & credentialData,
                                         uint16_t & createdUserIndex);
@@ -206,25 +205,22 @@ private:
     DlStatus modifyCredentialForUser(chip::EndpointId endpointId, chip::FabricIndex modifierFabricIdx, uint16_t userIndex,
                                      const DlCredential & credential);
 
-    DlStatus createCredential(chip::EndpointId endpointId, chip::FabricIndex creatorFabricIdx, chip::NodeId sourceNodeId,
-                              uint16_t credentialIndex, DlCredentialType credentialType,
-                              const EmberAfPluginDoorLockCredentialInfo & existingCredential, const chip::ByteSpan & credentialData,
-                              Nullable<uint16_t> userIndex, Nullable<DlUserStatus> userStatus, Nullable<DlUserType> userType,
-                              uint16_t & createdUserIndex);
-    DlStatus modifyProgrammingPIN(chip::EndpointId endpointId, chip::FabricIndex modifierFabricIndex, chip::NodeId sourceNodeId,
-                                  uint16_t credentialIndex, DlCredentialType credentialType,
-                                  const EmberAfPluginDoorLockCredentialInfo & existingCredential,
+    DlStatus createCredential(chip::EndpointId endpointId, chip::OperationalId operationalId, uint16_t credentialIndex,
+                              DlCredentialType credentialType, const EmberAfPluginDoorLockCredentialInfo & existingCredential,
+                              const chip::ByteSpan & credentialData, Nullable<uint16_t> userIndex,
+                              Nullable<DlUserStatus> userStatus, Nullable<DlUserType> userType, uint16_t & createdUserIndex);
+    DlStatus modifyProgrammingPIN(chip::EndpointId endpointId, chip::OperationalId operationalId, uint16_t credentialIndex,
+                                  DlCredentialType credentialType, const EmberAfPluginDoorLockCredentialInfo & existingCredential,
                                   const chip::ByteSpan & credentialData);
-    DlStatus modifyCredential(chip::EndpointId endpointId, chip::FabricIndex modifierFabricIndex, chip::NodeId sourceNodeId,
-                              uint16_t credentialIndex, DlCredentialType credentialType,
-                              const EmberAfPluginDoorLockCredentialInfo & existingCredential, const chip::ByteSpan & credentialData,
-                              uint16_t userIndex, Nullable<DlUserStatus> userStatus, Nullable<DlUserType> userType);
+    DlStatus modifyCredential(chip::EndpointId endpointId, chip::OperationalId operationalId, uint16_t credentialIndex,
+                              DlCredentialType credentialType, const EmberAfPluginDoorLockCredentialInfo & existingCredential,
+                              const chip::ByteSpan & credentialData, uint16_t userIndex, Nullable<DlUserStatus> userStatus,
+                              Nullable<DlUserType> userType);
 
-    EmberAfStatus clearCredential(chip::EndpointId endpointId, chip::FabricIndex modifier, chip::NodeId sourceNodeId,
-                                  DlCredentialType credentialType, uint16_t credentialIndex, bool sendUserChangeEvent);
-    EmberAfStatus clearCredentials(chip::EndpointId endpointId, chip::FabricIndex modifier, chip::NodeId sourceNodeId);
-    EmberAfStatus clearCredentials(chip::EndpointId endpointId, chip::FabricIndex modifier, chip::NodeId sourceNodeId,
-                                   DlCredentialType credentialType);
+    EmberAfStatus clearCredential(chip::EndpointId endpointId, chip::OperationalId operationalId, DlCredentialType credentialType,
+                                  uint16_t credentialIndex, bool sendUserChangeEvent);
+    EmberAfStatus clearCredentials(chip::EndpointId endpointId, chip::OperationalId operationalId);
+    EmberAfStatus clearCredentials(chip::EndpointId endpointId, chip::OperationalId operationalId, DlCredentialType credentialType);
 
     CHIP_ERROR sendSetCredentialResponse(chip::app::CommandHandler * commandObj, DlStatus status, uint16_t userIndex,
                                          uint16_t nextCredentialIndex);
@@ -255,8 +251,7 @@ private:
                                               uint32_t localEndTime = 0);
 
     bool sendRemoteLockUserChange(chip::EndpointId endpointId, DlLockDataType dataType, DlDataOperationType operation,
-                                  chip::NodeId nodeId, chip::FabricIndex fabricIndex, uint16_t userIndex = 0,
-                                  uint16_t dataIndex = 0);
+                                  chip::OperationalId operationalId, uint16_t userIndex = 0, uint16_t dataIndex = 0);
 
     DlLockDataType credentialTypeToLockDataType(DlCredentialType credentialType);
 

--- a/src/lib/core/OperationalId.h
+++ b/src/lib/core/OperationalId.h
@@ -1,0 +1,48 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/NodeId.h>
+
+namespace chip {
+
+class OperationalId
+{
+public:
+    OperationalId(NodeId nodeId, FabricIndex fabricIndex) : mNodeId(nodeId), mFabricIndex(fabricIndex)
+    {
+        VerifyOrDie(mNodeId != kUndefinedNodeId);
+        VerifyOrDie(mFabricIndex != kUndefinedFabricIndex);
+    }
+
+    NodeId GetNodeId() const { return mNodeId; }
+    FabricIndex GetFabricIndex() const { return mFabricIndex; }
+
+    static constexpr OperationalId UndefinedOperationalId() { return OperationalId(); }
+
+    bool operator==(const OperationalId & that) const { return (mNodeId == that.mNodeId) && (mFabricIndex == that.mFabricIndex); }
+    bool operator!=(const OperationalId & that) const { return !(*this == that); }
+
+private:
+    NodeId mNodeId;
+    // TODO: replace FabricIndex with a pointer to FabricInfo structure.
+    FabricIndex mFabricIndex;
+
+    constexpr OperationalId() : mNodeId(kUndefinedNodeId), mFabricIndex(kUndefinedFabricIndex) {}
+};
+
+} // namespace chip

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -378,5 +378,11 @@ bool IsCategoryEnabled(uint8_t category);
  */
 #define ChipLogFormatMessageType "0x%x"
 
+/**
+ * Logging helpers for OperationalId
+ */
+#define ChipLogFormatOperationalId "<" ChipLogFormatX64 ", %u>"
+#define ChipLogValueOperationalId(operationalId) ChipLogValueX64(operationalId.GetNodeId()), operationalId.GetFabricIndex()
+
 } // namespace Logging
 } // namespace chip

--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -78,7 +78,8 @@ CHIP_ERROR MessageCounterManager::QueueReceivedMessageAndStartSync(const PacketH
                                                                    System::PacketBufferHandle && msgBuf)
 {
     // Queue the message to be reprocessed when sync completes.
-    ReturnErrorOnFailure(AddToReceiveTable(packetHeader, peerAddress, std::move(msgBuf)));
+    ReturnErrorOnFailure(
+        AddToReceiveTable(session->GetPeerOperationalId().GetFabricIndex(), packetHeader, peerAddress, std::move(msgBuf)));
     ReturnErrorOnFailure(StartSync(session, state));
 
     // After the message that triggers message counter synchronization is stored, and a message counter
@@ -114,7 +115,8 @@ void MessageCounterManager::OnResponseTimeout(Messaging::ExchangeContext * excha
     }
 }
 
-CHIP_ERROR MessageCounterManager::AddToReceiveTable(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
+CHIP_ERROR MessageCounterManager::AddToReceiveTable(FabricIndex fabricIndex, const PacketHeader & packetHeader,
+                                                    const Transport::PeerAddress & peerAddress,
                                                     System::PacketBufferHandle && msgBuf)
 {
     ReturnErrorOnFailure(packetHeader.EncodeBeforeData(msgBuf));
@@ -124,6 +126,7 @@ CHIP_ERROR MessageCounterManager::AddToReceiveTable(const PacketHeader & packetH
         if (entry.msgBuf.IsNull())
         {
             entry.peerAddress = peerAddress;
+            entry.fabricIndex = fabricIndex;
             entry.msgBuf      = std::move(msgBuf);
 
             return CHIP_NO_ERROR;
@@ -141,7 +144,7 @@ CHIP_ERROR MessageCounterManager::AddToReceiveTable(const PacketHeader & packetH
  *  @param[in] peerNodeId    Node ID of the destination node.
  *
  */
-void MessageCounterManager::ProcessPendingMessages(NodeId peerNodeId)
+void MessageCounterManager::ProcessPendingMessages(OperationalId operationalId)
 {
     auto * sessionManager = mExchangeMgr->GetSessionManager();
 
@@ -161,7 +164,8 @@ void MessageCounterManager::ProcessPendingMessages(NodeId peerNodeId)
                 continue;
             }
 
-            if (packetHeader.GetSourceNodeId().HasValue() && packetHeader.GetSourceNodeId().Value() == peerNodeId)
+            if (packetHeader.GetSourceNodeId().HasValue() &&
+                OperationalId(packetHeader.GetSourceNodeId().Value(), entry.fabricIndex) == operationalId)
             {
                 // Reprocess message.
                 sessionManager->OnMessageReceived(entry.peerAddress, std::move(entry.msgBuf));
@@ -292,7 +296,7 @@ CHIP_ERROR MessageCounterManager::HandleMsgCounterSyncResp(Messaging::ExchangeCo
     SuccessOrExit(err);
 
     // Process all queued incoming messages after message counter synchronization is completed.
-    ProcessPendingMessages(exchangeContext->GetSessionHandle()->AsSecureSession()->GetPeerNodeId());
+    ProcessPendingMessages(exchangeContext->GetSessionHandle()->GetPeerOperationalId());
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/protocols/secure_channel/MessageCounterManager.h
+++ b/src/protocols/secure_channel/MessageCounterManager.h
@@ -74,8 +74,8 @@ public:
      *  @retval  #CHIP_ERROR_NO_MEMORY If there is no empty slot left in the table for addition.
      *  @retval  #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR AddToReceiveTable(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
-                                 System::PacketBufferHandle && msgBuf);
+    CHIP_ERROR AddToReceiveTable(FabricIndex fabricIndex, const PacketHeader & packetHeader,
+                                 const Transport::PeerAddress & peerAddress, System::PacketBufferHandle && msgBuf);
 
 private:
     /**
@@ -91,7 +91,8 @@ private:
     struct ReceiveTableEntry
     {
         Transport::PeerAddress peerAddress; /**< The peer address for the message*/
-        System::PacketBufferHandle msgBuf;  /**< A handle to the PacketBuffer object holding the message data. */
+        FabricIndex fabricIndex;
+        System::PacketBufferHandle msgBuf; /**< A handle to the PacketBuffer object holding the message data. */
     };
 
     Messaging::ExchangeManager * mExchangeMgr; // [READ ONLY] Associated Exchange Manager object.
@@ -99,7 +100,7 @@ private:
     // MessageCounterManager cache table to queue the incoming messages that trigger message counter synchronization protocol.
     ReceiveTableEntry mReceiveTable[CHIP_CONFIG_MCSP_RECEIVE_TABLE_SIZE];
 
-    void ProcessPendingMessages(NodeId peerNodeId);
+    void ProcessPendingMessages(OperationalId operationalId);
 
     CHIP_ERROR SendMsgCounterSyncResp(Messaging::ExchangeContext * exchangeContext, FixedByteSpan<kChallengeSize> challenge);
     CHIP_ERROR HandleMsgCounterSyncReq(Messaging::ExchangeContext * exchangeContext, System::PacketBufferHandle && msgBuf);

--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -38,6 +38,8 @@ public:
     const char * GetSessionTypeString() const override { return "secure"; };
 #endif
 
+    OperationalId GetPeerOperationalId() const override { return OperationalId::UndefinedOperationalId(); }
+
     Access::SubjectDescriptor GetSubjectDescriptor() const override
     {
         Access::SubjectDescriptor subjectDescriptor;

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -20,6 +20,11 @@
 namespace chip {
 namespace Transport {
 
+OperationalId SecureSession::GetPeerOperationalId() const
+{
+    return OperationalId(mPeerNodeId, GetFabricIndex());
+}
+
 Access::SubjectDescriptor SecureSession::GetSubjectDescriptor() const
 {
     Access::SubjectDescriptor subjectDescriptor;

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -83,6 +83,8 @@ public:
     const char * GetSessionTypeString() const override { return "secure"; };
 #endif
 
+    OperationalId GetPeerOperationalId() const override;
+
     Access::SubjectDescriptor GetSubjectDescriptor() const override;
 
     bool RequireMRP() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kUdp; }

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -18,6 +18,7 @@
 
 #include <credentials/FabricTable.h>
 #include <lib/core/CHIPConfig.h>
+#include <lib/core/OperationalId.h>
 #include <messaging/ReliableMessageProtocolConfig.h>
 #include <transport/SessionHolder.h>
 #include <transport/raw/PeerAddress.h>
@@ -63,6 +64,7 @@ public:
     virtual void Retain() {}
     virtual void Release() {}
 
+    virtual OperationalId GetPeerOperationalId() const                 = 0;
     virtual Access::SubjectDescriptor GetSubjectDescriptor() const     = 0;
     virtual bool RequireMRP() const                                    = 0;
     virtual const ReliableMessageProtocolConfig & GetMRPConfig() const = 0;

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -74,6 +74,8 @@ public:
     void Retain() override { ReferenceCounted<UnauthenticatedSession, UnauthenticatedSessionDeleter, 0>::Retain(); }
     void Release() override { ReferenceCounted<UnauthenticatedSession, UnauthenticatedSessionDeleter, 0>::Release(); }
 
+    OperationalId GetPeerOperationalId() const override { return OperationalId::UndefinedOperationalId(); }
+
     Access::SubjectDescriptor GetSubjectDescriptor() const override
     {
         return Access::SubjectDescriptor(); // return an empty ISD for unauthenticated session.


### PR DESCRIPTION
#### Problem
Partially fixes #13397

#### Change overview
* Add a new class `OperationalId` contains tuple `<FabricIndex, NodeId>`
* Add a new API `GetPeerOperationalId` in session interface.
  * For secure sessions returns corresponding `OperationalId`
  * For group and unsecure sessions return an undefined OperationalId
* Introduce log maco `ChipLogFormatOperationalId` and `ChipLogValueOperationalId` to help print `OperationalId` structure

#### Testing
Passes tests.