### PR TITLE
[hot fix] fix commissioning error in android tv example

### DIFF
--- a/src/platform/android/java/chip/platform/PreferencesConfigurationManager.java
+++ b/src/platform/android/java/chip/platform/PreferencesConfigurationManager.java
@@ -59,7 +59,7 @@ public class PreferencesConfigurationManager implements ConfigurationManager {
          * src/include/platform/CHIPDeviceConfig.h for debug
          */
       case kConfigNamespace_ChipFactory + ":" + kConfigKey_ProductId:
-        return 65278;
+        return 0x8003;
 
         /**
          * The default hardware version number assigned to the device or product by the device
@@ -91,9 +91,6 @@ public class PreferencesConfigurationManager implements ConfigurationManager {
 
       case kConfigNamespace_ChipFactory + ":" + kConfigKey_SetupDiscriminator:
         return 0xF00;
-
-      case kConfigNamespace_ChipFactory + ":" + kConfigKey_Spake2pIterationCount:
-        return 100;
     }
 
     if (preferences.contains(key)) {


### PR DESCRIPTION
#### Problem
* Android TV example failed to commissioning with below error logs
```
[1644981641867] [4635:6728600] CHIP: [SC] Received spake2p msg2
[1644981641867] [4635:6728600] CHIP: [SC] Failed to verify peer's MAC. This can happen when setup code is incorrect.
[1644981641867] [4635:6728600] CHIP: [SC] Sending status report. Protocol code 2, exchange 48396
```

#### Change overview
* This is because the Spake2pIterationCount in PreferencesConfigurationManager.java is not match with CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_VERIFIER and CHIP_DEVICE_CONFIG_EVENT_ID_COUNTER_EPOCH
    * remove it and using default value
* Changing ProductId to match Certification

#### Testing
* chip-tool pairing ethernet 
