### PR TITLE
Add --interface-id option to examples/platform/Linux

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -572,8 +572,10 @@ void ChipLinuxAppMainLoop()
     unsecurePort = LinuxDeviceOptions::GetInstance().unsecuredCommissionerPort;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
+    Inet::InterfaceId interfaceId = LinuxDeviceOptions::GetInstance().interfaceId;
+
     // Init ZCL Data Model and CHIP App Server
-    Server::GetInstance().Init(nullptr, securePort, unsecurePort);
+    Server::GetInstance().Init(nullptr, securePort, unsecurePort, interfaceId);
 
     // Now that the server has started and we are done with our startup logging,
     // log our discovery/onboarding information again so it's not lost in the

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -47,7 +47,8 @@ enum
     kDeviceOption_UnsecuredCommissionerPort = 0x100c,
     kDeviceOption_Command                   = 0x100d,
     kDeviceOption_PICS                      = 0x100e,
-    kDeviceOption_KVS                       = 0x100f
+    kDeviceOption_KVS                       = 0x100f,
+    kDeviceOption_InterfaceId               = 0x1010
 };
 
 constexpr unsigned kAppUsageLength = 64;
@@ -75,6 +76,7 @@ OptionDef sDeviceOptionDefs[] = {
     { "command", kArgumentRequired, kDeviceOption_Command },
     { "PICS", kArgumentRequired, kDeviceOption_PICS },
     { "KVS", kArgumentRequired, kDeviceOption_KVS },
+    { "interface-id", kArgumentRequired, kDeviceOption_InterfaceId },
     {}
 };
 
@@ -133,6 +135,9 @@ const char * sDeviceOptionHelp =
     "\n"
     "  --KVS <filepath>\n"
     "       A file to store Key Value Store items.\n"
+    "\n"
+    "  --interface-id <interface>\n"
+    "       A interface id to advertise on.\n"
     "\n";
 
 bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue)
@@ -218,6 +223,11 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
 
     case kDeviceOption_KVS:
         LinuxDeviceOptions::GetInstance().KVS = aValue;
+        break;
+
+    case kDeviceOption_InterfaceId:
+        LinuxDeviceOptions::GetInstance().interfaceId =
+            Inet::InterfaceId(static_cast<chip::Inet::InterfaceId::PlatformType>(atoi(aValue)));
         break;
 
     default:

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 
+#include <inet/InetInterface.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPArgParser.hpp>
 #include <setup_payload/SetupPayload.h>
@@ -33,15 +34,16 @@
 struct LinuxDeviceOptions
 {
     chip::SetupPayload payload;
-    uint32_t mBleDevice                = 0;
-    bool mWiFi                         = false;
-    bool mThread                       = false;
-    uint32_t securedDevicePort         = CHIP_PORT;
-    uint32_t securedCommissionerPort   = CHIP_PORT + 2;
-    uint32_t unsecuredCommissionerPort = CHIP_UDC_PORT;
-    const char * command               = nullptr;
-    const char * PICS                  = nullptr;
-    const char * KVS                   = nullptr;
+    uint32_t mBleDevice                 = 0;
+    bool mWiFi                          = false;
+    bool mThread                        = false;
+    uint32_t securedDevicePort          = CHIP_PORT;
+    uint32_t securedCommissionerPort    = CHIP_PORT + 2;
+    uint32_t unsecuredCommissionerPort  = CHIP_UDC_PORT;
+    const char * command                = nullptr;
+    const char * PICS                   = nullptr;
+    const char * KVS                    = nullptr;
+    chip::Inet::InterfaceId interfaceId = chip::Inet::InterfaceId::Null();
 
     static LinuxDeviceOptions & GetInstance();
 };

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -107,6 +107,7 @@ class App:
         logging.debug(
             'Executing application under test with discriminator %s.' % discriminator)
         app_cmd = command + ['--discriminator', str(discriminator)]
+        app_cmd = app_cmd + ['--interface-id', str(-1)]
         return runner.RunSubprocess(app_cmd, name='APP ', wait=False)
 
     def __waitFor(self, waitForString, server_process, outpipe):

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -266,6 +266,7 @@ CHIP_ERROR DnssdServer::AdvertiseOperational()
                                                  .SetPeerId(fabricInfo.GetPeerId())
                                                  .SetMac(mac)
                                                  .SetPort(GetSecuredPort())
