### PR TITLE
Move build timeout only linux to 120 min (matches mac now)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,7 +97,7 @@ jobs:
               run: scripts/run_in_build_env.sh "ninja -C ./out"
     build_linux:
         name: Build on Linux (fake, gcc_release, clang, mbedtls, simulated)
-        timeout-minutes: 90
+        timeout-minutes: 120 
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'


### PR DESCRIPTION
#### Problem
90 minutes seems to be right at the limit. Seeing CI timeouts.

#### Change overview
90 to 120 minutes timeout.

#### Testing
Trivial change, CI can validate as well.