### PR TITLE
Groups cluster: XML types fixed.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -1553,7 +1553,7 @@ server cluster Groups = 4 {
   }
 
   response struct GetGroupMembershipResponse {
-    INT8U capacity = 0;
+    nullable INT8U capacity = 0;
     group_id groupList[] = 1;
   }
 

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -1526,45 +1526,45 @@ server cluster Groups = 4 {
   readonly global attribute int16u clusterRevision = 65533;
 
   request struct AddGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
     CHAR_STRING groupName = 1;
   }
 
   request struct AddGroupIfIdentifyingRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
     CHAR_STRING groupName = 1;
   }
 
   request struct GetGroupMembershipRequest {
-    INT16U groupList[] = 0;
+    group_id groupList[] = 0;
   }
 
   request struct RemoveGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
   }
 
   request struct ViewGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
   }
 
   response struct AddGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
   }
 
   response struct GetGroupMembershipResponse {
     INT8U capacity = 0;
-    INT16U groupList[] = 1;
+    group_id groupList[] = 1;
   }
 
   response struct RemoveGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
   }
 
   response struct ViewGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
     CHAR_STRING groupName = 2;
   }
 

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -614,25 +614,25 @@ client cluster Groups = 4 {
   readonly global attribute int16u clusterRevision = 65533;
 
   request struct AddGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
     CHAR_STRING groupName = 1;
   }
 
   request struct AddGroupIfIdentifyingRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
     CHAR_STRING groupName = 1;
   }
 
   request struct GetGroupMembershipRequest {
-    INT16U groupList[] = 0;
+    group_id groupList[] = 0;
   }
 
   request struct RemoveGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
   }
 
   request struct ViewGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
   }
 
   command AddGroup(AddGroupRequest): AddGroupResponse = 0;

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -692,45 +692,45 @@ server cluster Groups = 4 {
   readonly global attribute int16u clusterRevision = 65533;
 
   request struct AddGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
     CHAR_STRING groupName = 1;
   }
 
   request struct AddGroupIfIdentifyingRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
     CHAR_STRING groupName = 1;
   }
 
   request struct GetGroupMembershipRequest {
-    INT16U groupList[] = 0;
+    group_id groupList[] = 0;
   }
 
   request struct RemoveGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
   }
 
   request struct ViewGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
   }
 
   response struct AddGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
   }
 
   response struct GetGroupMembershipResponse {
     INT8U capacity = 0;
-    INT16U groupList[] = 1;
+    group_id groupList[] = 1;
   }
 
   response struct RemoveGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
   }
 
   response struct ViewGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
     CHAR_STRING groupName = 2;
   }
 

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -719,7 +719,7 @@ server cluster Groups = 4 {
   }
 
   response struct GetGroupMembershipResponse {
-    INT8U capacity = 0;
+    nullable INT8U capacity = 0;
     group_id groupList[] = 1;
   }
 

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -275,7 +275,7 @@ server cluster Groups = 4 {
   }
 
   response struct GetGroupMembershipResponse {
-    INT8U capacity = 0;
+    nullable INT8U capacity = 0;
     group_id groupList[] = 1;
   }
 

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -248,45 +248,45 @@ server cluster Groups = 4 {
   readonly global attribute int16u clusterRevision = 65533;
 
   request struct AddGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
     CHAR_STRING groupName = 1;
   }
 
   request struct AddGroupIfIdentifyingRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
     CHAR_STRING groupName = 1;
   }
 
   request struct GetGroupMembershipRequest {
-    INT16U groupList[] = 0;
+    group_id groupList[] = 0;
   }
 
   request struct RemoveGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
   }
 
   request struct ViewGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
   }
 
   response struct AddGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
   }
 
   response struct GetGroupMembershipResponse {
     INT8U capacity = 0;
-    INT16U groupList[] = 1;
+    group_id groupList[] = 1;
   }
 
   response struct RemoveGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
   }
 
   response struct ViewGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
     CHAR_STRING groupName = 2;
   }
 

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -275,7 +275,7 @@ server cluster Groups = 4 {
   }
 
   response struct GetGroupMembershipResponse {
-    INT8U capacity = 0;
+    nullable INT8U capacity = 0;
     group_id groupList[] = 1;
   }
 

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -248,45 +248,45 @@ server cluster Groups = 4 {
   readonly global attribute int16u clusterRevision = 65533;
 
   request struct AddGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
     CHAR_STRING groupName = 1;
   }
 
   request struct AddGroupIfIdentifyingRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
     CHAR_STRING groupName = 1;
   }
 
   request struct GetGroupMembershipRequest {
-    INT16U groupList[] = 0;
+    group_id groupList[] = 0;
   }
 
   request struct RemoveGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
   }
 
   request struct ViewGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
   }
 
   response struct AddGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
   }
 
   response struct GetGroupMembershipResponse {
     INT8U capacity = 0;
-    INT16U groupList[] = 1;
+    group_id groupList[] = 1;
   }
 
   response struct RemoveGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
   }
 
   response struct ViewGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
     CHAR_STRING groupName = 2;
   }
 

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -407,45 +407,45 @@ server cluster Groups = 4 {
   readonly global attribute int16u clusterRevision = 65533;
 
   request struct AddGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
     CHAR_STRING groupName = 1;
   }
 
   request struct AddGroupIfIdentifyingRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
     CHAR_STRING groupName = 1;
   }
 
   request struct GetGroupMembershipRequest {
-    INT16U groupList[] = 0;
+    group_id groupList[] = 0;
   }
 
   request struct RemoveGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
   }
 
   request struct ViewGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
   }
 
   response struct AddGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
   }
 
   response struct GetGroupMembershipResponse {
     INT8U capacity = 0;
-    INT16U groupList[] = 1;
+    group_id groupList[] = 1;
   }
 
   response struct RemoveGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
   }
 
   response struct ViewGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
     CHAR_STRING groupName = 2;
   }
 

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -434,7 +434,7 @@ server cluster Groups = 4 {
   }
 
   response struct GetGroupMembershipResponse {
-    INT8U capacity = 0;
+    nullable INT8U capacity = 0;
     group_id groupList[] = 1;
   }
 

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -1408,45 +1408,45 @@ server cluster Groups = 4 {
   readonly global attribute int16u clusterRevision = 65533;
 
   request struct AddGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
     CHAR_STRING groupName = 1;
   }
 
   request struct AddGroupIfIdentifyingRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
     CHAR_STRING groupName = 1;
   }
 
   request struct GetGroupMembershipRequest {
-    INT16U groupList[] = 0;
+    group_id groupList[] = 0;
   }
 
   request struct RemoveGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
   }
 
   request struct ViewGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
   }
 
   response struct AddGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
   }
 
   response struct GetGroupMembershipResponse {
     INT8U capacity = 0;
-    INT16U groupList[] = 1;
+    group_id groupList[] = 1;
   }
 
   response struct RemoveGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
   }
 
   response struct ViewGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
     CHAR_STRING groupName = 2;
   }
 

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -1435,7 +1435,7 @@ server cluster Groups = 4 {
   }
 
   response struct GetGroupMembershipResponse {
-    INT8U capacity = 0;
+    nullable INT8U capacity = 0;
     group_id groupList[] = 1;
   }
 

