### PR TITLE
Add lock/unlock calls for efr32 examples

### DIFF
--- a/examples/light-switch-app/efr32/include/binding-handler.h
+++ b/examples/light-switch-app/efr32/include/binding-handler.h
@@ -19,4 +19,4 @@
 #include "lib/core/CHIPError.h"
 
 CHIP_ERROR InitBindingHandler();
-void SwitchToggleOnOff();
+void SwitchToggleOnOff(intptr_t context);

--- a/examples/light-switch-app/efr32/src/AppTask.cpp
+++ b/examples/light-switch-app/efr32/src/AppTask.cpp
@@ -189,8 +189,11 @@ CHIP_ERROR AppTask::Init()
 
     sWiFiNetworkCommissioningInstance.Init();
 #endif
+
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
     // Init ZCL Data Model
     chip::Server::GetInstance().Init();
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
@@ -347,7 +350,7 @@ void AppTask::SwitchActionEventHandler(AppEvent * aEvent)
 {
     if (aEvent->Type == AppEvent::kEventType_Button)
     {
-        SwitchToggleOnOff();
+        chip::DeviceLayer::PlatformMgr().ScheduleWork(SwitchToggleOnOff, reinterpret_cast<intptr_t>(nullptr));
     }
 }
 

--- a/examples/light-switch-app/efr32/src/AppTask.cpp
+++ b/examples/light-switch-app/efr32/src/AppTask.cpp
@@ -352,7 +352,7 @@ void AppTask::SwitchActionEventHandler(AppEvent * aEvent)
 {
     if (aEvent->Type == AppEvent::kEventType_Button)
     {
-        chip::DeviceLayer::PlatformMgr().ScheduleWork(SwitchToggleOnOff, reinterpret_cast<intptr_t>(nullptr));
+        chip::DeviceLayer::PlatformMgr().ScheduleWork(SwitchToggleOnOff, 0);
     }
 }
 

--- a/examples/light-switch-app/efr32/src/AppTask.cpp
+++ b/examples/light-switch-app/efr32/src/AppTask.cpp
@@ -191,11 +191,6 @@ CHIP_ERROR AppTask::Init()
 #endif
 
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-    // Init ZCL Data Model
-    chip::Server::GetInstance().Init();
-    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-
-    chip::DeviceLayer::PlatformMgr().LockChipStack();
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();

--- a/examples/light-switch-app/efr32/src/AppTask.cpp
+++ b/examples/light-switch-app/efr32/src/AppTask.cpp
@@ -195,8 +195,10 @@ CHIP_ERROR AppTask::Init()
     chip::Server::GetInstance().Init();
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
     // Create FreeRTOS sw timer for Function Selection.
     sFunctionTimer = xTimerCreate("FnTmr",          // Just a text name, not used by the RTOS kernel

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -53,7 +53,7 @@ void BoundDeviceChangedHandler(const EmberBindingTableEntry * binding, chip::Dev
 }
 } // namespace
 
-void SwitchToggleOnOff()
+void SwitchToggleOnOff(intptr_t context)
 {
     chip::BindingManager::GetInstance().NotifyBoundClusterChanged(1, chip::app::Clusters::OnOff::Id, nullptr);
 }

--- a/examples/light-switch-app/efr32/src/main.cpp
+++ b/examples/light-switch-app/efr32/src/main.cpp
@@ -165,13 +165,6 @@ int main(void)
     }
 #endif // CHIP_ENABLE_OPENTHREAD
 
-    EFR32_LOG("Starting Platform Manager Event Loop");
-    ret = PlatformMgr().StartEventLoopTask();
-    if (ret != CHIP_NO_ERROR)
-    {
-        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
-        appError(ret);
-    }
 #ifdef WF200_WIFI
     // Start wfx bus communication task.
     wfx_bus_start();
@@ -210,6 +203,14 @@ int main(void)
 #ifdef ENABLE_CHIP_SHELL
     chip::startShellTask();
 #endif
+
+    EFR32_LOG("Starting Platform Manager Event Loop");
+    ret = PlatformMgr().StartEventLoopTask();
+    if (ret != CHIP_NO_ERROR)
+    {
+        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
+        appError(ret);
+    }
 
     EFR32_LOG("Starting FreeRTOS scheduler");
     sl_system_kernel_start();

