### PR TITLE
Fix chip-tool resolve command to work.

### DIFF
--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -32,11 +32,11 @@ public:
     /////////// DiscoverCommand Interface /////////
     CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) override
     {
-        ReturnErrorOnFailure(chip::Dnssd::Resolver::Instance().Init(chip::DeviceLayer::UDPEndPointManager()));
-        chip::Dnssd::Resolver::Instance().SetResolverDelegate(this);
+        ReturnErrorOnFailure(mDNSResolver.Init(chip::DeviceLayer::UDPEndPointManager()));
+        mDNSResolver.SetResolverDelegate(this);
         ChipLogProgress(chipTool, "Dnssd: Searching for NodeId: %" PRIx64 " FabricId: %" PRIx64 " ...", remoteId, fabricId);
-        return chip::Dnssd::Resolver::Instance().ResolveNodeId(chip::PeerId().SetNodeId(remoteId).SetCompressedFabricId(fabricId),
-                                                               chip::Inet::IPAddressType::kAny);
+        return mDNSResolver.ResolveNodeId(chip::PeerId().SetNodeId(remoteId).SetCompressedFabricId(fabricId),
+                                          chip::Inet::IPAddressType::kAny);
     }
 
     void OnNodeIdResolved(const chip::Dnssd::ResolvedNodeData & nodeData) override
@@ -71,6 +71,9 @@ public:
         SetCommandExitStatus(CHIP_ERROR_INTERNAL);
     }
     void OnNodeDiscoveryComplete(const chip::Dnssd::DiscoveredNodeData & nodeData) override {}
+
+private:
+    chip::Dnssd::ResolverProxy mDNSResolver;
 };
 
 class Update : public DiscoverCommand


### PR DESCRIPTION
Trying to use the global resolver directly only works for minimal mdns.
Switch to using the supported ResolverProxy API.

#### Problem
Running `chip-tool discover resolve node-id fabric-id` does not work because we end up trying to use a never-inited resolver proxy (`mResolverProxy` in the platform mdns stuff).

#### Change overview
Use ResolverProxy directly to make this work.

#### Testing
Ran that command, resolved the node id to an IP.