### PR TITLE
Fix handling of > 32 bit ints in struct/lists in chip-tool.

### DIFF
--- a/examples/chip-tool/commands/clusters/ComplexArgument.h
+++ b/examples/chip-tool/commands/clusters/ComplexArgument.h
@@ -45,7 +45,7 @@ public:
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
 
-        request = static_cast<T>(value.asUInt());
+        request = static_cast<T>(value.asLargestUInt());
         return CHIP_NO_ERROR;
     }
 
@@ -58,7 +58,7 @@ public:
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
 
-        request = static_cast<T>(value.asInt());
+        request = static_cast<T>(value.asLargestInt());
         return CHIP_NO_ERROR;
     }
 


### PR DESCRIPTION
The CanCastTo checks were using the right getter, but the actual casts
were using one that only works for 32-bit ints.

Fixes https://github.com/project-chip/connectedhomeip/issues/15360

#### Problem
Assertion failures.

#### Change overview
Use the right int getter.

#### Testing
Ran commands from #15360 and they did not crash.