### PR TITLE
Remove hardcoded rejection of Spake2+ configs

### DIFF
--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -339,7 +339,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetSpake2pSalt(uint8_t 
     size_t saltB64Len                       = 0;
 
     err = ReadConfigValueStr(ConfigClass::kConfigKey_Spake2pSalt, saltB64, sizeof(saltB64), saltB64Len);
-    err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_SALT)
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
@@ -369,7 +369,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetSpake2pVerifier(uint
     size_t verifierB64Len                                     = 0;
 
     err = ReadConfigValueStr(ConfigClass::kConfigKey_Spake2pVerifier, verifierB64, sizeof(verifierB64), verifierB64Len);
-    err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_VERIFIER)
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fix GetSpake2pSalt and GetSpake2pVerifier

#### Change overview
What's in this PR
* The ConfigurationManager API should decode the stored configs when test Spake2+ values aren't defined.

#### Testing
How was this tested? (at least one bullet point required)
* Manually tested with chip-tool on RC2 against an external device platform using real Spake2+ values.
