### PR TITLE
Fix artifact name for chip cert tool

### DIFF
--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -87,8 +87,8 @@ class HostApp(Enum):
             yield 'chip-shell'
             yield 'chip-shell.map'
         elif self == HostApp.CERT_TOOL:
-            yield 'cert-tool'
-            yield 'cert-tool.map'
+            yield 'chip-cert'
+            yield 'chip-cert.map'
         else:
             raise Exception('Unknown app type: %r' % self)
 


### PR DESCRIPTION
#### Problem
Bad naming for cert tool causes artifact copy errors. 

#### Change overview
Use the correct binary name for chip cert tool

#### Testing
```
./scripts/build/build_examples.py --enable-flashbundle --target-glob 'linux-*' --skip-target-glob '*-tests' build --create-archives /workspace/artifacts/
```
