### PR TITLE
[OTA] Send more useful StatusReport errors during download failures

### DIFF
--- a/src/app/clusters/ota-requestor/BDXDownloader.cpp
+++ b/src/app/clusters/ota-requestor/BDXDownloader.cpp
@@ -128,8 +128,18 @@ void BDXDownloader::EndDownload(CHIP_ERROR reason)
 {
     if (mState == State::kInProgress)
     {
-        // There's no method for a BDX receiving driver to cleanly end a transfer
-        mBdxTransfer.AbortTransfer(chip::bdx::StatusCode::kUnknown);
+        bdx::StatusCode status = bdx::StatusCode::kUnknown;
+        if (reason == CHIP_ERROR_INVALID_FILE_IDENTIFIER)
+        {
+            status = bdx::StatusCode::kBadMessageContents;
+        }
+        else if (reason == CHIP_ERROR_WRITE_FAILED)
+        {
+            status = bdx::StatusCode::kTransferFailedUnknownError;
+        }
+
+        // There is no method for a BDX receiving driver to cleanly end a transfer
+        mBdxTransfer.AbortTransfer(status);
         if (mImageProcessor != nullptr)
         {
             mImageProcessor->Abort();

--- a/src/platform/Linux/OTAImageProcessorImpl.cpp
+++ b/src/platform/Linux/OTAImageProcessorImpl.cpp
@@ -169,16 +169,16 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
 
     ByteSpan block   = imageProcessor->mBlock;
     CHIP_ERROR error = imageProcessor->ProcessHeader(block);
-
-    if (error == CHIP_NO_ERROR &&
-        !imageProcessor->mOfs.write(reinterpret_cast<const char *>(block.data()), static_cast<std::streamsize>(block.size())))
-    {
-        error = CHIP_ERROR_WRITE_FAILED;
-    }
-
     if (error != CHIP_NO_ERROR)
     {
-        imageProcessor->mDownloader->EndDownload(error);
+        ChipLogError(SoftwareUpdate, "Image does not contain a valid header");
+        imageProcessor->mDownloader->EndDownload(CHIP_ERROR_INVALID_FILE_IDENTIFIER);
+        return;
+    }
+
+    if (!imageProcessor->mOfs.write(reinterpret_cast<const char *>(block.data()), static_cast<std::streamsize>(block.size())))
+    {
+        imageProcessor->mDownloader->EndDownload(CHIP_ERROR_WRITE_FAILED);
         return;
     }
 

--- a/src/protocols/bdx/BdxMessages.h
+++ b/src/protocols/bdx/BdxMessages.h
@@ -48,8 +48,6 @@ enum class MessageType : uint8_t
 
 enum class StatusCode : uint16_t
 {
-    kNone                       = 0x0000,
-    kOverflow                   = 0x0011,
     kLengthTooLarge             = 0x0012,
     kLengthTooShort             = 0x0013,
     kLengthMismatch             = 0x0014,
@@ -57,8 +55,8 @@ enum class StatusCode : uint16_t
     kBadMessageContents         = 0x0016,
     kBadBlockCounter            = 0x0017,
     kUnexpectedMessage          = 0x0018,
+    kResponderBusy              = 0x0019,
     kTransferFailedUnknownError = 0x001F,
-    kFailureToSend              = 0x0021,
     kTransferMethodNotSupported = 0x0050,
     kFileDesignatorUnknown      = 0x0051,
     kStartOffsetNotSupported    = 0x0052,

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -130,8 +130,8 @@ public:
             TransferSkipData bytesToSkip;
         };
 
-        OutputEvent() : EventType(OutputEventType::kNone) { statusData = { StatusCode::kNone }; }
-        OutputEvent(OutputEventType type) : EventType(type) { statusData = { StatusCode::kNone }; }
+        OutputEvent() : EventType(OutputEventType::kNone) { statusData = { StatusCode::kUnknown }; }
+        OutputEvent(OutputEventType type) : EventType(type) { statusData = { StatusCode::kUnknown }; }
 
         const char * ToString(OutputEventType outputEventType);
 


### PR DESCRIPTION
#### Problem
When an OTA provider supplies an image without a proper header, the logging is very vague that this has occurred. Also, the StatusReport received on the provider side is for `Unknown` but this error could be more descriptive.

Fixes: https://github.com/project-chip/connectedhomeip/issues/15219

#### Change overview
- Add logging to point out that a transfer failed due to an image missing header
- Pass more useful StatusReport error when transfer fails because of missing header or because of failure to write
- Update the `StatusCode` enum to match the spec

#### Testing
- Verified that basic file transfer works
- Verified that when an image without a header is supplied, the appropriate error is logged and the StatusReport error reflects the error