### PR TITLE
Issue 14864 - DelayedActionTime field in Query Image Response defaults to 120 seconds for OTA-P Linux app when status is Busy/NotAvailable

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -51,7 +51,6 @@ using namespace chip::app::Clusters::OtaSoftwareUpdateProvider::Commands;
 constexpr uint8_t kUpdateTokenLen            = 32;                      // must be between 8 and 32
 constexpr uint8_t kUpdateTokenStrLen         = kUpdateTokenLen * 2 + 1; // Hex string needs 2 hex chars for every byte
 constexpr size_t kUriMaxLen                  = 256;
-constexpr uint32_t kMinimumDelayedActionTime = 120; // Spec mentions delayed action time should be at least 120 seconds
 
 // Arbitrary BDX Transfer Params
 constexpr uint32_t kMaxBdxBlockSize                 = 1024;
@@ -210,13 +209,11 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
 
             case UserConsentState::kObtaining:
                 queryStatus          = OTAQueryStatus::kBusy;
-                delayedActionTimeSec = std::max(kMinimumDelayedActionTime, delayedActionTimeSec);
                 break;
 
             case UserConsentState::kDenied:
             case UserConsentState::kUnknown:
                 queryStatus          = OTAQueryStatus::kNotAvailable;
-                delayedActionTimeSec = std::max(kMinimumDelayedActionTime, delayedActionTimeSec);
                 break;
             }
         }
@@ -228,17 +225,14 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
 
     case kRespondWithBusy:
         queryStatus          = OTAQueryStatus::kBusy;
-        delayedActionTimeSec = std::max(kMinimumDelayedActionTime, delayedActionTimeSec);
         break;
 
     case kRespondWithNotAvailable:
         queryStatus          = OTAQueryStatus::kNotAvailable;
-        delayedActionTimeSec = std::max(kMinimumDelayedActionTime, delayedActionTimeSec);
         break;
 
     default:
         queryStatus          = OTAQueryStatus::kNotAvailable;
-        delayedActionTimeSec = std::max(kMinimumDelayedActionTime, delayedActionTimeSec);
         break;
     }
 

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -48,9 +48,9 @@ using namespace chip::ota;
 using namespace chip::app::Clusters::OtaSoftwareUpdateProvider;
 using namespace chip::app::Clusters::OtaSoftwareUpdateProvider::Commands;
 
-constexpr uint8_t kUpdateTokenLen            = 32;                      // must be between 8 and 32
-constexpr uint8_t kUpdateTokenStrLen         = kUpdateTokenLen * 2 + 1; // Hex string needs 2 hex chars for every byte
-constexpr size_t kUriMaxLen                  = 256;
+constexpr uint8_t kUpdateTokenLen    = 32;                      // must be between 8 and 32
+constexpr uint8_t kUpdateTokenStrLen = kUpdateTokenLen * 2 + 1; // Hex string needs 2 hex chars for every byte
+constexpr size_t kUriMaxLen          = 256;
 
 // Arbitrary BDX Transfer Params
 constexpr uint32_t kMaxBdxBlockSize                 = 1024;
@@ -208,12 +208,12 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
                 break;
 
             case UserConsentState::kObtaining:
-                queryStatus          = OTAQueryStatus::kBusy;
+                queryStatus = OTAQueryStatus::kBusy;
                 break;
 
             case UserConsentState::kDenied:
             case UserConsentState::kUnknown:
-                queryStatus          = OTAQueryStatus::kNotAvailable;
+                queryStatus = OTAQueryStatus::kNotAvailable;
                 break;
             }
         }
@@ -224,15 +224,15 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
         break;
 
     case kRespondWithBusy:
-        queryStatus          = OTAQueryStatus::kBusy;
+        queryStatus = OTAQueryStatus::kBusy;
         break;
 
     case kRespondWithNotAvailable:
-        queryStatus          = OTAQueryStatus::kNotAvailable;
+        queryStatus = OTAQueryStatus::kNotAvailable;
         break;
 
     default:
-        queryStatus          = OTAQueryStatus::kNotAvailable;
+        queryStatus = OTAQueryStatus::kNotAvailable;
         break;
     }
 

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -44,7 +44,7 @@ using bdx::TransferSession;
 // Global instance of the OTARequestorInterface.
 OTARequestorInterface * globalOTARequestorInstance = nullptr;
 
