### PR TITLE
Rename channel cluster ErrorTypeEnum to StatusEnum

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -136,11 +136,6 @@ server cluster ApplicationLauncher = 1292 {
     kApplicationPlatform = 0x1;
   }
 
-  bitmap ChannelFeature : BITMAP32 {
-    kChannelList = 0x1;
-    kLineupInfo = 0x2;
-  }
-
   struct Application {
     INT16U catalogVendorId = 0;
     CHAR_STRING applicationId = 1;
@@ -344,13 +339,19 @@ server cluster BridgedActions = 37 {
 }
 
 server cluster Channel = 1284 {
-  enum ErrorTypeEnum : ENUM8 {
-    kMultipleMatches = 0;
-    kNoMatches = 1;
-  }
-
   enum LineupInfoTypeEnum : ENUM8 {
     kMso = 0;
+  }
+
+  enum StatusEnum : ENUM8 {
+    kSuccess = 0;
+    kMultipleMatches = 1;
+    kNoMatches = 2;
+  }
+
+  bitmap ChannelFeature : BITMAP32 {
+    kChannelList = 0x1;
+    kLineupInfo = 0x2;
   }
 
   struct ChannelInfo {

--- a/examples/tv-app/android/java/ChannelManager.cpp
+++ b/examples/tv-app/android/java/ChannelManager.cpp
@@ -267,9 +267,9 @@ void ChannelManager::HandleChangeChannel(CommandResponseHelper<ChangeChannelResp
 
         jclass channelClass = env->GetObjectClass(channelObject);
 
-        jfieldID getErrorTypeField = env->GetFieldID(channelClass, "errorType", "I");
-        jint jerrorType            = env->GetIntField(channelObject, getErrorTypeField);
-        response.errorType         = static_cast<app::Clusters::Channel::ErrorTypeEnum>(jerrorType);
+        jfieldID getStatusField = env->GetFieldID(channelClass, "status", "I");
+        jint jstatus            = env->GetIntField(channelObject, getStatusField);
+        response.status         = static_cast<app::Clusters::Channel::StatusEnum>(jstatus);
 
         jfieldID getCallSignField = env->GetFieldID(channelClass, "callSign", "Ljava/lang/String;");
         jstring jcallSign         = static_cast<jstring>(env->GetObjectField(channelObject, getCallSignField));

--- a/examples/tv-app/linux/include/channel/ChannelManager.cpp
+++ b/examples/tv-app/linux/include/channel/ChannelManager.cpp
@@ -132,7 +132,7 @@ void ChannelManager::HandleChangeChannel(CommandResponseHelper<ChangeChannelResp
     }
     else
     {
-        response.status = chip::app::Clusters::Channel::StatusEnum::kSuccess;
+        response.status       = chip::app::Clusters::Channel::StatusEnum::kSuccess;
         response.channelMatch = matchedChannels[0];
         mCurrentChannel       = matchedChannels[0];
         mCurrentChannelIndex  = index;

--- a/examples/tv-app/linux/include/channel/ChannelManager.cpp
+++ b/examples/tv-app/linux/include/channel/ChannelManager.cpp
@@ -121,17 +121,18 @@ void ChannelManager::HandleChangeChannel(CommandResponseHelper<ChangeChannelResp
     // Error: Found multiple matches
     if (matchedChannels.size() > 1)
     {
-        response.errorType = chip::app::Clusters::Channel::ErrorTypeEnum::kMultipleMatches;
+        response.status = chip::app::Clusters::Channel::StatusEnum::kMultipleMatches;
         helper.Success(response);
     }
     else if (matchedChannels.size() == 0)
     {
         // Error: Found no match
-        response.errorType = chip::app::Clusters::Channel::ErrorTypeEnum::kNoMatches;
+        response.status = chip::app::Clusters::Channel::StatusEnum::kNoMatches;
         helper.Success(response);
     }
     else
     {
+        response.status = chip::app::Clusters::Channel::StatusEnum::kSuccess;
         response.channelMatch = matchedChannels[0];
         mCurrentChannel       = matchedChannels[0];
         mCurrentChannelIndex  = index;

--- a/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
+++ b/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
@@ -94,10 +94,7 @@ void MediaPlaybackManager::HandleFastForward(CommandResponseHelper<Commands::Pla
 void MediaPlaybackManager::HandlePrevious(CommandResponseHelper<Commands::PlaybackResponse::Type> & helper)
 {
     // TODO: Insert code here
-    mPlaybackPosition = {
-      0, 
-      chip::app::DataModel::Nullable<uint64_t>(0)
-    };
+    mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(0) };
     Commands::PlaybackResponse::Type response;
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
@@ -106,10 +103,7 @@ void MediaPlaybackManager::HandlePrevious(CommandResponseHelper<Commands::Playba
 void MediaPlaybackManager::HandleRewind(CommandResponseHelper<Commands::PlaybackResponse::Type> & helper)
 {
     // TODO: Insert code here
-    mPlaybackPosition = {
-      0, 
-      chip::app::DataModel::Nullable<uint64_t>(0)
-    };
+    mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(0) };
     Commands::PlaybackResponse::Type response;
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
@@ -120,11 +114,8 @@ void MediaPlaybackManager::HandleSkipBackward(CommandResponseHelper<Commands::Pl
 {
     // TODO: Insert code here
     uint64_t newPosition = mPlaybackPosition.position.Value() - deltaPositionMilliseconds;
-    newPosition = newPosition < 0 ? 0 : newPosition;
-    mPlaybackPosition = {
-      0, 
-      chip::app::DataModel::Nullable<uint64_t>(newPosition)
-    };
+    newPosition          = newPosition < 0 ? 0 : newPosition;
+    mPlaybackPosition    = { 0, chip::app::DataModel::Nullable<uint64_t>(newPosition) };
 
     Commands::PlaybackResponse::Type response;
     response.status = StatusEnum::kSuccess;
@@ -133,14 +124,11 @@ void MediaPlaybackManager::HandleSkipBackward(CommandResponseHelper<Commands::Pl
 
 void MediaPlaybackManager::HandleSkipForward(CommandResponseHelper<Commands::PlaybackResponse::Type> & helper,
                                              const uint64_t & deltaPositionMilliseconds)
-{  
+{
     // TODO: Insert code here
     uint64_t newPosition = mPlaybackPosition.position.Value() + deltaPositionMilliseconds;
-    newPosition = newPosition > mDuration ? mDuration : newPosition;
-    mPlaybackPosition = {
-      0, 
-      chip::app::DataModel::Nullable<uint64_t>(newPosition)
-    };
+    newPosition          = newPosition > mDuration ? mDuration : newPosition;
+    mPlaybackPosition    = { 0, chip::app::DataModel::Nullable<uint64_t>(newPosition) };
 
     Commands::PlaybackResponse::Type response;
     response.status = StatusEnum::kSuccess;
@@ -151,15 +139,15 @@ void MediaPlaybackManager::HandleSeek(CommandResponseHelper<Commands::PlaybackRe
                                       const uint64_t & positionMilliseconds)
 {
     // TODO: Insert code here
-    if (positionMilliseconds > mDuration || positionMilliseconds < 0) {
+    if (positionMilliseconds > mDuration || positionMilliseconds < 0)
+    {
         Commands::PlaybackResponse::Type response;
         response.status = StatusEnum::kSeekOutOfRange;
         helper.Success(response);
-    } else {
-        mPlaybackPosition = {
-          0, 
-          chip::app::DataModel::Nullable<uint64_t>(positionMilliseconds)
-        };
+    }
+    else
+    {
+        mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(positionMilliseconds) };
 
         Commands::PlaybackResponse::Type response;
         response.status = StatusEnum::kSuccess;
@@ -178,10 +166,7 @@ void MediaPlaybackManager::HandleNext(CommandResponseHelper<Commands::PlaybackRe
 void MediaPlaybackManager::HandleStartOver(CommandResponseHelper<Commands::PlaybackResponse::Type> & helper)
 {
     // TODO: Insert code here
-    mPlaybackPosition = {
-      0, 
-      chip::app::DataModel::Nullable<uint64_t>(0)
-    };
+    mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(0) };
     Commands::PlaybackResponse::Type response;
     response.status = StatusEnum::kSuccess;
     helper.Success(response);

--- a/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
+++ b/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
@@ -114,7 +114,6 @@ void MediaPlaybackManager::HandleSkipBackward(CommandResponseHelper<Commands::Pl
 {
     // TODO: Insert code here
     uint64_t newPosition = mPlaybackPosition.position.Value() - deltaPositionMilliseconds;
-    newPosition          = newPosition < 0 ? 0 : newPosition;
     mPlaybackPosition    = { 0, chip::app::DataModel::Nullable<uint64_t>(newPosition) };
 
     Commands::PlaybackResponse::Type response;
@@ -139,7 +138,7 @@ void MediaPlaybackManager::HandleSeek(CommandResponseHelper<Commands::PlaybackRe
                                       const uint64_t & positionMilliseconds)
 {
     // TODO: Insert code here
-    if (positionMilliseconds > mDuration || positionMilliseconds < 0)
+    if (positionMilliseconds > mDuration)
     {
         Commands::PlaybackResponse::Type response;
         response.status = StatusEnum::kSeekOutOfRange;

--- a/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
+++ b/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
@@ -28,36 +28,32 @@ PlaybackStateEnum MediaPlaybackManager::HandleGetCurrentState()
 
 uint64_t MediaPlaybackManager::HandleGetStartTime()
 {
-    return 0;
+    return mStartTime;
 }
 
 uint64_t MediaPlaybackManager::HandleGetDuration()
 {
-    return 0;
+    return mDuration;
 }
 
 CHIP_ERROR MediaPlaybackManager::HandleGetSampledPosition(AttributeValueEncoder & aEncoder)
 {
-    Structs::PlaybackPosition::Type sampledPosition;
-    sampledPosition.updatedAt = 0;
-    sampledPosition.position  = Nullable<uint64_t>(0);
-
-    return aEncoder.Encode(sampledPosition);
+    return aEncoder.Encode(mPlaybackPosition);
 }
 
 float MediaPlaybackManager::HandleGetPlaybackSpeed()
 {
-    return 0;
+    return mPlaybackSpeed;
 }
 
 uint64_t MediaPlaybackManager::HandleGetSeekRangeStart()
 {
-    return 0;
+    return mPlaybackPosition.position.Value();
 }
 
 uint64_t MediaPlaybackManager::HandleGetSeekRangeEnd()
 {
-    return 0;
+    return mDuration - mPlaybackPosition.position.Value();
 }
 
 void MediaPlaybackManager::HandlePlay(CommandResponseHelper<Commands::PlaybackResponse::Type> & helper)
@@ -98,6 +94,10 @@ void MediaPlaybackManager::HandleFastForward(CommandResponseHelper<Commands::Pla
 void MediaPlaybackManager::HandlePrevious(CommandResponseHelper<Commands::PlaybackResponse::Type> & helper)
 {
     // TODO: Insert code here
+    mPlaybackPosition = {
+      0, 
+      chip::app::DataModel::Nullable<uint64_t>(0)
+    };
     Commands::PlaybackResponse::Type response;
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
@@ -106,6 +106,10 @@ void MediaPlaybackManager::HandlePrevious(CommandResponseHelper<Commands::Playba
 void MediaPlaybackManager::HandleRewind(CommandResponseHelper<Commands::PlaybackResponse::Type> & helper)
 {
     // TODO: Insert code here
+    mPlaybackPosition = {
+      0, 
+      chip::app::DataModel::Nullable<uint64_t>(0)
+    };
     Commands::PlaybackResponse::Type response;
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
@@ -115,6 +119,13 @@ void MediaPlaybackManager::HandleSkipBackward(CommandResponseHelper<Commands::Pl
                                               const uint64_t & deltaPositionMilliseconds)
 {
     // TODO: Insert code here
+    uint64_t newPosition = mPlaybackPosition.position.Value() - deltaPositionMilliseconds;
+    newPosition = newPosition < 0 ? 0 : newPosition;
+    mPlaybackPosition = {
+      0, 
+      chip::app::DataModel::Nullable<uint64_t>(newPosition)
+    };
+
     Commands::PlaybackResponse::Type response;
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
@@ -122,8 +133,15 @@ void MediaPlaybackManager::HandleSkipBackward(CommandResponseHelper<Commands::Pl
 
 void MediaPlaybackManager::HandleSkipForward(CommandResponseHelper<Commands::PlaybackResponse::Type> & helper,
                                              const uint64_t & deltaPositionMilliseconds)
-{
+{  
     // TODO: Insert code here
+    uint64_t newPosition = mPlaybackPosition.position.Value() + deltaPositionMilliseconds;
+    newPosition = newPosition > mDuration ? mDuration : newPosition;
+    mPlaybackPosition = {
+      0, 
+      chip::app::DataModel::Nullable<uint64_t>(newPosition)
+    };
+
     Commands::PlaybackResponse::Type response;
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
@@ -133,9 +151,20 @@ void MediaPlaybackManager::HandleSeek(CommandResponseHelper<Commands::PlaybackRe
                                       const uint64_t & positionMilliseconds)
 {
     // TODO: Insert code here
-    Commands::PlaybackResponse::Type response;
-    response.status = StatusEnum::kSuccess;
-    helper.Success(response);
+    if (positionMilliseconds > mDuration || positionMilliseconds < 0) {
+        Commands::PlaybackResponse::Type response;
+        response.status = StatusEnum::kSeekOutOfRange;
+        helper.Success(response);
+    } else {
+        mPlaybackPosition = {
+          0, 
+          chip::app::DataModel::Nullable<uint64_t>(positionMilliseconds)
+        };
+
+        Commands::PlaybackResponse::Type response;
+        response.status = StatusEnum::kSuccess;
+        helper.Success(response);
+    }
 }
 
 void MediaPlaybackManager::HandleNext(CommandResponseHelper<Commands::PlaybackResponse::Type> & helper)
@@ -149,6 +178,10 @@ void MediaPlaybackManager::HandleNext(CommandResponseHelper<Commands::PlaybackRe
 void MediaPlaybackManager::HandleStartOver(CommandResponseHelper<Commands::PlaybackResponse::Type> & helper)
 {
     // TODO: Insert code here
+    mPlaybackPosition = {
+      0, 
+      chip::app::DataModel::Nullable<uint64_t>(0)
+    };
     Commands::PlaybackResponse::Type response;
     response.status = StatusEnum::kSuccess;
     helper.Success(response);

--- a/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.h
+++ b/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.h
@@ -24,6 +24,7 @@ using chip::app::AttributeValueEncoder;
 using chip::app::CommandResponseHelper;
 using MediaPlaybackDelegate = chip::app::Clusters::MediaPlayback::Delegate;
 using PlaybackResponseType  = chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::Type;
+using PlaybackPositionType  = chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::Type;
 
 class MediaPlaybackManager : public MediaPlaybackDelegate
 {
@@ -52,4 +53,12 @@ public:
 
 protected:
     chip::app::Clusters::MediaPlayback::PlaybackStateEnum mCurrentState;
+    PlaybackPositionType mPlaybackPosition = {
+      0, 
+      chip::app::DataModel::Nullable<uint64_t>(0)
+    };
+    float mPlaybackSpeed = 0;
+    uint64_t mStartTime = 0;
+    // Magic number for testing.
+    uint64_t mDuration = 80000;
 };

--- a/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.h
+++ b/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.h
@@ -53,12 +53,9 @@ public:
 
 protected:
     chip::app::Clusters::MediaPlayback::PlaybackStateEnum mCurrentState;
-    PlaybackPositionType mPlaybackPosition = {
-      0, 
-      chip::app::DataModel::Nullable<uint64_t>(0)
-    };
-    float mPlaybackSpeed = 0;
-    uint64_t mStartTime = 0;
+    PlaybackPositionType mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(0) };
+    float mPlaybackSpeed                   = 0;
+    uint64_t mStartTime                    = 0;
     // Magic number for testing.
     uint64_t mDuration = 80000;
 };

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -160,11 +160,6 @@ server cluster ApplicationLauncher = 1292 {
     kApplicationPlatform = 0x1;
   }
 
-  bitmap ChannelFeature : BITMAP32 {
-    kChannelList = 0x1;
-    kLineupInfo = 0x2;
-  }
-
   struct ApplicationEP {
     Application application = 0;
     optional ENDPOINT_NO endpoint = 1;
@@ -319,13 +314,19 @@ server cluster Binding = 30 {
 }
 
 server cluster Channel = 1284 {
-  enum ErrorTypeEnum : ENUM8 {
-    kMultipleMatches = 0;
-    kNoMatches = 1;
-  }
-
   enum LineupInfoTypeEnum : ENUM8 {
     kMso = 0;
+  }
+
+  enum StatusEnum : ENUM8 {
+    kSuccess = 0;
+    kMultipleMatches = 1;
+    kNoMatches = 2;
+  }
+
+  bitmap ChannelFeature : BITMAP32 {
+    kChannelList = 0x1;
+    kLineupInfo = 0x2;
   }
 
   struct ChannelInfo {
@@ -363,7 +364,7 @@ server cluster Channel = 1284 {
 
   response struct ChangeChannelResponse {
     ChannelInfo channelMatch = 0;
-    ErrorTypeEnum errorType = 1;
+    StatusEnum status = 1;
   }
 
   command ChangeChannel(ChangeChannelRequest): ChangeChannelResponse = 0;

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -149,11 +149,6 @@ client cluster ApplicationLauncher = 1292 {
     kApplicationPlatform = 0x1;
   }
 
-  bitmap ChannelFeature : BITMAP32 {
-    kChannelList = 0x1;
-    kLineupInfo = 0x2;
-  }
-
   struct Application {
     INT16U catalogVendorId = 0;
     CHAR_STRING applicationId = 1;
@@ -297,13 +292,19 @@ server cluster Binding = 30 {
 }
 
 client cluster Channel = 1284 {
-  enum ErrorTypeEnum : ENUM8 {
-    kMultipleMatches = 0;
-    kNoMatches = 1;
-  }
-
   enum LineupInfoTypeEnum : ENUM8 {
     kMso = 0;
+  }
+
+  enum StatusEnum : ENUM8 {
+    kSuccess = 0;
+    kMultipleMatches = 1;
+    kNoMatches = 2;
+  }
+
+  bitmap ChannelFeature : BITMAP32 {
+    kChannelList = 0x1;
+    kLineupInfo = 0x2;
   }
 
   struct ChannelInfo {

--- a/src/app/tests/suites/TV_ApplicationBasicCluster.yaml
+++ b/src/app/tests/suites/TV_ApplicationBasicCluster.yaml
@@ -59,9 +59,8 @@ tests:
       attribute: "Status"
       response:
           value: 0
-    # TODO: Enable once attribute struct is supported
+
     - label: "Read attribute application status"
-      disabled: true
       command: "readAttribute"
       attribute: "Application"
       response:
@@ -75,8 +74,7 @@ tests:
           value: "exampleVersion"
 
     - label: "Read attribute application allowed vendor list"
-      disabled: true
       command: "readAttribute"
       attribute: "AllowedVendorList"
       response:
-          value: [123, 456]
+          value: [1, 456]

--- a/src/app/tests/suites/TV_ApplicationLauncherCluster.yaml
+++ b/src/app/tests/suites/TV_ApplicationLauncherCluster.yaml
@@ -34,13 +34,12 @@ tests:
       response:
           value: [123, 456]
 
-    # TODO: Enable once attribute struct is supported
+
     - label: "Read attribute application launcher app"
-      disabled: true
       command: "readAttribute"
       attribute: "CurrentApp"
       response:
-          value: { catalogVendorId: 123, applicationId: "applicationId" }
+          value: null
 
     - label: "Launch App Command"
       command: "launchApp"

--- a/src/app/tests/suites/TV_ApplicationLauncherCluster.yaml
+++ b/src/app/tests/suites/TV_ApplicationLauncherCluster.yaml
@@ -34,7 +34,6 @@ tests:
       response:
           value: [123, 456]
 
-
     - label: "Read attribute application launcher app"
       command: "readAttribute"
       attribute: "CurrentApp"

--- a/src/app/tests/suites/TV_ChannelCluster.yaml
+++ b/src/app/tests/suites/TV_ChannelCluster.yaml
@@ -97,7 +97,7 @@ tests:
                 value: "PBS"
       response:
           values:
-              - name: "errorType"
+              - name: "status"
                 value: 0
               - name: "channelMatch"
                 value:

--- a/src/app/tests/suites/TV_MediaPlaybackCluster.yaml
+++ b/src/app/tests/suites/TV_MediaPlaybackCluster.yaml
@@ -44,11 +44,9 @@ tests:
       command: "readAttribute"
       attribute: "Duration"
       response:
-          value: 0
+          value: 80000
 
-    # TODO: Enable once attribute struct is supported
     - label: "Read attribute position"
-      disabled: true
       command: "readAttribute"
       attribute: "SampledPosition"
       response:
@@ -64,7 +62,7 @@ tests:
       command: "readAttribute"
       attribute: "SeekRangeEnd"
       response:
-          value: 0
+          value: 80000
 
     - label: "Read attribute seek range start"
       command: "readAttribute"
@@ -133,11 +131,17 @@ tests:
       arguments:
           values:
               - name: "deltaPositionMilliseconds"
-                value: 100
+                value: 500
       response:
           values:
               - name: "status"
                 value: 0
+
+    - label: "Read attribute position after skip forward"
+      command: "readAttribute"
+      attribute: "SampledPosition"
+      response:
+          value: { updatedAt: 0, position: 500 }
 
     - label: "Media Playback Skip Backward Command"
       command: "skipBackward"
@@ -150,13 +154,25 @@ tests:
               - name: "status"
                 value: 0
 
+    - label: "Read attribute position after skip backward"
+      command: "readAttribute"
+      attribute: "SampledPosition"
+      response:
+          value: { updatedAt: 0, position: 400 }
+
     - label: "Media Playback Seek Command"
       command: "seek"
       arguments:
           values:
               - name: "position"
-                value: 100
+                value: 1000
       response:
           values:
               - name: "status"
                 value: 0
+
+    - label: "Read attribute position after seek"
+      command: "readAttribute"
+      attribute: "SampledPosition"
+      response:
+          value: { updatedAt: 0, position: 1000 }            

--- a/src/app/tests/suites/TV_MediaPlaybackCluster.yaml
+++ b/src/app/tests/suites/TV_MediaPlaybackCluster.yaml
@@ -175,4 +175,4 @@ tests:
       command: "readAttribute"
       attribute: "SampledPosition"
       response:
-          value: { updatedAt: 0, position: 1000 }            
+          value: { updatedAt: 0, position: 1000 }

--- a/src/app/zap-templates/zcl/data-model/chip/channel-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/channel-cluster.xml
@@ -47,7 +47,7 @@ limitations under the License.
     <command source="server" code="0x01" name="ChangeChannelResponse" optional="false">
       <description>Upon receipt, this SHALL display the active status of the input list on screen.</description>
       <arg name="channelMatch" type="ChannelInfo"/>
-      <arg name="errorType"    type="ErrorTypeEnum"/>
+      <arg name="status"       type="StatusEnum"/>
     </command>
 
   </cluster>
@@ -74,14 +74,15 @@ limitations under the License.
     <item name="Mso" value="0x00"/>
   </enum>
 
-  <enum name="ErrorTypeEnum" type="ENUM8">
+  <enum name="StatusEnum" type="ENUM8">
     <cluster code="0x0504"/>
-    <item name="MultipleMatches" value="0x00"/>
-    <item name="NoMatches" value="0x01"/>
+    <item name="Success" value="0x00"/>
+    <item name="MultipleMatches" value="0x01"/>
+    <item name="NoMatches" value="0x02"/>
   </enum>
 
   <bitmap name="ChannelFeature" type="BITMAP32">
-    <cluster code="0x050c"/>
+    <cluster code="0x0504"/>
     <field name="ChannelList" mask="0x1"/>
     <field name="LineupInfo"  mask="0x2"/>
   </bitmap>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -171,11 +171,6 @@ client cluster ApplicationLauncher = 1292 {
     kApplicationPlatform = 0x1;
   }
 
-  bitmap ChannelFeature : BITMAP32 {
-    kChannelList = 0x1;
-    kLineupInfo = 0x2;
-  }
-
   struct ApplicationEP {
     Application application = 0;
     optional ENDPOINT_NO endpoint = 1;
@@ -557,13 +552,19 @@ client cluster BridgedDeviceBasic = 57 {
 }
 
 client cluster Channel = 1284 {
-  enum ErrorTypeEnum : ENUM8 {
-    kMultipleMatches = 0;
-    kNoMatches = 1;
-  }
-
   enum LineupInfoTypeEnum : ENUM8 {
     kMso = 0;
+  }
+
+  enum StatusEnum : ENUM8 {
+    kSuccess = 0;
+    kMultipleMatches = 1;
+    kNoMatches = 2;
+  }
+
+  bitmap ChannelFeature : BITMAP32 {
+    kChannelList = 0x1;
+    kLineupInfo = 0x2;
   }
 
   struct ChannelInfo {
@@ -604,7 +605,7 @@ client cluster Channel = 1284 {
 
   response struct ChangeChannelResponse {
     ChannelInfo channelMatch = 0;
-    ErrorTypeEnum errorType = 1;
+    StatusEnum status = 1;
   }
 
   command ChangeChannel(ChangeChannelRequest): ChangeChannelResponse = 0;

--- a/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
@@ -270,13 +270,13 @@ void CHIPChannelClusterChangeChannelResponseCallback::CallbackFn(
 
     channelMatch = env->NewObject(channelInfoStructClass, channelInfoStructCtor, channelMatch_majorNumber, channelMatch_minorNumber,
                                   channelMatch_name, channelMatch_callSign, channelMatch_affiliateCallSign);
-    jobject errorType;
-    std::string errorTypeClassName     = "java/lang/Integer";
-    std::string errorTypeCtorSignature = "(I)V";
-    chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(errorTypeClassName.c_str(), errorTypeCtorSignature.c_str(),
-                                                                  static_cast<uint8_t>(dataResponse.errorType), errorType);
+    jobject status;
+    std::string statusClassName     = "java/lang/Integer";
+    std::string statusCtorSignature = "(I)V";
+    chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(statusClassName.c_str(), statusCtorSignature.c_str(),
+                                                                  static_cast<uint8_t>(dataResponse.status), status);
 
-    env->CallVoidMethod(javaCallbackRef, javaMethod, channelMatch, errorType);
+    env->CallVoidMethod(javaCallbackRef, javaMethod, channelMatch, status);
 }
 CHIPContentLauncherClusterLaunchResponseCallback::CHIPContentLauncherClusterLaunchResponseCallback(jobject javaCallback) :
     Callback::Callback<CHIPContentLauncherClusterLaunchResponseCallbackType>(CallbackFn, this)

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -3323,7 +3323,7 @@ public class ChipClusters {
         @Nullable Integer timedInvokeTimeoutMs);
 
     public interface ChangeChannelResponseCallback {
-      void onSuccess(ChipStructs.ChannelClusterChannelInfo channelMatch, Integer errorType);
+      void onSuccess(ChipStructs.ChannelClusterChannelInfo channelMatch, Integer status);
 
       void onError(Exception error);
     }

--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
@@ -1403,12 +1403,12 @@ public class ClusterInfoMapping {
     }
 
     @Override
-    public void onSuccess(ChipStructs.ChannelClusterChannelInfo channelMatch, Integer errorType) {
+    public void onSuccess(ChipStructs.ChannelClusterChannelInfo channelMatch, Integer status) {
       Map<CommandResponseInfo, Object> responseValues = new LinkedHashMap<>();
       // channelMatch: Struct ChannelInfo
       // Conversion from this type to Java is not properly implemented yet
-      CommandResponseInfo errorTypeResponseValue = new CommandResponseInfo("errorType", "Integer");
-      responseValues.put(errorTypeResponseValue, errorType);
+      CommandResponseInfo statusResponseValue = new CommandResponseInfo("status", "Integer");
+      responseValues.put(statusResponseValue, status);
       callback.onSuccess(responseValues);
     }
 

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -31328,12 +31328,13 @@ class Channel(Cluster):
     clusterRevision: 'uint' = None
 
     class Enums:
-        class ErrorTypeEnum(IntEnum):
-            kMultipleMatches = 0x00
-            kNoMatches = 0x01
-
         class LineupInfoTypeEnum(IntEnum):
             kMso = 0x00
+
+        class StatusEnum(IntEnum):
+            kSuccess = 0x00
+            kMultipleMatches = 0x01
+            kNoMatches = 0x02
 
 
     class Structs:
@@ -31402,11 +31403,11 @@ class Channel(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="channelMatch", Tag=0, Type=Channel.Structs.ChannelInfo),
-                            ClusterObjectFieldDescriptor(Label="errorType", Tag=1, Type=Channel.Enums.ErrorTypeEnum),
+                            ClusterObjectFieldDescriptor(Label="status", Tag=1, Type=Channel.Enums.StatusEnum),
                     ])
 
             channelMatch: 'Channel.Structs.ChannelInfo' = field(default_factory=lambda: Channel.Structs.ChannelInfo())
-            errorType: 'Channel.Enums.ErrorTypeEnum' = 0
+            status: 'Channel.Enums.StatusEnum' = 0
 
         @dataclass
         class ChangeChannelByNumber(ClusterCommand):

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -10117,7 +10117,7 @@ void CHIPChannelClusterChangeChannelResponseCallbackBridge::OnSuccessFn(
         }
     }
     {
-        response.errorType = [NSNumber numberWithUnsignedChar:chip::to_underlying(data.errorType)];
+        response.status = [NSNumber numberWithUnsignedChar:chip::to_underlying(data.status)];
     }
     DispatchSuccess(context, response);
 };
@@ -16501,58 +16501,6 @@ void CHIPNullableIasAceClusterIasZoneTypeAttributeCallbackSubscriptionBridge::On
     }
 }
 
-void CHIPChannelClusterErrorTypeEnumAttributeCallbackBridge::OnSuccessFn(
-    void * context, chip::app::Clusters::Channel::ErrorTypeEnum value)
-{
-    NSNumber * _Nonnull objCValue;
-    objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value)];
-    DispatchSuccess(context, objCValue);
-};
-
-void CHIPChannelClusterErrorTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
-{
-    auto * self = static_cast<CHIPChannelClusterErrorTypeEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
-        return;
-    }
-
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
-        // On failure, mEstablishedHandler will be cleaned up by our destructor,
-        // but we can clean it up earlier on successful subscription
-        // establishment.
-        self->mEstablishedHandler = nil;
-    }
-}
-
-void CHIPNullableChannelClusterErrorTypeEnumAttributeCallbackBridge::OnSuccessFn(
-    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::ErrorTypeEnum> & value)
-{
-    NSNumber * _Nullable objCValue;
-    if (value.IsNull()) {
-        objCValue = nil;
-    } else {
-        objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value.Value())];
-    }
-    DispatchSuccess(context, objCValue);
-};
-
-void CHIPNullableChannelClusterErrorTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
-{
-    auto * self = static_cast<CHIPNullableChannelClusterErrorTypeEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
-        return;
-    }
-
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
-        // On failure, mEstablishedHandler will be cleaned up by our destructor,
-        // but we can clean it up earlier on successful subscription
-        // establishment.
-        self->mEstablishedHandler = nil;
-    }
-}
-
 void CHIPChannelClusterLineupInfoTypeEnumAttributeCallbackBridge::OnSuccessFn(
     void * context, chip::app::Clusters::Channel::LineupInfoTypeEnum value)
 {
@@ -16592,6 +16540,58 @@ void CHIPNullableChannelClusterLineupInfoTypeEnumAttributeCallbackBridge::OnSucc
 void CHIPNullableChannelClusterLineupInfoTypeEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
 {
     auto * self = static_cast<CHIPNullableChannelClusterLineupInfoTypeEnumAttributeCallbackSubscriptionBridge *>(context);
+    if (!self->mQueue) {
+        return;
+    }
+
+    if (self->mEstablishedHandler != nil) {
+        dispatch_async(self->mQueue, self->mEstablishedHandler);
+        // On failure, mEstablishedHandler will be cleaned up by our destructor,
+        // but we can clean it up earlier on successful subscription
+        // establishment.
+        self->mEstablishedHandler = nil;
+    }
+}
+
+void CHIPChannelClusterStatusEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, chip::app::Clusters::Channel::StatusEnum value)
+{
+    NSNumber * _Nonnull objCValue;
+    objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value)];
+    DispatchSuccess(context, objCValue);
+};
+
+void CHIPChannelClusterStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+{
+    auto * self = static_cast<CHIPChannelClusterStatusEnumAttributeCallbackSubscriptionBridge *>(context);
+    if (!self->mQueue) {
+        return;
+    }
+
+    if (self->mEstablishedHandler != nil) {
+        dispatch_async(self->mQueue, self->mEstablishedHandler);
+        // On failure, mEstablishedHandler will be cleaned up by our destructor,
+        // but we can clean it up earlier on successful subscription
+        // establishment.
+        self->mEstablishedHandler = nil;
+    }
+}
+
+void CHIPNullableChannelClusterStatusEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::StatusEnum> & value)
+{
+    NSNumber * _Nullable objCValue;
+    if (value.IsNull()) {
+        objCValue = nil;
+    } else {
+        objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value.Value())];
+    }
+    DispatchSuccess(context, objCValue);
+};
+
+void CHIPNullableChannelClusterStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+{
+    auto * self = static_cast<CHIPNullableChannelClusterStatusEnumAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
@@ -472,12 +472,12 @@ typedef void (*NullableIasAceClusterIasAcePanelStatusAttributeCallback)(
 typedef void (*IasAceClusterIasZoneTypeAttributeCallback)(void *, chip::app::Clusters::IasAce::IasZoneType);
 typedef void (*NullableIasAceClusterIasZoneTypeAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::IasAce::IasZoneType> &);
-typedef void (*ChannelClusterErrorTypeEnumAttributeCallback)(void *, chip::app::Clusters::Channel::ErrorTypeEnum);
-typedef void (*NullableChannelClusterErrorTypeEnumAttributeCallback)(
-    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::ErrorTypeEnum> &);
 typedef void (*ChannelClusterLineupInfoTypeEnumAttributeCallback)(void *, chip::app::Clusters::Channel::LineupInfoTypeEnum);
 typedef void (*NullableChannelClusterLineupInfoTypeEnumAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::LineupInfoTypeEnum> &);
+typedef void (*ChannelClusterStatusEnumAttributeCallback)(void *, chip::app::Clusters::Channel::StatusEnum);
+typedef void (*NullableChannelClusterStatusEnumAttributeCallback)(
+    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::StatusEnum> &);
 typedef void (*TargetNavigatorClusterStatusEnumAttributeCallback)(void *, chip::app::Clusters::TargetNavigator::StatusEnum);
 typedef void (*NullableTargetNavigatorClusterStatusEnumAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::TargetNavigator::StatusEnum> &);
@@ -14300,63 +14300,6 @@ private:
     SubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class CHIPChannelClusterErrorTypeEnumAttributeCallbackBridge
-    : public CHIPCallbackBridge<ChannelClusterErrorTypeEnumAttributeCallback>
-{
-public:
-    CHIPChannelClusterErrorTypeEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
-                                                           bool keepAlive = false) :
-        CHIPCallbackBridge<ChannelClusterErrorTypeEnumAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
-
-    static void OnSuccessFn(void * context, chip::app::Clusters::Channel::ErrorTypeEnum value);
-};
-
-class CHIPChannelClusterErrorTypeEnumAttributeCallbackSubscriptionBridge
-    : public CHIPChannelClusterErrorTypeEnumAttributeCallbackBridge
-{
-public:
-    CHIPChannelClusterErrorTypeEnumAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                       CHIPActionBlock action,
-                                                                       SubscriptionEstablishedHandler establishedHandler) :
-        CHIPChannelClusterErrorTypeEnumAttributeCallbackBridge(queue, handler, action, true),
-        mEstablishedHandler(establishedHandler)
-    {}
-
-    static void OnSubscriptionEstablished(void * context);
-
-private:
-    SubscriptionEstablishedHandler mEstablishedHandler;
-};
-
-class CHIPNullableChannelClusterErrorTypeEnumAttributeCallbackBridge
-    : public CHIPCallbackBridge<NullableChannelClusterErrorTypeEnumAttributeCallback>
-{
-public:
-    CHIPNullableChannelClusterErrorTypeEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                   CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<NullableChannelClusterErrorTypeEnumAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
-
-    static void OnSuccessFn(void * context,
-                            const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::ErrorTypeEnum> & value);
-};
-
-class CHIPNullableChannelClusterErrorTypeEnumAttributeCallbackSubscriptionBridge
-    : public CHIPNullableChannelClusterErrorTypeEnumAttributeCallbackBridge
-{
-public:
-    CHIPNullableChannelClusterErrorTypeEnumAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                               CHIPActionBlock action,
-                                                                               SubscriptionEstablishedHandler establishedHandler) :
-        CHIPNullableChannelClusterErrorTypeEnumAttributeCallbackBridge(queue, handler, action, true),
-        mEstablishedHandler(establishedHandler)
-    {}
-
-    static void OnSubscriptionEstablished(void * context);
-
-private:
-    SubscriptionEstablishedHandler mEstablishedHandler;
-};
-
 class CHIPChannelClusterLineupInfoTypeEnumAttributeCallbackBridge
     : public CHIPCallbackBridge<ChannelClusterLineupInfoTypeEnumAttributeCallback>
 {
@@ -14406,6 +14349,60 @@ public:
         dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
         SubscriptionEstablishedHandler establishedHandler) :
         CHIPNullableChannelClusterLineupInfoTypeEnumAttributeCallbackBridge(queue, handler, action, true),
+        mEstablishedHandler(establishedHandler)
+    {}
+
+    static void OnSubscriptionEstablished(void * context);
+
+private:
+    SubscriptionEstablishedHandler mEstablishedHandler;
+};
+
+class CHIPChannelClusterStatusEnumAttributeCallbackBridge : public CHIPCallbackBridge<ChannelClusterStatusEnumAttributeCallback>
+{
+public:
+    CHIPChannelClusterStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
+                                                        bool keepAlive = false) :
+        CHIPCallbackBridge<ChannelClusterStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+
+    static void OnSuccessFn(void * context, chip::app::Clusters::Channel::StatusEnum value);
+};
+
+class CHIPChannelClusterStatusEnumAttributeCallbackSubscriptionBridge : public CHIPChannelClusterStatusEnumAttributeCallbackBridge
+{
+public:
+    CHIPChannelClusterStatusEnumAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                    CHIPActionBlock action,
+                                                                    SubscriptionEstablishedHandler establishedHandler) :
+        CHIPChannelClusterStatusEnumAttributeCallbackBridge(queue, handler, action, true),
+        mEstablishedHandler(establishedHandler)
+    {}
+
+    static void OnSubscriptionEstablished(void * context);
+
+private:
+    SubscriptionEstablishedHandler mEstablishedHandler;
+};
+
+class CHIPNullableChannelClusterStatusEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<NullableChannelClusterStatusEnumAttributeCallback>
+{
+public:
+    CHIPNullableChannelClusterStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                CHIPActionBlock action, bool keepAlive = false) :
+        CHIPCallbackBridge<NullableChannelClusterStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+
+    static void OnSuccessFn(void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::StatusEnum> & value);
+};
+
+class CHIPNullableChannelClusterStatusEnumAttributeCallbackSubscriptionBridge
+    : public CHIPNullableChannelClusterStatusEnumAttributeCallbackBridge
+{
+public:
+    CHIPNullableChannelClusterStatusEnumAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                            CHIPActionBlock action,
+                                                                            SubscriptionEstablishedHandler establishedHandler) :
+        CHIPNullableChannelClusterStatusEnumAttributeCallbackBridge(queue, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
@@ -1542,7 +1542,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPChannelClusterChangeChannelResponseParams : NSObject
 @property (strong, nonatomic) CHIPChannelClusterChannelInfo * _Nonnull channelMatch;
-@property (strong, nonatomic) NSNumber * _Nonnull errorType;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
@@ -3277,7 +3277,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _channelMatch = [CHIPChannelClusterChannelInfo new];
 
-        _errorType = @(0);
+        _status = @(0);
     }
     return self;
 }

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -14800,7 +14800,7 @@ bool emberAfChannelClusterChangeChannelCallback(
  */
 bool emberAfChannelClusterChangeChannelResponseCallback(
     chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-    chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType channelMatch, uint8_t errorType);
+    chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType channelMatch, uint8_t status);
 /**
  * @brief Channel Cluster ChangeChannelByNumber Command callback (from client)
  */

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -20297,7 +20297,7 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kChannelMatch)), channelMatch));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kErrorType)), errorType));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kStatus)), status));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
@@ -20316,8 +20316,8 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         case to_underlying(Fields::kChannelMatch):
             ReturnErrorOnFailure(DataModel::Decode(reader, channelMatch));
             break;
-        case to_underlying(Fields::kErrorType):
-            ReturnErrorOnFailure(DataModel::Decode(reader, errorType));
+        case to_underlying(Fields::kStatus):
+            ReturnErrorOnFailure(DataModel::Decode(reader, status));
             break;
         default:
             break;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -33453,16 +33453,24 @@ struct TypeInfo
 } // namespace Attributes
 } // namespace WakeOnLan
 namespace Channel {
-// Enum for ErrorTypeEnum
-enum class ErrorTypeEnum : uint8_t
-{
-    kMultipleMatches = 0x00,
-    kNoMatches       = 0x01,
-};
 // Enum for LineupInfoTypeEnum
 enum class LineupInfoTypeEnum : uint8_t
 {
     kMso = 0x00,
+};
+// Enum for StatusEnum
+enum class StatusEnum : uint8_t
+{
+    kSuccess         = 0x00,
+    kMultipleMatches = 0x01,
+    kNoMatches       = 0x02,
+};
+
+// Bitmap for ChannelFeature
+enum class ChannelFeature : uint32_t
+{
+    kChannelList = 0x1,
+    kLineupInfo  = 0x2,
 };
 
 namespace Structs {
@@ -33586,7 +33594,7 @@ namespace ChangeChannelResponse {
 enum class Fields
 {
     kChannelMatch = 0,
-    kErrorType    = 1,
+    kStatus       = 1,
 };
 
 struct Type
@@ -33597,7 +33605,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Channel::Id; }
 
     Structs::ChannelInfo::Type channelMatch;
-    ErrorTypeEnum errorType = static_cast<ErrorTypeEnum>(0);
+    StatusEnum status = static_cast<StatusEnum>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -33613,7 +33621,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Channel::Id; }
 
     Structs::ChannelInfo::DecodableType channelMatch;
-    ErrorTypeEnum errorType = static_cast<ErrorTypeEnum>(0);
+    StatusEnum status = static_cast<StatusEnum>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ChangeChannelResponse
@@ -36087,13 +36095,6 @@ enum class StatusEnum : uint8_t
 enum class ApplicationLauncherFeature : uint32_t
 {
     kApplicationPlatform = 0x1,
-};
-
-// Bitmap for ChannelFeature
-enum class ChannelFeature : uint32_t
-{
-    kChannelList = 0x1,
-    kLineupInfo  = 0x2,
 };
 
 namespace Structs {

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
@@ -3463,7 +3463,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("channelMatch", indent + 1, value.channelMatch));
-    ReturnErrorOnFailure(DataModelLogger::LogValue("errorType", indent + 1, value.errorType));
+    ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -55094,7 +55094,7 @@ private:
         request.match = chip::Span<const char>("PBSgarbage: not in length on purpose", 3);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TV_ChannelCluster *>(context))->OnSuccessResponse_4(data.channelMatch, data.errorType);
+            (static_cast<TV_ChannelCluster *>(context))->OnSuccessResponse_4(data.channelMatch, data.status);
         };
 
         auto failure = [](void * context, CHIP_ERROR error) {
@@ -55112,7 +55112,7 @@ private:
     }
 
     void OnSuccessResponse_4(const chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType & channelMatch,
-                             chip::app::Clusters::Channel::ErrorTypeEnum errorType)
+                             chip::app::Clusters::Channel::StatusEnum status)
     {
         VerifyOrReturn(CheckValue("channelMatch.majorNumber", channelMatch.majorNumber, 9U));
         VerifyOrReturn(CheckValue("channelMatch.minorNumber", channelMatch.minorNumber, 1U));
@@ -55125,7 +55125,7 @@ private:
         VerifyOrReturn(CheckValueAsString("channelMatch.affiliateCallSign.Value()", channelMatch.affiliateCallSign.Value(),
                                           chip::CharSpan("KCTS", 4)));
 
-        VerifyOrReturn(CheckValue("errorType", errorType, 0));
+        VerifyOrReturn(CheckValue("status", status, 0));
 
         NextTest();
     }

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -53119,16 +53119,20 @@ public:
             err = TestReadAttributeApplicationLauncherList_1();
             break;
         case 2:
-            ChipLogProgress(chipTool, " ***** Test Step 2 : Launch App Command\n");
-            err = TestLaunchAppCommand_2();
+            ChipLogProgress(chipTool, " ***** Test Step 2 : Read attribute application launcher app\n");
+            err = TestReadAttributeApplicationLauncherApp_2();
             break;
         case 3:
-            ChipLogProgress(chipTool, " ***** Test Step 3 : Stop App Command\n");
-            err = TestStopAppCommand_3();
+            ChipLogProgress(chipTool, " ***** Test Step 3 : Launch App Command\n");
+            err = TestLaunchAppCommand_3();
             break;
         case 4:
-            ChipLogProgress(chipTool, " ***** Test Step 4 : Hide App Command\n");
-            err = TestHideAppCommand_4();
+            ChipLogProgress(chipTool, " ***** Test Step 4 : Stop App Command\n");
+            err = TestStopAppCommand_4();
+            break;
+        case 5:
+            ChipLogProgress(chipTool, " ***** Test Step 5 : Hide App Command\n");
+            err = TestHideAppCommand_5();
             break;
         }
 
@@ -53141,7 +53145,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 5;
+    const uint16_t mTestCount = 6;
 
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
@@ -53163,6 +53167,19 @@ private:
     static void OnSuccessCallback_1(void * context, const chip::app::DataModel::DecodableList<uint16_t> & catalogList)
     {
         (static_cast<TV_ApplicationLauncherCluster *>(context))->OnSuccessResponse_1(catalogList);
+    }
+
+    static void OnFailureCallback_2(void * context, CHIP_ERROR error)
+    {
+        (static_cast<TV_ApplicationLauncherCluster *>(context))->OnFailureResponse_2(error);
+    }
+
+    static void OnSuccessCallback_2(
+        void * context,
+        const chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::DecodableType> &
+            currentApp)
+    {
+        (static_cast<TV_ApplicationLauncherCluster *>(context))->OnSuccessResponse_2(currentApp);
     }
 
     //
