### PR TITLE
Fix TC_SWDIAG_3_1.yaml test case on Linux

### DIFF
--- a/scripts/tools/zap_regen_yaml_tests.sh
+++ b/scripts/tools/zap_regen_yaml_tests.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+#
+#    Copyright (c) 2022 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      Run this from root of SDK to regenerate only the ZAP needed by chip-tool,
+#      rather than all of zap like `./scripts/tools/zap_regen_all.py
+#
+
+./scripts/tools/zap/generate.py src/controller/data_model/controller-clusters.zap \
+  -o zzz_generated/chip-tool/zap-generated -t examples/chip-tool/templates/templates.json
+

--- a/scripts/tools/zap_regen_yaml_tests.sh
+++ b/scripts/tools/zap_regen_yaml_tests.sh
@@ -23,4 +23,4 @@
 #
 
 ./scripts/tools/zap/generate.py src/controller/data_model/controller-clusters.zap \
-  -o zzz_generated/chip-tool/zap-generated -t examples/chip-tool/templates/templates.json
+    -o zzz_generated/chip-tool/zap-generated -t examples/chip-tool/templates/templates.json

--- a/scripts/tools/zap_regen_yaml_tests.sh
+++ b/scripts/tools/zap_regen_yaml_tests.sh
@@ -24,4 +24,3 @@
 
 ./scripts/tools/zap/generate.py src/controller/data_model/controller-clusters.zap \
   -o zzz_generated/chip-tool/zap-generated -t examples/chip-tool/templates/templates.json
-

--- a/src/app/tests/suites/certification/Test_TC_SWDIAG_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SWDIAG_3_1.yaml
@@ -47,7 +47,8 @@ tests:
       attribute: "CurrentHeapUsed"
       PICS: A_CURRENTHEAPUSED
       response:
-          value: 0
+          constraints:
+              type: uint64
 
     - label: "Reads CurrentHeapHighWaterMark attribute value from DUT"
       optional: true
@@ -55,4 +56,5 @@ tests:
       attribute: "CurrentHeapHighWatermark"
       PICS: A_CURRENTHEAPHIGHWATERMARK
       response:
-          value: 0
+          constraints:
+              type: uint64

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -45112,11 +45112,6 @@ NSNumber * _Nonnull ourFabricIndex;
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
 
-        {
-            id actualValue = value;
-            XCTAssertEqual([actualValue unsignedLongLongValue], 0ULL);
-        }
-
         [expectation fulfill];
     }];
 
@@ -45140,11 +45135,6 @@ NSNumber * _Nonnull ourFabricIndex;
         }
 
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
-
-        {
-            id actualValue = value;
-            XCTAssertEqual([actualValue unsignedLongLongValue], 0ULL);
-        }
 
         [expectation fulfill];
     }];

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -81421,8 +81421,7 @@ private:
 
     void OnSuccessResponse_2(uint64_t currentHeapUsed)
     {
-        VerifyOrReturn(CheckValue("currentHeapUsed", currentHeapUsed, 0ULL));
-
+        VerifyOrReturn(CheckConstraintType("currentHeapUsed", "", "uint64"));
         NextTest();
     }
 
@@ -81448,8 +81447,7 @@ private:
 
     void OnSuccessResponse_3(uint64_t currentHeapHighWatermark)
     {
-        VerifyOrReturn(CheckValue("currentHeapHighWatermark", currentHeapHighWatermark, 0ULL));
-
+        VerifyOrReturn(CheckConstraintType("currentHeapHighWatermark", "", "uint64"));
         NextTest();
     }
 };


### PR DESCRIPTION
#### Problem
- The test case previously expected used/free heap value of 0.
- Now the SDK is implementing heap read properly from Linux when
  built with glibc. This made the code return a real value
  that fails the test.
- Overall, there is no "value" value for heap, we just need
  a value.

#### Change overview

- The explicit value was replaced with expecting
  a returned value back.
- A new script was written with help @vivien-apple to
  save time when regenerating ZAP for just chip-tool

#### Testing
Ran the modified integration test, now passes on Linux
