### PR TITLE
Add regulatory location read and defaults.

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -323,8 +323,10 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
             {
                 mParams.SetFailsafeTimerSeconds(mDeviceCommissioningInfo.general.recommendedFailsafe);
             }
-            mParams.SetRemoteVendorId(report.Get<ReadCommissioningInfo>().basic.vendorId);
-            mParams.SetRemoteProductId(report.Get<ReadCommissioningInfo>().basic.productId);
+            mParams.SetRemoteVendorId(mDeviceCommissioningInfo.basic.vendorId)
+                .SetRemoteProductId(mDeviceCommissioningInfo.basic.productId)
+                .SetDefaultRegulatoryLocation(mDeviceCommissioningInfo.general.currentRegulatoryLocation)
+                .SetLocationCapability(mDeviceCommissioningInfo.general.locationCapability);
             break;
         case CommissioningStage::kSendPAICertificateRequest:
             SetPAI(report.Get<RequestedCertificate>().certificate);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1563,15 +1563,38 @@ void DeviceCommissioner::OnDone()
     // Using ForEachAttribute because this attribute can be queried on any endpoint.
     err = mAttributeCache->ForEachAttribute(
         app::Clusters::GeneralCommissioning::Id, [this, &info](const app::ConcreteAttributePath & path) {
-            if (path.mAttributeId != app::Clusters::GeneralCommissioning::Attributes::BasicCommissioningInfo::Id)
+            switch (path.mAttributeId)
             {
+            case app::Clusters::GeneralCommissioning::Attributes::BasicCommissioningInfo::Id: {
+                app::Clusters::GeneralCommissioning::Attributes::BasicCommissioningInfo::TypeInfo::DecodableType basicInfo;
+                ReturnErrorOnFailure(
+                    this->mAttributeCache->Get<app::Clusters::GeneralCommissioning::Attributes::BasicCommissioningInfo::TypeInfo>(
+                        path, basicInfo));
+                info.general.recommendedFailsafe = basicInfo.failSafeExpiryLengthSeconds;
+            }
+            break;
+            case app::Clusters::GeneralCommissioning::Attributes::RegulatoryConfig::Id: {
+                ReturnErrorOnFailure(
+                    this->mAttributeCache->Get<app::Clusters::GeneralCommissioning::Attributes::RegulatoryConfig::TypeInfo>(
+                        path, info.general.currentRegulatoryLocation));
+            }
+            break;
+            case app::Clusters::GeneralCommissioning::Attributes::LocationCapability::Id: {
+                ReturnErrorOnFailure(
+                    this->mAttributeCache->Get<app::Clusters::GeneralCommissioning::Attributes::LocationCapability::TypeInfo>(
+                        path, info.general.locationCapability));
+            }
+            break;
+            case app::Clusters::GeneralCommissioning::Attributes::Breadcrumb::Id: {
+                ReturnErrorOnFailure(
+                    this->mAttributeCache->Get<app::Clusters::GeneralCommissioning::Attributes::Breadcrumb::TypeInfo>(
+                        path, info.general.breadcrumb));
+            }
+            break;
+            default:
                 return CHIP_NO_ERROR;
             }
-            app::Clusters::GeneralCommissioning::Attributes::BasicCommissioningInfo::TypeInfo::DecodableType basicInfo;
-            ReturnErrorOnFailure(
-                this->mAttributeCache->Get<app::Clusters::GeneralCommissioning::Attributes::BasicCommissioningInfo::TypeInfo>(
-                    path, basicInfo));
-            info.general.recommendedFailsafe = basicInfo.failSafeExpiryLengthSeconds;
+
             return CHIP_NO_ERROR;
         });
 
@@ -1734,22 +1757,29 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         app::InteractionModelEngine * engine = app::InteractionModelEngine::GetInstance();
         app::ReadPrepareParams readParams(proxy->GetSecureSession().Value());
 
-        app::AttributePathParams readPaths[5];
+        app::AttributePathParams readPaths[8];
         // Read all the feature maps for all the networking clusters on any endpoint to determine what is supported
         readPaths[0] = app::AttributePathParams(app::Clusters::NetworkCommissioning::Id,
                                                 app::Clusters::NetworkCommissioning::Attributes::FeatureMap::Id);
-        // Get the basic commissioning info from the general commissioning cluster on this endpoint (recommended failsafe time)
+        // Get required general commissioning attributes on this endpoint (recommended failsafe time, regulatory location
+        // info, breadcrumb)
         readPaths[1] = app::AttributePathParams(endpoint, app::Clusters::GeneralCommissioning::Id,
+                                                app::Clusters::GeneralCommissioning::Attributes::Breadcrumb::Id);
+        readPaths[2] = app::AttributePathParams(endpoint, app::Clusters::GeneralCommissioning::Id,
                                                 app::Clusters::GeneralCommissioning::Attributes::BasicCommissioningInfo::Id);