--- a/examples/light-switch-app/efr32/src/main.cpp
+++ b/examples/light-switch-app/efr32/src/main.cpp
@@ -165,6 +165,19 @@ int main(void)
     }
 #endif // CHIP_ENABLE_OPENTHREAD
 
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
+    // Init ZCL Data Model
+    chip::Server::GetInstance().Init();
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+
+    EFR32_LOG("Starting Platform Manager Event Loop");
+    ret = PlatformMgr().StartEventLoopTask();
+    if (ret != CHIP_NO_ERROR)
+    {
+        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
+        appError(ret);
+    }
+
 #ifdef WF200_WIFI
     // Start wfx bus communication task.
     wfx_bus_start();
@@ -203,14 +216,6 @@ int main(void)
 #ifdef ENABLE_CHIP_SHELL
     chip::startShellTask();
 #endif
-
-    EFR32_LOG("Starting Platform Manager Event Loop");
-    ret = PlatformMgr().StartEventLoopTask();
-    if (ret != CHIP_NO_ERROR)
-    {
-        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
-        appError(ret);
-    }
 
     EFR32_LOG("Starting FreeRTOS scheduler");
     sl_system_kernel_start();

--- a/examples/lighting-app/efr32/include/AppTask.h
+++ b/examples/lighting-app/efr32/include/AppTask.h
@@ -68,7 +68,7 @@ private:
     static void LightActionEventHandler(AppEvent * aEvent);
     static void TimerEventHandler(TimerHandle_t xTimer);
 
-    static void UpdateClusterState(void);
+    static void UpdateClusterState(intptr_t context);
 
     void StartTimer(uint32_t aTimeoutMs);
 

--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -248,8 +248,10 @@ CHIP_ERROR AppTask::Init()
     chip::Server::GetInstance().Init();
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
     // Create FreeRTOS sw timer for Function Selection.
     sFunctionTimer = xTimerCreate("FnTmr",          // Just a text name, not used by the RTOS kernel

--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -244,11 +244,6 @@ CHIP_ERROR AppTask::Init()
 #endif
 
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-    // Init ZCL Data Model
-    chip::Server::GetInstance().Init();
-    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-
-    chip::DeviceLayer::PlatformMgr().LockChipStack();
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();

--- a/examples/lighting-app/efr32/src/main.cpp
+++ b/examples/lighting-app/efr32/src/main.cpp
@@ -169,6 +169,19 @@ int main(void)
     }
 #endif // CHIP_ENABLE_OPENTHREAD
 
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
+    // Init ZCL Data Model
+    chip::Server::GetInstance().Init();
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+
+    EFR32_LOG("Starting Platform Manager Event Loop");
+    ret = PlatformMgr().StartEventLoopTask();
+    if (ret != CHIP_NO_ERROR)
+    {
+        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
+        appError(ret);
+    }
+
 #ifdef WF200_WIFI
     // Start wfx bus communication task.
     wfx_bus_start();
@@ -212,14 +225,6 @@ int main(void)
 #ifdef ENABLE_CHIP_SHELL
     chip::startShellTask();
 #endif
-
-    EFR32_LOG("Starting Platform Manager Event Loop");
-    ret = PlatformMgr().StartEventLoopTask();
-    if (ret != CHIP_NO_ERROR)
-    {
-        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
-        appError(ret);
-    }
 
     EFR32_LOG("Starting FreeRTOS scheduler");
     sl_system_kernel_start();

--- a/examples/lighting-app/efr32/src/main.cpp
+++ b/examples/lighting-app/efr32/src/main.cpp
@@ -169,13 +169,6 @@ int main(void)
     }
 #endif // CHIP_ENABLE_OPENTHREAD
 
-    EFR32_LOG("Starting Platform Manager Event Loop");
-    ret = PlatformMgr().StartEventLoopTask();
-    if (ret != CHIP_NO_ERROR)
-    {
-        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
-        appError(ret);
-    }
 #ifdef WF200_WIFI
     // Start wfx bus communication task.
     wfx_bus_start();
@@ -203,7 +196,9 @@ int main(void)
      */
 #endif
 #ifdef EFR32_OTA_ENABLED
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
     OTAConfig::Init();
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 #endif // EFR32_OTA_ENABLED
 
     EFR32_LOG("Starting App Task");
