### PR TITLE
Move Spake2p Verifier class to CHIPCryptoPAL

### DIFF
--- a/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.h
+++ b/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.h
@@ -31,8 +31,7 @@ public:
         AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
         AddArgument("option", 0, 2, &mCommissioningWindowOption);
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
-        AddArgument("iteration", chip::Crypto::kSpake2pPBKDFMinimumIterations, chip::Crypto::kSpake2pPBKDFMaximumIterations,
-                    &mIteration);
+        AddArgument("iteration", chip::kSpake2p_Min_PBKDF_Iterations, chip::kSpake2p_Max_PBKDF_Iterations, &mIteration);
         AddArgument("discriminator", 0, 4096, &mDiscriminator);
     }
 

--- a/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
+++ b/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
@@ -98,7 +98,7 @@ bool emberAfAdministratorCommissioningClusterOpenCommissioningWindowCallback(
     auto & passcodeID           = commandData.passcodeID;
 
     Optional<StatusCode> status = Optional<StatusCode>::Missing();
-    PASEVerifier verifier;
+    Spake2pVerifier verifier;
 
     ChipLogProgress(Zcl, "Received command to open commissioning window");
 
@@ -109,13 +109,13 @@ bool emberAfAdministratorCommissioningClusterOpenCommissioningWindowCallback(
     VerifyOrExit(Server::GetInstance().GetCommissioningWindowManager().CommissioningWindowStatus() ==
                      CommissioningWindowStatus::kWindowNotOpen,
                  status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_BUSY));
-    VerifyOrExit(iterations >= Crypto::kSpake2pPBKDFMinimumIterations,
+    VerifyOrExit(iterations >= kSpake2p_Min_PBKDF_Iterations,
                  status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR));
-    VerifyOrExit(iterations <= Crypto::kSpake2pPBKDFMaximumIterations,
+    VerifyOrExit(iterations <= kSpake2p_Max_PBKDF_Iterations,
                  status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR));
-    VerifyOrExit(salt.size() >= Crypto::kSpake2pPBKDFMinimumSaltLen,
+    VerifyOrExit(salt.size() >= kSpake2p_Min_PBKDF_Salt_Length,
                  status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR));
-    VerifyOrExit(salt.size() <= Crypto::kSpake2pPBKDFMaximumSaltLen,
+    VerifyOrExit(salt.size() <= kSpake2p_Max_PBKDF_Salt_Length,
                  status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR));
     VerifyOrExit(commissioningTimeout <= kMaxCommissionioningTimeoutSeconds,
                  status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR));

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -187,18 +187,18 @@ CHIP_ERROR CommissioningWindowManager::OpenCommissioningWindow()
     }
     else
     {
-        uint32_t iterationCount                           = 0;
-        uint8_t salt[Crypto::kSpake2pPBKDFMaximumSaltLen] = { 0 };
-        size_t saltLen                                    = 0;
-        PASEVerifierSerialized serializedVerifier         = { 0 };
-        size_t serializedVerifierLen                      = 0;
-        PASEVerifier verifier;
+        uint32_t iterationCount                      = 0;
+        uint8_t salt[kSpake2p_Max_PBKDF_Salt_Length] = { 0 };
+        size_t saltLen                               = 0;
+        Spake2pVerifierSerialized serializedVerifier = { 0 };
+        size_t serializedVerifierLen                 = 0;
+        Spake2pVerifier verifier;
 
         ReturnErrorOnFailure(DeviceLayer::ConfigurationMgr().GetSpake2pIterationCount(iterationCount));
         ReturnErrorOnFailure(DeviceLayer::ConfigurationMgr().GetSpake2pSalt(salt, sizeof(salt), saltLen));
         ReturnErrorOnFailure(DeviceLayer::ConfigurationMgr().GetSpake2pVerifier(
-            serializedVerifier, Crypto::kSpake2pSerializedVerifierSize, serializedVerifierLen));
-        VerifyOrReturnError(Crypto::kSpake2pSerializedVerifierSize == serializedVerifierLen, CHIP_ERROR_INVALID_ARGUMENT);
+            serializedVerifier, kSpake2p_VerifierSerialized_Length, serializedVerifierLen));
+        VerifyOrReturnError(kSpake2p_VerifierSerialized_Length == serializedVerifierLen, CHIP_ERROR_INVALID_ARGUMENT);
         ReturnErrorOnFailure(verifier.Deserialize(ByteSpan(serializedVerifier)));
 
         ReturnErrorOnFailure(
@@ -239,8 +239,8 @@ CHIP_ERROR CommissioningWindowManager::OpenBasicCommissioningWindow(uint16_t com
 }
 
 CHIP_ERROR CommissioningWindowManager::OpenEnhancedCommissioningWindow(uint16_t commissioningTimeoutSeconds, uint16_t discriminator,
-                                                                       PASEVerifier & verifier, uint32_t iterations, ByteSpan salt,
-                                                                       PasscodeId passcodeID)
+                                                                       Spake2pVerifier & verifier, uint32_t iterations,
+                                                                       ByteSpan salt, PasscodeId passcodeID)
 {
     // Once a device is operational, it shall be commissioned into subsequent fabrics using
     // the operational network only.
@@ -258,7 +258,7 @@ CHIP_ERROR CommissioningWindowManager::OpenEnhancedCommissioningWindow(uint16_t 
     mECMPasscodeID    = passcodeID;
     mECMIterations    = iterations;
 
-    memcpy(&mECMPASEVerifier, &verifier, sizeof(PASEVerifier));
+    memcpy(&mECMPASEVerifier, &verifier, sizeof(Spake2pVerifier));
 
     mUseECM = true;
 

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -54,7 +54,7 @@ public:
         CommissioningWindowAdvertisement advertisementMode = chip::CommissioningWindowAdvertisement::kAllSupported);
 
     CHIP_ERROR OpenEnhancedCommissioningWindow(uint16_t commissioningTimeoutSeconds, uint16_t discriminator,
-                                               PASEVerifier & verifier, uint32_t iterations, chip::ByteSpan salt,
+                                               Spake2pVerifier & verifier, uint32_t iterations, chip::ByteSpan salt,
                                                PasscodeId passcodeID);
 
     void CloseCommissioningWindow();
@@ -106,12 +106,12 @@ private:
     uint8_t mFailedCommissioningAttempts = 0;
 
     bool mUseECM = false;
-    PASEVerifier mECMPASEVerifier;
+    Spake2pVerifier mECMPASEVerifier;
     uint16_t mECMDiscriminator = 0;
     PasscodeId mECMPasscodeID  = kDefaultCommissioningPasscodeId;
     uint32_t mECMIterations    = 0;
     uint32_t mECMSaltLength    = 0;
-    uint8_t mECMSalt[Crypto::kSpake2pPBKDFMaximumSaltLen];
+    uint8_t mECMSalt[kSpake2p_Max_PBKDF_Salt_Length];
 };
 
 } // namespace chip