--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -196,8 +196,8 @@ exit:
 
 struct GroupMembershipResponse
 {
-    // A capacity of 0xFF means that it is unknown if any further groups MAY be added.
-    static constexpr uint8_t kCapacityUnknown = 0xff;
+    // A null capacity means that it is unknown if any further groups MAY be added.
+    const chip::app::DataModel::Nullable<uint8_t> kCapacityUnknown;
 
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
     static constexpr CommandId GetCommandId() { return Commands::GetGroupMembershipResponse::Id; }

--- a/src/app/tests/suites/TestGroupsCluster.yaml
+++ b/src/app/tests/suites/TestGroupsCluster.yaml
@@ -106,7 +106,7 @@ tests:
       response:
           values:
               - name: "capacity"
-                value: 0xff
+                value: null
               - name: "groupList"
                 value: [0x01]
 
@@ -217,7 +217,7 @@ tests:
       response:
           values:
               - name: "capacity"
-                value: 0xff
+                value: null
               - name: "groupList"
                 value: [0x7fff]
 
@@ -333,7 +333,7 @@ tests:
       response:
           values:
               - name: "capacity"
-                value: 0xff
+                value: null
               - name: "groupList"
                 value: [0x01]
 
@@ -388,6 +388,6 @@ tests:
       response:
           values:
               - name: "capacity"
-                value: 0xff
+                value: null
               - name: "groupList"
                 value: []

--- a/src/app/zap-templates/zcl/data-model/silabs/general.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/general.xml
@@ -189,26 +189,26 @@ limitations under the License.
       <description>
         Command description for AddGroup
       </description>
-      <arg name="groupId" type="INT16U"/>
+      <arg name="groupId" type="group_id"/>
       <arg name="groupName" type="CHAR_STRING"/>
     </command>
     <command source="client" code="0x01" name="ViewGroup" response="ViewGroupResponse" optional="false" cli="zcl groups view">
       <description>
         Command description for ViewGroup
       </description>
-      <arg name="groupId" type="INT16U"/>
+      <arg name="groupId" type="group_id"/>
     </command>
     <command source="client" code="0x02" name="GetGroupMembership" response="GetGroupMembershipResponse" cliFunctionName="zclGroupsGetCommand" optional="false" cli="zcl groups get">
       <description>
         Command description for GetGroupMembership
       </description>
-      <arg name="groupList" type="INT16U" array="true"/>
+      <arg name="groupList" type="group_id" array="true"/>
     </command>
     <command source="client" code="0x03" name="RemoveGroup" response="RemoveGroupResponse" optional="false" cli="zcl groups remove">
       <description>
         Command description for RemoveGroup
       </description>
-      <arg name="groupId" type="INT16U"/>
+      <arg name="groupId" type="group_id"/>
     </command>
     <command source="client" code="0x04" name="RemoveAllGroups" optional="false" cli="zcl groups rmall">
       <description>
@@ -219,7 +219,7 @@ limitations under the License.
       <description>
         Command description for AddGroupIfIdentifying
       </description>
-      <arg name="groupId" type="INT16U"/>
+      <arg name="groupId" type="group_id"/>
       <arg name="groupName" type="CHAR_STRING"/>
     </command>
     <command source="server" code="0x00" name="AddGroupResponse" optional="false" disableDefaultResponse="true">
@@ -227,14 +227,14 @@ limitations under the License.
         Command description for AddGroupResponse
       </description>
       <arg name="status" type="ENUM8"/>
-      <arg name="groupId" type="INT16U"/>
+      <arg name="groupId" type="group_id"/>
     </command>
     <command source="server" code="0x01" name="ViewGroupResponse" optional="false" disableDefaultResponse="true">
       <description>
         Command description for ViewGroupResponse
       </description>
       <arg name="status" type="ENUM8"/>
-      <arg name="groupId" type="INT16U"/>
+      <arg name="groupId" type="group_id"/>
       <arg name="groupName" type="CHAR_STRING"/>
     </command>
     <command source="server" code="0x02" name="GetGroupMembershipResponse" optional="false" disableDefaultResponse="true">
@@ -242,14 +242,14 @@ limitations under the License.
         Command description for GetGroupMembershipResponse
       </description>
       <arg name="capacity" type="INT8U"/>
-      <arg name="groupList" type="INT16U" array="true"/>
+      <arg name="groupList" type="group_id" array="true"/>
     </command>
     <command source="server" code="0x03" name="RemoveGroupResponse" optional="false" disableDefaultResponse="true">
       <description>
         Command description for RemoveGroupResponse
       </description>
       <arg name="status" type="ENUM8"/>
-      <arg name="groupId" type="INT16U"/>
+      <arg name="groupId" type="group_id"/>
     </command>
   </cluster>
   <cluster>

--- a/src/app/zap-templates/zcl/data-model/silabs/general.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/general.xml
@@ -241,7 +241,7 @@ limitations under the License.
       <description>
         Command description for GetGroupMembershipResponse
       </description>
-      <arg name="capacity" type="INT8U"/>
+      <arg name="capacity" type="INT8U" isNullable="true"/>
       <arg name="groupList" type="group_id" array="true"/>
     </command>
     <command source="server" code="0x03" name="RemoveGroupResponse" optional="false" disableDefaultResponse="true">

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -1923,7 +1923,7 @@ client cluster Groups = 4 {
   }
 
   response struct GetGroupMembershipResponse {
-    INT8U capacity = 0;
+    nullable INT8U capacity = 0;
     group_id groupList[] = 1;
   }
 

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -1896,45 +1896,45 @@ client cluster Groups = 4 {
   readonly global attribute int16u clusterRevision = 65533;
 
   request struct AddGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
     CHAR_STRING groupName = 1;
   }
 
   request struct AddGroupIfIdentifyingRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
     CHAR_STRING groupName = 1;
   }
 
   request struct GetGroupMembershipRequest {
-    INT16U groupList[] = 0;
+    group_id groupList[] = 0;
   }
 
   request struct RemoveGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
   }
 
   request struct ViewGroupRequest {
-    INT16U groupId = 0;
+    group_id groupId = 0;
   }
 
   response struct AddGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
   }
 
   response struct GetGroupMembershipResponse {
     INT8U capacity = 0;
-    INT16U groupList[] = 1;
+    group_id groupList[] = 1;
   }
 
   response struct RemoveGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
   }
 
   response struct ViewGroupResponse {
     ENUM8 status = 0;
-    INT16U groupId = 1;
+    group_id groupId = 1;
     CHAR_STRING groupName = 2;
   }
 

