### PR TITLE
Fix MessageDef parsing of messages

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -93,7 +93,6 @@ CHIP_ERROR CommandHandler::ProcessInvokeRequest(System::PacketBufferHandle && pa
     InvokeRequestMessage::Parser invokeRequestMessage;
     InvokeRequests::Parser invokeRequests;
     reader.Init(std::move(payload));
-    ReturnErrorOnFailure(reader.Next());
     ReturnErrorOnFailure(invokeRequestMessage.Init(reader));
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     ReturnErrorOnFailure(invokeRequestMessage.CheckSchemaValidity());
@@ -147,7 +146,8 @@ CHIP_ERROR CommandHandler::ProcessInvokeRequest(System::PacketBufferHandle && pa
     {
         err = CHIP_NO_ERROR;
     }
-    return err;
+    ReturnErrorOnFailure(err);
+    return invokeRequestMessage.ExitContainer();
 }
 
 void CommandHandler::Close()

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -174,7 +174,6 @@ CHIP_ERROR CommandSender::ProcessInvokeResponse(System::PacketBufferHandle && pa
     bool suppressResponse = false;
 
     reader.Init(std::move(payload));
-    ReturnErrorOnFailure(reader.Next());
     ReturnErrorOnFailure(invokeResponseMessage.Init(reader));
 
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
@@ -198,7 +197,8 @@ CHIP_ERROR CommandSender::ProcessInvokeResponse(System::PacketBufferHandle && pa
     {
         err = CHIP_NO_ERROR;
     }
-    return err;
+    ReturnErrorOnFailure(err);
+    return invokeResponseMessage.ExitContainer();
 }
 
 void CommandSender::OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext)

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -257,7 +257,6 @@ CHIP_ERROR InteractionModelEngine::OnReadInitialRequest(Messaging::ExchangeConte
         bool keepExistingSubscriptions = true;
 
         reader.Init(aPayload.Retain());
-        ReturnErrorOnFailure(reader.Next());
 
         SubscribeRequestMessage::Parser subscribeRequestParser;
         ReturnErrorOnFailure(subscribeRequestParser.Init(reader));
@@ -371,13 +370,13 @@ CHIP_ERROR InteractionModelEngine::OnUnsolicitedReportData(Messaging::ExchangeCo
 {
     System::PacketBufferTLVReader reader;
     reader.Init(aPayload.Retain());
-    ReturnLogErrorOnFailure(reader.Next());
 
     ReportDataMessage::Parser report;
-    ReturnLogErrorOnFailure(report.Init(reader));
+    ReturnErrorOnFailure(report.Init(reader));
 
     uint64_t subscriptionId = 0;
-    ReturnLogErrorOnFailure(report.GetSubscriptionId(&subscriptionId));
+    ReturnErrorOnFailure(report.GetSubscriptionId(&subscriptionId));
+    ReturnErrorOnFailure(report.ExitContainer());
 
     for (auto * readClient = mpActiveReadClientList; readClient != nullptr; readClient = readClient->GetNextClient())
     {

--- a/src/app/MessageDef/MessageParser.cpp
+++ b/src/app/MessageDef/MessageParser.cpp
@@ -20,6 +20,22 @@
 
 namespace chip {
 namespace app {
+CHIP_ERROR MessageParser::Init(TLV::TLVReader & aReader)
+{
+    ReturnErrorOnFailure(aReader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag()));
+    return StructParser::Init(aReader);
+}
+
+CHIP_ERROR MessageParser::ExitContainer()
+{
+    // Ignore any other tags that might be here.
+    ReturnErrorOnFailure(mReader.ExitContainer(mOuterContainerType));
+
+    // There should be nothing outside the toplevel struct.
+    VerifyOrReturnError(mReader.Next() == CHIP_END_OF_TLV, CHIP_ERROR_INVALID_TLV_TAG);
+    return CHIP_NO_ERROR;
+}
+
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR MessageParser::CheckInteractionModelRevision(TLV::TLVReader & aReader) const
 {

--- a/src/app/MessageDef/MessageParser.h
+++ b/src/app/MessageDef/MessageParser.h
@@ -28,6 +28,8 @@ namespace app {
 class MessageParser : public StructParser
 {
 public:
+    CHIP_ERROR Init(TLV::TLVReader & aReader);
+    CHIP_ERROR ExitContainer();
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     CHIP_ERROR CheckInteractionModelRevision(TLV::TLVReader & aReader) const;
 #endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -419,8 +419,6 @@ CHIP_ERROR ReadClient::ProcessReportData(System::PacketBufferHandle && aPayload)
     System::PacketBufferTLVReader reader;
 
     reader.Init(std::move(aPayload));
-    reader.Next();
-
     err = report.Init(reader);
     SuccessOrExit(err);
 
@@ -514,6 +512,8 @@ CHIP_ERROR ReadClient::ProcessReportData(System::PacketBufferHandle && aPayload)
             mIsInitialReport = true;
         }
     }
+
+    SuccessOrExit(err = report.ExitContainer());
 
 exit:
     if (IsSubscriptionType())
@@ -717,21 +717,20 @@ CHIP_ERROR ReadClient::ProcessSubscribeResponse(System::PacketBufferHandle && aP
 {
     System::PacketBufferTLVReader reader;
     reader.Init(std::move(aPayload));
-    ReturnLogErrorOnFailure(reader.Next());
 
     SubscribeResponseMessage::Parser subscribeResponse;
-    ReturnLogErrorOnFailure(subscribeResponse.Init(reader));
+    ReturnErrorOnFailure(subscribeResponse.Init(reader));
 
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    ReturnLogErrorOnFailure(subscribeResponse.CheckSchemaValidity());
+    ReturnErrorOnFailure(subscribeResponse.CheckSchemaValidity());
 #endif
 
     uint64_t subscriptionId = 0;
-    ReturnLogErrorOnFailure(subscribeResponse.GetSubscriptionId(&subscriptionId));
-    VerifyOrReturnLogError(IsMatchingClient(subscriptionId), CHIP_ERROR_INVALID_ARGUMENT);
-    ReturnLogErrorOnFailure(subscribeResponse.GetMinIntervalFloorSeconds(&mMinIntervalFloorSeconds));
-    ReturnLogErrorOnFailure(subscribeResponse.GetMaxIntervalCeilingSeconds(&mMaxIntervalCeilingSeconds));
-
+    ReturnErrorOnFailure(subscribeResponse.GetSubscriptionId(&subscriptionId));
+    VerifyOrReturnError(IsMatchingClient(subscriptionId), CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnErrorOnFailure(subscribeResponse.GetMinIntervalFloorSeconds(&mMinIntervalFloorSeconds));
+    ReturnErrorOnFailure(subscribeResponse.GetMaxIntervalCeilingSeconds(&mMaxIntervalCeilingSeconds));
+    ReturnErrorOnFailure(subscribeResponse.ExitContainer());
     mpCallback.OnSubscriptionEstablished(subscriptionId);
 
     MoveToState(ClientState::SubscriptionActive);

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -312,7 +312,6 @@ CHIP_ERROR ReadHandler::ProcessReadRequest(System::PacketBufferHandle && aPayloa
 
     reader.Init(std::move(aPayload));
 
-    ReturnErrorOnFailure(reader.Next());
     ReturnErrorOnFailure(readRequestParser.Init(reader));
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     ReturnErrorOnFailure(readRequestParser.CheckSchemaValidity());
@@ -359,7 +358,7 @@ CHIP_ERROR ReadHandler::ProcessReadRequest(System::PacketBufferHandle && aPayloa
     ReturnErrorOnFailure(err);
 
     ReturnErrorOnFailure(readRequestParser.GetIsFabricFiltered(&mIsFabricFiltered));
-
+    ReturnErrorOnFailure(readRequestParser.ExitContainer());
     MoveToState(HandlerState::GeneratingReports);
 
     ReturnErrorOnFailure(InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun());
@@ -637,7 +636,6 @@ CHIP_ERROR ReadHandler::ProcessSubscribeRequest(System::PacketBufferHandle && aP
     System::PacketBufferTLVReader reader;
     reader.Init(std::move(aPayload));
 
-    ReturnErrorOnFailure(reader.Next());
     SubscribeRequestMessage::Parser subscribeRequestParser;
     ReturnErrorOnFailure(subscribeRequestParser.Init(reader));
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
@@ -693,7 +691,7 @@ CHIP_ERROR ReadHandler::ProcessSubscribeRequest(System::PacketBufferHandle && aP
     VerifyOrReturnError(mMinIntervalFloorSeconds <= mMaxIntervalCeilingSeconds, CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorOnFailure(subscribeRequestParser.GetIsFabricFiltered(&mIsFabricFiltered));
     ReturnErrorOnFailure(Crypto::DRBG_get_bytes(reinterpret_cast<uint8_t *>(&mSubscriptionId), sizeof(mSubscriptionId)));
-
+    ReturnErrorOnFailure(subscribeRequestParser.ExitContainer());
     MoveToState(HandlerState::GeneratingReports);
 
     InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();

--- a/src/app/StatusResponse.cpp
+++ b/src/app/StatusResponse.cpp
@@ -47,7 +47,6 @@ CHIP_ERROR StatusResponse::ProcessStatusResponse(System::PacketBufferHandle && a
     StatusResponseMessage::Parser response;
     System::PacketBufferTLVReader reader;
     reader.Init(std::move(aPayload));
-    ReturnErrorOnFailure(reader.Next());
     ReturnErrorOnFailure(response.Init(reader));
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     ReturnErrorOnFailure(response.CheckSchemaValidity());
@@ -55,6 +54,7 @@ CHIP_ERROR StatusResponse::ProcessStatusResponse(System::PacketBufferHandle && a
     StatusIB status;
     ReturnErrorOnFailure(response.GetStatus(status.mStatus));
     ChipLogProgress(InteractionModel, "Received status response, status is %u", to_underlying(status.mStatus));
+    ReturnErrorOnFailure(response.ExitContainer());
 
     if (status.mStatus == Protocols::InteractionModel::Status::Success)
     {

--- a/src/app/TimedHandler.cpp
+++ b/src/app/TimedHandler.cpp
@@ -111,9 +111,6 @@ CHIP_ERROR TimedHandler::HandleTimedRequestAction(Messaging::ExchangeContext * a
 
     System::PacketBufferTLVReader reader;
     reader.Init(std::move(aPayload));
-
-    reader.Next();
-
     TimedRequestMessage::Parser parser;
     ReturnErrorOnFailure(parser.Init(reader));
 
@@ -123,6 +120,7 @@ CHIP_ERROR TimedHandler::HandleTimedRequestAction(Messaging::ExchangeContext * a
 
     uint16_t timeoutMs;
     ReturnErrorOnFailure(parser.GetTimeoutMs(&timeoutMs));
+    ReturnErrorOnFailure(parser.ExitContainer());
 
     ChipLogDetail(DataManagement, "Got Timed Request with timeout %" PRIu16 ": handler %p exchange " ChipLogFormatExchange,
                   timeoutMs, this, ChipLogValueExchange(aExchangeContext));

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -84,8 +84,6 @@ CHIP_ERROR WriteClient::ProcessWriteResponseMessage(System::PacketBufferHandle &
     AttributeStatusIBs::Parser attributeStatusesParser;
 
     reader.Init(std::move(payload));
-    err = reader.Next();
-    SuccessOrExit(err);
 
     err = writeResponse.Init(reader);
     SuccessOrExit(err);
@@ -117,6 +115,8 @@ CHIP_ERROR WriteClient::ProcessWriteResponseMessage(System::PacketBufferHandle &
     {
         err = CHIP_NO_ERROR;
     }
+    SuccessOrExit(err);
+    ReturnErrorOnFailure(writeResponse.ExitContainer());
 
 exit:
     return err;

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -393,9 +393,6 @@ Status WriteHandler::ProcessWriteRequest(System::PacketBufferHandle && aPayload,
 
     reader.Init(std::move(aPayload));
 
-    err = reader.Next();
-    SuccessOrExit(err);
-
     err = writeRequestParser.Init(reader);
     SuccessOrExit(err);
 
@@ -448,6 +445,8 @@ Status WriteHandler::ProcessWriteRequest(System::PacketBufferHandle && aPayload,
     {
         err = ProcessAttributeDataIBs(AttributeDataIBsReader);
     }
+    SuccessOrExit(err);
+    SuccessOrExit(err = writeRequestParser.ExitContainer());
 
     if (err == CHIP_NO_ERROR)
     {

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -487,8 +487,6 @@ void TestCommandInteraction::ValidateCommandHandlerWithSendCommand(nlTestSuite *
     chip::System::PacketBufferTLVReader reader;
     InvokeResponseMessage::Parser invokeResponseMessageParser;
     reader.Init(std::move(commandPacket));
-    err = reader.Next();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     err = invokeResponseMessageParser.Init(reader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     err = invokeResponseMessageParser.CheckSchemaValidity();
@@ -535,8 +533,6 @@ void TestCommandInteraction::TestCommandHandlerCommandDataEncoding(nlTestSuite *
     chip::System::PacketBufferTLVReader reader;
     InvokeResponseMessage::Parser invokeResponseMessageParser;
     reader.Init(std::move(commandPacket));
-    err = reader.Next();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     err = invokeResponseMessageParser.Init(reader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     err = invokeResponseMessageParser.CheckSchemaValidity();

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -985,6 +985,7 @@ void ParseInvokeRequestMessage(nlTestSuite * apSuite, chip::TLV::TLVReader & aRe
     err = invokeRequestMessageParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 #endif
+    NL_TEST_ASSERT(apSuite, invokeRequestMessageParser.ExitContainer() == CHIP_NO_ERROR);
 }
 
 void BuildInvokeResponseMessage(nlTestSuite * apSuite, chip::TLV::TLVWriter & aWriter)
@@ -1017,6 +1018,7 @@ void ParseInvokeResponseMessage(nlTestSuite * apSuite, chip::TLV::TLVReader & aR
     err = invokeResponseMessageParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 #endif
+    NL_TEST_ASSERT(apSuite, invokeResponseMessageParser.ExitContainer() == CHIP_NO_ERROR);
 }
 
 void BuildReportDataMessage(nlTestSuite * apSuite, chip::TLV::TLVWriter & aWriter)
@@ -1075,6 +1077,7 @@ void ParseReportDataMessage(nlTestSuite * apSuite, chip::TLV::TLVReader & aReade
 
     err = reportDataParser.GetMoreChunkedMessages(&moreChunkedMessages);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && moreChunkedMessages);
+    NL_TEST_ASSERT(apSuite, reportDataParser.ExitContainer() == CHIP_NO_ERROR);
 }
 
 void BuildReadRequestMessage(nlTestSuite * apSuite, chip::TLV::TLVWriter & aWriter)
@@ -1140,6 +1143,7 @@ void ParseReadRequestMessage(nlTestSuite * apSuite, chip::TLV::TLVReader & aRead
 
     err = readRequestParser.GetIsFabricFiltered(&isFabricFiltered);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && isFabricFiltered);
+    NL_TEST_ASSERT(apSuite, readRequestParser.ExitContainer() == CHIP_NO_ERROR);
 }
 
 void BuildWriteRequestMessage(nlTestSuite * apSuite, chip::TLV::TLVWriter & aWriter)
@@ -1226,6 +1230,7 @@ void ParseWriteResponseMessage(nlTestSuite * apSuite, chip::TLV::TLVReader & aRe
 #endif
     err = writeResponseParser.GetWriteResponses(&attributeStatusesParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(apSuite, writeResponseParser.ExitContainer() == CHIP_NO_ERROR);
 }
 
 void BuildSubscribeRequestMessage(nlTestSuite * apSuite, chip::TLV::TLVWriter & aWriter)
@@ -1319,6 +1324,7 @@ void ParseSubscribeRequestMessage(nlTestSuite * apSuite, chip::TLV::TLVReader & 
 
     err = subscribeRequestParser.GetIsFabricFiltered(&isFabricFiltered);
     NL_TEST_ASSERT(apSuite, isFabricFiltered && err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(apSuite, subscribeRequestParser.ExitContainer() == CHIP_NO_ERROR);
 }
 
 void BuildSubscribeResponseMessage(nlTestSuite * apSuite, chip::TLV::TLVWriter & aWriter)
@@ -1364,6 +1370,8 @@ void ParseSubscribeResponseMessage(nlTestSuite * apSuite, chip::TLV::TLVReader &
 
     err = subscribeResponseParser.GetMaxIntervalCeilingSeconds(&maxIntervalCeilingSeconds);
     NL_TEST_ASSERT(apSuite, maxIntervalCeilingSeconds == 2 && err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(apSuite, subscribeResponseParser.ExitContainer() == CHIP_NO_ERROR);
 }
 
 void BuildTimedRequestMessage(nlTestSuite * apSuite, chip::TLV::TLVWriter & aWriter)
@@ -1382,17 +1390,19 @@ void ParseTimedRequestMessage(nlTestSuite * apSuite, chip::TLV::TLVReader & aRea
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    TimedRequestMessage::Parser TimedRequestMessagearser;
+    TimedRequestMessage::Parser timedRequestMessageParser;
     uint16_t timeout = 0;
 
-    err = TimedRequestMessagearser.Init(aReader);
+    err = timedRequestMessageParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = TimedRequestMessagearser.CheckSchemaValidity();
+    err = timedRequestMessageParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 #endif
-    err = TimedRequestMessagearser.GetTimeoutMs(&timeout);
+    err = timedRequestMessageParser.GetTimeoutMs(&timeout);
     NL_TEST_ASSERT(apSuite, timeout == 1 && err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(apSuite, timedRequestMessageParser.ExitContainer() == CHIP_NO_ERROR);
 }
 
 void DataVersionFilterIBTest(nlTestSuite * apSuite, void * apContext)
@@ -2058,8 +2068,6 @@ void InvokeInvokeRequestMessageTest(nlTestSuite * apSuite, void * apContext)
     DebugPrettyPrint(buf);
 
     reader.Init(std::move(buf));
-    err = reader.Next();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseInvokeRequestMessage(apSuite, reader);
 }
 
@@ -2077,8 +2085,6 @@ void InvokeInvokeResponseMessageTest(nlTestSuite * apSuite, void * apContext)
     DebugPrettyPrint(buf);
 
     reader.Init(std::move(buf));
-    err = reader.Next();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseInvokeResponseMessage(apSuite, reader);
 }
 
@@ -2096,8 +2102,6 @@ void ReportDataMessageTest(nlTestSuite * apSuite, void * apContext)
     DebugPrettyPrint(buf);
 
     reader.Init(std::move(buf));
-    err = reader.Next();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseReportDataMessage(apSuite, reader);
 }
 
@@ -2115,8 +2119,6 @@ void ReadRequestMessageTest(nlTestSuite * apSuite, void * apContext)
     DebugPrettyPrint(buf);
 
     reader.Init(std::move(buf));
-    err = reader.Next();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseReadRequestMessage(apSuite, reader);
 }
 
@@ -2134,8 +2136,6 @@ void WriteRequestMessageTest(nlTestSuite * apSuite, void * apContext)
     DebugPrettyPrint(buf);
 
     reader.Init(std::move(buf));
-    err = reader.Next();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseWriteRequestMessage(apSuite, reader);
 }
 
@@ -2153,8 +2153,6 @@ void WriteResponseMessageTest(nlTestSuite * apSuite, void * apContext)
     DebugPrettyPrint(buf);
 
     reader.Init(std::move(buf));
-    err = reader.Next();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseWriteResponseMessage(apSuite, reader);
 }
 
@@ -2172,8 +2170,6 @@ void SubscribeRequestMessageTest(nlTestSuite * apSuite, void * apContext)
     DebugPrettyPrint(buf);
 
     reader.Init(std::move(buf));
-    err = reader.Next();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseSubscribeRequestMessage(apSuite, reader);
 }
 
@@ -2191,8 +2187,6 @@ void SubscribeResponseMessageTest(nlTestSuite * apSuite, void * apContext)
     DebugPrettyPrint(buf);
 
     reader.Init(std::move(buf));
-    err = reader.Next();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseSubscribeResponseMessage(apSuite, reader);
 }
 
@@ -2210,8 +2204,6 @@ void TimedRequestMessageTest(nlTestSuite * apSuite, void * apContext)
     DebugPrettyPrint(buf);
 
     reader.Init(std::move(buf));
-    err = reader.Next();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseTimedRequestMessage(apSuite, reader);
 }
 

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -606,8 +606,6 @@ void TestReadInteraction::TestReadClientGenerateOneEventPaths(nlTestSuite * apSu
     ReadRequestMessage::Parser readRequestParser;
 
     reader.Init(msgBuf.Retain());
-    reader.Next();
-
     err = readRequestParser.Init(reader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -659,8 +657,6 @@ void TestReadInteraction::TestReadClientGenerateTwoEventPaths(nlTestSuite * apSu
     ReadRequestMessage::Parser readRequestParser;
 
     reader.Init(msgBuf.Retain());
-    reader.Next();
-
     err = readRequestParser.Init(reader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 

--- a/src/app/tests/TestStatusResponseMessage.cpp
+++ b/src/app/tests/TestStatusResponseMessage.cpp
@@ -85,8 +85,6 @@ void StatusResponseMessagePositiveTest(nlTestSuite * apSuite, void * apContext)
     err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     reader.Init(std::move(buf));
-    err = reader.Next();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseStatusResponseMessage(apSuite, reader, true /*aTestPositiveCase*/);
 }
 
@@ -101,8 +99,6 @@ void StatusResponseMessageNegativeTest(nlTestSuite * apSuite, void * apContext)
     err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     reader.Init(std::move(buf));
-    err = reader.Next();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseStatusResponseMessage(apSuite, reader, false /*aTestPositiveCase*/);
 }
 


### PR DESCRIPTION
#### Problem
* Fixes #12393

#### Change overview
--For IM message, do Next(TLV::kTLVType_Structure, TLV::AnonymousTag) check when init message parser.
--Checks the type, but not the tag, of that toplevel struct for IM message's end

#### Testing
Update the unit tests.
