### PR TITLE
[linux]: Reland fix detached thread resource leak if Matter stack is restarted

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -176,7 +176,7 @@ uint32_t InteractionModelEngine::GetNumActiveWriteHandlers() const
 }
 
 void InteractionModelEngine::CloseTransactionsFromFabricIndex(FabricIndex aFabricIndex)
-{ 
+{
     //
     // Walk through all existing subscriptions and shut down those whose subscriber matches
     // that which just came in.

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -252,7 +252,7 @@ CHIP_ERROR PlatformManagerImpl::_Shutdown()
         ChipLogError(DeviceLayer, "Failed to cancel GDBus thread");
     }
 
-    if (pthread_join(mGdbusThread, NULL))
+    if (pthread_join(mGdbusThread, NULL) != 0)
     {
         ChipLogError(DeviceLayer, "Failed to join GDBus thread");
     }

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -264,7 +264,7 @@ CHIP_ERROR PlatformManagerImpl::_Shutdown()
         ChipLogError(DeviceLayer, "Failed to cancel WiFi IP thread");
     }
 
-    if (pthread_join(mWifiIPThread, NULL))
+    if (pthread_join(mWifiIPThread, NULL) != 0)
     {
         ChipLogError(DeviceLayer, "Failed to join WiFi IP thread");
     }

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -30,8 +30,6 @@
 #include <gio/gio.h>
 #endif
 
-#include <thread>
-
 namespace chip {
 namespace DeviceLayer {
 
@@ -90,7 +88,7 @@ private:
 
     // The temporary hack for getting IP address change on linux for network provisioning in the rendezvous session.
     // This should be removed or find a better place once we depercate the rendezvous session.
-    static void WiFIIPChangeListener(int sock);
+    static void * WiFIIPChangeListener(void * arg);
 
 #if CHIP_WITH_GIO
     struct GDBusConnectionDeleter
@@ -100,13 +98,11 @@ private:
     using UniqueGDBusConnection = std::unique_ptr<GDBusConnection, GDBusConnectionDeleter>;
     UniqueGDBusConnection mpGDBusConnection;
 
-    std::thread mGdbusThread;
-    GMainLoop * mGdbusLoop = nullptr;
+    pthread_t mGdbusThread;
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    std::thread mWifiIPThread;
-    int mWiFiSocket = 0;
+    pthread_t mWifiIPThread;
 #endif
 };
 

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -30,6 +30,8 @@
 #include <gio/gio.h>
 #endif
 
+#include <thread>
+
 namespace chip {
 namespace DeviceLayer {
 
@@ -88,7 +90,7 @@ private:
 
     // The temporary hack for getting IP address change on linux for network provisioning in the rendezvous session.
     // This should be removed or find a better place once we depercate the rendezvous session.
-    static void WiFIIPChangeListener();
+    static void WiFIIPChangeListener(int sock);
 
 #if CHIP_WITH_GIO
     struct GDBusConnectionDeleter
@@ -97,6 +99,14 @@ private:
     };
     using UniqueGDBusConnection = std::unique_ptr<GDBusConnection, GDBusConnectionDeleter>;
     UniqueGDBusConnection mpGDBusConnection;
+
+    std::thread mGdbusThread;
+    GMainLoop * mGdbusLoop = nullptr;
+#endif
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    std::thread mWifiIPThread;
+    int mWiFiSocket = 0;
 #endif
 };
 

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -30,6 +30,8 @@
 #include <gio/gio.h>
 #endif
 
+#include <thread>
+
 namespace chip {
 namespace DeviceLayer {
 
@@ -88,7 +90,7 @@ private:
 
     // The temporary hack for getting IP address change on linux for network provisioning in the rendezvous session.
     // This should be removed or find a better place once we depercate the rendezvous session.
-    static void * WiFIIPChangeListener(void * arg);
+    static void WiFIIPChangeListener(int sock);
 
 #if CHIP_WITH_GIO
     struct GDBusConnectionDeleter
@@ -98,11 +100,13 @@ private:
     using UniqueGDBusConnection = std::unique_ptr<GDBusConnection, GDBusConnectionDeleter>;
     UniqueGDBusConnection mpGDBusConnection;
 
-    pthread_t mGdbusThread;
+    std::thread mGdbusThread;
+    GMainLoop * mGdbusLoop = nullptr;
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    pthread_t mWifiIPThread;
+    std::thread mWifiIPThread;
+    int mWiFiSocket = 0;
 #endif
 };
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, we don't maintain a reference to a working thread after the thread has been detached, this causes the thread resource is leaked when the Matter stack is stopped and then restarted.
* Fixes https://github.com/project-chip/connectedhomeip/issues/9212

#### Change overview
Linux platform retain a reference to the spawned working threads
The _Shutdown method signal to the the spawned working threads and then join them

#### Testing
How was this tested? (at least one bullet point required)
* Start the stop chip-lighting-app and confirm thread 'GDBus_Thread' and 'WiFIIPChangeListener' are cleaned during shutdown process
