### PR TITLE
Best-effort flush events at shutdown

### DIFF
--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -42,6 +42,9 @@ CHIP_ERROR Engine::Init()
 
 void Engine::Shutdown()
 {
+    // Flush out the event buffer synchronously
+    ScheduleUrgentEventDeliverySync();
+
     mNumReportsInFlight = 0;
     mCurReadHandlerIdx  = 0;
     mGlobalDirtySet.ReleaseAll();
@@ -737,6 +740,22 @@ CHIP_ERROR Engine::ScheduleEventDelivery(ConcreteEventPath & aPath, EventOptions
         return ScheduleUrgentEventDelivery(aPath);
     }
     return CHIP_NO_ERROR;
+}
+
+void Engine::ScheduleUrgentEventDeliverySync()
+{
+    InteractionModelEngine::GetInstance()->mReadHandlers.ForEachActiveObject([](ReadHandler * handler) {
+        if (handler->IsType(ReadHandler::InteractionType::Read))
+        {
+            return Loop::Continue;
+        }
+
+        handler->UnblockUrgentEventDelivery();
+
+        return Loop::Continue;
+    });
+
+    Run();
 }
 
 }; // namespace reporting

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -146,6 +146,7 @@ private:
     CHIP_ERROR ScheduleUrgentEventDelivery(ConcreteEventPath & aPath);
     CHIP_ERROR ScheduleBufferPressureEventDelivery(uint32_t aBytesWritten);
     void GetMinEventLogPosition(uint32_t & aMinLogPosition);
+    void ScheduleUrgentEventDeliverySync();
 
     /**
      * If the provided path is a superset of our of our existing paths, update that existing path to match the


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, we don't flush event during shut down, and all pending events will get lost after device is shut down. This prevent CSG from verifying the events only occurs before device is shutdown.

* Fixes #13008

#### Change overview
Best-effort flush events at shutdown

#### Testing
How was this tested? (at least one bullet point required)
* Confirm the ScheduleUrgentEventDelivery is triggered on Shutdown from log. Note, this is best effort operation, no guarantee all pending urgent events can be sent out during shutdown 