--- a/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
@@ -1599,10 +1599,17 @@ void CHIPGroupsClusterGetGroupMembershipResponseCallback::CallbackFn(
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error invoking Java callback: %s", ErrorStr(err)));
 
     jobject capacity;
-    std::string capacityClassName     = "java/lang/Integer";
-    std::string capacityCtorSignature = "(I)V";
-    chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(capacityClassName.c_str(), capacityCtorSignature.c_str(),
-                                                                  dataResponse.capacity, capacity);
+    if (dataResponse.capacity.IsNull())
+    {
+        capacity = nullptr;
+    }
+    else
+    {
+        std::string capacityClassName     = "java/lang/Integer";
+        std::string capacityCtorSignature = "(I)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(capacityClassName.c_str(), capacityCtorSignature.c_str(),
+                                                                      dataResponse.capacity.Value(), capacity);
+    }
     jobject groupList;
     chip::JniReferences::GetInstance().CreateArrayList(groupList);
 

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -8724,7 +8724,7 @@ public class ChipClusters {
     }
 
     public interface GetGroupMembershipResponseCallback {
-      void onSuccess(Integer capacity, ArrayList<Integer> groupList);
+      void onSuccess(@Nullable Integer capacity, ArrayList<Integer> groupList);
 
       void onError(Exception error);
     }

