### PR TITLE
Increase iMX build timeouts - 10min occasionally fail

### DIFF
--- a/.github/workflows/examples-linux-imx.yaml
+++ b/.github/workflows/examples-linux-imx.yaml
@@ -40,12 +40,12 @@ jobs:
                   submodules: true
 
             - name: Build App
-              timeout-minutes: 10
+              timeout-minutes: 30
               run: |
                   ./scripts/examples/imxlinux_example.sh \
                   examples/lighting-app/linux/ examples/lighting-app/linux/out/aarch64
             - name: Build chip-tool
-              timeout-minutes: 10
+              timeout-minutes: 30
               run: |
                    ./scripts/examples/imxlinux_example.sh \
                    examples/chip-tool examples/chip-tool/out/aarch64


### PR DESCRIPTION
#### Problem
CI timeout for iMX builds

#### Change overview
Switch timeouts from 10min to 30min.

#### Testing
CI will validate, but generally safe change.