### PR TITLE
Add cosmetic_enabled to config cosmetic

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -262,7 +262,7 @@ config("std_default") {
 
 config("cosmetic_default") {
   if (cosmetic_enabled) {
-      configs = [ "$dir_pw_build:colorize_output" ]
+    configs = [ "$dir_pw_build:colorize_output" ]
   }
 }
 

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -261,7 +261,9 @@ config("std_default") {
 }
 
 config("cosmetic_default") {
-  configs = [ "$dir_pw_build:colorize_output" ]
+  if (cosmetic_enabled) {
+      configs = [ "$dir_pw_build:colorize_output" ]
+  }
 }
 
 config("runtime_default") {

--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -44,4 +44,7 @@ declare_args() {
 
   # enable libfuzzer
   is_libfuzzer = false
+
+  # cosmetic enabled
+  cosmetic_enabled = true
 }


### PR DESCRIPTION
Some build integration environment cannot work with pw_build which is
imported by default_configs_cosmetic. So add a variable to ignore it.

TEST:
gn gen --args="cosmetic_enabled=false"
ninja -C

Signed-off-by: Haoran Wang <elven.wang@nxp.com>

#### Problem
What is being fixed?  Examples:
As the default cosmetic using pw_build and it will include all pw_build related module into it.
For regular build environment, there is no problem. But for some special environment which don't want to build pw_build it will make it force to build.
The reason why I make this change is because of issue #15191  and with the --args="cosmetic_enabled=false" the default Python2.7 in my integration environment can make the target complete successfully. 

Actually I'm not very sure whether this is the best solution, hope maintainers can give some comments in it.