--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
@@ -3148,7 +3148,7 @@ public class ClusterInfoMapping {
     }
 
     @Override
-    public void onSuccess(Integer capacity, ArrayList<Integer> groupList) {
+    public void onSuccess(@Nullable Integer capacity, ArrayList<Integer> groupList) {
       Map<CommandResponseInfo, Object> responseValues = new LinkedHashMap<>();
       CommandResponseInfo capacityResponseValue = new CommandResponseInfo("capacity", "Integer");
       responseValues.put(capacityResponseValue, capacity);

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -1777,11 +1777,11 @@ class Groups(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="capacity", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="capacity", Tag=0, Type=typing.Union[Nullable, uint]),
                             ClusterObjectFieldDescriptor(Label="groupList", Tag=1, Type=typing.List[uint]),
                     ])
 
-            capacity: 'uint' = 0
+            capacity: 'typing.Union[Nullable, uint]' = NullValue
             groupList: 'typing.List[uint]' = field(default_factory=lambda: [])
 
         @dataclass

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -10575,7 +10575,11 @@ void CHIPGroupsClusterGetGroupMembershipResponseCallbackBridge::OnSuccessFn(
 {
     auto * response = [CHIPGroupsClusterGetGroupMembershipResponseParams new];
     {
-        response.capacity = [NSNumber numberWithUnsignedChar:data.capacity];
+        if (data.capacity.IsNull()) {
+            response.capacity = nil;
+        } else {
+            response.capacity = [NSNumber numberWithUnsignedChar:data.capacity.Value()];
+        }
     }
     {
         { // Scope for our temporary variables

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface CHIPGroupsClusterGetGroupMembershipResponseParams : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull capacity;
+@property (strong, nonatomic) NSNumber * _Nullable capacity;
 @property (strong, nonatomic) NSArray * _Nonnull groupList;
 - (instancetype)init;
 @end

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
@@ -124,7 +124,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
 
-        _capacity = @(0);
+        _capacity = nil;
 
         _groupList = [NSArray array];
     }

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -43378,7 +43378,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
 
                             {
                                 id actualValue = values.capacity;
-                                XCTAssertEqual([actualValue unsignedCharValue], 255);
+                                XCTAssertTrue(actualValue == nil);
                             }
                             {
                                 id actualValue = values.groupList;
@@ -43612,7 +43612,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
 
                             {
                                 id actualValue = values.capacity;
-                                XCTAssertEqual([actualValue unsignedCharValue], 255);
+                                XCTAssertTrue(actualValue == nil);
                             }
                             {
                                 id actualValue = values.groupList;
@@ -43765,7 +43765,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
 
                             {
                                 id actualValue = values.capacity;
-                                XCTAssertEqual([actualValue unsignedCharValue], 255);
+                                XCTAssertTrue(actualValue == nil);
                             }
                             {
                                 id actualValue = values.groupList;

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -13290,7 +13290,7 @@ bool emberAfGroupsClusterAddGroupCallback(chip::app::CommandHandler * commandObj
  * @brief Groups Cluster AddGroupResponse Command callback (from server)
  */
 bool emberAfGroupsClusterAddGroupResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t status,
-                                                  uint16_t groupId);
+                                                  chip::GroupId groupId);
 /**
  * @brief Groups Cluster ViewGroup Command callback (from client)
  */
@@ -13301,7 +13301,7 @@ bool emberAfGroupsClusterViewGroupCallback(chip::app::CommandHandler * commandOb
  * @brief Groups Cluster ViewGroupResponse Command callback (from server)
  */
 bool emberAfGroupsClusterViewGroupResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t status,
-                                                   uint16_t groupId, chip::CharSpan groupName);
+                                                   chip::GroupId groupId, chip::CharSpan groupName);
 /**
  * @brief Groups Cluster GetGroupMembership Command callback (from client)
  */
@@ -13324,7 +13324,7 @@ bool emberAfGroupsClusterRemoveGroupCallback(chip::app::CommandHandler * command
  * @brief Groups Cluster RemoveGroupResponse Command callback (from server)
  */
 bool emberAfGroupsClusterRemoveGroupResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                     uint8_t status, uint16_t groupId);
+                                                     uint8_t status, chip::GroupId groupId);
 /**
  * @brief Groups Cluster RemoveAllGroups Command callback (from client)
  */

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -1473,7 +1473,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AddGroup::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint16_t groupId = static_cast<uint16_t>(0);
+    chip::GroupId groupId = static_cast<chip::GroupId>(0);
     chip::CharSpan groupName;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -1489,7 +1489,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AddGroup::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint16_t groupId = static_cast<uint16_t>(0);
+    chip::GroupId groupId = static_cast<chip::GroupId>(0);
     chip::CharSpan groupName;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -1508,8 +1508,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AddGroupResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint8_t status   = static_cast<uint8_t>(0);
-    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t status        = static_cast<uint8_t>(0);
+    chip::GroupId groupId = static_cast<chip::GroupId>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -1524,8 +1524,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AddGroupResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint8_t status   = static_cast<uint8_t>(0);
-    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t status        = static_cast<uint8_t>(0);
+    chip::GroupId groupId = static_cast<chip::GroupId>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace AddGroupResponse
@@ -1542,7 +1542,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ViewGroup::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint16_t groupId = static_cast<uint16_t>(0);
+    chip::GroupId groupId = static_cast<chip::GroupId>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -1557,7 +1557,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ViewGroup::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint16_t groupId = static_cast<uint16_t>(0);
+    chip::GroupId groupId = static_cast<chip::GroupId>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ViewGroup
@@ -1576,8 +1576,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ViewGroupResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint8_t status   = static_cast<uint8_t>(0);
-    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t status        = static_cast<uint8_t>(0);
+    chip::GroupId groupId = static_cast<chip::GroupId>(0);
     chip::CharSpan groupName;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -1593,8 +1593,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ViewGroupResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint8_t status   = static_cast<uint8_t>(0);
-    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t status        = static_cast<uint8_t>(0);
+    chip::GroupId groupId = static_cast<chip::GroupId>(0);
     chip::CharSpan groupName;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -1612,7 +1612,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetGroupMembership::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    DataModel::List<const uint16_t> groupList;
+    DataModel::List<const chip::GroupId> groupList;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -1627,7 +1627,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetGroupMembership::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    DataModel::DecodableList<uint16_t> groupList;
+    DataModel::DecodableList<chip::GroupId> groupList;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetGroupMembership
@@ -1646,7 +1646,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint8_t capacity = static_cast<uint8_t>(0);
-    DataModel::List<const uint16_t> groupList;
+    DataModel::List<const chip::GroupId> groupList;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -1662,7 +1662,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint8_t capacity = static_cast<uint8_t>(0);
-    DataModel::DecodableList<uint16_t> groupList;
+    DataModel::DecodableList<chip::GroupId> groupList;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetGroupMembershipResponse
@@ -1679,7 +1679,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveGroup::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint16_t groupId = static_cast<uint16_t>(0);
+    chip::GroupId groupId = static_cast<chip::GroupId>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -1694,7 +1694,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveGroup::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint16_t groupId = static_cast<uint16_t>(0);
+    chip::GroupId groupId = static_cast<chip::GroupId>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RemoveGroup
@@ -1712,8 +1712,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveGroupResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint8_t status   = static_cast<uint8_t>(0);
-    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t status        = static_cast<uint8_t>(0);
+    chip::GroupId groupId = static_cast<chip::GroupId>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -1728,8 +1728,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::RemoveGroupResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint8_t status   = static_cast<uint8_t>(0);
-    uint16_t groupId = static_cast<uint16_t>(0);
+    uint8_t status        = static_cast<uint8_t>(0);
+    chip::GroupId groupId = static_cast<chip::GroupId>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RemoveGroupResponse
@@ -1775,7 +1775,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AddGroupIfIdentifying::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint16_t groupId = static_cast<uint16_t>(0);
+    chip::GroupId groupId = static_cast<chip::GroupId>(0);
     chip::CharSpan groupName;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -1791,7 +1791,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::AddGroupIfIdentifying::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint16_t groupId = static_cast<uint16_t>(0);
+    chip::GroupId groupId = static_cast<chip::GroupId>(0);
     chip::CharSpan groupName;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -1645,7 +1645,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetGroupMembershipResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint8_t capacity = static_cast<uint8_t>(0);
+    DataModel::Nullable<uint8_t> capacity;
     DataModel::List<const chip::GroupId> groupList;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -1661,7 +1661,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::GetGroupMembershipResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
-    uint8_t capacity = static_cast<uint8_t>(0);
+    DataModel::Nullable<uint8_t> capacity;
     DataModel::DecodableList<chip::GroupId> groupList;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -1570,7 +1570,7 @@ public:
 
 private:
     chip::app::Clusters::Groups::Commands::GetGroupMembership::Type mRequest;
-    TypedComplexArgument<chip::app::DataModel::List<const uint16_t>> mComplex_GroupList;
+    TypedComplexArgument<chip::app::DataModel::List<const chip::GroupId>> mComplex_GroupList;
 };
 
 /*

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -92306,7 +92306,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_1(uint8_t status, uint16_t groupId)
+    void OnSuccessResponse_1(uint8_t status, chip::GroupId groupId)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
 
@@ -92342,7 +92342,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_2(uint8_t status, uint16_t groupId)
+    void OnSuccessResponse_2(uint8_t status, chip::GroupId groupId)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
 
@@ -92873,7 +92873,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_1(uint8_t status, uint16_t groupId, chip::CharSpan groupName)
+    void OnSuccessResponse_1(uint8_t status, chip::GroupId groupId, chip::CharSpan groupName)
     {
         VerifyOrReturn(CheckValue("status", status, 135));
 
@@ -92908,7 +92908,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_2(uint8_t status, uint16_t groupId, chip::CharSpan groupName)
+    void OnSuccessResponse_2(uint8_t status, chip::GroupId groupId, chip::CharSpan groupName)
     {
         VerifyOrReturn(CheckValue("status", status, 139));
 
@@ -92944,7 +92944,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_3(uint8_t status, uint16_t groupId)
+    void OnSuccessResponse_3(uint8_t status, chip::GroupId groupId)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
 
@@ -92979,7 +92979,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_4(uint8_t status, uint16_t groupId, chip::CharSpan groupName)
+    void OnSuccessResponse_4(uint8_t status, chip::GroupId groupId, chip::CharSpan groupName)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
 
@@ -93016,7 +93016,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_5(uint8_t status, uint16_t groupId, chip::CharSpan groupName)
+    void OnSuccessResponse_5(uint8_t status, chip::GroupId groupId, chip::CharSpan groupName)
     {
         VerifyOrReturn(CheckValue("status", status, 139));
 
@@ -93033,7 +93033,7 @@ private:
         ListFreer listFreer;
         RequestType request;
 
-        request.groupList = chip::app::DataModel::List<uint16_t>();
+        request.groupList = chip::app::DataModel::List<chip::GroupId>();
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestGroupsClusterSuite *>(context))->OnSuccessResponse_6(data.capacity, data.groupList);
@@ -93053,7 +93053,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_6(uint8_t capacity, const chip::app::DataModel::DecodableList<uint16_t> & groupList)
+    void OnSuccessResponse_6(uint8_t capacity, const chip::app::DataModel::DecodableList<chip::GroupId> & groupList)
     {
         VerifyOrReturn(CheckValue("capacity", capacity, 255));
 
@@ -93093,7 +93093,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_7(uint8_t status, uint16_t groupId, chip::CharSpan groupName)
+    void OnSuccessResponse_7(uint8_t status, chip::GroupId groupId, chip::CharSpan groupName)
     {
         VerifyOrReturn(CheckValue("status", status, 139));
 
@@ -93128,7 +93128,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_8(uint8_t status, uint16_t groupId, chip::CharSpan groupName)
+    void OnSuccessResponse_8(uint8_t status, chip::GroupId groupId, chip::CharSpan groupName)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
 
@@ -93165,7 +93165,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_9(uint8_t status, uint16_t groupId)
+    void OnSuccessResponse_9(uint8_t status, chip::GroupId groupId)
     {
         VerifyOrReturn(CheckValue("status", status, 135));
 
@@ -93200,7 +93200,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_10(uint8_t status, uint16_t groupId)
+    void OnSuccessResponse_10(uint8_t status, chip::GroupId groupId)
     {
         VerifyOrReturn(CheckValue("status", status, 139));
 
@@ -93235,7 +93235,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_11(uint8_t status, uint16_t groupId, chip::CharSpan groupName)
+    void OnSuccessResponse_11(uint8_t status, chip::GroupId groupId, chip::CharSpan groupName)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
 
@@ -93272,7 +93272,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_12(uint8_t status, uint16_t groupId, chip::CharSpan groupName)
+    void OnSuccessResponse_12(uint8_t status, chip::GroupId groupId, chip::CharSpan groupName)
     {
         VerifyOrReturn(CheckValue("status", status, 139));
 
@@ -93290,13 +93290,13 @@ private:
         RequestType request;
 
         {
-            auto * listHolder_0 = new ListHolder<uint16_t>(4);
+            auto * listHolder_0 = new ListHolder<chip::GroupId>(4);
             listFreer.add(listHolder_0);
             listHolder_0->mList[0] = 1U;
             listHolder_0->mList[1] = 2U;
             listHolder_0->mList[2] = 4369U;
             listHolder_0->mList[3] = 3U;
-            request.groupList      = chip::app::DataModel::List<uint16_t>(listHolder_0->mList, 4);
+            request.groupList      = chip::app::DataModel::List<chip::GroupId>(listHolder_0->mList, 4);
         }
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -93317,7 +93317,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_13(uint8_t capacity, const chip::app::DataModel::DecodableList<uint16_t> & groupList)
+    void OnSuccessResponse_13(uint8_t capacity, const chip::app::DataModel::DecodableList<chip::GroupId> & groupList)
     {
         VerifyOrReturn(CheckValue("capacity", capacity, 255));
 
@@ -93384,7 +93384,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_15(uint8_t status, uint16_t groupId, chip::CharSpan groupName)
+    void OnSuccessResponse_15(uint8_t status, chip::GroupId groupId, chip::CharSpan groupName)
     {
         VerifyOrReturn(CheckValue("status", status, 139));
 
@@ -93419,7 +93419,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_16(uint8_t status, uint16_t groupId, chip::CharSpan groupName)
+    void OnSuccessResponse_16(uint8_t status, chip::GroupId groupId, chip::CharSpan groupName)
     {
         VerifyOrReturn(CheckValue("status", status, 139));
 
@@ -93454,7 +93454,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_17(uint8_t status, uint16_t groupId, chip::CharSpan groupName)
+    void OnSuccessResponse_17(uint8_t status, chip::GroupId groupId, chip::CharSpan groupName)
     {
         VerifyOrReturn(CheckValue("status", status, 139));
 
@@ -93472,14 +93472,14 @@ private:
         RequestType request;
 
         {
-            auto * listHolder_0 = new ListHolder<uint16_t>(5);
+            auto * listHolder_0 = new ListHolder<chip::GroupId>(5);
             listFreer.add(listHolder_0);
             listHolder_0->mList[0] = 1U;
             listHolder_0->mList[1] = 2U;
             listHolder_0->mList[2] = 4369U;
             listHolder_0->mList[3] = 3U;
             listHolder_0->mList[4] = 32767U;
-            request.groupList      = chip::app::DataModel::List<uint16_t>(listHolder_0->mList, 5);
+            request.groupList      = chip::app::DataModel::List<chip::GroupId>(listHolder_0->mList, 5);
         }
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -93500,7 +93500,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_18(uint8_t capacity, const chip::app::DataModel::DecodableList<uint16_t> & groupList)
+    void OnSuccessResponse_18(uint8_t capacity, const chip::app::DataModel::DecodableList<chip::GroupId> & groupList)
     {
         VerifyOrReturn(CheckValue("capacity", capacity, 255));
 
@@ -93786,7 +93786,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_3(uint8_t status, uint16_t groupId)
+    void OnSuccessResponse_3(uint8_t status, chip::GroupId groupId)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
 
@@ -93822,7 +93822,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_4(uint8_t status, uint16_t groupId)
+    void OnSuccessResponse_4(uint8_t status, chip::GroupId groupId)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
 
@@ -96095,7 +96095,7 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_1(uint8_t status, uint16_t groupId)
+    void OnSuccessResponse_1(uint8_t status, chip::GroupId groupId)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
 

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -93053,9 +93053,10 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_6(uint8_t capacity, const chip::app::DataModel::DecodableList<chip::GroupId> & groupList)
+    void OnSuccessResponse_6(const chip::app::DataModel::Nullable<uint8_t> & capacity,
+                             const chip::app::DataModel::DecodableList<chip::GroupId> & groupList)
     {
-        VerifyOrReturn(CheckValue("capacity", capacity, 255));
+        VerifyOrReturn(CheckValueNull("capacity", capacity));
 
         {
             auto iter_0 = groupList.begin();
@@ -93317,9 +93318,10 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_13(uint8_t capacity, const chip::app::DataModel::DecodableList<chip::GroupId> & groupList)
+    void OnSuccessResponse_13(const chip::app::DataModel::Nullable<uint8_t> & capacity,
+                              const chip::app::DataModel::DecodableList<chip::GroupId> & groupList)
     {
-        VerifyOrReturn(CheckValue("capacity", capacity, 255));
+        VerifyOrReturn(CheckValueNull("capacity", capacity));
 
         {
             auto iter_0 = groupList.begin();
@@ -93500,9 +93502,10 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_18(uint8_t capacity, const chip::app::DataModel::DecodableList<chip::GroupId> & groupList)
+    void OnSuccessResponse_18(const chip::app::DataModel::Nullable<uint8_t> & capacity,
+                              const chip::app::DataModel::DecodableList<chip::GroupId> & groupList)
     {
-        VerifyOrReturn(CheckValue("capacity", capacity, 255));
+        VerifyOrReturn(CheckValueNull("capacity", capacity));
 
         {
             auto iter_0 = groupList.begin();


### PR DESCRIPTION
#### Problem
Groups cluster XML uses UINT16 for group IDs. The correct type is `group_id`
* Fixes [#10335: Command arguments for Get Group Membership command](https://github.com/project-chip/connectedhomeip/issues/10335).

#### Change overview
UINT16 replaced with group_id for all group IDs within the groups cluster XML.

#### Testing
* Project built successfully.
* YAML tests ran successfully.