### PR TITLE
Add isCommand to zapTypeToClusterObjectType and use if in various templates

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -46,7 +46,7 @@ public:
     }
 
 private:
-    chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::Type mRequest;
+    {{zapTypeToEncodableClusterObjectType name ns=parent.name forceNotOptional=true}} mRequest;
     {{#zcl_command_arguments}}
     {{#if_chip_complex}}
     TypedComplexArgument<{{zapTypeToEncodableClusterObjectType type ns=parent.parent.name}}> mComplex_{{asUpperCamelCase label}};

--- a/examples/chip-tool/templates/logging/DataModelLogger-src.zapt
+++ b/examples/chip-tool/templates/logging/DataModelLogger-src.zapt
@@ -26,7 +26,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, {{zapTyp
 
 {{#zcl_clusters}}
 {{#zcl_events}}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const {{asUpperCamelCase parent.name}}::Events::{{asUpperCamelCase name}}::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, {{zapTypeToDecodableClusterObjectType name ns=parent.name isArgument=true forceNotOptional=true}} value)
 {
   DataModelLogger::LogString(label, indent, "{");
 {{#zcl_event_fields}}
@@ -48,7 +48,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const {{
 
 {{#chip_client_clusters}}
 {{#zcl_commands_source_server}}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const {{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, {{zapTypeToDecodableClusterObjectType name ns=parent.name isArgument=true forceNotOptional=true}} value)
 {
   DataModelLogger::LogString(label, indent, "{");
   {{#zcl_command_arguments}}
@@ -112,7 +112,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
 {{/first}}
             case {{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::Id:
             {
-                {{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType value;
+                {{zapTypeToDecodableClusterObjectType name ns=parent.name forceNotOptional=true}} value;
                 ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
                 return DataModelLogger::LogValue("{{name}}", 1, value);
             }

--- a/examples/chip-tool/templates/logging/DataModelLogger.zapt
+++ b/examples/chip-tool/templates/logging/DataModelLogger.zapt
@@ -6,12 +6,12 @@ static CHIP_ERROR LogValue(const char * label, size_t indent, {{zapTypeToDecodab
 
 {{#zcl_clusters}}
 {{#zcl_events}}
-static CHIP_ERROR LogValue(const char * label, size_t indent, const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Events::{{asUpperCamelCase name}}::DecodableType & value);
+static CHIP_ERROR LogValue(const char * label, size_t indent, {{zapTypeToDecodableClusterObjectType name ns=parent.name isArgument=true forceNotOptional=true}} value);
 {{/zcl_events}}
 {{/zcl_clusters}}
 
 {{#chip_client_clusters}}
 {{#zcl_commands_source_server}}
-static CHIP_ERROR LogValue(const char * label, size_t indent, const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType & value);
+static CHIP_ERROR LogValue(const char * label, size_t indent, {{zapTypeToDecodableClusterObjectType name ns=parent.name isArgument=true forceNotOptional=true}} value);
 {{/zcl_commands_source_server}}
 {{/chip_client_clusters}}

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -299,7 +299,7 @@ class {{filename}}: public TestCommand
         {{/inline~}}
 
         {{#if isCommand}}
-        using RequestType = chip::app::Clusters::{{asUpperCamelCase cluster}}::Commands::{{asUpperCamelCase command}}::Type;
+        using RequestType = {{zapTypeToEncodableClusterObjectType (asUpperCamelCase command) ns=cluster forceNotOptional=true}};
 
         ListFreer listFreer;
         RequestType request;

--- a/src/app/zap-templates/templates/app/callback.zapt
+++ b/src/app/zap-templates/templates/app/callback.zapt
@@ -157,8 +157,7 @@ bool emberAf{{asUpperCamelCase parent.label}}Cluster{{asUpperCamelCase name}}Cal
        {{#zcl_command_arguments}}, {{#if isArray}}{{asUnderlyingZclType type}}{{else}}{{#if_is_struct type}}{{zapTypeToDecodableClusterObjectType type ns=parent.parent.label}}{{else}}{{asUnderlyingZclType type}}{{/if_is_struct}}{{/if}} {{asSymbol label}}{{/zcl_command_arguments}});
  {{else}}
 bool emberAf{{asUpperCamelCase parent.label}}Cluster{{asUpperCamelCase name}}Callback(chip::app::CommandHandler * commandObj,
-      const chip::app::ConcreteCommandPath & commandPath,
-      const chip::app::Clusters::{{asUpperCamelCase parent.label}}::Commands::{{asUpperCamelCase name}}::DecodableType & commandData);
+      const chip::app::ConcreteCommandPath & commandPath, {{zapTypeToDecodableClusterObjectType name ns=parent.label isArgument=true forceNotOptional=true}} commandData);
 {{/if}}
 {{/zcl_commands}}
 {{/zcl_clusters}}

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -120,7 +120,7 @@ public:
 
     using ResponseType =
     {{~#if responseName}}
-      Clusters::{{asUpperCamelCase parent.name}}::Commands::{{responseName}}::DecodableType;
+      {{zapTypeToDecodableClusterObjectType responseName ns=parent.name forceNotOptional=true}};
     {{else}}
       DataModel::NullObjectType;
     {{/if}}

--- a/src/darwin/Framework/CHIP/templates/CHIPCallbackBridge_internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPCallbackBridge_internal.zapt
@@ -16,7 +16,7 @@ typedef void (*NullableVendorIdAttributeCallback)(void *, const chip::app::DataM
 
 {{#chip_client_clusters}}
 {{#chip_cluster_responses}}
-typedef void (*CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}CallbackType)(void *, const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType &);
+typedef void (*CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}CallbackType)(void *, {{zapTypeToDecodableClusterObjectType name ns=parent.name isArgument=true forceNotOptional=true}});
 {{/chip_cluster_responses}}
 {{/chip_client_clusters}}
 

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -40,7 +40,7 @@ using namespace chip::app::Clusters;
 {{/chip_cluster_command_arguments}}
 {
     ListFreer listFreer;
-    {{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::Type request;
+    {{zapTypeToEncodableClusterObjectType name ns=parent.name forceNotOptional=true}} request;
     {{#chip_cluster_command_arguments}}
       {{#first}}
         {{#unless (commandHasRequiredField parent)}}

--- a/src/darwin/Framework/CHIP/templates/partials/CHIPCallbackBridge.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/CHIPCallbackBridge.zapt
@@ -22,7 +22,7 @@ public:
         {{#if (isStrEqual partial-type "Status")}}
         {{! No more args in this case }}
         {{else if (isStrEqual partial-type "Command")}}
-        , const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType & data
+        , {{zapTypeToDecodableClusterObjectType name ns=parent.name isArgument=true forceNotOptional=true}} data
         {{else if (isStrEqual partial-type "CommandStatus")}}
         , const chip::app::DataModel::NullObjectType &
         {{else}}
@@ -56,7 +56,7 @@ void CHIP{{> @partial-block}}Bridge::OnSuccessFn(void * context
     {{#if (isStrEqual partial-type "Status")}}
     {{! No more args in this case }}
     {{else if (isStrEqual partial-type "Command")}}
-    , const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType & data
+    , {{zapTypeToDecodableClusterObjectType name ns=parent.name isArgument=true forceNotOptional=true}} data
     {{else if (isStrEqual partial-type "CommandStatus")}}
     , const chip::app::DataModel::NullObjectType &
     {{else}}

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -401,7 +401,7 @@ using namespace chip::app::Clusters;
                                   NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    AccountLogin::Commands::GetSetupPIN::Type request;
+    chip::app::Clusters::AccountLogin::Commands::GetSetupPIN::Type request;
     request.tempAccountIdentifier = [self asCharSpan:params.tempAccountIdentifier];
 
     new CHIPAccountLoginClusterGetSetupPINResponseCallbackBridge(
@@ -415,7 +415,7 @@ using namespace chip::app::Clusters;
 - (void)loginWithParams:(CHIPAccountLoginClusterLoginParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    AccountLogin::Commands::Login::Type request;
+    chip::app::Clusters::AccountLogin::Commands::Login::Type request;
     request.tempAccountIdentifier = [self asCharSpan:params.tempAccountIdentifier];
     request.setupPIN = [self asCharSpan:params.setupPIN];
 
@@ -434,7 +434,7 @@ using namespace chip::app::Clusters;
 - (void)logoutWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    AccountLogin::Commands::Logout::Type request;
+    chip::app::Clusters::AccountLogin::Commands::Logout::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -585,7 +585,7 @@ using namespace chip::app::Clusters;
                              completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type request;
+    chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type request;
     request.commissioningTimeout = params.commissioningTimeout.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(
@@ -604,7 +604,7 @@ using namespace chip::app::Clusters;
                         completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    AdministratorCommissioning::Commands::OpenCommissioningWindow::Type request;
+    chip::app::Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Type request;
     request.commissioningTimeout = params.commissioningTimeout.unsignedShortValue;
     request.PAKEVerifier = [self asByteSpan:params.pakeVerifier];
     request.discriminator = params.discriminator.unsignedShortValue;
@@ -627,7 +627,7 @@ using namespace chip::app::Clusters;
 - (void)revokeCommissioningWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    AdministratorCommissioning::Commands::RevokeCommissioning::Type request;
+    chip::app::Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -1246,7 +1246,7 @@ using namespace chip::app::Clusters;
                               NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    ApplicationLauncher::Commands::HideApp::Type request;
+    chip::app::Clusters::ApplicationLauncher::Commands::HideApp::Type request;
     request.application.catalogVendorId = params.application.catalogVendorId.unsignedShortValue;
     request.application.applicationId = [self asCharSpan:params.application.applicationId];
 
@@ -1263,7 +1263,7 @@ using namespace chip::app::Clusters;
                                 NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    ApplicationLauncher::Commands::LaunchApp::Type request;
+    chip::app::Clusters::ApplicationLauncher::Commands::LaunchApp::Type request;
     request.application.catalogVendorId = params.application.catalogVendorId.unsignedShortValue;
     request.application.applicationId = [self asCharSpan:params.application.applicationId];
     if (params.data != nil) {
@@ -1284,7 +1284,7 @@ using namespace chip::app::Clusters;
                               NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    ApplicationLauncher::Commands::StopApp::Type request;
+    chip::app::Clusters::ApplicationLauncher::Commands::StopApp::Type request;
     request.application.catalogVendorId = params.application.catalogVendorId.unsignedShortValue;
     request.application.applicationId = [self asCharSpan:params.application.applicationId];
 
@@ -1525,7 +1525,7 @@ using namespace chip::app::Clusters;
              completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    AudioOutput::Commands::RenameOutput::Type request;
+    chip::app::Clusters::AudioOutput::Commands::RenameOutput::Type request;
     request.index = params.index.unsignedCharValue;
     request.name = [self asCharSpan:params.name];
 
@@ -1545,7 +1545,7 @@ using namespace chip::app::Clusters;
              completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    AudioOutput::Commands::SelectOutput::Type request;
+    chip::app::Clusters::AudioOutput::Commands::SelectOutput::Type request;
     request.index = params.index.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(
@@ -1757,7 +1757,7 @@ using namespace chip::app::Clusters;
                           completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    BarrierControl::Commands::BarrierControlGoToPercent::Type request;
+    chip::app::Clusters::BarrierControl::Commands::BarrierControlGoToPercent::Type request;
     request.percentOpen = params.percentOpen.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(
@@ -1775,7 +1775,7 @@ using namespace chip::app::Clusters;
 - (void)barrierControlStopWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    BarrierControl::Commands::BarrierControlStop::Type request;
+    chip::app::Clusters::BarrierControl::Commands::BarrierControlStop::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -3051,7 +3051,7 @@ using namespace chip::app::Clusters;
 - (void)bindWithParams:(CHIPBindingClusterBindParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    Binding::Commands::Bind::Type request;
+    chip::app::Clusters::Binding::Commands::Bind::Type request;
     request.nodeId = params.nodeId.unsignedLongLongValue;
     request.groupId = params.groupId.unsignedShortValue;
     request.endpointId = params.endpointId.unsignedShortValue;
@@ -3072,7 +3072,7 @@ using namespace chip::app::Clusters;
 - (void)unbindWithParams:(CHIPBindingClusterUnbindParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    Binding::Commands::Unbind::Type request;
+    chip::app::Clusters::Binding::Commands::Unbind::Type request;
     request.nodeId = params.nodeId.unsignedLongLongValue;
     request.groupId = params.groupId.unsignedShortValue;
     request.endpointId = params.endpointId.unsignedShortValue;
@@ -3389,7 +3389,7 @@ using namespace chip::app::Clusters;
               completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    BridgedActions::Commands::DisableAction::Type request;
+    chip::app::Clusters::BridgedActions::Commands::DisableAction::Type request;
     request.actionID = params.actionID.unsignedShortValue;
     if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
@@ -3412,7 +3412,7 @@ using namespace chip::app::Clusters;
                           completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    BridgedActions::Commands::DisableActionWithDuration::Type request;
+    chip::app::Clusters::BridgedActions::Commands::DisableActionWithDuration::Type request;
     request.actionID = params.actionID.unsignedShortValue;
     if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
@@ -3436,7 +3436,7 @@ using namespace chip::app::Clusters;
              completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    BridgedActions::Commands::EnableAction::Type request;
+    chip::app::Clusters::BridgedActions::Commands::EnableAction::Type request;
     request.actionID = params.actionID.unsignedShortValue;
     if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
@@ -3459,7 +3459,7 @@ using namespace chip::app::Clusters;
                          completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    BridgedActions::Commands::EnableActionWithDuration::Type request;
+    chip::app::Clusters::BridgedActions::Commands::EnableActionWithDuration::Type request;
     request.actionID = params.actionID.unsignedShortValue;
     if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
@@ -3483,7 +3483,7 @@ using namespace chip::app::Clusters;
               completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    BridgedActions::Commands::InstantAction::Type request;
+    chip::app::Clusters::BridgedActions::Commands::InstantAction::Type request;
     request.actionID = params.actionID.unsignedShortValue;
     if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
@@ -3506,7 +3506,7 @@ using namespace chip::app::Clusters;
                             completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    BridgedActions::Commands::InstantActionWithTransition::Type request;
+    chip::app::Clusters::BridgedActions::Commands::InstantActionWithTransition::Type request;
     request.actionID = params.actionID.unsignedShortValue;
     if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
@@ -3530,7 +3530,7 @@ using namespace chip::app::Clusters;
             completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    BridgedActions::Commands::PauseAction::Type request;
+    chip::app::Clusters::BridgedActions::Commands::PauseAction::Type request;
     request.actionID = params.actionID.unsignedShortValue;
     if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
@@ -3553,7 +3553,7 @@ using namespace chip::app::Clusters;
                         completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    BridgedActions::Commands::PauseActionWithDuration::Type request;
+    chip::app::Clusters::BridgedActions::Commands::PauseActionWithDuration::Type request;
     request.actionID = params.actionID.unsignedShortValue;
     if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
@@ -3577,7 +3577,7 @@ using namespace chip::app::Clusters;
              completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    BridgedActions::Commands::ResumeAction::Type request;
+    chip::app::Clusters::BridgedActions::Commands::ResumeAction::Type request;
     request.actionID = params.actionID.unsignedShortValue;
     if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
@@ -3600,7 +3600,7 @@ using namespace chip::app::Clusters;
             completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    BridgedActions::Commands::StartAction::Type request;
+    chip::app::Clusters::BridgedActions::Commands::StartAction::Type request;
     request.actionID = params.actionID.unsignedShortValue;
     if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
@@ -3623,7 +3623,7 @@ using namespace chip::app::Clusters;
                         completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    BridgedActions::Commands::StartActionWithDuration::Type request;
+    chip::app::Clusters::BridgedActions::Commands::StartActionWithDuration::Type request;
     request.actionID = params.actionID.unsignedShortValue;
     if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
@@ -3647,7 +3647,7 @@ using namespace chip::app::Clusters;
            completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    BridgedActions::Commands::StopAction::Type request;
+    chip::app::Clusters::BridgedActions::Commands::StopAction::Type request;
     request.actionID = params.actionID.unsignedShortValue;
     if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
@@ -4486,7 +4486,7 @@ using namespace chip::app::Clusters;
                                     NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    Channel::Commands::ChangeChannel::Type request;
+    chip::app::Clusters::Channel::Commands::ChangeChannel::Type request;
     request.match = [self asCharSpan:params.match];
 
     new CHIPChannelClusterChangeChannelResponseCallbackBridge(
@@ -4501,7 +4501,7 @@ using namespace chip::app::Clusters;
                       completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    Channel::Commands::ChangeChannelByNumber::Type request;
+    chip::app::Clusters::Channel::Commands::ChangeChannelByNumber::Type request;
     request.majorNumber = params.majorNumber.unsignedShortValue;
     request.minorNumber = params.minorNumber.unsignedShortValue;
 
@@ -4520,7 +4520,7 @@ using namespace chip::app::Clusters;
 - (void)skipChannelWithParams:(CHIPChannelClusterSkipChannelParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    Channel::Commands::SkipChannel::Type request;
+    chip::app::Clusters::Channel::Commands::SkipChannel::Type request;
     request.count = params.count.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(
@@ -4764,7 +4764,7 @@ using namespace chip::app::Clusters;
              completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::ColorLoopSet::Type request;
+    chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
     request.updateFlags = static_cast<std::remove_reference_t<decltype(request.updateFlags)>>(params.updateFlags.unsignedCharValue);
     request.action = static_cast<std::remove_reference_t<decltype(request.action)>>(params.action.unsignedCharValue);
     request.direction = static_cast<std::remove_reference_t<decltype(request.direction)>>(params.direction.unsignedCharValue);
@@ -4789,7 +4789,7 @@ using namespace chip::app::Clusters;
                 completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::EnhancedMoveHue::Type request;
+    chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type request;
     request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(params.moveMode.unsignedCharValue);
     request.rate = params.rate.unsignedShortValue;
     request.optionsMask = params.optionsMask.unsignedCharValue;
@@ -4811,7 +4811,7 @@ using namespace chip::app::Clusters;
                   completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::EnhancedMoveToHue::Type request;
+    chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type request;
     request.enhancedHue = params.enhancedHue.unsignedShortValue;
     request.direction = static_cast<std::remove_reference_t<decltype(request.direction)>>(params.direction.unsignedCharValue);
     request.transitionTime = params.transitionTime.unsignedShortValue;
@@ -4834,7 +4834,7 @@ using namespace chip::app::Clusters;
                                completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::EnhancedMoveToHueAndSaturation::Type request;
+    chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHueAndSaturation::Type request;
     request.enhancedHue = params.enhancedHue.unsignedShortValue;
     request.saturation = params.saturation.unsignedCharValue;
     request.transitionTime = params.transitionTime.unsignedShortValue;
@@ -4857,7 +4857,7 @@ using namespace chip::app::Clusters;
                 completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::EnhancedStepHue::Type request;
+    chip::app::Clusters::ColorControl::Commands::EnhancedStepHue::Type request;
     request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(params.stepMode.unsignedCharValue);
     request.stepSize = params.stepSize.unsignedShortValue;
     request.transitionTime = params.transitionTime.unsignedShortValue;
@@ -4879,7 +4879,7 @@ using namespace chip::app::Clusters;
 - (void)moveColorWithParams:(CHIPColorControlClusterMoveColorParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::MoveColor::Type request;
+    chip::app::Clusters::ColorControl::Commands::MoveColor::Type request;
     request.rateX = params.rateX.shortValue;
     request.rateY = params.rateY.shortValue;
     request.optionsMask = params.optionsMask.unsignedCharValue;
@@ -4901,7 +4901,7 @@ using namespace chip::app::Clusters;
                      completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::MoveColorTemperature::Type request;
+    chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type request;
     request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(params.moveMode.unsignedCharValue);
     request.rate = params.rate.unsignedShortValue;
     request.colorTemperatureMinimum = params.colorTemperatureMinimum.unsignedShortValue;
@@ -4924,7 +4924,7 @@ using namespace chip::app::Clusters;
 - (void)moveHueWithParams:(CHIPColorControlClusterMoveHueParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::MoveHue::Type request;
+    chip::app::Clusters::ColorControl::Commands::MoveHue::Type request;
     request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(params.moveMode.unsignedCharValue);
     request.rate = params.rate.unsignedCharValue;
     request.optionsMask = params.optionsMask.unsignedCharValue;
@@ -4946,7 +4946,7 @@ using namespace chip::app::Clusters;
                completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::MoveSaturation::Type request;
+    chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type request;
     request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(params.moveMode.unsignedCharValue);
     request.rate = params.rate.unsignedCharValue;
     request.optionsMask = params.optionsMask.unsignedCharValue;
@@ -4968,7 +4968,7 @@ using namespace chip::app::Clusters;
             completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::MoveToColor::Type request;
+    chip::app::Clusters::ColorControl::Commands::MoveToColor::Type request;
     request.colorX = params.colorX.unsignedShortValue;
     request.colorY = params.colorY.unsignedShortValue;
     request.transitionTime = params.transitionTime.unsignedShortValue;
@@ -4991,7 +4991,7 @@ using namespace chip::app::Clusters;
                        completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::MoveToColorTemperature::Type request;
+    chip::app::Clusters::ColorControl::Commands::MoveToColorTemperature::Type request;
     request.colorTemperature = params.colorTemperature.unsignedShortValue;
     request.transitionTime = params.transitionTime.unsignedShortValue;
     request.optionsMask = params.optionsMask.unsignedCharValue;
@@ -5012,7 +5012,7 @@ using namespace chip::app::Clusters;
 - (void)moveToHueWithParams:(CHIPColorControlClusterMoveToHueParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::MoveToHue::Type request;
+    chip::app::Clusters::ColorControl::Commands::MoveToHue::Type request;
     request.hue = params.hue.unsignedCharValue;
     request.direction = static_cast<std::remove_reference_t<decltype(request.direction)>>(params.direction.unsignedCharValue);
     request.transitionTime = params.transitionTime.unsignedShortValue;
@@ -5035,7 +5035,7 @@ using namespace chip::app::Clusters;
                        completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::MoveToHueAndSaturation::Type request;
+    chip::app::Clusters::ColorControl::Commands::MoveToHueAndSaturation::Type request;
     request.hue = params.hue.unsignedCharValue;
     request.saturation = params.saturation.unsignedCharValue;
     request.transitionTime = params.transitionTime.unsignedShortValue;
@@ -5058,7 +5058,7 @@ using namespace chip::app::Clusters;
                  completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::MoveToSaturation::Type request;
+    chip::app::Clusters::ColorControl::Commands::MoveToSaturation::Type request;
     request.saturation = params.saturation.unsignedCharValue;
     request.transitionTime = params.transitionTime.unsignedShortValue;
     request.optionsMask = params.optionsMask.unsignedCharValue;
@@ -5079,7 +5079,7 @@ using namespace chip::app::Clusters;
 - (void)stepColorWithParams:(CHIPColorControlClusterStepColorParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::StepColor::Type request;
+    chip::app::Clusters::ColorControl::Commands::StepColor::Type request;
     request.stepX = params.stepX.shortValue;
     request.stepY = params.stepY.shortValue;
     request.transitionTime = params.transitionTime.unsignedShortValue;
@@ -5102,7 +5102,7 @@ using namespace chip::app::Clusters;
                      completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::StepColorTemperature::Type request;
+    chip::app::Clusters::ColorControl::Commands::StepColorTemperature::Type request;
     request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(params.stepMode.unsignedCharValue);
     request.stepSize = params.stepSize.unsignedShortValue;
     request.transitionTime = params.transitionTime.unsignedShortValue;
@@ -5126,7 +5126,7 @@ using namespace chip::app::Clusters;
 - (void)stepHueWithParams:(CHIPColorControlClusterStepHueParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::StepHue::Type request;
+    chip::app::Clusters::ColorControl::Commands::StepHue::Type request;
     request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(params.stepMode.unsignedCharValue);
     request.stepSize = params.stepSize.unsignedCharValue;
     request.transitionTime = params.transitionTime.unsignedCharValue;
@@ -5149,7 +5149,7 @@ using namespace chip::app::Clusters;
                completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::StepSaturation::Type request;
+    chip::app::Clusters::ColorControl::Commands::StepSaturation::Type request;
     request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(params.stepMode.unsignedCharValue);
     request.stepSize = params.stepSize.unsignedCharValue;
     request.transitionTime = params.transitionTime.unsignedCharValue;
@@ -5172,7 +5172,7 @@ using namespace chip::app::Clusters;
              completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ColorControl::Commands::StopMoveStep::Type request;
+    chip::app::Clusters::ColorControl::Commands::StopMoveStep::Type request;
     request.optionsMask = params.optionsMask.unsignedCharValue;
     request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
@@ -7107,7 +7107,7 @@ using namespace chip::app::Clusters;
                                     NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    ContentLauncher::Commands::LaunchContent::Type request;
+    chip::app::Clusters::ContentLauncher::Commands::LaunchContent::Type request;
     {
         using ListType_1 = std::remove_reference_t<decltype(request.search.parameterList)>;
         using ListMemberType_1 = ListMemberTypeGetter<ListType_1>::Type;
@@ -7178,7 +7178,7 @@ using namespace chip::app::Clusters;
                                 NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    ContentLauncher::Commands::LaunchURL::Type request;
+    chip::app::Clusters::ContentLauncher::Commands::LaunchURL::Type request;
     request.contentURL = [self asCharSpan:params.contentURL];
     if (params.displayString != nil) {
         auto & definedValue_0 = request.displayString.Emplace();
@@ -7758,7 +7758,7 @@ using namespace chip::app::Clusters;
                                           NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    DiagnosticLogs::Commands::RetrieveLogsRequest::Type request;
+    chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::Type request;
     request.intent = static_cast<std::remove_reference_t<decltype(request.intent)>>(params.intent.unsignedCharValue);
     request.requestedProtocol
         = static_cast<std::remove_reference_t<decltype(request.requestedProtocol)>>(params.requestedProtocol.unsignedCharValue);
@@ -7879,7 +7879,7 @@ using namespace chip::app::Clusters;
                 completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    DoorLock::Commands::ClearCredential::Type request;
+    chip::app::Clusters::DoorLock::Commands::ClearCredential::Type request;
     if (params.credential == nil) {
         request.credential.SetNull();
     } else {
@@ -7904,7 +7904,7 @@ using namespace chip::app::Clusters;
 - (void)clearUserWithParams:(CHIPDoorLockClusterClearUserParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    DoorLock::Commands::ClearUser::Type request;
+    chip::app::Clusters::DoorLock::Commands::ClearUser::Type request;
     request.userIndex = params.userIndex.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(
@@ -7923,7 +7923,7 @@ using namespace chip::app::Clusters;
                      completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    DoorLock::Commands::ClearWeekDaySchedule::Type request;
+    chip::app::Clusters::DoorLock::Commands::ClearWeekDaySchedule::Type request;
     request.weekDayIndex = params.weekDayIndex.unsignedCharValue;
     request.userIndex = params.userIndex.unsignedShortValue;
 
@@ -7943,7 +7943,7 @@ using namespace chip::app::Clusters;
                      completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    DoorLock::Commands::ClearYearDaySchedule::Type request;
+    chip::app::Clusters::DoorLock::Commands::ClearYearDaySchedule::Type request;
     request.yearDayIndex = params.yearDayIndex.unsignedCharValue;
     request.userIndex = params.userIndex.unsignedShortValue;
 
@@ -7964,7 +7964,7 @@ using namespace chip::app::Clusters;
                                           NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    DoorLock::Commands::GetCredentialStatus::Type request;
+    chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::Type request;
     request.credential.credentialType = static_cast<std::remove_reference_t<decltype(request.credential.credentialType)>>(
         params.credential.credentialType.unsignedCharValue);
     request.credential.credentialIndex = params.credential.credentialIndex.unsignedShortValue;
@@ -7982,7 +7982,7 @@ using namespace chip::app::Clusters;
             (void (^)(CHIPDoorLockClusterGetUserResponseParams * _Nullable data, NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    DoorLock::Commands::GetUser::Type request;
+    chip::app::Clusters::DoorLock::Commands::GetUser::Type request;
     request.userIndex = params.userIndex.unsignedShortValue;
 
     new CHIPDoorLockClusterGetUserResponseCallbackBridge(
@@ -7998,7 +7998,7 @@ using namespace chip::app::Clusters;
                                          NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    DoorLock::Commands::GetWeekDaySchedule::Type request;
+    chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::Type request;
     request.weekDayIndex = params.weekDayIndex.unsignedCharValue;
     request.userIndex = params.userIndex.unsignedShortValue;
 
@@ -8015,7 +8015,7 @@ using namespace chip::app::Clusters;
                                          NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    DoorLock::Commands::GetYearDaySchedule::Type request;
+    chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type request;
     request.yearDayIndex = params.yearDayIndex.unsignedCharValue;
     request.userIndex = params.userIndex.unsignedShortValue;
 
@@ -8031,7 +8031,7 @@ using namespace chip::app::Clusters;
          completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    DoorLock::Commands::LockDoor::Type request;
+    chip::app::Clusters::DoorLock::Commands::LockDoor::Type request;
     if (params != nil) {
         if (params.pinCode != nil) {
             auto & definedValue_0 = request.pinCode.Emplace();
@@ -8056,7 +8056,7 @@ using namespace chip::app::Clusters;
                                     NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    DoorLock::Commands::SetCredential::Type request;
+    chip::app::Clusters::DoorLock::Commands::SetCredential::Type request;
     request.operationType
         = static_cast<std::remove_reference_t<decltype(request.operationType)>>(params.operationType.unsignedCharValue);
     request.credential.credentialType = static_cast<std::remove_reference_t<decltype(request.credential.credentialType)>>(
@@ -8093,7 +8093,7 @@ using namespace chip::app::Clusters;
 - (void)setUserWithParams:(CHIPDoorLockClusterSetUserParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    DoorLock::Commands::SetUser::Type request;
+    chip::app::Clusters::DoorLock::Commands::SetUser::Type request;
     request.operationType
         = static_cast<std::remove_reference_t<decltype(request.operationType)>>(params.operationType.unsignedCharValue);
     request.userIndex = params.userIndex.unsignedShortValue;
@@ -8144,7 +8144,7 @@ using namespace chip::app::Clusters;
                    completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    DoorLock::Commands::SetWeekDaySchedule::Type request;
+    chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::Type request;
     request.weekDayIndex = params.weekDayIndex.unsignedCharValue;
     request.userIndex = params.userIndex.unsignedShortValue;
     request.daysMask = static_cast<std::remove_reference_t<decltype(request.daysMask)>>(params.daysMask.unsignedCharValue);
@@ -8169,7 +8169,7 @@ using namespace chip::app::Clusters;
                    completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    DoorLock::Commands::SetYearDaySchedule::Type request;
+    chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::Type request;
     request.yearDayIndex = params.yearDayIndex.unsignedCharValue;
     request.userIndex = params.userIndex.unsignedShortValue;
     request.localStartTime = params.localStartTime.unsignedIntValue;
@@ -8191,7 +8191,7 @@ using namespace chip::app::Clusters;
            completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    DoorLock::Commands::UnlockDoor::Type request;
+    chip::app::Clusters::DoorLock::Commands::UnlockDoor::Type request;
     if (params != nil) {
         if (params.pinCode != nil) {
             auto & definedValue_0 = request.pinCode.Emplace();
@@ -8215,7 +8215,7 @@ using namespace chip::app::Clusters;
                   completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    DoorLock::Commands::UnlockWithTimeout::Type request;
+    chip::app::Clusters::DoorLock::Commands::UnlockWithTimeout::Type request;
     request.timeout = params.timeout.unsignedShortValue;
     if (params.pinCode != nil) {
         auto & definedValue_0 = request.pinCode.Emplace();
@@ -9602,7 +9602,7 @@ using namespace chip::app::Clusters;
 - (void)resetCountsWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    EthernetNetworkDiagnostics::Commands::ResetCounts::Type request;
+    chip::app::Clusters::EthernetNetworkDiagnostics::Commands::ResetCounts::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -10478,7 +10478,7 @@ using namespace chip::app::Clusters;
                                   NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    GeneralCommissioning::Commands::ArmFailSafe::Type request;
+    chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafe::Type request;
     request.expiryLengthSeconds = params.expiryLengthSeconds.unsignedShortValue;
     request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
     request.timeoutMs = params.timeoutMs.unsignedIntValue;
@@ -10496,7 +10496,7 @@ using namespace chip::app::Clusters;
         NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    GeneralCommissioning::Commands::CommissioningComplete::Type request;
+    chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type request;
 
     new CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -10512,7 +10512,7 @@ using namespace chip::app::Clusters;
                                           NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    GeneralCommissioning::Commands::SetRegulatoryConfig::Type request;
+    chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Type request;
     request.location = static_cast<std::remove_reference_t<decltype(request.location)>>(params.location.unsignedCharValue);
     request.countryCode = [self asCharSpan:params.countryCode];
     request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
@@ -11187,7 +11187,7 @@ using namespace chip::app::Clusters;
                                  NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    GroupKeyManagement::Commands::KeySetRead::Type request;
+    chip::app::Clusters::GroupKeyManagement::Commands::KeySetRead::Type request;
     request.groupKeySetID = params.groupKeySetID.unsignedShortValue;
 
     new CHIPGroupKeyManagementClusterKeySetReadResponseCallbackBridge(
@@ -11203,7 +11203,7 @@ using namespace chip::app::Clusters;
                                            NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    GroupKeyManagement::Commands::KeySetReadAllIndices::Type request;
+    chip::app::Clusters::GroupKeyManagement::Commands::KeySetReadAllIndices::Type request;
     {
         using ListType_0 = std::remove_reference_t<decltype(request.groupKeySetIDs)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
@@ -11240,7 +11240,7 @@ using namespace chip::app::Clusters;
              completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    GroupKeyManagement::Commands::KeySetRemove::Type request;
+    chip::app::Clusters::GroupKeyManagement::Commands::KeySetRemove::Type request;
     request.groupKeySetID = params.groupKeySetID.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(
@@ -11259,7 +11259,7 @@ using namespace chip::app::Clusters;
             completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    GroupKeyManagement::Commands::KeySetWrite::Type request;
+    chip::app::Clusters::GroupKeyManagement::Commands::KeySetWrite::Type request;
     request.groupKeySet.groupKeySetID = params.groupKeySet.groupKeySetID.unsignedShortValue;
     request.groupKeySet.groupKeySecurityPolicy
         = static_cast<std::remove_reference_t<decltype(request.groupKeySet.groupKeySecurityPolicy)>>(
@@ -11619,7 +11619,7 @@ using namespace chip::app::Clusters;
              (void (^)(CHIPGroupsClusterAddGroupResponseParams * _Nullable data, NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    Groups::Commands::AddGroup::Type request;
+    chip::app::Clusters::Groups::Commands::AddGroup::Type request;
     request.groupId = params.groupId.unsignedShortValue;
     request.groupName = [self asCharSpan:params.groupName];
 
@@ -11635,7 +11635,7 @@ using namespace chip::app::Clusters;
                       completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    Groups::Commands::AddGroupIfIdentifying::Type request;
+    chip::app::Clusters::Groups::Commands::AddGroupIfIdentifying::Type request;
     request.groupId = params.groupId.unsignedShortValue;
     request.groupName = [self asCharSpan:params.groupName];
 
@@ -11656,7 +11656,7 @@ using namespace chip::app::Clusters;
                                          NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    Groups::Commands::GetGroupMembership::Type request;
+    chip::app::Clusters::Groups::Commands::GetGroupMembership::Type request;
     {
         using ListType_0 = std::remove_reference_t<decltype(request.groupList)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
@@ -11691,7 +11691,7 @@ using namespace chip::app::Clusters;
 - (void)removeAllGroupsWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    Groups::Commands::RemoveAllGroups::Type request;
+    chip::app::Clusters::Groups::Commands::RemoveAllGroups::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -11710,7 +11710,7 @@ using namespace chip::app::Clusters;
                 (void (^)(CHIPGroupsClusterRemoveGroupResponseParams * _Nullable data, NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    Groups::Commands::RemoveGroup::Type request;
+    chip::app::Clusters::Groups::Commands::RemoveGroup::Type request;
     request.groupId = params.groupId.unsignedShortValue;
 
     new CHIPGroupsClusterRemoveGroupResponseCallbackBridge(
@@ -11726,7 +11726,7 @@ using namespace chip::app::Clusters;
               (void (^)(CHIPGroupsClusterViewGroupResponseParams * _Nullable data, NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    Groups::Commands::ViewGroup::Type request;
+    chip::app::Clusters::Groups::Commands::ViewGroup::Type request;
     request.groupId = params.groupId.unsignedShortValue;
 
     new CHIPGroupsClusterViewGroupResponseCallbackBridge(
@@ -11902,7 +11902,7 @@ using namespace chip::app::Clusters;
 - (void)identifyWithParams:(CHIPIdentifyClusterIdentifyParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    Identify::Commands::Identify::Type request;
+    chip::app::Clusters::Identify::Commands::Identify::Type request;
     request.identifyTime = params.identifyTime.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(
@@ -11921,7 +11921,7 @@ using namespace chip::app::Clusters;
                                                NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    Identify::Commands::IdentifyQuery::Type request;
+    chip::app::Clusters::Identify::Commands::IdentifyQuery::Type request;
 
     new CHIPIdentifyClusterIdentifyQueryResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -11935,7 +11935,7 @@ using namespace chip::app::Clusters;
               completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    Identify::Commands::TriggerEffect::Type request;
+    chip::app::Clusters::Identify::Commands::TriggerEffect::Type request;
     request.effectIdentifier
         = static_cast<std::remove_reference_t<decltype(request.effectIdentifier)>>(params.effectIdentifier.unsignedCharValue);
     request.effectVariant
@@ -12459,7 +12459,7 @@ using namespace chip::app::Clusters;
             (void (^)(CHIPKeypadInputClusterSendKeyResponseParams * _Nullable data, NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    KeypadInput::Commands::SendKey::Type request;
+    chip::app::Clusters::KeypadInput::Commands::SendKey::Type request;
     request.keyCode = static_cast<std::remove_reference_t<decltype(request.keyCode)>>(params.keyCode.unsignedCharValue);
 
     new CHIPKeypadInputClusterSendKeyResponseCallbackBridge(
@@ -12606,7 +12606,7 @@ using namespace chip::app::Clusters;
 - (void)moveWithParams:(CHIPLevelControlClusterMoveParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    LevelControl::Commands::Move::Type request;
+    chip::app::Clusters::LevelControl::Commands::Move::Type request;
     request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(params.moveMode.unsignedCharValue);
     request.rate = params.rate.unsignedCharValue;
     request.optionMask = params.optionMask.unsignedCharValue;
@@ -12628,7 +12628,7 @@ using namespace chip::app::Clusters;
             completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    LevelControl::Commands::MoveToLevel::Type request;
+    chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type request;
     request.level = params.level.unsignedCharValue;
     request.transitionTime = params.transitionTime.unsignedShortValue;
     request.optionMask = params.optionMask.unsignedCharValue;
@@ -12650,7 +12650,7 @@ using namespace chip::app::Clusters;
                      completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    LevelControl::Commands::MoveToLevelWithOnOff::Type request;
+    chip::app::Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type request;
     request.level = params.level.unsignedCharValue;
     request.transitionTime = params.transitionTime.unsignedShortValue;
 
@@ -12670,7 +12670,7 @@ using namespace chip::app::Clusters;
               completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    LevelControl::Commands::MoveWithOnOff::Type request;
+    chip::app::Clusters::LevelControl::Commands::MoveWithOnOff::Type request;
     request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(params.moveMode.unsignedCharValue);
     request.rate = params.rate.unsignedCharValue;
 
@@ -12689,7 +12689,7 @@ using namespace chip::app::Clusters;
 - (void)stepWithParams:(CHIPLevelControlClusterStepParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    LevelControl::Commands::Step::Type request;
+    chip::app::Clusters::LevelControl::Commands::Step::Type request;
     request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(params.stepMode.unsignedCharValue);
     request.stepSize = params.stepSize.unsignedCharValue;
     request.transitionTime = params.transitionTime.unsignedShortValue;
@@ -12712,7 +12712,7 @@ using namespace chip::app::Clusters;
               completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    LevelControl::Commands::StepWithOnOff::Type request;
+    chip::app::Clusters::LevelControl::Commands::StepWithOnOff::Type request;
     request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(params.stepMode.unsignedCharValue);
     request.stepSize = params.stepSize.unsignedCharValue;
     request.transitionTime = params.transitionTime.unsignedShortValue;
@@ -12732,7 +12732,7 @@ using namespace chip::app::Clusters;
 - (void)stopWithParams:(CHIPLevelControlClusterStopParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    LevelControl::Commands::Stop::Type request;
+    chip::app::Clusters::LevelControl::Commands::Stop::Type request;
     request.optionMask = params.optionMask.unsignedCharValue;
     request.optionOverride = params.optionOverride.unsignedCharValue;
 
@@ -12751,7 +12751,7 @@ using namespace chip::app::Clusters;
 - (void)stopWithOnOffWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    LevelControl::Commands::StopWithOnOff::Type request;
+    chip::app::Clusters::LevelControl::Commands::StopWithOnOff::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -13686,7 +13686,7 @@ using namespace chip::app::Clusters;
 - (void)sleepWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    LowPower::Commands::Sleep::Type request;
+    chip::app::Clusters::LowPower::Commands::Sleep::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -13836,7 +13836,7 @@ using namespace chip::app::Clusters;
 - (void)hideInputStatusWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    MediaInput::Commands::HideInputStatus::Type request;
+    chip::app::Clusters::MediaInput::Commands::HideInputStatus::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -13853,7 +13853,7 @@ using namespace chip::app::Clusters;
 - (void)renameInputWithParams:(CHIPMediaInputClusterRenameInputParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    MediaInput::Commands::RenameInput::Type request;
+    chip::app::Clusters::MediaInput::Commands::RenameInput::Type request;
     request.index = params.index.unsignedCharValue;
     request.name = [self asCharSpan:params.name];
 
@@ -13872,7 +13872,7 @@ using namespace chip::app::Clusters;
 - (void)selectInputWithParams:(CHIPMediaInputClusterSelectInputParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    MediaInput::Commands::SelectInput::Type request;
+    chip::app::Clusters::MediaInput::Commands::SelectInput::Type request;
     request.index = params.index.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(
@@ -13890,7 +13890,7 @@ using namespace chip::app::Clusters;
 - (void)showInputStatusWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    MediaInput::Commands::ShowInputStatus::Type request;
+    chip::app::Clusters::MediaInput::Commands::ShowInputStatus::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -14100,7 +14100,7 @@ using namespace chip::app::Clusters;
                                              NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    MediaPlayback::Commands::FastForward::Type request;
+    chip::app::Clusters::MediaPlayback::Commands::FastForward::Type request;
 
     new CHIPMediaPlaybackClusterPlaybackResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -14114,7 +14114,7 @@ using namespace chip::app::Clusters;
                                       NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    MediaPlayback::Commands::Next::Type request;
+    chip::app::Clusters::MediaPlayback::Commands::Next::Type request;
 
     new CHIPMediaPlaybackClusterPlaybackResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -14128,7 +14128,7 @@ using namespace chip::app::Clusters;
                                        NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    MediaPlayback::Commands::Pause::Type request;
+    chip::app::Clusters::MediaPlayback::Commands::Pause::Type request;
 
     new CHIPMediaPlaybackClusterPlaybackResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -14142,7 +14142,7 @@ using namespace chip::app::Clusters;
                                       NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    MediaPlayback::Commands::Play::Type request;
+    chip::app::Clusters::MediaPlayback::Commands::Play::Type request;
 
     new CHIPMediaPlaybackClusterPlaybackResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -14156,7 +14156,7 @@ using namespace chip::app::Clusters;
                                           NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    MediaPlayback::Commands::Previous::Type request;
+    chip::app::Clusters::MediaPlayback::Commands::Previous::Type request;
 
     new CHIPMediaPlaybackClusterPlaybackResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -14170,7 +14170,7 @@ using namespace chip::app::Clusters;
                                         NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    MediaPlayback::Commands::Rewind::Type request;
+    chip::app::Clusters::MediaPlayback::Commands::Rewind::Type request;
 
     new CHIPMediaPlaybackClusterPlaybackResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -14185,7 +14185,7 @@ using namespace chip::app::Clusters;
          (void (^)(CHIPMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    MediaPlayback::Commands::Seek::Type request;
+    chip::app::Clusters::MediaPlayback::Commands::Seek::Type request;
     request.position = params.position.unsignedLongLongValue;
 
     new CHIPMediaPlaybackClusterPlaybackResponseCallbackBridge(
@@ -14201,7 +14201,7 @@ using namespace chip::app::Clusters;
                                    NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    MediaPlayback::Commands::SkipBackward::Type request;
+    chip::app::Clusters::MediaPlayback::Commands::SkipBackward::Type request;
     request.deltaPositionMilliseconds = params.deltaPositionMilliseconds.unsignedLongLongValue;
 
     new CHIPMediaPlaybackClusterPlaybackResponseCallbackBridge(
@@ -14217,7 +14217,7 @@ using namespace chip::app::Clusters;
                                   NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    MediaPlayback::Commands::SkipForward::Type request;
+    chip::app::Clusters::MediaPlayback::Commands::SkipForward::Type request;
     request.deltaPositionMilliseconds = params.deltaPositionMilliseconds.unsignedLongLongValue;
 
     new CHIPMediaPlaybackClusterPlaybackResponseCallbackBridge(
@@ -14232,7 +14232,7 @@ using namespace chip::app::Clusters;
                                            NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    MediaPlayback::Commands::StartOver::Type request;
+    chip::app::Clusters::MediaPlayback::Commands::StartOver::Type request;
 
     new CHIPMediaPlaybackClusterPlaybackResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -14246,7 +14246,7 @@ using namespace chip::app::Clusters;
                                               NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    MediaPlayback::Commands::StopPlayback::Type request;
+    chip::app::Clusters::MediaPlayback::Commands::StopPlayback::Type request;
 
     new CHIPMediaPlaybackClusterPlaybackResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -14605,7 +14605,7 @@ using namespace chip::app::Clusters;
              completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ModeSelect::Commands::ChangeToMode::Type request;
+    chip::app::Clusters::ModeSelect::Commands::ChangeToMode::Type request;
     request.newMode = params.newMode.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(
@@ -14922,7 +14922,7 @@ using namespace chip::app::Clusters;
                                                NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    NetworkCommissioning::Commands::AddOrUpdateThreadNetwork::Type request;
+    chip::app::Clusters::NetworkCommissioning::Commands::AddOrUpdateThreadNetwork::Type request;
     request.operationalDataset = [self asByteSpan:params.operationalDataset];
     request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
 
@@ -14939,7 +14939,7 @@ using namespace chip::app::Clusters;
                                              NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    NetworkCommissioning::Commands::AddOrUpdateWiFiNetwork::Type request;
+    chip::app::Clusters::NetworkCommissioning::Commands::AddOrUpdateWiFiNetwork::Type request;
     request.ssid = [self asByteSpan:params.ssid];
     request.credentials = [self asByteSpan:params.credentials];
     request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
@@ -14957,7 +14957,7 @@ using namespace chip::app::Clusters;
                                      NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    NetworkCommissioning::Commands::ConnectNetwork::Type request;
+    chip::app::Clusters::NetworkCommissioning::Commands::ConnectNetwork::Type request;
     request.networkID = [self asByteSpan:params.networkID];
     request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
 
@@ -14974,7 +14974,7 @@ using namespace chip::app::Clusters;
                                     NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    NetworkCommissioning::Commands::RemoveNetwork::Type request;
+    chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetwork::Type request;
     request.networkID = [self asByteSpan:params.networkID];
     request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
 
@@ -14991,7 +14991,7 @@ using namespace chip::app::Clusters;
                                      NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    NetworkCommissioning::Commands::ReorderNetwork::Type request;
+    chip::app::Clusters::NetworkCommissioning::Commands::ReorderNetwork::Type request;
     request.networkID = [self asByteSpan:params.networkID];
     request.networkIndex = params.networkIndex.unsignedCharValue;
     request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
@@ -15009,7 +15009,7 @@ using namespace chip::app::Clusters;
                                    NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    NetworkCommissioning::Commands::ScanNetworks::Type request;
+    chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworks::Type request;
     request.ssid = [self asByteSpan:params.ssid];
     request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
 
@@ -15424,7 +15424,7 @@ using namespace chip::app::Clusters;
                                          NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Type request;
+    chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Type request;
     request.updateToken = [self asByteSpan:params.updateToken];
     request.newVersion = params.newVersion.unsignedIntValue;
 
@@ -15440,7 +15440,7 @@ using namespace chip::app::Clusters;
                     completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Type request;
+    chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Type request;
     request.updateToken = [self asByteSpan:params.updateToken];
     request.softwareVersion = params.softwareVersion.unsignedIntValue;
 
@@ -15461,7 +15461,7 @@ using namespace chip::app::Clusters;
                                  NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    OtaSoftwareUpdateProvider::Commands::QueryImage::Type request;
+    chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::Type request;
     request.vendorId = static_cast<std::remove_reference_t<decltype(request.vendorId)>>(params.vendorId.unsignedShortValue);
     request.productId = params.productId.unsignedShortValue;
     request.softwareVersion = params.softwareVersion.unsignedIntValue;
@@ -15586,7 +15586,7 @@ using namespace chip::app::Clusters;
                     completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::Type request;
+    chip::app::Clusters::OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::Type request;
     request.providerNodeId = params.providerNodeId.unsignedLongLongValue;
     request.vendorId = static_cast<std::remove_reference_t<decltype(request.vendorId)>>(params.vendorId.unsignedShortValue);
     request.announcementReason
@@ -16076,7 +16076,7 @@ using namespace chip::app::Clusters;
 - (void)offWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    OnOff::Commands::Off::Type request;
+    chip::app::Clusters::OnOff::Commands::Off::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -16093,7 +16093,7 @@ using namespace chip::app::Clusters;
 - (void)offWithEffectWithParams:(CHIPOnOffClusterOffWithEffectParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    OnOff::Commands::OffWithEffect::Type request;
+    chip::app::Clusters::OnOff::Commands::OffWithEffect::Type request;
     request.effectId = static_cast<std::remove_reference_t<decltype(request.effectId)>>(params.effectId.unsignedCharValue);
     request.effectVariant
         = static_cast<std::remove_reference_t<decltype(request.effectVariant)>>(params.effectVariant.unsignedCharValue);
@@ -16113,7 +16113,7 @@ using namespace chip::app::Clusters;
 - (void)onWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    OnOff::Commands::On::Type request;
+    chip::app::Clusters::OnOff::Commands::On::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -16130,7 +16130,7 @@ using namespace chip::app::Clusters;
 - (void)onWithRecallGlobalSceneWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    OnOff::Commands::OnWithRecallGlobalScene::Type request;
+    chip::app::Clusters::OnOff::Commands::OnWithRecallGlobalScene::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -16148,7 +16148,7 @@ using namespace chip::app::Clusters;
                completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    OnOff::Commands::OnWithTimedOff::Type request;
+    chip::app::Clusters::OnOff::Commands::OnWithTimedOff::Type request;
     request.onOffControl
         = static_cast<std::remove_reference_t<decltype(request.onOffControl)>>(params.onOffControl.unsignedCharValue);
     request.onTime = params.onTime.unsignedShortValue;
@@ -16169,7 +16169,7 @@ using namespace chip::app::Clusters;
 - (void)toggleWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    OnOff::Commands::Toggle::Type request;
+    chip::app::Clusters::OnOff::Commands::Toggle::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -16764,7 +16764,7 @@ using namespace chip::app::Clusters;
                              NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    OperationalCredentials::Commands::AddNOC::Type request;
+    chip::app::Clusters::OperationalCredentials::Commands::AddNOC::Type request;
     request.NOCValue = [self asByteSpan:params.nocValue];
     if (params.icacValue != nil) {
         auto & definedValue_0 = request.ICACValue.Emplace();
@@ -16786,7 +16786,7 @@ using namespace chip::app::Clusters;
                           completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    OperationalCredentials::Commands::AddTrustedRootCertificate::Type request;
+    chip::app::Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Type request;
     request.rootCertificate = [self asByteSpan:params.rootCertificate];
 
     new CHIPCommandSuccessCallbackBridge(
@@ -16806,7 +16806,7 @@ using namespace chip::app::Clusters;
                                          NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    OperationalCredentials::Commands::AttestationRequest::Type request;
+    chip::app::Clusters::OperationalCredentials::Commands::AttestationRequest::Type request;
     request.attestationNonce = [self asByteSpan:params.attestationNonce];
 
     new CHIPOperationalCredentialsClusterAttestationResponseCallbackBridge(
@@ -16822,7 +16822,7 @@ using namespace chip::app::Clusters;
                                  NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    OperationalCredentials::Commands::CSRRequest::Type request;
+    chip::app::Clusters::OperationalCredentials::Commands::CSRRequest::Type request;
     request.CSRNonce = [self asByteSpan:params.csrNonce];
 
     new CHIPOperationalCredentialsClusterCSRResponseCallbackBridge(
@@ -16839,7 +16839,7 @@ using namespace chip::app::Clusters;
                                 NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    OperationalCredentials::Commands::CertificateChainRequest::Type request;
+    chip::app::Clusters::OperationalCredentials::Commands::CertificateChainRequest::Type request;
     request.certificateType = params.certificateType.unsignedCharValue;
 
     new CHIPOperationalCredentialsClusterCertificateChainResponseCallbackBridge(
@@ -16856,7 +16856,7 @@ using namespace chip::app::Clusters;
                                    NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    OperationalCredentials::Commands::RemoveFabric::Type request;
+    chip::app::Clusters::OperationalCredentials::Commands::RemoveFabric::Type request;
     request.fabricIndex = params.fabricIndex.unsignedCharValue;
 
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
@@ -16871,7 +16871,7 @@ using namespace chip::app::Clusters;
                              completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    OperationalCredentials::Commands::RemoveTrustedRootCertificate::Type request;
+    chip::app::Clusters::OperationalCredentials::Commands::RemoveTrustedRootCertificate::Type request;
     request.trustedRootIdentifier = [self asByteSpan:params.trustedRootIdentifier];
 
     new CHIPCommandSuccessCallbackBridge(
@@ -16891,7 +16891,7 @@ using namespace chip::app::Clusters;
                                         NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    OperationalCredentials::Commands::UpdateFabricLabel::Type request;
+    chip::app::Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Type request;
     request.label = [self asCharSpan:params.label];
 
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
@@ -16907,7 +16907,7 @@ using namespace chip::app::Clusters;
                                 NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    OperationalCredentials::Commands::UpdateNOC::Type request;
+    chip::app::Clusters::OperationalCredentials::Commands::UpdateNOC::Type request;
     request.NOCValue = [self asByteSpan:params.nocValue];
     if (params.icacValue != nil) {
         auto & definedValue_0 = request.ICACValue.Emplace();
@@ -19237,7 +19237,7 @@ using namespace chip::app::Clusters;
              (void (^)(CHIPScenesClusterAddSceneResponseParams * _Nullable data, NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    Scenes::Commands::AddScene::Type request;
+    chip::app::Clusters::Scenes::Commands::AddScene::Type request;
     request.groupId = params.groupId.unsignedShortValue;
     request.sceneId = params.sceneId.unsignedCharValue;
     request.transitionTime = params.transitionTime.unsignedShortValue;
@@ -19280,7 +19280,7 @@ using namespace chip::app::Clusters;
                                          NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    Scenes::Commands::GetSceneMembership::Type request;
+    chip::app::Clusters::Scenes::Commands::GetSceneMembership::Type request;
     request.groupId = params.groupId.unsignedShortValue;
 
     new CHIPScenesClusterGetSceneMembershipResponseCallbackBridge(
@@ -19294,7 +19294,7 @@ using namespace chip::app::Clusters;
 - (void)recallSceneWithParams:(CHIPScenesClusterRecallSceneParams *)params completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    Scenes::Commands::RecallScene::Type request;
+    chip::app::Clusters::Scenes::Commands::RecallScene::Type request;
     request.groupId = params.groupId.unsignedShortValue;
     request.sceneId = params.sceneId.unsignedCharValue;
     request.transitionTime = params.transitionTime.unsignedShortValue;
@@ -19316,7 +19316,7 @@ using namespace chip::app::Clusters;
                                       NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    Scenes::Commands::RemoveAllScenes::Type request;
+    chip::app::Clusters::Scenes::Commands::RemoveAllScenes::Type request;
     request.groupId = params.groupId.unsignedShortValue;
 
     new CHIPScenesClusterRemoveAllScenesResponseCallbackBridge(
@@ -19332,7 +19332,7 @@ using namespace chip::app::Clusters;
                 (void (^)(CHIPScenesClusterRemoveSceneResponseParams * _Nullable data, NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    Scenes::Commands::RemoveScene::Type request;
+    chip::app::Clusters::Scenes::Commands::RemoveScene::Type request;
     request.groupId = params.groupId.unsignedShortValue;
     request.sceneId = params.sceneId.unsignedCharValue;
 
@@ -19349,7 +19349,7 @@ using namespace chip::app::Clusters;
                (void (^)(CHIPScenesClusterStoreSceneResponseParams * _Nullable data, NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    Scenes::Commands::StoreScene::Type request;
+    chip::app::Clusters::Scenes::Commands::StoreScene::Type request;
     request.groupId = params.groupId.unsignedShortValue;
     request.sceneId = params.sceneId.unsignedCharValue;
 
@@ -19366,7 +19366,7 @@ using namespace chip::app::Clusters;
               (void (^)(CHIPScenesClusterViewSceneResponseParams * _Nullable data, NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    Scenes::Commands::ViewScene::Type request;
+    chip::app::Clusters::Scenes::Commands::ViewScene::Type request;
     request.groupId = params.groupId.unsignedShortValue;
     request.sceneId = params.sceneId.unsignedCharValue;
 
@@ -19659,7 +19659,7 @@ using namespace chip::app::Clusters;
 - (void)resetWatermarksWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    SoftwareDiagnostics::Commands::ResetWatermarks::Type request;
+    chip::app::Clusters::SoftwareDiagnostics::Commands::ResetWatermarks::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -20215,7 +20215,7 @@ using namespace chip::app::Clusters;
                                      NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    TargetNavigator::Commands::NavigateTarget::Type request;
+    chip::app::Clusters::TargetNavigator::Commands::NavigateTarget::Type request;
     request.target = params.target.unsignedCharValue;
     if (params.data != nil) {
         auto & definedValue_0 = request.data.Emplace();
@@ -20616,7 +20616,7 @@ using namespace chip::app::Clusters;
                                               NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::SimpleStructEchoRequest::Type request;
+    chip::app::Clusters::TestCluster::Commands::SimpleStructEchoRequest::Type request;
     request.arg1.a = params.arg1.a.unsignedCharValue;
     request.arg1.b = params.arg1.b.boolValue;
     request.arg1.c = static_cast<std::remove_reference_t<decltype(request.arg1.c)>>(params.arg1.c.unsignedCharValue);
@@ -20637,7 +20637,7 @@ using namespace chip::app::Clusters;
 - (void)testWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::Test::Type request;
+    chip::app::Clusters::TestCluster::Commands::Test::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -20656,7 +20656,7 @@ using namespace chip::app::Clusters;
                                        NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::TestAddArguments::Type request;
+    chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type request;
     request.arg1 = params.arg1.unsignedCharValue;
     request.arg2 = params.arg2.unsignedCharValue;
 
@@ -20673,7 +20673,7 @@ using namespace chip::app::Clusters;
                                                NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::TestEmitTestEventRequest::Type request;
+    chip::app::Clusters::TestCluster::Commands::TestEmitTestEventRequest::Type request;
     request.arg1 = params.arg1.unsignedCharValue;
     request.arg2 = static_cast<std::remove_reference_t<decltype(request.arg2)>>(params.arg2.unsignedCharValue);
     request.arg3 = params.arg3.boolValue;
@@ -20691,7 +20691,7 @@ using namespace chip::app::Clusters;
                                        NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::TestEnumsRequest::Type request;
+    chip::app::Clusters::TestCluster::Commands::TestEnumsRequest::Type request;
     request.arg1 = static_cast<std::remove_reference_t<decltype(request.arg1)>>(params.arg1.unsignedShortValue);
     request.arg2 = static_cast<std::remove_reference_t<decltype(request.arg2)>>(params.arg2.unsignedCharValue);
 
@@ -20708,7 +20708,7 @@ using namespace chip::app::Clusters;
                                                    NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::TestListInt8UArgumentRequest::Type request;
+    chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type request;
     {
         using ListType_0 = std::remove_reference_t<decltype(request.arg1)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
@@ -20745,7 +20745,7 @@ using namespace chip::app::Clusters;
                                                   NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::TestListInt8UReverseRequest::Type request;
+    chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type request;
     {
         using ListType_0 = std::remove_reference_t<decltype(request.arg1)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
@@ -20783,7 +20783,7 @@ using namespace chip::app::Clusters;
                                                               NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::TestListNestedStructListArgumentRequest::Type request;
+    chip::app::Clusters::TestCluster::Commands::TestListNestedStructListArgumentRequest::Type request;
     {
         using ListType_0 = std::remove_reference_t<decltype(request.arg1)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
@@ -20928,7 +20928,7 @@ using namespace chip::app::Clusters;
                                                     NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::TestListStructArgumentRequest::Type request;
+    chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type request;
     {
         using ListType_0 = std::remove_reference_t<decltype(request.arg1)>;
         using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
@@ -20974,7 +20974,7 @@ using namespace chip::app::Clusters;
                                                       NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::TestNestedStructArgumentRequest::Type request;
+    chip::app::Clusters::TestCluster::Commands::TestNestedStructArgumentRequest::Type request;
     request.arg1.a = params.arg1.a.unsignedCharValue;
     request.arg1.b = params.arg1.b.boolValue;
     request.arg1.c.a = params.arg1.c.a.unsignedCharValue;
@@ -20999,7 +20999,7 @@ using namespace chip::app::Clusters;
                                                           NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::TestNestedStructListArgumentRequest::Type request;
+    chip::app::Clusters::TestCluster::Commands::TestNestedStructListArgumentRequest::Type request;
     request.arg1.a = params.arg1.a.unsignedCharValue;
     request.arg1.b = params.arg1.b.boolValue;
     request.arg1.c.a = params.arg1.c.a.unsignedCharValue;
@@ -21119,7 +21119,7 @@ using namespace chip::app::Clusters;
 - (void)testNotHandledWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::TestNotHandled::Type request;
+    chip::app::Clusters::TestCluster::Commands::TestNotHandled::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -21138,7 +21138,7 @@ using namespace chip::app::Clusters;
                                                   NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::TestNullableOptionalRequest::Type request;
+    chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type request;
     if (params != nil) {
         if (params.arg1 != nil) {
             auto & definedValue_0 = request.arg1.Emplace();
@@ -21164,7 +21164,7 @@ using namespace chip::app::Clusters;
                                   completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::TestSimpleOptionalArgumentRequest::Type request;
+    chip::app::Clusters::TestCluster::Commands::TestSimpleOptionalArgumentRequest::Type request;
     if (params != nil) {
         if (params.arg1 != nil) {
             auto & definedValue_0 = request.arg1.Emplace();
@@ -21188,7 +21188,7 @@ using namespace chip::app::Clusters;
                                               NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::TestSpecific::Type request;
+    chip::app::Clusters::TestCluster::Commands::TestSpecific::Type request;
 
     new CHIPTestClusterClusterTestSpecificResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -21203,7 +21203,7 @@ using namespace chip::app::Clusters;
                                                 NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::TestStructArgumentRequest::Type request;
+    chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type request;
     request.arg1.a = params.arg1.a.unsignedCharValue;
     request.arg1.b = params.arg1.b.boolValue;
     request.arg1.c = static_cast<std::remove_reference_t<decltype(request.arg1.c)>>(params.arg1.c.unsignedCharValue);
@@ -21224,7 +21224,7 @@ using namespace chip::app::Clusters;
 - (void)testUnknownCommandWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::TestUnknownCommand::Type request;
+    chip::app::Clusters::TestCluster::Commands::TestUnknownCommand::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -21241,7 +21241,7 @@ using namespace chip::app::Clusters;
 - (void)timedInvokeRequestWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    TestCluster::Commands::TimedInvokeRequest::Type request;
+    chip::app::Clusters::TestCluster::Commands::TimedInvokeRequest::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -25701,7 +25701,7 @@ using namespace chip::app::Clusters;
 - (void)clearWeeklyScheduleWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    Thermostat::Commands::ClearWeeklySchedule::Type request;
+    chip::app::Clusters::Thermostat::Commands::ClearWeeklySchedule::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -25719,7 +25719,7 @@ using namespace chip::app::Clusters;
                                                    NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    Thermostat::Commands::GetRelayStatusLog::Type request;
+    chip::app::Clusters::Thermostat::Commands::GetRelayStatusLog::Type request;
 
     new CHIPThermostatClusterGetRelayStatusLogResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -25734,7 +25734,7 @@ using namespace chip::app::Clusters;
                                         NSError * _Nullable error))completionHandler
 {
     ListFreer listFreer;
-    Thermostat::Commands::GetWeeklySchedule::Type request;
+    chip::app::Clusters::Thermostat::Commands::GetWeeklySchedule::Type request;
     request.daysToReturn
         = static_cast<std::remove_reference_t<decltype(request.daysToReturn)>>(params.daysToReturn.unsignedCharValue);
     request.modeToReturn
@@ -25752,7 +25752,7 @@ using namespace chip::app::Clusters;
                   completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    Thermostat::Commands::SetWeeklySchedule::Type request;
+    chip::app::Clusters::Thermostat::Commands::SetWeeklySchedule::Type request;
     request.numberOfTransitionsForSequence = params.numberOfTransitionsForSequence.unsignedCharValue;
     request.dayOfWeekForSequence = static_cast<std::remove_reference_t<decltype(request.dayOfWeekForSequence)>>(
         params.dayOfWeekForSequence.unsignedCharValue);
@@ -25797,7 +25797,7 @@ using namespace chip::app::Clusters;
                    completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    Thermostat::Commands::SetpointRaiseLower::Type request;
+    chip::app::Clusters::Thermostat::Commands::SetpointRaiseLower::Type request;
     request.mode = static_cast<std::remove_reference_t<decltype(request.mode)>>(params.mode.unsignedCharValue);
     request.amount = params.amount.charValue;
 
@@ -26895,7 +26895,7 @@ using namespace chip::app::Clusters;
 - (void)resetCountsWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    ThreadNetworkDiagnostics::Commands::ResetCounts::Type request;
+    chip::app::Clusters::ThreadNetworkDiagnostics::Commands::ResetCounts::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -29697,7 +29697,7 @@ using namespace chip::app::Clusters;
 - (void)resetCountsWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    WiFiNetworkDiagnostics::Commands::ResetCounts::Type request;
+    chip::app::Clusters::WiFiNetworkDiagnostics::Commands::ResetCounts::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -30278,7 +30278,7 @@ using namespace chip::app::Clusters;
 - (void)downOrCloseWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    WindowCovering::Commands::DownOrClose::Type request;
+    chip::app::Clusters::WindowCovering::Commands::DownOrClose::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -30296,7 +30296,7 @@ using namespace chip::app::Clusters;
                    completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    WindowCovering::Commands::GoToLiftPercentage::Type request;
+    chip::app::Clusters::WindowCovering::Commands::GoToLiftPercentage::Type request;
     request.liftPercentageValue = params.liftPercentageValue.unsignedCharValue;
     request.liftPercent100thsValue = params.liftPercent100thsValue.unsignedShortValue;
 
@@ -30316,7 +30316,7 @@ using namespace chip::app::Clusters;
               completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    WindowCovering::Commands::GoToLiftValue::Type request;
+    chip::app::Clusters::WindowCovering::Commands::GoToLiftValue::Type request;
     request.liftValue = params.liftValue.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(
@@ -30335,7 +30335,7 @@ using namespace chip::app::Clusters;
                    completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    WindowCovering::Commands::GoToTiltPercentage::Type request;
+    chip::app::Clusters::WindowCovering::Commands::GoToTiltPercentage::Type request;
     request.tiltPercentageValue = params.tiltPercentageValue.unsignedCharValue;
     request.tiltPercent100thsValue = params.tiltPercent100thsValue.unsignedShortValue;
 
@@ -30355,7 +30355,7 @@ using namespace chip::app::Clusters;
               completionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    WindowCovering::Commands::GoToTiltValue::Type request;
+    chip::app::Clusters::WindowCovering::Commands::GoToTiltValue::Type request;
     request.tiltValue = params.tiltValue.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(
@@ -30373,7 +30373,7 @@ using namespace chip::app::Clusters;
 - (void)stopMotionWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    WindowCovering::Commands::StopMotion::Type request;
+    chip::app::Clusters::WindowCovering::Commands::StopMotion::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,
@@ -30390,7 +30390,7 @@ using namespace chip::app::Clusters;
 - (void)upOrOpenWithCompletionHandler:(StatusCompletion)completionHandler
 {
     ListFreer listFreer;
-    WindowCovering::Commands::UpOrOpen::Type request;
+    chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type request;
 
     new CHIPCommandSuccessCallbackBridge(
         self.callbackQueue,

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -1244,7 +1244,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -1478,7 +1478,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Groups::Commands::AddGroupResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -1546,7 +1546,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Groups::Commands::ViewGroupResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -1616,7 +1616,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Groups::Commands::GetGroupMembershipResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Groups::Commands::GetGroupMembershipResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -1683,7 +1683,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Groups::Commands::RemoveGroupResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Groups::Commands::RemoveGroupResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -2053,7 +2053,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Scenes::Commands::AddSceneResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Scenes::Commands::AddSceneResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -2129,7 +2129,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Scenes::Commands::ViewSceneResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Scenes::Commands::ViewSceneResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -2211,7 +2211,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Scenes::Commands::RemoveSceneResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Scenes::Commands::RemoveSceneResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -2282,7 +2282,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Scenes::Commands::RemoveAllScenesResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Scenes::Commands::RemoveAllScenesResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -2351,7 +2351,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Scenes::Commands::StoreSceneResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Scenes::Commands::StoreSceneResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -2460,7 +2460,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Scenes::Commands::GetSceneMembershipResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Scenes::Commands::GetSceneMembershipResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -2544,7 +2544,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Scenes::Commands::EnhancedAddSceneResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Scenes::Commands::EnhancedAddSceneResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -2620,7 +2620,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Scenes::Commands::EnhancedViewSceneResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Scenes::Commands::EnhancedViewSceneResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -2708,7 +2708,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Scenes::Commands::CopySceneResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Scenes::Commands::CopySceneResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -4277,7 +4277,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Alarms::Commands::GetAlarmResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Alarms::Commands::GetAlarmResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -5042,7 +5042,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::PowerProfile::Commands::PowerProfileResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::PowerProfile::Commands::PowerProfileResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -5112,7 +5112,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::PowerProfile::Commands::PowerProfileStateResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::PowerProfile::Commands::PowerProfileStateResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -5298,7 +5298,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::PowerProfile::Commands::GetPowerProfilePriceResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::PowerProfile::Commands::GetPowerProfilePriceResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -5438,7 +5438,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::PowerProfile::Commands::GetOverallSchedulePriceResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::PowerProfile::Commands::GetOverallSchedulePriceResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -5469,7 +5469,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::PowerProfile::Commands::PowerProfileScheduleConstraintsResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::PowerProfile::Commands::PowerProfileScheduleConstraintsResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -5501,7 +5501,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::PowerProfile::Commands::EnergyPhasesScheduleResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::PowerProfile::Commands::EnergyPhasesScheduleResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -5533,7 +5533,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::PowerProfile::Commands::EnergyPhasesScheduleStateResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::PowerProfile::Commands::EnergyPhasesScheduleStateResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -5762,7 +5762,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::PowerProfile::Commands::GetPowerProfilePriceExtendedResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::PowerProfile::Commands::GetPowerProfilePriceExtendedResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -6110,7 +6110,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::ApplianceControl::Commands::SignalStateResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::ApplianceControl::Commands::SignalStateResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -7224,7 +7224,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::PollControl::Commands::CheckInResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::PollControl::Commands::CheckInResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -8962,7 +8962,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -9056,7 +9056,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -10818,7 +10818,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -10893,7 +10893,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -10960,7 +10960,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -11343,7 +11343,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -11421,7 +11421,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -11457,7 +11457,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -11492,7 +11492,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -11562,7 +11562,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::NetworkCommissioning::Commands::ConnectNetworkResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::NetworkCommissioning::Commands::ConnectNetworkResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -11637,7 +11637,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -11905,7 +11905,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::DiagnosticLogs::Commands::RetrieveLogsResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -15973,7 +15973,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::OperationalCredentials::Commands::AttestationResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::OperationalCredentials::Commands::AttestationResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -16040,7 +16040,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::OperationalCredentials::Commands::CertificateChainResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::OperationalCredentials::Commands::CertificateChainResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -16104,7 +16104,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::OperationalCredentials::Commands::CSRResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::OperationalCredentials::Commands::CSRResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -16179,7 +16179,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -16217,7 +16217,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -16288,7 +16288,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -16320,7 +16320,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -16775,7 +16775,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::GroupKeyManagement::Commands::KeySetReadResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::GroupKeyManagement::Commands::KeySetReadResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -16871,7 +16871,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::GroupKeyManagement::Commands::KeySetReadAllIndicesResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::GroupKeyManagement::Commands::KeySetReadAllIndicesResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -18799,7 +18799,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::DoorLock::Commands::GetLogRecordResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::DoorLock::Commands::GetLogRecordResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -18922,7 +18922,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::DoorLock::Commands::GetPINCodeResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::DoorLock::Commands::GetPINCodeResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -19090,7 +19090,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::DoorLock::Commands::GetUserStatusResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::DoorLock::Commands::GetUserStatusResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -19209,7 +19209,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::DoorLock::Commands::GetWeekDayScheduleResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::DoorLock::Commands::GetWeekDayScheduleResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -19373,7 +19373,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::DoorLock::Commands::GetYearDayScheduleResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::DoorLock::Commands::GetYearDayScheduleResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -19526,7 +19526,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::DoorLock::Commands::GetHolidayScheduleResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::DoorLock::Commands::GetHolidayScheduleResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -19669,7 +19669,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::DoorLock::Commands::GetUserTypeResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::DoorLock::Commands::GetUserTypeResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -19777,7 +19777,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::DoorLock::Commands::GetRFIDCodeResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::DoorLock::Commands::GetRFIDCodeResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -19960,7 +19960,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::DoorLock::Commands::GetUserResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::DoorLock::Commands::GetUserResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -20193,7 +20193,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::DoorLock::Commands::SetCredentialResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::DoorLock::Commands::SetCredentialResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return true; }
 };
@@ -20268,7 +20268,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::DoorLock::Commands::GetCredentialStatusResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::DoorLock::Commands::GetCredentialStatusResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -23392,7 +23392,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Thermostat::Commands::GetWeeklyScheduleResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Thermostat::Commands::GetWeeklyScheduleResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -23450,7 +23450,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Thermostat::Commands::GetRelayStatusLogResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Thermostat::Commands::GetRelayStatusLogResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -31829,7 +31829,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::IasZone::Commands::InitiateNormalOperationModeResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::IasZone::Commands::InitiateNormalOperationModeResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -31862,7 +31862,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::IasZone::Commands::ZoneEnrollResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::IasZone::Commands::ZoneEnrollResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -31897,7 +31897,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::IasZone::Commands::InitiateTestModeResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::IasZone::Commands::InitiateTestModeResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -32395,7 +32395,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::IasAce::Commands::ArmResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::IasAce::Commands::ArmResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -32465,7 +32465,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::IasAce::Commands::BypassResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::IasAce::Commands::BypassResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -32780,7 +32780,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::IasAce::Commands::GetZoneIdMapResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::IasAce::Commands::GetZoneIdMapResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -32852,7 +32852,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::IasAce::Commands::GetZoneInformationResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::IasAce::Commands::GetZoneInformationResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -32916,7 +32916,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::IasAce::Commands::GetPanelStatusResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::IasAce::Commands::GetPanelStatusResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -33054,7 +33054,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::IasAce::Commands::GetZoneStatusResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::IasAce::Commands::GetZoneStatusResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -33575,7 +33575,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::Channel::Commands::ChangeChannelResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::Channel::Commands::ChangeChannelResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -33886,7 +33886,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TargetNavigator::Commands::NavigateTargetResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TargetNavigator::Commands::NavigateTargetResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -34173,7 +34173,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -34201,7 +34201,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -34229,7 +34229,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -34257,7 +34257,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -34285,7 +34285,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -34313,7 +34313,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -34341,7 +34341,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -34369,7 +34369,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -34400,7 +34400,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -34432,7 +34432,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -34496,7 +34496,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -35262,7 +35262,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::KeypadInput::Commands::SendKeyResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::KeypadInput::Commands::SendKeyResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -35646,7 +35646,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::ContentLauncher::Commands::LaunchResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::ContentLauncher::Commands::LaunchResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -35684,7 +35684,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::ContentLauncher::Commands::LaunchResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::ContentLauncher::Commands::LaunchResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -36191,7 +36191,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::ApplicationLauncher::Commands::LauncherResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -36224,7 +36224,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::ApplicationLauncher::Commands::LauncherResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -36256,7 +36256,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::ApplicationLauncher::Commands::LauncherResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -36685,7 +36685,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::AccountLogin::Commands::GetSetupPINResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return true; }
 };
@@ -37452,7 +37452,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::TestSpecificResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::TestSpecificResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -37592,7 +37592,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::TestAddArgumentsResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::TestAddArgumentsResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -37657,7 +37657,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::TestSimpleArgumentResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::TestSimpleArgumentResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -37734,7 +37734,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::TestStructArrayArgumentResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::TestStructArrayArgumentResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -37812,7 +37812,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -37957,7 +37957,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -38021,7 +38021,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -38085,7 +38085,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -38149,7 +38149,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -38213,7 +38213,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -38245,7 +38245,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -38279,7 +38279,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::TestEnumsResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::TestEnumsResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -38312,7 +38312,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -38366,7 +38366,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::TestComplexNullableOptionalResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::TestComplexNullableOptionalResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -38409,7 +38409,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::SimpleStructResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::SimpleStructResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -38505,7 +38505,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::TestEmitTestEventResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::TestEmitTestEventResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -38539,7 +38539,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::TestCluster::Commands::TestEmitTestFabricScopedEventResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::TestCluster::Commands::TestEmitTestFabricScopedEventResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -40870,7 +40870,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::ApplianceEventsAndAlert::Commands::GetAlertsResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::ApplianceEventsAndAlert::Commands::GetAlertsResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -41167,7 +41167,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::ApplianceStatistics::Commands::LogResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::ApplianceStatistics::Commands::LogResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };
@@ -41237,7 +41237,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = Clusters::ApplianceStatistics::Commands::LogQueueResponse::DecodableType;
+    using ResponseType = chip::app::Clusters::ApplianceStatistics::Commands::LogQueueResponse::DecodableType;
 
     static constexpr bool MustUseTimedInvoke() { return false; }
 };

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
@@ -2336,8 +2336,58 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const AccessControl::Events::AccessControlEntryChanged::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::AccessControl::Events::AccessControlEntryChanged::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    {
+        CHIP_ERROR err = DataModelLogger::LogValue("AdminFabricIndex", indent + 1, value.adminFabricIndex);
+        if (err != CHIP_NO_ERROR)
+        {
+            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'AdminFabricIndex'");
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = DataModelLogger::LogValue("AdminNodeID", indent + 1, value.adminNodeID);
+        if (err != CHIP_NO_ERROR)
+        {
+            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'AdminNodeID'");
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = DataModelLogger::LogValue("AdminPasscodeID", indent + 1, value.adminPasscodeID);
+        if (err != CHIP_NO_ERROR)
+        {
+            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'AdminPasscodeID'");
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = DataModelLogger::LogValue("ChangeType", indent + 1, value.changeType);
+        if (err != CHIP_NO_ERROR)
+        {
+            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'ChangeType'");
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = DataModelLogger::LogValue("LatestValue", indent + 1, value.latestValue);
+        if (err != CHIP_NO_ERROR)
+        {
+            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'LatestValue'");
+            return err;
+        }
+    }
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::AccessControl::Events::AccessControlExtensionChanged::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2385,55 +2435,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const AccessControl::Events::AccessControlExtensionChanged::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    {
-        CHIP_ERROR err = DataModelLogger::LogValue("AdminFabricIndex", indent + 1, value.adminFabricIndex);
-        if (err != CHIP_NO_ERROR)
-        {
-            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'AdminFabricIndex'");
-            return err;
-        }
-    }
-    {
-        CHIP_ERROR err = DataModelLogger::LogValue("AdminNodeID", indent + 1, value.adminNodeID);
-        if (err != CHIP_NO_ERROR)
-        {
-            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'AdminNodeID'");
-            return err;
-        }
-    }
-    {
-        CHIP_ERROR err = DataModelLogger::LogValue("AdminPasscodeID", indent + 1, value.adminPasscodeID);
-        if (err != CHIP_NO_ERROR)
-        {
-            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'AdminPasscodeID'");
-            return err;
-        }
-    }
-    {
-        CHIP_ERROR err = DataModelLogger::LogValue("ChangeType", indent + 1, value.changeType);
-        if (err != CHIP_NO_ERROR)
-        {
-            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'ChangeType'");
-            return err;
-        }
-    }
-    {
-        CHIP_ERROR err = DataModelLogger::LogValue("LatestValue", indent + 1, value.latestValue);
-        if (err != CHIP_NO_ERROR)
-        {
-            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'LatestValue'");
-            return err;
-        }
-    }
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const BridgedActions::Events::StateChanged::DecodableType & value)
+                                     const chip::app::Clusters::BridgedActions::Events::StateChanged::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2465,7 +2467,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const BridgedActions::Events::ActionFailed::DecodableType & value)
+                                     const chip::app::Clusters::BridgedActions::Events::ActionFailed::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2504,7 +2506,8 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const Basic::Events::StartUp::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
+                                     const chip::app::Clusters::Basic::Events::StartUp::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2519,14 +2522,8 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const Ba
 
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const Basic::Events::ShutDown::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const Basic::Events::Leave::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
+                                     const chip::app::Clusters::Basic::Events::ShutDown::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     DataModelLogger::LogString(indent, "}");
@@ -2534,7 +2531,15 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const Ba
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Basic::Events::ReachableChanged::DecodableType & value)
+                                     const chip::app::Clusters::Basic::Events::Leave::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
+                                     const chip::app::Clusters::Basic::Events::ReachableChanged::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2549,8 +2554,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const OtaSoftwareUpdateRequestor::Events::StateTransition::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::OtaSoftwareUpdateRequestor::Events::StateTransition::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2589,8 +2595,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const OtaSoftwareUpdateRequestor::Events::VersionApplied::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::OtaSoftwareUpdateRequestor::Events::VersionApplied::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2613,8 +2620,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const OtaSoftwareUpdateRequestor::Events::DownloadError::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::OtaSoftwareUpdateRequestor::Events::DownloadError::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2653,8 +2661,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const GeneralDiagnostics::Events::HardwareFaultChange::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::GeneralDiagnostics::Events::HardwareFaultChange::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2678,7 +2687,32 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const GeneralDiagnostics::Events::RadioFaultChange::DecodableType & value)
+                                     const chip::app::Clusters::GeneralDiagnostics::Events::RadioFaultChange::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    {
+        CHIP_ERROR err = DataModelLogger::LogValue("Current", indent + 1, value.current);
+        if (err != CHIP_NO_ERROR)
+        {
+            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'Current'");
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = DataModelLogger::LogValue("Previous", indent + 1, value.previous);
+        if (err != CHIP_NO_ERROR)
+        {
+            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'Previous'");
+            return err;
+        }
+    }
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::GeneralDiagnostics::Events::NetworkFaultChange::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2702,31 +2736,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const GeneralDiagnostics::Events::NetworkFaultChange::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    {
-        CHIP_ERROR err = DataModelLogger::LogValue("Current", indent + 1, value.current);
-        if (err != CHIP_NO_ERROR)
-        {
-            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'Current'");
-            return err;
-        }
-    }
-    {
-        CHIP_ERROR err = DataModelLogger::LogValue("Previous", indent + 1, value.previous);
-        if (err != CHIP_NO_ERROR)
-        {
-            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'Previous'");
-            return err;
-        }
-    }
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const GeneralDiagnostics::Events::BootReason::DecodableType & value)
+                                     const chip::app::Clusters::GeneralDiagnostics::Events::BootReason::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2742,7 +2752,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const SoftwareDiagnostics::Events::SoftwareFault::DecodableType & value)
+                                     const chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2757,8 +2767,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const ThreadNetworkDiagnostics::Events::ConnectionStatus::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::ThreadNetworkDiagnostics::Events::ConnectionStatus::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2773,8 +2784,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const WiFiNetworkDiagnostics::Events::Disconnection::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::WiFiNetworkDiagnostics::Events::Disconnection::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2789,8 +2801,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const WiFiNetworkDiagnostics::Events::AssociationFailure::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::WiFiNetworkDiagnostics::Events::AssociationFailure::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2813,8 +2826,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const WiFiNetworkDiagnostics::Events::ConnectionStatus::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::WiFiNetworkDiagnostics::Events::ConnectionStatus::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2830,7 +2844,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const BridgedDeviceBasic::Events::StartUp::DecodableType & value)
+                                     const chip::app::Clusters::BridgedDeviceBasic::Events::StartUp::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2846,7 +2860,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const BridgedDeviceBasic::Events::ShutDown::DecodableType & value)
+                                     const chip::app::Clusters::BridgedDeviceBasic::Events::ShutDown::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     DataModelLogger::LogString(indent, "}");
@@ -2854,7 +2868,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const BridgedDeviceBasic::Events::Leave::DecodableType & value)
+                                     const chip::app::Clusters::BridgedDeviceBasic::Events::Leave::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     DataModelLogger::LogString(indent, "}");
@@ -2862,7 +2876,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const BridgedDeviceBasic::Events::ReachableChanged::DecodableType & value)
+                                     const chip::app::Clusters::BridgedDeviceBasic::Events::ReachableChanged::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2877,7 +2891,8 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const Switch::Events::SwitchLatched::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
+                                     const chip::app::Clusters::Switch::Events::SwitchLatched::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2892,7 +2907,8 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const Sw
 
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const Switch::Events::InitialPress::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
+                                     const chip::app::Clusters::Switch::Events::InitialPress::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2907,7 +2923,8 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const Sw
 
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const Switch::Events::LongPress::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
+                                     const chip::app::Clusters::Switch::Events::LongPress::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2922,22 +2939,8 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const Sw
 
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const Switch::Events::ShortRelease::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    {
-        CHIP_ERROR err = DataModelLogger::LogValue("PreviousPosition", indent + 1, value.previousPosition);
-        if (err != CHIP_NO_ERROR)
-        {
-            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'PreviousPosition'");
-            return err;
-        }
-    }
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const Switch::Events::LongRelease::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
+                                     const chip::app::Clusters::Switch::Events::ShortRelease::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2953,7 +2956,23 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const Sw
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Switch::Events::MultiPressOngoing::DecodableType & value)
+                                     const chip::app::Clusters::Switch::Events::LongRelease::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    {
+        CHIP_ERROR err = DataModelLogger::LogValue("PreviousPosition", indent + 1, value.previousPosition);
+        if (err != CHIP_NO_ERROR)
+        {
+            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'PreviousPosition'");
+            return err;
+        }
+    }
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
+                                     const chip::app::Clusters::Switch::Events::MultiPressOngoing::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -2978,7 +2997,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Switch::Events::MultiPressComplete::DecodableType & value)
+                                     const chip::app::Clusters::Switch::Events::MultiPressComplete::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -3002,7 +3021,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const BooleanState::Events::StateChange::DecodableType & value)
+                                     const chip::app::Clusters::BooleanState::Events::StateChange::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -3018,7 +3037,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Events::DoorLockAlarm::DecodableType & value)
+                                     const chip::app::Clusters::DoorLock::Events::DoorLockAlarm::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -3034,7 +3053,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Events::DoorStateChange::DecodableType & value)
+                                     const chip::app::Clusters::DoorLock::Events::DoorStateChange::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -3050,7 +3069,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Events::LockOperation::DecodableType & value)
+                                     const chip::app::Clusters::DoorLock::Events::LockOperation::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -3106,7 +3125,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Events::LockOperationError::DecodableType & value)
+                                     const chip::app::Clusters::DoorLock::Events::LockOperationError::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -3170,7 +3189,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Events::LockUserChange::DecodableType & value)
+                                     const chip::app::Clusters::DoorLock::Events::LockUserChange::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -3233,8 +3252,126 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::SupplyVoltageLow::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::PumpConfigurationAndControl::Events::SupplyVoltageLow::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::PumpConfigurationAndControl::Events::SupplyVoltageHigh::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::PumpConfigurationAndControl::Events::PowerMissingPhase::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::PumpConfigurationAndControl::Events::SystemPressureLow::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::PumpConfigurationAndControl::Events::SystemPressureHigh::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::PumpConfigurationAndControl::Events::DryRunning::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR DataModelLogger::LogValue(
+    const char * label, size_t indent,
+    const chip::app::Clusters::PumpConfigurationAndControl::Events::MotorTemperatureHigh::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR DataModelLogger::LogValue(
+    const char * label, size_t indent,
+    const chip::app::Clusters::PumpConfigurationAndControl::Events::PumpMotorFatalFailure::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR DataModelLogger::LogValue(
+    const char * label, size_t indent,
+    const chip::app::Clusters::PumpConfigurationAndControl::Events::ElectronicTemperatureHigh::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::PumpConfigurationAndControl::Events::PumpBlocked::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::PumpConfigurationAndControl::Events::SensorFailure::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR DataModelLogger::LogValue(
+    const char * label, size_t indent,
+    const chip::app::Clusters::PumpConfigurationAndControl::Events::ElectronicNonFatalFailure::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR DataModelLogger::LogValue(
+    const char * label, size_t indent,
+    const chip::app::Clusters::PumpConfigurationAndControl::Events::ElectronicFatalFailure::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::PumpConfigurationAndControl::Events::GeneralFault::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     DataModelLogger::LogString(indent, "}");
@@ -3242,7 +3379,25 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::SupplyVoltageHigh::DecodableType & value)
+                                     const chip::app::Clusters::PumpConfigurationAndControl::Events::Leakage::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::PumpConfigurationAndControl::Events::AirDetection::DecodableType & value)
+{
+    DataModelLogger::LogString(label, indent, "{");
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::PumpConfigurationAndControl::Events::TurbineOperation::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     DataModelLogger::LogString(indent, "}");
@@ -3250,126 +3405,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::PowerMissingPhase::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::SystemPressureLow::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::SystemPressureHigh::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::DryRunning::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::MotorTemperatureHigh::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::PumpMotorFatalFailure::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::ElectronicTemperatureHigh::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::PumpBlocked::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::SensorFailure::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::ElectronicNonFatalFailure::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::ElectronicFatalFailure::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::GeneralFault::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::Leakage::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::AirDetection::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const PumpConfigurationAndControl::Events::TurbineOperation::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const TestCluster::Events::TestEvent::DecodableType & value)
+                                     const chip::app::Clusters::TestCluster::Events::TestEvent::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -3425,7 +3461,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const Te
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const TestCluster::Events::TestFabricScopedEvent::DecodableType & value)
+                                     const chip::app::Clusters::TestCluster::Events::TestFabricScopedEvent::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     {
@@ -3442,15 +3478,16 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 }
 
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const AccountLogin::Commands::GetSetupPINResponse::DecodableType & value)
+                                     const chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("setupPIN", indent + 1, value.setupPIN));
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const ApplicationLauncher::Commands::LauncherResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3459,7 +3496,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Channel::Commands::ChangeChannelResponse::DecodableType & value)
+                                     const chip::app::Clusters::Channel::Commands::ChangeChannelResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("channelMatch", indent + 1, value.channelMatch));
@@ -3468,7 +3505,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const ContentLauncher::Commands::LaunchResponse::DecodableType & value)
+                                     const chip::app::Clusters::ContentLauncher::Commands::LaunchResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3476,8 +3513,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DiagnosticLogs::Commands::RetrieveLogsResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3488,7 +3526,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Commands::GetLogRecordResponse::DecodableType & value)
+                                     const chip::app::Clusters::DoorLock::Commands::GetLogRecordResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("logEntryId", indent + 1, value.logEntryId));
@@ -3502,7 +3540,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Commands::GetPINCodeResponse::DecodableType & value)
+                                     const chip::app::Clusters::DoorLock::Commands::GetPINCodeResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("userId", indent + 1, value.userId));
@@ -3513,7 +3551,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Commands::GetUserStatusResponse::DecodableType & value)
+                                     const chip::app::Clusters::DoorLock::Commands::GetUserStatusResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("userId", indent + 1, value.userId));
@@ -3521,8 +3559,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Commands::GetWeekDayScheduleResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::DoorLock::Commands::GetWeekDayScheduleResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("weekDayIndex", indent + 1, value.weekDayIndex));
@@ -3536,8 +3575,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Commands::GetYearDayScheduleResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::DoorLock::Commands::GetYearDayScheduleResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("yearDayIndex", indent + 1, value.yearDayIndex));
@@ -3548,8 +3588,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Commands::GetHolidayScheduleResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::DoorLock::Commands::GetHolidayScheduleResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("holidayIndex", indent + 1, value.holidayIndex));
@@ -3561,7 +3602,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Commands::GetUserTypeResponse::DecodableType & value)
+                                     const chip::app::Clusters::DoorLock::Commands::GetUserTypeResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("userId", indent + 1, value.userId));
@@ -3570,7 +3611,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Commands::GetRFIDCodeResponse::DecodableType & value)
+                                     const chip::app::Clusters::DoorLock::Commands::GetRFIDCodeResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("userId", indent + 1, value.userId));
@@ -3581,7 +3622,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Commands::GetUserResponse::DecodableType & value)
+                                     const chip::app::Clusters::DoorLock::Commands::GetUserResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("userIndex", indent + 1, value.userIndex));
@@ -3597,8 +3638,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Commands::OperatingEventNotification::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::DoorLock::Commands::OperatingEventNotification::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("operationEventSource", indent + 1, value.operationEventSource));
@@ -3610,8 +3652,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Commands::ProgrammingEventNotification::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::DoorLock::Commands::ProgrammingEventNotification::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("programEventSource", indent + 1, value.programEventSource));
@@ -3626,7 +3669,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Commands::SetCredentialResponse::DecodableType & value)
+                                     const chip::app::Clusters::DoorLock::Commands::SetCredentialResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3635,8 +3678,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const DoorLock::Commands::GetCredentialStatusResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::DoorLock::Commands::GetCredentialStatusResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("credentialExists", indent + 1, value.credentialExists));
@@ -3645,8 +3689,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const ElectricalMeasurement::Commands::GetProfileInfoResponseCommand::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(
+    const char * label, size_t indent,
+    const chip::app::Clusters::ElectricalMeasurement::Commands::GetProfileInfoResponseCommand::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("profileCount", indent + 1, value.profileCount));
@@ -3656,9 +3701,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR
-DataModelLogger::LogValue(const char * label, size_t indent,
-                          const ElectricalMeasurement::Commands::GetMeasurementProfileResponseCommand::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(
+    const char * label, size_t indent,
+    const chip::app::Clusters::ElectricalMeasurement::Commands::GetMeasurementProfileResponseCommand::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("startTime", indent + 1, value.startTime));
@@ -3670,8 +3715,9 @@ DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("errorCode", indent + 1, value.errorCode));
@@ -3679,8 +3725,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(
+    const char * label, size_t indent,
+    const chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("errorCode", indent + 1, value.errorCode));
@@ -3688,8 +3735,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(
+    const char * label, size_t indent,
+    const chip::app::Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("errorCode", indent + 1, value.errorCode));
@@ -3697,16 +3745,18 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const GroupKeyManagement::Commands::KeySetReadResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::GroupKeyManagement::Commands::KeySetReadResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("groupKeySet", indent + 1, value.groupKeySet));
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const GroupKeyManagement::Commands::KeySetReadAllIndicesResponse::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(
+    const char * label, size_t indent,
+    const chip::app::Clusters::GroupKeyManagement::Commands::KeySetReadAllIndicesResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("groupKeySetIDs", indent + 1, value.groupKeySetIDs));
@@ -3714,7 +3764,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Groups::Commands::AddGroupResponse::DecodableType & value)
+                                     const chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3723,7 +3773,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Groups::Commands::ViewGroupResponse::DecodableType & value)
+                                     const chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3733,7 +3783,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Groups::Commands::GetGroupMembershipResponse::DecodableType & value)
+                                     const chip::app::Clusters::Groups::Commands::GetGroupMembershipResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("capacity", indent + 1, value.capacity));
@@ -3742,7 +3792,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Groups::Commands::RemoveGroupResponse::DecodableType & value)
+                                     const chip::app::Clusters::Groups::Commands::RemoveGroupResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3751,7 +3801,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Identify::Commands::IdentifyQueryResponse::DecodableType & value)
+                                     const chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("timeout", indent + 1, value.timeout));
@@ -3759,7 +3809,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const KeypadInput::Commands::SendKeyResponse::DecodableType & value)
+                                     const chip::app::Clusters::KeypadInput::Commands::SendKeyResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3767,15 +3817,16 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const MediaPlayback::Commands::PlaybackResponse::DecodableType & value)
+                                     const chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("networkingStatus", indent + 1, value.networkingStatus));
@@ -3785,8 +3836,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("networkingStatus", indent + 1, value.networkingStatus));
@@ -3794,8 +3846,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const NetworkCommissioning::Commands::ConnectNetworkResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::NetworkCommissioning::Commands::ConnectNetworkResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("networkingStatus", indent + 1, value.networkingStatus));
@@ -3804,8 +3857,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3819,8 +3873,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(
+    const char * label, size_t indent,
+    const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("action", indent + 1, value.action));
@@ -3828,8 +3883,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const OperationalCredentials::Commands::AttestationResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::OperationalCredentials::Commands::AttestationResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("attestationElements", indent + 1, value.attestationElements));
@@ -3837,16 +3893,18 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const OperationalCredentials::Commands::CertificateChainResponse::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(
+    const char * label, size_t indent,
+    const chip::app::Clusters::OperationalCredentials::Commands::CertificateChainResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("certificate", indent + 1, value.certificate));
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const OperationalCredentials::Commands::CSRResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::OperationalCredentials::Commands::CSRResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("NOCSRElements", indent + 1, value.NOCSRElements));
@@ -3854,8 +3912,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const OperationalCredentials::Commands::NOCResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("statusCode", indent + 1, value.statusCode));
@@ -3865,7 +3924,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Scenes::Commands::AddSceneResponse::DecodableType & value)
+                                     const chip::app::Clusters::Scenes::Commands::AddSceneResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3875,7 +3934,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Scenes::Commands::ViewSceneResponse::DecodableType & value)
+                                     const chip::app::Clusters::Scenes::Commands::ViewSceneResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3888,7 +3947,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Scenes::Commands::RemoveSceneResponse::DecodableType & value)
+                                     const chip::app::Clusters::Scenes::Commands::RemoveSceneResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3898,7 +3957,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Scenes::Commands::RemoveAllScenesResponse::DecodableType & value)
+                                     const chip::app::Clusters::Scenes::Commands::RemoveAllScenesResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3907,7 +3966,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Scenes::Commands::StoreSceneResponse::DecodableType & value)
+                                     const chip::app::Clusters::Scenes::Commands::StoreSceneResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3917,7 +3976,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Scenes::Commands::GetSceneMembershipResponse::DecodableType & value)
+                                     const chip::app::Clusters::Scenes::Commands::GetSceneMembershipResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3929,7 +3988,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Scenes::Commands::EnhancedAddSceneResponse::DecodableType & value)
+                                     const chip::app::Clusters::Scenes::Commands::EnhancedAddSceneResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3939,7 +3998,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Scenes::Commands::EnhancedViewSceneResponse::DecodableType & value)
+                                     const chip::app::Clusters::Scenes::Commands::EnhancedViewSceneResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3952,7 +4011,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Scenes::Commands::CopySceneResponse::DecodableType & value)
+                                     const chip::app::Clusters::Scenes::Commands::CopySceneResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3961,8 +4020,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const TargetNavigator::Commands::NavigateTargetResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::TargetNavigator::Commands::NavigateTargetResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
@@ -3971,31 +4031,34 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const TestCluster::Commands::TestSpecificResponse::DecodableType & value)
+                                     const chip::app::Clusters::TestCluster::Commands::TestSpecificResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("returnValue", indent + 1, value.returnValue));
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const TestCluster::Commands::TestAddArgumentsResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::TestCluster::Commands::TestAddArgumentsResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("returnValue", indent + 1, value.returnValue));
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const TestCluster::Commands::TestSimpleArgumentResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::TestCluster::Commands::TestSimpleArgumentResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("returnValue", indent + 1, value.returnValue));
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const TestCluster::Commands::TestStructArrayArgumentResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::TestCluster::Commands::TestStructArrayArgumentResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("arg1", indent + 1, value.arg1));
@@ -4007,8 +4070,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const TestCluster::Commands::TestListInt8UReverseResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("arg1", indent + 1, value.arg1));
@@ -4016,7 +4080,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const TestCluster::Commands::TestEnumsResponse::DecodableType & value)
+                                     const chip::app::Clusters::TestCluster::Commands::TestEnumsResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("arg1", indent + 1, value.arg1));
@@ -4024,8 +4088,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const TestCluster::Commands::TestNullableOptionalResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("wasPresent", indent + 1, value.wasPresent));
@@ -4035,8 +4100,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const TestCluster::Commands::TestComplexNullableOptionalResponse::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(
+    const char * label, size_t indent,
+    const chip::app::Clusters::TestCluster::Commands::TestComplexNullableOptionalResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("nullableIntWasNull", indent + 1, value.nullableIntWasNull));
@@ -4077,7 +4143,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const TestCluster::Commands::BooleanResponse::DecodableType & value)
+                                     const chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("value", indent + 1, value.value));
@@ -4085,31 +4151,34 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const TestCluster::Commands::SimpleStructResponse::DecodableType & value)
+                                     const chip::app::Clusters::TestCluster::Commands::SimpleStructResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("arg1", indent + 1, value.arg1));
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const TestCluster::Commands::TestEmitTestEventResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::TestCluster::Commands::TestEmitTestEventResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("value", indent + 1, value.value));
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const TestCluster::Commands::TestEmitTestFabricScopedEventResponse::DecodableType & value)
+CHIP_ERROR DataModelLogger::LogValue(
+    const char * label, size_t indent,
+    const chip::app::Clusters::TestCluster::Commands::TestEmitTestFabricScopedEventResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("value", indent + 1, value.value));
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Thermostat::Commands::GetWeeklyScheduleResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::Thermostat::Commands::GetWeeklyScheduleResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(
@@ -4120,8 +4189,9 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const Thermostat::Commands::GetRelayStatusLogResponse::DecodableType & value)
+CHIP_ERROR
+DataModelLogger::LogValue(const char * label, size_t indent,
+                          const chip::app::Clusters::Thermostat::Commands::GetRelayStatusLogResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("timeOfDay", indent + 1, value.timeOfDay));
@@ -9796,7 +9866,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case AccountLogin::Commands::GetSetupPINResponse::Id: {
-            AccountLogin::Commands::GetSetupPINResponse::DecodableType value;
+            chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetSetupPINResponse", 1, value);
         }
@@ -9807,7 +9877,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case ApplicationLauncher::Commands::LauncherResponse::Id: {
-            ApplicationLauncher::Commands::LauncherResponse::DecodableType value;
+            chip::app::Clusters::ApplicationLauncher::Commands::LauncherResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("LauncherResponse", 1, value);
         }
@@ -9818,7 +9888,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case Channel::Commands::ChangeChannelResponse::Id: {
-            Channel::Commands::ChangeChannelResponse::DecodableType value;
+            chip::app::Clusters::Channel::Commands::ChangeChannelResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("ChangeChannelResponse", 1, value);
         }
@@ -9829,7 +9899,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case ContentLauncher::Commands::LaunchResponse::Id: {
-            ContentLauncher::Commands::LaunchResponse::DecodableType value;
+            chip::app::Clusters::ContentLauncher::Commands::LaunchResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("LaunchResponse", 1, value);
         }
@@ -9840,7 +9910,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case DiagnosticLogs::Commands::RetrieveLogsResponse::Id: {
-            DiagnosticLogs::Commands::RetrieveLogsResponse::DecodableType value;
+            chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("RetrieveLogsResponse", 1, value);
         }
@@ -9851,67 +9921,67 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case DoorLock::Commands::GetLogRecordResponse::Id: {
-            DoorLock::Commands::GetLogRecordResponse::DecodableType value;
+            chip::app::Clusters::DoorLock::Commands::GetLogRecordResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetLogRecordResponse", 1, value);
         }
         case DoorLock::Commands::GetPINCodeResponse::Id: {
-            DoorLock::Commands::GetPINCodeResponse::DecodableType value;
+            chip::app::Clusters::DoorLock::Commands::GetPINCodeResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetPINCodeResponse", 1, value);
         }
         case DoorLock::Commands::GetUserStatusResponse::Id: {
-            DoorLock::Commands::GetUserStatusResponse::DecodableType value;
+            chip::app::Clusters::DoorLock::Commands::GetUserStatusResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetUserStatusResponse", 1, value);
         }
         case DoorLock::Commands::GetWeekDayScheduleResponse::Id: {
-            DoorLock::Commands::GetWeekDayScheduleResponse::DecodableType value;
+            chip::app::Clusters::DoorLock::Commands::GetWeekDayScheduleResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetWeekDayScheduleResponse", 1, value);
         }
         case DoorLock::Commands::GetYearDayScheduleResponse::Id: {
-            DoorLock::Commands::GetYearDayScheduleResponse::DecodableType value;
+            chip::app::Clusters::DoorLock::Commands::GetYearDayScheduleResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetYearDayScheduleResponse", 1, value);
         }
         case DoorLock::Commands::GetHolidayScheduleResponse::Id: {
-            DoorLock::Commands::GetHolidayScheduleResponse::DecodableType value;
+            chip::app::Clusters::DoorLock::Commands::GetHolidayScheduleResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetHolidayScheduleResponse", 1, value);
         }
         case DoorLock::Commands::GetUserTypeResponse::Id: {
-            DoorLock::Commands::GetUserTypeResponse::DecodableType value;
+            chip::app::Clusters::DoorLock::Commands::GetUserTypeResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetUserTypeResponse", 1, value);
         }
         case DoorLock::Commands::GetRFIDCodeResponse::Id: {
-            DoorLock::Commands::GetRFIDCodeResponse::DecodableType value;
+            chip::app::Clusters::DoorLock::Commands::GetRFIDCodeResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetRFIDCodeResponse", 1, value);
         }
         case DoorLock::Commands::GetUserResponse::Id: {
-            DoorLock::Commands::GetUserResponse::DecodableType value;
+            chip::app::Clusters::DoorLock::Commands::GetUserResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetUserResponse", 1, value);
         }
         case DoorLock::Commands::OperatingEventNotification::Id: {
-            DoorLock::Commands::OperatingEventNotification::DecodableType value;
+            chip::app::Clusters::DoorLock::Commands::OperatingEventNotification::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("OperatingEventNotification", 1, value);
         }
         case DoorLock::Commands::ProgrammingEventNotification::Id: {
-            DoorLock::Commands::ProgrammingEventNotification::DecodableType value;
+            chip::app::Clusters::DoorLock::Commands::ProgrammingEventNotification::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("ProgrammingEventNotification", 1, value);
         }
         case DoorLock::Commands::SetCredentialResponse::Id: {
-            DoorLock::Commands::SetCredentialResponse::DecodableType value;
+            chip::app::Clusters::DoorLock::Commands::SetCredentialResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("SetCredentialResponse", 1, value);
         }
         case DoorLock::Commands::GetCredentialStatusResponse::Id: {
-            DoorLock::Commands::GetCredentialStatusResponse::DecodableType value;
+            chip::app::Clusters::DoorLock::Commands::GetCredentialStatusResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetCredentialStatusResponse", 1, value);
         }
@@ -9922,12 +9992,12 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case ElectricalMeasurement::Commands::GetProfileInfoResponseCommand::Id: {
-            ElectricalMeasurement::Commands::GetProfileInfoResponseCommand::DecodableType value;
+            chip::app::Clusters::ElectricalMeasurement::Commands::GetProfileInfoResponseCommand::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetProfileInfoResponseCommand", 1, value);
         }
         case ElectricalMeasurement::Commands::GetMeasurementProfileResponseCommand::Id: {
-            ElectricalMeasurement::Commands::GetMeasurementProfileResponseCommand::DecodableType value;
+            chip::app::Clusters::ElectricalMeasurement::Commands::GetMeasurementProfileResponseCommand::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetMeasurementProfileResponseCommand", 1, value);
         }
@@ -9938,17 +10008,17 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case GeneralCommissioning::Commands::ArmFailSafeResponse::Id: {
-            GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType value;
+            chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("ArmFailSafeResponse", 1, value);
         }
         case GeneralCommissioning::Commands::SetRegulatoryConfigResponse::Id: {
-            GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType value;
+            chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("SetRegulatoryConfigResponse", 1, value);
         }
         case GeneralCommissioning::Commands::CommissioningCompleteResponse::Id: {
-            GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType value;
+            chip::app::Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("CommissioningCompleteResponse", 1, value);
         }
@@ -9959,12 +10029,12 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case GroupKeyManagement::Commands::KeySetReadResponse::Id: {
-            GroupKeyManagement::Commands::KeySetReadResponse::DecodableType value;
+            chip::app::Clusters::GroupKeyManagement::Commands::KeySetReadResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("KeySetReadResponse", 1, value);
         }
         case GroupKeyManagement::Commands::KeySetReadAllIndicesResponse::Id: {
-            GroupKeyManagement::Commands::KeySetReadAllIndicesResponse::DecodableType value;
+            chip::app::Clusters::GroupKeyManagement::Commands::KeySetReadAllIndicesResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("KeySetReadAllIndicesResponse", 1, value);
         }
@@ -9975,22 +10045,22 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case Groups::Commands::AddGroupResponse::Id: {
-            Groups::Commands::AddGroupResponse::DecodableType value;
+            chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("AddGroupResponse", 1, value);
         }
         case Groups::Commands::ViewGroupResponse::Id: {
-            Groups::Commands::ViewGroupResponse::DecodableType value;
+            chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("ViewGroupResponse", 1, value);
         }
         case Groups::Commands::GetGroupMembershipResponse::Id: {
-            Groups::Commands::GetGroupMembershipResponse::DecodableType value;
+            chip::app::Clusters::Groups::Commands::GetGroupMembershipResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetGroupMembershipResponse", 1, value);
         }
         case Groups::Commands::RemoveGroupResponse::Id: {
-            Groups::Commands::RemoveGroupResponse::DecodableType value;
+            chip::app::Clusters::Groups::Commands::RemoveGroupResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("RemoveGroupResponse", 1, value);
         }
@@ -10001,7 +10071,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case Identify::Commands::IdentifyQueryResponse::Id: {
-            Identify::Commands::IdentifyQueryResponse::DecodableType value;
+            chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("IdentifyQueryResponse", 1, value);
         }
@@ -10012,7 +10082,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case KeypadInput::Commands::SendKeyResponse::Id: {
-            KeypadInput::Commands::SendKeyResponse::DecodableType value;
+            chip::app::Clusters::KeypadInput::Commands::SendKeyResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("SendKeyResponse", 1, value);
         }
@@ -10023,7 +10093,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case MediaPlayback::Commands::PlaybackResponse::Id: {
-            MediaPlayback::Commands::PlaybackResponse::DecodableType value;
+            chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("PlaybackResponse", 1, value);
         }
@@ -10034,17 +10104,17 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case NetworkCommissioning::Commands::ScanNetworksResponse::Id: {
-            NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType value;
+            chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("ScanNetworksResponse", 1, value);
         }
         case NetworkCommissioning::Commands::NetworkConfigResponse::Id: {
-            NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType value;
+            chip::app::Clusters::NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("NetworkConfigResponse", 1, value);
         }
         case NetworkCommissioning::Commands::ConnectNetworkResponse::Id: {
-            NetworkCommissioning::Commands::ConnectNetworkResponse::DecodableType value;
+            chip::app::Clusters::NetworkCommissioning::Commands::ConnectNetworkResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("ConnectNetworkResponse", 1, value);
         }
@@ -10055,12 +10125,12 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case OtaSoftwareUpdateProvider::Commands::QueryImageResponse::Id: {
-            OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType value;
+            chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("QueryImageResponse", 1, value);
         }
         case OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::Id: {
-            OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType value;
+            chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("ApplyUpdateResponse", 1, value);
         }
@@ -10071,22 +10141,22 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case OperationalCredentials::Commands::AttestationResponse::Id: {
-            OperationalCredentials::Commands::AttestationResponse::DecodableType value;
+            chip::app::Clusters::OperationalCredentials::Commands::AttestationResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("AttestationResponse", 1, value);
         }
         case OperationalCredentials::Commands::CertificateChainResponse::Id: {
-            OperationalCredentials::Commands::CertificateChainResponse::DecodableType value;
+            chip::app::Clusters::OperationalCredentials::Commands::CertificateChainResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("CertificateChainResponse", 1, value);
         }
         case OperationalCredentials::Commands::CSRResponse::Id: {
-            OperationalCredentials::Commands::CSRResponse::DecodableType value;
+            chip::app::Clusters::OperationalCredentials::Commands::CSRResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("CSRResponse", 1, value);
         }
         case OperationalCredentials::Commands::NOCResponse::Id: {
-            OperationalCredentials::Commands::NOCResponse::DecodableType value;
+            chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("NOCResponse", 1, value);
         }
@@ -10097,47 +10167,47 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case Scenes::Commands::AddSceneResponse::Id: {
-            Scenes::Commands::AddSceneResponse::DecodableType value;
+            chip::app::Clusters::Scenes::Commands::AddSceneResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("AddSceneResponse", 1, value);
         }
         case Scenes::Commands::ViewSceneResponse::Id: {
-            Scenes::Commands::ViewSceneResponse::DecodableType value;
+            chip::app::Clusters::Scenes::Commands::ViewSceneResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("ViewSceneResponse", 1, value);
         }
         case Scenes::Commands::RemoveSceneResponse::Id: {
-            Scenes::Commands::RemoveSceneResponse::DecodableType value;
+            chip::app::Clusters::Scenes::Commands::RemoveSceneResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("RemoveSceneResponse", 1, value);
         }
         case Scenes::Commands::RemoveAllScenesResponse::Id: {
-            Scenes::Commands::RemoveAllScenesResponse::DecodableType value;
+            chip::app::Clusters::Scenes::Commands::RemoveAllScenesResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("RemoveAllScenesResponse", 1, value);
         }
         case Scenes::Commands::StoreSceneResponse::Id: {
-            Scenes::Commands::StoreSceneResponse::DecodableType value;
+            chip::app::Clusters::Scenes::Commands::StoreSceneResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("StoreSceneResponse", 1, value);
         }
         case Scenes::Commands::GetSceneMembershipResponse::Id: {
-            Scenes::Commands::GetSceneMembershipResponse::DecodableType value;
+            chip::app::Clusters::Scenes::Commands::GetSceneMembershipResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetSceneMembershipResponse", 1, value);
         }
         case Scenes::Commands::EnhancedAddSceneResponse::Id: {
-            Scenes::Commands::EnhancedAddSceneResponse::DecodableType value;
+            chip::app::Clusters::Scenes::Commands::EnhancedAddSceneResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("EnhancedAddSceneResponse", 1, value);
         }
         case Scenes::Commands::EnhancedViewSceneResponse::Id: {
-            Scenes::Commands::EnhancedViewSceneResponse::DecodableType value;
+            chip::app::Clusters::Scenes::Commands::EnhancedViewSceneResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("EnhancedViewSceneResponse", 1, value);
         }
         case Scenes::Commands::CopySceneResponse::Id: {
-            Scenes::Commands::CopySceneResponse::DecodableType value;
+            chip::app::Clusters::Scenes::Commands::CopySceneResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("CopySceneResponse", 1, value);
         }
@@ -10148,7 +10218,7 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case TargetNavigator::Commands::NavigateTargetResponse::Id: {
-            TargetNavigator::Commands::NavigateTargetResponse::DecodableType value;
+            chip::app::Clusters::TargetNavigator::Commands::NavigateTargetResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("NavigateTargetResponse", 1, value);
         }
@@ -10159,62 +10229,62 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case TestCluster::Commands::TestSpecificResponse::Id: {
-            TestCluster::Commands::TestSpecificResponse::DecodableType value;
+            chip::app::Clusters::TestCluster::Commands::TestSpecificResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("TestSpecificResponse", 1, value);
         }
         case TestCluster::Commands::TestAddArgumentsResponse::Id: {
-            TestCluster::Commands::TestAddArgumentsResponse::DecodableType value;
+            chip::app::Clusters::TestCluster::Commands::TestAddArgumentsResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("TestAddArgumentsResponse", 1, value);
         }
         case TestCluster::Commands::TestSimpleArgumentResponse::Id: {
-            TestCluster::Commands::TestSimpleArgumentResponse::DecodableType value;
+            chip::app::Clusters::TestCluster::Commands::TestSimpleArgumentResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("TestSimpleArgumentResponse", 1, value);
         }
         case TestCluster::Commands::TestStructArrayArgumentResponse::Id: {
-            TestCluster::Commands::TestStructArrayArgumentResponse::DecodableType value;
+            chip::app::Clusters::TestCluster::Commands::TestStructArrayArgumentResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("TestStructArrayArgumentResponse", 1, value);
         }
         case TestCluster::Commands::TestListInt8UReverseResponse::Id: {
-            TestCluster::Commands::TestListInt8UReverseResponse::DecodableType value;
+            chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("TestListInt8UReverseResponse", 1, value);
         }
         case TestCluster::Commands::TestEnumsResponse::Id: {
-            TestCluster::Commands::TestEnumsResponse::DecodableType value;
+            chip::app::Clusters::TestCluster::Commands::TestEnumsResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("TestEnumsResponse", 1, value);
         }
         case TestCluster::Commands::TestNullableOptionalResponse::Id: {
-            TestCluster::Commands::TestNullableOptionalResponse::DecodableType value;
+            chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("TestNullableOptionalResponse", 1, value);
         }
         case TestCluster::Commands::TestComplexNullableOptionalResponse::Id: {
-            TestCluster::Commands::TestComplexNullableOptionalResponse::DecodableType value;
+            chip::app::Clusters::TestCluster::Commands::TestComplexNullableOptionalResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("TestComplexNullableOptionalResponse", 1, value);
         }
         case TestCluster::Commands::BooleanResponse::Id: {
-            TestCluster::Commands::BooleanResponse::DecodableType value;
+            chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("BooleanResponse", 1, value);
         }
         case TestCluster::Commands::SimpleStructResponse::Id: {
-            TestCluster::Commands::SimpleStructResponse::DecodableType value;
+            chip::app::Clusters::TestCluster::Commands::SimpleStructResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("SimpleStructResponse", 1, value);
         }
         case TestCluster::Commands::TestEmitTestEventResponse::Id: {
-            TestCluster::Commands::TestEmitTestEventResponse::DecodableType value;
+            chip::app::Clusters::TestCluster::Commands::TestEmitTestEventResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("TestEmitTestEventResponse", 1, value);
         }
         case TestCluster::Commands::TestEmitTestFabricScopedEventResponse::Id: {
-            TestCluster::Commands::TestEmitTestFabricScopedEventResponse::DecodableType value;
+            chip::app::Clusters::TestCluster::Commands::TestEmitTestFabricScopedEventResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("TestEmitTestFabricScopedEventResponse", 1, value);
         }
@@ -10225,12 +10295,12 @@ CHIP_ERROR DataModelLogger::LogCommand(const chip::app::ConcreteCommandPath & pa
         switch (path.mCommandId)
         {
         case Thermostat::Commands::GetWeeklyScheduleResponse::Id: {
-            Thermostat::Commands::GetWeeklyScheduleResponse::DecodableType value;
+            chip::app::Clusters::Thermostat::Commands::GetWeeklyScheduleResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetWeeklyScheduleResponse", 1, value);
         }
         case Thermostat::Commands::GetRelayStatusLogResponse::Id: {
-            Thermostat::Commands::GetRelayStatusLogResponse::DecodableType value;
+            chip::app::Clusters::Thermostat::Commands::GetRelayStatusLogResponse::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("GetRelayStatusLogResponse", 1, value);
         }


### PR DESCRIPTION
#### Problem

`zapTypeToClusterObjectType` does not supports checking if the type is a command and so the same code is repeated in various places.

#### Change overview
* Add `isCommand`to `zapTypeToClusterObjectType`
* Add a cache mechanism to not read all commands/events from the database each time...
