### PR TITLE
Fix check in TypedReadCallback to handle wildcards

### DIFF
--- a/src/controller/TypedReadCallback.h
+++ b/src/controller/TypedReadCallback.h
@@ -80,7 +80,9 @@ private:
         VerifyOrDie(!aPath.IsListItemOperation());
 
         VerifyOrExit(aStatus.IsSuccess(), err = aStatus.ToChipError());
-        VerifyOrExit(aPath.mClusterId == mClusterId && aPath.mAttributeId == mAttributeId, err = CHIP_ERROR_SCHEMA_MISMATCH);
+        VerifyOrExit((aPath.mClusterId == mClusterId || kInvalidClusterId == mClusterId) &&
+                         (aPath.mAttributeId == mAttributeId || kInvalidAttributeId == mAttributeId),
+                     err = CHIP_ERROR_SCHEMA_MISMATCH);
         VerifyOrExit(apData != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
         SuccessOrExit(err = app::DataModel::Decode(*apData, value));


### PR DESCRIPTION
Modify verify check to support use of wildcards so that the callback doesn't
crash when wildcards are used in the read request.

#### Problem
* Fix crash on when wildcard was used in read attribute path

#### Change overview
* Verify check of attribute path in TypedReadCallback was modified to allow wildcard path

#### Testing
* New integration test in another PR (https://github.com/project-chip/connectedhomeip/pull/15272) tested the fix.