@@ -217,6 +212,14 @@ int main(void)
 #ifdef ENABLE_CHIP_SHELL
     chip::startShellTask();
 #endif
+
+    EFR32_LOG("Starting Platform Manager Event Loop");
+    ret = PlatformMgr().StartEventLoopTask();
+    if (ret != CHIP_NO_ERROR)
+    {
+        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
+        appError(ret);
+    }
 
     EFR32_LOG("Starting FreeRTOS scheduler");
     sl_system_kernel_start();

--- a/examples/lock-app/efr32/include/AppTask.h
+++ b/examples/lock-app/efr32/include/AppTask.h
@@ -68,7 +68,7 @@ private:
     static void LockActionEventHandler(AppEvent * aEvent);
     static void TimerEventHandler(TimerHandle_t xTimer);
 
-    static void UpdateClusterState(void);
+    static void UpdateClusterState(intptr_t context);
 
     void StartTimer(uint32_t aTimeoutMs);
 

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -131,11 +131,6 @@ CHIP_ERROR AppTask::Init()
 #endif
 
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-    // Init ZCL Data Model
-    chip::Server::GetInstance().Init();
-    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-
-    chip::DeviceLayer::PlatformMgr().LockChipStack();
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -135,8 +135,10 @@ CHIP_ERROR AppTask::Init()
     chip::Server::GetInstance().Init();
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
     // Create FreeRTOS sw timer for Function Selection.
     sFunctionTimer = xTimerCreate("FnTmr",          // Just a text name, not used by the RTOS kernel

--- a/examples/lock-app/efr32/src/main.cpp
+++ b/examples/lock-app/efr32/src/main.cpp
@@ -165,14 +165,6 @@ int main(void)
     }
 #endif // CHIP_ENABLE_OPENTHREAD
 
-    EFR32_LOG("Starting Platform Manager Event Loop");
-    ret = PlatformMgr().StartEventLoopTask();
-    if (ret != CHIP_NO_ERROR)
-    {
-        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
-        appError(ret);
-    }
-
 #if CHIP_ENABLE_OPENTHREAD
     EFR32_LOG("Starting OpenThread task");
 
@@ -205,6 +197,14 @@ int main(void)
 #ifdef ENABLE_CHIP_SHELL
     chip::startShellTask();
 #endif
+
+    EFR32_LOG("Starting Platform Manager Event Loop");
+    ret = PlatformMgr().StartEventLoopTask();
+    if (ret != CHIP_NO_ERROR)
+    {
+        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
+        appError(ret);
+    }
 
     EFR32_LOG("Starting FreeRTOS scheduler");
     sl_system_kernel_start();

--- a/examples/lock-app/efr32/src/main.cpp
+++ b/examples/lock-app/efr32/src/main.cpp
@@ -165,6 +165,19 @@ int main(void)
     }
 #endif // CHIP_ENABLE_OPENTHREAD
 
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
+    // Init ZCL Data Model
+    chip::Server::GetInstance().Init();
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+
+    EFR32_LOG("Starting Platform Manager Event Loop");
+    ret = PlatformMgr().StartEventLoopTask();
+    if (ret != CHIP_NO_ERROR)
+    {
+        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
+        appError(ret);
+    }
+
 #if CHIP_ENABLE_OPENTHREAD
     EFR32_LOG("Starting OpenThread task");
 
@@ -184,8 +197,11 @@ int main(void)
 #endif                           // SL_WFX_USE_SECURE_LINK
 #endif                           /* WF200_WIFI */
 #ifdef EFR32_OTA_ENABLED
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
     OTAConfig::Init();
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 #endif // EFR32_OTA_ENABLED
+
     EFR32_LOG("Starting App Task");
     ret = GetAppTask().StartAppTask();
     if (ret != CHIP_NO_ERROR)
@@ -197,14 +213,6 @@ int main(void)
 #ifdef ENABLE_CHIP_SHELL
     chip::startShellTask();
 #endif
-
-    EFR32_LOG("Starting Platform Manager Event Loop");
-    ret = PlatformMgr().StartEventLoopTask();
-    if (ret != CHIP_NO_ERROR)
-    {
-        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
-        appError(ret);
-    }
 
     EFR32_LOG("Starting FreeRTOS scheduler");
     sl_system_kernel_start();