+                                                 .SetInterfaceId(GetInterfaceId())
                                                  .SetMRPConfig(GetLocalMRPConfig())
                                                  .SetTcpSupported(Optional<bool>(INET_CONFIG_ENABLE_TCP_ENDPOINT))
                                                  .EnableIpV4(true);
@@ -287,6 +288,7 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
 {
     auto advertiseParameters = chip::Dnssd::CommissionAdvertisingParameters()
                                    .SetPort(commissionableNode ? GetSecuredPort() : GetUnsecuredPort())
+                                   .SetInterfaceId(GetInterfaceId())
                                    .EnableIpV4(true);
     advertiseParameters.SetCommissionAdvertiseMode(commissionableNode ? chip::Dnssd::CommssionAdvertiseMode::kCommissionableNode
                                                                       : chip::Dnssd::CommssionAdvertiseMode::kCommissioner);

--- a/src/app/server/Dnssd.h
+++ b/src/app/server/Dnssd.h
@@ -51,6 +51,12 @@ public:
     /// Gets the unsecure Matter port
     uint16_t GetUnsecuredPort() { return mUnsecuredPort; }
 
+    /// Sets the interface id used for advertising
+    void SetInterfaceId(Inet::InterfaceId interfaceId) { mInterfaceId = interfaceId; }
+
+    /// Gets the interface id used for advertising
+    Inet::InterfaceId GetInterfaceId() { return mInterfaceId; }
+
     /// Sets the factory-new state commissionable node discovery timeout
     void SetDiscoveryTimeoutSecs(int16_t secs) { mDiscoveryTimeoutSecs = secs; }
 
@@ -118,8 +124,9 @@ private:
     // Helper for StartServer.
     void StartServer(Optional<Dnssd::CommissioningMode> mode);
 
-    uint16_t mSecuredPort   = CHIP_PORT;
-    uint16_t mUnsecuredPort = CHIP_UDC_PORT;
+    uint16_t mSecuredPort          = CHIP_PORT;
+    uint16_t mUnsecuredPort        = CHIP_UDC_PORT;
+    Inet::InterfaceId mInterfaceId = Inet::InterfaceId::Null();
 
     /// schedule next discovery expiration
     CHIP_ERROR ScheduleDiscoveryExpiration();

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -112,10 +112,12 @@ Server::Server() :
     mAttributePersister(mDeviceStorage), mAccessControl(Access::Examples::GetAccessControlDelegate(&mDeviceStorage))
 {}
 
-CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint16_t unsecureServicePort)
+CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint16_t unsecureServicePort,
+                        Inet::InterfaceId interfaceId)
 {
     mSecuredServicePort   = secureServicePort;
     mUnsecuredServicePort = unsecureServicePort;
+    mInterfaceId          = interfaceId;
 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -230,6 +232,7 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
     app::DnssdServer::Instance().SetSecuredPort(mSecuredServicePort);
     app::DnssdServer::Instance().SetUnsecuredPort(mUnsecuredServicePort);
+    app::DnssdServer::Instance().SetInterfaceId(mInterfaceId);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
 
     // TODO @bzbarsky-apple @cecille Move to examples

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -61,7 +61,7 @@ class Server
 {
 public:
     CHIP_ERROR Init(AppDelegate * delegate = nullptr, uint16_t secureServicePort = CHIP_PORT,
-                    uint16_t unsecureServicePort = CHIP_UDC_PORT);
+                    uint16_t unsecureServicePort = CHIP_UDC_PORT, Inet::InterfaceId interfaceId = Inet::InterfaceId::Null());
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     CHIP_ERROR SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress commissioner);
@@ -206,6 +206,7 @@ private:
     // TODO @ceille: Maybe use OperationalServicePort and CommissionableServicePort
     uint16_t mSecuredServicePort;
     uint16_t mUnsecuredServicePort;
+    Inet::InterfaceId mInterfaceId;
 };
 
 } // namespace chip

--- a/src/lib/dnssd/Advertiser.h
+++ b/src/lib/dnssd/Advertiser.h
@@ -65,6 +65,14 @@ public:
     }
     uint64_t GetPort() const { return mPort; }
 
