### PR TITLE
Revert "Fix detached thread resource leak if Matter stack is stopped and then… (#15167)"

### DIFF
--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -30,8 +30,6 @@
 #include <gio/gio.h>
 #endif
 
-#include <thread>
-
 namespace chip {
 namespace DeviceLayer {
 
@@ -99,12 +97,6 @@ private:
     };
     using UniqueGDBusConnection = std::unique_ptr<GDBusConnection, GDBusConnectionDeleter>;
     UniqueGDBusConnection mpGDBusConnection;
-
-    std::thread::native_handle_type mGdbusThreadHandle;
-#endif
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    std::thread::native_handle_type mWifiIPThreadHandle;
 #endif
 };
 


### PR DESCRIPTION
This reverts commit 6107c139d8c390968a2b2832f8a8d626ce23d74b.

PR #15167 was merged with a permanent CI failure (Tsan failures on
Linux), so now nothing can pass CI.

#### Problem
Broken CI

#### Change overview
Revert PR causing permanent breakage

#### Testing
Should be able to pass the Linux Tests CI job now.