--- a/examples/ota-requestor-app/efr32/args.gni
+++ b/examples/ota-requestor-app/efr32/args.gni
@@ -23,6 +23,9 @@ pw_assert_BACKEND = "$dir_pw_assert_log"
 chip_enable_openthread = true
 chip_openthread_ftd = false
 
+# Disable stack lock tracking
+chip_stack_lock_tracking = "None"
+
 declare_args() {
   chip_enable_ota_requestor = true
 }

--- a/examples/ota-requestor-app/efr32/args.gni
+++ b/examples/ota-requestor-app/efr32/args.gni
@@ -24,6 +24,7 @@ chip_enable_openthread = true
 chip_openthread_ftd = false
 
 # Disable stack lock tracking
+# Example will not be maintained in the long term and will be depraceted now that OTA is beeing intagrated into our examples
 chip_stack_lock_tracking = "None"
 
 declare_args() {

--- a/examples/ota-requestor-app/efr32/src/AppTask.cpp
+++ b/examples/ota-requestor-app/efr32/src/AppTask.cpp
@@ -125,8 +125,10 @@ CHIP_ERROR AppTask::Init()
     // Init ZCL Data Model
     chip::Server::GetInstance().Init();
 
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
     // Create FreeRTOS sw timer for Function Selection.
     sFunctionTimer = xTimerCreate("FnTmr",          // Just a text name, not used by the RTOS kernel

--- a/examples/shell/efr32/src/main.cpp
+++ b/examples/shell/efr32/src/main.cpp
@@ -119,6 +119,15 @@ int main(void)
         appError(ret);
     }
     chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName("EFR32_SHELL");
+
+    EFR32_LOG("Starting Platform Manager Event Loop");
+    ret = PlatformMgr().StartEventLoopTask();
+    if (ret != CHIP_NO_ERROR)
+    {
+        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
+        appError(ret);
+    }
+
 #if CHIP_ENABLE_OPENTHREAD
     EFR32_LOG("Initializing OpenThread stack");
     ret = ThreadStackMgr().InitThreadStack();
@@ -147,14 +156,6 @@ int main(void)
         appError(ret);
     }
 #endif // CHIP_ENABLE_OPENTHREAD
-
-    EFR32_LOG("Starting Platform Manager Event Loop");
-    ret = PlatformMgr().StartEventLoopTask();
-    if (ret != CHIP_NO_ERROR)
-    {
-        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
-        appError(ret);
-    }
 
     chip::startShellTask();
     sl_system_kernel_start();

--- a/examples/shell/efr32/src/main.cpp
+++ b/examples/shell/efr32/src/main.cpp
@@ -136,14 +136,6 @@ int main(void)
     }
 #endif // CHIP_ENABLE_OPENTHREAD
 
-    EFR32_LOG("Starting Platform Manager Event Loop");
-    ret = PlatformMgr().StartEventLoopTask();
-    if (ret != CHIP_NO_ERROR)
-    {
-        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
-        appError(ret);
-    }
-
 #if CHIP_ENABLE_OPENTHREAD
     EFR32_LOG("Starting OpenThread task");
 
@@ -155,6 +147,14 @@ int main(void)
         appError(ret);
     }
 #endif // CHIP_ENABLE_OPENTHREAD
+
+    EFR32_LOG("Starting Platform Manager Event Loop");
+    ret = PlatformMgr().StartEventLoopTask();
+    if (ret != CHIP_NO_ERROR)
+    {
+        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
+        appError(ret);
+    }
 
     chip::startShellTask();
     sl_system_kernel_start();

--- a/examples/window-app/common/include/WindowApp.h
+++ b/examples/window-app/common/include/WindowApp.h
@@ -135,6 +135,20 @@ public:
         Timer * mTiltTimer            = nullptr;
         OperationalState mLiftOpState = OperationalState::Stall;
         OperationalState mTiltOpState = OperationalState::Stall;
+
+        struct CoverWorkData
+        {
+            chip::EndpointId mEndpointId;
+
+            union
+            {
+                chip::Percent100ths percent100ths;
+                OperationalStatus opStatus;
+            };
+        };
+
+        static void ScheduleTiltPositionSet(intptr_t arg);
+        static void ScheduleOperationalStatusSetWithGlobalUpdate(intptr_t arg);
     };
 
     static WindowApp & Instance();

