### PR TITLE
[docker] Update nRF Connect SDK version

### DIFF
--- a/integrations/docker/images/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/chip-build-nrf-platform/Dockerfile
@@ -2,7 +2,7 @@ ARG VERSION=latest
 FROM connectedhomeip/chip-build:${VERSION} as build
 
 # Compatible Nordic Connect SDK revision.
-ARG NCS_REVISION=v1.8.0
+ARG NCS_REVISION=v1.9.0
 
 RUN set -x \
     && apt-get update \
@@ -28,7 +28,6 @@ RUN set -x \
 WORKDIR /opt/NordicSemiconductor/nrfconnect
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \
-    cmake==3.21.2 \
     west==0.12.0 \
     && west init -m https://github.com/nrfconnect/sdk-nrf \
     && git -C nrf fetch origin "$NCS_REVISION" \
@@ -60,6 +59,7 @@ COPY --from=build /opt/NordicSemiconductor/nrfconnect/ /opt/NordicSemiconductor/
 RUN set -x \
     # python3-yaml package conflicts with nRF Python requirements
     && (apt-get remove -fy python3-yaml && apt-get autoremove || exit 0) \
+    && python3 -m pip install -U --no-cache-dir cmake==3.22.2 \
     && python3 -m pip install --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/zephyr/scripts/requirements.txt \
     && python3 -m pip install --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/nrf/scripts/requirements.txt \
     && python3 -m pip install --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/bootloader/mcuboot/scripts/requirements.txt \

--- a/integrations/docker/images/chip-build-zap/Dockerfile
+++ b/integrations/docker/images/chip-build-zap/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14
 
 RUN apk add --no-cache \
-  nodejs=14.18.1-r0 \
+  nodejs=14.19.0-r0 \
   openjdk11=11.0.14_p9-r0 \
   npm=7.17.0-r0 \
   python3=3.9.5-r2 \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.55 Version bump reason: [Ameba] Support OTA header
+0.5.56 Version bump reason: Update nRF Connect SDK


### PR DESCRIPTION
#### Problem
New nRF Connect SDK version has been released.

#### Change overview
Use the recently released NCS 1.9.0 in Docker image.
Fix chip-build-zap Dockerfile as well, as it no longer builds.

#### Testing
Built the image locally.
