### PR TITLE
Fix ZAP variable lookups to not mis-treat non-strings as variable names.

### DIFF
--- a/examples/chip-tool/templates/partials/test_cluster_command_value.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster_command_value.zapt
@@ -10,6 +10,7 @@
   {{/if}}
 {{else if isArray}}
 
+  {{ensureIsArray definedValue~}}
   {{! forceNotList=true because we really want the type of a single item here.
       Similarly, forceNotOptional=true and forceNotNullable=true because we
       have accounted for those already. }}

--- a/examples/chip-tool/templates/partials/test_cluster_value_equals.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster_value_equals.zapt
@@ -21,6 +21,7 @@
     {{/if}}
   {{/if}}
 {{else if isArray}}
+    {{ensureIsArray expected~}}
     {
       auto iter_{{depth}} = {{actual}}.begin();
       {{#each expected}}

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -518,6 +518,12 @@ function chip_tests_items(options)
 
 function getVariable(context, key, name)
 {
+  if (!(typeof name == "string" || (typeof name == "object" && (name instanceof String)))) {
+    // Non-string key; don't try to look it up.  Could end up looking like a
+    // variable name by accident when stringified.
+    return null;
+  }
+
   while (!('variables' in context) && context.parent) {
     context = context.parent;
   }
@@ -756,6 +762,15 @@ function if_include_struct_item_value(structValue, name, options)
   return options.inverse(this);
 }
 
+// To be used to verify that things are actually arrays before trying to use
+// #each with them, since that silently treats non-arrays as empty arrays.
+function ensureIsArray(value, options)
+{
+  if (!(value instanceof Array)) {
+    printErrorAndExit(this, `Expected array but instead got ${typeof value}: ${JSON.stringify(value)}\n`);
+  }
+}
+
 //
 // Module exports
 //
@@ -775,3 +790,4 @@ exports.isTestOnlyCluster                   = isTestOnlyCluster;
 exports.isLiteralNull                       = isLiteralNull;
 exports.octetStringEscapedForCLiteral       = octetStringEscapedForCLiteral;
 exports.if_include_struct_item_value        = if_include_struct_item_value;
+exports.ensureIsArray                       = ensureIsArray;

--- a/src/darwin/Framework/CHIP/templates/partials/check_test_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/check_test_value.zapt
@@ -19,6 +19,7 @@
     {{/if}}
   {{/if}}
 {{else if isArray}}
+    {{ensureIsArray expected~}}
     XCTAssertEqual([{{actual}} count], {{expected.length}});
     {{#each expected}}
       {{>check_test_value actual=(concat ../actual "[" @index "]") expected=this cluster=../cluster isArray=false type=../type parent=../parent}}

--- a/src/darwin/Framework/CHIP/templates/partials/test_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_value.zapt
@@ -11,6 +11,7 @@
     {{>test_value target=target definedValue=definedValue cluster=cluster isNullable=false depth=(incrementDepth depth)}}
   {{/if}}
 {{else if isArray}}
+  {{ensureIsArray definedValue~}}
   {
     NSMutableArray * temp_{{depth}} = [[NSMutableArray alloc] init];
     {{#each definedValue}}


### PR DESCRIPTION
[nodeId] was being treated as a lookup of the nodeId varible and
ending up with a number, not an array containing a number.  Which
silently got treated as empty array!

Also adds sanity-checking so that "treat non-array as empty array"
silent thing does not happen anymore.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Tried using `[nodeId]` in a value to send and it worked as it should.  @mlepage-google will exercise this in YAML for ACLs.