--- a/examples/window-app/common/include/WindowApp.h
+++ b/examples/window-app/common/include/WindowApp.h
@@ -148,6 +148,7 @@ public:
         };
 
         static void ScheduleTiltPositionSet(intptr_t arg);
+        static void ScheduleLiftPositionSet(intptr_t arg);
         static void ScheduleOperationalStatusSetWithGlobalUpdate(intptr_t arg);
     };
 

--- a/examples/window-app/common/src/WindowApp.cpp
+++ b/examples/window-app/common/src/WindowApp.cpp
@@ -112,9 +112,6 @@ WindowApp::Cover * WindowApp::GetCover(chip::EndpointId endpoint)
 
 CHIP_ERROR WindowApp::Init()
 {
-    // Init ZCL Data Model
-    chip::Server::GetInstance().Init();
-
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 

--- a/examples/window-app/common/src/WindowApp.cpp
+++ b/examples/window-app/common/src/WindowApp.cpp
@@ -456,15 +456,9 @@ void WindowApp::Cover::LiftDown()
     chip::app::DataModel::Nullable<chip::Percent100ths> current;
     chip::Percent100ths percent100ths = 5000; // set at middle
 
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
-
     status = Attributes::CurrentPositionLiftPercent100ths::Get(mEndpoint, current);
-
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
 
     if ((status == EMBER_ZCL_STATUS_SUCCESS) && !current.IsNull())
         percent100ths = current.Value();
@@ -478,13 +472,9 @@ void WindowApp::Cover::LiftDown()
         percent100ths = 10000;
     }
 
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
     LiftPositionSet(mEndpoint, percent100ths);
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
 }
 
 void WindowApp::Cover::LiftUp()
@@ -493,15 +483,9 @@ void WindowApp::Cover::LiftUp()
     chip::app::DataModel::Nullable<chip::Percent100ths> current;
     chip::Percent100ths percent100ths = 5000; // set at middle
 
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
-
     status = Attributes::CurrentPositionLiftPercent100ths::Get(mEndpoint, current);
-
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
 
     if ((status == EMBER_ZCL_STATUS_SUCCESS) && !current.IsNull())
         percent100ths = current.Value();
