### PR TITLE
[mdns] Show interface on mDns failures.

### DIFF
--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -386,10 +386,13 @@ CHIP_ERROR ServerBase::BroadcastImpl(chip::System::PacketBufferHandle && data, u
             }
             else
             {
-                char ifaceName[chip::Inet::InterfaceId::kMaxIfNameLength];
-                info->mInterfaceId.GetInterfaceName(ifaceName, sizeof(ifaceName));
-                ChipLogDetail(Discovery, "Warning: Attempt to mDNS broadcast failed on %s:  %s", ifaceName, err.AsString());
                 lastError = err;
+#if CHIP_DETAIL_LOGGING    
+                char ifaceName[chip::Inet::InterfaceId::kMaxIfNameLength];
+                err = info->mInterfaceId.GetInterfaceName(ifaceName, sizeof(ifaceName));
+                if (err != CHIP_NO_ERROR) strcpy(ifaceName, "???");
+                ChipLogDetail(Discovery, "Warning: Attempt to mDNS broadcast failed on %s:  %s", ifaceName, lastError.AsString());
+#endif
             }
             return chip::Loop::Continue;
         }))

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -388,7 +388,7 @@ CHIP_ERROR ServerBase::BroadcastImpl(chip::System::PacketBufferHandle && data, u
             {
                 char ifaceName[20];
                 info->mInterfaceId.GetInterfaceName(ifaceName, sizeof(ifaceName));
-                ChipLogError(Discovery, "Attempt to mDNS broadcast failed on %s:  %s", ifaceName, chip::ErrorStr(err));
+                ChipLogDetail(Discovery, "Warning: Attempt to mDNS broadcast failed on %s:  %s", ifaceName, chip::ErrorStr(err));
                 lastError = err;
             }
             return chip::Loop::Continue;

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -386,9 +386,9 @@ CHIP_ERROR ServerBase::BroadcastImpl(chip::System::PacketBufferHandle && data, u
             }
             else
             {
-                char ifaceName[20];
+                char ifaceName[chip::Inet::InterfaceId::kMaxIfNameLength];
                 info->mInterfaceId.GetInterfaceName(ifaceName, sizeof(ifaceName));
-                ChipLogDetail(Discovery, "Warning: Attempt to mDNS broadcast failed on %s:  %s", ifaceName, chip::ErrorStr(err));
+                ChipLogDetail(Discovery, "Warning: Attempt to mDNS broadcast failed on %s:  %s", ifaceName, err.AsString());
                 lastError = err;
             }
             return chip::Loop::Continue;

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -387,10 +387,11 @@ CHIP_ERROR ServerBase::BroadcastImpl(chip::System::PacketBufferHandle && data, u
             else
             {
                 lastError = err;
-#if CHIP_DETAIL_LOGGING    
+#if CHIP_DETAIL_LOGGING
                 char ifaceName[chip::Inet::InterfaceId::kMaxIfNameLength];
                 err = info->mInterfaceId.GetInterfaceName(ifaceName, sizeof(ifaceName));
-                if (err != CHIP_NO_ERROR) strcpy(ifaceName, "???");
+                if (err != CHIP_NO_ERROR)
+                    strcpy(ifaceName, "???");
                 ChipLogDetail(Discovery, "Warning: Attempt to mDNS broadcast failed on %s:  %s", ifaceName, lastError.AsString());
 #endif
             }

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -386,7 +386,9 @@ CHIP_ERROR ServerBase::BroadcastImpl(chip::System::PacketBufferHandle && data, u
             }
             else
             {
-                ChipLogError(Discovery, "Attempt to mDNS broadcast failed:  %s", chip::ErrorStr(err));
+                char ifaceName[20];
+                info->mInterfaceId.GetInterfaceName(ifaceName, sizeof(ifaceName));
+                ChipLogError(Discovery, "Attempt to mDNS broadcast failed on %s:  %s", ifaceName, chip::ErrorStr(err));
                 lastError = err;
             }
             return chip::Loop::Continue;


### PR DESCRIPTION
#### Problem
chip-tool can fail to contact a node with the primary error log looking to blame mdns:

```
CHIP:DIS: Attempt to mDNS broadcast failed:  ../../src/inet/UDPEndPointImplSockets.cpp:417: OS Error 0x02000065: Network is unreachable
CHIP:DIS: Attempt to mDNS broadcast failed:  ../../src/inet/UDPEndPointImplSockets.cpp:417: OS Error 0x02000065: Network is unreachable
```

#### Change overview
Extend the log to display the interface name, so it is easier to see that the error is on a non-essential interface for reachability and can be ignored.

```
CHIP:DIS: Attempt to mDNS broadcast failed on enp0s31f6:  ../../src/inet/UDPEndPointImplSockets.cpp:417: OS Error 0x02000065: Network is unreachable
CHIP:DIS: Attempt to mDNS broadcast failed on docker0:  ../../src/inet/UDPEndPointImplSockets.cpp:417: OS Error 0x02000065: Network is unreachable
```

#### Testing
Manually on local environment and CI