### PR TITLE
Fix signature of GetEthPHYRate to produce the right type

### DIFF
--- a/src/app/clusters/ethernet-network-diagnostics-server/ethernet-network-diagnostics-server.cpp
+++ b/src/app/clusters/ethernet-network-diagnostics-server/ethernet-network-diagnostics-server.cpp
@@ -74,11 +74,11 @@ CHIP_ERROR EthernetDiagosticsAttrAccess::ReadIfSupported(CHIP_ERROR (DiagnosticD
 CHIP_ERROR EthernetDiagosticsAttrAccess::ReadPHYRate(AttributeValueEncoder & aEncoder)
 {
     Attributes::PHYRate::TypeInfo::Type pHYRate;
-    uint8_t value = 0;
+    PHYRateType value = EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_10_M;
 
     if (DeviceLayer::GetDiagnosticDataProvider().GetEthPHYRate(value) == CHIP_NO_ERROR)
     {
-        pHYRate.SetNonNull(static_cast<PHYRateType>(value));
+        pHYRate.SetNonNull(value);
         ChipLogProgress(Zcl, "The current nominal, usable speed at the top of the physical layer of the Node: %d", value);
     }
     else

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -199,7 +199,7 @@ public:
     /**
      * Ethernet network diagnostics methods
      */
-    virtual CHIP_ERROR GetEthPHYRate(uint8_t & pHYRate);
+    virtual CHIP_ERROR GetEthPHYRate(app::Clusters::EthernetNetworkDiagnostics::PHYRateType & pHYRate);
     virtual CHIP_ERROR GetEthFullDuplex(bool & fullDuplex);
     virtual CHIP_ERROR GetEthCarrierDetect(bool & carrierDetect);
     virtual CHIP_ERROR GetEthTimeSinceReset(uint64_t & timeSinceReset);
@@ -323,7 +323,7 @@ inline CHIP_ERROR DiagnosticDataProvider::GetNetworkInterfaces(NetworkInterface 
 
 inline void DiagnosticDataProvider::ReleaseNetworkInterfaces(NetworkInterface * netifp) {}
 
-inline CHIP_ERROR DiagnosticDataProvider::GetEthPHYRate(uint8_t & pHYRate)
+inline CHIP_ERROR DiagnosticDataProvider::GetEthPHYRate(app::Clusters::EthernetNetworkDiagnostics::PHYRateType & pHYRate)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/platform/Linux/ConnectivityUtils.cpp
+++ b/src/platform/Linux/ConnectivityUtils.cpp
@@ -537,7 +537,7 @@ CHIP_ERROR ConnectivityUtils::GetEthInterfaceName(char * ifname, size_t bufSize)
     return err;
 }
 
-CHIP_ERROR ConnectivityUtils::GetEthPHYRate(const char * ifname, uint8_t & pHYRate)
+CHIP_ERROR ConnectivityUtils::GetEthPHYRate(const char * ifname, app::Clusters::EthernetNetworkDiagnostics::PHYRateType & pHYRate)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -567,34 +567,34 @@ CHIP_ERROR ConnectivityUtils::GetEthPHYRate(const char * ifname, uint8_t & pHYRa
     switch (speed)
     {
     case 10:
-        pHYRate = static_cast<uint8_t>(EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_10_M);
+        pHYRate = EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_10_M;
         break;
     case 100:
-        pHYRate = static_cast<uint8_t>(EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_100_M);
+        pHYRate = EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_100_M;
         break;
     case 1000:
-        pHYRate = static_cast<uint8_t>(EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_1000_M);
+        pHYRate = EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_1000_M;
         break;
     case 25000:
-        pHYRate = static_cast<uint8_t>(EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_2__5_G);
+        pHYRate = EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_2__5_G;
         break;
     case 5000:
-        pHYRate = static_cast<uint8_t>(EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_5_G);
+        pHYRate = EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_5_G;
         break;
     case 10000:
-        pHYRate = static_cast<uint8_t>(EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_10_G);
+        pHYRate = EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_10_G;
         break;
     case 40000:
-        pHYRate = static_cast<uint8_t>(EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_40_G);
+        pHYRate = EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_40_G;
         break;
     case 100000:
-        pHYRate = static_cast<uint8_t>(EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_100_G);
+        pHYRate = EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_100_G;
         break;
     case 200000:
-        pHYRate = static_cast<uint8_t>(EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_200_G);
+        pHYRate = EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_200_G;
         break;
     case 400000:
-        pHYRate = static_cast<uint8_t>(EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_400_G);
+        pHYRate = EmberAfPHYRateType::EMBER_ZCL_PHY_RATE_TYPE_400_G;
         break;
     default:
         ChipLogError(DeviceLayer, "Undefined speed! (%d)\n", speed);

--- a/src/platform/Linux/ConnectivityUtils.h
+++ b/src/platform/Linux/ConnectivityUtils.h
@@ -50,7 +50,7 @@ public:
     static CHIP_ERROR GetWiFiBeaconLostCount(const char * ifname, uint32_t & beaconLostCount);
     static CHIP_ERROR GetWiFiCurrentMaxRate(const char * ifname, uint64_t & currentMaxRate);
     static CHIP_ERROR GetEthInterfaceName(char * ifname, size_t bufSize);
-    static CHIP_ERROR GetEthPHYRate(const char * ifname, uint8_t & pHYRate);
+    static CHIP_ERROR GetEthPHYRate(const char * ifname, app::Clusters::EthernetNetworkDiagnostics::PHYRateType & pHYRate);
     static CHIP_ERROR GetEthFullDuplex(const char * ifname, bool & fullDuplex);
 
 private:

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -485,7 +485,7 @@ void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * net
     }
 }
 
-CHIP_ERROR DiagnosticDataProviderImpl::GetEthPHYRate(uint8_t & pHYRate)
+CHIP_ERROR DiagnosticDataProviderImpl::GetEthPHYRate(app::Clusters::EthernetNetworkDiagnostics::PHYRateType & pHYRate)
 {
     if (ConnectivityMgrImpl().GetEthernetIfName() == nullptr)
     {

--- a/src/platform/Linux/DiagnosticDataProviderImpl.h
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.h
@@ -57,7 +57,7 @@ public:
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
 
-    CHIP_ERROR GetEthPHYRate(uint8_t & pHYRate) override;
+    CHIP_ERROR GetEthPHYRate(app::Clusters::EthernetNetworkDiagnostics::PHYRateType & pHYRate) override;
     CHIP_ERROR GetEthFullDuplex(bool & fullDuplex) override;
     CHIP_ERROR GetEthTimeSinceReset(uint64_t & timeSinceReset) override;
     CHIP_ERROR GetEthPacketRxCount(uint64_t & packetRxCount) override;


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, the prototype of GetEthPHYRate looks like:      
virtual CHIP_ERROR GetEthPHYRate(uint8_t & pHYRate);
We read pHYRate type as unit8 and need to convert to EthernetNetworkDiagnostics::PHYRateType in app layer

* Fixes #14933 
#### Change overview
Fix signature of GetEthPHYRate to produce the right type

#### Testing
How was this tested? (at least one bullet point required)
* Type conversion, covered by CI