@@ -515,25 +499,19 @@ void WindowApp::Cover::LiftUp()
         percent100ths = 0;
     }
 
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
     LiftPositionSet(mEndpoint, percent100ths);
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
 }
 
 void WindowApp::Cover::LiftUpdate(bool newTarget)
 {
     NPercent100ths current, target;
 
-    CoverWorkData * data = (CoverWorkData *) chip::Platform::MemoryAlloc(sizeof(CoverWorkData));
+    CoverWorkData * data = chip::Platform::New<CoverWorkData>();
     VerifyOrReturn(data != nullptr, emberAfWindowCoveringClusterPrint("Cover::LiftUpdate - Out of Memory for WorkData"));
 
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
 
     Attributes::TargetPositionLiftPercent100ths::Get(mEndpoint, target);
     Attributes::CurrentPositionLiftPercent100ths::Get(mEndpoint, current);
@@ -541,9 +519,7 @@ void WindowApp::Cover::LiftUpdate(bool newTarget)
     OperationalStatus opStatus = OperationalStatusGet(mEndpoint);
     OperationalState opState   = ComputeOperationalState(target, current);
 
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
 
     /* If Triggered by a TARGET update */
     if (newTarget)
@@ -571,15 +547,9 @@ void WindowApp::Cover::LiftUpdate(bool newTarget)
     {
         /* Actuator finalize the movement AND CURRENT Must be equal to TARGET at the end */
 
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
         chip::DeviceLayer::PlatformMgr().LockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
-
         Attributes::CurrentPositionLiftPercent100ths::Set(mEndpoint, target);
-
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
         chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
 
         mLiftOpState = OperationalState::Stall;
     }
@@ -602,18 +572,12 @@ void WindowApp::Cover::TiltDown()
     chip::app::DataModel::Nullable<chip::Percent100ths> current;
     chip::Percent100ths percent100ths = 5000; // set at middle
 
-    CoverWorkData * data = (CoverWorkData *) chip::Platform::MemoryAlloc(sizeof(CoverWorkData));
+    CoverWorkData * data = chip::Platform::New<CoverWorkData>();
     VerifyOrReturn(data != nullptr, emberAfWindowCoveringClusterPrint("Cover::TiltDown - Out of Memory for WorkData"));
 
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
-
     status = Attributes::CurrentPositionTiltPercent100ths::Get(mEndpoint, current);
-
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
 
     if ((status == EMBER_ZCL_STATUS_SUCCESS) && !current.IsNull())
         percent100ths = current.Value();
@@ -639,18 +603,12 @@ void WindowApp::Cover::TiltUp()
     chip::app::DataModel::Nullable<chip::Percent100ths> current;
     chip::Percent100ths percent100ths = 5000; // set at middle
 
-    CoverWorkData * data = (CoverWorkData *) chip::Platform::MemoryAlloc(sizeof(CoverWorkData));
+    CoverWorkData * data = chip::Platform::New<CoverWorkData>();
     VerifyOrReturn(data != nullptr, emberAfWindowCoveringClusterPrint("Cover::TiltUp - Out of Memory for WorkData"));
 
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
-
     status = Attributes::CurrentPositionTiltPercent100ths::Get(mEndpoint, current);
-
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
 
     if ((status == EMBER_ZCL_STATUS_SUCCESS) && !current.IsNull())
         percent100ths = current.Value();
@@ -674,12 +632,10 @@ void WindowApp::Cover::TiltUpdate(bool newTarget)
 {
     NPercent100ths current, target;
 
-    CoverWorkData * data = (CoverWorkData *) chip::Platform::MemoryAlloc(sizeof(CoverWorkData));
+    CoverWorkData * data = chip::Platform::New<CoverWorkData>();
     VerifyOrReturn(data != nullptr, emberAfWindowCoveringClusterPrint("Cover::TiltUpdate - Out of Memory for WorkData"));
 
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
 
     Attributes::TargetPositionTiltPercent100ths::Get(mEndpoint, target);
     Attributes::CurrentPositionTiltPercent100ths::Get(mEndpoint, current);
@@ -687,9 +643,7 @@ void WindowApp::Cover::TiltUpdate(bool newTarget)
     OperationalStatus opStatus = OperationalStatusGet(mEndpoint);
     OperationalState opState   = ComputeOperationalState(target, current);
 
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
 
     /* If Triggered by a TARGET update */
     if (newTarget)
@@ -734,15 +688,9 @@ void WindowApp::Cover::TiltUpdate(bool newTarget)
 
 EmberAfWcType WindowApp::Cover::CycleType()
 {
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
-
     EmberAfWcType type = TypeGet(mEndpoint);
-
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLE
 
     switch (type)
     {
@@ -760,15 +708,10 @@ EmberAfWcType WindowApp::Cover::CycleType()
     default:
         type = EMBER_ZCL_WC_TYPE_TILT_BLIND_LIFT_AND_TILT;
     }
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
+
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
-
     TypeSet(mEndpoint, type);
-
-#ifdef CHIP_STACK_LOCK_TRACKING_ENABLED
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-#endif // CHIP_STACK_LOCK_TRACKING_ENABLED
 
     return type;
 }
@@ -796,7 +739,7 @@ void WindowApp::Cover::ScheduleTiltPositionSet(intptr_t arg)
     WindowApp::Cover::CoverWorkData * data = reinterpret_cast<WindowApp::Cover::CoverWorkData *>(arg);
     TiltPositionSet(data->mEndpointId, data->percent100ths);
 
-    chip::Platform::MemoryFree(data);
+    chip::Platform::Delete(data);
 }
 
 void WindowApp::Cover::ScheduleOperationalStatusSetWithGlobalUpdate(intptr_t arg)
@@ -804,5 +747,5 @@ void WindowApp::Cover::ScheduleOperationalStatusSetWithGlobalUpdate(intptr_t arg
     WindowApp::Cover::CoverWorkData * data = reinterpret_cast<WindowApp::Cover::CoverWorkData *>(arg);
     OperationalStatusSetWithGlobalUpdated(data->mEndpointId, data->opStatus);
 
-    chip::Platform::MemoryFree(data);
+    chip::Platform::Delete(data);
 }

--- a/examples/window-app/efr32/src/WindowAppImpl.cpp
+++ b/examples/window-app/efr32/src/WindowAppImpl.cpp
@@ -376,7 +376,9 @@ void WindowAppImpl::UpdateLEDs()
         NPercent100ths current;
         LimitStatus liftLimit = LimitStatus::Intermediate;
 
+        chip::DeviceLayer::PlatformMgr().LockChipStack();
         Attributes::CurrentPositionLiftPercent100ths::Get(cover.mEndpoint, current);
+        chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
         if (!current.IsNull())
         {
@@ -413,12 +415,16 @@ void WindowAppImpl::UpdateLCD()
     if (mState.isWiFiProvisioned)
 #endif
     {
-        Cover & cover      = GetCover();
-        EmberAfWcType type = TypeGet(cover.mEndpoint);
+        Cover & cover = GetCover();
         chip::app::DataModel::Nullable<uint16_t> lift;
         chip::app::DataModel::Nullable<uint16_t> tilt;
+
+        chip::DeviceLayer::PlatformMgr().LockChipStack();
+        EmberAfWcType type = TypeGet(cover.mEndpoint);
+
         Attributes::CurrentPositionLift::Get(cover.mEndpoint, lift);
         Attributes::CurrentPositionTilt::Get(cover.mEndpoint, tilt);
+        chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
         if (!tilt.IsNull() && !lift.IsNull())
         {

--- a/examples/window-app/efr32/src/main.cpp
+++ b/examples/window-app/efr32/src/main.cpp
@@ -118,14 +118,6 @@ int main(void)
     }
     chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(BLE_DEV_NAME);
 
-    EFR32_LOG("Starting Platform Manager Event Loop");
-    err = PlatformMgr().StartEventLoopTask();
-    if (err != CHIP_NO_ERROR)
-    {
-        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
-        appError(err);
-    }
-
 #if CHIP_ENABLE_OPENTHREAD
     EFR32_LOG("Initializing OpenThread stack");
     err = ThreadStackMgr().InitThreadStack();
@@ -172,15 +164,28 @@ int main(void)
     chip::startShellTask();
 #endif
 #ifdef EFR32_OTA_ENABLED
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
     OTAConfig::Init();
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 #endif // EFR32_OTA_ENABLED
     WindowApp & app = WindowApp::Instance();
 
     EFR32_LOG("Starting App");
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
     err = app.Init();
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+
     if (err != CHIP_NO_ERROR)
     {
         EFR32_LOG("App Init failed");
+        appError(err);
+    }
+
+    EFR32_LOG("Starting Platform Manager Event Loop");
+    err = PlatformMgr().StartEventLoopTask();
+    if (err != CHIP_NO_ERROR)
+    {
+        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
         appError(err);
     }
 

--- a/examples/window-app/efr32/src/main.cpp
+++ b/examples/window-app/efr32/src/main.cpp
@@ -141,8 +141,20 @@ int main(void)
         appError(err);
     }
 
-    EFR32_LOG("Starting OpenThread task");
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
+    // Init ZCL Data Model
+    chip::Server::GetInstance().Init();
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
+    EFR32_LOG("Starting Platform Manager Event Loop");
+    err = PlatformMgr().StartEventLoopTask();
+    if (err != CHIP_NO_ERROR)
+    {
+        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
+        appError(err);
+    }
+
+    EFR32_LOG("Starting OpenThread task");
     // Start OpenThread task
     err = ThreadStackMgrImpl().StartThreadTask();
     if (err != CHIP_NO_ERROR)
@@ -178,14 +190,6 @@ int main(void)
     if (err != CHIP_NO_ERROR)
     {
         EFR32_LOG("App Init failed");
-        appError(err);
-    }
-
-    EFR32_LOG("Starting Platform Manager Event Loop");
-    err = PlatformMgr().StartEventLoopTask();
-    if (err != CHIP_NO_ERROR)
-    {
-        EFR32_LOG("PlatformMgr().StartEventLoopTask() failed");
         appError(err);
     }
 


### PR DESCRIPTION
#### Problem
* Applications was not holding lock on the matter task when reading/writing or calling commands
* Fixes #15325 

#### Change overview
* Add lock/unlock or scheduleWork to application calls interacting with matter stack

#### Testing
* Manual tests with every examples to verify that app doesn't try to access the matter stack without holding the semaphore