--- a/src/app/tests/TestCommissionManager.cpp
+++ b/src/app/tests/TestCommissionManager.cpp
@@ -117,9 +117,9 @@ void CheckCommissioningWindowManagerEnhancedWindowTask(intptr_t context)
     CHIP_ERROR err = chip::DeviceLayer::ConfigurationMgr().GetSetupDiscriminator(originDiscriminator);
     NL_TEST_ASSERT(suite, err == CHIP_NO_ERROR);
     uint16_t newDiscriminator = static_cast<uint16_t>(originDiscriminator + 1);
-    chip::PASEVerifier verifier;
-    constexpr uint32_t kIterations = chip::Crypto::kSpake2pPBKDFMinimumIterations;
-    uint8_t salt[chip::Crypto::kSpake2pPBKDFMinimumSaltLen];
+    chip::Spake2pVerifier verifier;
+    constexpr uint32_t kIterations = chip::kSpake2p_Min_PBKDF_Iterations;
+    uint8_t salt[chip::kSpake2p_Min_PBKDF_Salt_Length];
     chip::ByteSpan saltData(salt);
     constexpr chip::PasscodeId kPasscodeID = 1;
     uint16_t currentDiscriminator;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -434,7 +434,7 @@ void DeviceController::OnOpenPairingWindowFailureResponse(void * context, CHIP_E
 }
 
 CHIP_ERROR DeviceController::ComputePASEVerifier(uint32_t iterations, uint32_t setupPincode, const ByteSpan & salt,
-                                                 PASEVerifier & outVerifier, PasscodeId & outPasscodeId)
+                                                 Spake2pVerifier & outVerifier, PasscodeId & outPasscodeId)
 {
     ReturnErrorOnFailure(PASESession::GeneratePASEVerifier(outVerifier, iterations, salt, /* useRandomPIN= */ false, setupPincode));
 
@@ -506,12 +506,12 @@ CHIP_ERROR DeviceController::OpenCommissioningWindowInternal()
         const char kSpake2pKeyExchangeSalt[] = "SPAKE2P Key Salt";
         ByteSpan salt(Uint8::from_const_char(kSpake2pKeyExchangeSalt), sizeof(kSpake2pKeyExchangeSalt));
         bool randomSetupPIN = (mCommissioningWindowOption == CommissioningWindowOption::kTokenWithRandomPIN);
-        PASEVerifier verifier;
+        Spake2pVerifier verifier;
 
         ReturnErrorOnFailure(PASESession::GeneratePASEVerifier(verifier, mCommissioningWindowIteration, salt, randomSetupPIN,
                                                                mSetupPayload.setUpPINCode));
 
-        chip::PASEVerifierSerialized serializedVerifier;
+        chip::Spake2pVerifierSerialized serializedVerifier;
         MutableByteSpan serializedVerifierSpan(serializedVerifier);
         ReturnErrorOnFailure(verifier.Serialize(serializedVerifierSpan));
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -242,12 +242,12 @@ public:
      * @param[in] iterations      The number of iterations to use when generating the verifier
      * @param[in] setupPincode    The desired PIN code to use
      * @param[in] salt            The 16-byte salt for verifier computation
-     * @param[out] outVerifier    The PASEVerifier to be populated on success
+     * @param[out] outVerifier    The Spake2pVerifier to be populated on success
      * @param[out] outPasscodeId  The passcode ID to be populated on success
      *
      * @return CHIP_ERROR         CHIP_NO_ERROR on success, or corresponding error
      */
-    CHIP_ERROR ComputePASEVerifier(uint32_t iterations, uint32_t setupPincode, const ByteSpan & salt, PASEVerifier & outVerifier,
+    CHIP_ERROR ComputePASEVerifier(uint32_t iterations, uint32_t setupPincode, const ByteSpan & salt, Spake2pVerifier & outVerifier,
                                    PasscodeId & outPasscodeId);
 
     /**

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -630,8 +630,8 @@ JNI_METHOD(jobject, computePaseVerifier)
     jobject params;
     jbyteArray verifierBytes;
     PasscodeId passcodeId;
-    PASEVerifier verifier;
-    PASEVerifierSerialized serializedVerifier;
+    Spake2pVerifier verifier;
+    Spake2pVerifierSerialized serializedVerifier;
     MutableByteSpan serializedVerifierSpan(serializedVerifier);
     JniByteArray jniSalt(env, salt);
 
@@ -644,8 +644,7 @@ JNI_METHOD(jobject, computePaseVerifier)
     err = verifier.Serialize(serializedVerifierSpan);
     SuccessOrExit(err);
 
-    err =
-        JniReferences::GetInstance().N2J_ByteArray(env, serializedVerifier, Crypto::kSpake2pSerializedVerifierSize, verifierBytes);
+    err = JniReferences::GetInstance().N2J_ByteArray(env, serializedVerifier, kSpake2p_VerifierSerialized_Length, verifierBytes);
     SuccessOrExit(err);
 
     err = N2J_PaseVerifierParams(env, setupPincode, static_cast<jlong>(passcodeId), verifierBytes, params);

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -67,8 +67,10 @@ constexpr size_t kMAX_CSR_Length = 255;
 
 constexpr size_t CHIP_CRYPTO_HASH_LEN_BYTES = kSHA256_Hash_Length;
 
-constexpr size_t kMin_Salt_Length = 16;
-constexpr size_t kMax_Salt_Length = 32;
+constexpr size_t kSpake2p_Min_PBKDF_Salt_Length  = 16;
+constexpr size_t kSpake2p_Max_PBKDF_Salt_Length  = 32;
+constexpr uint32_t kSpake2p_Min_PBKDF_Iterations = 1000;
+constexpr uint32_t kSpake2p_Max_PBKDF_Iterations = 100000;
 
 constexpr size_t kP256_PrivateKey_Length = CHIP_CRYPTO_GROUP_SIZE_BYTES;
 constexpr size_t kP256_PublicKey_Length  = CHIP_CRYPTO_PUBLIC_KEY_SIZE_BYTES;
@@ -91,6 +93,9 @@ constexpr size_t kEmitDerIntegerWithoutTagOverhead = 1; // 1 sign stuffer
 constexpr size_t kEmitDerIntegerOverhead           = 3; // Tag + Length byte + 1 sign stuffer
 
 constexpr size_t kMAX_Hash_SHA256_Context_Size = CHIP_CONFIG_SHA256_CONTEXT_SIZE;
+
+constexpr size_t kSpake2p_WS_Length                 = kP256_FE_Length + 8;
+constexpr size_t kSpake2p_VerifierSerialized_Length = kP256_FE_Length + kP256_Point_Length;
 
 /*
  * Overhead to encode a raw ECDSA signature in X9.62 format in ASN.1 DER
@@ -133,26 +138,6 @@ const uint8_t spake2p_N_p256[65] = {
     0xd6, 0x0a, 0xa6, 0xbf, 0xad, 0xe4, 0x50, 0x08, 0xa6, 0x36, 0x33, 0x7f, 0x51, 0x68, 0xc6, 0x4d, 0x9b,
     0xd3, 0x60, 0x34, 0x80, 0x8c, 0xd5, 0x64, 0x49, 0x0b, 0x1e, 0x65, 0x6e, 0xdb, 0xe7,
 };
-
-/** @brief Spake2p parameters.
- *
- * Specifications section 3.9. Password-Based Key Derivation Function
- * Specifications section 5.1.1.6
- **/
-constexpr uint32_t kSpake2pPBKDFMinimumIterations = 1000;
-constexpr uint32_t kSpake2pPBKDFMaximumIterations = 100000;
-constexpr uint32_t kSpake2pPBKDFMinimumSaltLen    = 16;
-constexpr uint32_t kSpake2pPBKDFMaximumSaltLen    = 32;
-
-/** @brief Serialized format of the PASE Verifier components.
- *
- *  This is used when the Verifier should be presented in a serialized form.
- *  For example, when it is generated using PBKDF function, when stored in the
- *  memory or when sent over the wire.
- *  The serialized format is concatentation of { W0, L } verifier components
- *  as per Specifications section 3.10. Password-Authenticated Key Exchange.
- **/
-constexpr size_t kSpake2pSerializedVerifierSize = kP256_FE_Length + kP256_Point_Length;
 
 /**
  * Spake2+ state machine to ensure proper execution of the protocol.
@@ -1257,6 +1242,55 @@ private:
 
     Spake2pOpaqueContext mSpake2pContext;
 };
+
+/**
+ * @brief Class used for verifying PASE secure sessions.
+ **/
+class Spake2pVerifier
+{
+public:
+    uint8_t mW0[kP256_FE_Length];
+    uint8_t mL[kP256_Point_Length];
+
+    CHIP_ERROR Serialize(MutableByteSpan & outSerialized);
+    CHIP_ERROR Deserialize(ByteSpan inSerialized);
+
+    /**
+     * @brief Generate the Spake2+ verifier.
+     *
+     * @param pbkdf2IterCount Iteration count for PBKDF2 function
+     * @param salt            Salt to be used for Spake2+ operation
+     * @param setupPin        Provided setup PIN (passcode)
+     *
+     * @return CHIP_ERROR     The result of Spake2+ verifier generation
+     */
+    CHIP_ERROR Generate(uint32_t pbkdf2IterCount, const ByteSpan & salt, uint32_t & setupPin);
+
+    /**
+     * @brief Compute the initiator values (w0, w1) used for PAKE input.
+     *
+     * @param pbkdf2IterCount Iteration count for PBKDF2 function
+     * @param salt            Salt to be used for Spake2+ operation
+     * @param setupPin        Provided setup PIN (passcode)
+     * @param ws              The output pair (w0, w1) stored sequentially
+     * @param ws_len          The output length
+     *
+     * @return CHIP_ERROR     The result from running PBKDF2
+     */
+    static CHIP_ERROR ComputeWS(uint32_t pbkdf2IterCount, const ByteSpan & salt, uint32_t & setupPin, uint8_t * ws,
+                                uint32_t ws_len);
+};
+
+/**
+ * @brief Serialized format of the Spake2+ Verifier components.
+ *
+ *  This is used when the Verifier should be presented in a serialized form.
+ *  For example, when it is generated using PBKDF function, when stored in the
+ *  memory or when sent over the wire.
+ *  The serialized format is concatentation of 'W0' and 'L' verifier components:
+ *      { Spake2pVerifier.mW0[kP256_FE_Length], Spake2pVerifier.mL[kP256_Point_Length] }
+ **/
+typedef uint8_t Spake2pVerifierSerialized[kSpake2p_VerifierSerialized_Length];
 
 /**
  * @brief Compute the compressed fabric identifier used for operational discovery service

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -536,8 +536,8 @@ CHIP_ERROR PBKDF2_sha256::pbkdf2_sha256(const uint8_t * password, size_t plen, c
     VerifyOrExit(password != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(plen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(salt != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(slen >= kMin_Salt_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(slen <= kMax_Salt_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(slen >= kSpake2p_Min_PBKDF_Salt_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(slen <= kSpake2p_Max_PBKDF_Salt_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(key_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(output != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
 

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -379,8 +379,8 @@ CHIP_ERROR PBKDF2_sha256::pbkdf2_sha256(const uint8_t * password, size_t plen, c
     VerifyOrExit(password != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(plen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(salt != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(slen >= kMin_Salt_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(slen <= kMax_Salt_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(slen >= kSpake2p_Min_PBKDF_Salt_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(slen <= kSpake2p_Max_PBKDF_Salt_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(key_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(output != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
 

--- a/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_PBKDF.cpp
+++ b/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_PBKDF.cpp
@@ -44,8 +44,8 @@ CHIP_ERROR PBKDF2_sha256HSM::pbkdf2_sha256(const uint8_t * password, size_t plen
     VerifyOrReturnError(plen > 0, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(key_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(output != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(slen >= chip::Crypto::kMin_Salt_Length, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(slen <= chip::Crypto::kMax_Salt_Length, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(slen >= kSpake2p_Min_PBKDF_Salt_Length, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(slen <= kSpake2p_Max_PBKDF_Salt_Length, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(salt != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     VerifyOrReturnError(keyid != kKeyId_NotInitialized, CHIP_ERROR_HSM);

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -332,7 +332,7 @@ exit:
 template <class ConfigClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetSpake2pSalt(uint8_t * buf, size_t bufSize, size_t & saltLen)
 {
-    static constexpr size_t kSpake2pSalt_MaxBase64Len = BASE64_ENCODED_LEN(chip::Crypto::kSpake2pPBKDFMaximumSaltLen) + 1;
+    static constexpr size_t kSpake2pSalt_MaxBase64Len = BASE64_ENCODED_LEN(chip::Crypto::kSpake2p_Max_PBKDF_Salt_Length) + 1;
 
     CHIP_ERROR err                          = CHIP_NO_ERROR;
     char saltB64[kSpake2pSalt_MaxBase64Len] = { 0 };
@@ -362,7 +362,7 @@ template <class ConfigClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetSpake2pVerifier(uint8_t * buf, size_t bufSize, size_t & verifierLen)
 {
     static constexpr size_t kSpake2pSerializedVerifier_MaxBase64Len =
-        BASE64_ENCODED_LEN(chip::Crypto::kSpake2pSerializedVerifierSize) + 1;
+        BASE64_ENCODED_LEN(chip::Crypto::kSpake2p_VerifierSerialized_Length) + 1;
 
     CHIP_ERROR err                                            = CHIP_NO_ERROR;
     char verifierB64[kSpake2pSerializedVerifier_MaxBase64Len] = { 0 };

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -63,12 +63,6 @@ const char * kSpake2pR2ISessionInfo = "Commissioning R2I Key";
 // The session establishment fails if the response is not received with in timeout window.
 static constexpr ExchangeContext::Timeout kSpake2p_Response_Timeout = System::Clock::Seconds16(30);
 
-#ifdef ENABLE_HSM_PBKDF2
-using PBKDF2_sha256_crypto = PBKDF2_sha256HSM;
-#else
-using PBKDF2_sha256_crypto = PBKDF2_sha256;
-#endif
-
 PASESession::PASESession() : PairingSession(Transport::SecureSession::Type::kPASE) {}
 
 PASESession::~PASESession()
@@ -203,26 +197,14 @@ CHIP_ERROR PASESession::Init(uint16_t mySessionId, uint32_t setupCode, SessionEs
 
     ChipLogDetail(SecureChannel, "Assigned local session key ID %d", mySessionId);
     SetLocalSessionId(mySessionId);
+
+    ReturnErrorCodeIf(setupCode >= (1 << kSetupPINCodeFieldLengthInBits), CHIP_ERROR_INVALID_ARGUMENT);
     mSetupPINCode = setupCode;
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR PASESession::ComputeWS(uint32_t setUpPINCode, uint32_t pbkdf2IterCount, const ByteSpan & salt, uint32_t wsSize,
-                                  uint8_t * ws)
-{
-    PBKDF2_sha256_crypto mPBKDF;
-    uint8_t littleEndianSetupPINCode[sizeof(uint32_t)];
-    Encoding::LittleEndian::Put32(littleEndianSetupPINCode, setUpPINCode);
-
-    ReturnErrorCodeIf(salt.empty(), CHIP_ERROR_INVALID_ARGUMENT);
-    ReturnErrorCodeIf(setUpPINCode >= (1 << kSetupPINCodeFieldLengthInBits), CHIP_ERROR_INVALID_ARGUMENT);
-
-    return mPBKDF.pbkdf2_sha256(littleEndianSetupPINCode, sizeof(littleEndianSetupPINCode), salt.data(), salt.size(),
-                                pbkdf2IterCount, wsSize, ws);
-}
-
-CHIP_ERROR PASESession::GeneratePASEVerifier(PASEVerifier & verifier, uint32_t pbkdf2IterCount, const ByteSpan & salt,
+CHIP_ERROR PASESession::GeneratePASEVerifier(Spake2pVerifier & verifier, uint32_t pbkdf2IterCount, const ByteSpan & salt,
                                              bool useRandomPIN, uint32_t & setupPINCode)
 {
     TRACE_EVENT_SCOPE("GeneratePASEVerifier", "PASESession");
@@ -235,30 +217,7 @@ CHIP_ERROR PASESession::GeneratePASEVerifier(PASEVerifier & verifier, uint32_t p
         setupPINCode = (setupPINCode % kSetupPINCodeMaximumValue) + 1;
     }
 
-    uint8_t serializedWS[kSpake2p_WS_Length * 2] = { 0 };
-    ReturnErrorOnFailure(ComputeWS(setupPINCode, pbkdf2IterCount, salt, sizeof(serializedWS), serializedWS));
-
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    size_t len;
-
-    // Create local spake2p object for W0 and L camputations.
-    Spake2p_P256_SHA256_HKDF_HMAC spake2p;
-    uint8_t context[kSHA256_Hash_Length] = { 0 };
-    SuccessOrExit(err = spake2p.Init(context, sizeof(context)));
-
-    // Compute W0
-    len = sizeof(verifier.mW0);
-    SuccessOrExit(err = spake2p.ComputeW0(verifier.mW0, &len, &serializedWS[0], kSpake2p_WS_Length));
-    VerifyOrExit(len == sizeof(verifier.mW0), err = CHIP_ERROR_INTERNAL);
-
-    // Compute L
-    len = sizeof(verifier.mL);
-    SuccessOrExit(err = spake2p.ComputeL(verifier.mL, &len, &serializedWS[kSpake2p_WS_Length], kSpake2p_WS_Length));
-    VerifyOrExit(len == sizeof(verifier.mL), err = CHIP_ERROR_INTERNAL);
-
-exit:
-    spake2p.Clear();
-    return err;
+    return verifier.Generate(pbkdf2IterCount, salt, setupPINCode);
 }
 
 CHIP_ERROR PASESession::SetupSpake2p()
@@ -273,14 +232,14 @@ CHIP_ERROR PASESession::SetupSpake2p()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR PASESession::WaitForPairing(const PASEVerifier & verifier, uint32_t pbkdf2IterCount, const ByteSpan & salt,
+CHIP_ERROR PASESession::WaitForPairing(const Spake2pVerifier & verifier, uint32_t pbkdf2IterCount, const ByteSpan & salt,
                                        PasscodeId passcodeID, uint16_t mySessionId,
                                        Optional<ReliableMessageProtocolConfig> mrpConfig, SessionEstablishmentDelegate * delegate)
 {
     // Return early on error here, as we have not initialized any state yet
     ReturnErrorCodeIf(salt.empty(), CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorCodeIf(salt.data() == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    ReturnErrorCodeIf(salt.size() < Crypto::kSpake2pPBKDFMinimumSaltLen || salt.size() > Crypto::kSpake2pPBKDFMaximumSaltLen,
+    ReturnErrorCodeIf(salt.size() < kSpake2p_Min_PBKDF_Salt_Length || salt.size() > kSpake2p_Max_PBKDF_Salt_Length,
                       CHIP_ERROR_INVALID_ARGUMENT);
 
     CHIP_ERROR err = Init(mySessionId, kSetupPINCodeUndefinedValue, delegate);
@@ -616,7 +575,7 @@ CHIP_ERROR PASESession::HandlePBKDFParamResponse(System::PacketBufferHandle && m
     err = SetupSpake2p();
     SuccessOrExit(err);
 
-    err = ComputeWS(mSetupPINCode, mIterationCount, salt, sizeof(serializedWS), serializedWS);
+    err = Spake2pVerifier::ComputeWS(mIterationCount, salt, mSetupPINCode, serializedWS, sizeof(serializedWS));
     SuccessOrExit(err);
 
     err = mSpake2p.BeginProver(nullptr, 0, nullptr, 0, &serializedWS[0], kSpake2p_WS_Length, &serializedWS[kSpake2p_WS_Length],
@@ -974,28 +933,6 @@ exit:
         mDelegate->OnSessionEstablishmentError(err);
     }
     return err;
-}
-
-CHIP_ERROR PASEVerifier::Serialize(MutableByteSpan & outSerialized)
-{
-    VerifyOrReturnError(outSerialized.size() >= Crypto::kSpake2pSerializedVerifierSize, CHIP_ERROR_INVALID_ARGUMENT);
-
-    memcpy(&outSerialized.data()[0], mW0, sizeof(mW0));
-    memcpy(&outSerialized.data()[sizeof(mW0)], mL, sizeof(mL));
-
-    outSerialized.reduce_size(Crypto::kSpake2pSerializedVerifierSize);
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR PASEVerifier::Deserialize(ByteSpan inSerialized)
-{
-    VerifyOrReturnError(inSerialized.size() >= Crypto::kSpake2pSerializedVerifierSize, CHIP_ERROR_INVALID_ARGUMENT);
-
-    memcpy(mW0, &inSerialized.data()[0], sizeof(mW0));
-    memcpy(mL, &inSerialized.data()[sizeof(mW0)], sizeof(mL));
-
-    return CHIP_NO_ERROR;
 }
 
 } // namespace chip

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -55,8 +55,6 @@ constexpr uint32_t kSetupPINCodeUndefinedValue = 0;
 
 using namespace Crypto;
 
-constexpr size_t kSpake2p_WS_Length = kP256_FE_Length + 8;
-
 struct PASESessionSerialized;
 
 struct PASESessionSerializable
@@ -67,17 +65,6 @@ struct PASESessionSerializable
     uint16_t mLocalSessionId;
     uint16_t mPeerSessionId;
 };
-
-struct PASEVerifier
-{
-    uint8_t mW0[kP256_FE_Length];
-    uint8_t mL[kP256_Point_Length];
-
-    CHIP_ERROR Serialize(MutableByteSpan & outSerialized);
-    CHIP_ERROR Deserialize(ByteSpan inSerialized);
-};
-
-typedef uint8_t PASEVerifierSerialized[Crypto::kSpake2pSerializedVerifierSize];
 
 class DLL_EXPORT PASESession : public Messaging::ExchangeDelegate, public PairingSession
 {
@@ -105,8 +92,8 @@ public:
      *
      * @return CHIP_ERROR     The result of initialization
      */
-    CHIP_ERROR WaitForPairing(const PASEVerifier & verifier, uint32_t pbkdf2IterCount, const ByteSpan & salt, PasscodeId passcodeID,
-                              uint16_t mySessionId, Optional<ReliableMessageProtocolConfig> mrpConfig,
+    CHIP_ERROR WaitForPairing(const Spake2pVerifier & verifier, uint32_t pbkdf2IterCount, const ByteSpan & salt,
+                              PasscodeId passcodeID, uint16_t mySessionId, Optional<ReliableMessageProtocolConfig> mrpConfig,
                               SessionEstablishmentDelegate * delegate);
 
     /**
@@ -141,7 +128,7 @@ public:
      *
      * @return CHIP_ERROR      The result of PASE verifier generation
      */
-    static CHIP_ERROR GeneratePASEVerifier(PASEVerifier & verifier, uint32_t pbkdf2IterCount, const ByteSpan & salt,
+    static CHIP_ERROR GeneratePASEVerifier(Spake2pVerifier & verifier, uint32_t pbkdf2IterCount, const ByteSpan & salt,
                                            bool useRandomPIN, uint32_t & setupPIN);
 
     /**
@@ -225,9 +212,6 @@ private:
     CHIP_ERROR ValidateReceivedMessage(Messaging::ExchangeContext * exchange, const PayloadHeader & payloadHeader,
                                        System::PacketBufferHandle && msg);
 
-    static CHIP_ERROR ComputeWS(uint32_t mySetUpPINCode, uint32_t pbkdf2IterCount, const ByteSpan & salt, uint32_t wsSize,
-                                uint8_t * ws);
-
     CHIP_ERROR SetupSpake2p();
 
     CHIP_ERROR SendPBKDFParamRequest();
@@ -263,7 +247,7 @@ private:
     Spake2p_P256_SHA256_HKDF_HMAC mSpake2p;
 #endif
 
-    PASEVerifier mPASEVerifier;
+    Spake2pVerifier mPASEVerifier;
 
     PasscodeId mPasscodeID = kDefaultCommissioningPasscodeId;
 

--- a/src/protocols/secure_channel/RendezvousParameters.h
+++ b/src/protocols/secure_channel/RendezvousParameters.h
@@ -63,8 +63,8 @@ public:
     }
 
     bool HasPASEVerifier() const { return mHasPASEVerifier; }
-    const PASEVerifier & GetPASEVerifier() const { return mPASEVerifier; }
-    RendezvousParameters & SetPASEVerifier(PASEVerifier & verifier)
+    const Spake2pVerifier & GetPASEVerifier() const { return mPASEVerifier; }
+    RendezvousParameters & SetPASEVerifier(Spake2pVerifier & verifier)
     {
         memmove(&mPASEVerifier, &verifier, sizeof(verifier));
         mHasPASEVerifier = true;
@@ -96,7 +96,7 @@ private:
     uint32_t mSetupPINCode  = 0;          ///< the target peripheral setup PIN Code
     uint16_t mDiscriminator = UINT16_MAX; ///< the target peripheral discriminator
 
-    PASEVerifier mPASEVerifier;
+    Spake2pVerifier mPASEVerifier;
     bool mHasPASEVerifier = false;
 
 #if CONFIG_NETWORK_LAYER_BLE

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -48,7 +48,7 @@ constexpr uint32_t sTestSpake2p01_PinCode        = 20202021;
 constexpr uint32_t sTestSpake2p01_IterationCount = 1000;
 constexpr uint8_t sTestSpake2p01_Salt[]          = { 0x53, 0x50, 0x41, 0x4B, 0x45, 0x32, 0x50, 0x20,
                                             0x4B, 0x65, 0x79, 0x20, 0x53, 0x61, 0x6C, 0x74 };
-constexpr PASEVerifier sTestSpake2p01_PASEVerifier = { .mW0 = {
+constexpr Spake2pVerifier sTestSpake2p01_PASEVerifier = { .mW0 = {
     0xB9, 0x61, 0x70, 0xAA, 0xE8, 0x03, 0x34, 0x68, 0x84, 0x72, 0x4F, 0xE9, 0xA3, 0xB2, 0x87, 0xC3,
     0x03, 0x30, 0xC2, 0xA6, 0x60, 0x37, 0x5D, 0x17, 0xBB, 0x20, 0x5A, 0x8C, 0xF1, 0xAE, 0xCB, 0x35,
 },
@@ -59,7 +59,7 @@ constexpr PASEVerifier sTestSpake2p01_PASEVerifier = { .mW0 = {
     0xB7, 0xC0, 0x7F, 0xCC, 0x06, 0x27, 0xA1, 0xB8, 0x57, 0x3A, 0x14, 0x9F, 0xCD, 0x1F, 0xA4, 0x66,
     0xCF
 } };
-constexpr PASEVerifierSerialized sTestSpake2p01_SerializedVerifier = {
+constexpr Spake2pVerifierSerialized sTestSpake2p01_SerializedVerifier = {
     0xB9, 0x61, 0x70, 0xAA, 0xE8, 0x03, 0x34, 0x68, 0x84, 0x72, 0x4F, 0xE9, 0xA3, 0xB2, 0x87, 0xC3, 0x03, 0x30, 0xC2, 0xA6,
     0x60, 0x37, 0x5D, 0x17, 0xBB, 0x20, 0x5A, 0x8C, 0xF1, 0xAE, 0xCB, 0x35, 0x04, 0x57, 0xF8, 0xAB, 0x79, 0xEE, 0x25, 0x3A,
     0xB6, 0xA8, 0xE4, 0x6B, 0xB0, 0x9E, 0x54, 0x3A, 0xE4, 0x22, 0x73, 0x6D, 0xE5, 0x01, 0xE3, 0xDB, 0x37, 0xD4, 0x41, 0xFE,
@@ -441,24 +441,22 @@ void SecurePairingSerializeTest(nlTestSuite * inSuite, void * inContext)
 
 void PASEVerifierSerializeTest(nlTestSuite * inSuite, void * inContext)
 {
-    PASEVerifier verifier;
+    Spake2pVerifier verifier;
     NL_TEST_ASSERT(inSuite, verifier.Deserialize(ByteSpan(sTestSpake2p01_SerializedVerifier)) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, memcmp(&verifier, &sTestSpake2p01_PASEVerifier, sizeof(PASEVerifier)) == 0);
+    NL_TEST_ASSERT(inSuite, memcmp(&verifier, &sTestSpake2p01_PASEVerifier, sizeof(Spake2pVerifier)) == 0);
 
-    PASEVerifierSerialized serializedVerifier;
+    Spake2pVerifierSerialized serializedVerifier;
     MutableByteSpan serializedVerifierSpan(serializedVerifier);
     NL_TEST_ASSERT(inSuite, verifier.Serialize(serializedVerifierSpan) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, serializedVerifierSpan.size() == Crypto::kSpake2pSerializedVerifierSize);
-    NL_TEST_ASSERT(inSuite,
-                   memcmp(serializedVerifier, sTestSpake2p01_SerializedVerifier, Crypto::kSpake2pSerializedVerifierSize) == 0);
+    NL_TEST_ASSERT(inSuite, serializedVerifierSpan.size() == kSpake2p_VerifierSerialized_Length);
+    NL_TEST_ASSERT(inSuite, memcmp(serializedVerifier, sTestSpake2p01_SerializedVerifier, kSpake2p_VerifierSerialized_Length) == 0);
 
-    PASEVerifierSerialized serializedVerifier2;
+    Spake2pVerifierSerialized serializedVerifier2;
     MutableByteSpan serializedVerifier2Span(serializedVerifier2);
-    NL_TEST_ASSERT(inSuite,
-                   chip::Crypto::DRBG_get_bytes(serializedVerifier, Crypto::kSpake2pSerializedVerifierSize) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, chip::Crypto::DRBG_get_bytes(serializedVerifier, kSpake2p_VerifierSerialized_Length) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, verifier.Deserialize(ByteSpan(serializedVerifier)) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, verifier.Serialize(serializedVerifier2Span) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, memcmp(serializedVerifier, serializedVerifier2, Crypto::kSpake2pSerializedVerifierSize) == 0);
+    NL_TEST_ASSERT(inSuite, memcmp(serializedVerifier, serializedVerifier2, kSpake2p_VerifierSerialized_Length) == 0);
 }
 
 // Test Suite


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fix the dependency cycle introduced in #14676.

#### Change overview
What's in this PR
#15127 merged first, but this PR offers some marginal improvements that are worth considering:
* Move the Spake2p Verifier and serialized verifier to CHIPCryptoPAL
  * Since platform replaced pin code API with GetSpake2p functions, it makes sense for platform impls to be able to generate Spake2p params without adding a dependency on protocols/secure_channel
* Add checks for PBKDF salt size and iteration count
* Make constant names consistent

#### Testing
How was this tested? (at least one bullet point required)
* This is covered by TestPASESession.cpp
* This does not introduce any logical changes other than additional sanity checks.