-constexpr uint32_t kImmediateStartDelayMs = 1; // Start the timer with this value when starting OTA "immediately"
+constexpr uint32_t kImmediateStartDelayMs    = 1;   // Start the timer with this value when starting OTA "immediately"
 constexpr uint32_t kMinimumDelayedActionTime = 120; // Spec mentions delayed action time should be at least 120 seconds
 
 static void LogQueryImageResponse(const QueryImageResponse::DecodableType & response)
@@ -150,20 +150,23 @@ void OTARequestor::OnQueryImageResponse(void * context, const QueryImageResponse
             ChipLogDetail(SoftwareUpdate, "Version %" PRIu32 " is older or same than current version %" PRIu32 ", not updating",
                           update.softwareVersion, requestorCore->mCurrentVersion);
 
-            requestorCore->mOtaRequestorDriver->UpdateNotFound(UpdateNotFoundReason::UpToDate,
-                                                               System::Clock::Seconds32(std::max(kMinimumDelayedActionTime, response.delayedActionTime.ValueOr(0))));
+            requestorCore->mOtaRequestorDriver->UpdateNotFound(
+                UpdateNotFoundReason::UpToDate,
+                System::Clock::Seconds32(std::max(kMinimumDelayedActionTime, response.delayedActionTime.ValueOr(0))));
         }
 
         break;
     }
     case OTAQueryStatus::kBusy:
-        requestorCore->mOtaRequestorDriver->UpdateNotFound(UpdateNotFoundReason::Busy,
-                                                           System::Clock::Seconds32(std::max(kMinimumDelayedActionTime, response.delayedActionTime.ValueOr(0))));
+        requestorCore->mOtaRequestorDriver->UpdateNotFound(
+            UpdateNotFoundReason::Busy,
+            System::Clock::Seconds32(std::max(kMinimumDelayedActionTime, response.delayedActionTime.ValueOr(0))));
         requestorCore->RecordNewUpdateState(OTAUpdateStateEnum::kDelayedOnQuery, OTAChangeReasonEnum::kDelayByProvider);
         break;
     case OTAQueryStatus::kNotAvailable:
-        requestorCore->mOtaRequestorDriver->UpdateNotFound(UpdateNotFoundReason::NotAvailable,
-                                                           System::Clock::Seconds32(std::max(kMinimumDelayedActionTime, response.delayedActionTime.ValueOr(0))));
+        requestorCore->mOtaRequestorDriver->UpdateNotFound(
+            UpdateNotFoundReason::NotAvailable,
+            System::Clock::Seconds32(std::max(kMinimumDelayedActionTime, response.delayedActionTime.ValueOr(0))));
         requestorCore->RecordNewUpdateState(OTAUpdateStateEnum::kIdle, OTAChangeReasonEnum::kSuccess);
         break;
     default:
