### PR TITLE
Added Validate Attestation Certificate Command to the chip-cert Tool.

### DIFF
--- a/src/tools/chip-cert/BUILD.gn
+++ b/src/tools/chip-cert/BUILD.gn
@@ -28,6 +28,7 @@ executable("chip-cert") {
     "Cmd_GenCert.cpp",
     "Cmd_PrintCert.cpp",
     "Cmd_ResignCert.cpp",
+    "Cmd_ValidateAttCert.cpp",
     "Cmd_ValidateCert.cpp",
     "GeneralUtils.cpp",
     "KeyUtils.cpp",

--- a/src/tools/chip-cert/CertUtils.cpp
+++ b/src/tools/chip-cert/CertUtils.cpp
@@ -457,6 +457,27 @@ exit:
     return res;
 }
 
+bool ReadCertDERRaw(const char * fileName, MutableByteSpan & cert)
+{
+    bool res = true;
+    std::unique_ptr<X509, void (*)(X509 *)> certX509(X509_new(), &X509_free);
+
+    VerifyOrReturnError(ReadCertPEM(fileName, certX509.get()) == true, false);
+
+    uint8_t * certPtr = cert.data();
+    int certLen       = i2d_X509(certX509.get(), &certPtr);
+    if (certLen < 0)
+    {
+        ReportOpenSSLErrorAndExit("i2d_X509", res = false);
+    }
+
+    VerifyOrReturnError(chip::CanCastTo<size_t>(certLen), false);
+    cert.reduce_size(static_cast<size_t>(certLen));
+
+exit:
+    return res;
+}
+
 bool X509ToChipCert(X509 * cert, MutableByteSpan & chipCert)
 {
     bool res = true;

--- a/src/tools/chip-cert/Cmd_ValidateAttCert.cpp
+++ b/src/tools/chip-cert/Cmd_ValidateAttCert.cpp
@@ -1,0 +1,274 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements the command handler for the 'chip-cert' tool
+ *      that validates a CHIP attestation certificate chain.
+ *
+ */
+
+#include "chip-cert.h"
+
+//#include "vector"
+
+#include <credentials/DeviceAttestationVerifier.h>
+
+namespace {
+
+using namespace chip;
+using namespace chip::ArgParser;
+using namespace chip::Credentials;
+using namespace chip::Crypto;
+using namespace chip::ASN1;
+
+#define CMD_NAME "chip-cert validate-att-cert"
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
+
+// clang-format off
+OptionDef gCmdOptionDefs[] =
+{
+    { "dac",            kArgumentRequired,  'd' },
+    { "pai",            kArgumentRequired,  'i' },
+    { "paa",            kArgumentRequired,  'a' },
+    { }
+};
+
+const char * const gCmdOptionHelp =
+    "  -d, --dac <cert-file>\n"
+    "\n"
+    "       A file containing Device Attestation Certificate (DAC) to be\n"
+    "       validated. The DAC is provided in the DER encoded format.\n"
+    "\n"
+    "  -i, --pai <cert-file>\n"
+    "\n"
+    "       A file containing Product Attestation Intermediate (PAI) Certificate.\n"
+    "       The PAI is provided in the DER encoded format.\n"
+    "\n"
+    "  -a, --paa <cert-file>\n"
+    "\n"
+    "       A file containing trusted Product Attestation Authority (PAA) Certificate.\n"
+    "       The PAA is provided in the DER encoded format.\n"
+    "\n"
+    ;
+
+OptionSet gCmdOptions =
+{
+    HandleOption,
+    gCmdOptionDefs,
+    "COMMAND OPTIONS",
+    gCmdOptionHelp
+};
+
+HelpOptions gHelpOptions(
+    CMD_NAME,
+    "Usage: " CMD_NAME " [ <options...> ]\n",
+    CHIP_VERSION_STRING "\n" COPYRIGHT_STRING,
+    "Validate a chain of CHIP attestation certificates"
+);
+
+OptionSet * gCmdOptionSets[] =
+{
+    &gCmdOptions,
+    &gHelpOptions,
+    nullptr
+};
+// clang-format on
+
+const char * gDACFileName = nullptr;
+const char * gPAIFileName = nullptr;
+const char * gPAAFileName = nullptr;
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
+{
+    switch (id)
+    {
+    case 'd':
+        gDACFileName = arg;
+        break;
+    case 'i':
+        gPAIFileName = arg;
+        break;
+    case 'a':
+        gPAAFileName = arg;
+        break;
+    default:
+        PrintArgError("%s: Unhandled option: %s\n", progName, name);
+        return false;
+    }
+
+    return true;
+}
+
+AttestationVerificationResult MapError(CertificateChainValidationResult certificateChainValidationResult)
+{
+    switch (certificateChainValidationResult)
+    {
+    case CertificateChainValidationResult::kRootFormatInvalid:
+        return AttestationVerificationResult::kPaaFormatInvalid;
+
+    case CertificateChainValidationResult::kRootArgumentInvalid:
+        return AttestationVerificationResult::kPaaArgumentInvalid;
+
+    case CertificateChainValidationResult::kICAFormatInvalid:
+        return AttestationVerificationResult::kPaiFormatInvalid;
+
+    case CertificateChainValidationResult::kICAArgumentInvalid:
+        return AttestationVerificationResult::kPaiArgumentInvalid;
+
+    case CertificateChainValidationResult::kLeafFormatInvalid:
+        return AttestationVerificationResult::kDacFormatInvalid;
+
+    case CertificateChainValidationResult::kLeafArgumentInvalid:
+        return AttestationVerificationResult::kDacArgumentInvalid;
+
+    case CertificateChainValidationResult::kChainInvalid:
+        return AttestationVerificationResult::kDacSignatureInvalid;
+
+    case CertificateChainValidationResult::kNoMemory:
+        return AttestationVerificationResult::kNoMemory;
+
+    case CertificateChainValidationResult::kInternalFrameworkError:
+        return AttestationVerificationResult::kInternalError;
+
+    default:
+        return AttestationVerificationResult::kInternalError;
+    }
+}
+
+} // namespace
+
+bool Cmd_ValidateAttCert(int argc, char * argv[])
+{
+    CHIP_ERROR err;
+    uint8_t dacBuf[kMaxDERCertLength] = { 0 };
+    uint8_t paiBuf[kMaxDERCertLength] = { 0 };
+    uint8_t paaBuf[kMaxDERCertLength] = { 0 };
+    MutableByteSpan dac(dacBuf);
+    MutableByteSpan pai(paiBuf);
+    MutableByteSpan paa(paaBuf);
+
+    AttestationVerificationResult attestationError = AttestationVerificationResult::kSuccess;
+
+    if (argc == 1)
+    {
+        gHelpOptions.PrintBriefUsage(stderr);
+        return true;
+    }
+
+    VerifyOrReturnError(ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets), false);
+
+    if (gDACFileName == nullptr)
+    {
+        fprintf(stderr, "Please specify the DAC certificate file name using the --dac option.\n");
+        return false;
+    }
+
+    if (gPAIFileName == nullptr)
+    {
+        fprintf(stderr, "Please specify the PAI certificate file name using the --pai option.\n");
+        return false;
+    }
+
+    if (gPAAFileName == nullptr)
+    {
+        fprintf(stderr, "Please specify the PAA certificate file name using the --paa option.\n");
+        return false;
+    }
+
+    if (!ReadCertDERRaw(gDACFileName, dac))
+    {
+        fprintf(stderr, "Unable to open DAC Certificate File: %s\n", gDACFileName);
+        return false;
+    }
+    if (!ReadCertDERRaw(gPAIFileName, pai))
+    {
+        fprintf(stderr, "Unable to open PAI Certificate File: %s\n", gPAIFileName);
+        return false;
+    }
+    if (!ReadCertDERRaw(gPAAFileName, paa))
+    {
+        fprintf(stderr, "Unable to open PAA Certificate File: %s\n", gPAAFileName);
+        return false;
+    }
+
+    // Verify certificate validity information
+    {
+        VerifyOrExit(IsCertificateValidAtCurrentTime(dac) == CHIP_NO_ERROR,
+                     attestationError = AttestationVerificationResult::kDacExpired);
+
+        VerifyOrExit(IsCertificateValidAtIssuance(dac, pai) == CHIP_NO_ERROR,
+                     attestationError = AttestationVerificationResult::kPaiExpired);
+
+        VerifyOrExit(IsCertificateValidAtIssuance(dac, paa) == CHIP_NO_ERROR,
+                     attestationError = AttestationVerificationResult::kPaaExpired);
+    }
+
+    // Verify that VID and PID in the certificates match.
+    {
+        uint16_t dacVid = VendorId::NotSpecified;
+        uint16_t paiVid = VendorId::NotSpecified;
+        uint16_t paaVid = VendorId::NotSpecified;
+        uint16_t dacPid = 0;
+        uint16_t paiPid = 0;
+        uint16_t paaPid = 0;
+
+        VerifyOrExit(ExtractDNAttributeFromX509Cert(MatterOid::kVendorId, dac, dacVid) == CHIP_NO_ERROR,
+                     attestationError = AttestationVerificationResult::kDacFormatInvalid);
+        VerifyOrExit(ExtractDNAttributeFromX509Cert(MatterOid::kVendorId, pai, paiVid) == CHIP_NO_ERROR,
+                     attestationError = AttestationVerificationResult::kPaiFormatInvalid);
+        VerifyOrExit(paiVid == dacVid, attestationError = AttestationVerificationResult::kDacVendorIdMismatch);
+
+        err = ExtractDNAttributeFromX509Cert(MatterOid::kVendorId, paa, paaVid);
+        VerifyOrExit(err == CHIP_NO_ERROR || err == CHIP_ERROR_KEY_NOT_FOUND,
+                     attestationError = AttestationVerificationResult::kPaaFormatInvalid);
+        if (err != CHIP_ERROR_KEY_NOT_FOUND)
+        {
+            VerifyOrExit(dacVid == paaVid, attestationError = AttestationVerificationResult::kDacVendorIdMismatch);
+        }
+
+        VerifyOrExit(ExtractDNAttributeFromX509Cert(MatterOid::kProductId, dac, dacPid) == CHIP_NO_ERROR,
+                     attestationError = AttestationVerificationResult::kDacFormatInvalid);
+        err = ExtractDNAttributeFromX509Cert(MatterOid::kProductId, pai, paiPid);
+        VerifyOrExit(err == CHIP_NO_ERROR || err == CHIP_ERROR_KEY_NOT_FOUND,
+                     attestationError = AttestationVerificationResult::kPaiFormatInvalid);
+        if (err != CHIP_ERROR_KEY_NOT_FOUND)
+        {
+            VerifyOrExit(dacPid == paiPid, attestationError = AttestationVerificationResult::kDacProductIdMismatch);
+        }
+
+        VerifyOrExit(ExtractDNAttributeFromX509Cert(MatterOid::kProductId, paa, paaPid) == CHIP_ERROR_KEY_NOT_FOUND,
+                     attestationError = AttestationVerificationResult::kPaaFormatInvalid);
+    }
+
+    // Validate certificate chain.
+    chip::Crypto::CertificateChainValidationResult chainValidationResult;
+    VerifyOrExit(ValidateCertificateChain(paa.data(), paa.size(), pai.data(), pai.size(), dac.data(), dac.size(),
+                                          chainValidationResult) == CHIP_NO_ERROR,
+                 attestationError = MapError(chainValidationResult));
+
+exit:
+    if (attestationError != AttestationVerificationResult::kSuccess)
+    {
+        fprintf(stderr, "Attestation Certificates Validation Failed with Error Code: %d\n", static_cast<int>(attestationError));
+        return false;
+    }
+
+    return true;
+}

