### PR TITLE
Added get/set API for advertisement version

### DIFF
--- a/src/ble/CHIPBleServiceData.h
+++ b/src/ble/CHIPBleServiceData.h
@@ -45,12 +45,13 @@ enum chipBLEServiceDataType
  */
 struct ChipBLEDeviceIdentificationInfo
 {
-    constexpr static uint16_t kDiscriminatorMask        = 0xfff;
-    constexpr static uint8_t kAdditionalDataFlagMask    = 0x1;
-    constexpr static uint16_t kAdvertisementVersionMask = 0xf000;
+    constexpr static uint16_t kDiscriminatorMask       = 0xfff;
+    constexpr static uint8_t kAdditionalDataFlagMask   = 0x1;
+    constexpr static uint8_t kAdvertisementVersionMask = 0x0f;
+    constexpr static uint16_t kAdvertisementMask       = 0xf000;
 
     uint8_t OpCode;
-    uint8_t DeviceDiscriminator[2]; // 12 bits for device discriminator and 4 bits for advertisement version
+    uint8_t DeviceDiscriminatorAndAdvVersion[2]; // 12 bits for device discriminator and 4 bits for advertisement version
     uint8_t DeviceVendorId[2];
     uint8_t DeviceProductId[2];
     uint8_t AdditionalDataFlag;
@@ -67,29 +68,29 @@ struct ChipBLEDeviceIdentificationInfo
 
     uint16_t GetAdvertisementVersion() const
     {
-        return chip::Encoding::LittleEndian::Get16(DeviceDiscriminator) & kAdvertisementVersionMask;
+        return chip::Encoding::LittleEndian::Get16(DeviceDiscriminatorAndAdvVersion) & kAdvertisementMask;
     }
 
     // Use only 4 bits to set advertisement version
-    void SetAdvertisementVersion(uint16_t advertisementVersion)
+    void SetAdvertisementVersion(uint8_t advertisementVersion)
     {
         // Advertisement Version is 4 bit long from 12th to 15th
         advertisementVersion &= kAdvertisementVersionMask;
-        advertisementVersion |= static_cast<uint16_t>(DeviceDiscriminator[1] << 8u & ~kAdvertisementVersionMask);
-        chip::Encoding::LittleEndian::Put16(DeviceDiscriminator, advertisementVersion);
+        advertisementVersion <<= 4u;
+        DeviceDiscriminatorAndAdvVersion[1] |= advertisementVersion;
     }
 
     uint16_t GetDeviceDiscriminator() const
     {
-        return chip::Encoding::LittleEndian::Get16(DeviceDiscriminator) & kDiscriminatorMask;
+        return chip::Encoding::LittleEndian::Get16(DeviceDiscriminatorAndAdvVersion) & kDiscriminatorMask;
     }
 
     void SetDeviceDiscriminator(uint16_t deviceDiscriminator)
     {
         // Discriminator is 12-bit long, so don't overwrite bits 12th through 15th
         deviceDiscriminator &= kDiscriminatorMask;
-        deviceDiscriminator |= static_cast<uint16_t>(DeviceDiscriminator[1] << 8u & ~kDiscriminatorMask);
-        chip::Encoding::LittleEndian::Put16(DeviceDiscriminator, deviceDiscriminator);
+        deviceDiscriminator |= static_cast<uint16_t>(DeviceDiscriminatorAndAdvVersion[1] << 8u & ~kDiscriminatorMask);
+        chip::Encoding::LittleEndian::Put16(DeviceDiscriminatorAndAdvVersion, deviceDiscriminator);
     }
 
     uint8_t GetAdditionalDataFlag() const { return (AdditionalDataFlag & kAdditionalDataFlagMask); }

--- a/src/ble/CHIPBleServiceData.h
+++ b/src/ble/CHIPBleServiceData.h
@@ -45,14 +45,15 @@ enum chipBLEServiceDataType
  */
 struct ChipBLEDeviceIdentificationInfo
 {
-    constexpr static uint16_t kDiscriminatorMask           = 0xfff;
-    constexpr static uint8_t kAdditionalDataFlagMask       = 0x1;
-    constexpr static uint8_t kAdvertisementVersionMask     = 0x0f;
-    constexpr static uint8_t AdvertisementVersionShiftBits = 4u;
+    constexpr static uint16_t kDiscriminatorMask            = 0xfff;
+    constexpr static uint8_t kAdditionalDataFlagMask        = 0x1;
+    constexpr static uint8_t kAdvertisementVersionMask      = 0xf0;
+    constexpr static uint8_t kAdvertisementVersionShiftBits = 4u;
 
     uint8_t OpCode;
-    // from lsb 0-11 bits (i.e. 8 bits of DeviceDiscriminatorAndAdvVersion[0] and 4 bits of DeviceDiscriminatorAndAdvVersion[1]) for
-    // device discriminator and 12-15 bits (i.e 4 bits of DeviceDiscriminatorAndAdvVersion[1]) for advertisement version
+    // DeviceDiscriminatorAndAdvVersion[0] contains the low 8 bits of the 12-bit discriminator.
+    // DeviceDiscriminatorAndAdvVersion[1] contains the high 8 bits of the 12-bit discriminator in its low 4 bits and
+    // the 4 bits of the advertisement version in its high 4 bits.
     uint8_t DeviceDiscriminatorAndAdvVersion[2];
     uint8_t DeviceVendorId[2];
     uint8_t DeviceProductId[2];
@@ -70,8 +71,8 @@ struct ChipBLEDeviceIdentificationInfo
 
     uint8_t GetAdvertisementVersion() const
     {
-        uint8_t advertisementVersion = static_cast<uint8_t>((DeviceDiscriminatorAndAdvVersion[1] >> AdvertisementVersionShiftBits) &
-                                                            kAdvertisementVersionMask);
+        uint8_t advertisementVersion = static_cast<uint8_t>((DeviceDiscriminatorAndAdvVersion[1] & kAdvertisementVersionMask) >>
+                                                            kAdvertisementVersionShiftBits);
         return advertisementVersion;
     }
 
@@ -80,9 +81,9 @@ struct ChipBLEDeviceIdentificationInfo
     {
         // Advertisement Version is 4 bit long from 12th to 15th
         advertisementVersion =
-            static_cast<uint8_t>((advertisementVersion & kAdvertisementVersionMask) << AdvertisementVersionShiftBits);
+            static_cast<uint8_t>((advertisementVersion << kAdvertisementVersionShiftBits) & kAdvertisementVersionMask);
         DeviceDiscriminatorAndAdvVersion[1] =
-            (DeviceDiscriminatorAndAdvVersion[1] & kAdvertisementVersionMask) | advertisementVersion;
+            static_cast<uint8_t>((DeviceDiscriminatorAndAdvVersion[1] & ~kAdvertisementVersionMask) | advertisementVersion);
     }
 
     uint16_t GetDeviceDiscriminator() const

--- a/src/ble/CHIPBleServiceData.h
+++ b/src/ble/CHIPBleServiceData.h
@@ -45,12 +45,12 @@ enum chipBLEServiceDataType
  */
 struct ChipBLEDeviceIdentificationInfo
 {
-    constexpr static uint16_t kDiscriminatorMask     = 0xfff;
-    constexpr static uint8_t kAdditionalDataFlagMask = 0x1;
-    constexpr static uint16_t kAdvertisementVersionMask  = 0xf000;
+    constexpr static uint16_t kDiscriminatorMask        = 0xfff;
+    constexpr static uint8_t kAdditionalDataFlagMask    = 0x1;
+    constexpr static uint16_t kAdvertisementVersionMask = 0xf000;
 
     uint8_t OpCode;
-    uint8_t DeviceDiscriminator[2];                // 12 bits for device discriminator and 4 bits for advertisement version
+    uint8_t DeviceDiscriminator[2]; // 12 bits for device discriminator and 4 bits for advertisement version
     uint8_t DeviceVendorId[2];
     uint8_t DeviceProductId[2];
     uint8_t AdditionalDataFlag;

--- a/src/ble/CHIPBleServiceData.h
+++ b/src/ble/CHIPBleServiceData.h
@@ -47,9 +47,10 @@ struct ChipBLEDeviceIdentificationInfo
 {
     constexpr static uint16_t kDiscriminatorMask     = 0xfff;
     constexpr static uint8_t kAdditionalDataFlagMask = 0x1;
+    constexpr static uint16_t kAdvertisementVersionMask  = 0xf000;
 
     uint8_t OpCode;
-    uint8_t DeviceDiscriminator[2];
+    uint8_t DeviceDiscriminator[2];                // 12 bits for device discriminator and 4 bits for advertisement version
     uint8_t DeviceVendorId[2];
     uint8_t DeviceProductId[2];
     uint8_t AdditionalDataFlag;
@@ -63,6 +64,20 @@ struct ChipBLEDeviceIdentificationInfo
     uint16_t GetProductId() const { return chip::Encoding::LittleEndian::Get16(DeviceProductId); }
 
     void SetProductId(uint16_t productId) { chip::Encoding::LittleEndian::Put16(DeviceProductId, productId); }
+
+    uint16_t GetAdvertisementVersion() const
+    {
+        return chip::Encoding::LittleEndian::Get16(DeviceDiscriminator) & kAdvertisementVersionMask;
+    }
+
+    // Use only 4 bits to set advertisement version
+    void SetAdvertisementVersion(uint16_t advertisementVersion)
+    {
+        // Advertisement Version is 4 bit long from 12th to 15th
+        advertisementVersion &= kAdvertisementVersionMask;
+        advertisementVersion |= static_cast<uint16_t>(DeviceDiscriminator[1] << 8u & ~kAdvertisementVersionMask);
+        chip::Encoding::LittleEndian::Put16(DeviceDiscriminator, advertisementVersion);
+    }
 
     uint16_t GetDeviceDiscriminator() const
     {

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -41,6 +41,8 @@
 #include <platform/ThreadStackManager.h>
 #endif
 
+#define BLE_ADVERTISEMENT_VERSION 0
+
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
@@ -563,6 +565,8 @@ GenericConfigurationManagerImpl<ConfigClass>::GetBLEDeviceIdentificationInfo(Ble
     err = GetSetupDiscriminator(discriminator);
     SuccessOrExit(err);
     deviceIdInfo.SetDeviceDiscriminator(discriminator);
+
+    deviceIdInfo.SetAdvertisementVersion(BLE_ADVERTISEMENT_VERSION);
 
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
     deviceIdInfo.SetAdditionalDataFlag(true);

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -41,6 +41,7 @@
 #include <platform/ThreadStackManager.h>
 #endif
 
+// TODO : may be we can make it configurable
 #define BLE_ADVERTISEMENT_VERSION 0
 
 namespace chip {


### PR DESCRIPTION
Problem
* Added get/set API's for advertisement version.
* Fixes #5369 

Change overview
get/set API's for advertisement version

Testing
* Tested commissioning esp32 and linux all clusters app by setting advertisement version manually.