@@ -194,7 +197,8 @@ void OTARequestor::OnApplyUpdateResponse(void * context, const ApplyUpdateRespon
         requestorCore->mOtaRequestorDriver->UpdateConfirmed(System::Clock::Seconds32(response.delayedActionTime));
         break;
     case OTAApplyUpdateAction::kAwaitNextAction:
-        requestorCore->mOtaRequestorDriver->UpdateSuspended(System::Clock::Seconds32(std::max(kMinimumDelayedActionTime, response.delayedActionTime)));
+        requestorCore->mOtaRequestorDriver->UpdateSuspended(
+            System::Clock::Seconds32(std::max(kMinimumDelayedActionTime, response.delayedActionTime)));
         requestorCore->RecordNewUpdateState(OTAUpdateStateEnum::kDelayedOnApply, OTAChangeReasonEnum::kDelayByProvider);
         break;
     case OTAApplyUpdateAction::kDiscontinue:

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -44,8 +44,7 @@ using bdx::TransferSession;
 // Global instance of the OTARequestorInterface.
 OTARequestorInterface * globalOTARequestorInstance = nullptr;
 
-constexpr uint32_t kImmediateStartDelayMs    = 1;   // Start the timer with this value when starting OTA "immediately"
-constexpr uint32_t kMinimumDelayedActionTime = 120; // Spec mentions delayed action time should be at least 120 seconds
+constexpr uint32_t kImmediateStartDelayMs = 1; // Start the timer with this value when starting OTA "immediately"
 
 static void LogQueryImageResponse(const QueryImageResponse::DecodableType & response)
 {
@@ -150,23 +149,20 @@ void OTARequestor::OnQueryImageResponse(void * context, const QueryImageResponse
             ChipLogDetail(SoftwareUpdate, "Version %" PRIu32 " is older or same than current version %" PRIu32 ", not updating",
                           update.softwareVersion, requestorCore->mCurrentVersion);
 
-            requestorCore->mOtaRequestorDriver->UpdateNotFound(
-                UpdateNotFoundReason::UpToDate,
-                System::Clock::Seconds32(std::max(kMinimumDelayedActionTime, response.delayedActionTime.ValueOr(0))));
+            requestorCore->mOtaRequestorDriver->UpdateNotFound(UpdateNotFoundReason::UpToDate,
+                                                               System::Clock::Seconds32(response.delayedActionTime.ValueOr(0)));
         }
 
         break;
     }
     case OTAQueryStatus::kBusy:
-        requestorCore->mOtaRequestorDriver->UpdateNotFound(
-            UpdateNotFoundReason::Busy,
-            System::Clock::Seconds32(std::max(kMinimumDelayedActionTime, response.delayedActionTime.ValueOr(0))));
+        requestorCore->mOtaRequestorDriver->UpdateNotFound(UpdateNotFoundReason::Busy,
+                                                           System::Clock::Seconds32(response.delayedActionTime.ValueOr(0)));
         requestorCore->RecordNewUpdateState(OTAUpdateStateEnum::kDelayedOnQuery, OTAChangeReasonEnum::kDelayByProvider);
         break;
     case OTAQueryStatus::kNotAvailable:
-        requestorCore->mOtaRequestorDriver->UpdateNotFound(
-            UpdateNotFoundReason::NotAvailable,
-            System::Clock::Seconds32(std::max(kMinimumDelayedActionTime, response.delayedActionTime.ValueOr(0))));
+        requestorCore->mOtaRequestorDriver->UpdateNotFound(UpdateNotFoundReason::NotAvailable,
+                                                           System::Clock::Seconds32(response.delayedActionTime.ValueOr(0)));
         requestorCore->RecordNewUpdateState(OTAUpdateStateEnum::kIdle, OTAChangeReasonEnum::kSuccess);
         break;
     default:
@@ -197,8 +193,7 @@ void OTARequestor::OnApplyUpdateResponse(void * context, const ApplyUpdateRespon
         requestorCore->mOtaRequestorDriver->UpdateConfirmed(System::Clock::Seconds32(response.delayedActionTime));
         break;
     case OTAApplyUpdateAction::kAwaitNextAction:
-        requestorCore->mOtaRequestorDriver->UpdateSuspended(
-            System::Clock::Seconds32(std::max(kMinimumDelayedActionTime, response.delayedActionTime)));
+        requestorCore->mOtaRequestorDriver->UpdateSuspended(System::Clock::Seconds32(response.delayedActionTime));
         requestorCore->RecordNewUpdateState(OTAUpdateStateEnum::kDelayedOnApply, OTAChangeReasonEnum::kDelayByProvider);
         break;
     case OTAApplyUpdateAction::kDiscontinue:


### PR DESCRIPTION
#### Problem
When using CLI option to set `DelayedActionTime` field (-t) to anything less than 120 seconds with status Busy/NotAvailable, OTA-P Linux app defaults it to 120 seconds.

Fixes: https://github.com/project-chip/connectedhomeip/issues/14864

#### Change overview
- Update OTA-P Linux app to send the actual `DelayedActionTime` value passed in via `-t `command line argument in the responses.  OTA-R already takes care of using the maximum of `DelayedActionTime`  and 120 seconds.

#### Testing
- Verified above combinations of logic with OTA-P and OTA-R Linux apps to ensure the responses contain the actual CLI argument passed in for `DelayedActionTime`.
- Verified OTA-R Linux app uses the maximum of `DelayedActionTime` from OTA-P responses and 120 seconds in above scenarios.