@@ -53208,7 +53225,35 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestLaunchAppCommand_2()
+    CHIP_ERROR TestReadAttributeApplicationLauncherApp_2()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        chip::Controller::ApplicationLauncherClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationLauncher::Attributes::CurrentApp::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2, true));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_2(CHIP_ERROR error)
+    {
+        chip::app::StatusIB status(error);
+        ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_2(
+        const chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::Structs::ApplicationEP::DecodableType> &
+            currentApp)
+    {
+        VerifyOrReturn(CheckValueNull("currentApp", currentApp));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestLaunchAppCommand_3()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
         using RequestType               = chip::app::Clusters::ApplicationLauncher::Commands::LaunchApp::Type;
@@ -53221,44 +53266,6 @@ private:
 
         request.data.Emplace();
         request.data.Value() = chip::ByteSpan(chip::Uint8::from_const_char("datagarbage: not in length on purpose"), 4);
-
-        auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TV_ApplicationLauncherCluster *>(context))->OnSuccessResponse_2(data.status, data.data);
-        };
-
-        auto failure = [](void * context, CHIP_ERROR error) {
-            (static_cast<TV_ApplicationLauncherCluster *>(context))->OnFailureResponse_2(error);
-        };
-
-        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevices[kIdentityAlpha], this, success, failure, endpoint, request));
-        return CHIP_NO_ERROR;
-    }
-
-    void OnFailureResponse_2(CHIP_ERROR error)
-    {
-        chip::app::StatusIB status(error);
-        ThrowFailureResponse();
-    }
-
-    void OnSuccessResponse_2(chip::app::Clusters::ApplicationLauncher::StatusEnum status, chip::ByteSpan data)
-    {
-        VerifyOrReturn(CheckValue("status", status, 0));
-
-        VerifyOrReturn(CheckValueAsString("data", data, chip::ByteSpan(chip::Uint8::from_const_char("data"), 4)));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestStopAppCommand_3()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
-        using RequestType               = chip::app::Clusters::ApplicationLauncher::Commands::StopApp::Type;
-
-        ListFreer listFreer;
-        RequestType request;
-
-        request.application.catalogVendorId = 123U;
-        request.application.applicationId   = chip::Span<const char>("applicationIdgarbage: not in length on purpose", 13);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_ApplicationLauncherCluster *>(context))->OnSuccessResponse_3(data.status, data.data);
@@ -53287,10 +53294,10 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestHideAppCommand_4()
+    CHIP_ERROR TestStopAppCommand_4()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
-        using RequestType               = chip::app::Clusters::ApplicationLauncher::Commands::HideApp::Type;
+        using RequestType               = chip::app::Clusters::ApplicationLauncher::Commands::StopApp::Type;
 
         ListFreer listFreer;
         RequestType request;