--- a/src/tools/chip-cert/README.md
+++ b/src/tools/chip-cert/README.md
@@ -105,8 +105,14 @@ Attestation Certificates (DAC):
 ./chip-cert gen-att-cert --type d --subject-cn "Matter Development DAC 01" --subject-vid FFF1 --subject-pid 0123 --valid-from "2020-10-15 14:23:43" --lifetime 7305 --ca-key Chip-PAI-Key.pem --ca-cert Chip-PAI-Cert.pem --out-key Chip-DAC-Key.pem --out Chip-DAC-Cert.pem
 ```
 
-The standard openssl command line tool can be used to verify the attestation
-certificate chain that was just created:
+Now the 'chip-cert' tool can be used to validate generated Node certificate:
+
+```
+./chip-cert validate-att-cert --dac Chip-DAC-Cert.pem --pai Chip-PAI-Cert.pem --paa Chip-PAA-Cert.pem
+```
+
+The equivalent openssl command line tool can also be used to verify the
+attestation certificate chain that was just created:
 
 ```
 openssl verify -CAfile Chip-PAA-Cert.pem -untrusted Chip-PAI-Cert.pem Chip-DAC-Cert.pem

--- a/src/tools/chip-cert/chip-cert.cpp
+++ b/src/tools/chip-cert/chip-cert.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -59,6 +59,8 @@ const char * const sHelp =
     "    print-cert -- Print a CHIP certificate.\n"
     "\n"
     "    gen-att-cert -- Generate a CHIP attestation certificate.\n"
