### PR TITLE
Verify the device is under commissioning before accessing/storing inf…

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -527,6 +527,10 @@ bool emberAfOperationalCredentialsClusterAddNOCCallback(app::CommandHandler * co
 
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: commissioner has added a NOC");
 
+    VerifyOrExit(Server::GetInstance().GetCommissioningWindowManager().CommissioningWindowStatus() !=
+                     AdministratorCommissioning::CommissioningWindowStatus::kWindowNotOpen,
+                 nocResponse = OperationalCertStatus::kInvalidNOC);
+
     err = gFabricBeingCommissioned.SetNOCCert(NOCValue);
     VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
 
@@ -747,6 +751,10 @@ bool emberAfOperationalCredentialsClusterCSRRequestCallback(app::CommandHandler 
         size_t nocsrLengthEstimate = 0;
         ByteSpan kNoVendorReserved;
 
+        VerifyOrExit(Server::GetInstance().GetCommissioningWindowManager().CommissioningWindowStatus() !=
+                         AdministratorCommissioning::CommissioningWindowStatus::kWindowNotOpen,
+                     err = CHIP_ERROR_INCORRECT_STATE);
+
         // Always generate a new operational keypair for any new CSRRequest
         if (gFabricBeingCommissioned.GetOperationalKey() != nullptr)
         {
@@ -814,6 +822,10 @@ bool emberAfOperationalCredentialsClusterAddTrustedRootCertificateCallback(
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
 
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: commissioner has added a trusted root Cert");
+
+    VerifyOrExit(Server::GetInstance().GetCommissioningWindowManager().CommissioningWindowStatus() !=
+                     AdministratorCommissioning::CommissioningWindowStatus::kWindowNotOpen,
+                 status = EMBER_ZCL_STATUS_FAILURE);
 
     // TODO: Ensure we do not duplicate roots in storage, and detect "same key, different cert" errors
     // TODO: Validate cert signature prior to setting.

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -88,6 +88,7 @@ void CommissioningWindowManager::ResetState()
     mECMPasscodeID    = 0;
     mECMIterations    = 0;
     mECMSaltLength    = 0;
+    mWindowStatus     = app::Clusters::AdministratorCommissioning::CommissioningWindowStatus::kWindowNotOpen;
 
     memset(&mECMPASEVerifier, 0, sizeof(mECMPASEVerifier));
     memset(mECMSalt, 0, sizeof(mECMSalt));
@@ -333,8 +334,6 @@ CHIP_ERROR CommissioningWindowManager::StopAdvertisement(bool aShuttingDown)
         DeviceLayer::ConnectivityMgr().RequestSEDFastPollingMode(false);
     }
 #endif
-
-    mWindowStatus = AdministratorCommissioning::CommissioningWindowStatus::kWindowNotOpen;
 
     // If aShuttingDown, don't try to change our DNS-SD advertisements.
     if (!aShuttingDown)


### PR DESCRIPTION
…ormation in fabric

#### Problem
What is being fixed?  Examples:
* The device commissioning window might be closed due to various reasons (e.g. failsafe timeout, already commissioned and commissioning window not reopened). Current operational credentials cluster does not check if gFabricBeingCommissioned is valid before storing information in it. The code should check the validity of gFabricBeingCommissioned before accessing/storing information in it.
* Fixes #8919

#### Change overview
* Verify the device is under commissioning before accessing/storing information in fabric
* Close the commissioning window after commissioning complete or timeout

#### Testing
How was this tested? (at least one bullet point required)

On Server Side:
./chip-all-clusters-app

On Client Side:
./chip-tool pairing ethernet 12344321 20202021 3840 ::1 5540

Confirm the commissioning complete successfully. 

