### PR TITLE
Add generic interaction methods to CHIP Framework

### DIFF
--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -52,6 +52,17 @@
 		51B22C262740CB32008D5055 /* CHIPStructsObjc.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51B22C252740CB32008D5055 /* CHIPStructsObjc.mm */; };
 		51B22C2A2740CB47008D5055 /* CHIPCommandPayloadsObjc.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51B22C292740CB47008D5055 /* CHIPCommandPayloadsObjc.mm */; };
 		51E24E73274E0DAC007CCF6E /* CHIPErrorTestUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51E24E72274E0DAC007CCF6E /* CHIPErrorTestUtils.mm */; };
+		5A6FEC9027B563D900F25F42 /* CHIPDeviceControllerOverXPC.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A6FEC8F27B563D900F25F42 /* CHIPDeviceControllerOverXPC.m */; };
+		5A6FEC9227B5669C00F25F42 /* CHIPDeviceControllerOverXPC.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A6FEC8D27B5624E00F25F42 /* CHIPDeviceControllerOverXPC.h */; };
+		5A6FEC9627B5983000F25F42 /* CHIPDeviceControllerXPCConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A6FEC9527B5983000F25F42 /* CHIPDeviceControllerXPCConnection.m */; };
+		5A6FEC9827B5C6AF00F25F42 /* CHIPDeviceOverXPC.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A6FEC9727B5C6AF00F25F42 /* CHIPDeviceOverXPC.m */; };
+		5A6FEC9927B5C88900F25F42 /* CHIPDeviceOverXPC.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A6FEC8B27B5609C00F25F42 /* CHIPDeviceOverXPC.h */; };
+		5A6FEC9A27B5C89300F25F42 /* CHIPDeviceControllerXPCConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A6FEC9427B5976200F25F42 /* CHIPDeviceControllerXPCConnection.h */; };
+		5A6FEC9D27B5E48900F25F42 /* CHIPXPCProtocolTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A6FEC9C27B5E48800F25F42 /* CHIPXPCProtocolTests.m */; };
+		5A7947DE27BEC3F500434CF2 /* CHIPXPCListenerSampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A7947DD27BEC3F500434CF2 /* CHIPXPCListenerSampleTests.m */; };
+		5A7947E427C0129600434CF2 /* CHIPDeviceController+XPC.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A7947E327C0129500434CF2 /* CHIPDeviceController+XPC.m */; };
+		5A7947E527C0129F00434CF2 /* CHIPDeviceController+XPC.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A7947E227C0101200434CF2 /* CHIPDeviceController+XPC.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AE6D4E427A99041001F2493 /* CHIPDeviceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AE6D4E327A99041001F2493 /* CHIPDeviceTests.m */; };
 		991DC0842475F45400C13860 /* CHIPDeviceController.h in Headers */ = {isa = PBXBuildFile; fileRef = 991DC0822475F45400C13860 /* CHIPDeviceController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		991DC0892475F47D00C13860 /* CHIPDeviceController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 991DC0872475F47D00C13860 /* CHIPDeviceController.mm */; };
 		991DC08B247704DC00C13860 /* CHIPLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 991DC08A247704DC00C13860 /* CHIPLogging.h */; };
@@ -137,6 +148,17 @@
 		51B22C252740CB32008D5055 /* CHIPStructsObjc.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = CHIPStructsObjc.mm; path = "zap-generated/CHIPStructsObjc.mm"; sourceTree = "<group>"; };
 		51B22C292740CB47008D5055 /* CHIPCommandPayloadsObjc.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = CHIPCommandPayloadsObjc.mm; path = "zap-generated/CHIPCommandPayloadsObjc.mm"; sourceTree = "<group>"; };
 		51E24E72274E0DAC007CCF6E /* CHIPErrorTestUtils.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPErrorTestUtils.mm; sourceTree = "<group>"; };
+		5A6FEC8B27B5609C00F25F42 /* CHIPDeviceOverXPC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPDeviceOverXPC.h; sourceTree = "<group>"; };
+		5A6FEC8D27B5624E00F25F42 /* CHIPDeviceControllerOverXPC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPDeviceControllerOverXPC.h; sourceTree = "<group>"; };
+		5A6FEC8F27B563D900F25F42 /* CHIPDeviceControllerOverXPC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CHIPDeviceControllerOverXPC.m; sourceTree = "<group>"; };
+		5A6FEC9427B5976200F25F42 /* CHIPDeviceControllerXPCConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPDeviceControllerXPCConnection.h; sourceTree = "<group>"; };
+		5A6FEC9527B5983000F25F42 /* CHIPDeviceControllerXPCConnection.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CHIPDeviceControllerXPCConnection.m; sourceTree = "<group>"; };
+		5A6FEC9727B5C6AF00F25F42 /* CHIPDeviceOverXPC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CHIPDeviceOverXPC.m; sourceTree = "<group>"; };
+		5A6FEC9C27B5E48800F25F42 /* CHIPXPCProtocolTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CHIPXPCProtocolTests.m; sourceTree = "<group>"; };
+		5A7947DD27BEC3F500434CF2 /* CHIPXPCListenerSampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CHIPXPCListenerSampleTests.m; sourceTree = "<group>"; };
+		5A7947E227C0101200434CF2 /* CHIPDeviceController+XPC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CHIPDeviceController+XPC.h"; sourceTree = "<group>"; };
+		5A7947E327C0129500434CF2 /* CHIPDeviceController+XPC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "CHIPDeviceController+XPC.m"; sourceTree = "<group>"; };
+		5AE6D4E327A99041001F2493 /* CHIPDeviceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CHIPDeviceTests.m; sourceTree = "<group>"; };
 		991DC0822475F45400C13860 /* CHIPDeviceController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPDeviceController.h; sourceTree = "<group>"; };
 		991DC0872475F47D00C13860 /* CHIPDeviceController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPDeviceController.mm; sourceTree = "<group>"; };
 		991DC08A247704DC00C13860 /* CHIPLogging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPLogging.h; sourceTree = "<group>"; };
@@ -291,10 +313,18 @@
 				B2E0D7B0245B0B5C003C5B48 /* CHIPSetupPayload.mm */,
 				991DC0822475F45400C13860 /* CHIPDeviceController.h */,
 				991DC0872475F47D00C13860 /* CHIPDeviceController.mm */,
+				5A7947E227C0101200434CF2 /* CHIPDeviceController+XPC.h */,
+				5A7947E327C0129500434CF2 /* CHIPDeviceController+XPC.m */,
 				B20252912459E34F00F97062 /* Info.plist */,
 				998F286C26D55E10001846C6 /* CHIPKeypair.h */,
 				998F286E26D55EC5001846C6 /* CHIPP256KeypairBridge.h */,
 				998F287026D56940001846C6 /* CHIPP256KeypairBridge.mm */,
+				5A6FEC8B27B5609C00F25F42 /* CHIPDeviceOverXPC.h */,
+				5A6FEC9727B5C6AF00F25F42 /* CHIPDeviceOverXPC.m */,
+				5A6FEC8D27B5624E00F25F42 /* CHIPDeviceControllerOverXPC.h */,
+				5A6FEC8F27B563D900F25F42 /* CHIPDeviceControllerOverXPC.m */,
+				5A6FEC9427B5976200F25F42 /* CHIPDeviceControllerXPCConnection.h */,
+				5A6FEC9527B5983000F25F42 /* CHIPDeviceControllerXPCConnection.m */,
 			);
 			path = CHIP;
 			sourceTree = "<group>";
@@ -305,6 +335,9 @@
 				51E24E72274E0DAC007CCF6E /* CHIPErrorTestUtils.mm */,
 				1EB41B7A263C4CC60048E4C1 /* CHIPClustersTests.m */,
 				99C65E0F267282F1003402F6 /* CHIPControllerTests.m */,
+				5AE6D4E327A99041001F2493 /* CHIPDeviceTests.m */,
+				5A6FEC9C27B5E48800F25F42 /* CHIPXPCProtocolTests.m */,
+				5A7947DD27BEC3F500434CF2 /* CHIPXPCListenerSampleTests.m */,
 				B2F53AF1245B0DCF0010745E /* CHIPSetupPayloadParserTests.m */,
 				997DED1926955D0200975E97 /* CHIPThreadOperationalDatasetTests.mm */,
 				B202529D2459E34F00F97062 /* Info.plist */,
@@ -328,10 +361,12 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5A6FEC9927B5C88900F25F42 /* CHIPDeviceOverXPC.h in Headers */,
 				51B22C222740CB1D008D5055 /* CHIPCommandPayloadsObjc.h in Headers */,
 				51B22C1E2740CB0A008D5055 /* CHIPStructsObjc.h in Headers */,
 				2CB7163B252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.h in Headers */,
 				1E16A90326B98AF100683C53 /* CHIPTestClustersObjc.h in Headers */,
+				5A6FEC9227B5669C00F25F42 /* CHIPDeviceControllerOverXPC.h in Headers */,
 				2C1B027B2641DB4E00780EF1 /* CHIPOperationalCredentialsDelegate.h in Headers */,
 				99D466E12798936D0089A18F /* CHIPCommissioningParameters.h in Headers */,
 				B289D4212639C0D300D4E314 /* CHIPOnboardingPayloadParser.h in Headers */,
@@ -346,6 +381,7 @@
 				9956064426420367000C28DE /* CHIPSetupPayload_Internal.h in Headers */,
 				998F286D26D55E10001846C6 /* CHIPKeypair.h in Headers */,
 				1ED276E426C5832500547A89 /* CHIPCluster.h in Headers */,
+				5A6FEC9A27B5C89300F25F42 /* CHIPDeviceControllerXPCConnection.h in Headers */,
 				5129BCFD26A9EE3300122DDF /* CHIPError.h in Headers */,
 				2C8C8FC1253E0C2100797F05 /* CHIPPersistentStorageDelegate.h in Headers */,
 				B2E0D7B5245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.h in Headers */,
@@ -355,6 +391,7 @@
 				998F286F26D55EC5001846C6 /* CHIPP256KeypairBridge.h in Headers */,
 				2C222ADF255C811800E446B9 /* CHIPDevice_Internal.h in Headers */,
 				991DC08B247704DC00C13860 /* CHIPLogging.h in Headers */,
+				5A7947E527C0129F00434CF2 /* CHIPDeviceController+XPC.h in Headers */,
 				B2E0D7B4245B0B5C003C5B48 /* CHIPError_Internal.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -502,9 +539,12 @@
 				1E85730C265519AE0050A4D9 /* callback-stub.cpp in Sources */,
 				1E857310265519AE0050A4D9 /* IMClusterCommandHandler.cpp in Sources */,
 				1ED276E026C57CF000547A89 /* CHIPCallbackBridge.mm in Sources */,
+				5A6FEC9627B5983000F25F42 /* CHIPDeviceControllerXPCConnection.m in Sources */,
 				1E85732D26551A490050A4D9 /* util.cpp in Sources */,
 				513DDB8A2761F6F900DAA01A /* CHIPAttributeTLVValueDecoder.mm in Sources */,
 				2FD775552695557E00FF4B12 /* error-mapping.cpp in Sources */,
+				5A7947E427C0129600434CF2 /* CHIPDeviceController+XPC.m in Sources */,
+				5A6FEC9027B563D900F25F42 /* CHIPDeviceControllerOverXPC.m in Sources */,
 				1E85732A26551A490050A4D9 /* ember-compatibility-functions.cpp in Sources */,
 				B289D4222639C0D300D4E314 /* CHIPOnboardingPayloadParser.m in Sources */,
 				1E85732F26551A490050A4D9 /* attribute-size-util.cpp in Sources */,
@@ -512,6 +552,7 @@
 				1E85732926551A490050A4D9 /* af-event.cpp in Sources */,
 				B2E0D7B9245B0B5C003C5B48 /* CHIPSetupPayload.mm in Sources */,
 				B2E0D7B6245B0B5C003C5B48 /* CHIPManualSetupPayloadParser.mm in Sources */,
+				5A6FEC9827B5C6AF00F25F42 /* CHIPDeviceOverXPC.m in Sources */,
 				1E85732826551A490050A4D9 /* attribute-table.cpp in Sources */,
 				1E85732626551A490050A4D9 /* attribute-storage.cpp in Sources */,
 				1E85732C26551A490050A4D9 /* DataModelHandler.cpp in Sources */,
@@ -525,6 +566,9 @@
 				1EB41B7B263C4CC60048E4C1 /* CHIPClustersTests.m in Sources */,
 				997DED1A26955D0200975E97 /* CHIPThreadOperationalDatasetTests.mm in Sources */,
 				99C65E10267282F1003402F6 /* CHIPControllerTests.m in Sources */,
+				5A6FEC9D27B5E48900F25F42 /* CHIPXPCProtocolTests.m in Sources */,
+				5AE6D4E427A99041001F2493 /* CHIPDeviceTests.m in Sources */,
+				5A7947DE27BEC3F500434CF2 /* CHIPXPCListenerSampleTests.m in Sources */,
 				B2F53AF2245B0DCF0010745E /* CHIPSetupPayloadParserTests.m in Sources */,
 				51E24E73274E0DAC007CCF6E /* CHIPErrorTestUtils.mm in Sources */,
 			);

--- a/src/darwin/Framework/CHIP.xcodeproj/xcshareddata/xcschemes/CHIP Framework Tests.xcscheme
+++ b/src/darwin/Framework/CHIP.xcodeproj/xcshareddata/xcschemes/CHIP Framework Tests.xcscheme
@@ -37,6 +37,17 @@
                BlueprintName = "CHIPTests"
                ReferencedContainer = "container:CHIP.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "CHIPDeviceTests">
+               </Test>
+               <Test
+                  Identifier = "CHIPRemoteDeviceSampleTests">
+               </Test>
+               <Test
+                  Identifier = "CHIPXPCListenerSampleTests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/src/darwin/Framework/CHIP/CHIP.h
+++ b/src/darwin/Framework/CHIP/CHIP.h
@@ -21,6 +21,7 @@
 #import <CHIP/CHIPCommandPayloadsObjc.h>
 #import <CHIP/CHIPCommissioningParameters.h>
 #import <CHIP/CHIPDevice.h>
+#import <CHIP/CHIPDeviceController+XPC.h>
 #import <CHIP/CHIPDeviceController.h>
 #import <CHIP/CHIPDevicePairingDelegate.h>
 #import <CHIP/CHIPError.h>

--- a/src/darwin/Framework/CHIP/CHIPDevice.h
+++ b/src/darwin/Framework/CHIP/CHIPDevice.h
@@ -22,6 +22,29 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef void (^CHIPDeviceResponseHandler)(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error);
+
+extern NSString * const kCHIPTypeKey;
+extern NSString * const kCHIPValueKey;
+extern NSString * const kCHIPTagKey;
+extern NSString * const kCHIPSignedIntegerValueTypeKey;
+extern NSString * const kCHIPUnsignedIntegerValueTypeKey;
+extern NSString * const kCHIPBooleanValueTypeKey;
+extern NSString * const kCHIPUTF8StringValueTypeKey;
+extern NSString * const kCHIPOctetStringValueTypeKey;
+extern NSString * const kCHIPFloatValueTypeKey;
+extern NSString * const kCHIPDoubleValueTypeKey;
+extern NSString * const kCHIPNullValueTypeKey;
+extern NSString * const kCHIPStructureValueTypeKey;
+extern NSString * const kCHIPArrayValueTypeKey;
+extern NSString * const kCHIPListValueTypeKey;
+extern NSString * const kCHIPEndpointIdKey;
+extern NSString * const kCHIPClusterIdKey;
+extern NSString * const kCHIPAttributeIdKey;
+extern NSString * const kCHIPCommandIdKey;
+extern NSString * const kCHIPDataKey;
+extern NSString * const kCHIPStatusKey;
+
 @interface CHIPDevice : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -49,6 +72,91 @@ NS_ASSUME_NONNULL_BEGIN
                 maxInterval:(uint16_t)maxInterval
               reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
     subscriptionEstablished:(nullable void (^)(void))subscriptionEstablishedHandler;
+
+/**
+ * Read attribute in a designated attribute path
+ *
+ * @param completion  response handler will receive either value or error. value will be an NSArray object with NSDictionary
+ * elements. Each NSDictionary will have "endpointId", "clusterId", "attributeId", "status" and "data" keys. "endpointId",
+ * "clusterId", "attributeId" and "status" will be mapped to NSNumber objects. "status" with 0 value indicates success and non-zero
+ * value indicates failure. "data" key is present only when "status" value is 0. "data" key will be mapped to an NSDictionary
+ * object, representing attribute value of the path. NSDictionary representing attribute value will contain "type" and "value" keys.
+ *                        "type" will be mapped to "SignedInteger", "UnsignedInteger", "UTF8String", "OctetString", "Float",
+ * "Double", "Boolean", "Null", "Structure", "Array" or "List. "value" will be mapped to an NSNumber, NSString, nil or NSArray
+ * instance. When "type" is "OctetStriing", "value" will be an NSData object. When "type" is "Structure", "Array" or "List", "value"
+ * will be NSArray with NSDictionary elements. Each NSDictionary element will have "tag" and "value" keys. "tag" will be mapped to
+ * an NSNumber value. "value" will be mapped to an NSDictionary instance representing any attribute value recursively.
+ */
+- (void)readAttributeWithEndpointId:(NSUInteger)endpointId
+                          clusterId:(NSUInteger)clusterId
+                        attributeId:(NSUInteger)attributeId
+                        clientQueue:(dispatch_queue_t)clientQueue
+                         completion:(CHIPDeviceResponseHandler)completion;
+
+/**
+ * Write to attribute in a designated attribute path
+ *
+ * @param completion  response handler will receive either value or error. value will be an NSArray object with NSDictionary
+ * elements. Each NSDictionary will have "endpointId", "clusterId", "attributeId" and "status" keys. "endpointId", "clusterId",
+ * "attributeId" and "status" will be mapped to NSNumber objects. "status" with 0 value indicates success and non-zero value
+ * indicates failure.
+ */
+- (void)writeAttributeWithEndpointId:(NSUInteger)endpointId
+                           clusterId:(NSUInteger)clusterId
+                         attributeId:(NSUInteger)attributeId
+                               value:(id)value
+                         clientQueue:(dispatch_queue_t)clientQueue
+                          completion:(CHIPDeviceResponseHandler)completion;
+
+/**
+ * Invoke a command with a designated command path
+ *
+ * @param commandFields   command fields object. The object must be an NSDictionary object representing attribute value
+ *                      as described in the readAttributeWithEndpointId:clusterId:attributeId:clientQueue:responseHandler: method.
+ *                      The attribute must be a Structure, i.e., the NSDictionary "type" key must have the value "Structure".
+ *
+ * @param completion  response handler will receive either value or error. value will be an NSArray object with NSDictionary
+ * elements. Each NSDictionary will have "endpointId", "clusterId", "commandId", "status" and "responseData" keys. "endpointId",
+ * "clusterId", "attributeId" and "status" will be mapped to NSNumber objects. "status" with 0 value indicates success and non-zero
+ * value indicates failure. "responseData" key will be included only when "status" key has 0 value and there is response data for
+ * the command. "responseData" key value will be an NSDictionary object representing attribute value as described in the
+ * readAttributeWithEndpointId:clusterId:attributeId:clientQueue:responseHandler: method.
+ */
+- (void)invokeCommandWithEndpointId:(NSUInteger)endpointId
+                          clusterId:(NSUInteger)clusterId
+                          commandId:(NSUInteger)commandId
+                      commandFields:(id)commandFields
+                        clientQueue:(dispatch_queue_t)clientQueue
+                         completion:(CHIPDeviceResponseHandler)completion;
+
+/**
+ * Subscribe an attribute in a designated attribute path
+ *
+ * @param reportHandler   handler for the reports. Note that only the report handler by the last call to this method per the same
+ * attribute path will receive reports. Report handler will receive either value or error. value will be an NSDictionary object. The
+ * NSDictionary object will have "endpointId", "clusterId", "attributeId" and "value" keys. "endpointId", "clusterId" and
+ * "attributeId" will be mapped to NSNumber objects. "value" key value will be an NSDictionary object representing attribute value
+ *                      as described in the readAttributeWithEndpointId:clusterId:attributeId:clientQueue:responseHandler: method.
+ */
+- (void)subscribeAttributeWithEndpointId:(NSUInteger)endpointId
+                               clusterId:(NSUInteger)clusterId
+                             attributeId:(NSUInteger)attributeId
+                             minInterval:(NSUInteger)minInterval
+                             maxInterval:(NSUInteger)maxInterval
+                             clientQueue:(dispatch_queue_t)clientQueue
+                           reportHandler:(void (^)(NSDictionary<NSString *, id> * _Nullable value,
+                                             NSError * _Nullable error))reportHandler
+                 subscriptionEstablished:(nullable void (^)(void))subscriptionEstablishedHandler;
+
+/**
+ * Deregister all local report handlers for a remote device
+ *
+ * This method is applicable only for a remote device. For a local device, the stack has to be shutdown to stop report handlers.
+ * There could be multiple clients accessing a node through a remote controller object and hence it is not appropriate
+ * for one of those clients to shut down the entire stack to stop receiving reports.
+ */
+- (void)deregisterReportHandlersWithClientQueue:(dispatch_queue_t)clientQueue completion:(void (^)(void))completion;
+
 @end
 
 @interface CHIPAttributePath : NSObject

--- a/src/darwin/Framework/CHIP/CHIPDevice.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevice.mm
@@ -16,6 +16,7 @@
  */
 
 #import "CHIPAttributeTLVValueDecoder_Internal.h"
+#import "CHIPCallbackBridgeBase_internal.h"
 #import "CHIPDevice_Internal.h"
 #import "CHIPError_Internal.h"
 #import "CHIPLogging.h"
@@ -26,6 +27,10 @@
 #include <app/InteractionModelEngine.h>
 #include <app/ReadClient.h>
 #include <app/util/error-mapping.h>
+#include <controller/ReadInteraction.h>
+#include <controller/WriteInteraction.h>
+
+#include <memory>
 
 typedef void (^SubscriptionEstablishedHandler)(void);
 
@@ -33,10 +38,34 @@ using namespace chip;
 using namespace chip::app;
 using namespace chip::Protocols::InteractionModel;
 
+NSString * const kCHIPTypeKey = @"type";
+NSString * const kCHIPValueKey = @"value";
+NSString * const kCHIPTagKey = @"tag";
+NSString * const kCHIPSignedIntegerValueTypeKey = @"SignedInteger";
+NSString * const kCHIPUnsignedIntegerValueTypeKey = @"UnsignedInteger";
+NSString * const kCHIPBooleanValueTypeKey = @"Boolean";
+NSString * const kCHIPUTF8StringValueTypeKey = @"UTF8String";
+NSString * const kCHIPOctetStringValueTypeKey = @"OctetString";
+NSString * const kCHIPFloatValueTypeKey = @"Float";
+NSString * const kCHIPDoubleValueTypeKey = @"Double";
+NSString * const kCHIPNullValueTypeKey = @"Null";
+NSString * const kCHIPStructureValueTypeKey = @"Structure";
+NSString * const kCHIPArrayValueTypeKey = @"Array";
+NSString * const kCHIPListValueTypeKey = @"List";
+NSString * const kCHIPEndpointIdKey = @"endpointId";
+NSString * const kCHIPClusterIdKey = @"clusterId";
+NSString * const kCHIPAttributeIdKey = @"attributeId";
+NSString * const kCHIPCommandIdKey = @"commandId";
+NSString * const kCHIPDataKey = @"data";
+NSString * const kCHIPStatusKey = @"status";
+
+class NSObjectAttributeCallbackBridge;
+
 @interface CHIPDevice ()
 
 @property (nonatomic, readonly, strong, nonnull) NSRecursiveLock * lock;
 @property (readonly) chip::DeviceProxy * cppDevice;
+@property (nonatomic, readwrite) NSMutableDictionary * reportHandlerBridges;
 
 @end
 
@@ -173,6 +202,898 @@ private:
     callback->AdoptReadClient(std::move(readClient));
     callback.release();
 }