+        readPaths[3] = app::AttributePathParams(endpoint, app::Clusters::GeneralCommissioning::Id,
+                                                app::Clusters::GeneralCommissioning::Attributes::RegulatoryConfig::Id);
+        readPaths[4] = app::AttributePathParams(endpoint, app::Clusters::GeneralCommissioning::Id,
+                                                app::Clusters::GeneralCommissioning::Attributes::LocationCapability::Id);
         // Read attributes from the basic info cluster (vendor id / product id / software version)
-        readPaths[2] = app::AttributePathParams(endpoint, app::Clusters::Basic::Id, app::Clusters::Basic::Attributes::VendorID::Id);
-        readPaths[3] =
+        readPaths[5] = app::AttributePathParams(endpoint, app::Clusters::Basic::Id, app::Clusters::Basic::Attributes::VendorID::Id);
+        readPaths[6] =
             app::AttributePathParams(endpoint, app::Clusters::Basic::Id, app::Clusters::Basic::Attributes::ProductID::Id);
-        readPaths[4] =
+        readPaths[7] =
             app::AttributePathParams(endpoint, app::Clusters::Basic::Id, app::Clusters::Basic::Attributes::SoftwareVersion::Id);
 
         readParams.mpAttributePathParamsList    = readPaths;
-        readParams.mAttributePathParamsListSize = 5;
+        readParams.mAttributePathParamsListSize = 8;
         if (timeout.HasValue())
         {
             readParams.mTimeout = timeout.Value();
@@ -1778,25 +1808,46 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         // TODO(cecille): Worthwhile to keep this around as part of the class?
         // TODO(cecille): Where is the country config actually set?
         ChipLogProgress(Controller, "Setting Regulatory Config");
-        uint8_t regulatoryLocation = to_underlying(app::Clusters::GeneralCommissioning::RegulatoryLocationType::kOutdoor);
-#if CONFIG_DEVICE_LAYER
-        CHIP_ERROR status = DeviceLayer::ConfigurationMgr().GetRegulatoryLocation(regulatoryLocation);
-#else
-        CHIP_ERROR status = CHIP_ERROR_NOT_IMPLEMENTED;
-#endif
-        if (status != CHIP_NO_ERROR)
+        auto capability =
+            params.GetLocationCapability().ValueOr(app::Clusters::GeneralCommissioning::RegulatoryLocationType::kOutdoor);
+        app::Clusters::GeneralCommissioning::RegulatoryLocationType regulatoryLocation;
+        // Value is only switchable on the devices with indoor/outdoor capability
+        if (capability == app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoorOutdoor)
         {
-            ChipLogError(Controller, "Unable to find regulatory location, defaulting to outdoor");
+            // If the device supports indoor and outdoor configs, use the setting from the commissioner, otherwise fall back to the
+            // current device setting then to outdoor (most restrictive)
+            if (params.GetDeviceRegulatoryLocation().HasValue())
+            {
+                regulatoryLocation = params.GetDeviceRegulatoryLocation().Value();
+                ChipLogProgress(Controller, "Setting regulatory location to %u from commissioner override",
+                                static_cast<uint8_t>(regulatoryLocation));
+            }
+            else if (params.GetDefaultRegulatoryLocation().HasValue())
+            {
+                regulatoryLocation = params.GetDefaultRegulatoryLocation().Value();
+                ChipLogProgress(Controller, "No regulatory location supplied by controller, leaving as device default (%u)",
+                                static_cast<uint8_t>(regulatoryLocation));
+            }
+            else
+            {
+                regulatoryLocation = app::Clusters::GeneralCommissioning::RegulatoryLocationType::kOutdoor;
+                ChipLogProgress(Controller, "No overrride or device regulatory location supplied, setting to outdoor");
+            }
         }
-
+        else
+        {
+            ChipLogProgress(Controller, "Device does not support configurable regulatory location");
+            regulatoryLocation = capability;
+        }
         static constexpr size_t kMaxCountryCodeSize = 3;
         char countryCodeStr[kMaxCountryCodeSize]    = "XX";
         size_t actualCountryCodeSize                = 2;
 
 #if CONFIG_DEVICE_LAYER
-        status = DeviceLayer::ConfigurationMgr().GetCountryCode(countryCodeStr, kMaxCountryCodeSize, actualCountryCodeSize);
+        CHIP_ERROR status =
+            DeviceLayer::ConfigurationMgr().GetCountryCode(countryCodeStr, kMaxCountryCodeSize, actualCountryCodeSize);
 #else
-        status = CHIP_ERROR_NOT_IMPLEMENTED;
+        CHIP_ERROR status = CHIP_ERROR_NOT_IMPLEMENTED;
 #endif
         if (status != CHIP_NO_ERROR)
         {
@@ -1805,7 +1856,7 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         chip::CharSpan countryCode(countryCodeStr, actualCountryCodeSize);
 
         GeneralCommissioning::Commands::SetRegulatoryConfig::Type request;
-        request.location    = static_cast<GeneralCommissioning::RegulatoryLocationType>(regulatoryLocation);
+        request.location    = regulatoryLocation;
         request.countryCode = countryCode;
         request.breadcrumb  = breadcrumb;
         request.timeoutMs   = kCommandTimeoutMs;

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -78,6 +78,10 @@ public:
     static constexpr size_t kMaxCredentialsLen   = 64;
 
     const Optional<uint16_t> GetFailsafeTimerSeconds() const { return mFailsafeTimerSeconds; }
+    const Optional<app::Clusters::GeneralCommissioning::RegulatoryLocationType> GetDeviceRegulatoryLocation() const
+    {
+        return mDeviceRegulatoryLocation;
+    }
     const Optional<ByteSpan> GetCSRNonce() const { return mCSRNonce; }
     const Optional<ByteSpan> GetAttestationNonce() const { return mAttestationNonce; }
     const Optional<WiFiCredentials> GetWiFiCredentials() const { return mWiFiCreds; }
@@ -97,11 +101,25 @@ public:
     const Optional<ByteSpan> GetDAC() const { return mDAC; }
     const Optional<VendorId> GetRemoteVendorId() const { return mRemoteVendorId; }
     const Optional<uint16_t> GetRemoteProductId() const { return mRemoteProductId; }
+    const Optional<app::Clusters::GeneralCommissioning::RegulatoryLocationType> GetDefaultRegulatoryLocation() const
+    {
+        return mDefaultRegulatoryLocation;
+    }
+    const Optional<app::Clusters::GeneralCommissioning::RegulatoryLocationType> GetLocationCapability() const
+    {
+        return mLocationCapability;
+    }
     CHIP_ERROR GetCompletionStatus() { return completionStatus; }
 
     CommissioningParameters & SetFailsafeTimerSeconds(uint16_t seconds)
     {
         mFailsafeTimerSeconds.SetValue(seconds);
+        return *this;
+    }
+
+    CommissioningParameters & SetDeviceRegulatoryLocation(app::Clusters::GeneralCommissioning::RegulatoryLocationType location)
+    {
+        mDeviceRegulatoryLocation.SetValue(location);
         return *this;
     }
 
@@ -195,10 +213,22 @@ public:
         mRemoteProductId = MakeOptional(id);
         return *this;
     }
+    CommissioningParameters & SetDefaultRegulatoryLocation(app::Clusters::GeneralCommissioning::RegulatoryLocationType location)
+    {
+        mDefaultRegulatoryLocation = MakeOptional(location);
+        return *this;
+    }
+    CommissioningParameters & SetLocationCapability(app::Clusters::GeneralCommissioning::RegulatoryLocationType capability)
+    {
+        mLocationCapability = MakeOptional(capability);
+        return *this;
+    }
     void SetCompletionStatus(CHIP_ERROR err) { completionStatus = err; }
 
 private:
+    // Items that can be set by the commissioner
     Optional<uint16_t> mFailsafeTimerSeconds;
+    Optional<app::Clusters::GeneralCommissioning::RegulatoryLocationType> mDeviceRegulatoryLocation;
     Optional<ByteSpan> mCSRNonce;         ///< CSR Nonce passed by the commissioner
     Optional<ByteSpan> mAttestationNonce; ///< Attestation Nonce passed by the commissioner
     Optional<WiFiCredentials> mWiFiCreds;
@@ -209,12 +239,15 @@ private:
     Optional<ByteSpan> mIcac;
     Optional<AesCcm128Key> mIpk;
     Optional<NodeId> mAdminSubject;
+    // Items that come from the device in commissioning steps
     Optional<ByteSpan> mAttestationElements;
     Optional<ByteSpan> mAttestationSignature;
     Optional<ByteSpan> mPAI;
     Optional<ByteSpan> mDAC;
     Optional<VendorId> mRemoteVendorId;
     Optional<uint16_t> mRemoteProductId;
+    Optional<app::Clusters::GeneralCommissioning::RegulatoryLocationType> mDefaultRegulatoryLocation;
+    Optional<app::Clusters::GeneralCommissioning::RegulatoryLocationType> mLocationCapability;
     CHIP_ERROR completionStatus = CHIP_NO_ERROR;
 };
 
@@ -265,7 +298,13 @@ struct BasicClusterInfo
 };
 struct GeneralCommissioningInfo
 {
+    uint64_t breadcrumb          = 0;
     uint16_t recommendedFailsafe = 0;
+    app::Clusters::GeneralCommissioning::RegulatoryLocationType currentRegulatoryLocation =
+        app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoorOutdoor;
+    app::Clusters::GeneralCommissioning::RegulatoryLocationType locationCapability =
+        app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoorOutdoor;
+    ;
 };
 
 struct ReadCommissioningInfo


### PR DESCRIPTION


#### Problem
Per 11.9.6.4 we should be checking the location capability.
Per 11.9.6.3 the device has a valid default value that should be
used when we call SetRegulatoryLocation.

The device is also not necessarily in the same regulatory location as the commissioner - this is something that needs to be passed in explicitly rather than read from the commissioner's configuration.

#### Change overview
- read current regulatory location and capabilities from the device, only set if the device has indoor/outdoor capability
- add parameter to pass in the device regulatory location
- fall back to device current regulatory location and then to outdoor

#### Testing
Linux all platforms - tested first with current (indoor) capability.  Set the device location capability to indoor/outdoor, saw commissioner read correctly, tested using default (device setting) and with a location set in the parameters.
