### PR TITLE
Don't encode fabric-index in fabric scoped structs for a write.

### DIFF
--- a/examples/chip-tool/commands/clusters/CustomArgument.h
+++ b/examples/chip-tool/commands/clusters/CustomArgument.h
@@ -255,6 +255,10 @@ public:
         return writer.CopyElement(tag, reader);
     }
 
+    // We trust our consumers to do the encoding of our data correctly, so don't
+    // need to know whether we are being encoded for a write.
+    static constexpr bool kIsFabricScoped = false;
+
 private:
     uint8_t * mData                       = nullptr;
     uint32_t mDataLen                     = 0;

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -26,6 +26,7 @@
 #include <app/MessageDef/StatusIB.h>
 #include <app/MessageDef/WriteRequestMessage.h>
 #include <app/data-model/Encode.h>
+#include <app/data-model/FabricScoped.h>
 #include <app/data-model/List.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPTLVDebug.hpp>
@@ -260,7 +261,7 @@ private:
     /**
      *  Encode an attribute value that can be directly encoded using DataModel::Encode.
      */
-    template <class T>
+    template <class T, std::enable_if_t<!DataModel::IsFabricScoped<T>::value, int> = 0>
     CHIP_ERROR TryEncodeSingleAttributeDataIB(const ConcreteDataAttributePath & attributePath, const T & value)
     {
         chip::TLV::TLVWriter * writer = nullptr;
@@ -269,6 +270,20 @@ private:
         VerifyOrReturnError((writer = GetAttributeDataIBTLVWriter()) != nullptr, CHIP_ERROR_INCORRECT_STATE);
         ReturnErrorOnFailure(
             DataModel::Encode(*writer, chip::TLV::ContextTag(to_underlying(chip::app::AttributeDataIB::Tag::kData)), value));
+        ReturnErrorOnFailure(FinishAttributeIB());
+
+        return CHIP_NO_ERROR;
+    }
+
+    template <class T, std::enable_if_t<DataModel::IsFabricScoped<T>::value, int> = 0>
+    CHIP_ERROR TryEncodeSingleAttributeDataIB(const ConcreteDataAttributePath & attributePath, const T & value)
+    {
+        chip::TLV::TLVWriter * writer = nullptr;
+
+        ReturnErrorOnFailure(PrepareAttributeIB(attributePath));
+        VerifyOrReturnError((writer = GetAttributeDataIBTLVWriter()) != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        ReturnErrorOnFailure(DataModel::EncodeForWrite(
+            *writer, chip::TLV::ContextTag(to_underlying(chip::app::AttributeDataIB::Tag::kData)), value));
         ReturnErrorOnFailure(FinishAttributeIB());
 
         return CHIP_NO_ERROR;

--- a/src/app/data-model/Encode.h
+++ b/src/app/data-model/Encode.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <app/data-model/FabricScoped.h>
 #include <app/data-model/Nullable.h>
 #include <lib/core/CHIPTLV.h>
 #include <lib/core/Optional.h>
@@ -88,6 +89,23 @@ template <typename X,
 CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, const X & x)
 {
     return x.Encode(writer, tag);
+}
+
+/*
+ * @brief
+ *
+ * A way to encode fabric-scoped structs for a write.
+ */
+template <typename X,
+          typename std::enable_if_t<
+              std::is_class<X>::value &&
+                  std::is_same<decltype(std::declval<X>().Encode(std::declval<TLV::TLVWriter &>(), std::declval<TLV::Tag>())),
+                               CHIP_ERROR>::value &&
+                  DataModel::IsFabricScoped<X>::value,
+              X> * = nullptr>
+CHIP_ERROR EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag, const X & x)
+{
+    return x.EncodeForWrite(writer, tag);
 }
 
 /*

--- a/src/app/data-model/List.h
+++ b/src/app/data-model/List.h
@@ -20,6 +20,7 @@
 
 #include <app/data-model/Decode.h>
 #include <app/data-model/Encode.h>
+#include <app/data-model/FabricScoped.h>
 #include <lib/core/CHIPTLV.h>
 
 namespace chip {
@@ -55,6 +56,8 @@ struct List : public Span<T>
         Span<T>::operator=(databuf);
         return (*this);
     }
+
+    static constexpr bool kIsFabricScoped = DataModel::IsFabricScoped<T>::value;
 };
 
 template <typename X>
@@ -66,6 +69,21 @@ inline CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, List<X> list)
     for (auto & item : list)
     {
         ReturnErrorOnFailure(Encode(writer, TLV::AnonymousTag(), item));
+    }
+    ReturnErrorOnFailure(writer.EndContainer(type));
+
+    return CHIP_NO_ERROR;
+}
+
+template <typename X, std::enable_if_t<DataModel::IsFabricScoped<X>::value, int> = 0>
+inline CHIP_ERROR EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag, List<X> list)
+{
+    TLV::TLVType type;
+
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Array, type));
+    for (auto & item : list)
+    {
+        ReturnErrorOnFailure(EncodeForWrite(writer, TLV::AnonymousTag(), item));
     }
     ReturnErrorOnFailure(writer.EndContainer(type));
 

--- a/src/app/zap-templates/partials/cluster-objects-struct.zapt
+++ b/src/app/zap-templates/partials/cluster-objects-struct.zapt
@@ -27,6 +27,9 @@ namespace {{asUpperCamelCase name}} {
         void SetFabricIndex(chip::FabricIndex fabricIndex_) {
             {{ asLowerCamelCase struct_fabric_idx_field }} = fabricIndex_;
         }
+        CHIP_ERROR EncodeForWrite(TLV::TLVWriter &writer, TLV::Tag tag) const;
+    private:
+        CHIP_ERROR DoEncode(TLV::TLVWriter &writer, TLV::Tag tag, bool isForWrite) const;
         {{/if}}
     };
 
@@ -58,7 +61,36 @@ namespace {{asUpperCamelCase name}} {
 } // namespace {{asUpperCamelCase name}}
 {{else}}
 namespace {{asUpperCamelCase name}} {
-CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, TLV::Tag tag) const{
+{{#if struct_is_fabric_scoped}}
+CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, TLV::Tag tag) const
+{
+    return DoEncode(writer, tag, false);
+}
+
+CHIP_ERROR Type::EncodeForWrite(TLV::TLVWriter &writer, TLV::Tag tag) const
+{
+    return DoEncode(writer, tag, true);
+}
+
+CHIP_ERROR Type::DoEncode(TLV::TLVWriter &writer, TLV::Tag tag, bool isForWrite) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    {{#zcl_struct_items}}
+    {{#if (isStrEqual label ../struct_fabric_idx_field)}}
+      if (!isForWrite || 1) {
+        ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::k{{asUpperCamelCase label}})), {{asLowerCamelCase label}}));
+      }
+    {{else}}
+        ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::k{{asUpperCamelCase label}})), {{asLowerCamelCase label}}));
+    {{/if}}
+    {{/zcl_struct_items}}
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+{{else}}
+CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, TLV::Tag tag) const
+{
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
     {{#zcl_struct_items}}
@@ -67,6 +99,7 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, TLV::Tag tag) const{
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
+{{/if}}
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader &reader) {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -4615,9 +4615,22 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 namespace AccessControlEntry {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
+    return DoEncode(writer, tag, false);
+}
+
+CHIP_ERROR Type::EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag) const
+{
+    return DoEncode(writer, tag, true);
+}
+
+CHIP_ERROR Type::DoEncode(TLV::TLVWriter & writer, TLV::Tag tag, bool isForWrite) const
+{
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
+    if (!isForWrite || 1)
+    {
+        ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
+    }
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kPrivilege)), privilege));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kAuthMode)), authMode));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kSubjects)), subjects));
@@ -4668,9 +4681,22 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 namespace ExtensionEntry {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
+    return DoEncode(writer, tag, false);
+}
+
+CHIP_ERROR Type::EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag) const
+{
+    return DoEncode(writer, tag, true);
+}
+
+CHIP_ERROR Type::DoEncode(TLV::TLVWriter & writer, TLV::Tag tag, bool isForWrite) const
+{
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
+    if (!isForWrite || 1)
+    {
+        ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
+    }
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kData)), data));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
@@ -6330,9 +6356,22 @@ namespace Structs {
 namespace ProviderLocation {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
+    return DoEncode(writer, tag, false);
+}
+
+CHIP_ERROR Type::EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag) const
+{
+    return DoEncode(writer, tag, true);
+}
+
+CHIP_ERROR Type::DoEncode(TLV::TLVWriter & writer, TLV::Tag tag, bool isForWrite) const
+{
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
+    if (!isForWrite || 1)
+    {
+        ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
+    }
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kProviderNodeID)), providerNodeID));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kEndpoint)), endpoint));
     ReturnErrorOnFailure(writer.EndContainer(outer));
@@ -10157,9 +10196,22 @@ namespace Structs {
 namespace FabricDescriptor {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
+    return DoEncode(writer, tag, false);
+}
+
+CHIP_ERROR Type::EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag) const
+{
+    return DoEncode(writer, tag, true);
+}
+
+CHIP_ERROR Type::DoEncode(TLV::TLVWriter & writer, TLV::Tag tag, bool isForWrite) const
+{
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
+    if (!isForWrite || 1)
+    {
+        ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
+    }
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kRootPublicKey)), rootPublicKey));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kVendorId)), vendorId));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricId)), fabricId));
@@ -10214,9 +10266,22 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 namespace NOCStruct {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
+    return DoEncode(writer, tag, false);
+}
+
+CHIP_ERROR Type::EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag) const
+{
+    return DoEncode(writer, tag, true);
+}
+
+CHIP_ERROR Type::DoEncode(TLV::TLVWriter & writer, TLV::Tag tag, bool isForWrite) const
+{
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
+    if (!isForWrite || 1)
+    {
+        ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
+    }
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kNoc)), noc));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kIcac)), icac));
     ReturnErrorOnFailure(writer.EndContainer(outer));
@@ -10797,9 +10862,22 @@ namespace Structs {
 namespace GroupInfoMapStruct {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
+    return DoEncode(writer, tag, false);
+}
+
+CHIP_ERROR Type::EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag) const
+{
+    return DoEncode(writer, tag, true);
+}
+
+CHIP_ERROR Type::DoEncode(TLV::TLVWriter & writer, TLV::Tag tag, bool isForWrite) const
+{
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
+    if (!isForWrite || 1)
+    {
+        ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
+    }
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kGroupId)), groupId));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kEndpoints)), endpoints));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kGroupName)), groupName));
@@ -10846,9 +10924,22 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 namespace GroupKeyMapStruct {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
+    return DoEncode(writer, tag, false);
+}
+
+CHIP_ERROR Type::EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag) const
+{
+    return DoEncode(writer, tag, true);
+}
+
+CHIP_ERROR Type::DoEncode(TLV::TLVWriter & writer, TLV::Tag tag, bool isForWrite) const
+{
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
+    if (!isForWrite || 1)
+    {
+        ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
+    }
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kGroupId)), groupId));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kGroupKeySetID)), groupKeySetID));
     ReturnErrorOnFailure(writer.EndContainer(outer));
@@ -22838,9 +22929,22 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 namespace TestFabricScoped {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
+    return DoEncode(writer, tag, false);
+}
+
+CHIP_ERROR Type::EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag) const
+{
+    return DoEncode(writer, tag, true);
+}
+
+CHIP_ERROR Type::DoEncode(TLV::TLVWriter & writer, TLV::Tag tag, bool isForWrite) const
+{
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
+    if (!isForWrite || 1)
+    {
+        ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
+    }
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -6906,6 +6906,10 @@ public:
     auto GetFabricIndex() const { return fabricIndex; }
 
     void SetFabricIndex(chip::FabricIndex fabricIndex_) { fabricIndex = fabricIndex_; }
+    CHIP_ERROR EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+private:
+    CHIP_ERROR DoEncode(TLV::TLVWriter & writer, TLV::Tag tag, bool isForWrite) const;
 };
 
 struct DecodableType
@@ -6948,6 +6952,10 @@ public:
     auto GetFabricIndex() const { return fabricIndex; }
 
     void SetFabricIndex(chip::FabricIndex fabricIndex_) { fabricIndex = fabricIndex_; }
+    CHIP_ERROR EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+private:
+    CHIP_ERROR DoEncode(TLV::TLVWriter & writer, TLV::Tag tag, bool isForWrite) const;
 };
 
 using DecodableType = Type;
@@ -9262,6 +9270,10 @@ public:
     auto GetFabricIndex() const { return fabricIndex; }
 
     void SetFabricIndex(chip::FabricIndex fabricIndex_) { fabricIndex = fabricIndex_; }
+    CHIP_ERROR EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+private:
+    CHIP_ERROR DoEncode(TLV::TLVWriter & writer, TLV::Tag tag, bool isForWrite) const;
 };
 
 using DecodableType = Type;
@@ -15806,6 +15818,10 @@ public:
     auto GetFabricIndex() const { return fabricIndex; }
 
     void SetFabricIndex(chip::FabricIndex fabricIndex_) { fabricIndex = fabricIndex_; }
+    CHIP_ERROR EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+private:
+    CHIP_ERROR DoEncode(TLV::TLVWriter & writer, TLV::Tag tag, bool isForWrite) const;
 };
 
 using DecodableType = Type;
@@ -15834,6 +15850,10 @@ public:
     auto GetFabricIndex() const { return fabricIndex; }
 
     void SetFabricIndex(chip::FabricIndex fabricIndex_) { fabricIndex = fabricIndex_; }
+    CHIP_ERROR EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+private:
+    CHIP_ERROR DoEncode(TLV::TLVWriter & writer, TLV::Tag tag, bool isForWrite) const;
 };
 
 using DecodableType = Type;
@@ -16552,6 +16572,10 @@ public:
     auto GetFabricIndex() const { return fabricIndex; }
 
     void SetFabricIndex(chip::FabricIndex fabricIndex_) { fabricIndex = fabricIndex_; }
+    CHIP_ERROR EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+private:
+    CHIP_ERROR DoEncode(TLV::TLVWriter & writer, TLV::Tag tag, bool isForWrite) const;
 };
 
 struct DecodableType
@@ -16595,6 +16619,10 @@ public:
     auto GetFabricIndex() const { return fabricIndex; }
 
     void SetFabricIndex(chip::FabricIndex fabricIndex_) { fabricIndex = fabricIndex_; }
+    CHIP_ERROR EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+private:
+    CHIP_ERROR DoEncode(TLV::TLVWriter & writer, TLV::Tag tag, bool isForWrite) const;
 };
 
 using DecodableType = Type;
@@ -37033,6 +37061,10 @@ public:
     auto GetFabricIndex() const { return fabricIndex; }
 
     void SetFabricIndex(chip::FabricIndex fabricIndex_) { fabricIndex = fabricIndex_; }
+    CHIP_ERROR EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+private:
+    CHIP_ERROR DoEncode(TLV::TLVWriter & writer, TLV::Tag tag, bool isForWrite) const;
 };
 
 using DecodableType = Type;


### PR DESCRIPTION
#### Problem
We are encoding (uselessly) fabric indices for a write.

#### Change overview
Stop doing that, at least when the WriteClient is doing the encoding itself.

Some notes:

1. I would really prefer it if fabric-scoped things don't have an `Encode()` at all and have separate `EncodeForWrite` and `EncodeForRead` APIs, so when you are encoding them you have to think about what you are doing.  That's a slightly more invasive change in terms of needing to change some code that currently calls `Encode` to call `EncodeForRead`, but absolutely doable.
2. Alternately, we could make `DataModel::Encode` (and presumably the struct's `Encode`) just take a boolean for whether it's an encode for a write.  If we default it to false, that is more or less equivalent to the proposed change.  More slightly inscrutable booleans floating around (esp. in all the `Encode` methods that have nothing to do with structs), a little less template duplication involved.
3. Or we could add a boolean to `DataMode::Encode` but only default it for things that are not fabric scoped, while requiring it for things that are fabric-scoped, so consumers have to think about it.  This might have the least copy/paste code and should be a little simpler to get to than separate `EncodeForRead`/`EncodeForWrite` methods that only exist for fabric-scoped structs, since all `Encode` signatures would allow passing in the boolean.

#### Testing
Checked that if I do:
```
chip-tool accesscontrol write acl '[{"fabricIndex": 0, "privilege": 0, "authMode": 0, "subjects": [], "targets": []}]' 17 0
```
without this change the recipient sees:
```
Data = 
{
	0x0 = 0, 
	0x1 = 0, 
	0x2 = 0, 
	0x3 = [
		
	],
	0x4 = [
		
	],
},
```
and with this change the tag `0x0` is gone.