### PR TITLE
Increase cloud build "build all" disk size to 200GB since our build a…

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -42,3 +42,4 @@ artifacts:
 # slow.
 options:
     machineType: "E2_HIGHCPU_32"
+    diskSizeGb: 200


### PR DESCRIPTION
…rtifacts became very large

#### Problem
Cloudbuild 'build all' runs out of storage space with the default build options (100GB storage).

#### Change overview
Increase VM storage to 200GB

#### Testing
Created a manual yaml trigger and checked that the build starts (yaml format is valid). Did not wait for it to run since it takes 2 hours. YAML change seems safe enough.