### PR TITLE
Add ZAP helper for detecting fabric-scoped structs.

### DIFF
--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -834,6 +834,25 @@ async function zcl_commands_that_need_timed_invoke(options)
   return templateUtil.collectBlocks(commands, options, this);
 }
 
+// Allows conditioning generation on whether the given type is a fabric-scoped
+// struct.
+async function if_is_fabric_scoped_struct(type, options)
+{
+  let packageId = await templateUtil.ensureZclPackageId(this);
+  let st        = await zclQuery.selectStructByName(this.global.db, type, packageId);
+
+  if (st) {
+    // TODO: Should know whether a struct is fabric-scoped without sniffing its
+    // members.
+    let fields = await zclQuery.selectAllStructItemsById(this.global.db, st.id);
+    if (fields.find((i) => i.type.toLowerCase() == "fabric_idx")) {
+      return options.fn(this);
+    }
+  }
+
+  return options.inverse(this);
+}
+
 //
 // Module exports
 //
@@ -857,3 +876,4 @@ exports.getPythonFieldDefault                 = getPythonFieldDefault;
 exports.incrementDepth                        = incrementDepth;
 exports.zcl_events_fields_by_event_name       = zcl_events_fields_by_event_name;
 exports.zcl_commands_that_need_timed_invoke   = zcl_commands_that_need_timed_invoke;
+exports.if_is_fabric_scoped_struct            = if_is_fabric_scoped_struct


### PR DESCRIPTION
We want to condition some codegen on whether a type is a fabric-scoped
struct.

#### Problem
Can't do special fabric-y things for fabric-scoped stuff easily in codegen.

#### Change overview
Add a way to do it ... if not easily, then at least somewhat.

#### Testing
Checked that if I do this for event fields it catches just the ACL event bits that use fabric-scoped structs.