### PR TITLE
Send OnSessionEstablishmentError if pairing in progress during shutdown

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -664,6 +664,14 @@ CHIP_ERROR DeviceCommissioner::Shutdown()
 
     ChipLogDetail(Controller, "Shutting down the commissioner");
 
+    // Check to see if pairing in progress before shutting down
+    CommissioneeDeviceProxy * device = mDeviceBeingCommissioned;
+    if (device->IsSessionSetupInProgress())
+    {
+        ChipLogDetail(Controller, "Setup in progress, stopping setup before shutting down");
+        OnSessionEstablishmentError(CHIP_ERROR_CONNECTION_ABORTED);
+    }
+
     mSystemState->SessionMgr()->UnregisterRecoveryDelegate(*this);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY // make this commissioner discoverable

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -666,7 +666,7 @@ CHIP_ERROR DeviceCommissioner::Shutdown()
 
     // Check to see if pairing in progress before shutting down
     CommissioneeDeviceProxy * device = mDeviceBeingCommissioned;
-    if (device->IsSessionSetupInProgress())
+    if (device != nullptr && device->IsSessionSetupInProgress())
     {
         ChipLogDetail(Controller, "Setup in progress, stopping setup before shutting down");
         OnSessionEstablishmentError(CHIP_ERROR_CONNECTION_ABORTED);


### PR DESCRIPTION
#### Problem
What is being fixed?
* Fix SIGABRT due to pairing being in-progress when Shutdown() is called
 
#### Change overview
During Commissioner's Shutdown, if session setup is in-progress, call an OnSessionEstablishmentError to clean up the ContextExchange prior to continuing shutdown. Otherwise, the pairing exchange will remain inside ExchangeMgr's mContextPool and signal SIGABRT.

#### Testing
How was this tested? (at least one bullet point required)
* Manual testing, using ESP32, tested manually, calling Shutdown() during session establishment with no devices in pairing mode present.
