### PR TITLE
[OTA] Convert ObjectPool to a custom array type for DefaultOTAProviders attribute

### DIFF
--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -76,15 +76,15 @@ public:
     // cleared, UpdateState is reset to Idle
     void CancelImageUpdate() override;
 
-    // Retrieve the default OTA provider list as an encoded list
-    CHIP_ERROR GetDefaultOtaProviderList(app::AttributeValueEncoder & encoder) override;
-
     // Clear all entries with the specified fabric index in the default OTA provider list
     CHIP_ERROR ClearDefaultOtaProviderList(FabricIndex fabricIndex) override;
 
     // Add a default OTA provider to the cached list
     CHIP_ERROR AddDefaultOtaProvider(
-        app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type const & providerLocation) override;
+        const app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type & providerLocation) override;
+
+    // Retrieve an iterator to the cached default OTA provider list
+    ProviderLocationList::Iterator GetDefaultOTAProviderListIterator(void) override { return mDefaultOtaProviderList.Begin(); }
 
     //////////// BDXDownloader::StateDelegate Implementation ///////////////
     void OnDownloadStateChanged(OTADownloader::State state,
@@ -205,9 +205,14 @@ private:
     };
 
     /**
-     * Update the cached default OTA provider location (with a value from the default list) to use for the next periodic query
+     * Set the cached default OTA provider location to use for the next query
      */
