### PR TITLE
ESP32: Maximum length of NVS key should be 15 characters

### DIFF
--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -72,7 +72,7 @@ const ESP32Config::Key ESP32Config::kConfigKey_GroupKeyIndex      = { kConfigNam
 const ESP32Config::Key ESP32Config::kConfigKey_LastUsedEpochKeyId = { kConfigNamespace_ChipConfig, "last-ek-id" };
 const ESP32Config::Key ESP32Config::kConfigKey_FailSafeArmed      = { kConfigNamespace_ChipConfig, "fail-safe-armed" };
 const ESP32Config::Key ESP32Config::kConfigKey_WiFiStationSecType = { kConfigNamespace_ChipConfig, "sta-sec-type" };
-const ESP32Config::Key ESP32Config::kConfigKey_RegulatoryLocation = { kConfigNamespace_ChipConfig, "regulatory-location" };
+const ESP32Config::Key ESP32Config::kConfigKey_RegulatoryLocation = { kConfigNamespace_ChipConfig, "reg-location" };
 const ESP32Config::Key ESP32Config::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
 const ESP32Config::Key ESP32Config::kConfigKey_Breadcrumb         = { kConfigNamespace_ChipConfig, "breadcrumb" };
 

--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -113,7 +113,7 @@ struct ESP32Config::Key
     const char * Name;
 
     bool operator==(const Key & other) const;
-    
+
     template<typename T, typename std::enable_if_t<std::is_convertible<T, const char *>::value, int> = 0>
     Key(const char * aNamespace, T aName) :
         Namespace(aNamespace), Name(aName)

--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -114,18 +114,15 @@ struct ESP32Config::Key
 
     bool operator==(const Key & other) const;
 
-    template<typename T, typename std::enable_if_t<std::is_convertible<T, const char *>::value, int> = 0>
-    Key(const char * aNamespace, T aName) :
-        Namespace(aNamespace), Name(aName)
+    template <typename T, typename std::enable_if_t<std::is_convertible<T, const char *>::value, int> = 0>
+    Key(const char * aNamespace, T aName) : Namespace(aNamespace), Name(aName)
     {}
 
-    template<size_t N>
-    Key(const char * aNamespace, const char (& aName)[N]) :
-        Namespace(aNamespace), Name(aName)
+    template <size_t N>
+    Key(const char * aNamespace, const char (&aName)[N]) : Namespace(aNamespace), Name(aName)
     {
         // Note: N includes null-terminator.
-        static_assert(N <= ESP32Config::kMaxConfigKeyNameLength + 1,
-                      "Key too long");
+        static_assert(N <= ESP32Config::kMaxConfigKeyNameLength + 1, "Key too long");
     }
 };
 

--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -113,6 +113,20 @@ struct ESP32Config::Key
     const char * Name;
 
     bool operator==(const Key & other) const;
+    
+    template<typename T, typename std::enable_if_t<std::is_convertible<T, const char *>::value, int> = 0>
+    Key(const char * aNamespace, T aName) :
+        Namespace(aNamespace), Name(aName)
+    {}
+
+    template<size_t N>
+    Key(const char * aNamespace, const char (& aName)[N]) :
+        Namespace(aNamespace), Name(aName)
+    {
+        // Note: N includes null-terminator.
+        static_assert(N <= ESP32Config::kMaxConfigKeyNameLength + 1,
+                      "Key too long");
+    }
 };
 
 inline bool ESP32Config::Key::operator==(const Key & other) const


### PR DESCRIPTION
Problem
* Length of kConfigKey_RegulatoryLocation's name was more than 15 characters. 

Change overview
Maximum length of key name should be 15 characters

Testing
Before the fix we were not able to read the parameter, with the fix we can