### PR TITLE
Check for not-exactly-representable ints in more places in YAML.

### DIFF
--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -695,7 +695,8 @@ function chip_tests_item_response_parameters(options)
 
         if ('constraints' in expected) {
           responseArg.hasExpectedConstraints = true;
-          responseArg.expectedConstraints    = expected.constraints;
+          responseArg.expectedConstraints
+              = attachGlobal(this.global, expected.constraints, { thisVal : this, name : responseArg.name });
         }
 
         if ('saveAs' in expected) {

--- a/src/app/zap-templates/common/variables/Variables.js
+++ b/src/app/zap-templates/common/variables/Variables.js
@@ -81,12 +81,16 @@ async function extractVariablesFromConfig(context, suite)
     }
 
     if (!isKnownVariable && !('defaultValue' in target)) {
-      throw new Error(`${suite.filename}: No default value defined for config ${key}`);
+      throw new Error(`${suite.filename}: No default value defined for config '${key}'`);
     }
 
     value.defaultValue = isKnownVariable ? suite.config[key] : suite.config[key].defaultValue;
-    value.chipType     = await zclHelper.asUnderlyingZclType.call(context, value.type, { 'hash' : {} });
-    value.name         = key;
+    if (Number.isInteger(value.defaultValue) && !Number.isSafeInteger(value.defaultValue)) {
+      throw new Error(`${suite.filename}: Default value defined for config '${
+          key}' is too large to represent exactly as an integer in YAML.  Put quotes around it to treat it as a string.`);
+    }
+    value.chipType = await zclHelper.asUnderlyingZclType.call(context, value.type, { 'hash' : {} });
+    value.name     = key;
     variables.push(value);
   }
 

--- a/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
@@ -127,14 +127,14 @@ ResponseHandler {{> subscribeDataCallback}} = nil;
         {
           {{> actualValue}}
           BOOL isLowerCase = [actualValue isEqualToString:[actualValue lowercaseString]];
-          XCTAssert{{#if expectedConstraints.isLowerCase}}True{{else}}False{{/if}}(isLowerCase);
+          XCTAssert{{#if (isStrEqual "true" expectedConstraints.isLowerCase)}}True{{else}}False{{/if}}(isLowerCase);
         }
         {{/if}}
         {{#if (hasProperty expectedConstraints "isUpperCase")}}
         {
           {{> actualValue}}
           BOOL isUpperCase = [actualValue isEqualToString:[actualValue uppercaseString]];
-          XCTAssert{{#if expectedConstraints.isUpperCase}}True{{else}}False{{/if}}(isUpperCase);
+          XCTAssert{{#if (isStrEqual "true" expectedConstraints.isUpperCase)}}True{{else}}False{{/if}}(isUpperCase);
         }
         {{/if}}
         {{#if (hasProperty expectedConstraints "isHexString")}}
@@ -142,7 +142,7 @@ ResponseHandler {{> subscribeDataCallback}} = nil;
           {{> actualValue}}
           NSCharacterSet *chars = [[NSCharacterSet characterSetWithCharactersInString:@"0123456789ABCDEF"] invertedSet];
           BOOL isHexString = (NSNotFound == [actualValue rangeOfCharacterFromSet:chars].location);
-          XCTAssert{{#if expectedConstraints.isHexString}}True{{else}}False{{/if}}(isHexString);
+          XCTAssert{{#if (isStrEqual "true" expectedConstraints.isHexString)}}True{{else}}False{{/if}}(isHexString);
         }
         {{/if}}
         {{#if (hasProperty expectedConstraints "maxLength")}}


### PR DESCRIPTION
Specifically constraints and config variables.

#### Problem
Trying to use `0xFFFFFFFFFFFFFFFF` in constraints or config vars doesn't fail out and just silently gives you the wrong values.

#### Change overview
Make the bad situation fail codegen, with a helpful error message.

#### Testing
Tried such values in constraints and configs.