-    void UpdateDefaultProviderLocation(void);
+    bool SetDefaultProviderLocation(const ProviderLocationType & providerLocation);
+
+    /**
+     * Clear the cached default OTA provider location to indicate no OTA update may be in progress
+     */
+    bool ClearDefaultProviderLocation(void);
 
     /**
      * Record the new update state by updating the corresponding server attribute and logging a StateTransition event
@@ -290,7 +295,7 @@ private:
     OTAUpdateStateEnum mCurrentUpdateState = OTAUpdateStateEnum::kIdle;
     Server * mServer                       = nullptr;
     chip::Optional<bool> mRequestorCanConsent;
-    ObjectPool<ProviderLocationType, CHIP_CONFIG_MAX_FABRICS> mDefaultOtaProviderList;
+    ProviderLocationList mDefaultOtaProviderList;
     Optional<ProviderLocationType> mProviderLocation; // Provider location used for the current update in progress
 };
 

--- a/src/app/clusters/ota-requestor/ota-requestor-server.cpp
+++ b/src/app/clusters/ota-requestor/ota-requestor-server.cpp
@@ -31,6 +31,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::OtaSoftwareUpdateRequestor;
 using namespace chip::app::Clusters::OtaSoftwareUpdateRequestor::Attributes;
+using namespace chip::app::Clusters::OtaSoftwareUpdateRequestor::Structs;
 
 namespace {
 
@@ -87,7 +88,16 @@ CHIP_ERROR OtaSoftwareUpdateRequestorAttrAccess::ReadDefaultOtaProviders(Attribu
         return aEncoder.EncodeEmptyList();
     }
 
-    return requestor->GetDefaultOtaProviderList(aEncoder);
+    return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
+        auto iterator = requestor->GetDefaultOTAProviderListIterator();
+        while (iterator.Next())
+        {
+            ProviderLocation::Type pl = iterator.GetValue();
+            ReturnErrorOnFailure(encoder.Encode(pl));
+        }
+
+        return CHIP_NO_ERROR;
+    });
 }
 
 CHIP_ERROR OtaSoftwareUpdateRequestorAttrAccess::WriteDefaultOtaProviders(const ConcreteDataAttributePath & aPath,

--- a/src/include/platform/OTARequestorInterface.h
+++ b/src/include/platform/OTARequestorInterface.h
@@ -30,6 +30,115 @@
 
 namespace chip {
 
+/**
+ * A class to represent a list of the provider locations
+ */
+class ProviderLocationList
+{
+public:
+    /**
+     * A class to iterate over an instance of ProviderLocationList
+     */
+    class Iterator
+    {
+    public:
+        /**
+         * Initialize iterator values, must be called before calling Next()/GetValue()
+         */
+        Iterator(const Optional<app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type> * const list,
+                 size_t size)
+        {
+            mList         = list;
+            mListSize     = size;
+            mCurrentIndex = 0;
+            mNextIndex    = 0;
+        }
+
+        /**
+         * Search for the next provider location found in the list
+         */
+        bool Next()
+        {
+            for (size_t i = mNextIndex; i < mListSize; i++)
+            {
+                if (mList[i].HasValue())
+                {
+                    mCurrentIndex = i;
+                    mNextIndex    = mCurrentIndex + 1;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /**
+         * Retrieves a reference to the provider location found on a previous call to Next()
+         */
+        const app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type & GetValue() const
+        {
+            return mList[mCurrentIndex].Value();
+        }
+
+    private:
+        const Optional<app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type> * mList;
+        size_t mListSize;
+        size_t mCurrentIndex;
+        size_t mNextIndex;
+    };
+
+    /**
+     * Retrieve an iterator to the list
+     */
+    Iterator Begin() const { return Iterator(mList, CHIP_CONFIG_MAX_FABRICS); }
+
+    /**
+     * Add a provider location to the list if there is space available
+     */
+    CHIP_ERROR Add(const app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type & providerLocation)
+    {
+        for (size_t i = 0; i < mMaxSize; i++)
+        {
+            if (!mList[i].HasValue())
+            {
+                mList[i].SetValue(providerLocation);
+                mListSize++;
+                return CHIP_NO_ERROR;
+            }
+        }
+
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    /**
+     * Delete a provider location from the list if found
+     */
+    CHIP_ERROR Delete(const app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type & providerLocation)
+    {
+        for (size_t i = 0; i < mMaxSize; i++)
+        {
+            if (mList[i].HasValue())
+            {
+                const app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type & pl = mList[i].Value();
+                if ((pl.GetFabricIndex() == providerLocation.GetFabricIndex()) &&
+                    (pl.providerNodeID == providerLocation.providerNodeID) && (pl.endpoint == providerLocation.endpoint))
+                {
+                    mList[i].ClearValue();
+                    mListSize--;
+                    return CHIP_NO_ERROR;
+                }
+            }
+        }
+
+        return CHIP_ERROR_NOT_FOUND;
+    }
+
+private:
+    Optional<app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type> mList[CHIP_CONFIG_MAX_FABRICS];
+    size_t mListSize = 0;
+    size_t mMaxSize  = CHIP_CONFIG_MAX_FABRICS;
+};
+
 // Interface class to connect the OTA Software Update Requestor cluster command processing
 // with the core OTA Requestor logic. The OTARequestor class implements this interface
 class OTARequestorInterface
@@ -79,15 +188,15 @@ public:
     // cleared, UpdateState is reset to Idle
     virtual void CancelImageUpdate() = 0;
 
-    // Retrieve the default OTA provider list as an encoded list
-    virtual CHIP_ERROR GetDefaultOtaProviderList(app::AttributeValueEncoder & encoder) = 0;
-
     // Clear all entries with the specified fabric index in the default OTA provider list
     virtual CHIP_ERROR ClearDefaultOtaProviderList(FabricIndex fabricIndex) = 0;
 
     // Add a default OTA provider to the cached list
     virtual CHIP_ERROR
-    AddDefaultOtaProvider(app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type const & providerLocation) = 0;
+    AddDefaultOtaProvider(const app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type & providerLocation) = 0;
+
+    // Retrieve an iterator to the cached default OTA provider list
+    virtual ProviderLocationList::Iterator GetDefaultOTAProviderListIterator(void) = 0;
 };
 
 // The instance of the class implementing OTARequestorInterface must be managed through


### PR DESCRIPTION
#### Problem
The DefaultOTAProviders attribute is being cached as an `ObjectPool`. This makes persistence pretty difficult. The `ObjectPool` is a linked-list of memory blocks (might or might not be contiguous). Therefore, this data cannot be directly written to the flash, since the KVS manager expects a pointer to a contiguous block of memory to write.

This is a precursor for https://github.com/project-chip/connectedhomeip/issues/14338

#### Change overview
- Convert `ObjectPool` to a custom array type `ProviderLocationList` to store provider location structs
- Add an API that makes it easy to traverse the providers in the list
- Add APIs that can set/clear the current provider location to use for query
- Use the traverse API to encode data for DefaultOTAProviders attribute read

#### Testing
Verified that reading/writing of the DefaultOTAProviders attribute is still functional.
