### PR TITLE
Fix WiFi auto scan stopping - wait for iface proxy

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -448,6 +448,15 @@ void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * source_object,
         mWpaSupplicant.state = GDBusWpaSupplicant::WPA_NOT_CONNECTED;
     }
 
+    // We need to stop auto scan or it will block our network scan.
+    DeviceLayer::SystemLayer().ScheduleLambda([]() {
+        CHIP_ERROR errInner = StopAutoScan();
+        if (errInner != CHIP_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer, "wpa_supplicant: Failed to stop auto scan: %s", ErrorStr(errInner));
+        }
+    });
+
     if (err != nullptr)
         g_error_free(err);
 }
@@ -643,17 +652,6 @@ void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * source_object, GAsyncRe
                         err ? err->message : "unknown error");
         mWpaSupplicant.state = GDBusWpaSupplicant::WPA_NOT_CONNECTED;
     }
-
-    // We need to stop auto scan or it will block our network scan.
-    DeviceLayer::SystemLayer().ScheduleLambda([]() {
-        std::lock_guard<std::mutex> innerLock(mWpaSupplicantMutex);
-        ChipLogDetail(DeviceLayer, "Disabling auto scan");
-        CHIP_ERROR errInner = StopAutoScan();
-        if (errInner != CHIP_NO_ERROR)
-        {
-            ChipLogError(DeviceLayer, "Failed to stop auto scan");
-        }
-    });
 
     if (err != nullptr)
         g_error_free(err);
@@ -1312,9 +1310,14 @@ CHIP_ERROR ConnectivityManagerImpl::GetConnectedNetwork(NetworkCommissioning::Ne
 
 CHIP_ERROR ConnectivityManagerImpl::StopAutoScan()
 {
-    std::unique_ptr<GError, GErrorDeleter> err;
+    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+    VerifyOrReturnError(mWpaSupplicant.iface != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    std::unique_ptr<GError, GErrorDeleter> err;
     gboolean result;
+
+    ChipLogDetail(DeviceLayer, "wpa_supplicant: disabling auto scan");
+
     result = wpa_fi_w1_wpa_supplicant1_interface_call_auto_scan_sync(
         mWpaSupplicant.iface, "" /* empty string means disabling auto scan */, nullptr, &MakeUniquePointerReceiver(err).Get());
     if (!result)


### PR DESCRIPTION
#### Problem

In order to disable WiFi auto scan we need a wpa_supplicant interface proxy to be ready.  The proxy object is created in the _OnWpaInterfaceProxyReady handler. So, the request for stopping auto scan has to be done after this handler has been called. Otherwise, we will see GLib critical assertion.

```
[1645106663.089045][661007:661012] CHIP:DL: Disabling auto scan

(process:661007): GLib-GIO-CRITICAL **: 15:04:23.089: g_dbus_proxy_call_sync_internal: assertion 'G_IS_DBUS_PROXY (proxy)' failed
[1645106663.089161][661007:661012] CHIP:DL: wpa_supplicant: Failed to stop auto network scan: unknown

```

#### Change overview

Scheduling lambda call for stopping auto scan has been moved from _OnWpaProxyReady into the _OnWpaInterfaceProxyReady handler. 

#### Testing

Tests with chip-shell tool with WPA support enabled.