+    "\n"
+    "    validate-att-cert -- Validate a CHIP attestation certificate chain.\n"
     "\n"
     "    gen-cd -- Generate a CHIP certification declaration signed message.\n"
     "\n"
@@ -126,6 +128,10 @@ extern "C" int main(int argc, char * argv[])
     else if (strcasecmp(argv[1], "gen-att-cert") == 0 || strcasecmp(argv[1], "genattcert") == 0)
     {
         res = Cmd_GenAttCert(argc - 1, argv + 1);
+    }
+    else if (strcasecmp(argv[1], "validate-att-cert") == 0 || strcasecmp(argv[1], "validateattcert") == 0)
+    {
+        res = Cmd_ValidateAttCert(argc - 1, argv + 1);
     }
     else if (strcasecmp(argv[1], "gen-cd") == 0 || strcasecmp(argv[1], "gencd") == 0)
     {

--- a/src/tools/chip-cert/chip-cert.h
+++ b/src/tools/chip-cert/chip-cert.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -123,12 +123,14 @@ extern bool Cmd_GenCert(int argc, char * argv[]);
 extern bool Cmd_ConvertCert(int argc, char * argv[]);
 extern bool Cmd_ConvertKey(int argc, char * argv[]);
 extern bool Cmd_ResignCert(int argc, char * argv[]);
+extern bool Cmd_ValidateAttCert(int argc, char * argv[]);
 extern bool Cmd_ValidateCert(int argc, char * argv[]);
 extern bool Cmd_PrintCert(int argc, char * argv[]);
 extern bool Cmd_GenAttCert(int argc, char * argv[]);
 
 extern bool ReadCert(const char * fileName, X509 * cert);
 extern bool ReadCert(const char * fileName, X509 * cert, CertFormat & origCertFmt);
+extern bool ReadCertDERRaw(const char * fileName, chip::MutableByteSpan & cert);
 extern bool LoadChipCert(const char * fileName, bool isTrused, chip::Credentials::ChipCertificateSet & certSet,
                          chip::MutableByteSpan & chipCert);
 


### PR DESCRIPTION
#### Problem
Need tool to validate attestation certificates.

#### Change overview
Added command to validate DAC, PAI, PAA chain.
This command validates:
  - correct structure of the subjects of all provided certificate and verifies that VID and PID values match
  - correct validity times of all certificates according to the spec
  - certificate chain validation

As next step this tool can be extended to support validation of CD and other attestation elements. 

#### Testing
manual testing