### PR TITLE
[YAML] Remove error wrong value

### DIFF
--- a/examples/chip-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_cluster.zapt
@@ -374,9 +374,6 @@ class {{filename}}: public TestCommand
         {{#if response.error}}
           VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), {{response.error}}));
           {{#unless async}}NextTest();{{/unless}}
-        {{else if response.errorWrongValue}}
-          VerifyOrReturn(CheckConstraintNotValue("status", chip::to_underlying(status.mStatus), 0));
-          {{#unless async}}NextTest();{{/unless}}
         {{else}}
           {{#if optional}}(status.mStatus == chip::Protocols::InteractionModel::Status::UnsupportedAttribute) ? NextTest() : {{/if}}ThrowFailureResponse();
         {{/if}}

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -31,23 +31,22 @@ const { getClusters, getCommands, getAttributes, getEvents, isTestOnlyCluster }
 const { asBlocks, ensureClusters } = require('./ClustersHelper.js');
 const { Variables }                = require('./variables/Variables.js');
 
-const kIdentityName           = 'identity';
-const kClusterName            = 'cluster';
-const kEndpointName           = 'endpoint';
-const kGroupId                = 'groupId';
-const kCommandName            = 'command';
-const kWaitCommandName        = 'wait';
-const kIndexName              = 'index';
-const kValuesName             = 'values';
-const kConstraintsName        = 'constraints';
-const kArgumentsName          = 'arguments';
-const kResponseName           = 'response';
-const kDisabledName           = 'disabled';
-const kResponseErrorName      = 'error';
-const kResponseWrongErrorName = 'errorWrongValue';
-const kPICSName               = 'PICS';
-const kSaveAsName             = 'saveAs';
-const kFabricFiltered         = 'fabricFiltered';
+const kIdentityName      = 'identity';
+const kClusterName       = 'cluster';
+const kEndpointName      = 'endpoint';
+const kGroupId           = 'groupId';
+const kCommandName       = 'command';
+const kWaitCommandName   = 'wait';
+const kIndexName         = 'index';
+const kValuesName        = 'values';
+const kConstraintsName   = 'constraints';
+const kArgumentsName     = 'arguments';
+const kResponseName      = 'response';
+const kDisabledName      = 'disabled';
+const kResponseErrorName = 'error';
+const kPICSName          = 'PICS';
+const kSaveAsName        = 'saveAs';
+const kFabricFiltered    = 'fabricFiltered';
 
 class NullObject {
   toString()
@@ -242,11 +241,10 @@ function setDefaultResponse(test)
   const defaultResponse = {};
   setDefault(test, kResponseName, defaultResponse);
 
-  const hasResponseError = (kResponseErrorName in test[kResponseName]) || (kResponseWrongErrorName in test[kResponseName]);
+  const hasResponseError = (kResponseErrorName in test[kResponseName]);
 
   const defaultResponseError = 0;
   setDefault(test[kResponseName], kResponseErrorName, defaultResponseError);
-  setDefault(test[kResponseName], kResponseWrongErrorName, defaultResponseError);
 
   const defaultResponseValues = [];
   setDefault(test[kResponseName], kValuesName, defaultResponseValues);
@@ -275,7 +273,6 @@ function setDefaultResponse(test)
   }
 
   ensureValidError(test[kResponseName], kResponseErrorName);
-  ensureValidError(test[kResponseName], kResponseWrongErrorName);
 
   // Step that waits for a particular event does not requires constraints nor expected values.
   if (test.isWait) {

--- a/src/darwin/Framework/CHIP/templates/tests/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/tests/partials/test_cluster.zapt
@@ -97,9 +97,6 @@ ResponseHandler {{> subscribeDataCallback}} = nil;
         {{#if response.error}}
           XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], {{response.error}});
           [expectation fulfill];
-        {{else if response.errorWrongValue}}
-          XCTAssertNotEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
-          [expectation fulfill];
         {{else}}
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
         {{#unless isSubscribeAttribute}}


### PR DESCRIPTION
#### Problem

It seems like `errorWrongValue` is unused now. Let's just remove it.

#### Change overview
 * Remove `errrorWrongValue` and the references to it.

#### Testing
I have regenerated everything and it seems that nothing is changed...