@@ -53317,6 +53324,44 @@ private:
     }
 
     void OnSuccessResponse_4(chip::app::Clusters::ApplicationLauncher::StatusEnum status, chip::ByteSpan data)
+    {
+        VerifyOrReturn(CheckValue("status", status, 0));
+
+        VerifyOrReturn(CheckValueAsString("data", data, chip::ByteSpan(chip::Uint8::from_const_char("data"), 4)));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestHideAppCommand_5()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 1;
+        using RequestType               = chip::app::Clusters::ApplicationLauncher::Commands::HideApp::Type;
+
+        ListFreer listFreer;
+        RequestType request;
+
+        request.application.catalogVendorId = 123U;
+        request.application.applicationId   = chip::Span<const char>("applicationIdgarbage: not in length on purpose", 13);
+
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
+            (static_cast<TV_ApplicationLauncherCluster *>(context))->OnSuccessResponse_5(data.status, data.data);
+        };
+
+        auto failure = [](void * context, CHIP_ERROR error) {
+            (static_cast<TV_ApplicationLauncherCluster *>(context))->OnFailureResponse_5(error);
+        };
+
+        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevices[kIdentityAlpha], this, success, failure, endpoint, request));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_5(CHIP_ERROR error)
+    {
+        chip::app::StatusIB status(error);
+        ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_5(chip::app::Clusters::ApplicationLauncher::StatusEnum status, chip::ByteSpan data)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
 
@@ -53808,8 +53853,16 @@ public:
             err = TestReadAttributeApplicationStatus_5();
             break;
         case 6:
-            ChipLogProgress(chipTool, " ***** Test Step 6 : Read attribute application version\n");
-            err = TestReadAttributeApplicationVersion_6();
+            ChipLogProgress(chipTool, " ***** Test Step 6 : Read attribute application status\n");
+            err = TestReadAttributeApplicationStatus_6();
+            break;
+        case 7:
+            ChipLogProgress(chipTool, " ***** Test Step 7 : Read attribute application version\n");
+            err = TestReadAttributeApplicationVersion_7();
+            break;
+        case 8:
+            ChipLogProgress(chipTool, " ***** Test Step 8 : Read attribute application allowed vendor list\n");
+            err = TestReadAttributeApplicationAllowedVendorList_8();
             break;
         }
 
