### PR TITLE
fix mdns leak on android

### DIFF
--- a/src/platform/android/java/chip/platform/NsdManagerServiceResolver.java
+++ b/src/platform/android/java/chip/platform/NsdManagerServiceResolver.java
@@ -183,9 +183,7 @@ public class NsdManagerServiceResolver implements ServiceResolver {
     registrationListeners.add(registrationListener);
 
     nsdManager.registerService(serviceInfo, NsdManager.PROTOCOL_DNS_SD, registrationListener);
-    Log.d(
-        TAG,
-        "publish " + registrationListener + " count = " + registrationListeners.size());
+    Log.d(TAG, "publish " + registrationListener + " count = " + registrationListeners.size());
   }
 
   @Override

--- a/src/platform/android/java/chip/platform/NsdManagerServiceResolver.java
+++ b/src/platform/android/java/chip/platform/NsdManagerServiceResolver.java
@@ -185,7 +185,7 @@ public class NsdManagerServiceResolver implements ServiceResolver {
     nsdManager.registerService(serviceInfo, NsdManager.PROTOCOL_DNS_SD, registrationListener);
     Log.d(
         TAG,
-        "publish " + registrationListener + " count = " + registrationListeners.stream().count());
+        "publish " + registrationListener + " count = " + registrationListeners.size());
   }
 
   @Override
@@ -193,11 +193,7 @@ public class NsdManagerServiceResolver implements ServiceResolver {
     Log.d(TAG, "removeServices: ");
     for (NsdManager.RegistrationListener l : registrationListeners) {
       Log.i(TAG, "Remove " + l);
-      try {
-        nsdManager.unregisterService(l);
-      } catch (Exception exception) {
-        Log.e(TAG, "removeServices: error = " + exception.getMessage());
-      }
+      nsdManager.unregisterService(l);
     }
     registrationListeners.clear();
   }

--- a/src/platform/android/java/chip/platform/NsdManagerServiceResolver.java
+++ b/src/platform/android/java/chip/platform/NsdManagerServiceResolver.java
@@ -168,31 +168,37 @@ public class NsdManagerServiceResolver implements ServiceResolver {
 
           @Override
           public void onServiceRegistered(NsdServiceInfo serviceInfo) {
-            Log.i(TAG, "service " + serviceInfo.getServiceName() + "(" + this + ") onServiceRegistered");
+            Log.i(
+                TAG,
+                "service " + serviceInfo.getServiceName() + "(" + this + ") onServiceRegistered");
           }
 
           @Override
           public void onServiceUnregistered(NsdServiceInfo serviceInfo) {
-            Log.i(TAG, "service " + serviceInfo.getServiceName() + "(" + this + ") onServiceUnregistered");
+            Log.i(
+                TAG,
+                "service " + serviceInfo.getServiceName() + "(" + this + ") onServiceUnregistered");
           }
         };
     registrationListeners.add(registrationListener);
 
     nsdManager.registerService(serviceInfo, NsdManager.PROTOCOL_DNS_SD, registrationListener);
-    Log.d(TAG, "publish " + registrationListener + " count = " + registrationListeners.stream().count());
+    Log.d(
+        TAG,
+        "publish " + registrationListener + " count = " + registrationListeners.stream().count());
   }
 
   @Override
   public void removeServices() {
-      Log.d(TAG, "removeServices: ");
-      for (NsdManager.RegistrationListener l : registrationListeners) {
-          Log.i(TAG, "Remove " + l);
-          try {
-              nsdManager.unregisterService(l);
-          } catch (Exception exception) {
-              Log.e(TAG, "removeServices: error = " + exception.getMessage());
-          }
+    Log.d(TAG, "removeServices: ");
+    for (NsdManager.RegistrationListener l : registrationListeners) {
+      Log.i(TAG, "Remove " + l);
+      try {
+        nsdManager.unregisterService(l);
+      } catch (Exception exception) {
+        Log.e(TAG, "removeServices: error = " + exception.getMessage());
       }
-      registrationListeners.clear();
+    }
+    registrationListeners.clear();
   }
 }

--- a/src/platform/android/java/chip/platform/NsdManagerServiceResolver.java
+++ b/src/platform/android/java/chip/platform/NsdManagerServiceResolver.java
@@ -168,23 +168,31 @@ public class NsdManagerServiceResolver implements ServiceResolver {
 
           @Override
           public void onServiceRegistered(NsdServiceInfo serviceInfo) {
-            Log.i(TAG, "service " + serviceInfo.getServiceName() + " onServiceRegistered");
+            Log.i(TAG, "service " + serviceInfo.getServiceName() + "(" + this + ") onServiceRegistered");
           }
 
           @Override
           public void onServiceUnregistered(NsdServiceInfo serviceInfo) {
-            Log.i(TAG, "service " + serviceInfo.getServiceName() + " onServiceRegistered");
+            Log.i(TAG, "service " + serviceInfo.getServiceName() + "(" + this + ") onServiceUnregistered");
           }
         };
     registrationListeners.add(registrationListener);
 
     nsdManager.registerService(serviceInfo, NsdManager.PROTOCOL_DNS_SD, registrationListener);
+    Log.d(TAG, "publish " + registrationListener + " count = " + registrationListeners.stream().count());
   }
 
   @Override
   public void removeServices() {
-    for (NsdManager.RegistrationListener l : registrationListeners) {
-      nsdManager.unregisterService(l);
-    }
+      Log.d(TAG, "removeServices: ");
+      for (NsdManager.RegistrationListener l : registrationListeners) {
+          Log.i(TAG, "Remove " + l);
+          try {
+              nsdManager.unregisterService(l);
+          } catch (Exception exception) {
+              Log.e(TAG, "removeServices: error = " + exception.getMessage());
+          }
+      }
+      registrationListeners.clear();
   }
 }


### PR DESCRIPTION
#### Problem
* sometimes, mdns service may not be found on Android TV
    * it is because we forget to clear the listeners list in removeServices
    * so next time when we call removeServices again, we will get unregisterService exception, and all other listeners are not unregistered
    * and then we will get listeners leak, until we can not register more and failed to register

#### Change overview
* add registrationListeners.clear(); and catch unregister exception

#### Testing
* chip-tool pairing
