### PR TITLE
Fix the ScreenManager lock release

### DIFF
--- a/examples/common/screen-framework/ScreenManager.cpp
+++ b/examples/common/screen-framework/ScreenManager.cpp
@@ -53,7 +53,7 @@ SemaphoreHandle_t mutex;
 struct Lock
 {
     Lock() { xSemaphoreTakeRecursive(mutex, portMAX_DELAY); }
-    ~Lock() { xSemaphoreGive(mutex); }
+    ~Lock() { xSemaphoreGiveRecursive(mutex); }
 };
 
 struct VLED


### PR DESCRIPTION
#### Problem

Releasing this lock occasionally aborts, and it goes away when changing
xSemaphoreGive to xSemaphoreGiveRecursive.

#### Change overview

Do that.

#### Testing

Cause lots of screen draws by clicking on/off repeatedly.