@@ -53822,7 +53875,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 7;
+    const uint16_t mTestCount = 9;
 
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
@@ -53891,9 +53944,31 @@ private:
         (static_cast<TV_ApplicationBasicCluster *>(context))->OnFailureResponse_6(error);
     }
 
-    static void OnSuccessCallback_6(void * context, chip::CharSpan applicationVersion)
+    static void OnSuccessCallback_6(
+        void * context,
+        const chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::DecodableType & application)
     {
-        (static_cast<TV_ApplicationBasicCluster *>(context))->OnSuccessResponse_6(applicationVersion);
+        (static_cast<TV_ApplicationBasicCluster *>(context))->OnSuccessResponse_6(application);
+    }
+
+    static void OnFailureCallback_7(void * context, CHIP_ERROR error)
+    {
+        (static_cast<TV_ApplicationBasicCluster *>(context))->OnFailureResponse_7(error);
+    }
+
+    static void OnSuccessCallback_7(void * context, chip::CharSpan applicationVersion)
+    {
+        (static_cast<TV_ApplicationBasicCluster *>(context))->OnSuccessResponse_7(applicationVersion);
+    }
+
+    static void OnFailureCallback_8(void * context, CHIP_ERROR error)
+    {
+        (static_cast<TV_ApplicationBasicCluster *>(context))->OnFailureResponse_8(error);
+    }
+
+    static void OnSuccessCallback_8(void * context, const chip::app::DataModel::DecodableList<chip::VendorId> & allowedVendorList)
+    {
+        (static_cast<TV_ApplicationBasicCluster *>(context))->OnSuccessResponse_8(allowedVendorList);
     }
 
     //