+
+// Convert TLV data into NSObject
+static id ObjectFromTLV(chip::TLV::TLVReader * data)
+{
+    chip::TLV::TLVType dataTLVType = data->GetType();
+    switch (dataTLVType) {
+    case chip::TLV::kTLVType_SignedInteger: {
+        int64_t val;
+        CHIP_ERROR err = data->Get(val);
+        if (err != CHIP_NO_ERROR) {
+            CHIP_LOG_ERROR("Error(%s): TLV signed integer decoding failed", chip::ErrorStr(err));
+            return nil;
+        }
+        return [NSDictionary dictionaryWithObjectsAndKeys:kCHIPSignedIntegerValueTypeKey, kCHIPTypeKey,
+                             [NSNumber numberWithLongLong:val], kCHIPValueKey, nil];
+    }
+    case chip::TLV::kTLVType_UnsignedInteger: {
+        uint64_t val;
+        CHIP_ERROR err = data->Get(val);
+        if (err != CHIP_NO_ERROR) {
+            CHIP_LOG_ERROR("Error(%s): TLV unsigned integer decoding failed", chip::ErrorStr(err));
+            return nil;
+        }
+        return [NSDictionary dictionaryWithObjectsAndKeys:kCHIPUnsignedIntegerValueTypeKey, kCHIPTypeKey,
+                             [NSNumber numberWithUnsignedLongLong:val], kCHIPValueKey, nil];
+    }
+    case chip::TLV::kTLVType_Boolean: {
+        bool val;
+        CHIP_ERROR err = data->Get(val);
+        if (err != CHIP_NO_ERROR) {
+            CHIP_LOG_ERROR("Error(%s): TLV boolean decoding failed", chip::ErrorStr(err));
+            return nil;
+        }
+        return [NSDictionary
+            dictionaryWithObjectsAndKeys:kCHIPBooleanValueTypeKey, kCHIPTypeKey, [NSNumber numberWithBool:val], kCHIPValueKey, nil];
+    }
+    case chip::TLV::kTLVType_FloatingPointNumber: {
+        double val;
+        CHIP_ERROR err = data->Get(val);
+        if (err != CHIP_NO_ERROR) {
+            CHIP_LOG_ERROR("Error(%s): TLV floating point decoding failed", chip::ErrorStr(err));
+            return nil;
+        }
+        return [NSDictionary dictionaryWithObjectsAndKeys:kCHIPDoubleValueTypeKey, kCHIPTypeKey, [NSNumber numberWithDouble:val],
+                             kCHIPValueKey, nil];
+    }
+    case chip::TLV::kTLVType_UTF8String: {
+        const uint8_t * ptr;
+        CHIP_ERROR err = data->GetDataPtr(ptr);
+        if (err != CHIP_NO_ERROR) {
+            CHIP_LOG_ERROR("Error(%s): TLV UTF8String decoding failed", chip::ErrorStr(err));
+            return nil;
+        }
+        return [NSDictionary dictionaryWithObjectsAndKeys:kCHIPUTF8StringValueTypeKey, kCHIPTypeKey,
+                             [NSString stringWithUTF8String:(const char *) ptr], kCHIPValueKey, nil];
+    }
+    case chip::TLV::kTLVType_ByteString: {
+        uint32_t len = data->GetLength();
+        const uint8_t * ptr;
+        CHIP_ERROR err = data->GetDataPtr(ptr);
+        if (err != CHIP_NO_ERROR) {
+            CHIP_LOG_ERROR("Error(%s): TLV ByteString decoding failed", chip::ErrorStr(err));
+            return nil;
+        }
+        return [NSDictionary dictionaryWithObjectsAndKeys:kCHIPOctetStringValueTypeKey, kCHIPTypeKey,
+                             [NSData dataWithBytes:ptr length:len], kCHIPValueKey, nil];
+    }
+    case chip::TLV::kTLVType_Null: {
+        return [NSDictionary dictionaryWithObjectsAndKeys:kCHIPNullValueTypeKey, kCHIPTypeKey, nil];
+    }
+    case chip::TLV::kTLVType_Structure:
+    case chip::TLV::kTLVType_Array:
+    case chip::TLV::kTLVType_List: {
+        NSString * typeName;
+        switch (dataTLVType) {
+        case chip::TLV::kTLVType_Structure:
+            typeName = kCHIPStructureValueTypeKey;
+            break;
+        case chip::TLV::kTLVType_Array:
+            typeName = kCHIPArrayValueTypeKey;
+            break;
+        case chip::TLV::kTLVType_List:
+            typeName = kCHIPListValueTypeKey;
+            break;
+        default:
+            typeName = @"Unsupported";
+            break;
+        }
+        chip::TLV::TLVType tlvType;
+        CHIP_ERROR err = data->EnterContainer(tlvType);
+        if (err != CHIP_NO_ERROR) {
+            CHIP_LOG_ERROR("Error(%s): TLV container entering failed", chip::ErrorStr(err));
+            return nil;
+        }
+        NSMutableArray * array = [[NSMutableArray alloc] init];
+        while ((err = data->Next()) == CHIP_NO_ERROR) {
+            chip::TLV::Tag tag = data->GetTag();
+            id value = ObjectFromTLV(data);
+            if (value == nullptr) {
+                CHIP_LOG_ERROR("Error when decoding TLV container");
+                return nil;
+            }
+            [array addObject:[NSDictionary dictionaryWithObjectsAndKeys:value, kCHIPValueKey,
+                                           [NSNumber numberWithUnsignedLongLong:(unsigned long long) tag.mVal], kCHIPTagKey, nil]];
+        }
+        if (err != CHIP_END_OF_TLV) {
+            CHIP_LOG_ERROR("Error(%s): TLV container decoding failed", chip::ErrorStr(err));
+            return nil;
+        }
+        err = data->ExitContainer(tlvType);
+        if (err != CHIP_NO_ERROR) {
+            CHIP_LOG_ERROR("Error(%s): TLV container exiting failed", chip::ErrorStr(err));
+            return nil;
+        }
+        return [NSDictionary dictionaryWithObjectsAndKeys:typeName, kCHIPTypeKey, array, kCHIPValueKey, nil];
+    }
+    default:
+        CHIP_LOG_ERROR("Error: Unsupported TLV type for conversion: %u", (unsigned) data->GetType());
+        return nil;
+    }
+}
+
+static CHIP_ERROR EncodeTLVFromObject(id object, chip::TLV::TLVWriter & writer, chip::TLV::Tag tag)
+{
+    if (![object isKindOfClass:[NSDictionary class]]) {
+        CHIP_LOG_ERROR("Error: Unsupported object to encode: %@", [object class]);
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+    NSString * typeName = ((NSDictionary *) object)[kCHIPTypeKey];
+    id value = ((NSDictionary *) object)[kCHIPValueKey];
+    if (!typeName) {
+        CHIP_LOG_ERROR("Error: Object to encode is corrupt");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+    if ([typeName isEqualToString:kCHIPSignedIntegerValueTypeKey]) {
+        if (![value isKindOfClass:[NSNumber class]]) {
+            CHIP_LOG_ERROR("Error: Object to encode has corrupt signed integer type: %@", [value class]);
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        return writer.Put(tag, [value intValue]);
+    }
+    if ([typeName isEqualToString:kCHIPUnsignedIntegerValueTypeKey]) {
+        if (![value isKindOfClass:[NSNumber class]]) {
+            CHIP_LOG_ERROR("Error: Object to encode has corrupt unsigned integer type: %@", [value class]);
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        return writer.Put(tag, [value unsignedIntValue]);
+    }
+    if ([typeName isEqualToString:kCHIPBooleanValueTypeKey]) {
+        if (![value isKindOfClass:[NSNumber class]]) {
+            CHIP_LOG_ERROR("Error: Object to encode has corrupt boolean type: %@", [value class]);
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        return writer.Put(tag, [value unsignedIntValue] ? true : false);
+    }
+    if ([typeName isEqualToString:kCHIPFloatValueTypeKey]) {
+        if (![value isKindOfClass:[NSNumber class]]) {
+            CHIP_LOG_ERROR("Error: Object to encode has corrupt float type: %@", [value class]);
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        return writer.Put(tag, [value floatValue]);
+    }
+    if ([typeName isEqualToString:kCHIPDoubleValueTypeKey]) {
+        if (![value isKindOfClass:[NSNumber class]]) {
+            CHIP_LOG_ERROR("Error: Object to encode has corrupt double type: %@", [value class]);
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        return writer.Put(tag, [value doubleValue]);
+    }
+    if ([typeName isEqualToString:kCHIPNullValueTypeKey]) {
+        return writer.PutNull(tag);
+    }
+    if ([typeName isEqualToString:kCHIPUTF8StringValueTypeKey]) {
+        if (![value isKindOfClass:[NSString class]]) {
+            CHIP_LOG_ERROR("Error: Object to encode has corrupt UTF8 string type: %@", [value class]);
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        return writer.PutString(tag, [value cStringUsingEncoding:NSUTF8StringEncoding]);
+    }
+    if ([typeName isEqualToString:kCHIPOctetStringValueTypeKey]) {
+        if (![value isKindOfClass:[NSData class]]) {
+            CHIP_LOG_ERROR("Error: Object to encode has corrupt octet string type: %@", [value class]);
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        return writer.Put(tag, chip::ByteSpan(static_cast<const uint8_t *>([value bytes]), [value length]));
+    }
+    if ([typeName isEqualToString:kCHIPStructureValueTypeKey]) {
+        if (![value isKindOfClass:[NSArray class]]) {
+            CHIP_LOG_ERROR("Error: Object to encode has corrupt structure type: %@", [value class]);
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        TLV::TLVType outer;
+        ReturnErrorOnFailure(writer.StartContainer(tag, chip::TLV::kTLVType_Structure, outer));
+        for (id element in value) {
+            if (![element isKindOfClass:[NSDictionary class]]) {
+                CHIP_LOG_ERROR("Error: Structure element to encode has corrupt type: %@", [element class]);
+                return CHIP_ERROR_INVALID_ARGUMENT;
+            }
+            NSNumber * elementTag = element[kCHIPTagKey];
+            id elementValue = element[kCHIPValueKey];
+            if (!elementTag || !elementValue) {
+                CHIP_LOG_ERROR("Error: Structure element to encode has corrupt value: %@", element);
+                return CHIP_ERROR_INVALID_ARGUMENT;
+            }
+            ReturnErrorOnFailure(EncodeTLVFromObject(elementValue, writer, chip::TLV::ContextTag([elementTag unsignedCharValue])));
+        }
+        ReturnErrorOnFailure(writer.EndContainer(outer));
+        return CHIP_NO_ERROR;
+    }
+    if ([typeName isEqualToString:kCHIPArrayValueTypeKey]) {
+        if (![value isKindOfClass:[NSArray class]]) {
+            CHIP_LOG_ERROR("Error: Object to encode has corrupt array type: %@", [value class]);
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        TLV::TLVType outer;
+        ReturnErrorOnFailure(writer.StartContainer(tag, chip::TLV::kTLVType_Array, outer));
+        for (id element in value) {
+            if (![element isKindOfClass:[NSDictionary class]]) {
+                CHIP_LOG_ERROR("Error: Array element to encode has corrupt type: %@", [element class]);
+                return CHIP_ERROR_INVALID_ARGUMENT;
+            }
+            id elementValue = element[kCHIPValueKey];
+            if (!elementValue) {
+                CHIP_LOG_ERROR("Error: Array element to encode has corrupt value: %@", element);
+                return CHIP_ERROR_INVALID_ARGUMENT;
+            }
+            ReturnErrorOnFailure(EncodeTLVFromObject(elementValue, writer, chip::TLV::AnonymousTag()));
+        }
+        ReturnErrorOnFailure(writer.EndContainer(outer));
+        return CHIP_NO_ERROR;
+    }
+    if ([typeName isEqualToString:kCHIPListValueTypeKey]) {
+        if (![value isKindOfClass:[NSArray class]]) {
+            CHIP_LOG_ERROR("Error: Object to encode has corrupt list type: %@", [value class]);
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        TLV::TLVType outer;
+        ReturnErrorOnFailure(writer.StartContainer(tag, chip::TLV::kTLVType_List, outer));
+        for (id element in value) {
+            if (![element isKindOfClass:[NSDictionary class]]) {
+                CHIP_LOG_ERROR("Error: List element to encode has corrupt type: %@", [element class]);
+                return CHIP_ERROR_INVALID_ARGUMENT;
+            }
+            NSNumber * elementTag = element[kCHIPTagKey];
+            id elementValue = element[kCHIPValueKey];
+            if (!elementValue) {
+                CHIP_LOG_ERROR("Error: Array element to encode has corrupt value: %@", element);
+                return CHIP_ERROR_INVALID_ARGUMENT;
+            }
+            ReturnErrorOnFailure(EncodeTLVFromObject(elementValue, writer,
+                elementTag ? chip::TLV::ContextTag((uint8_t)[elementTag unsignedCharValue]) : chip::TLV::AnonymousTag()));
+        }
+        ReturnErrorOnFailure(writer.EndContainer(outer));
+        return CHIP_NO_ERROR;
+    }
+    CHIP_LOG_ERROR("Error: Unsupported type to encode: %@", typeName);
+    return CHIP_ERROR_INVALID_ARGUMENT;
+}
+
+// Callback type to pass attribute value as an NSObject
+typedef void (*NSObjectAttributeCallback)(void * context, id value);
+typedef void (*CHIPErrorCallback)(void * context, CHIP_ERROR error);
+
+// Rename to be generic for decode and encode
+class NSObjectData {
+public:
+    NSObjectData()
+        : decodedObj(nil)
+    {
+    }
+    NSObjectData(id obj)
+        : decodedObj(obj)
+    {
+    }
+
+    CHIP_ERROR Decode(chip::TLV::TLVReader & data)
+    {
+        decodedObj = ObjectFromTLV(&data);
+        if (decodedObj == nil) {
+            CHIP_LOG_ERROR("Error: Failed to get value from TLV data for attribute reading response");
+        }
+        return (decodedObj) ? CHIP_NO_ERROR : CHIP_ERROR_DECODE_FAILED;
+    }
+
+    CHIP_ERROR Encode(chip::TLV::TLVWriter & writer, chip::TLV::Tag tag) const
+    {
+        return EncodeTLVFromObject(decodedObj, writer, tag);
+    }
+
+    static constexpr bool kIsFabricScoped = false;
+
+    static bool MustUseTimedInvoke() { return false; }
+
+    id _Nullable GetDecodedObject() const { return decodedObj; }
+
+private:
+    id _Nullable decodedObj;
+};
+
+// Callback bridge for NSObjectAttributeCallback
+class NSObjectAttributeCallbackBridge : public CHIPCallbackBridge<NSObjectAttributeCallback> {
+public:
+    NSObjectAttributeCallbackBridge(
+        dispatch_queue_t queue, CHIPDeviceResponseHandler handler, CHIPActionBlock action, bool keepAlive = false)
+        : CHIPCallbackBridge<NSObjectAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive) {};
+
+    static void OnSuccessFn(void * context, id value) { DispatchSuccess(context, value); }
+};
+
+// Subscribe bridge for NSObjectAttributeCallback
+class NSObjectAttributeCallbackSubscribeBridge : public NSObjectAttributeCallbackBridge {
+public:
+    NSObjectAttributeCallbackSubscribeBridge(dispatch_queue_t queue,
+        void (^handler)(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error), CHIPActionBlock action,
+        SubscriptionEstablishedHandler establishedHandler)
+        : NSObjectAttributeCallbackBridge(queue, (CHIPDeviceResponseHandler) handler, action, true)
+        , mQueue(queue)
+        , mEstablishedHandler(establishedHandler) {};
+
+    static void OnSubscriptionEstablished(void * context)
+    {
+        auto * self = static_cast<NSObjectAttributeCallbackSubscribeBridge *>(context);
+        if (!self->mQueue) {
+            return;
+        }
+
+        if (self->mEstablishedHandler != nil) {
+            dispatch_async(self->mQueue, self->mEstablishedHandler);
+            // On failure, mEstablishedHandler will be cleaned up by our destructor,
+            // but we can clean it up earlier on successful subscription
+            // establishment.
+            self->mEstablishedHandler = nil;
+        }
+    }
+
+private:
+    dispatch_queue_t mQueue;
+    SubscriptionEstablishedHandler mEstablishedHandler;
+};
+
+template <typename DecodableAttributeType> class BufferedReadAttributeCallback final : public app::ReadClient::Callback {
+public:
+    using OnSuccessCallbackType
+        = std::function<void(const app::ConcreteDataAttributePath & aPath, const DecodableAttributeType & aData)>;
+    using OnErrorCallbackType = std::function<void(const app::ConcreteDataAttributePath * aPath, CHIP_ERROR aError)>;
+    using OnDoneCallbackType = std::function<void(BufferedReadAttributeCallback * callback)>;
+    using OnSubscriptionEstablishedCallbackType = std::function<void()>;
+
+    BufferedReadAttributeCallback(ClusterId aClusterId, AttributeId aAttributeId, OnSuccessCallbackType aOnSuccess,
+        OnErrorCallbackType aOnError, OnDoneCallbackType aOnDone,
+        OnSubscriptionEstablishedCallbackType aOnSubscriptionEstablished = nullptr)
+        : mClusterId(aClusterId)
+        , mAttributeId(aAttributeId)
+        , mOnSuccess(aOnSuccess)
+        , mOnError(aOnError)
+        , mOnDone(aOnDone)
+        , mOnSubscriptionEstablished(aOnSubscriptionEstablished)
+        , mBufferedReadAdapter(*this)
+    {
+    }
+
+    app::BufferedReadCallback & GetBufferedCallback() { return mBufferedReadAdapter; }
+
+    void AdoptReadClient(Platform::UniquePtr<app::ReadClient> aReadClient) { mReadClient = std::move(aReadClient); }
+
+private:
+    void OnAttributeData(
+        const app::ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const app::StatusIB & aStatus) override
+    {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+        DecodableAttributeType value;
+
+        //
+        // We shouldn't be getting list item operations in the provided path since that should be handled by the buffered read
+        // callback. If we do, that's a bug.
+        //
+        VerifyOrDie(!aPath.IsListItemOperation());
+
+        VerifyOrExit(aStatus.IsSuccess(), err = aStatus.ToChipError());
+        VerifyOrExit((aPath.mClusterId == mClusterId || mClusterId == kInvalidClusterId)
+                && (aPath.mAttributeId == mAttributeId || mAttributeId == kInvalidAttributeId),
+            err = CHIP_ERROR_SCHEMA_MISMATCH);
+        VerifyOrExit(apData != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+        SuccessOrExit(err = app::DataModel::Decode(*apData, value));
+
+        mOnSuccess(aPath, value);
+
+    exit:
+        if (err != CHIP_NO_ERROR) {
+            mOnError(&aPath, err);
+        }
+    }
+
+    void OnError(CHIP_ERROR aError) override { mOnError(nullptr, aError); }
+
+    void OnDone() override { mOnDone(this); }
+
+    void OnSubscriptionEstablished(uint64_t aSubscriptionId) override
+    {
+        if (mOnSubscriptionEstablished) {
+            mOnSubscriptionEstablished();
+        }
+    }
+
+    void OnDeallocatePaths(chip::app::ReadPrepareParams && aReadPrepareParams) override
+    {
+        VerifyOrDie(
+            aReadPrepareParams.mAttributePathParamsListSize == 1 && aReadPrepareParams.mpAttributePathParamsList != nullptr);
+        chip::Platform::Delete<app::AttributePathParams>(aReadPrepareParams.mpAttributePathParamsList);
+
+        VerifyOrDie(aReadPrepareParams.mDataVersionFilterListSize == 1 && aReadPrepareParams.mpDataVersionFilterList != nullptr);
+        chip::Platform::Delete<app::DataVersionFilter>(aReadPrepareParams.mpDataVersionFilterList);
+    }
+
+    ClusterId mClusterId;
+    AttributeId mAttributeId;
+    OnSuccessCallbackType mOnSuccess;
+    OnErrorCallbackType mOnError;
+    OnDoneCallbackType mOnDone;
+    OnSubscriptionEstablishedCallbackType mOnSubscriptionEstablished;
+    app::BufferedReadCallback mBufferedReadAdapter;
+    Platform::UniquePtr<app::ReadClient> mReadClient;
+};
+
+- (void)readAttributeWithEndpointId:(NSUInteger)endpointId
+                          clusterId:(NSUInteger)clusterId
+                        attributeId:(NSUInteger)attributeId
+                        clientQueue:(dispatch_queue_t)clientQueue
+                         completion:(CHIPDeviceResponseHandler)completion
+{
+    new NSObjectAttributeCallbackBridge(
+        clientQueue, completion, ^(chip::Callback::Cancelable * success, chip::Callback::Cancelable * failure) {
+            auto successFn = chip::Callback::Callback<NSObjectAttributeCallback>::FromCancelable(success);
+            auto failureFn = chip::Callback::Callback<CHIPErrorCallback>::FromCancelable(failure);
+            auto context = successFn->mContext;
+            auto successCb = successFn->mCall;
+            auto failureCb = failureFn->mCall;
+            auto resultArray = [[NSMutableArray alloc] init];
+            auto resultSuccess = [[NSMutableArray alloc] init];
+            auto resultFailure = [[NSMutableArray alloc] init];
+            auto onSuccessCb = [resultArray, resultSuccess](
+                                   const app::ConcreteAttributePath & attribPath, const NSObjectData & aData) {
+                [resultArray
+                    addObject:[[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithUnsignedInt:attribPath.mEndpointId],
+                                                    kCHIPEndpointIdKey, [NSNumber numberWithUnsignedInt:attribPath.mClusterId],
+                                                    kCHIPClusterIdKey, [NSNumber numberWithUnsignedInt:attribPath.mAttributeId],
+                                                    kCHIPAttributeIdKey, aData.GetDecodedObject(), kCHIPDataKey,
+                                                    [NSNumber numberWithUnsignedInt:0], kCHIPStatusKey, nil]];
+                if ([resultSuccess count] == 0) {
+                    [resultSuccess addObject:[NSNumber numberWithBool:YES]];
+                }
+            };
+
+            auto onFailureCb = [resultArray, resultFailure](const app::ConcreteAttributePath * attribPath, CHIP_ERROR aError) {
+                if (attribPath) {
+                    [resultArray addObject:[[NSDictionary alloc]
+                                               initWithObjectsAndKeys:[NSNumber numberWithUnsignedInt:attribPath->mEndpointId],
+                                               kCHIPEndpointIdKey, [NSNumber numberWithUnsignedInt:attribPath->mClusterId],
+                                               kCHIPClusterIdKey, [NSNumber numberWithUnsignedInt:attribPath->mAttributeId],
+                                               kCHIPAttributeIdKey, [NSNumber numberWithUnsignedInteger:aError.AsInteger()],
+                                               kCHIPStatusKey, nil]];
+                } else if ([resultFailure count] == 0) {
+                    [resultFailure addObject:[NSNumber numberWithUnsignedInteger:aError.AsInteger()]];
+                }
+            };
+
+            auto chipEndpointId = static_cast<chip::EndpointId>(endpointId);
+            auto chipClusterId = static_cast<chip::ClusterId>(clusterId);
+            auto chipAttributeId = static_cast<chip::AttributeId>(attributeId);
+
+            app::AttributePathParams attributePath(chipEndpointId, chipClusterId, chipAttributeId);
+            app::InteractionModelEngine * engine = app::InteractionModelEngine::GetInstance();
+            CHIP_ERROR err = CHIP_NO_ERROR;
+
+            chip::app::ReadPrepareParams readParams([self internalDevice]->GetSecureSession().Value());
+            readParams.mpAttributePathParamsList = &attributePath;
+            readParams.mAttributePathParamsListSize = 1;
+
+            auto onDone = [resultArray, resultSuccess, resultFailure, context, successCb, failureCb](
+                              BufferedReadAttributeCallback<NSObjectData> * callback) {
+                if ([resultFailure count] > 0 || [resultSuccess count] == 0) {
+                    // Failure
+                    if (failureCb) {
+                        if ([resultFailure count] > 0) {
+                            failureCb(
+                                context, CHIP_ERROR(static_cast<CHIP_ERROR::StorageType>([resultFailure[0] unsignedIntegerValue])));
+                        } else if ([resultArray count] > 0) {
+                            failureCb(context,
+                                CHIP_ERROR(
+                                    static_cast<CHIP_ERROR::StorageType>([resultArray[0][kCHIPStatusKey] unsignedIntegerValue])));
+                        } else {
+                            failureCb(context, CHIP_ERROR_READ_FAILED);
+                        }
+                    }
+                } else {
+                    // Success
+                    if (successCb) {
+                        successCb(context, resultArray);
+                    }
+                }
+                chip::Platform::Delete(callback);
+            };
+
+            auto callback = chip::Platform::MakeUnique<BufferedReadAttributeCallback<NSObjectData>>(
+                chipClusterId, chipAttributeId, onSuccessCb, onFailureCb, onDone, nullptr);
+            VerifyOrReturnError(callback != nullptr, CHIP_ERROR_NO_MEMORY);
+
+            auto readClient = chip::Platform::MakeUnique<app::ReadClient>(engine, [self internalDevice]->GetExchangeManager(),
+                callback -> GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
+            VerifyOrReturnError(readClient != nullptr, CHIP_ERROR_NO_MEMORY);
+
+            err = readClient->SendRequest(readParams);
+
+            if (err != CHIP_NO_ERROR) {
+                return err;
+            }
+
+            //
+            // At this point, we'll get a callback through the OnDone callback above regardless of success or failure
+            // of the read operation to permit us to free up the callback object. So, release ownership of the callback
+            // object now to prevent it from being reclaimed at the end of this scoped block.
+            //
+            callback->AdoptReadClient(std::move(readClient));
+            callback.release();
+            return err;
+        });
+}
+
+- (void)writeAttributeWithEndpointId:(NSUInteger)endpointId
+                           clusterId:(NSUInteger)clusterId
+                         attributeId:(NSUInteger)attributeId
+                               value:(id)value
+                         clientQueue:(dispatch_queue_t)clientQueue
+                          completion:(CHIPDeviceResponseHandler)completion
+{
+    new NSObjectAttributeCallbackBridge(
+        clientQueue, completion, ^(chip::Callback::Cancelable * success, chip::Callback::Cancelable * failure) {
+            auto successFn = chip::Callback::Callback<NSObjectAttributeCallback>::FromCancelable(success);
+            auto failureFn = chip::Callback::Callback<CHIPErrorCallback>::FromCancelable(failure);
+            auto context = successFn->mContext;
+            auto successCb = successFn->mCall;
+            auto failureCb = failureFn->mCall;
+            auto resultArray = [[NSMutableArray alloc] init];
+            auto resultSuccess = [[NSMutableArray alloc] init];
+            auto resultFailure = [[NSMutableArray alloc] init];
+            auto onSuccessCb = [resultArray, resultSuccess](const app::ConcreteAttributePath & commandPath) {
+                [resultArray
+                    addObject:[[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithUnsignedInt:commandPath.mEndpointId],
+                                                    kCHIPEndpointIdKey, [NSNumber numberWithUnsignedInt:commandPath.mClusterId],
+                                                    kCHIPClusterIdKey, [NSNumber numberWithUnsignedInt:commandPath.mAttributeId],
+                                                    kCHIPAttributeIdKey, [NSNumber numberWithUnsignedInt:0], kCHIPStatusKey, nil]];
+                if ([resultSuccess count] == 0) {
+                    [resultSuccess addObject:[NSNumber numberWithBool:YES]];
+                }
+            };
+
+            auto onFailureCb = [resultArray, resultFailure](const app::ConcreteAttributePath * commandPath, CHIP_ERROR aError) {
+                if (commandPath) {
+                    [resultArray addObject:[[NSDictionary alloc]
+                                               initWithObjectsAndKeys:[NSNumber numberWithUnsignedInt:commandPath->mEndpointId],
+                                               kCHIPEndpointIdKey, [NSNumber numberWithUnsignedInt:commandPath->mClusterId],
+                                               kCHIPClusterIdKey, [NSNumber numberWithUnsignedInt:commandPath->mAttributeId],
+                                               kCHIPAttributeIdKey, [NSNumber numberWithUnsignedInteger:aError.AsInteger()],
+                                               kCHIPStatusKey, nil]];
+                } else {
+                    if ([resultFailure count] == 0) {
+                        [resultFailure addObject:[NSNumber numberWithUnsignedInteger:aError.AsInteger()]];
+                    }
+                }
+            };
+
+            auto onDoneCb = [context, successCb, failureCb, resultArray, resultSuccess, resultFailure](
+                                app::WriteClient * pWriteClient) {
+                if ([resultFailure count] > 0 || [resultSuccess count] == 0) {
+                    // Failure
+                    if (failureCb) {
+                        if ([resultFailure count] > 0) {
+                            failureCb(
+                                context, CHIP_ERROR(static_cast<CHIP_ERROR::StorageType>([resultFailure[0] unsignedIntegerValue])));
+                        } else if ([resultArray count] > 0) {
+                            failureCb(context,
+                                CHIP_ERROR(
+                                    static_cast<CHIP_ERROR::StorageType>([resultArray[0][kCHIPStatusKey] unsignedIntegerValue])));
+                        } else {
+                            failureCb(context, CHIP_ERROR_WRITE_FAILED);
+                        }
+                    }
+                } else {
+                    // Success
+                    if (successCb) {
+                        successCb(context, resultArray);
+                    }
+                }
+            };
+
+            return chip::Controller::WriteAttribute<NSObjectData>([self internalDevice]->GetSecureSession().Value(),
+                static_cast<chip::EndpointId>(endpointId), static_cast<chip::ClusterId>(clusterId),
+                static_cast<chip::AttributeId>(attributeId), NSObjectData(value), onSuccessCb, onFailureCb, NullOptional, onDoneCb,
+                NullOptional);
+        });
+}
+
+class NSObjectCommandCallback final : public app::CommandSender::Callback {
+public:
+    using OnSuccessCallbackType
+        = std::function<void(const app::ConcreteCommandPath &, const app::StatusIB &, const NSObjectData &)>;
+    using OnErrorCallbackType = std::function<void(CHIP_ERROR aError)>;
+    using OnDoneCallbackType = std::function<void(app::CommandSender * commandSender)>;
+
+    /*
+     * Constructor that takes in success, failure and onDone callbacks.
+     *
+     * The latter can be provided later through the SetOnDoneCallback below in cases where the
+     * TypedCommandCallback object needs to be created first before it can be passed in as a closure
+     * into a hypothetical OnDoneCallback function.
+     */
+    NSObjectCommandCallback(chip::ClusterId clusterId, chip::CommandId commandId, OnSuccessCallbackType aOnSuccess,
+        OnErrorCallbackType aOnError, OnDoneCallbackType aOnDone = {})
+        : mOnSuccess(aOnSuccess)
+        , mOnError(aOnError)
+        , mOnDone(aOnDone)
+        , mClusterId(clusterId)
+        , mCommandId(commandId)
+    {
+    }
+
+    void SetOnDoneCallback(OnDoneCallbackType callback) { mOnDone = callback; }
+
+private:
+    void OnResponse(app::CommandSender * apCommandSender, const app::ConcreteCommandPath & aCommandPath,
+        const app::StatusIB & aStatus, TLV::TLVReader * aReader) override;
+
+    void OnError(const app::CommandSender * apCommandSender, CHIP_ERROR aError) override { mOnError(aError); }
+
+    void OnDone(app::CommandSender * apCommandSender) override { mOnDone(apCommandSender); }
+
+    OnSuccessCallbackType mOnSuccess;
+    OnErrorCallbackType mOnError;
+    OnDoneCallbackType mOnDone;
+    chip::ClusterId mClusterId;
+    chip::CommandId mCommandId;
+};
+
+void NSObjectCommandCallback::OnResponse(app::CommandSender * apCommandSender, const app::ConcreteCommandPath & aCommandPath,
+    const app::StatusIB & aStatus, TLV::TLVReader * aReader)
+{
+    NSObjectData response;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    //
+    // Validate that the data response we received matches what we expect in terms of its cluster and command IDs.
+    //
+    VerifyOrExit(aCommandPath.mClusterId == mClusterId && aCommandPath.mCommandId == mCommandId, err = CHIP_ERROR_SCHEMA_MISMATCH);
+
+    if (aReader != nullptr) {
+        err = app::DataModel::Decode(*aReader, response);
+        SuccessOrExit(err);
+    }
+
+    mOnSuccess(aCommandPath, aStatus, response);
+
+exit:
+    if (err != CHIP_NO_ERROR) {
+        mOnError(err);
+    }
+}
+
+- (void)invokeCommandWithEndpointId:(NSUInteger)endpointId
+                          clusterId:(NSUInteger)clusterId
+                          commandId:(NSUInteger)commandId
+                      commandFields:(id)commandFields
+                        clientQueue:(dispatch_queue_t)clientQueue
+                         completion:(CHIPDeviceResponseHandler)completion
+{
+    new NSObjectAttributeCallbackBridge(
+        clientQueue, completion, ^(chip::Callback::Cancelable * success, chip::Callback::Cancelable * failure) {
+            auto successFn = chip::Callback::Callback<NSObjectAttributeCallback>::FromCancelable(success);
+            auto failureFn = chip::Callback::Callback<CHIPErrorCallback>::FromCancelable(failure);
+            auto context = successFn->mContext;
+            auto successCb = successFn->mCall;
+            auto failureCb = failureFn->mCall;
+            auto resultArray = [[NSMutableArray alloc] init];
+            auto resultSuccess = [[NSMutableArray alloc] init];
+            auto resultFailure = [[NSMutableArray alloc] init];
+            auto onSuccessCb = [resultArray, resultSuccess](const app::ConcreteCommandPath & commandPath,
+                                   const app::StatusIB & status, const NSObjectData & responseData) {
+                if (responseData.GetDecodedObject()) {
+                    [resultArray addObject:[[NSDictionary alloc]
+                                               initWithObjectsAndKeys:[NSNumber numberWithUnsignedInt:commandPath.mEndpointId],
+                                               kCHIPEndpointIdKey, [NSNumber numberWithUnsignedInt:commandPath.mClusterId],
+                                               kCHIPClusterIdKey, [NSNumber numberWithUnsignedInt:commandPath.mCommandId],
+                                               kCHIPCommandIdKey, [NSNumber numberWithUnsignedInt:0], kCHIPStatusKey,
+                                               responseData.GetDecodedObject(), kCHIPDataKey, nil]];
+                } else {
+                    [resultArray addObject:[[NSDictionary alloc]
+                                               initWithObjectsAndKeys:[NSNumber numberWithUnsignedInt:commandPath.mEndpointId],
+                                               kCHIPEndpointIdKey, [NSNumber numberWithUnsignedInt:commandPath.mClusterId],
+                                               kCHIPClusterIdKey, [NSNumber numberWithUnsignedInt:commandPath.mCommandId],
+                                               kCHIPCommandIdKey, [NSNumber numberWithUnsignedInt:0], kCHIPStatusKey, nil]];
+                }
+                if ([resultSuccess count] == 0) {
+                    [resultSuccess addObject:[NSNumber numberWithBool:YES]];
+                }
+            };
+
+            auto onFailureCb = [resultFailure](CHIP_ERROR aError) {
+                if ([resultFailure count] == 0) {
+                    [resultFailure addObject:[NSNumber numberWithUnsignedInteger:aError.AsInteger()]];
+                }
+            };
+
+            app::CommandPathParams commandPath = { (chip::EndpointId) endpointId, 0, (chip::ClusterId) clusterId,
+                (chip::CommandId) commandId, (app::CommandPathFlags::kEndpointIdValid) };
+
+            auto decoder = chip::Platform::MakeUnique<NSObjectCommandCallback>(
+                commandPath.mClusterId, commandPath.mCommandId, onSuccessCb, onFailureCb);
+            VerifyOrReturnError(decoder != nullptr, CHIP_ERROR_NO_MEMORY);
+
+            auto rawDecoderPtr = decoder.get();
+            auto onDoneCb = [rawDecoderPtr, context, successCb, failureCb, resultArray, resultSuccess, resultFailure](
+                                app::CommandSender * commandSender) {
+                if ([resultFailure count] > 0 || [resultSuccess count] == 0) {
+                    // Failure
+                    if (failureCb) {
+                        if ([resultFailure count] > 0) {
+                            failureCb(
+                                context, CHIP_ERROR(static_cast<CHIP_ERROR::StorageType>([resultFailure[0] unsignedIntegerValue])));
+                        } else {
+                            failureCb(context, CHIP_ERROR_WRITE_FAILED);
+                        }
+                    }
+                } else {
+                    // Success
+                    if (successCb) {
+                        successCb(context, resultArray);
+                    }
+                }
+                chip::Platform::Delete(commandSender);
+                chip::Platform::Delete(rawDecoderPtr);
+            };
+
+            decoder->SetOnDoneCallback(onDoneCb);
+
+            auto commandSender
+                = chip::Platform::MakeUnique<app::CommandSender>(decoder.get(), [self internalDevice]->GetExchangeManager(), false);
+            VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_NO_MEMORY);
+
+            ReturnErrorOnFailure(commandSender->AddRequestData(commandPath, NSObjectData(commandFields), chip::NullOptional));
+            ReturnErrorOnFailure(commandSender->SendCommandRequest([self internalDevice]->GetSecureSession().Value()));
+
+            decoder.release();
+            commandSender.release();
+            return CHIP_NO_ERROR;
+        });
+}
+
+- (void)subscribeAttributeWithEndpointId:(NSUInteger)endpointId
+                               clusterId:(NSUInteger)clusterId
+                             attributeId:(NSUInteger)attributeId
+                             minInterval:(NSUInteger)minInterval
+                             maxInterval:(NSUInteger)maxInterval
+                             clientQueue:(dispatch_queue_t)clientQueue
+                           reportHandler:(void (^)(NSDictionary<NSString *, id> * _Nullable value,
+                                             NSError * _Nullable error))reportHandler
+                 subscriptionEstablished:(SubscriptionEstablishedHandler)subscriptionEstablishedHandler
+{
+    new NSObjectAttributeCallbackSubscribeBridge(
+        clientQueue, (void (^)(id _Nullable, NSError * _Nullable)) reportHandler,
+        ^(chip::Callback::Cancelable * success, chip::Callback::Cancelable * failure) {
+            auto successFn = chip::Callback::Callback<NSObjectAttributeCallback>::FromCancelable(success);
+            auto failureFn = chip::Callback::Callback<CHIPErrorCallback>::FromCancelable(failure);
+            auto context = successFn->mContext;
+            auto successCb = successFn->mCall;
+            auto failureCb = failureFn->mCall;
+            auto onReportCb = [context, successCb](const app::ConcreteAttributePath & attribPath, const NSObjectData & data) {
+                if (successCb != nullptr) {
+                    successCb(context,
+                        [[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithUnsignedInt:attribPath.mEndpointId],
+                                              kCHIPEndpointIdKey, [NSNumber numberWithUnsignedInt:attribPath.mClusterId],
+                                              kCHIPClusterIdKey, [NSNumber numberWithUnsignedInt:attribPath.mAttributeId],
+                                              kCHIPAttributeIdKey, data.GetDecodedObject(), kCHIPValueKey, nil]);
+                }
+            };
+
+            auto establishedOrFailed = std::make_shared<BOOL>(NO);
+            auto onFailureCb
+                = [context, failureCb, establishedOrFailed](const app::ConcreteAttributePath * attribPath, CHIP_ERROR error) {
+                      if (!(*establishedOrFailed)) {
+                          *establishedOrFailed = YES;
+                          NSObjectAttributeCallbackSubscribeBridge::OnSubscriptionEstablished(context);
+                      }
+                      if (failureCb != nullptr) {
+                          failureCb(context, error);
+                      }
+                  };
+
+            auto onEstablishedCb = [context, establishedOrFailed]() {
+                if (*establishedOrFailed) {
+                    return;
+                }
+                *establishedOrFailed = YES;
+                NSObjectAttributeCallbackSubscribeBridge::OnSubscriptionEstablished(context);
+            };
+
+            auto chipEndpointId = static_cast<chip::EndpointId>(endpointId);
+            auto chipClusterId = static_cast<chip::ClusterId>(clusterId);
+            auto chipAttributeId = static_cast<chip::AttributeId>(attributeId);
+
+            app::AttributePathParams attributePath(chipEndpointId, chipClusterId, chipAttributeId);
+            app::InteractionModelEngine * engine = app::InteractionModelEngine::GetInstance();
+            CHIP_ERROR err = CHIP_NO_ERROR;
+
+            chip::app::ReadPrepareParams readParams([self internalDevice]->GetSecureSession().Value());
+            readParams.mpAttributePathParamsList = &attributePath;
+            readParams.mAttributePathParamsListSize = 1;
+
+            auto onDone = [](BufferedReadAttributeCallback<NSObjectData> * callback) { chip::Platform::Delete(callback); };
+
+            auto callback = chip::Platform::MakeUnique<BufferedReadAttributeCallback<NSObjectData>>(
+                chipClusterId, chipAttributeId, onReportCb, onFailureCb, onDone, onEstablishedCb);
+            VerifyOrReturnError(callback != nullptr, CHIP_ERROR_NO_MEMORY);
+
+            auto readClient = chip::Platform::MakeUnique<app::ReadClient>(engine, [self internalDevice]->GetExchangeManager(),
+                callback -> GetBufferedCallback(), chip::app::ReadClient::InteractionType::Subscribe);
+            VerifyOrReturnError(readClient != nullptr, CHIP_ERROR_NO_MEMORY);
+
+            err = readClient->SendAutoResubscribeRequest(std::move(readParams));
+
+            if (err != CHIP_NO_ERROR) {
+                return err;
+            }
+
+            //
+            // At this point, we'll get a callback through the OnDone callback above regardless of success or failure
+            // of the read operation to permit us to free up the callback object. So, release ownership of the callback
+            // object now to prevent it from being reclaimed at the end of this scoped block.
+            //
+            callback->AdoptReadClient(std::move(readClient));
+            callback.release();
+            return err;
+        },
+        subscriptionEstablishedHandler);
+}
+
+- (void)deregisterReportHandlersWithClientQueue:(dispatch_queue_t)clientQueue completion:(void (^)(void))completion
+{
+    // Do nothing for a local instance.
+    CHIP_LOG_ERROR("Unexpected call to deregister report handlers");
+    dispatch_async(clientQueue, completion);
+}
+
+// The following method is for unit testing purpose only
++ (id)CHIPEncodeAndDecodeNSObject:(id)object
+{
+    NSObjectData originalData(object);
+    chip::TLV::TLVWriter writer;
+    uint8_t buffer[1024];
+    writer.Init(buffer, sizeof(buffer));
+
+    CHIP_ERROR error = originalData.Encode(writer, chip::TLV::Tag(1));
+    if (error != CHIP_NO_ERROR) {
+        CHIP_LOG_ERROR("Error: Data encoding failed: %s", error.AsString());
+        return nil;
+    }
+
+    error = writer.Finalize();
+    if (error != CHIP_NO_ERROR) {
+        CHIP_LOG_ERROR("Error: TLV writer finalizing failed: %s", error.AsString());
+        return nil;
+    }
+    chip::TLV::TLVReader reader;
+    reader.Init(buffer, writer.GetLengthWritten());
+    error = reader.Next();
+    if (error != CHIP_NO_ERROR) {
+        CHIP_LOG_ERROR("Error: TLV reader failed to fetch next element: %s", error.AsString());
+        return nil;
+    }
+    __auto_type tag = reader.GetTag();
+    if (tag != chip::TLV::Tag(1)) {
+        CHIP_LOG_ERROR("Error: TLV reader did not read the tag correctly: %llu", tag.mVal);
+        return nil;
+    }
+    NSObjectData decodedData;
+    error = decodedData.Decode(reader);
+    if (error != CHIP_NO_ERROR) {
+        CHIP_LOG_ERROR("Error: Data decoding failed: %s", error.AsString());
+        return nil;
+    }
+    return decodedData.GetDecodedObject();
+}
+
 @end
 
 @implementation CHIPAttributePath

--- a/src/darwin/Framework/CHIP/CHIPDeviceController+XPC.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController+XPC.h
@@ -1,0 +1,117 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <CHIP/CHIPDeviceController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Extended methods for CHIPDeviceController object over XPC
+ */
+@interface CHIPDeviceController (XPC)
+
+/**
+ * Returns a shared device controller proxy for the controller object over XPC connection.
+ *
+ * @param controllerId  an implementation specific id in case multiple shared device controllers are available over XPC connection
+ * @param connectBlock  block to connect to an XPC listener serving the shared device controllers in an implementation specific way
+ */
++ (CHIPDeviceController *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerId
+                                 xpcConnectBlock:(NSXPCConnection * (^)(void) )connectBlock;
+
+@end
+
+/**
+ * Protocol that remote object must support over XPC
+ */
+@protocol CHIPDeviceControllerServerProtocol <NSObject>
+
+/**
+ * Gets device controller ID corresponding to a specific fabric Id
+ */
+- (void)getDeviceControllerWithFabricId:(uint64_t)fabricId
+                             completion:(void (^)(id _Nullable controller, NSError * _Nullable error))completion;
+
+/**
+ * Gets any available device controller ID
+ */
+- (void)getAnyDeviceControllerWithCompletion:(void (^)(id _Nullable controller, NSError * _Nullable error))completion;
+
+/**
+ * Requests reading attribute
+ */
+- (void)readAttributeWithController:(id _Nullable)controller
+                             nodeId:(uint64_t)nodeId
+                         endpointId:(NSUInteger)endpointId
+                          clusterId:(NSUInteger)clusterId
+                        attributeId:(NSUInteger)attributeId
+                         completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion;
+
+/**
+ * Requests writing attribute
+ */
+- (void)writeAttributeWithController:(id _Nullable)controller
+                              nodeId:(uint64_t)nodeId
+                          endpointId:(NSUInteger)endpointId
+                           clusterId:(NSUInteger)clusterId
+                         attributeId:(NSUInteger)attributeId
+                               value:(id)value
+                          completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion;
+
+/**
+ * Requests invoking command
+ */
+- (void)invokeCommandWithController:(id _Nullable)controller
+                             nodeId:(uint64_t)nodeId
+                         endpointId:(NSUInteger)endpointId
+                          clusterId:(NSUInteger)clusterId
+                          commandId:(NSUInteger)commandId
+                             fields:(id)fields
+                         completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion;
+
+/**
+ * Requests subscribing attribute
+ */
+- (void)subscribeAttributeWithController:(id _Nullable)controller
+                                  nodeId:(uint64_t)nodeId
+                              endpointId:(NSUInteger)endpointId
+                               clusterId:(NSUInteger)clusterId
+                             attributeId:(NSUInteger)attributeId
+                             minInterval:(NSUInteger)minInterval
+                             maxInterval:(NSUInteger)maxInterval
+                      establishedHandler:(void (^)(void))establishedHandler;
+
+@end
+
+/**
+ * Protocol that the XPC client local object must support
+ */
+@protocol CHIPDeviceControllerClientProtocol <NSObject>
+
+/**
+ * Handles a report received by a device controller
+ */
+- (void)handleReportWithController:(id _Nullable)controller
+                            nodeId:(uint64_t)nodeId
+                             value:(id _Nullable)value
+                             error:(NSError * _Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPDeviceController+XPC.m
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController+XPC.m
@@ -1,0 +1,34 @@
+/**
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "CHIPDeviceController+XPC.h"
+
+#import "CHIPDeviceControllerOverXPC.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation CHIPDeviceController (XPC)
+
++ (CHIPDeviceController *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerId
+                                 xpcConnectBlock:(NSXPCConnection * (^)(void) )connectBlock
+{
+    return [CHIPDeviceControllerOverXPC sharedControllerWithId:controllerId xpcConnectBlock:connectBlock];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPDeviceControllerOverXPC.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceControllerOverXPC.h
@@ -1,0 +1,38 @@
+/**
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <CHIP/CHIPDeviceController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class CHIPDeviceControllerXPCConnection;
+
+@interface CHIPDeviceControllerOverXPC : CHIPDeviceController
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+/**
+ * Returns a shared remote device controller associated with an implementation specific id and implementation specific way to
+ * connect to an XPC listener.
+ */
++ (CHIPDeviceControllerOverXPC *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerId
+                                        xpcConnectBlock:(NSXPCConnection * (^)(void) )connectBlock;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPDeviceControllerOverXPC.m
+++ b/src/darwin/Framework/CHIP/CHIPDeviceControllerOverXPC.m
@@ -1,0 +1,190 @@
+/**
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "CHIPDeviceControllerOverXPC.h"
+
+#import "CHIPDeviceController+XPC.h"
+#import "CHIPDeviceControllerXPCConnection.h"
+#import "CHIPDeviceOverXPC.h"
+#import "CHIPError.h"
+#import "CHIPLogging.h"
+
+#import <Foundation/Foundation.h>
+
+static dispatch_once_t workQueueInitOnceToken;
+static dispatch_queue_t globalWorkQueue;
+
+static void SetupXPCQueue(void)
+{
+    dispatch_once(&workQueueInitOnceToken, ^{
+        globalWorkQueue = dispatch_queue_create("com.apple.matter.framework.xpc.workqueue", DISPATCH_QUEUE_SERIAL);
+    });
+}
+
+@interface CHIPDeviceControllerOverXPC ()
+
+@property (nonatomic, readwrite, strong) id<NSCopying> _Nullable controllerId;
+@property (nonatomic, readonly, strong) dispatch_queue_t workQueue;
+@property (nonatomic, readonly, strong) CHIPDeviceControllerXPCConnection * xpcConnection;
+
+@end
+
+@implementation CHIPDeviceControllerOverXPC
+
++ (CHIPDeviceControllerOverXPC *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerId
+                                        xpcConnectBlock:(NSXPCConnection * (^)(void) )connectBlock
+{
+    SetupXPCQueue();
+    return [[CHIPDeviceControllerOverXPC alloc] initWithControllerId:controllerId
+                                                           workQueue:globalWorkQueue
+                                                        connectBlock:connectBlock];
+}
+
+- (BOOL)pairDevice:(uint64_t)deviceID
+     discriminator:(uint16_t)discriminator
+      setupPINCode:(uint32_t)setupPINCode
+             error:(NSError * __autoreleasing *)error
+{
+    CHIP_LOG_ERROR("CHIPDevice doesn't support pairDevice over XPC");
+    return NO;
+}
+
+- (BOOL)pairDevice:(uint64_t)deviceID
+           address:(NSString *)address
+              port:(uint16_t)port
+     discriminator:(uint16_t)discriminator
+      setupPINCode:(uint32_t)setupPINCode
+             error:(NSError * __autoreleasing *)error
+{
+    CHIP_LOG_ERROR("CHIPDevice doesn't support pairDevice over XPC");
+    return NO;
+}
+
+- (BOOL)pairDevice:(uint64_t)deviceID onboardingPayload:(NSString *)onboardingPayload error:(NSError * __autoreleasing *)error
+{
+    CHIP_LOG_ERROR("CHIPDevice doesn't support pairDevice over XPC");
+    return NO;
+}
+
+- (BOOL)commissionDevice:(uint64_t)deviceId
+     commissioningParams:(CHIPCommissioningParameters *)commissioningParams
+                   error:(NSError * __autoreleasing *)error
+{
+    CHIP_LOG_ERROR("CHIPDevice doesn't support pairDevice over XPC");
+    return NO;
+}
+
+- (void)setListenPort:(uint16_t)port
+{
+    CHIP_LOG_ERROR("CHIPDevice doesn't support setListenPort over XPC");
+}
+
+- (BOOL)stopDevicePairing:(uint64_t)deviceID error:(NSError * __autoreleasing *)error
+{
+    CHIP_LOG_ERROR("CHIPDevice doesn't support stopDevicePairing over XPC");
+    return NO;
+}
+
+- (void)updateDevice:(uint64_t)deviceID fabricId:(uint64_t)fabricId
+{
+    CHIP_LOG_ERROR("CHIPDevice doesn't support updateDevice:fabricId: over XPC");
+}
+
+- (nullable CHIPDevice *)getDeviceBeingCommissioned:(uint64_t)deviceId error:(NSError * __autoreleasing *)error
+{
+    CHIP_LOG_ERROR("CHIPDevice doesn't support getDeviceBeingCommissioned over XPC");
+    return nil;
+}
+
+- (BOOL)getConnectedDevice:(uint64_t)deviceID
+                     queue:(dispatch_queue_t)queue
+         completionHandler:(CHIPDeviceConnectionCallback)completionHandler
+{
+    dispatch_async(_workQueue, ^{
+        dispatch_group_t group = dispatch_group_create();
+        if (!self.controllerId) {
+            dispatch_group_enter(group);
+            [self.xpcConnection getProxyHandleWithCompletion:^(
+                dispatch_queue_t _Nonnull queue, CHIPDeviceControllerXPCProxyHandle * _Nullable handle) {
+                if (handle) {
+                    [handle.proxy getAnyDeviceControllerWithCompletion:^(id _Nullable controller, NSError * _Nullable error) {
+                        if (error) {
+                            CHIP_LOG_ERROR("Failed to fetch any shared remote controller");
+                        } else {
+                            self.controllerId = controller;
+                        }
+                        dispatch_group_leave(group);
+                        __auto_type handleRetainer = handle;
+                        (void) handleRetainer;
+                    }];
+                } else {
+                    CHIP_LOG_ERROR("XPC disconnected while retrieving any shared remote controller");
+                    dispatch_group_leave(group);
+                }
+            }];
+        }
+        dispatch_group_notify(group, queue, ^{
+            if (self.controllerId) {
+                CHIPDeviceOverXPC * device = [[CHIPDeviceOverXPC alloc] initWithController:self.controllerId
+                                                                                  deviceId:deviceID
+                                                                             xpcConnection:self.xpcConnection];
+                completionHandler(device, nil);
+            } else {
+                completionHandler(nil, [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil]);
+            }
+        });
+    });
+    return YES;
+}
+
+- (BOOL)openPairingWindow:(uint64_t)deviceID duration:(NSUInteger)duration error:(NSError * __autoreleasing *)error
+{
+    CHIP_LOG_ERROR("CHIPDevice doesn't support openPairingWindow over XPC");
+    return NO;
+}
+
+- (nullable NSString *)openPairingWindowWithPIN:(uint64_t)deviceID
+                                       duration:(NSUInteger)duration
+                                  discriminator:(NSUInteger)discriminator
+                                       setupPIN:(NSUInteger)setupPIN
+                                          error:(NSError * __autoreleasing *)error
+{
+    CHIP_LOG_ERROR("CHIPDevice doesn't support openPairingWindow over XPC");
+    return nil;
+}
+
+- (instancetype)initWithControllerId:(id)controllerId
+                           workQueue:(dispatch_queue_t)queue
+                       xpcConnection:(CHIPDeviceControllerXPCConnection *)connection
+{
+    _controllerId = controllerId;
+    _workQueue = queue;
+    _xpcConnection = connection;
+    return self;
+}
+
+// This is interface for unit testing
+- (instancetype)initWithControllerId:(id)controllerId
+                           workQueue:(dispatch_queue_t)queue
+                        connectBlock:(NSXPCConnection * (^)(void) )connectBlock
+{
+    return [self initWithControllerId:controllerId
+                            workQueue:queue
+                        xpcConnection:[CHIPDeviceControllerXPCConnection connectionWithWorkQueue:queue connectBlock:connectBlock]];
+}
+
+@end

--- a/src/darwin/Framework/CHIP/CHIPDeviceControllerXPCConnection.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceControllerXPCConnection.h
@@ -1,0 +1,57 @@
+/**
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "CHIPDeviceController+XPC.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * handle for XPC remote object proxy for remote device controller
+ *
+ * Releasing the handle may cause invalidating the XPC connection. Hence, in order to retain the connection, the handle must not be
+ * released.
+ */
+@interface CHIPDeviceControllerXPCProxyHandle : NSObject
+
+@property (nonatomic, readonly, getter=proxy) id<CHIPDeviceControllerServerProtocol> proxy;
+
+@end
+
+/**
+ * class to manage XPC connection for remote device controller
+ *
+ * This class is in charge of making a new XPC connection and disconnecting as needed by the clients and by the report handlers.
+ */
+@interface CHIPDeviceControllerXPCConnection<CHIPDeviceControllerClientProtocol> : NSObject
+
+/**
+ * This method is just for test purpsoe.
+ */
++ (instancetype)connectionWithWorkQueue:(dispatch_queue_t)workQueue connectBlock:(NSXPCConnection * (^)(void) )connectBlock;
+
+- (void)getProxyHandleWithCompletion:(void (^)(dispatch_queue_t queue,
+                                         CHIPDeviceControllerXPCProxyHandle * _Nullable container))completion;
+- (void)registerReportHandlerWithController:(id<NSCopying>)controller
+                                     nodeId:(NSUInteger)nodeId
+                                    handler:(void (^)(id _Nullable value, NSError * _Nullable error))handler;
+- (void)deregisterReportHandlersWithController:(id<NSCopying>)controller
+                                        nodeId:(NSUInteger)nodeId
+                                    completion:(void (^)(void))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPDeviceControllerXPCConnection.m
+++ b/src/darwin/Framework/CHIP/CHIPDeviceControllerXPCConnection.m
@@ -1,0 +1,191 @@
+/**
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "CHIPDeviceControllerXPCConnection.h"
+#import "CHIPDeviceControllerOverXPC.h"
+#import "CHIPLogging.h"
+
+#import <Foundation/Foundation.h>
+
+@interface CHIPDeviceControllerXPCProxyHandle ()
+@property (weak, nonatomic, readonly) NSXPCConnection * xpcConnection;
+
+- (instancetype)initWithXPCConnection:(NSXPCConnection *)xpcConnection;
+
+@end
+
+@implementation CHIPDeviceControllerXPCProxyHandle
+
+- (instancetype)initWithXPCConnection:(NSXPCConnection *)xpcConnection
+{
+    if ([super init]) {
+        _xpcConnection = xpcConnection;
+    }
+    return self;
+}
+
+- (id<CHIPDeviceControllerServerProtocol>)proxy
+{
+    return [_xpcConnection remoteObjectProxy];
+}
+
+- (void)dealloc
+{
+    [_xpcConnection invalidate];
+}
+
+@end
+
+@interface CHIPDeviceControllerXPCConnection ()
+
+@property (strong, nonatomic, readonly) NSXPCInterface * remoteDeviceServerProtocol;
+@property (strong, nonatomic, readonly) NSXPCInterface * remoteDeviceClientProtocol;
+@property (strong, nonatomic, readonly) NSXPCConnection * (^connectBlock)(void);
+@property (weak, nonatomic, readwrite) CHIPDeviceControllerXPCProxyHandle * proxyHandle;
+@property (strong, nonatomic, readwrite) CHIPDeviceControllerXPCProxyHandle * proxyRetainerForReports;
+@property (strong, atomic, readonly) dispatch_queue_t workQueue;
+
+@property (strong, nonatomic, readonly) NSMutableDictionary<id, NSMutableDictionary *> * reportRegistry;
+
+@end
+
+@implementation CHIPDeviceControllerXPCConnection
+
+- (instancetype)initWithWorkQueue:(dispatch_queue_t)workQueue connectBlock:(NSXPCConnection * (^)(void) )connectBlock
+{
+    if ([super init]) {
+        _remoteDeviceServerProtocol = [NSXPCInterface interfaceWithProtocol:@protocol(CHIPDeviceControllerServerProtocol)];
+        _remoteDeviceClientProtocol = [NSXPCInterface interfaceWithProtocol:@protocol(CHIPDeviceControllerClientProtocol)];
+        _connectBlock = connectBlock;
+        _workQueue = workQueue;
+        _reportRegistry = [[NSMutableDictionary alloc] init];
+    }
+    return self;
+}
+
+// This class method is for unit testing
++ (instancetype)connectionWithWorkQueue:(dispatch_queue_t)workQueue connectBlock:(NSXPCConnection * (^)(void) )connectBlock
+{
+    return [[CHIPDeviceControllerXPCConnection alloc] initWithWorkQueue:workQueue connectBlock:connectBlock];
+}
+
+- (void)getProxyHandleWithCompletion:(void (^)(dispatch_queue_t queue,
+                                         CHIPDeviceControllerXPCProxyHandle * _Nullable container))completion
+{
+    dispatch_async(_workQueue, ^{
+        CHIPDeviceControllerXPCProxyHandle * container = self.proxyHandle;
+        if (!container) {
+            NSXPCConnection * xpcConnection = self.connectBlock();
+            if (!xpcConnection) {
+                CHIP_LOG_ERROR("Cannot connect to XPC server for remote controller");
+                completion(self.workQueue, nil);
+            }
+            xpcConnection.remoteObjectInterface = self.remoteDeviceServerProtocol;
+            xpcConnection.exportedInterface = self.remoteDeviceClientProtocol;
+            xpcConnection.exportedObject = self;
+            [xpcConnection resume];
+            container = [[CHIPDeviceControllerXPCProxyHandle alloc] initWithXPCConnection:xpcConnection];
+            self.proxyHandle = container;
+            __weak typeof(self) weakSelf = self;
+            xpcConnection.invalidationHandler = ^{
+                typeof(self) strongSelf = weakSelf;
+                if (strongSelf) {
+                    dispatch_async(strongSelf.workQueue, ^{
+                        strongSelf.proxyHandle = nil;
+                        strongSelf.proxyRetainerForReports = nil;
+                        [strongSelf.reportRegistry removeAllObjects];
+                        CHIP_LOG_DEBUG("CHIP XPC connection disconnected");
+                    });
+                }
+            };
+            CHIP_LOG_DEBUG("CHIP XPC connection established");
+        }
+        completion(self.workQueue, container);
+    });
+}
+
+- (void)registerReportHandlerWithController:(id<NSCopying>)controller
+                                     nodeId:(NSUInteger)nodeId
+                                    handler:(void (^)(id _Nullable value, NSError * _Nullable error))handler
+{
+    dispatch_async(_workQueue, ^{
+        BOOL shouldRetainProxyForReport = ([self.reportRegistry count] == 0);
+        NSMutableDictionary * controllerDictionary = self.reportRegistry[controller];
+        if (!controllerDictionary) {
+            controllerDictionary = [[NSMutableDictionary alloc] init];
+            [self.reportRegistry setObject:controllerDictionary forKey:controller];
+        }
+        NSNumber * nodeIdKey = [NSNumber numberWithUnsignedInteger:nodeId];
+        NSMutableArray * nodeArray = controllerDictionary[nodeIdKey];
+        if (!nodeArray) {
+            nodeArray = [[NSMutableArray alloc] init];
+            [controllerDictionary setObject:nodeArray forKey:nodeIdKey];
+        }
+        [nodeArray addObject:handler];
+        if (shouldRetainProxyForReport) {
+            self.proxyRetainerForReports = self.proxyHandle;
+        }
+    });
+}
+
+- (void)deregisterReportHandlersWithController:(id<NSCopying>)controller
+                                        nodeId:(NSUInteger)nodeId
+                                    completion:(void (^)(void))completion
+{
+    dispatch_async(_workQueue, ^{
+        NSMutableDictionary * controllerDictionary = self.reportRegistry[controller];
+        if (!controllerDictionary) {
+            completion();
+            return;
+        }
+        NSNumber * nodeIdKey = [NSNumber numberWithUnsignedInteger:nodeId];
+        NSMutableArray * nodeArray = controllerDictionary[nodeIdKey];
+        if (!nodeArray) {
+            completion();
+            return;
+        }
+        [controllerDictionary removeObjectForKey:nodeIdKey];
+        if ([controllerDictionary count] == 0) {
+            // Dereference proxy retainer for reports so that XPC connection may be invalidated if no longer used.
+            self.proxyRetainerForReports = nil;
+        }
+        completion();
+    });
+}
+
+- (void)handleReportWithController:(id)controller
+                            nodeId:(NSUInteger)nodeId
+                             value:(id _Nullable)value
+                             error:(NSError * _Nullable)error
+{
+    dispatch_async(_workQueue, ^{
+        NSMutableDictionary * controllerDictionary = self.reportRegistry[controller];
+        if (!controllerDictionary) {
+            return;
+        }
+        NSNumber * nodeIdKey = [NSNumber numberWithUnsignedInteger:nodeId];
+        NSMutableArray * nodeArray = controllerDictionary[nodeIdKey];
+        if (!nodeArray) {
+            return;
+        }
+        for (void (^handler)(id _Nullable value, NSError * _Nullable error) in nodeArray) {
+            handler(value, error);
+        }
+    });
+}
+
+@end

--- a/src/darwin/Framework/CHIP/CHIPDeviceOverXPC.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceOverXPC.h
@@ -1,0 +1,39 @@
+/**
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "CHIPDevice.h"
+#import "CHIPDeviceControllerXPCConnection.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CHIPDeviceOverXPC : CHIPDevice
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+- (void)subscribeWithQueue:(dispatch_queue_t)queue
+                minInterval:(uint16_t)minInterval
+                maxInterval:(uint16_t)maxInterval
+              reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
+    subscriptionEstablished:(void (^_Nullable)(void))subscriptionEstablishedHandler NS_UNAVAILABLE;
+
+- (instancetype)initWithController:(id<NSCopying>)controller
+                          deviceId:(uint64_t)deviceId
+                     xpcConnection:(CHIPDeviceControllerXPCConnection *)xpcConnection;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPDeviceOverXPC.m
+++ b/src/darwin/Framework/CHIP/CHIPDeviceOverXPC.m
@@ -1,0 +1,237 @@
+/**
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "CHIPDeviceOverXPC.h"
+
+#import "CHIPDeviceController+XPC.h"
+#import "CHIPDeviceControllerXPCConnection.h"
+#import "CHIPError.h"
+#import "CHIPLogging.h"
+
+@interface CHIPDeviceOverXPC ()
+
+@property (nonatomic, strong, readonly) id<NSCopying> controller;
+@property (nonatomic, readonly) uint64_t nodeId;
+@property (nonatomic, strong, readonly) CHIPDeviceControllerXPCConnection * xpcConnection;
+
+@end
+
+@implementation CHIPDeviceOverXPC
+
+- (instancetype)initWithController:(id<NSCopying>)controller
+                          deviceId:(uint64_t)deviceId
+                     xpcConnection:(CHIPDeviceControllerXPCConnection *)xpcConnection
+{
+    _controller = controller;
+    _nodeId = deviceId;
+    _xpcConnection = xpcConnection;
+    return self;
+}
+
+- (void)subscribeWithQueue:(dispatch_queue_t)queue
+                minInterval:(uint16_t)minInterval
+                maxInterval:(uint16_t)maxInterval
+              reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler
+    subscriptionEstablished:(void (^_Nullable)(void))subscriptionEstablishedHandler
+{
+    dispatch_async(queue, ^{
+        CHIP_LOG_ERROR("All attribute subscription is not supported by remote device");
+        subscriptionEstablishedHandler();
+        reportHandler(nil, [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil]);
+    });
+}
+
+- (void)readAttributeWithEndpointId:(NSUInteger)endpointId
+                          clusterId:(NSUInteger)clusterId
+                        attributeId:(NSUInteger)attributeId
+                        clientQueue:(dispatch_queue_t)clientQueue
+                         completion:(CHIPDeviceResponseHandler)completion
+{
+    CHIP_LOG_DEBUG("Reading attribute ...");
+    [_xpcConnection
+        getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull queue, CHIPDeviceControllerXPCProxyHandle * _Nullable handle) {
+            if (handle) {
+                [handle.proxy readAttributeWithController:self.controller
+                                                   nodeId:self.nodeId
+                                               endpointId:endpointId
+                                                clusterId:clusterId
+                                              attributeId:attributeId
+                                               completion:^(id _Nullable values, NSError * _Nullable error) {
+                                                   dispatch_async(clientQueue, ^{
+                                                       CHIP_LOG_DEBUG("Attribute read");
+                                                       completion(values, error);
+                                                       // The following captures the proxy handle in the closure so that the
+                                                       // handle won't be released prior to block call.
+                                                       __auto_type handleRetainer = handle;
+                                                       (void) handleRetainer;
+                                                   });
+                                               }];
+            } else {
+                dispatch_async(clientQueue, ^{
+                    CHIP_LOG_ERROR("Failed to obtain XPC connection to read attribute");
+                    completion(nil, [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil]);
+                });
+            }
+        }];
+}
+
+- (void)writeAttributeWithEndpointId:(NSUInteger)endpointId
+                           clusterId:(NSUInteger)clusterId
+                         attributeId:(NSUInteger)attributeId
+                               value:(id)value
+                         clientQueue:(dispatch_queue_t)clientQueue
+                          completion:(CHIPDeviceResponseHandler)completion
+{
+    CHIP_LOG_DEBUG("Writing attribute ...");
+    [_xpcConnection
+        getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull queue, CHIPDeviceControllerXPCProxyHandle * _Nullable handle) {
+            if (handle) {
+                [handle.proxy writeAttributeWithController:self.controller
+                                                    nodeId:self.nodeId
+                                                endpointId:endpointId
+                                                 clusterId:clusterId
+                                               attributeId:attributeId
+                                                     value:value
+                                                completion:^(id _Nullable values, NSError * _Nullable error) {
+                                                    dispatch_async(clientQueue, ^{
+                                                        CHIP_LOG_DEBUG("Attribute written");
+                                                        completion(values, error);
+                                                        // The following captures the proxy handle in the closure so that the
+                                                        // handle won't be released prior to block call.
+                                                        __auto_type handleRetainer = handle;
+                                                        (void) handleRetainer;
+                                                    });
+                                                }];
+            } else {
+                dispatch_async(clientQueue, ^{
+                    CHIP_LOG_ERROR("Failed to obtain XPC connection to write attribute");
+                    completion(nil, [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil]);
+                });
+            }
+        }];
+}
+
+- (void)invokeCommandWithEndpointId:(NSUInteger)endpointId
+                          clusterId:(NSUInteger)clusterId
+                          commandId:(NSUInteger)commandId
+                      commandFields:(id)commandFields
+                        clientQueue:(dispatch_queue_t)clientQueue
+                         completion:(CHIPDeviceResponseHandler)completion
+{
+    CHIP_LOG_DEBUG("Invoking command ...");
+    [_xpcConnection
+        getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull queue, CHIPDeviceControllerXPCProxyHandle * _Nullable handle) {
+            if (handle) {
+                [handle.proxy invokeCommandWithController:self.controller
+                                                   nodeId:self.nodeId
+                                               endpointId:endpointId
+                                                clusterId:clusterId
+                                                commandId:commandId
+                                                   fields:commandFields
+                                               completion:^(id _Nullable values, NSError * _Nullable error) {
+                                                   dispatch_async(clientQueue, ^{
+                                                       CHIP_LOG_DEBUG("Command invoked");
+                                                       completion(values, error);
+                                                       // The following captures the proxy handle in the closure so that the
+                                                       // handle won't be released prior to block call.
+                                                       __auto_type handleRetainer = handle;
+                                                       (void) handleRetainer;
+                                                   });
+                                               }];
+            } else {
+                dispatch_async(clientQueue, ^{
+                    CHIP_LOG_ERROR("Failed to obtain XPC connection to invoke command");
+                    completion(nil, [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil]);
+                });
+            }
+        }];
+}
+
+- (void)subscribeAttributeWithEndpointId:(NSUInteger)endpointId
+                               clusterId:(NSUInteger)clusterId
+                             attributeId:(NSUInteger)attributeId
+                             minInterval:(NSUInteger)minInterval
+                             maxInterval:(NSUInteger)maxInterval
+                             clientQueue:(dispatch_queue_t)clientQueue
+                           reportHandler:(void (^)(NSDictionary<NSString *, id> * _Nullable value,
+                                             NSError * _Nullable error))reportHandler
+                 subscriptionEstablished:(void (^_Nullable)(void))subscriptionEstablishedHandler
+{
+    CHIP_LOG_DEBUG("Subscribing attribute ...");
+    [_xpcConnection getProxyHandleWithCompletion:^(
+        dispatch_queue_t _Nonnull queue, CHIPDeviceControllerXPCProxyHandle * _Nullable handle) {
+        if (handle) {
+            CHIP_LOG_DEBUG("Setup report handler");
+            [self.xpcConnection
+                registerReportHandlerWithController:self.controller
+                                             nodeId:self.nodeId
+                                            handler:^(id _Nullable value, NSError * _Nullable error) {
+                                                if (value && ![value isKindOfClass:[NSDictionary class]]) {
+                                                    CHIP_LOG_ERROR("Unsupported report format");
+                                                    return;
+                                                }
+                                                NSUInteger receivedEndpointId = [value[kCHIPEndpointIdKey] unsignedIntegerValue];
+                                                NSUInteger receivedClusterId = [value[kCHIPClusterIdKey] unsignedIntegerValue];
+                                                NSUInteger receivedAttributeId = [value[kCHIPAttributeIdKey] unsignedIntegerValue];
+                                                if (error
+                                                    || ((receivedEndpointId == endpointId || endpointId == 0xffff)
+                                                        && (receivedClusterId == clusterId || clusterId == 0xffffffff)
+                                                        && (receivedAttributeId == attributeId || attributeId == 0xffffffff))) {
+                                                    CHIP_LOG_DEBUG("Report received");
+                                                    dispatch_async(clientQueue, ^{
+                                                        reportHandler(value, error);
+                                                    });
+                                                }
+                                            }];
+            [handle.proxy subscribeAttributeWithController:self.controller
+                                                    nodeId:self.nodeId
+                                                endpointId:endpointId
+                                                 clusterId:clusterId
+                                               attributeId:attributeId
+                                               minInterval:minInterval
+                                               maxInterval:maxInterval
+                                        establishedHandler:^{
+                                            dispatch_async(clientQueue, ^{
+                                                CHIP_LOG_DEBUG("Subscription established");
+                                                subscriptionEstablishedHandler();
+                                                // The following captures the proxy handle in the closure so that the handle
+                                                // won't be released prior to block call.
+                                                __auto_type handleRetainer = handle;
+                                                (void) handleRetainer;
+                                            });
+                                        }];
+        } else {
+            dispatch_async(clientQueue, ^{
+                CHIP_LOG_ERROR("Failed to obtain XPC connection to subscribe to attribute");
+                subscriptionEstablishedHandler();
+                reportHandler(nil, [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil]);
+            });
+        }
+    }];
+}
+
+- (void)deregisterReportHandlersWithClientQueue:(dispatch_queue_t)clientQueue completion:(void (^)(void))completion
+{
+    CHIP_LOG_DEBUG("Deregistering report handlers");
+    [_xpcConnection deregisterReportHandlersWithController:self.controller
+                                                    nodeId:self.nodeId
+                                                completion:^{
+                                                    dispatch_async(clientQueue, completion);
+                                                }];
+}
+
+@end

--- a/src/darwin/Framework/CHIPTests/CHIPDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPDeviceTests.m
@@ -1,0 +1,1008 @@
+//
+//  CHIPDeviceTests.m
+//  CHIPDeviceTests
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+// module headers
+#import <CHIP/CHIP.h>
+#import <CHIP/CHIPDevice.h>
+
+#import "CHIPErrorTestUtils.h"
+
+#import <app/util/af-enums.h>
+
+#import <math.h> // For INFINITY
+
+// system dependencies
+#import <XCTest/XCTest.h>
+
+// Set the following to 1 in order to run individual test case manually.
+#define MANUAL_INDIVIDUAL_TEST 0
+
+static const uint16_t kPairingTimeoutInSeconds = 10;
+static const uint16_t kCASESetupTimeoutInSeconds = 30;
+static const uint16_t kTimeoutInSeconds = 3;
+static const uint64_t kDeviceId = 0x12344321;
+static const uint16_t kDiscriminator = 3840;
+static const uint32_t kSetupPINCode = 20202021;
+static const uint16_t kRemotePort = 5540;
+static const uint16_t kLocalPort = 5541;
+static NSString * kAddress = @"::1";
+
+// This test suite reuses a device object to speed up the test process for CI.
+// The following global variable holds the reference to the device object.
+static CHIPDevice * mConnectedDevice;
+
+static void WaitForCommissionee(XCTestExpectation * expectation, dispatch_queue_t queue)
+{
+    CHIPDeviceController * controller = [CHIPDeviceController sharedController];
+    XCTAssertNotNil(controller);
+
+    [controller getConnectedDevice:kDeviceId
+                             queue:dispatch_get_main_queue()
+                 completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                     XCTAssertEqual(error.code, 0);
+                     [expectation fulfill];
+                     mConnectedDevice = device;
+                 }];
+}
+
+static CHIPDevice * GetConnectedDevice(void)
+{
+    XCTAssertNotNil(mConnectedDevice);
+    return mConnectedDevice;
+}
+
+@interface CHIPDeviceTestPairingDelegate : NSObject <CHIPDevicePairingDelegate>
+@property (nonatomic, strong) XCTestExpectation * expectation;
+@end
+
+@implementation CHIPDeviceTestPairingDelegate
+- (id)initWithExpectation:(XCTestExpectation *)expectation
+{
+    self = [super init];
+    if (self) {
+        _expectation = expectation;
+    }
+    return self;
+}
+
+- (void)onPairingComplete:(NSError *)error
+{
+    XCTAssertEqual(error.code, 0);
+    [_expectation fulfill];
+    _expectation = nil;
+}
+
+- (void)onCommissioningComplete:(NSError *)error
+{
+    XCTAssertEqual(error.code, 0);
+    [_expectation fulfill];
+    _expectation = nil;
+}
+
+- (void)onAddressUpdated:(NSError *)error
+{
+    XCTAssertEqual(error.code, 0);
+    [_expectation fulfill];
+    _expectation = nil;
+}
+@end
+
+@interface CHIPDeviceTests : XCTestCase
+@end
+
+@implementation CHIPDeviceTests
+
+- (void)setUp
+{
+    [super setUp];
+    [self setContinueAfterFailure:NO];
+}
+
+- (void)tearDown
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self shutdownStack];
+#endif
+    [super tearDown];
+}
+
+- (void)initStack
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Pairing Complete"];
+
+    CHIPDeviceController * controller = [CHIPDeviceController sharedController];
+    XCTAssertNotNil(controller);
+
+    CHIPDeviceTestPairingDelegate * pairing = [[CHIPDeviceTestPairingDelegate alloc] initWithExpectation:expectation];
+    dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.pairing", DISPATCH_QUEUE_SERIAL);
+
+    [controller setListenPort:kLocalPort];
+    [controller setPairingDelegate:pairing queue:callbackQueue];
+
+    BOOL started = [controller startup:nil vendorId:0 nocSigner:nil];
+    XCTAssertTrue(started);
+
+    NSError * error;
+    [controller pairDevice:kDeviceId
+                   address:kAddress
+                      port:kRemotePort
+             discriminator:kDiscriminator
+              setupPINCode:kSetupPINCode
+                     error:&error];
+    XCTAssertEqual(error.code, 0);
+
+    [self waitForExpectationsWithTimeout:kPairingTimeoutInSeconds handler:nil];
+
+    __block XCTestExpectation * connectionExpectation = [self expectationWithDescription:@"CASE established"];
+    [controller getConnectedDevice:kDeviceId
+                             queue:dispatch_get_main_queue()
+                 completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                     XCTAssertEqual(error.code, 0);
+                     [connectionExpectation fulfill];
+                     connectionExpectation = nil;
+                 }];
+    [self waitForExpectationsWithTimeout:kCASESetupTimeoutInSeconds handler:nil];
+}
+
+- (void)shutdownStack
+{
+    CHIPDeviceController * controller = [CHIPDeviceController sharedController];
+    XCTAssertNotNil(controller);
+
+    BOOL stopped = [controller shutdown];
+    XCTAssertTrue(stopped);
+}
+
+- (void)waitForCommissionee
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
+
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    WaitForCommissionee(expectation, queue);
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+#if !MANUAL_INDIVIDUAL_TEST
+- (void)test000_SetUp
+{
+    [self initStack];
+    [self waitForCommissionee];
+}
+#endif
+
+- (void)test001_ReadAttribute
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"read DeviceDescriptor DeviceType attribute for all endpoints"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    [device readAttributeWithEndpointId:0xffff
+                              clusterId:29
+                            attributeId:0
+                            clientQueue:queue
+                             completion:^(id _Nullable values, NSError * _Nullable error) {
+                                 NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+
+                                 {
+                                     XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                     NSArray * resultArray = values;
+                                     for (NSDictionary * result in resultArray) {
+                                         XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 29);
+                                         XCTAssertEqual([result[@"attributeId"] unsignedIntegerValue], 0);
+                                         XCTAssertTrue([result[@"endpointId"] isKindOfClass:[NSNumber class]]);
+                                         XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
+                                         XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Array"]);
+                                     }
+                                     XCTAssertTrue([resultArray count] > 0);
+                                 }
+
+                                 [expectation fulfill];
+                             }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)test002_WriteAttribute
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    XCTestExpectation * expectation = [self expectationWithDescription:@"write LevelControl Brightness attribute"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    NSDictionary * writeValue = [NSDictionary
+        dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:200], @"value", nil];
+    [device writeAttributeWithEndpointId:1
+                               clusterId:8
+                             attributeId:17
+                                   value:writeValue
+                             clientQueue:queue
+                              completion:^(id _Nullable values, NSError * _Nullable error) {
+                                  NSLog(@"write attribute: Brightness values: %@, error: %@", values, error);
+
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+
+                                  {
+                                      XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                      NSArray * resultArray = values;
+                                      for (NSDictionary * result in resultArray) {
+                                          XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
+                                          XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 8);
+                                          XCTAssertEqual([result[@"attributeId"] unsignedIntegerValue], 17);
+                                          XCTAssertEqual([result[@"status"] unsignedIntegerValue], 0);
+                                      }
+                                      XCTAssertEqual([resultArray count], 1);
+                                  }
+
+                                  [expectation fulfill];
+                              }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)test003_InvokeCommand
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    XCTestExpectation * expectation = [self expectationWithDescription:@"invoke MoveToLevelWithOnOff command"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    NSDictionary * fields = [NSDictionary
+        dictionaryWithObjectsAndKeys:@"Structure", @"type",
+        [NSArray arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:0], @"tag",
+                                                [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type",
+                                                              [NSNumber numberWithUnsignedInteger:0], @"value", nil],
+                                                @"value", nil],
+                 [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:1], @"tag",
+                               [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type",
+                                             [NSNumber numberWithUnsignedInteger:10], @"value", nil],
+                               @"value", nil],
+                 nil],
+        @"value", nil];
+    [device invokeCommandWithEndpointId:1
+                              clusterId:8
+                              commandId:4
+                          commandFields:fields
+                            clientQueue:queue
+                             completion:^(id _Nullable values, NSError * _Nullable error) {
+                                 NSLog(@"invoke command: MoveToLevelWithOnOff values: %@, error: %@", values, error);
+
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+
+                                 {
+                                     XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                     NSArray * resultArray = values;
+                                     for (NSDictionary * result in resultArray) {
+                                         XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
+                                         XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 8);
+                                         XCTAssertEqual([result[@"commandId"] unsignedIntegerValue], 4);
+                                         XCTAssertEqual([result[@"status"] unsignedIntegerValue], 0);
+                                     }
+                                     XCTAssertEqual([resultArray count], 1);
+                                 }
+
+                                 [expectation fulfill];
+                             }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable error) = nil;
+
+#if !MANUAL_INDIVIDUAL_TEST
+- (void)test004_SubscribeOnly
+{
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    // Subscribe
+    XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
+    [device subscribeAttributeWithEndpointId:1
+        clusterId:6
+        attributeId:0
+        minInterval:1
+        maxInterval:10
+        clientQueue:queue
+        reportHandler:^(id _Nullable values, NSError * _Nullable error) {
+            NSLog(@"report attribute: OnOff values: %@, error: %@", values, error);
+
+            if (globalReportHandler) {
+                __auto_type callback = globalReportHandler;
+                callback(values, error);
+            }
+        }
+        subscriptionEstablished:^{
+            NSLog(@"subscribe attribute: OnOff established");
+            [expectation fulfill];
+        }];
+
+    // Wait till establishment
+    [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:kTimeoutInSeconds];
+}
+#endif
+
+// Report behavior is erratic on the accessory side at the moment.
+// Hence this test is enabled only for individual manual test.
+#if MANUAL_INDIVIDUAL_TEST
+- (void)test005_Subscribe
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+#if MANUAL_INDIVIDUAL_TEST
+    // Subscribe
+    XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
+    [device subscribeAttributeWithEndpointId:1
+        clusterId:6
+        attributeId:0
+        minInterval:1
+        maxInterval:10
+        clientQueue:queue
+        reportHandler:^(id _Nullable values, NSError * _Nullable error) {
+            NSLog(@"report attribute: OnOff values: %@, error: %@", values, error);
+
+            if (globalReportHandler) {
+                __auto_type callback = globalReportHandler;
+                callback(values, error);
+            }
+        }
+        subscriptionEstablished:^{
+            NSLog(@"subscribe attribute: OnOff established");
+            [expectation fulfill];
+        }];
+
+    // Wait till establishment
+    [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:kTimeoutInSeconds];
+#endif
+
+    // Set up expectation for report
+    XCTestExpectation * reportExpectation = [self expectationWithDescription:@"report received"];
+    globalReportHandler = ^(id _Nullable value, NSError * _Nullable error) {
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+        XCTAssertTrue([value isKindOfClass:[NSDictionary class]]);
+        NSDictionary * result = value;
+        XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
+        XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 6);
+        XCTAssertEqual([result[@"attributeId"] unsignedIntegerValue], 0);
+        XCTAssertTrue([result[@"value"] isKindOfClass:[NSDictionary class]]);
+        XCTAssertTrue([result[@"value"][@"type"] isEqualToString:@"Boolean"]);
+        if ([result[@"value"][@"value"] boolValue] == YES) {
+            [reportExpectation fulfill];
+            globalReportHandler = nil;
+        }
+    };
+
+    // Send commands to trigger attribute change
+    XCTestExpectation * commandExpectation = [self expectationWithDescription:@"command responded"];
+    NSDictionary * fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
+    [device invokeCommandWithEndpointId:1
+                              clusterId:6
+                              commandId:1
+                          commandFields:fields
+                            clientQueue:queue
+                             completion:^(id _Nullable values, NSError * _Nullable error) {
+                                 NSLog(@"invoke command: On values: %@, error: %@", values, error);
+
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+
+                                 {
+                                     XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                     NSArray * resultArray = values;
+                                     for (NSDictionary * result in resultArray) {
+                                         XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
+                                         XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 6);
+                                         XCTAssertEqual([result[@"commandId"] unsignedIntegerValue], 1);
+                                         XCTAssertEqual([result[@"status"] unsignedIntegerValue], 0);
+                                     }
+                                     XCTAssertEqual([resultArray count], 1);
+                                 }
+                                 [commandExpectation fulfill];
+                             }];
+    [self waitForExpectations:[NSArray arrayWithObject:commandExpectation] timeout:kTimeoutInSeconds];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Set up expectation for 2nd report
+    reportExpectation = [self expectationWithDescription:@"receive OnOff attribute report"];
+    globalReportHandler = ^(id _Nullable value, NSError * _Nullable error) {
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+        XCTAssertTrue([value isKindOfClass:[NSDictionary class]]);
+        NSDictionary * result = value;
+        XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
+        XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 6);
+        XCTAssertEqual([result[@"attributeId"] unsignedIntegerValue], 0);
+        XCTAssertTrue([result[@"value"] isKindOfClass:[NSDictionary class]]);
+        XCTAssertTrue([result[@"value"][@"type"] isEqualToString:@"Boolean"]);
+        if ([result[@"value"][@"value"] boolValue] == NO) {
+            [reportExpectation fulfill];
+            globalReportHandler = nil;
+        }
+    };
+
+    // Send command to trigger attribute change
+    fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
+    [device invokeCommandWithEndpointId:1
+                              clusterId:6
+                              commandId:0
+                          commandFields:fields
+                            clientQueue:queue
+                             completion:^(id _Nullable values, NSError * _Nullable error) {
+                                 NSLog(@"invoke command: On values: %@, error: %@", values, error);
+
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+
+                                 {
+                                     XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                     NSArray * resultArray = values;
+                                     for (NSDictionary * result in resultArray) {
+                                         XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
+                                         XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 6);
+                                         XCTAssertEqual([result[@"commandId"] unsignedIntegerValue], 0);
+                                         XCTAssertEqual([result[@"status"] unsignedIntegerValue], 0);
+                                     }
+                                     XCTAssertEqual([resultArray count], 1);
+                                 }
+                             }];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+}
+#endif
+
+- (void)test006_ReadAttributeFailure
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read failed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    [device
+        readAttributeWithEndpointId:0
+                          clusterId:10000
+                        attributeId:0
+                        clientQueue:queue
+                         completion:^(id _Nullable values, NSError * _Nullable error) {
+                             NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+
+                             XCTAssertNil(values);
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:kTimeoutInSeconds];
+}
+
+- (void)test007_WriteAttributeFailure
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    XCTestExpectation * expectation = [self expectationWithDescription:@"write failed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    NSDictionary * writeValue = [NSDictionary
+        dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:200], @"value", nil];
+    [device writeAttributeWithEndpointId:1
+                               clusterId:8
+                             attributeId:10000
+                                   value:writeValue
+                             clientQueue:queue
+                              completion:^(id _Nullable values, NSError * _Nullable error) {
+                                  NSLog(@"write attribute: Brightness values: %@, error: %@", values, error);
+
+                                  XCTAssertNil(values);
+                                  XCTAssertEqual(
+                                      [CHIPErrorTestUtils errorToZCLErrorCode:error], EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE);
+
+                                  [expectation fulfill];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:kTimeoutInSeconds];
+}
+
+#if 0 // Re-enable test if the crash bug in CHIP stack is fixed to handle bad command Id
+- (void)test008_InvokeCommandFailure
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    XCTestExpectation * expectation = [self expectationWithDescription:@"invoke MoveToLevelWithOnOff command"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    NSDictionary *fields = [NSDictionary dictionaryWithObjectsAndKeys:
+                            @"Structure", @"type",
+                            [NSArray arrayWithObjects:
+                             [NSDictionary dictionaryWithObjectsAndKeys:
+                              [NSNumber numberWithUnsignedInteger:0], @"tag",
+                              [NSDictionary dictionaryWithObjectsAndKeys:
+                               @"UnsignedInteger", @"type",
+                               [NSNumber numberWithUnsignedInteger:0], @"value", nil], @"value", nil],
+                             [NSDictionary dictionaryWithObjectsAndKeys:
+                              [NSNumber numberWithUnsignedInteger:1], @"tag",
+                              [NSDictionary dictionaryWithObjectsAndKeys:
+                               @"UnsignedInteger", @"type",
+                               [NSNumber numberWithUnsignedInteger:10], @"value", nil], @"value", nil],
+                             nil], @"value", nil];
+    [device invokeCommandWithEndpointId:1 clusterId:8 commandId:40000 commandFields:fields clientQueue:queue completion:^(id _Nullable values, NSError * _Nullable error) {
+        NSLog(@"invoke command: MoveToLevelWithOnOff values: %@, error: %@", values, error);
+
+        XCTAssertNil(values);
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], EMBER_ZCL_STATUS_UNSUPPORTED_COMMAND);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:kTimeoutInSeconds];
+}
+#endif
+
+- (void)test009_SubscribeFailure
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
+    __block void (^reportHandler)(id _Nullable values, NSError * _Nullable error) = nil;
+
+    // Set up expectation for report
+    XCTestExpectation * errorReportExpectation = [self expectationWithDescription:@"receive OnOff attribute report"];
+    reportHandler = ^(id _Nullable value, NSError * _Nullable error) {
+        XCTAssertNil(value);
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], EMBER_ZCL_STATUS_UNSUPPORTED_ENDPOINT);
+        [errorReportExpectation fulfill];
+    };
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    [device subscribeAttributeWithEndpointId:10000
+        clusterId:6
+        attributeId:0
+        minInterval:2
+        maxInterval:10
+        clientQueue:queue
+        reportHandler:^(id _Nullable values, NSError * _Nullable error) {
+            NSLog(@"report attribute: OnOff values: %@, error: %@", values, error);
+
+            if (reportHandler) {
+                __auto_type callback = reportHandler;
+                reportHandler = nil;
+                callback(values, error);
+            }
+        }
+        subscriptionEstablished:^{
+            NSLog(@"subscribe attribute: OnOff established");
+            [expectation fulfill];
+        }];
+
+    // Wait till establishment and error report
+    [self waitForExpectations:[NSArray arrayWithObjects:expectation, errorReportExpectation, nil] timeout:kTimeoutInSeconds];
+}
+
+- (void)test010_ReadAllAttribute
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"read DeviceDescriptor DeviceType attribute for all endpoints"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    [device readAttributeWithEndpointId:1
+                              clusterId:29
+                            attributeId:0xffffffff
+                            clientQueue:queue
+                             completion:^(id _Nullable values, NSError * _Nullable error) {
+                                 NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+
+                                 {
+                                     XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                     NSArray * resultArray = values;
+                                     for (NSDictionary * result in resultArray) {
+                                         XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 29);
+                                         XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
+                                         XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
+                                     }
+                                     XCTAssertTrue([resultArray count] > 0);
+                                 }
+
+                                 [expectation fulfill];
+                             }];
+
+    [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:kTimeoutInSeconds];
+}
+
+// Report behavior is erratic on the accessory side at the moment.
+// Hence this test is enabled only for individual manual test.
+#if MANUAL_INDIVIDUAL_TEST
+- (void)test900_SubscribeAllAttributes
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
+    __block void (^reportHandler)(id _Nullable values, NSError * _Nullable error) = nil;
+
+    [device subscribeAttributeWithEndpointId:1
+        clusterId:6
+        attributeId:0xffffffff
+        minInterval:2
+        maxInterval:10
+        clientQueue:queue
+        reportHandler:^(id _Nullable values, NSError * _Nullable error) {
+            NSLog(@"Subscribe all - report attribute values: %@, error: %@, report handler: %d", values, error,
+                (reportHandler != nil));
+
+            if (reportHandler) {
+                __auto_type callback = reportHandler;
+                callback(values, error);
+            }
+        }
+        subscriptionEstablished:^{
+            NSLog(@"subscribe attribute: OnOff established");
+            [expectation fulfill];
+        }];
+
+    // Wait till establishment
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+
+    // Set up expectation for report
+    __auto_type reportExpectation = [self expectationWithDescription:@"receive OnOff attribute report"];
+    reportHandler = ^(id _Nullable value, NSError * _Nullable error) {
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+        XCTAssertTrue([value isKindOfClass:[NSDictionary class]]);
+        NSDictionary * result = value;
+        XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
+        XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 6);
+        XCTAssertTrue([result[@"value"] isKindOfClass:[NSDictionary class]]);
+
+        if ([result[@"attributeId"] unsignedIntegerValue] == 0 && [result[@"value"][@"value"] boolValue] == YES) {
+            [reportExpectation fulfill];
+            reportHandler = nil;
+        }
+    };
+
+    // Send commands to trigger attribute change
+    XCTestExpectation * commandExpectation = [self expectationWithDescription:@"command responded"];
+    NSDictionary * fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
+    [device invokeCommandWithEndpointId:1
+                              clusterId:6
+                              commandId:1
+                          commandFields:fields
+                            clientQueue:queue
+                             completion:^(id _Nullable values, NSError * _Nullable error) {
+                                 NSLog(@"invoke command: On values: %@, error: %@", values, error);
+
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+
+                                 {
+                                     XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                     NSArray * resultArray = values;
+                                     for (NSDictionary * result in resultArray) {
+                                         XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
+                                         XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 6);
+                                         XCTAssertEqual([result[@"commandId"] unsignedIntegerValue], 1);
+                                         XCTAssertEqual([result[@"status"] unsignedIntegerValue], 0);
+                                     }
+                                     XCTAssertEqual([resultArray count], 1);
+                                 }
+                                 [commandExpectation fulfill];
+                             }];
+    [self waitForExpectations:[NSArray arrayWithObject:commandExpectation] timeout:kTimeoutInSeconds];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Set up expectation for 2nd report
+    reportExpectation = [self expectationWithDescription:@"receive OnOff attribute report"];
+    reportHandler = ^(id _Nullable value, NSError * _Nullable error) {
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+        XCTAssertTrue([value isKindOfClass:[NSDictionary class]]);
+        NSDictionary * result = value;
+        XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
+        XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 6);
+        XCTAssertTrue([result[@"value"] isKindOfClass:[NSDictionary class]]);
+        if ([result[@"attributeId"] unsignedIntegerValue] == 0 && [result[@"value"][@"value"] boolValue] == NO) {
+            [reportExpectation fulfill];
+            reportHandler = nil;
+        }
+    };
+
+    // Send command to trigger attribute change
+    commandExpectation = [self expectationWithDescription:@"command responded"];
+    fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
+    [device invokeCommandWithEndpointId:1
+                              clusterId:6
+                              commandId:0
+                          commandFields:fields
+                            clientQueue:queue
+                             completion:^(id _Nullable values, NSError * _Nullable error) {
+                                 NSLog(@"invoke command: On values: %@, error: %@", values, error);
+
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+
+                                 {
+                                     XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                     NSArray * resultArray = values;
+                                     for (NSDictionary * result in resultArray) {
+                                         XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
+                                         XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 6);
+                                         XCTAssertEqual([result[@"commandId"] unsignedIntegerValue], 0);
+                                         XCTAssertEqual([result[@"status"] unsignedIntegerValue], 0);
+                                     }
+                                     XCTAssertEqual([resultArray count], 1);
+                                 }
+                                 [commandExpectation fulfill];
+                             }];
+    [self waitForExpectations:[NSArray arrayWithObject:commandExpectation] timeout:kTimeoutInSeconds];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+}
+#endif
+
+#if !MANUAL_INDIVIDUAL_TEST
+- (void)test999_TearDown
+{
+    [self shutdownStack];
+}
+#endif
+
+@end
+
+@interface CHIPDevice (Test)
+// Test function for whitebox testing
++ (id)CHIPEncodeAndDecodeNSObject:(id)object;
+@end
+
+@interface CHIPDeviceEncoderTests : XCTestCase
+@end
+
+@implementation CHIPDeviceEncoderTests
+
+- (void)testSignedInteger
+{
+    NSDictionary * input =
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:-713], @"value", nil];
+    id output = [CHIPDevice CHIPEncodeAndDecodeNSObject:input];
+    NSLog(@"Conversion input: %@\nOutput: %@", input, output);
+    XCTAssertNotNil(output);
+    XCTAssertTrue([output isKindOfClass:[NSDictionary class]]);
+    XCTAssertTrue([output isEqualTo:input]);
+}
+
+- (void)testUnsignedInteger
+{
+    NSDictionary * input =
+        [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithInteger:1025], @"value", nil];
+    id output = [CHIPDevice CHIPEncodeAndDecodeNSObject:input];
+    NSLog(@"Conversion input: %@\nOutput: %@", input, output);
+    XCTAssertNotNil(output);
+    XCTAssertTrue([output isKindOfClass:[NSDictionary class]]);
+    XCTAssertTrue([output isEqualTo:input]);
+}
+
+- (void)testBoolean
+{
+    NSDictionary * input =
+        [NSDictionary dictionaryWithObjectsAndKeys:@"Boolean", @"type", [NSNumber numberWithBool:YES], @"value", nil];
+    id output = [CHIPDevice CHIPEncodeAndDecodeNSObject:input];
+    NSLog(@"Conversion input: %@\nOutput: %@", input, output);
+    XCTAssertNotNil(output);
+    XCTAssertTrue([output isKindOfClass:[NSDictionary class]]);
+    XCTAssertTrue([output isEqualTo:input]);
+}
+
+- (void)testUTF8String
+{
+    NSDictionary * input = [NSDictionary dictionaryWithObjectsAndKeys:@"UTF8String", @"type", @"Hello World", @"value", nil];
+    id output = [CHIPDevice CHIPEncodeAndDecodeNSObject:input];
+    NSLog(@"Conversion input: %@\nOutput: %@", input, output);
+    XCTAssertNotNil(output);
+    XCTAssertTrue([output isKindOfClass:[NSDictionary class]]);
+    XCTAssertTrue([output isEqualTo:input]);
+}
+
+- (void)testOctetString
+{
+    const uint8_t data[] = { 0x00, 0xF2, 0x63 };
+    NSDictionary * input = [NSDictionary
+        dictionaryWithObjectsAndKeys:@"OctetString", @"type", [NSData dataWithBytes:data length:sizeof(data)], @"value", nil];
+    id output = [CHIPDevice CHIPEncodeAndDecodeNSObject:input];
+    NSLog(@"Conversion input: %@\nOutput: %@", input, output);
+    XCTAssertNotNil(output);
+    XCTAssertTrue([output isKindOfClass:[NSDictionary class]]);
+    XCTAssertTrue([output isEqualTo:input]);
+}
+
+- (void)testFloat
+{
+    NSDictionary * input =
+        [NSDictionary dictionaryWithObjectsAndKeys:@"Float", @"type", [NSNumber numberWithFloat:0.1245], @"value", nil];
+    id output = [CHIPDevice CHIPEncodeAndDecodeNSObject:input];
+    NSLog(@"Conversion input: %@\nOutput: %@", input, output);
+    XCTAssertNotNil(output);
+    XCTAssertTrue([output isKindOfClass:[NSDictionary class]]);
+    // Note that conversion doesn't guarantee back to Float.
+    XCTAssertTrue([output[@"type"] isEqualToString:@"Float"] || [output[@"type"] isEqualToString:@"Double"]);
+    XCTAssertTrue(([output[@"value"] doubleValue] - [input[@"value"] doubleValue]) < 0.0001);
+}
+
+- (void)testDouble
+{
+    NSDictionary * input =
+        [NSDictionary dictionaryWithObjectsAndKeys:@"Double", @"type", [NSNumber numberWithFloat:0.1245], @"value", nil];
+    id output = [CHIPDevice CHIPEncodeAndDecodeNSObject:input];
+    NSLog(@"Conversion input: %@\nOutput: %@", input, output);
+    XCTAssertNotNil(output);
+    XCTAssertTrue([output isKindOfClass:[NSDictionary class]]);
+    // Note that conversion doesn't guarantee back to Double.
+    XCTAssertTrue([output[@"type"] isEqualToString:@"Float"] || [output[@"type"] isEqualToString:@"Double"]);
+    XCTAssertTrue(([output[@"value"] doubleValue] - [input[@"value"] doubleValue]) < 0.0001);
+}
+
+- (void)testNull
+{
+    NSDictionary * input = [NSDictionary dictionaryWithObjectsAndKeys:@"Null", @"type", nil];
+    id output = [CHIPDevice CHIPEncodeAndDecodeNSObject:input];
+    NSLog(@"Conversion input: %@\nOutput: %@", input, output);
+    XCTAssertNotNil(output);
+    XCTAssertTrue([output isKindOfClass:[NSDictionary class]]);
+    XCTAssertTrue([output isEqualTo:input]);
+}
+
+- (void)testStructure
+{
+    NSArray * inputFields = [NSArray
+        arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:1], @"tag",
+                                       [NSDictionary dictionaryWithObjectsAndKeys:@"Boolean", @"type", [NSNumber numberWithBool:NO],
+                                                     @"value", nil],
+                                       @"value", nil],
+        [NSDictionary
+            dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:2], @"tag",
+            [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:5], @"value", nil],
+            @"value", nil],
+        nil];
+    NSDictionary * inputValue = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", inputFields, @"value", nil];
+
+    // Output will have context tags and hence build object with context tags for comparison
+    NSMutableArray * contextTaggedInputFields = [NSMutableArray arrayWithCapacity:[inputFields count]];
+    for (NSDictionary * field in inputFields) {
+        [contextTaggedInputFields
+            addObject:[NSDictionary
+                          dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:([field[@"tag"] unsignedIntegerValue]
+                                                                                               | 0xffffffff00000000ull)],
+                          @"tag", field[@"value"], @"value", nil]];
+    }
+
+    id output = [CHIPDevice CHIPEncodeAndDecodeNSObject:inputValue];
+    NSLog(@"Conversion input: %@\nOutput: %@", inputValue, output);
+    XCTAssertNotNil(output);
+    XCTAssertTrue([output isKindOfClass:[NSDictionary class]]);
+
+    NSDictionary * compare =
+        [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", contextTaggedInputFields, @"value", nil];
+    XCTAssertTrue([output isEqualTo:compare]);
+}
+
+- (void)testArray
+{
+    NSArray * inputFields = [NSArray
+        arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:[NSDictionary dictionaryWithObjectsAndKeys:@"Boolean", @"type",
+                                                                                  [NSNumber numberWithBool:NO], @"value", nil],
+                                       @"value", nil],
+        [NSDictionary dictionaryWithObjectsAndKeys:[NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
+                                                                 [NSNumber numberWithInteger:5], @"value", nil],
+                      @"value", nil],
+        nil];
+    NSDictionary * inputValue = [NSDictionary dictionaryWithObjectsAndKeys:@"Array", @"type", inputFields, @"value", nil];
+
+    // Output will have anonymous tags and hence build object with context tags for comparison
+    NSMutableArray * contextTaggedInputFields = [NSMutableArray arrayWithCapacity:[inputFields count]];
+    for (NSDictionary * field in inputFields) {
+        [contextTaggedInputFields
+            addObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:0xffffffffffffffffull], @"tag",
+                                    field[@"value"], @"value", nil]];
+    }
+
+    id output = [CHIPDevice CHIPEncodeAndDecodeNSObject:inputValue];
+    NSLog(@"Conversion input: %@\nOutput: %@", inputValue, output);
+    XCTAssertNotNil(output);
+    XCTAssertTrue([output isKindOfClass:[NSDictionary class]]);
+
+    NSDictionary * compare = [NSDictionary dictionaryWithObjectsAndKeys:@"Array", @"type", contextTaggedInputFields, @"value", nil];
+    XCTAssertTrue([output isEqualTo:compare]);
+}
+
+- (void)testList
+{
+    NSArray * inputFields = [NSArray
+        arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:1], @"tag",
+                                       [NSDictionary dictionaryWithObjectsAndKeys:@"Boolean", @"type", [NSNumber numberWithBool:NO],
+                                                     @"value", nil],
+                                       @"value", nil],
+        [NSDictionary
+            dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:2], @"tag",
+            [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:5], @"value", nil],
+            @"value", nil],
+        nil];
+    NSDictionary * inputValue = [NSDictionary dictionaryWithObjectsAndKeys:@"List", @"type", inputFields, @"value", nil];
+
+    // Output will have context tags and hence build object with context tags for comparison
+    NSMutableArray * contextTaggedInputFields = [NSMutableArray arrayWithCapacity:[inputFields count]];
+    for (NSDictionary * field in inputFields) {
+        [contextTaggedInputFields
+            addObject:[NSDictionary
+                          dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:([field[@"tag"] unsignedIntegerValue]
+                                                                                               | 0xffffffff00000000ull)],
+                          @"tag", field[@"value"], @"value", nil]];
+    }
+
+    id output = [CHIPDevice CHIPEncodeAndDecodeNSObject:inputValue];
+    NSLog(@"Conversion input: %@\nOutput: %@", inputValue, output);
+    XCTAssertNotNil(output);
+    XCTAssertTrue([output isKindOfClass:[NSDictionary class]]);
+
+    NSDictionary * compare = [NSDictionary dictionaryWithObjectsAndKeys:@"List", @"type", contextTaggedInputFields, @"value", nil];
+    XCTAssertTrue([output isEqualTo:compare]);
+}
+
+@end

--- a/src/darwin/Framework/CHIPTests/CHIPXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPXPCListenerSampleTests.m
@@ -1,0 +1,832 @@
+//
+//  CHIPRemoteDeviceSampleTests.m
+//  CHIPTests
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+// module headers
+#import <CHIP/CHIP.h>
+#import <CHIP/CHIPDevice.h>
+
+#import "CHIPErrorTestUtils.h"
+
+#import <app/util/af-enums.h>
+
+#import <math.h> // For INFINITY
+
+// system dependencies
+#import <XCTest/XCTest.h>
+
+// Set the following to 1 in order to run individual test case manually.
+#define MANUAL_INDIVIDUAL_TEST 0
+
+//
+// Sample XPC Listener implementation that directly communicates with local CHIPDevice instance
+//
+// Note that real implementation could look almost the same as the sample if the remote device controller object
+// is in a separate process in the same machine.
+// If the remote device controller object is in a remote machine, the server protocol must implement
+// routing the requests to the remote object in a remote machine using implementation specific transport protocol
+// between the two machines.
+
+@interface CHIPXPCListenerSample<NSXPCListenerDelegate> : NSObject
+
+@property (nonatomic, readonly, getter=listenerEndpoint) NSXPCListenerEndpoint * listenerEndpoint;
+
+- (void)start;
+- (void)stop;
+
+@end
+
+@interface CHIPDeviceControllerServerSample<CHIPDeviceControllerServerProtocol> : NSObject
+@property (nonatomic, readonly, strong) NSString * identifier;
+- (instancetype)initWithClientProxy:(id<CHIPDeviceControllerClientProtocol>)proxy;
+@end
+
+@interface CHIPXPCListenerSample ()
+
+@property (nonatomic, readonly, strong) NSString * controllerId;
+@property (nonatomic, readonly, strong) NSXPCInterface * serviceInterface;
+@property (nonatomic, readonly, strong) NSXPCInterface * clientInterface;
+@property (nonatomic, readonly, strong) NSXPCListener * xpcListener;
+@property (nonatomic, readonly, strong) NSMutableDictionary<NSString *, CHIPDeviceControllerServerSample *> * servers;
+
+@end
+
+@implementation CHIPXPCListenerSample
+
+- (instancetype)init
+{
+    if ([super init]) {
+        _serviceInterface = [NSXPCInterface interfaceWithProtocol:@protocol(CHIPDeviceControllerServerProtocol)];
+        _clientInterface = [NSXPCInterface interfaceWithProtocol:@protocol(CHIPDeviceControllerClientProtocol)];
+        _servers = [NSMutableDictionary dictionary];
+        _xpcListener = [NSXPCListener anonymousListener];
+        [_xpcListener setDelegate:(id<NSXPCListenerDelegate>) self];
+    }
+    return self;
+}
+
+- (void)start
+{
+    [_xpcListener resume];
+}
+
+- (void)stop
+{
+    [_xpcListener suspend];
+}
+
+- (NSXPCListenerEndpoint *)listenerEndpoint
+{
+    return _xpcListener.endpoint;
+}
+
+- (BOOL)listener:(NSXPCListener *)listener shouldAcceptNewConnection:(NSXPCConnection *)newConnection
+{
+    NSLog(@"XPC listener accepting connection");
+    newConnection.exportedInterface = _serviceInterface;
+    newConnection.remoteObjectInterface = _clientInterface;
+    __auto_type newServer = [[CHIPDeviceControllerServerSample alloc] initWithClientProxy:[newConnection remoteObjectProxy]];
+    newConnection.exportedObject = newServer;
+    [_servers setObject:newServer forKey:newServer.identifier];
+    newConnection.invalidationHandler = ^{
+        NSLog(@"XPC connection disconnected");
+        [self.servers removeObjectForKey:newServer.identifier];
+    };
+    [newConnection resume];
+    return YES;
+}
+
+@end
+
+@interface CHIPDeviceControllerServerSample ()
+@property (nonatomic, readwrite, strong) id<CHIPDeviceControllerClientProtocol> clientProxy;
+@end
+
+// This sample does not have multiple controllers and hence controller Id shall be the same.
+static NSString * const kCHIPDeviceControllerId = @"CHIPController";
+
+@implementation CHIPDeviceControllerServerSample
+
+- (instancetype)initWithClientProxy:(id<CHIPDeviceControllerClientProtocol>)proxy
+{
+    if ([super init]) {
+        _clientProxy = proxy;
+        _identifier = [[NSUUID UUID] UUIDString];
+    }
+    return self;
+}
+
+- (void)getDeviceControllerWithFabricId:(uint64_t)fabricId
+                             completion:(void (^)(id _Nullable controller, NSError * _Nullable error))completion
+{
+    // We are using a shared local device controller and hence no disctinction per fabricId.
+    (void) fabricId;
+    completion(kCHIPDeviceControllerId, nil);
+}
+
+- (void)getAnyDeviceControllerWithCompletion:(void (^)(id _Nullable controller, NSError * _Nullable error))completion
+{
+    completion(kCHIPDeviceControllerId, nil);
+}
+
+- (void)readAttributeWithController:(id)controller
+                             nodeId:(uint64_t)nodeId
+                         endpointId:(NSUInteger)endpointId
+                          clusterId:(NSUInteger)clusterId
+                        attributeId:(NSUInteger)attributeId
+                         completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion
+{
+    (void) controller;
+    __auto_type sharedController = [CHIPDeviceController sharedController];
+    if (sharedController) {
+        [sharedController getConnectedDevice:nodeId
+                                       queue:dispatch_get_main_queue()
+                           completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                               if (error) {
+                                   NSLog(@"Failed to get connected device");
+                                   completion(nil, error);
+                               } else {
+                                   [device readAttributeWithEndpointId:endpointId
+                                                             clusterId:clusterId
+                                                           attributeId:attributeId
+                                                           clientQueue:dispatch_get_main_queue()
+                                                            completion:completion];
+                               }
+                           }];
+    } else {
+        NSLog(@"Failed to get shared controller");
+        completion(nil, [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil]);
+    }
+}
+
+- (void)writeAttributeWithController:(id)controller
+                              nodeId:(uint64_t)nodeId
+                          endpointId:(NSUInteger)endpointId
+                           clusterId:(NSUInteger)clusterId
+                         attributeId:(NSUInteger)attributeId
+                               value:(id)value
+                          completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion
+{
+    (void) controller;
+    __auto_type sharedController = [CHIPDeviceController sharedController];
+    if (sharedController) {
+        [sharedController getConnectedDevice:nodeId
+                                       queue:dispatch_get_main_queue()
+                           completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                               if (error) {
+                                   NSLog(@"Failed to get connected device");
+                                   completion(nil, error);
+                               } else {
+                                   [device writeAttributeWithEndpointId:endpointId
+                                                              clusterId:clusterId
+                                                            attributeId:attributeId
+                                                                  value:value
+                                                            clientQueue:dispatch_get_main_queue()
+                                                             completion:completion];
+                               }
+                           }];
+    } else {
+        NSLog(@"Failed to get shared controller");
+        completion(nil, [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil]);
+    }
+}
+
+- (void)invokeCommandWithController:(id)controller
+                             nodeId:(uint64_t)nodeId
+                         endpointId:(NSUInteger)endpointId
+                          clusterId:(NSUInteger)clusterId
+                          commandId:(NSUInteger)commandId
+                             fields:(id)fields
+                         completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion
+{
+    (void) controller;
+    __auto_type sharedController = [CHIPDeviceController sharedController];
+    if (sharedController) {
+        [sharedController getConnectedDevice:nodeId
+                                       queue:dispatch_get_main_queue()
+                           completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                               if (error) {
+                                   NSLog(@"Failed to get connected device");
+                                   completion(nil, error);
+                               } else {
+                                   [device invokeCommandWithEndpointId:endpointId
+                                                             clusterId:clusterId
+                                                             commandId:commandId
+                                                         commandFields:fields
+                                                           clientQueue:dispatch_get_main_queue()
+                                                            completion:completion];
+                               }
+                           }];
+    } else {
+        NSLog(@"Failed to get shared controller");
+        completion(nil, [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil]);
+    }
+}
+
+- (void)subscribeAttributeWithController:(id)controller
+                                  nodeId:(uint64_t)nodeId
+                              endpointId:(NSUInteger)endpointId
+                               clusterId:(NSUInteger)clusterId
+                             attributeId:(NSUInteger)attributeId
+                             minInterval:(NSUInteger)minInterval
+                             maxInterval:(NSUInteger)maxInterval
+                      establishedHandler:(void (^)(void))establishedHandler
+{
+    __auto_type sharedController = [CHIPDeviceController sharedController];
+    if (sharedController) {
+        [sharedController getConnectedDevice:nodeId
+                                       queue:dispatch_get_main_queue()
+                           completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                               if (error) {
+                                   NSLog(@"Failed to get connected device");
+                                   establishedHandler();
+                                   // Send an error report so that the client knows of the failure
+                                   [self.clientProxy handleReportWithController:controller
+                                                                         nodeId:nodeId
+                                                                          value:nil
+                                                                          error:[NSError errorWithDomain:CHIPErrorDomain
+                                                                                                    code:CHIPErrorCodeGeneralError
+                                                                                                userInfo:nil]];
+                               } else {
+                                   [device subscribeAttributeWithEndpointId:endpointId
+                                                                  clusterId:clusterId
+                                                                attributeId:attributeId
+                                                                minInterval:minInterval
+                                                                maxInterval:maxInterval
+                                                                clientQueue:dispatch_get_main_queue()
+                                                              reportHandler:^(NSDictionary<NSString *, id> * _Nullable value,
+                                                                  NSError * _Nullable error) {
+                                                                  [self.clientProxy handleReportWithController:controller
+                                                                                                        nodeId:nodeId
+                                                                                                         value:value
+                                                                                                         error:error];
+                                                              }
+                                                    subscriptionEstablished:establishedHandler];
+                               }
+                           }];
+    } else {
+        NSLog(@"Failed to get shared controller");
+        establishedHandler();
+        // Send an error report so that the client knows of the failure
+        [self.clientProxy handleReportWithController:controller
+                                              nodeId:nodeId
+                                               value:nil
+                                               error:[NSError errorWithDomain:CHIPErrorDomain
+                                                                         code:CHIPErrorCodeGeneralError
+                                                                     userInfo:nil]];
+    }
+}
+
+@end
+
+static const uint16_t kPairingTimeoutInSeconds = 10;
+static const uint16_t kCASESetupTimeoutInSeconds = 30;
+static const uint16_t kTimeoutInSeconds = 3;
+static const uint64_t kDeviceId = 0x12344321;
+static const uint16_t kDiscriminator = 3840;
+static const uint32_t kSetupPINCode = 20202021;
+static const uint16_t kRemotePort = 5540;
+static const uint16_t kLocalPort = 5541;
+static NSString * kAddress = @"::1";
+
+// This test suite reuses a device object to speed up the test process for CI.
+// The following global variable holds the reference to the device object.
+static CHIPDevice * mConnectedDevice;
+static CHIPXPCListenerSample * mSampleListener;
+
+static CHIPDevice * GetConnectedDevice(void)
+{
+    XCTAssertNotNil(mConnectedDevice);
+    return mConnectedDevice;
+}
+
+@interface CHIPRemoteDeviceSampleTestPairingDelegate : NSObject <CHIPDevicePairingDelegate>
+@property (nonatomic, strong) XCTestExpectation * expectation;
+@end
+
+@implementation CHIPRemoteDeviceSampleTestPairingDelegate
+- (id)initWithExpectation:(XCTestExpectation *)expectation
+{
+    self = [super init];
+    if (self) {
+        _expectation = expectation;
+    }
+    return self;
+}
+
+- (void)onPairingComplete:(NSError *)error
+{
+    XCTAssertEqual(error.code, 0);
+    [_expectation fulfill];
+    _expectation = nil;
+}
+
+- (void)onCommissioningComplete:(NSError *)error
+{
+    XCTAssertEqual(error.code, 0);
+    [_expectation fulfill];
+    _expectation = nil;
+}
+
+- (void)onAddressUpdated:(NSError *)error
+{
+    XCTAssertEqual(error.code, 0);
+    [_expectation fulfill];
+    _expectation = nil;
+}
+@end
+
+@interface CHIPXPCListenerSampleTests : XCTestCase
+
+@end
+
+@implementation CHIPXPCListenerSampleTests
+
+- (void)setUp
+{
+    [super setUp];
+    [self setContinueAfterFailure:NO];
+}
+
+- (void)tearDown
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self shutdownStack];
+#endif
+    [super tearDown];
+}
+
+- (void)initStack
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Pairing Complete"];
+
+    CHIPDeviceController * controller = [CHIPDeviceController sharedController];
+    XCTAssertNotNil(controller);
+
+    CHIPRemoteDeviceSampleTestPairingDelegate * pairing =
+        [[CHIPRemoteDeviceSampleTestPairingDelegate alloc] initWithExpectation:expectation];
+    dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.pairing", DISPATCH_QUEUE_SERIAL);
+
+    [controller setListenPort:kLocalPort];
+    [controller setPairingDelegate:pairing queue:callbackQueue];
+
+    BOOL started = [controller startup:nil vendorId:0 nocSigner:nil];
+    XCTAssertTrue(started);
+
+    NSError * error;
+    [controller pairDevice:kDeviceId
+                   address:kAddress
+                      port:kRemotePort
+             discriminator:kDiscriminator
+              setupPINCode:kSetupPINCode
+                     error:&error];
+    XCTAssertEqual(error.code, 0);
+
+    [self waitForExpectationsWithTimeout:kPairingTimeoutInSeconds handler:nil];
+
+    __block XCTestExpectation * connectionExpectation = [self expectationWithDescription:@"CASE established"];
+    [controller getConnectedDevice:kDeviceId
+                             queue:dispatch_get_main_queue()
+                 completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                     XCTAssertEqual(error.code, 0);
+                     [connectionExpectation fulfill];
+                     connectionExpectation = nil;
+                 }];
+    [self waitForExpectationsWithTimeout:kCASESetupTimeoutInSeconds handler:nil];
+
+    mSampleListener = [[CHIPXPCListenerSample alloc] init];
+    [mSampleListener start];
+}
+
+- (void)shutdownStack
+{
+    [mSampleListener stop];
+    mSampleListener = nil;
+
+    CHIPDeviceController * controller = [CHIPDeviceController sharedController];
+    XCTAssertNotNil(controller);
+
+    BOOL stopped = [controller shutdown];
+    XCTAssertTrue(stopped);
+}
+
+- (void)waitForCommissionee
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
+
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    __auto_type remoteController = [CHIPDeviceController
+        sharedControllerWithId:kCHIPDeviceControllerId
+               xpcConnectBlock:^NSXPCConnection * _Nonnull {
+                   if (mSampleListener.listenerEndpoint) {
+                       return [[NSXPCConnection alloc] initWithListenerEndpoint:mSampleListener.listenerEndpoint];
+                   }
+                   NSLog(@"Listener is not active");
+                   return nil;
+               }];
+    [remoteController getConnectedDevice:kDeviceId
+                                   queue:queue
+                       completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                           mConnectedDevice = device;
+                           [expectation fulfill];
+                       }];
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+#if !MANUAL_INDIVIDUAL_TEST
+- (void)test000_SetUp
+{
+    [self initStack];
+    [self waitForCommissionee];
+}
+#endif
+
+- (void)test001_ReadAttribute
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"read DeviceDescriptor DeviceType attribute for all endpoints"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    [device readAttributeWithEndpointId:0xffff
+                              clusterId:29
+                            attributeId:0
+                            clientQueue:queue
+                             completion:^(id _Nullable values, NSError * _Nullable error) {
+                                 NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+
+                                 {
+                                     XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                     NSArray * resultArray = values;
+                                     for (NSDictionary * result in resultArray) {
+                                         XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 29);
+                                         XCTAssertEqual([result[@"attributeId"] unsignedIntegerValue], 0);
+                                         XCTAssertTrue([result[@"endpointId"] isKindOfClass:[NSNumber class]]);
+                                         XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
+                                         XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Array"]);
+                                     }
+                                     XCTAssertTrue([resultArray count] > 0);
+                                 }
+
+                                 [expectation fulfill];
+                             }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)test002_WriteAttribute
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    XCTestExpectation * expectation = [self expectationWithDescription:@"write LevelControl Brightness attribute"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    NSDictionary * writeValue = [NSDictionary
+        dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:200], @"value", nil];
+    [device writeAttributeWithEndpointId:1
+                               clusterId:8
+                             attributeId:17
+                                   value:writeValue
+                             clientQueue:queue
+                              completion:^(id _Nullable values, NSError * _Nullable error) {
+                                  NSLog(@"write attribute: Brightness values: %@, error: %@", values, error);
+
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+
+                                  {
+                                      XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                      NSArray * resultArray = values;
+                                      for (NSDictionary * result in resultArray) {
+                                          XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
+                                          XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 8);
+                                          XCTAssertEqual([result[@"attributeId"] unsignedIntegerValue], 17);
+                                          XCTAssertEqual([result[@"status"] unsignedIntegerValue], 0);
+                                      }
+                                      XCTAssertEqual([resultArray count], 1);
+                                  }
+
+                                  [expectation fulfill];
+                              }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)test003_InvokeCommand
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    XCTestExpectation * expectation = [self expectationWithDescription:@"invoke MoveToLevelWithOnOff command"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    NSDictionary * fields = [NSDictionary
+        dictionaryWithObjectsAndKeys:@"Structure", @"type",
+        [NSArray arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:0], @"tag",
+                                                [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type",
+                                                              [NSNumber numberWithUnsignedInteger:0], @"value", nil],
+                                                @"value", nil],
+                 [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:1], @"tag",
+                               [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type",
+                                             [NSNumber numberWithUnsignedInteger:10], @"value", nil],
+                               @"value", nil],
+                 nil],
+        @"value", nil];
+    [device invokeCommandWithEndpointId:1
+                              clusterId:8
+                              commandId:4
+                          commandFields:fields
+                            clientQueue:queue
+                             completion:^(id _Nullable values, NSError * _Nullable error) {
+                                 NSLog(@"invoke command: MoveToLevelWithOnOff values: %@, error: %@", values, error);
+
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+
+                                 {
+                                     XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                     NSArray * resultArray = values;
+                                     for (NSDictionary * result in resultArray) {
+                                         XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
+                                         XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 8);
+                                         XCTAssertEqual([result[@"commandId"] unsignedIntegerValue], 4);
+                                         XCTAssertEqual([result[@"status"] unsignedIntegerValue], 0);
+                                     }
+                                     XCTAssertEqual([resultArray count], 1);
+                                 }
+
+                                 [expectation fulfill];
+                             }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable error) = nil;
+
+- (void)test004_Subscribe
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    [device subscribeAttributeWithEndpointId:1
+        clusterId:6
+        attributeId:0
+        minInterval:2
+        maxInterval:10
+        clientQueue:queue
+        reportHandler:^(id _Nullable values, NSError * _Nullable error) {
+            NSLog(@"report attribute: OnOff values: %@, error: %@", values, error);
+
+            if (globalReportHandler) {
+                __auto_type callback = globalReportHandler;
+                globalReportHandler = nil;
+                callback(values, error);
+            }
+        }
+        subscriptionEstablished:^{
+            NSLog(@"subscribe attribute: OnOff established");
+            [expectation fulfill];
+        }];
+
+    // Wait till establishment
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+
+    // Set up expectation for report
+    expectation = [self expectationWithDescription:@"receive OnOff attribute report"];
+    globalReportHandler = ^(id _Nullable value, NSError * _Nullable error) {
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+
+        {
+            XCTAssertTrue([value isKindOfClass:[NSDictionary class]]);
+            NSDictionary * result = value;
+            XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
+            XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 6);
+            XCTAssertEqual([result[@"attributeId"] unsignedIntegerValue], 0);
+            XCTAssertTrue([result[@"value"] isKindOfClass:[NSDictionary class]]);
+            XCTAssertTrue([result[@"value"][@"type"] isEqualToString:@"Boolean"]);
+            XCTAssertEqual([result[@"value"][@"value"] boolValue], YES);
+        }
+        [expectation fulfill];
+    };
+
+    // Send command to trigger attribute change
+    NSDictionary * fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
+    [device invokeCommandWithEndpointId:1
+                              clusterId:6
+                              commandId:1
+                          commandFields:fields
+                            clientQueue:queue
+                             completion:^(id _Nullable values, NSError * _Nullable error) {
+                                 NSLog(@"invoke command: On values: %@, error: %@", values, error);
+
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+
+                                 {
+                                     XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+                                     NSArray * resultArray = values;
+                                     for (NSDictionary * result in resultArray) {
+                                         XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
+                                         XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 6);
+                                         XCTAssertEqual([result[@"commandId"] unsignedIntegerValue], 1);
+                                         XCTAssertEqual([result[@"status"] unsignedIntegerValue], 0);
+                                     }
+                                     XCTAssertEqual([resultArray count], 1);
+                                 }
+                             }];
+
+    // Wait for report
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)test005_ReadAttributeFailure
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    XCTestExpectation * expectation = [self expectationWithDescription:@"read failed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    [device readAttributeWithEndpointId:0
+                              clusterId:10000
+                            attributeId:0
+                            clientQueue:queue
+                             completion:^(id _Nullable values, NSError * _Nullable error) {
+                                 NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
+
+                                 XCTAssertNil(values);
+                                 // Error is copied over XPC and hence cannot use CHIPErrorTestUtils utility which checks against a
+                                 // local domain string object.
+                                 XCTAssertTrue([error.domain isEqualToString:MatterInteractionErrorDomain]);
+                                 XCTAssertEqual(error.code, EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER);
+
+                                 [expectation fulfill];
+                             }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)test006_WriteAttributeFailure
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    XCTestExpectation * expectation = [self expectationWithDescription:@"write failed"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    NSDictionary * writeValue = [NSDictionary
+        dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:200], @"value", nil];
+    [device writeAttributeWithEndpointId:1
+                               clusterId:8
+                             attributeId:10000
+                                   value:writeValue
+                             clientQueue:queue
+                              completion:^(id _Nullable values, NSError * _Nullable error) {
+                                  NSLog(@"write attribute: Brightness values: %@, error: %@", values, error);
+
+                                  XCTAssertNil(values);
+                                  // Error is copied over XPC and hence cannot use CHIPErrorTestUtils utility which checks against a
+                                  // local domain string object.
+                                  XCTAssertTrue([error.domain isEqualToString:MatterInteractionErrorDomain]);
+                                  XCTAssertEqual(error.code, EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE);
+
+                                  [expectation fulfill];
+                              }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+#if 0 // Re-enable test if the crash bug in CHIP stack is fixed to handle bad command Id
+- (void)test007_InvokeCommandFailure
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    XCTestExpectation * expectation = [self expectationWithDescription:@"invoke MoveToLevelWithOnOff command"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    NSDictionary *fields = [NSDictionary dictionaryWithObjectsAndKeys:
+                            @"Structure", @"type",
+                            [NSArray arrayWithObjects:
+                             [NSDictionary dictionaryWithObjectsAndKeys:
+                              [NSNumber numberWithUnsignedInteger:0], @"tag",
+                              [NSDictionary dictionaryWithObjectsAndKeys:
+                               @"UnsignedInteger", @"type",
+                               [NSNumber numberWithUnsignedInteger:0], @"value", nil], @"value", nil],
+                             [NSDictionary dictionaryWithObjectsAndKeys:
+                              [NSNumber numberWithUnsignedInteger:1], @"tag",
+                              [NSDictionary dictionaryWithObjectsAndKeys:
+                               @"UnsignedInteger", @"type",
+                               [NSNumber numberWithUnsignedInteger:10], @"value", nil], @"value", nil],
+                             nil], @"value", nil];
+    [device invokeCommandWithEndpointId:1 clusterId:8 commandId:40000 commandFields:fields clientQueue:queue completion:^(id _Nullable values, NSError * _Nullable error) {
+        NSLog(@"invoke command: MoveToLevelWithOnOff values: %@, error: %@", values, error);
+
+        XCTAssertNil(values);
+        // Error is copied over XPC and hence cannot use CHIPErrorTestUtils utility which checks against a local domain string object.
+        XCTAssertTrue([error.domain isEqualToString:MatterInteractionErrorDomain]);
+        XCTAssertEqual(error.code, EMBER_ZCL_STATUS_UNSUPPORTED_COMMAND);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+#endif
+
+- (void)test008_SubscribeFailure
+{
+#if MANUAL_INDIVIDUAL_TEST
+    [self initStack];
+    [self waitForCommissionee];
+#endif
+    XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
+
+    // Set up expectation for report
+    XCTestExpectation * errorReportExpectation = [self expectationWithDescription:@"receive OnOff attribute report"];
+    globalReportHandler = ^(id _Nullable value, NSError * _Nullable error) {
+        XCTAssertNil(value);
+        // Error is copied over XPC and hence cannot use CHIPErrorTestUtils utility which checks against a local domain string
+        // object.
+        XCTAssertTrue([error.domain isEqualToString:MatterInteractionErrorDomain]);
+        XCTAssertEqual(error.code, EMBER_ZCL_STATUS_UNSUPPORTED_ENDPOINT);
+        [errorReportExpectation fulfill];
+    };
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    [device subscribeAttributeWithEndpointId:10000
+        clusterId:6
+        attributeId:0
+        minInterval:2
+        maxInterval:10
+        clientQueue:queue
+        reportHandler:^(id _Nullable values, NSError * _Nullable error) {
+            NSLog(@"report attribute: OnOff values: %@, error: %@", values, error);
+
+            if (globalReportHandler) {
+                __auto_type callback = globalReportHandler;
+                globalReportHandler = nil;
+                callback(values, error);
+            }
+        }
+        subscriptionEstablished:^{
+            NSLog(@"subscribe attribute: OnOff established");
+            [expectation fulfill];
+        }];
+
+    // Wait till establishment and error report
+    [self waitForExpectations:[NSArray arrayWithObjects:expectation, errorReportExpectation, nil] timeout:kTimeoutInSeconds];
+}
+
+#if !MANUAL_INDIVIDUAL_TEST
+- (void)test999_TearDown
+{
+    [self shutdownStack];
+}
+#endif
+
+@end

--- a/src/darwin/Framework/CHIPTests/CHIPXPCProtocolTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPXPCProtocolTests.m
@@ -1,0 +1,1615 @@
+//
+//  CHIPRemoteDeviceTests.m
+//  CHIPTests
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+// module headers
+#import <CHIP/CHIP.h>
+
+#import "CHIPErrorTestUtils.h"
+
+#import <app/util/af-enums.h>
+
+#import <math.h> // For INFINITY
+
+// system dependencies
+#import <XCTest/XCTest.h>
+
+static const uint16_t kTimeoutInSeconds = 3;
+// Inverted expectation timeout
+static const uint16_t kNegativeTimeoutInSeconds = 1;
+
+@interface CHIPXPCProtocolTests<NSXPCListenerDelegate, CHIPRemoteDeviceProtocol> : XCTestCase
+
+@property (nonatomic, readwrite, strong) NSXPCListener * xpcListener;
+@property (nonatomic, readwrite, strong) NSXPCInterface * serviceInterface;
+@property (nonatomic, readwrite, strong) NSXPCInterface * clientInterface;
+@property (readwrite, strong) NSXPCConnection * xpcConnection;
+@property (nonatomic, readwrite, strong) CHIPDeviceController * remoteDeviceController;
+@property (nonatomic, readwrite, strong) NSString * controllerUUID;
+@property (readwrite, strong) XCTestExpectation * xpcDisconnectExpectation;
+
+@property (readwrite, strong) void (^handleGetAnySharedRemoteControllerWithFabricId)
+    (uint64_t fabricId, void (^completion)(id _Nullable controller, NSError * _Nullable error));
+@property (readwrite, strong) void (^handleGetAnySharedRemoteController)
+    (void (^completion)(id _Nullable controller, NSError * _Nullable error));
+@property (readwrite, strong) void (^handleReadAttribute)(id controller, uint64_t nodeId, NSUInteger endpointId,
+    NSUInteger clusterId, NSUInteger attributeId, void (^completion)(id _Nullable values, NSError * _Nullable error));
+@property (readwrite, strong) void (^handleWriteAttribute)(id controller, uint64_t nodeId, NSUInteger endpointId,
+    NSUInteger clusterId, NSUInteger attributeId, id value, void (^completion)(id _Nullable values, NSError * _Nullable error));
+@property (readwrite, strong) void (^handleInvokeCommand)(id controller, uint64_t nodeId, NSUInteger endpointId,
+    NSUInteger clusterId, NSUInteger commandId, id fields, void (^completion)(id _Nullable values, NSError * _Nullable error));
+@property (readwrite, strong) void (^handleSubscribeAttribute)(id controller, uint64_t nodeId, NSUInteger endpointId,
+    NSUInteger clusterId, NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void));
+
+@end
+
+@implementation CHIPXPCProtocolTests
+
+- (BOOL)listener:(NSXPCListener *)listener shouldAcceptNewConnection:(NSXPCConnection *)newConnection
+{
+    XCTAssertNil(_xpcConnection);
+    XCTAssertNotNil(newConnection);
+    NSLog(@"XPC listener accepting connection");
+    newConnection.exportedInterface = _serviceInterface;
+    newConnection.remoteObjectInterface = _clientInterface;
+    newConnection.exportedObject = self;
+    newConnection.invalidationHandler = ^{
+        NSLog(@"XPC connection disconnected");
+        self.xpcConnection = nil;
+        if (self.xpcDisconnectExpectation) {
+            [self.xpcDisconnectExpectation fulfill];
+            self.xpcDisconnectExpectation = nil;
+        }
+    };
+    _xpcConnection = newConnection;
+    [newConnection resume];
+    return YES;
+}
+
+- (void)getDeviceControllerWithFabricId:(uint64_t)fabricId
+                             completion:(void (^)(id _Nullable controller, NSError * _Nullable error))completion
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        XCTAssertNotNil(self.handleGetAnySharedRemoteControllerWithFabricId);
+        self.handleGetAnySharedRemoteControllerWithFabricId(fabricId, completion);
+    });
+}
+
+- (void)getAnyDeviceControllerWithCompletion:(void (^)(id _Nullable controller, NSError * _Nullable error))completion
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        XCTAssertNotNil(self.handleGetAnySharedRemoteController);
+        self.handleGetAnySharedRemoteController(completion);
+    });
+}
+
+- (void)readAttributeWithController:(id)controller
+                             nodeId:(uint64_t)nodeId
+                         endpointId:(NSUInteger)endpointId
+                          clusterId:(NSUInteger)clusterId
+                        attributeId:(NSUInteger)attributeId
+                         completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        XCTAssertNotNil(self.handleReadAttribute);
+        self.handleReadAttribute(controller, nodeId, endpointId, clusterId, attributeId, completion);
+    });
+}
+
+- (void)writeAttributeWithController:(id)controller
+                              nodeId:(uint64_t)nodeId
+                          endpointId:(NSUInteger)endpointId
+                           clusterId:(NSUInteger)clusterId
+                         attributeId:(NSUInteger)attributeId
+                               value:(id)value
+                          completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        XCTAssertNotNil(self.handleWriteAttribute);
+        self.handleWriteAttribute(controller, nodeId, endpointId, clusterId, attributeId, value, completion);
+    });
+}
+
+- (void)invokeCommandWithController:(id)controller
+                             nodeId:(uint64_t)nodeId
+                         endpointId:(NSUInteger)endpointId
+                          clusterId:(NSUInteger)clusterId
+                          commandId:(NSUInteger)commandId
+                             fields:(id)fields
+                         completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        XCTAssertNotNil(self.handleInvokeCommand);
+        self.handleInvokeCommand(controller, nodeId, endpointId, clusterId, commandId, fields, completion);
+    });
+}
+
+- (void)subscribeAttributeWithController:(id)controller
+                                  nodeId:(uint64_t)nodeId
+                              endpointId:(NSUInteger)endpointId
+                               clusterId:(NSUInteger)clusterId
+                             attributeId:(NSUInteger)attributeId
+                             minInterval:(NSUInteger)minInterval
+                             maxInterval:(NSUInteger)maxInterval
+                      establishedHandler:(void (^)(void))establishedHandler
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        XCTAssertNotNil(self.handleSubscribeAttribute);
+        self.handleSubscribeAttribute(
+            controller, nodeId, endpointId, clusterId, attributeId, minInterval, maxInterval, establishedHandler);
+    });
+}
+
+- (void)setUp
+{
+    _xpcListener = [NSXPCListener anonymousListener];
+    [_xpcListener setDelegate:(id<NSXPCListenerDelegate>) self];
+    _serviceInterface = [NSXPCInterface interfaceWithProtocol:@protocol(CHIPDeviceControllerServerProtocol)];
+    _clientInterface = [NSXPCInterface interfaceWithProtocol:@protocol(CHIPDeviceControllerClientProtocol)];
+    [_xpcListener resume];
+    _controllerUUID = [[NSUUID UUID] UUIDString];
+    _remoteDeviceController =
+        [CHIPDeviceController sharedControllerWithId:_controllerUUID
+                                     xpcConnectBlock:^NSXPCConnection * {
+                                         return [[NSXPCConnection alloc] initWithListenerEndpoint:self.xpcListener.endpoint];
+                                     }];
+}
+
+- (void)tearDown
+{
+    _remoteDeviceController = nil;
+    [_xpcListener suspend];
+    _xpcListener = nil;
+    _xpcDisconnectExpectation = nil;
+}
+
+- (void)testReadAttributeSuccess
+{
+    uint64_t myNodeId = 9876543210;
+    NSUInteger myEndpointId = 100;
+    NSUInteger myClusterId = 200;
+    NSUInteger myAttributeId = 300;
+    NSArray * myValues =
+        [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId],
+                                               @"endpointId", [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId",
+                                               [NSNumber numberWithUnsignedInteger:myAttributeId], @"attributeId",
+                                               [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
+                                                             [NSNumber numberWithInteger:123456], @"value", nil],
+                                               @"data", nil]];
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
+
+    __auto_type uuid = self.controllerUUID;
+    _handleReadAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId, NSUInteger attributeId,
+        void (^completion)(id _Nullable values, NSError * _Nullable error)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual(endpointId, myEndpointId);
+        XCTAssertEqual(clusterId, myClusterId);
+        XCTAssertEqual(attributeId, myAttributeId);
+        [callExpectation fulfill];
+        completion(myValues, nil);
+    };
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Reading...");
+                                  [device readAttributeWithEndpointId:myEndpointId
+                                                            clusterId:myClusterId
+                                                          attributeId:myAttributeId
+                                                          clientQueue:dispatch_get_main_queue()
+                                                           completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                               NSLog(@"Read value: %@", value);
+                                                               XCTAssertNotNil(value);
+                                                               XCTAssertNil(error);
+                                                               XCTAssertTrue([myValues isEqualTo:value]);
+                                                               [responseExpectation fulfill];
+                                                               self.xpcDisconnectExpectation =
+                                                                   [self expectationWithDescription:@"XPC Disconnected"];
+                                                           }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, responseExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // When read is done, connection should have been released
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testReadAttributeFailure
+{
+    uint64_t myNodeId = 9876543210;
+    NSUInteger myEndpointId = 100;
+    NSUInteger myClusterId = 200;
+    NSUInteger myAttributeId = 300;
+    NSError * myError = [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil];
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
+
+    __auto_type uuid = self.controllerUUID;
+    _handleReadAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId, NSUInteger attributeId,
+        void (^completion)(id _Nullable values, NSError * _Nullable error)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual(endpointId, myEndpointId);
+        XCTAssertEqual(clusterId, myClusterId);
+        XCTAssertEqual(attributeId, myAttributeId);
+        [callExpectation fulfill];
+        completion(nil, myError);
+    };
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Reading...");
+                                  [device readAttributeWithEndpointId:myEndpointId
+                                                            clusterId:myClusterId
+                                                          attributeId:myAttributeId
+                                                          clientQueue:dispatch_get_main_queue()
+                                                           completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                               NSLog(@"Read value: %@", value);
+                                                               XCTAssertNil(value);
+                                                               XCTAssertNotNil(error);
+                                                               [responseExpectation fulfill];
+                                                               self.xpcDisconnectExpectation =
+                                                                   [self expectationWithDescription:@"XPC Disconnected"];
+                                                           }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, responseExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // When read is done, connection should have been released
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testWriteAttributeSuccess
+{
+    uint64_t myNodeId = 9876543210;
+    NSUInteger myEndpointId = 100;
+    NSUInteger myClusterId = 200;
+    NSUInteger myAttributeId = 300;
+    NSDictionary * myValue =
+        [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithInteger:654321], @"value", nil];
+    NSArray * myResults =
+        [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId],
+                                               @"endpointId", [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId",
+                                               [NSNumber numberWithUnsignedInteger:myAttributeId], @"attributeId",
+                                               [NSNumber numberWithInteger:0], @"status", nil]];
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
+
+    __auto_type uuid = self.controllerUUID;
+    _handleWriteAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId, NSUInteger attributeId,
+        id value, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual(endpointId, myEndpointId);
+        XCTAssertEqual(clusterId, myClusterId);
+        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertTrue([value isEqualTo:myValue]);
+        [callExpectation fulfill];
+        completion(myResults, nil);
+    };
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Writing...");
+                                  [device writeAttributeWithEndpointId:myEndpointId
+                                                             clusterId:myClusterId
+                                                           attributeId:myAttributeId
+                                                                 value:myValue
+                                                           clientQueue:dispatch_get_main_queue()
+                                                            completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                                NSLog(@"Write response: %@", value);
+                                                                XCTAssertNotNil(value);
+                                                                XCTAssertNil(error);
+                                                                XCTAssertTrue([myResults isEqualTo:value]);
+                                                                [responseExpectation fulfill];
+                                                                self.xpcDisconnectExpectation =
+                                                                    [self expectationWithDescription:@"XPC Disconnected"];
+                                                            }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, responseExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // When write is done, connection should have been released
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testWriteAttributeFailure
+{
+    uint64_t myNodeId = 9876543210;
+    NSUInteger myEndpointId = 100;
+    NSUInteger myClusterId = 200;
+    NSUInteger myAttributeId = 300;
+    NSDictionary * myValue =
+        [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithInteger:654321], @"value", nil];
+    NSError * myError = [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil];
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
+
+    __auto_type uuid = self.controllerUUID;
+    _handleWriteAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId, NSUInteger attributeId,
+        id value, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual(endpointId, myEndpointId);
+        XCTAssertEqual(clusterId, myClusterId);
+        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertTrue([value isEqualTo:myValue]);
+        [callExpectation fulfill];
+        completion(nil, myError);
+    };
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Writing...");
+                                  [device writeAttributeWithEndpointId:myEndpointId
+                                                             clusterId:myClusterId
+                                                           attributeId:myAttributeId
+                                                                 value:myValue
+                                                           clientQueue:dispatch_get_main_queue()
+                                                            completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                                NSLog(@"Write response: %@", value);
+                                                                XCTAssertNil(value);
+                                                                XCTAssertNotNil(error);
+                                                                [responseExpectation fulfill];
+                                                                self.xpcDisconnectExpectation =
+                                                                    [self expectationWithDescription:@"XPC Disconnected"];
+                                                            }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, responseExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // When write is done, connection should have been released
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testInvokeCommandSuccess
+{
+    uint64_t myNodeId = 9876543210;
+    NSUInteger myEndpointId = 100;
+    NSUInteger myClusterId = 200;
+    NSUInteger myCommandId = 300;
+    NSDictionary * myFields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type",
+                                            [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:@"Float", @"Type",
+                                                                                   [NSNumber numberWithFloat:1.0], @"value", nil]],
+                                            @"value", nil];
+    NSArray * myResults =
+        [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId],
+                                               @"endpointId", [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId",
+                                               [NSNumber numberWithUnsignedInteger:myCommandId], @"commandId",
+                                               [NSNumber numberWithInteger:0], @"status", nil]];
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
+
+    __auto_type uuid = self.controllerUUID;
+    _handleInvokeCommand = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId, NSUInteger commandId,
+        id commandFields, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual(endpointId, myEndpointId);
+        XCTAssertEqual(clusterId, myClusterId);
+        XCTAssertEqual(commandId, myCommandId);
+        XCTAssertTrue([commandFields isEqualTo:myFields]);
+        [callExpectation fulfill];
+        completion(myResults, nil);
+    };
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Invoking command...");
+                                  [device invokeCommandWithEndpointId:myEndpointId
+                                                            clusterId:myClusterId
+                                                            commandId:myCommandId
+                                                        commandFields:myFields
+                                                          clientQueue:dispatch_get_main_queue()
+                                                           completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                               NSLog(@"Command response: %@", value);
+                                                               XCTAssertNotNil(value);
+                                                               XCTAssertNil(error);
+                                                               XCTAssertTrue([myResults isEqualTo:value]);
+                                                               [responseExpectation fulfill];
+                                                               self.xpcDisconnectExpectation =
+                                                                   [self expectationWithDescription:@"XPC Disconnected"];
+                                                           }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, responseExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // When command is done, connection should have been released
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testInvokeCommandFailure
+{
+    uint64_t myNodeId = 9876543210;
+    NSUInteger myEndpointId = 100;
+    NSUInteger myClusterId = 200;
+    NSUInteger myCommandId = 300;
+    NSDictionary * myFields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type",
+                                            [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:@"Float", @"Type",
+                                                                                   [NSNumber numberWithFloat:1.0], @"value", nil]],
+                                            @"value", nil];
+    NSError * myError = [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil];
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
+
+    __auto_type uuid = self.controllerUUID;
+    _handleInvokeCommand = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId, NSUInteger commandId,
+        id commandFields, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual(endpointId, myEndpointId);
+        XCTAssertEqual(clusterId, myClusterId);
+        XCTAssertEqual(commandId, myCommandId);
+        XCTAssertTrue([commandFields isEqualTo:myFields]);
+        [callExpectation fulfill];
+        completion(nil, myError);
+    };
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Invoking command...");
+                                  [device invokeCommandWithEndpointId:myEndpointId
+                                                            clusterId:myClusterId
+                                                            commandId:myCommandId
+                                                        commandFields:myFields
+                                                          clientQueue:dispatch_get_main_queue()
+                                                           completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                               NSLog(@"Command response: %@", value);
+                                                               XCTAssertNil(value);
+                                                               XCTAssertNotNil(error);
+                                                               [responseExpectation fulfill];
+                                                               self.xpcDisconnectExpectation =
+                                                                   [self expectationWithDescription:@"XPC Disconnected"];
+                                                           }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, responseExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // When command is done, connection should have been released
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testSubscribeAttributeSuccess
+{
+    uint64_t myNodeId = 9876543210;
+    NSUInteger myEndpointId = 100;
+    NSUInteger myClusterId = 200;
+    NSUInteger myAttributeId = 300;
+    NSUInteger myMinInterval = 5;
+    NSUInteger myMaxInterval = 60;
+    __block NSDictionary * myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:123456], @"value", nil],
+        @"data", nil];
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
+    __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Report sent"];
+
+    __auto_type uuid = self.controllerUUID;
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
+        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual(endpointId, myEndpointId);
+        XCTAssertEqual(clusterId, myClusterId);
+        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertEqual(minInterval, myMinInterval);
+        XCTAssertEqual(maxInterval, myMaxInterval);
+        [callExpectation fulfill];
+        establishedHandler();
+    };
+
+    _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Subscribing...");
+                                  [device subscribeAttributeWithEndpointId:myEndpointId
+                                      clusterId:myClusterId
+                                      attributeId:myAttributeId
+                                      minInterval:myMinInterval
+                                      maxInterval:myMaxInterval
+                                      clientQueue:dispatch_get_main_queue()
+                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
+                                          NSLog(@"Report value: %@", value);
+                                          XCTAssertNotNil(value);
+                                          XCTAssertNil(error);
+                                          XCTAssertTrue([myReport isEqualTo:value]);
+                                          [reportExpectation fulfill];
+                                      }
+                                      subscriptionEstablished:^{
+                                          [establishExpectation fulfill];
+                                      }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // Inject report
+    id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Inject another report
+    reportExpectation = [self expectationWithDescription:@"2nd report sent"];
+    myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
+        @"data", nil];
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Deregister report handler
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  NSLog(@"Device acquired. Deregistering...");
+                                  [device deregisterReportHandlersWithClientQueue:dispatch_get_main_queue()
+                                                                       completion:^{
+                                                                           NSLog(@"Deregistered");
+                                                                       }];
+                              }];
+
+    // Wait for disconnection
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testBadlyFormattedReport
+{
+    uint64_t myNodeId = 9876543210;
+    NSUInteger myEndpointId = 100;
+    NSUInteger myClusterId = 200;
+    NSUInteger myAttributeId = 300;
+    NSUInteger myMinInterval = 5;
+    NSUInteger myMaxInterval = 60;
+    // Incorrect report value. Report must be a single NSDictionary
+    __block id myReport =
+        [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId],
+                                               @"endpointId", [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId",
+                                               [NSNumber numberWithUnsignedInteger:myAttributeId], @"attributeId",
+                                               [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
+                                                             [NSNumber numberWithInteger:123456], @"value", nil],
+                                               @"data", nil]];
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
+    __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Unexpected report sent"];
+    reportExpectation.inverted = YES;
+
+    __auto_type uuid = self.controllerUUID;
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
+        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual(endpointId, myEndpointId);
+        XCTAssertEqual(clusterId, myClusterId);
+        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertEqual(minInterval, myMinInterval);
+        XCTAssertEqual(maxInterval, myMaxInterval);
+        [callExpectation fulfill];
+        establishedHandler();
+    };
+
+    _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Subscribing...");
+                                  [device subscribeAttributeWithEndpointId:myEndpointId
+                                      clusterId:myClusterId
+                                      attributeId:myAttributeId
+                                      minInterval:myMinInterval
+                                      maxInterval:myMaxInterval
+                                      clientQueue:dispatch_get_main_queue()
+                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
+                                          NSLog(@"Report value: %@", value);
+                                          XCTAssertNotNil(value);
+                                          XCTAssertNil(error);
+                                          XCTAssertTrue([myReport isEqualTo:value]);
+                                          [reportExpectation fulfill];
+                                      }
+                                      subscriptionEstablished:^{
+                                          [establishExpectation fulfill];
+                                      }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // Inject badly formatted report
+    id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report, which isn't expected.
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kNegativeTimeoutInSeconds];
+
+    // Inject another report
+    reportExpectation = [self expectationWithDescription:@"Report sent"];
+    myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
+        @"data", nil];
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Deregister report handler
+    _xpcDisconnectExpectation.inverted = NO;
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  NSLog(@"Device acquired. Deregistering...");
+                                  [device deregisterReportHandlersWithClientQueue:dispatch_get_main_queue()
+                                                                       completion:^{
+                                                                           NSLog(@"Deregistered");
+                                                                       }];
+                              }];
+
+    // Wait for disconnection
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testReportWithUnrelatedEndpointId
+{
+    uint64_t myNodeId = 9876543210;
+    NSUInteger myEndpointId = 100;
+    NSUInteger myClusterId = 200;
+    NSUInteger myAttributeId = 300;
+    NSUInteger myMinInterval = 5;
+    NSUInteger myMaxInterval = 60;
+    __block NSDictionary * myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId + 1], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:123456], @"value", nil],
+        @"data", nil];
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
+    __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Unexpected report sent"];
+    reportExpectation.inverted = YES;
+
+    __auto_type uuid = self.controllerUUID;
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
+        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual(endpointId, myEndpointId);
+        XCTAssertEqual(clusterId, myClusterId);
+        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertEqual(minInterval, myMinInterval);
+        XCTAssertEqual(maxInterval, myMaxInterval);
+        [callExpectation fulfill];
+        establishedHandler();
+    };
+
+    _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Subscribing...");
+                                  [device subscribeAttributeWithEndpointId:myEndpointId
+                                      clusterId:myClusterId
+                                      attributeId:myAttributeId
+                                      minInterval:myMinInterval
+                                      maxInterval:myMaxInterval
+                                      clientQueue:dispatch_get_main_queue()
+                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
+                                          NSLog(@"Report value: %@", value);
+                                          XCTAssertNotNil(value);
+                                          XCTAssertNil(error);
+                                          XCTAssertTrue([myReport isEqualTo:value]);
+                                          [reportExpectation fulfill];
+                                      }
+                                      subscriptionEstablished:^{
+                                          [establishExpectation fulfill];
+                                      }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // Inject report
+    id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report which isn't expected
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kNegativeTimeoutInSeconds];
+
+    // Inject another report
+    reportExpectation = [self expectationWithDescription:@"2nd report sent"];
+    myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
+        @"data", nil];
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Deregister report handler
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  NSLog(@"Device acquired. Deregistering...");
+                                  [device deregisterReportHandlersWithClientQueue:dispatch_get_main_queue()
+                                                                       completion:^{
+                                                                           NSLog(@"Deregistered");
+                                                                       }];
+                              }];
+
+    // Wait for disconnection
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testReportWithUnrelatedClusterId
+{
+    uint64_t myNodeId = 9876543210;
+    NSUInteger myEndpointId = 100;
+    NSUInteger myClusterId = 200;
+    NSUInteger myAttributeId = 300;
+    NSUInteger myMinInterval = 5;
+    NSUInteger myMaxInterval = 60;
+    __block NSDictionary * myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId + 1], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:123456], @"value", nil],
+        @"data", nil];
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
+    __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Unexpected report sent"];
+    reportExpectation.inverted = YES;
+
+    __auto_type uuid = self.controllerUUID;
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
+        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual(endpointId, myEndpointId);
+        XCTAssertEqual(clusterId, myClusterId);
+        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertEqual(minInterval, myMinInterval);
+        XCTAssertEqual(maxInterval, myMaxInterval);
+        [callExpectation fulfill];
+        establishedHandler();
+    };
+
+    _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Subscribing...");
+                                  [device subscribeAttributeWithEndpointId:myEndpointId
+                                      clusterId:myClusterId
+                                      attributeId:myAttributeId
+                                      minInterval:myMinInterval
+                                      maxInterval:myMaxInterval
+                                      clientQueue:dispatch_get_main_queue()
+                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
+                                          NSLog(@"Report value: %@", value);
+                                          XCTAssertNotNil(value);
+                                          XCTAssertNil(error);
+                                          XCTAssertTrue([myReport isEqualTo:value]);
+                                          [reportExpectation fulfill];
+                                      }
+                                      subscriptionEstablished:^{
+                                          [establishExpectation fulfill];
+                                      }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // Inject report
+    id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report not to come
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kNegativeTimeoutInSeconds];
+
+    // Inject another report
+    reportExpectation = [self expectationWithDescription:@"2nd report sent"];
+    myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
+        @"data", nil];
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Deregister report handler
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  NSLog(@"Device acquired. Deregistering...");
+                                  [device deregisterReportHandlersWithClientQueue:dispatch_get_main_queue()
+                                                                       completion:^{
+                                                                           NSLog(@"Deregistered");
+                                                                       }];
+                              }];
+
+    // Wait for disconnection
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testReportWithUnrelatedAttributeId
+{
+    uint64_t myNodeId = 9876543210;
+    NSUInteger myEndpointId = 100;
+    NSUInteger myClusterId = 200;
+    NSUInteger myAttributeId = 300;
+    NSUInteger myMinInterval = 5;
+    NSUInteger myMaxInterval = 60;
+    __block NSDictionary * myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId + 1],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:123456], @"value", nil],
+        @"data", nil];
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
+    __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Unexpected report sent"];
+    reportExpectation.inverted = YES;
+
+    __auto_type uuid = self.controllerUUID;
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
+        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual(endpointId, myEndpointId);
+        XCTAssertEqual(clusterId, myClusterId);
+        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertEqual(minInterval, myMinInterval);
+        XCTAssertEqual(maxInterval, myMaxInterval);
+        [callExpectation fulfill];
+        establishedHandler();
+    };
+
+    _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Subscribing...");
+                                  [device subscribeAttributeWithEndpointId:myEndpointId
+                                      clusterId:myClusterId
+                                      attributeId:myAttributeId
+                                      minInterval:myMinInterval
+                                      maxInterval:myMaxInterval
+                                      clientQueue:dispatch_get_main_queue()
+                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
+                                          NSLog(@"Report value: %@", value);
+                                          XCTAssertNotNil(value);
+                                          XCTAssertNil(error);
+                                          XCTAssertTrue([myReport isEqualTo:value]);
+                                          [reportExpectation fulfill];
+                                      }
+                                      subscriptionEstablished:^{
+                                          [establishExpectation fulfill];
+                                      }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // Inject report
+    id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report not to come
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kNegativeTimeoutInSeconds];
+
+    // Inject another report
+    reportExpectation = [self expectationWithDescription:@"2nd report sent"];
+    myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
+        @"data", nil];
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Deregister report handler
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  NSLog(@"Device acquired. Deregistering...");
+                                  [device deregisterReportHandlersWithClientQueue:dispatch_get_main_queue()
+                                                                       completion:^{
+                                                                           NSLog(@"Deregistered");
+                                                                       }];
+                              }];
+
+    // Wait for disconnection
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testReportWithUnrelatedNode
+{
+    uint64_t myNodeId = 9876543210;
+    NSUInteger myEndpointId = 100;
+    NSUInteger myClusterId = 200;
+    NSUInteger myAttributeId = 300;
+    NSUInteger myMinInterval = 5;
+    NSUInteger myMaxInterval = 60;
+    __block NSDictionary * myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:123456], @"value", nil],
+        @"data", nil];
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
+    __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Unexpected report sent"];
+    reportExpectation.inverted = YES;
+
+    __auto_type uuid = self.controllerUUID;
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
+        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual(endpointId, myEndpointId);
+        XCTAssertEqual(clusterId, myClusterId);
+        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertEqual(minInterval, myMinInterval);
+        XCTAssertEqual(maxInterval, myMaxInterval);
+        [callExpectation fulfill];
+        establishedHandler();
+    };
+
+    _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Subscribing...");
+                                  [device subscribeAttributeWithEndpointId:myEndpointId
+                                      clusterId:myClusterId
+                                      attributeId:myAttributeId
+                                      minInterval:myMinInterval
+                                      maxInterval:myMaxInterval
+                                      clientQueue:dispatch_get_main_queue()
+                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
+                                          NSLog(@"Report value: %@", value);
+                                          XCTAssertNotNil(value);
+                                          XCTAssertNil(error);
+                                          XCTAssertTrue([myReport isEqualTo:value]);
+                                          [reportExpectation fulfill];
+                                      }
+                                      subscriptionEstablished:^{
+                                          [establishExpectation fulfill];
+                                      }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // Inject report
+    id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
+    [clientObject handleReportWithController:uuid nodeId:myNodeId + 1 value:myReport error:nil];
+
+    // Wait for report not to come
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kNegativeTimeoutInSeconds];
+
+    // Inject another report
+    reportExpectation = [self expectationWithDescription:@"2nd report sent"];
+    myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
+        @"data", nil];
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Deregister report handler
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  NSLog(@"Device acquired. Deregistering...");
+                                  [device deregisterReportHandlersWithClientQueue:dispatch_get_main_queue()
+                                                                       completion:^{
+                                                                           NSLog(@"Deregistered");
+                                                                       }];
+                              }];
+
+    // Wait for disconnection
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testSubscribeMultiEndpoints
+{
+    uint64_t myNodeId = 9876543210;
+    NSUInteger myEndpointId = 100;
+    NSUInteger myClusterId = 200;
+    NSUInteger myAttributeId = 300;
+    NSUInteger myMinInterval = 5;
+    NSUInteger myMaxInterval = 60;
+    __block NSDictionary * myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:123456], @"value", nil],
+        @"data", nil];
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
+    __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Report sent"];
+
+    __auto_type uuid = self.controllerUUID;
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
+        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual(endpointId, 0xffff);
+        XCTAssertEqual(clusterId, myClusterId);
+        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertEqual(minInterval, myMinInterval);
+        XCTAssertEqual(maxInterval, myMaxInterval);
+        [callExpectation fulfill];
+        establishedHandler();
+    };
+
+    _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Subscribing...");
+                                  [device subscribeAttributeWithEndpointId:0xffff
+                                      clusterId:myClusterId
+                                      attributeId:myAttributeId
+                                      minInterval:myMinInterval
+                                      maxInterval:myMaxInterval
+                                      clientQueue:dispatch_get_main_queue()
+                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
+                                          NSLog(@"Report value: %@", value);
+                                          XCTAssertNotNil(value);
+                                          XCTAssertNil(error);
+                                          XCTAssertTrue([myReport isEqualTo:value]);
+                                          [reportExpectation fulfill];
+                                      }
+                                      subscriptionEstablished:^{
+                                          [establishExpectation fulfill];
+                                      }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // Inject report
+    id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kNegativeTimeoutInSeconds];
+
+    // Inject another report
+    reportExpectation = [self expectationWithDescription:@"2nd report sent"];
+    myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
+        @"data", nil];
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Deregister report handler
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  NSLog(@"Device acquired. Deregistering...");
+                                  [device deregisterReportHandlersWithClientQueue:dispatch_get_main_queue()
+                                                                       completion:^{
+                                                                           NSLog(@"Deregistered");
+                                                                       }];
+                              }];
+
+    // Wait for disconnection
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testSubscribeMultiClusters
+{
+    uint64_t myNodeId = 9876543210;
+    NSUInteger myEndpointId = 100;
+    NSUInteger myClusterId = 200;
+    NSUInteger myAttributeId = 300;
+    NSUInteger myMinInterval = 5;
+    NSUInteger myMaxInterval = 60;
+    __block NSDictionary * myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:123456], @"value", nil],
+        @"data", nil];
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
+    __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Report sent"];
+
+    __auto_type uuid = self.controllerUUID;
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
+        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual(endpointId, myEndpointId);
+        XCTAssertEqual(clusterId, 0xffffffff);
+        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertEqual(minInterval, myMinInterval);
+        XCTAssertEqual(maxInterval, myMaxInterval);
+        [callExpectation fulfill];
+        establishedHandler();
+    };
+
+    _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Subscribing...");
+                                  [device subscribeAttributeWithEndpointId:myEndpointId
+                                      clusterId:0xffffffff
+                                      attributeId:myAttributeId
+                                      minInterval:myMinInterval
+                                      maxInterval:myMaxInterval
+                                      clientQueue:dispatch_get_main_queue()
+                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
+                                          NSLog(@"Report value: %@", value);
+                                          XCTAssertNotNil(value);
+                                          XCTAssertNil(error);
+                                          XCTAssertTrue([myReport isEqualTo:value]);
+                                          [reportExpectation fulfill];
+                                      }
+                                      subscriptionEstablished:^{
+                                          [establishExpectation fulfill];
+                                      }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // Inject report
+    id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kNegativeTimeoutInSeconds];
+
+    // Inject another report
+    reportExpectation = [self expectationWithDescription:@"2nd report sent"];
+    myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
+        @"data", nil];
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Deregister report handler
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  NSLog(@"Device acquired. Deregistering...");
+                                  [device deregisterReportHandlersWithClientQueue:dispatch_get_main_queue()
+                                                                       completion:^{
+                                                                           NSLog(@"Deregistered");
+                                                                       }];
+                              }];
+
+    // Wait for disconnection
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testSubscribeMultiAttributes
+{
+    uint64_t myNodeId = 9876543210;
+    NSUInteger myEndpointId = 100;
+    NSUInteger myClusterId = 200;
+    NSUInteger myAttributeId = 300;
+    NSUInteger myMinInterval = 5;
+    NSUInteger myMaxInterval = 60;
+    __block NSDictionary * myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:123456], @"value", nil],
+        @"data", nil];
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
+    __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Report sent"];
+
+    __auto_type uuid = self.controllerUUID;
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
+        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual(endpointId, myEndpointId);
+        XCTAssertEqual(clusterId, myClusterId);
+        XCTAssertEqual(attributeId, 0xffffffff);
+        XCTAssertEqual(minInterval, myMinInterval);
+        XCTAssertEqual(maxInterval, myMaxInterval);
+        [callExpectation fulfill];
+        establishedHandler();
+    };
+
+    _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Subscribing...");
+                                  [device subscribeAttributeWithEndpointId:myEndpointId
+                                      clusterId:myClusterId
+                                      attributeId:0xffffffff
+                                      minInterval:myMinInterval
+                                      maxInterval:myMaxInterval
+                                      clientQueue:dispatch_get_main_queue()
+                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
+                                          NSLog(@"Report value: %@", value);
+                                          XCTAssertNotNil(value);
+                                          XCTAssertNil(error);
+                                          XCTAssertTrue([myReport isEqualTo:value]);
+                                          [reportExpectation fulfill];
+                                      }
+                                      subscriptionEstablished:^{
+                                          [establishExpectation fulfill];
+                                      }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // Inject report
+    id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Inject another report
+    reportExpectation = [self expectationWithDescription:@"2nd report sent"];
+    myReport = [NSDictionary
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
+        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
+        @"attributeId",
+        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
+        @"data", nil];
+    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Deregister report handler
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  NSLog(@"Device acquired. Deregistering...");
+                                  [device deregisterReportHandlersWithClientQueue:dispatch_get_main_queue()
+                                                                       completion:^{
+                                                                           NSLog(@"Deregistered");
+                                                                       }];
+                              }];
+
+    // Wait for disconnection
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testMutiSubscriptions
+{
+    uint64_t nodeIds[] = { 9876543210, 9876543211 };
+    NSUInteger endpointIds[] = { 100, 150 };
+    NSUInteger clusterIds[] = { 200, 250 };
+    NSUInteger attributeIds[] = { 300, 350 };
+    NSUInteger minIntervals[] = { 5, 7 };
+    NSUInteger maxIntervals[] = { 60, 68 };
+    __block uint64_t myNodeId = nodeIds[0];
+    __block NSUInteger myEndpointId = endpointIds[0];
+    __block NSUInteger myClusterId = clusterIds[0];
+    __block NSUInteger myAttributeId = attributeIds[0];
+    __block NSUInteger myMinInterval = minIntervals[0];
+    __block NSUInteger myMaxInterval = maxIntervals[0];
+    __block NSArray<NSDictionary *> * myReports;
+    __block XCTestExpectation * callExpectation;
+    __block XCTestExpectation * establishExpectation;
+    __block NSArray<XCTestExpectation *> * reportExpectations;
+
+    __auto_type uuid = self.controllerUUID;
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
+        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual(endpointId, myEndpointId);
+        XCTAssertEqual(clusterId, myClusterId);
+        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertEqual(minInterval, myMinInterval);
+        XCTAssertEqual(maxInterval, myMaxInterval);
+        [callExpectation fulfill];
+        establishedHandler();
+    };
+
+    _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
+
+    // Multi-subscriptions
+    for (int i = 0; i < 2; i++) {
+        myNodeId = nodeIds[i];
+        myEndpointId = endpointIds[i];
+        myClusterId = clusterIds[i];
+        myAttributeId = attributeIds[i];
+        myMinInterval = minIntervals[i];
+        myMaxInterval = maxIntervals[i];
+        callExpectation = [self expectationWithDescription:[NSString stringWithFormat:@"XPC call (%d) received", i]];
+        establishExpectation = [self expectationWithDescription:[NSString stringWithFormat:@"Established (%d) called", i]];
+        [_remoteDeviceController
+            getConnectedDevice:myNodeId
+                         queue:dispatch_get_main_queue()
+             completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                 XCTAssertNotNil(device);
+                 XCTAssertNil(error);
+                 NSLog(@"Device acquired. Subscribing...");
+                 [device subscribeAttributeWithEndpointId:myEndpointId
+                     clusterId:myClusterId
+                     attributeId:myAttributeId
+                     minInterval:myMinInterval
+                     maxInterval:myMaxInterval
+                     clientQueue:dispatch_get_main_queue()
+                     reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
+                         NSLog(@"Subscriber [%d] report value: %@", i, value);
+                         XCTAssertNotNil(value);
+                         XCTAssertNil(error);
+                         XCTAssertTrue([myReports[i] isEqualTo:value]);
+                         [reportExpectations[i] fulfill];
+                     }
+                     subscriptionEstablished:^{
+                         [establishExpectation fulfill];
+                     }];
+             }];
+
+        [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
+    }
+
+    id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
+
+    // Inject reports
+    for (int count = 0; count < 2; count++) {
+        reportExpectations = [NSArray
+            arrayWithObjects:[self expectationWithDescription:[NSString
+                                                                  stringWithFormat:@"Report(%d) for first subscriber sent", count]],
+            [self expectationWithDescription:[NSString stringWithFormat:@"Report(%d) for second subscriber sent", count]], nil];
+        myReports = [NSArray
+            arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:endpointIds[0]],
+                                           @"endpointId", [NSNumber numberWithUnsignedInteger:clusterIds[0]], @"clusterId",
+                                           [NSNumber numberWithUnsignedInteger:attributeIds[0]], @"attributeId",
+                                           [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
+                                                         [NSNumber numberWithInteger:123456 + count * 100], @"value", nil],
+                                           @"data", nil],
+            [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:endpointIds[1]], @"endpointId",
+                          [NSNumber numberWithUnsignedInteger:clusterIds[1]], @"clusterId",
+                          [NSNumber numberWithUnsignedInteger:attributeIds[1]], @"attributeId",
+                          [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
+                                        [NSNumber numberWithInteger:123457 + count * 100], @"value", nil],
+                          @"data", nil],
+            nil];
+        for (int i = 0; i < 2; i++) {
+            NSUInteger nodeId = nodeIds[i];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [clientObject handleReportWithController:uuid nodeId:nodeId value:myReports[i] error:nil];
+            });
+        }
+        [self waitForExpectations:reportExpectations timeout:kTimeoutInSeconds];
+    }
+
+    // Deregister report handler for first subscriber
+    __auto_type deregisterExpectation = [self expectationWithDescription:@"First subscriber deregistered"];
+    [_remoteDeviceController getConnectedDevice:nodeIds[0]
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  NSLog(@"Device acquired. Deregistering...");
+                                  [device deregisterReportHandlersWithClientQueue:dispatch_get_main_queue()
+                                                                       completion:^{
+                                                                           NSLog(@"Deregistered");
+                                                                           [deregisterExpectation fulfill];
+                                                                       }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObject:deregisterExpectation] timeout:kTimeoutInSeconds];
+
+    // Inject reports
+    for (int count = 0; count < 1; count++) {
+        reportExpectations = [NSArray
+            arrayWithObjects:[self expectationWithDescription:[NSString
+                                                                  stringWithFormat:@"Report(%d) for first subscriber sent", count]],
+            [self expectationWithDescription:[NSString stringWithFormat:@"Report(%d) for second subscriber sent", count]], nil];
+        reportExpectations[0].inverted = YES;
+        myReports = [NSArray
+            arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:endpointIds[0]],
+                                           @"endpointId", [NSNumber numberWithUnsignedInteger:clusterIds[0]], @"clusterId",
+                                           [NSNumber numberWithUnsignedInteger:attributeIds[0]], @"attributeId",
+                                           [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
+                                                         [NSNumber numberWithInteger:223456 + count * 100], @"value", nil],
+                                           @"data", nil],
+            [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:endpointIds[1]], @"endpointId",
+                          [NSNumber numberWithUnsignedInteger:clusterIds[1]], @"clusterId",
+                          [NSNumber numberWithUnsignedInteger:attributeIds[1]], @"attributeId",
+                          [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
+                                        [NSNumber numberWithInteger:223457 + count * 100], @"value", nil],
+                          @"data", nil],
+            nil];
+        for (int i = 0; i < 2; i++) {
+            NSUInteger nodeId = nodeIds[i];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [clientObject handleReportWithController:uuid nodeId:nodeId value:myReports[i] error:nil];
+            });
+        }
+        [self waitForExpectations:reportExpectations timeout:kTimeoutInSeconds];
+    }
+
+    // Deregister report handler for second subscriber
+    __auto_type secondDeregisterExpectation = [self expectationWithDescription:@"Second subscriber deregistered"];
+    [_remoteDeviceController getConnectedDevice:nodeIds[1]
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  NSLog(@"Device acquired. Deregistering...");
+                                  [device deregisterReportHandlersWithClientQueue:dispatch_get_main_queue()
+                                                                       completion:^{
+                                                                           NSLog(@"Deregistered");
+                                                                           [secondDeregisterExpectation fulfill];
+                                                                       }];
+                              }];
+
+    // Wait for deregistration and disconnection
+    [self waitForExpectations:[NSArray arrayWithObjects:secondDeregisterExpectation, _xpcDisconnectExpectation, nil]
+                      timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+
+    // Inject reports
+    for (int count = 0; count < 1; count++) {
+        reportExpectations = [NSArray
+            arrayWithObjects:[self expectationWithDescription:[NSString
+                                                                  stringWithFormat:@"Report(%d) for first subscriber sent", count]],
+            [self expectationWithDescription:[NSString stringWithFormat:@"Report(%d) for second subscriber sent", count]], nil];
+        reportExpectations[0].inverted = YES;
+        reportExpectations[1].inverted = YES;
+        myReports = [NSArray
+            arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:endpointIds[0]],
+                                           @"endpointId", [NSNumber numberWithUnsignedInteger:clusterIds[0]], @"clusterId",
+                                           [NSNumber numberWithUnsignedInteger:attributeIds[0]], @"attributeId",
+                                           [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
+                                                         [NSNumber numberWithInteger:223456 + count * 100], @"value", nil],
+                                           @"data", nil],
+            [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:endpointIds[1]], @"endpointId",
+                          [NSNumber numberWithUnsignedInteger:clusterIds[1]], @"clusterId",
+                          [NSNumber numberWithUnsignedInteger:attributeIds[1]], @"attributeId",
+                          [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
+                                        [NSNumber numberWithInteger:223457 + count * 100], @"value", nil],
+                          @"data", nil],
+            nil];
+        for (int i = 0; i < 2; i++) {
+            NSUInteger nodeId = nodeIds[i];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [clientObject handleReportWithController:uuid nodeId:nodeId value:myReports[i] error:nil];
+            });
+        }
+        [self waitForExpectations:reportExpectations timeout:kNegativeTimeoutInSeconds];
+    }
+}
+
+- (void)testAnySharedRemoteController
+{
+    NSString * myUUID = [[NSUUID UUID] UUIDString];
+    uint64_t myNodeId = 9876543210;
+
+    __auto_type unspecifiedRemoteDeviceController =
+        [CHIPDeviceController sharedControllerWithId:nil
+                                     xpcConnectBlock:^NSXPCConnection * {
+                                         return [[NSXPCConnection alloc] initWithListenerEndpoint:self.xpcListener.endpoint];
+                                     }];
+
+    __auto_type anySharedRemoteControllerCallExpectation =
+        [self expectationWithDescription:@"getAnySharedRemoteController was called"];
+    _handleGetAnySharedRemoteController = ^(void (^completion)(id _Nullable controller, NSError * _Nullable error)) {
+        completion(myUUID, nil);
+        [anySharedRemoteControllerCallExpectation fulfill];
+    };
+
+    __auto_type deviceAcquired = [self expectationWithDescription:@"Connected device was acquired"];
+    [unspecifiedRemoteDeviceController getConnectedDevice:myNodeId
+                                                    queue:dispatch_get_main_queue()
+                                        completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                            XCTAssertNotNil(device);
+                                            XCTAssertNil(error);
+                                            [deviceAcquired fulfill];
+                                        }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:anySharedRemoteControllerCallExpectation, deviceAcquired, nil]
+                      timeout:kTimeoutInSeconds];
+}
+
+@end


### PR DESCRIPTION
Also add CHIPRemoteDeviceController to get CHIPDevice object
executing over XPC interface.

#### Problem
* Add support for interactions with generic attribute/command path and generic data type
* Add support for remote controller device access through XPC.

#### Change overview
* CHIPDevice added new methods to read/write/subscribe attribute and invoke command with generic path
* CHIPRemoveDeviceController object was added to retrieve a CHIPDevice object to interface through XPC.

#### Testing
How was this tested? (at least one bullet point required)
* Integration tests were added to test new CHIPDevice methods.
* Unit tests were added to test all data types of CHIPDevice.
* Unit tests were added to test XPC interface of the CHIPDevice object obtained through CHIPRemoteDeviceController.
* No integration test of XPC interface is included in this PR because remote object implementation is out of scope of the CHIP Framework.