### PR TITLE
move NRF CI timeout from 90 minutes to 120

### DIFF
--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
     nrfconnect:
         name: nRF Connect SDK
-        timeout-minutes: 90
+        timeout-minutes: 120
 
         env:
             BUILD_TYPE: nrfconnect


### PR DESCRIPTION
#### Problem
Seeing lots of 'nrf cancelled' recently. Looking at https://github.com/project-chip/connectedhomeip/runs/5240765173?check_suite_focus=true for example shows 1:30 as the time, which seems like the existing 90 minute timeout.

#### Change overview
Increase timeout. We may need to trim out what CI compiles as 1.5h of CI is already very long.

#### Testing
N/A (CI will validate, however this is a trivial change)