@@ -54036,7 +54111,7 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestReadAttributeApplicationVersion_6()
+    CHIP_ERROR TestReadAttributeApplicationStatus_6()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         chip::Controller::ApplicationBasicClusterTest cluster;
@@ -54044,7 +54119,7 @@ private:
 
         ListFreer listFreer;
 
-        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::ApplicationVersion::TypeInfo>(
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::Application::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6, true));
         return CHIP_NO_ERROR;
     }
@@ -54055,9 +54130,71 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_6(chip::CharSpan applicationVersion)
+    void OnSuccessResponse_6(
+        const chip::app::Clusters::ApplicationBasic::Structs::ApplicationBasicApplication::DecodableType & application)
+    {
+        VerifyOrReturn(CheckValue("application.catalogVendorId", application.catalogVendorId, 123U));
+        VerifyOrReturn(
+            CheckValueAsString("application.applicationId", application.applicationId, chip::CharSpan("applicationId", 13)));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeApplicationVersion_7()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
+        chip::Controller::ApplicationBasicClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::ApplicationVersion::TypeInfo>(
+            this, OnSuccessCallback_7, OnFailureCallback_7, true));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_7(CHIP_ERROR error)
+    {
+        chip::app::StatusIB status(error);
+        ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_7(chip::CharSpan applicationVersion)
     {
         VerifyOrReturn(CheckValueAsString("applicationVersion", applicationVersion, chip::CharSpan("exampleVersion", 14)));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeApplicationAllowedVendorList_8()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
+        chip::Controller::ApplicationBasicClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::AllowedVendorList::TypeInfo>(
+            this, OnSuccessCallback_8, OnFailureCallback_8, true));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_8(CHIP_ERROR error)
+    {
+        chip::app::StatusIB status(error);
+        ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_8(const chip::app::DataModel::DecodableList<chip::VendorId> & allowedVendorList)
+    {
+        {
+            auto iter_0 = allowedVendorList.begin();
+            VerifyOrReturn(CheckNextListItemDecodes<decltype(allowedVendorList)>("allowedVendorList", iter_0, 0));
+            VerifyOrReturn(CheckValue("allowedVendorList[0]", iter_0.GetValue(), 1U));
+            VerifyOrReturn(CheckNextListItemDecodes<decltype(allowedVendorList)>("allowedVendorList", iter_0, 1));
+            VerifyOrReturn(CheckValue("allowedVendorList[1]", iter_0.GetValue(), 456U));
+            VerifyOrReturn(CheckNoMoreListItems<decltype(allowedVendorList)>("allowedVendorList", iter_0, 2));
+        }
 
         NextTest();
     }
@@ -54118,60 +54255,76 @@ public:
             err = TestReadAttributeDuration_3();
             break;
         case 4:
-            ChipLogProgress(chipTool, " ***** Test Step 4 : Read attribute playback speed\n");
-            err = TestReadAttributePlaybackSpeed_4();
+            ChipLogProgress(chipTool, " ***** Test Step 4 : Read attribute position\n");
+            err = TestReadAttributePosition_4();
             break;
         case 5:
-            ChipLogProgress(chipTool, " ***** Test Step 5 : Read attribute seek range end\n");
-            err = TestReadAttributeSeekRangeEnd_5();
+            ChipLogProgress(chipTool, " ***** Test Step 5 : Read attribute playback speed\n");
+            err = TestReadAttributePlaybackSpeed_5();
             break;
         case 6:
-            ChipLogProgress(chipTool, " ***** Test Step 6 : Read attribute seek range start\n");
-            err = TestReadAttributeSeekRangeStart_6();
+            ChipLogProgress(chipTool, " ***** Test Step 6 : Read attribute seek range end\n");
+            err = TestReadAttributeSeekRangeEnd_6();
             break;
         case 7:
-            ChipLogProgress(chipTool, " ***** Test Step 7 : Media Playback Play Command\n");
-            err = TestMediaPlaybackPlayCommand_7();
+            ChipLogProgress(chipTool, " ***** Test Step 7 : Read attribute seek range start\n");
+            err = TestReadAttributeSeekRangeStart_7();
             break;
         case 8:
-            ChipLogProgress(chipTool, " ***** Test Step 8 : Media Playback Pause Command\n");
-            err = TestMediaPlaybackPauseCommand_8();
+            ChipLogProgress(chipTool, " ***** Test Step 8 : Media Playback Play Command\n");
+            err = TestMediaPlaybackPlayCommand_8();
             break;
         case 9:
-            ChipLogProgress(chipTool, " ***** Test Step 9 : Media Playback Stop Command\n");
-            err = TestMediaPlaybackStopCommand_9();
+            ChipLogProgress(chipTool, " ***** Test Step 9 : Media Playback Pause Command\n");
+            err = TestMediaPlaybackPauseCommand_9();
             break;
         case 10:
-            ChipLogProgress(chipTool, " ***** Test Step 10 : Media Playback Start Over Command\n");
-            err = TestMediaPlaybackStartOverCommand_10();
+            ChipLogProgress(chipTool, " ***** Test Step 10 : Media Playback Stop Command\n");
+            err = TestMediaPlaybackStopCommand_10();
             break;
         case 11:
-            ChipLogProgress(chipTool, " ***** Test Step 11 : Media Playback Previous Command\n");
-            err = TestMediaPlaybackPreviousCommand_11();
+            ChipLogProgress(chipTool, " ***** Test Step 11 : Media Playback Start Over Command\n");
+            err = TestMediaPlaybackStartOverCommand_11();
             break;
         case 12:
-            ChipLogProgress(chipTool, " ***** Test Step 12 : Media Playback Next Command\n");
-            err = TestMediaPlaybackNextCommand_12();
+            ChipLogProgress(chipTool, " ***** Test Step 12 : Media Playback Previous Command\n");
+            err = TestMediaPlaybackPreviousCommand_12();
             break;
         case 13:
-            ChipLogProgress(chipTool, " ***** Test Step 13 : Media Playback Rewind Command\n");
-            err = TestMediaPlaybackRewindCommand_13();
+            ChipLogProgress(chipTool, " ***** Test Step 13 : Media Playback Next Command\n");
+            err = TestMediaPlaybackNextCommand_13();
             break;
         case 14:
-            ChipLogProgress(chipTool, " ***** Test Step 14 : Media Playback Fast Forward Command\n");
-            err = TestMediaPlaybackFastForwardCommand_14();
+            ChipLogProgress(chipTool, " ***** Test Step 14 : Media Playback Rewind Command\n");
+            err = TestMediaPlaybackRewindCommand_14();
             break;
         case 15:
-            ChipLogProgress(chipTool, " ***** Test Step 15 : Media Playback Skip Forward Command\n");
-            err = TestMediaPlaybackSkipForwardCommand_15();
+            ChipLogProgress(chipTool, " ***** Test Step 15 : Media Playback Fast Forward Command\n");
+            err = TestMediaPlaybackFastForwardCommand_15();
             break;
         case 16:
-            ChipLogProgress(chipTool, " ***** Test Step 16 : Media Playback Skip Backward Command\n");
-            err = TestMediaPlaybackSkipBackwardCommand_16();
+            ChipLogProgress(chipTool, " ***** Test Step 16 : Media Playback Skip Forward Command\n");
+            err = TestMediaPlaybackSkipForwardCommand_16();
             break;
         case 17:
-            ChipLogProgress(chipTool, " ***** Test Step 17 : Media Playback Seek Command\n");
-            err = TestMediaPlaybackSeekCommand_17();
+            ChipLogProgress(chipTool, " ***** Test Step 17 : Read attribute position after skip forward\n");
+            err = TestReadAttributePositionAfterSkipForward_17();
+            break;
+        case 18:
+            ChipLogProgress(chipTool, " ***** Test Step 18 : Media Playback Skip Backward Command\n");
+            err = TestMediaPlaybackSkipBackwardCommand_18();
+            break;
+        case 19:
+            ChipLogProgress(chipTool, " ***** Test Step 19 : Read attribute position after skip backward\n");
+            err = TestReadAttributePositionAfterSkipBackward_19();
+            break;
+        case 20:
+            ChipLogProgress(chipTool, " ***** Test Step 20 : Media Playback Seek Command\n");
+            err = TestMediaPlaybackSeekCommand_20();
+            break;
+        case 21:
+            ChipLogProgress(chipTool, " ***** Test Step 21 : Read attribute position after seek\n");
+            err = TestReadAttributePositionAfterSeek_21();
             break;
         }
 
@@ -54184,7 +54337,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 18;
+    const uint16_t mTestCount = 22;
 
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
@@ -54233,9 +54386,12 @@ private:
         (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_4(error);
     }
 
-    static void OnSuccessCallback_4(void * context, float playbackSpeed)
+    static void OnSuccessCallback_4(
+        void * context,
+        const chip::app::DataModel::Nullable<chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::DecodableType> &
+            sampledPosition)
     {
-        (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_4(playbackSpeed);
+        (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_4(sampledPosition);
     }
 
     static void OnFailureCallback_5(void * context, CHIP_ERROR error)
@@ -54243,9 +54399,9 @@ private:
         (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_5(error);
     }
 
-    static void OnSuccessCallback_5(void * context, const chip::app::DataModel::Nullable<uint64_t> & seekRangeEnd)
+    static void OnSuccessCallback_5(void * context, float playbackSpeed)
     {
-        (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_5(seekRangeEnd);
+        (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_5(playbackSpeed);
     }
 
     static void OnFailureCallback_6(void * context, CHIP_ERROR error)
@@ -54253,9 +54409,58 @@ private:
         (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_6(error);
     }
 
-    static void OnSuccessCallback_6(void * context, const chip::app::DataModel::Nullable<uint64_t> & seekRangeStart)
+    static void OnSuccessCallback_6(void * context, const chip::app::DataModel::Nullable<uint64_t> & seekRangeEnd)
     {
-        (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_6(seekRangeStart);
+        (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_6(seekRangeEnd);
+    }
+
+    static void OnFailureCallback_7(void * context, CHIP_ERROR error)
+    {
+        (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_7(error);
+    }
+
+    static void OnSuccessCallback_7(void * context, const chip::app::DataModel::Nullable<uint64_t> & seekRangeStart)
+    {
+        (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_7(seekRangeStart);
+    }
+
+    static void OnFailureCallback_17(void * context, CHIP_ERROR error)
+    {
+        (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_17(error);
+    }
+
+    static void OnSuccessCallback_17(
+        void * context,
+        const chip::app::DataModel::Nullable<chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::DecodableType> &
+            sampledPosition)
+    {
+        (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_17(sampledPosition);
+    }
+
+    static void OnFailureCallback_19(void * context, CHIP_ERROR error)
+    {
+        (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_19(error);
+    }
+
+    static void OnSuccessCallback_19(
+        void * context,
+        const chip::app::DataModel::Nullable<chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::DecodableType> &
+            sampledPosition)
+    {
+        (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_19(sampledPosition);
+    }
+
+    static void OnFailureCallback_21(void * context, CHIP_ERROR error)
+    {
+        (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_21(error);
+    }
+
+    static void OnSuccessCallback_21(
+        void * context,
+        const chip::app::DataModel::Nullable<chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::DecodableType> &
+            sampledPosition)
+    {
+        (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_21(sampledPosition);
     }
 
     //
@@ -54343,12 +54548,12 @@ private:
     void OnSuccessResponse_3(const chip::app::DataModel::Nullable<uint64_t> & duration)
     {
         VerifyOrReturn(CheckValueNonNull("duration", duration));
-        VerifyOrReturn(CheckValue("duration.Value()", duration.Value(), 0ULL));
+        VerifyOrReturn(CheckValue("duration.Value()", duration.Value(), 80000ULL));
 
         NextTest();
     }
 
-    CHIP_ERROR TestReadAttributePlaybackSpeed_4()
+    CHIP_ERROR TestReadAttributePosition_4()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         chip::Controller::MediaPlaybackClusterTest cluster;
@@ -54356,7 +54561,7 @@ private:
 
         ListFreer listFreer;
 
-        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::PlaybackSpeed::TypeInfo>(
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::SampledPosition::TypeInfo>(
             this, OnSuccessCallback_4, OnFailureCallback_4, true));
         return CHIP_NO_ERROR;
     }
@@ -54367,14 +54572,19 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_4(float playbackSpeed)
+    void OnSuccessResponse_4(
+        const chip::app::DataModel::Nullable<chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::DecodableType> &
+            sampledPosition)
     {
-        VerifyOrReturn(CheckValue("playbackSpeed", playbackSpeed, 0.0f));
+        VerifyOrReturn(CheckValueNonNull("sampledPosition", sampledPosition));
+        VerifyOrReturn(CheckValue("sampledPosition.Value().updatedAt", sampledPosition.Value().updatedAt, 0ULL));
+        VerifyOrReturn(CheckValueNonNull("sampledPosition.Value().position", sampledPosition.Value().position));
+        VerifyOrReturn(CheckValue("sampledPosition.Value().position.Value()", sampledPosition.Value().position.Value(), 0ULL));
 
         NextTest();
     }
 
-    CHIP_ERROR TestReadAttributeSeekRangeEnd_5()
+    CHIP_ERROR TestReadAttributePlaybackSpeed_5()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         chip::Controller::MediaPlaybackClusterTest cluster;
@@ -54382,7 +54592,7 @@ private:
 
         ListFreer listFreer;
 
-        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::SeekRangeEnd::TypeInfo>(
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::PlaybackSpeed::TypeInfo>(
             this, OnSuccessCallback_5, OnFailureCallback_5, true));
         return CHIP_NO_ERROR;
     }
@@ -54393,15 +54603,14 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_5(const chip::app::DataModel::Nullable<uint64_t> & seekRangeEnd)
+    void OnSuccessResponse_5(float playbackSpeed)
     {
-        VerifyOrReturn(CheckValueNonNull("seekRangeEnd", seekRangeEnd));
-        VerifyOrReturn(CheckValue("seekRangeEnd.Value()", seekRangeEnd.Value(), 0ULL));
+        VerifyOrReturn(CheckValue("playbackSpeed", playbackSpeed, 0.0f));
 
         NextTest();
     }
 
-    CHIP_ERROR TestReadAttributeSeekRangeStart_6()
+    CHIP_ERROR TestReadAttributeSeekRangeEnd_6()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
         chip::Controller::MediaPlaybackClusterTest cluster;
@@ -54409,7 +54618,7 @@ private:
 
         ListFreer listFreer;
 
-        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::SeekRangeStart::TypeInfo>(
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::SeekRangeEnd::TypeInfo>(
             this, OnSuccessCallback_6, OnFailureCallback_6, true));
         return CHIP_NO_ERROR;
     }
@@ -54420,31 +54629,24 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_6(const chip::app::DataModel::Nullable<uint64_t> & seekRangeStart)
+    void OnSuccessResponse_6(const chip::app::DataModel::Nullable<uint64_t> & seekRangeEnd)
     {
-        VerifyOrReturn(CheckValueNonNull("seekRangeStart", seekRangeStart));
-        VerifyOrReturn(CheckValue("seekRangeStart.Value()", seekRangeStart.Value(), 0ULL));
+        VerifyOrReturn(CheckValueNonNull("seekRangeEnd", seekRangeEnd));
+        VerifyOrReturn(CheckValue("seekRangeEnd.Value()", seekRangeEnd.Value(), 80000ULL));
 
         NextTest();
     }
 
-    CHIP_ERROR TestMediaPlaybackPlayCommand_7()
+    CHIP_ERROR TestReadAttributeSeekRangeStart_7()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
-        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Play::Type;
+        chip::Controller::MediaPlaybackClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
         ListFreer listFreer;
-        RequestType request;
 
-        auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_7(data.status);
-        };
-
-        auto failure = [](void * context, CHIP_ERROR error) {
-            (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_7(error);
-        };
-
-        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevices[kIdentityAlpha], this, success, failure, endpoint, request));
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::SeekRangeStart::TypeInfo>(
+            this, OnSuccessCallback_7, OnFailureCallback_7, true));
         return CHIP_NO_ERROR;
     }
 
@@ -54454,17 +54656,18 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_7(chip::app::Clusters::MediaPlayback::StatusEnum status)
+    void OnSuccessResponse_7(const chip::app::DataModel::Nullable<uint64_t> & seekRangeStart)
     {
-        VerifyOrReturn(CheckValue("status", status, 0));
+        VerifyOrReturn(CheckValueNonNull("seekRangeStart", seekRangeStart));
+        VerifyOrReturn(CheckValue("seekRangeStart.Value()", seekRangeStart.Value(), 0ULL));
 
         NextTest();
     }
 
-    CHIP_ERROR TestMediaPlaybackPauseCommand_8()
+    CHIP_ERROR TestMediaPlaybackPlayCommand_8()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
-        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Pause::Type;
+        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Play::Type;
 
         ListFreer listFreer;
         RequestType request;
@@ -54494,10 +54697,10 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestMediaPlaybackStopCommand_9()
+    CHIP_ERROR TestMediaPlaybackPauseCommand_9()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
-        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::StopPlayback::Type;
+        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Pause::Type;
 
         ListFreer listFreer;
         RequestType request;
@@ -54527,10 +54730,10 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestMediaPlaybackStartOverCommand_10()
+    CHIP_ERROR TestMediaPlaybackStopCommand_10()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
-        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::StartOver::Type;
+        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::StopPlayback::Type;
 
         ListFreer listFreer;
         RequestType request;
@@ -54560,10 +54763,10 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestMediaPlaybackPreviousCommand_11()
+    CHIP_ERROR TestMediaPlaybackStartOverCommand_11()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
-        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Previous::Type;
+        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::StartOver::Type;
 
         ListFreer listFreer;
         RequestType request;
@@ -54593,10 +54796,10 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestMediaPlaybackNextCommand_12()
+    CHIP_ERROR TestMediaPlaybackPreviousCommand_12()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
-        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Next::Type;
+        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Previous::Type;
 
         ListFreer listFreer;
         RequestType request;
@@ -54626,10 +54829,10 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestMediaPlaybackRewindCommand_13()
+    CHIP_ERROR TestMediaPlaybackNextCommand_13()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
-        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Rewind::Type;
+        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Next::Type;
 
         ListFreer listFreer;
         RequestType request;
@@ -54659,10 +54862,10 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestMediaPlaybackFastForwardCommand_14()
+    CHIP_ERROR TestMediaPlaybackRewindCommand_14()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
-        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::FastForward::Type;
+        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Rewind::Type;
 
         ListFreer listFreer;
         RequestType request;
@@ -54692,14 +54895,13 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestMediaPlaybackSkipForwardCommand_15()
+    CHIP_ERROR TestMediaPlaybackFastForwardCommand_15()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
-        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::SkipForward::Type;
+        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::FastForward::Type;
 
         ListFreer listFreer;
         RequestType request;
-        request.deltaPositionMilliseconds = 100ULL;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_15(data.status);
@@ -54726,14 +54928,14 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestMediaPlaybackSkipBackwardCommand_16()
+    CHIP_ERROR TestMediaPlaybackSkipForwardCommand_16()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
-        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::SkipBackward::Type;
+        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::SkipForward::Type;
 
         ListFreer listFreer;
         RequestType request;
-        request.deltaPositionMilliseconds = 100ULL;
+        request.deltaPositionMilliseconds = 500ULL;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_16(data.status);
@@ -54760,24 +54962,16 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestMediaPlaybackSeekCommand_17()
+    CHIP_ERROR TestReadAttributePositionAfterSkipForward_17()
     {
         const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
-        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Seek::Type;
+        chip::Controller::MediaPlaybackClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
 
         ListFreer listFreer;
-        RequestType request;
-        request.position = 100ULL;
 
-        auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_17(data.status);
-        };
-
-        auto failure = [](void * context, CHIP_ERROR error) {
-            (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_17(error);
-        };
-
-        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevices[kIdentityAlpha], this, success, failure, endpoint, request));
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::SampledPosition::TypeInfo>(
+            this, OnSuccessCallback_17, OnFailureCallback_17, true));
         return CHIP_NO_ERROR;
     }
 
@@ -54787,9 +54981,144 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_17(chip::app::Clusters::MediaPlayback::StatusEnum status)
+    void OnSuccessResponse_17(
+        const chip::app::DataModel::Nullable<chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::DecodableType> &
+            sampledPosition)
+    {
+        VerifyOrReturn(CheckValueNonNull("sampledPosition", sampledPosition));
+        VerifyOrReturn(CheckValue("sampledPosition.Value().updatedAt", sampledPosition.Value().updatedAt, 0ULL));
+        VerifyOrReturn(CheckValueNonNull("sampledPosition.Value().position", sampledPosition.Value().position));
+        VerifyOrReturn(CheckValue("sampledPosition.Value().position.Value()", sampledPosition.Value().position.Value(), 500ULL));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestMediaPlaybackSkipBackwardCommand_18()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
+        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::SkipBackward::Type;
+
+        ListFreer listFreer;
+        RequestType request;
+        request.deltaPositionMilliseconds = 100ULL;
+
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
+            (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_18(data.status);
+        };
+
+        auto failure = [](void * context, CHIP_ERROR error) {
+            (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_18(error);
+        };
+
+        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevices[kIdentityAlpha], this, success, failure, endpoint, request));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_18(CHIP_ERROR error)
+    {
+        chip::app::StatusIB status(error);
+        ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_18(chip::app::Clusters::MediaPlayback::StatusEnum status)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributePositionAfterSkipBackward_19()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
+        chip::Controller::MediaPlaybackClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::SampledPosition::TypeInfo>(
+            this, OnSuccessCallback_19, OnFailureCallback_19, true));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_19(CHIP_ERROR error)
+    {
+        chip::app::StatusIB status(error);
+        ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_19(
+        const chip::app::DataModel::Nullable<chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::DecodableType> &
+            sampledPosition)
+    {
+        VerifyOrReturn(CheckValueNonNull("sampledPosition", sampledPosition));
+        VerifyOrReturn(CheckValue("sampledPosition.Value().updatedAt", sampledPosition.Value().updatedAt, 0ULL));
+        VerifyOrReturn(CheckValueNonNull("sampledPosition.Value().position", sampledPosition.Value().position));
+        VerifyOrReturn(CheckValue("sampledPosition.Value().position.Value()", sampledPosition.Value().position.Value(), 400ULL));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestMediaPlaybackSeekCommand_20()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
+        using RequestType               = chip::app::Clusters::MediaPlayback::Commands::Seek::Type;
+
+        ListFreer listFreer;
+        RequestType request;
+        request.position = 1000ULL;
+
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
+            (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_20(data.status);
+        };
+
+        auto failure = [](void * context, CHIP_ERROR error) {
+            (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_20(error);
+        };
+
+        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevices[kIdentityAlpha], this, success, failure, endpoint, request));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_20(CHIP_ERROR error)
+    {
+        chip::app::StatusIB status(error);
+        ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_20(chip::app::Clusters::MediaPlayback::StatusEnum status)
+    {
+        VerifyOrReturn(CheckValue("status", status, 0));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributePositionAfterSeek_21()
+    {
+        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 3;
+        chip::Controller::MediaPlaybackClusterTest cluster;
+        cluster.Associate(mDevices[kIdentityAlpha], endpoint);
+
+        ListFreer listFreer;
+
+        ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::MediaPlayback::Attributes::SampledPosition::TypeInfo>(
+            this, OnSuccessCallback_21, OnFailureCallback_21, true));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_21(CHIP_ERROR error)
+    {
+        chip::app::StatusIB status(error);
+        ThrowFailureResponse();
+    }
+
+    void OnSuccessResponse_21(
+        const chip::app::DataModel::Nullable<chip::app::Clusters::MediaPlayback::Structs::PlaybackPosition::DecodableType> &
+            sampledPosition)
+    {
+        VerifyOrReturn(CheckValueNonNull("sampledPosition", sampledPosition));
+        VerifyOrReturn(CheckValue("sampledPosition.Value().updatedAt", sampledPosition.Value().updatedAt, 0ULL));
+        VerifyOrReturn(CheckValueNonNull("sampledPosition.Value().position", sampledPosition.Value().position));
+        VerifyOrReturn(CheckValue("sampledPosition.Value().position.Value()", sampledPosition.Value().position.Value(), 1000ULL));
 
         NextTest();
     }


### PR DESCRIPTION
#### Problem
- Channel Cluster response command has a parameter errorTypeEnum, which needs to be renamed to statusEnum. 
- The spec. is also changed under this [PR](https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/4958)

#### Issues reported
This PR will resolve this reported issue related to MediaPlayback cluster:
https://github.com/project-chip/connectedhomeip/issues/15089

#### Change overview
see above

#### Testing
Run `./scripts/run_in_build_env.sh \  
                  "./scripts/tests/run_test_suite.py \
                     --chip-tool ./out/debug/standalone/chip-tool \
                     run \
                     --iterations 1 \
                     --all-clusters-app ./out/debug/standalone/chip-all-clusters-app \
                     --tv-app ./out/debug/standalone/chip-tv-app \
                  "`