+    Derived & SetInterfaceId(Inet::InterfaceId interfaceId)
+    {
+        mInterfaceId = interfaceId;
+        return *reinterpret_cast<Derived *>(this);
+    }
+
+    Inet::InterfaceId GetInterfaceId() const { return mInterfaceId; }
+
     Derived & EnableIpV4(bool enable)
     {
         mEnableIPv4 = enable;
@@ -95,6 +103,7 @@ public:
 
 private:
     uint16_t mPort                   = CHIP_PORT;
+    Inet::InterfaceId mInterfaceId   = Inet::InterfaceId::Null();
     bool mEnableIPv4                 = true;
     uint8_t mMacStorage[kMaxMacSize] = {};
     size_t mMacLength                = 0;

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -447,21 +447,22 @@ CHIP_ERROR DiscoveryImplPlatform::PublishService(const char * serviceType, TextE
                                                  const char ** subTypes, size_t subTypeSize,
                                                  const OperationalAdvertisingParameters & params)
 {
-    return PublishService(serviceType, textEntries, textEntrySize, subTypes, subTypeSize, params.GetPort(), params.GetMac(),
-                          DnssdServiceProtocol::kDnssdProtocolTcp, params.GetPeerId());
+    return PublishService(serviceType, textEntries, textEntrySize, subTypes, subTypeSize, params.GetPort(), params.GetInterfaceId(),
+                          params.GetMac(), DnssdServiceProtocol::kDnssdProtocolTcp, params.GetPeerId());
 }
 
 CHIP_ERROR DiscoveryImplPlatform::PublishService(const char * serviceType, TextEntry * textEntries, size_t textEntrySize,
                                                  const char ** subTypes, size_t subTypeSize,
                                                  const CommissionAdvertisingParameters & params)
 {
-    return PublishService(serviceType, textEntries, textEntrySize, subTypes, subTypeSize, params.GetPort(), params.GetMac(),
-                          DnssdServiceProtocol::kDnssdProtocolUdp, PeerId());
+    return PublishService(serviceType, textEntries, textEntrySize, subTypes, subTypeSize, params.GetPort(), params.GetInterfaceId(),
+                          params.GetMac(), DnssdServiceProtocol::kDnssdProtocolUdp, PeerId());
 }
 
 CHIP_ERROR DiscoveryImplPlatform::PublishService(const char * serviceType, TextEntry * textEntries, size_t textEntrySize,
                                                  const char ** subTypes, size_t subTypeSize, uint16_t port,
-                                                 const chip::ByteSpan & mac, DnssdServiceProtocol protocol, PeerId peerId)
+                                                 Inet::InterfaceId interfaceId, const chip::ByteSpan & mac,
+                                                 DnssdServiceProtocol protocol, PeerId peerId)
 {
     ReturnErrorCodeIf(mDnssdInitialized == false, CHIP_ERROR_INCORRECT_STATE);
 
@@ -472,7 +473,7 @@ CHIP_ERROR DiscoveryImplPlatform::PublishService(const char * serviceType, TextE
                              : GetCommissionableInstanceName(service.mName, sizeof(service.mName)));
     strncpy(service.mType, serviceType, sizeof(service.mType));
     service.mAddressType   = Inet::IPAddressType::kAny;
-    service.mInterface     = Inet::InterfaceId::Null();
+    service.mInterface     = interfaceId;
     service.mProtocol      = protocol;
     service.mPort          = port;
     service.mTextEntries   = textEntries;

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -80,8 +80,8 @@ private:
     CHIP_ERROR PublishService(const char * serviceType, TextEntry * textEntries, size_t textEntrySize, const char ** subTypes,
                               size_t subTypeSize, const CommissionAdvertisingParameters & params);
     CHIP_ERROR PublishService(const char * serviceType, TextEntry * textEntries, size_t textEntrySize, const char ** subTypes,
-                              size_t subTypeSize, uint16_t port, const chip::ByteSpan & mac, DnssdServiceProtocol procotol,
-                              PeerId peerId);
+                              size_t subTypeSize, uint16_t port, Inet::InterfaceId interfaceId, const chip::ByteSpan & mac,
+                              DnssdServiceProtocol procotol, PeerId peerId);
 
     OperationalAdvertisingParameters mOperationalNodeAdvertisingParams;
     CommissionAdvertisingParameters mCommissionableNodeAdvertisingParams;


### PR DESCRIPTION
#### Problem

This is still hard to run tests that relies on mdns on CI, notably because Darwin tests does not run into a network namespace and there is some collisions from advertisement of the outside world.
This PR gives an other attempt at limiting the scope of these advertisements by asking the server to only broadcast onto the local machine.

#### Change overview
* Add `interface-id` argument
* Update the test runner to pass -1, which means local only in this context.
