### PR TITLE
[events] Added generating events on factory reset

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -453,7 +453,7 @@ public:
         }
         else if (i == 1)
         {
-            ConfigurationMgr().InitiateFactoryReset();
+            chip::Server::GetInstance().ScheduleFactoryReset();
         }
         else if (i == 2)
         {

--- a/examples/light-switch-app/efr32/src/AppTask.cpp
+++ b/examples/light-switch-app/efr32/src/AppTask.cpp
@@ -411,7 +411,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
     {
         // Actually trigger Factory Reset
         sAppTask.mFunction = kFunction_NoneSelected;
-        ConfigurationMgr().InitiateFactoryReset();
+        chip::Server::GetInstance().ScheduleFactoryReset();
     }
 }
 

--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -494,7 +494,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
     {
         // Actually trigger Factory Reset
         sAppTask.mFunction = kFunction_NoneSelected;
-        ConfigurationMgr().InitiateFactoryReset();
+        chip::Server::GetInstance().ScheduleFactoryReset();
     }
 }
 

--- a/examples/lighting-app/mbed/main/AppTask.cpp
+++ b/examples/lighting-app/mbed/main/AppTask.cpp
@@ -399,7 +399,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
         // Actually trigger Factory Reset
         ChipLogProgress(NotSpecified, "Factory Reset initiated");
         sAppTask.mFunction = kFunction_NoneSelected;
-        ConfigurationMgr().InitiateFactoryReset();
+        chip::Server::GetInstance().ScheduleFactoryReset();
     }
 }
 

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -318,7 +318,8 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
     {
         // Actually trigger Factory Reset
         sAppTask.mFunction = kFunction_NoneSelected;
-        ConfigurationMgr().InitiateFactoryReset();
+
+        chip::Server::GetInstance().ScheduleFactoryReset();
     }
 }
 

--- a/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -384,7 +384,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
     K32W_LOG("Device will factory reset...");
 
     // Actually trigger Factory Reset
-    ConfigurationMgr().InitiateFactoryReset();
+    chip::Server::GetInstance().ScheduleFactoryReset();
 }
 
 void AppTask::ResetActionEventHandler(AppEvent * aEvent)

--- a/examples/lighting-app/p6/src/AppTask.cpp
+++ b/examples/lighting-app/p6/src/AppTask.cpp
@@ -335,7 +335,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
     {
         // Actually trigger Factory Reset
         sAppTask.mFunction = Function::kNoneSelected;
-        ConfigurationMgr().InitiateFactoryReset();
+        chip::Server::GetInstance().ScheduleFactoryReset();
     }
 }
 

--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -305,7 +305,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
     {
         // Actually trigger Factory Reset
         sAppTask.mFunction = kFunction_NoneSelected;
-        ConfigurationMgr().InitiateFactoryReset();
+        chip::Server::GetInstance().ScheduleFactoryReset();
     }
 }
 

--- a/examples/lighting-app/telink/src/AppTask.cpp
+++ b/examples/lighting-app/telink/src/AppTask.cpp
@@ -215,7 +215,7 @@ void AppTask::FactoryResetButtonEventHandler(void)
 void AppTask::FactoryResetHandler(AppEvent * aEvent)
 {
     LOG_INF("Factory Reset triggered.");
-    ConfigurationMgr().InitiateFactoryReset();
+    chip::Server::GetInstance().ScheduleFactoryReset();
 }
 
 void AppTask::StartThreadButtonEventHandler(void)

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -363,7 +363,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
     {
         // Actually trigger Factory Reset
         sAppTask.mFunction = kFunction_NoneSelected;
-        ConfigurationMgr().InitiateFactoryReset();
+        chip::Server::GetInstance().ScheduleFactoryReset();
     }
 }
 

--- a/examples/lock-app/esp32/main/AppTask.cpp
+++ b/examples/lock-app/esp32/main/AppTask.cpp
@@ -298,7 +298,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
     {
         // Actually trigger Factory Reset
         sAppTask.mFunction = kFunction_NoneSelected;
-        ConfigurationMgr().InitiateFactoryReset();
+        chip::Server::GetInstance().ScheduleFactoryReset();
     }
 }
 

--- a/examples/lock-app/mbed/main/AppTask.cpp
+++ b/examples/lock-app/mbed/main/AppTask.cpp
@@ -395,7 +395,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
         // Actually trigger Factory Reset
         ChipLogProgress(NotSpecified, "Factory Reset initiated");
         sAppTask.mFunction = kFunction_NoneSelected;
-        ConfigurationMgr().InitiateFactoryReset();
+        chip::Server::GetInstance().ScheduleFactoryReset();
     }
 }
 

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -268,7 +268,8 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
     {
         // Actually trigger Factory Reset
         sAppTask.mFunction = kFunction_NoneSelected;
-        ConfigurationMgr().InitiateFactoryReset();
+
+        chip::Server::GetInstance().ScheduleFactoryReset();
     }
 }
 

--- a/examples/lock-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lock-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -357,7 +357,7 @@ void AppTask::FunctionTimerEventHandler(void * aGenericEvent)
     K32W_LOG("Device will factory reset...");
 
     // Actually trigger Factory Reset
-    ConfigurationMgr().InitiateFactoryReset();
+    chip::Server::GetInstance().ScheduleFactoryReset();
 }
 
 void AppTask::ResetActionEventHandler(void * aGenericEvent)

--- a/examples/lock-app/p6/src/AppTask.cpp
+++ b/examples/lock-app/p6/src/AppTask.cpp
@@ -331,7 +331,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * event)
     {
         // Actually trigger Factory Reset
         sAppTask.mFunction = Function::kNoneSelected;
-        ConfigurationMgr().InitiateFactoryReset();
+        chip::Server::GetInstance().ScheduleFactoryReset();
     }
 }
 

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -315,7 +315,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
     {
         // Actually trigger Factory Reset
         sAppTask.mFunction = kFunction_NoneSelected;
-        ConfigurationMgr().InitiateFactoryReset();
+        chip::Server::GetInstance().ScheduleFactoryReset();
     }
 }
 

--- a/examples/ota-requestor-app/efr32/src/AppTask.cpp
+++ b/examples/ota-requestor-app/efr32/src/AppTask.cpp
@@ -350,7 +350,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
     {
         // Actually trigger Factory Reset
         sAppTask.mFunction = kFunction_NoneSelected;
-        ConfigurationMgr().InitiateFactoryReset();
+        chip::Server::GetInstance().ScheduleFactoryReset();
     }
 }
 

--- a/examples/ota-requestor-app/mbed/main/AppTask.cpp
+++ b/examples/ota-requestor-app/mbed/main/AppTask.cpp
@@ -416,7 +416,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
             sAppTask.CancelTimer(kFunction_Button_1);
             sAppTask.mFunction[kFunction_Button_1] = kFunction_NoneSelected;
 
-            ConfigurationMgr().InitiateFactoryReset();
+            chip::Server::GetInstance().ScheduleFactoryReset();
         }
         break;
     case kFunction_Button_2:

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -99,26 +99,26 @@ void OnSignalHandler(int signum)
     // The BootReason attribute SHALL indicate the reason for the Node’s most recent boot, the real usecase
     // for this attribute is embedded system. In Linux simulation, we use different signals to tell the current
     // running process to terminate with different reasons.
-    DiagnosticDataProvider::BootReasonType bootReason = DiagnosticDataProvider::BootReasonType::Unspecified;
+    BootReasonType bootReason = BootReasonType::Unspecified;
     switch (signum)
     {
     case SIGVTALRM:
-        bootReason = DiagnosticDataProvider::BootReasonType::PowerOnReboot;
+        bootReason = BootReasonType::PowerOnReboot;
         break;
     case SIGALRM:
-        bootReason = DiagnosticDataProvider::BootReasonType::BrownOutReset;
+        bootReason = BootReasonType::BrownOutReset;
         break;
     case SIGILL:
-        bootReason = DiagnosticDataProvider::BootReasonType::SoftwareWatchdogReset;
+        bootReason = BootReasonType::SoftwareWatchdogReset;
         break;
     case SIGTRAP:
-        bootReason = DiagnosticDataProvider::BootReasonType::HardwareWatchdogReset;
+        bootReason = BootReasonType::HardwareWatchdogReset;
         break;
     case SIGIO:
-        bootReason = DiagnosticDataProvider::BootReasonType::SoftwareUpdateCompleted;
+        bootReason = BootReasonType::SoftwareUpdateCompleted;
         break;
     case SIGINT:
-        bootReason = DiagnosticDataProvider::BootReasonType::SoftwareReset;
+        bootReason = BootReasonType::SoftwareReset;
         break;
     default:
         IgnoreUnusedVariable(bootReason);

--- a/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -352,7 +352,7 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
         }
         else if (AppEvent::kAppEventButtonType_LongPressed == aEvent->ButtonEvent.Type)
         {
-            ConfigurationMgr().InitiateFactoryReset();
+            chip::Server::GetInstance().ScheduleFactoryReset();
         }
         break;
 

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -267,7 +267,8 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
     {
         // Actually trigger Factory Reset
         sAppTask.mFunction = kFunction_NoneSelected;
-        ConfigurationMgr().InitiateFactoryReset();
+
+        chip::Server::GetInstance().ScheduleFactoryReset();
     }
 }
 

--- a/examples/pump-controller-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/pump-controller-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -335,7 +335,7 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
         }
         else if (AppEvent::kAppEventButtonType_LongPressed == aEvent->ButtonEvent.Type)
         {
-            ConfigurationMgr().InitiateFactoryReset();
+            chip::Server::GetInstance().ScheduleFactoryReset();
         }
         break;
 

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -263,7 +263,8 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
     {
         // Actually trigger Factory Reset
         sAppTask.mFunction = kFunction_NoneSelected;
-        ConfigurationMgr().InitiateFactoryReset();
+
+        chip::Server::GetInstance().ScheduleFactoryReset();
     }
 }
 

--- a/examples/shell/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/shell/nxp/k32w/k32w0/main/AppTask.cpp
@@ -286,7 +286,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
     K32W_LOG("Device will factory reset...");
 
     // Actually trigger Factory Reset
-    ConfigurationMgr().InitiateFactoryReset();
+    chip::Server::GetInstance().ScheduleFactoryReset();
 }
 
 void AppTask::ResetActionEventHandler(AppEvent * aEvent)

--- a/examples/window-app/common/src/WindowApp.cpp
+++ b/examples/window-app/common/src/WindowApp.cpp
@@ -215,7 +215,7 @@ void WindowApp::DispatchEvent(const WindowApp::Event & event)
         break;
 
     case EventId::Reset:
-        ConfigurationMgr().InitiateFactoryReset();
+        chip::Server::GetInstance().ScheduleFactoryReset();
         break;
 
     case EventId::UpPressed:

--- a/src/app/clusters/general-diagnostics-server/general-diagnostics-server.cpp
+++ b/src/app/clusters/general-diagnostics-server/general-diagnostics-server.cpp
@@ -36,10 +36,10 @@ using chip::DeviceLayer::ConnectivityMgr;
 using chip::DeviceLayer::DiagnosticDataProvider;
 using chip::DeviceLayer::GetDiagnosticDataProvider;
 
-static_assert(sizeof(DiagnosticDataProvider::BootReasonType) == sizeof(EmberAfBootReasonType),
+static_assert(sizeof(chip::DeviceLayer::BootReasonType) == sizeof(EmberAfBootReasonType),
               "BootReasonType size doesn't match EmberAfBootReasonType size");
-static_assert(static_cast<uint8_t>(DiagnosticDataProvider::BootReasonType::Unspecified) == EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED &&
-                  static_cast<uint8_t>(DiagnosticDataProvider::BootReasonType::SoftwareReset) ==
+static_assert(static_cast<uint8_t>(chip::DeviceLayer::BootReasonType::Unspecified) == EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED &&
+                  static_cast<uint8_t>(chip::DeviceLayer::BootReasonType::SoftwareReset) ==
                       EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_RESET,
               "BootReasonType and EmberAfBootReasonType values does not match.");
 
@@ -195,23 +195,21 @@ class GeneralDiagnosticsDelegate : public DeviceLayer::ConnectivityManagerDelega
     }
 
     // Gets called when the device has been rebooted.
-    void OnDeviceRebooted(uint8_t bootReason) override
+    void OnDeviceRebooted(chip::DeviceLayer::BootReasonType bootReason) override
     {
         ChipLogProgress(Zcl, "GeneralDiagnosticsDelegate: OnDeviceRebooted");
 
         ReportAttributeOnAllEndpoints(GeneralDiagnostics::Attributes::BootReasons::Id);
 
-        for (auto endpoint : EnabledEndpointsWithServerCluster(GeneralDiagnostics::Id))
-        {
-            Events::BootReason::Type event{ static_cast<BootReasonType>(bootReason) };
-            EventNumber eventNumber;
+        // GeneralDiagnostics cluster should exist only for endpoint 0.
 
-            CHIP_ERROR err = LogEvent(event, endpoint, eventNumber, EventOptions::Type::kUrgent);
-            if (CHIP_NO_ERROR != err)
-            {
-                ChipLogError(Zcl, "GeneralDiagnosticsDelegate: Failed to record BootReason event: %" CHIP_ERROR_FORMAT,
-                             err.Format());
-            }
+        Events::BootReason::Type event{ static_cast<EmberAfBootReasonType>(bootReason) };
+        EventNumber eventNumber;
+
+        CHIP_ERROR err = LogEvent(event, 0, eventNumber, EventOptions::Type::kUrgent);
+        if (CHIP_NO_ERROR != err)
+        {
+            ChipLogError(Zcl, "GeneralDiagnosticsDelegate: Failed to record BootReason event: %" CHIP_ERROR_FORMAT, err.Format());
         }
     }
 

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -120,6 +120,8 @@ public:
 
     uint32_t GetNumReportsInFlight() { return mNumReportsInFlight; }
 
+    void ScheduleUrgentEventDeliverySync();
+
 private:
     friend class TestReportingEngine;
     /**
@@ -165,7 +167,6 @@ private:
     CHIP_ERROR ScheduleUrgentEventDelivery(ConcreteEventPath & aPath);
     CHIP_ERROR ScheduleBufferPressureEventDelivery(uint32_t aBytesWritten);
     void GetMinEventLogPosition(uint32_t & aMinLogPosition);
-    void ScheduleUrgentEventDeliverySync();
 
     /**
      * If the provided path is a superset of our of our existing paths, update that existing path to match the

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -298,6 +298,25 @@ void Server::DispatchShutDownAndStopEventLoop()
     chip::DeviceLayer::PlatformMgr().ScheduleWork(StopEventLoop);
 }
 
+void Server::ScheduleFactoryReset()
+{
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(FactoryReset);
+}
+
+void Server::FactoryReset(intptr_t arg)
+{
+    // Delete all fabrics and emit Leave event.
+    GetInstance().GetFabricTable().DeleteAllFabrics();
+
+    // Emit Shutdown event, as shutdown will come after factory reset.
+    DispatchShutDownEvent(0);
+
+    // Flush all dispatched events.
+    chip::app::InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleUrgentEventDeliverySync();
+
+    chip::DeviceLayer::ConfigurationMgr().InitiateFactoryReset();
+}
+
 void Server::Shutdown()
 {
     chip::Dnssd::ServiceAdvertiser::Instance().Shutdown();

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -95,6 +95,10 @@ public:
 
     void Shutdown();
 
+    void ScheduleFactoryReset();
+
+    static void FactoryReset(intptr_t arg);
+
     static Server & GetInstance() { return sServer; }
 
 private:

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -70,7 +70,7 @@ public:
      * @brief
      *   Called after the current device is rebooted.
      */
-    virtual void OnDeviceRebooted() {}
+    virtual void OnDeviceRebooted(uint8_t bootReason) {}
 
     /**
      * @brief

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -41,6 +41,17 @@ constexpr size_t kMaxIPv6AddrSize  = 16;
 constexpr size_t kMaxIPv4AddrCount = 4;
 constexpr size_t kMaxIPv6AddrCount = 8;
 
+enum BootReasonType : uint8_t
+{
+    Unspecified             = 0,
+    PowerOnReboot           = 1,
+    BrownOutReset           = 2,
+    SoftwareWatchdogReset   = 3,
+    HardwareWatchdogReset   = 4,
+    SoftwareUpdateCompleted = 5,
+    SoftwareReset           = 6,
+};
+
 struct ThreadMetrics : public app::Clusters::SoftwareDiagnostics::Structs::ThreadMetrics::Type
 {
     char NameBuf[kMaxThreadNameLength + 1];
@@ -70,7 +81,7 @@ public:
      * @brief
      *   Called after the current device is rebooted.
      */
-    virtual void OnDeviceRebooted(uint8_t bootReason) {}
+    virtual void OnDeviceRebooted(BootReasonType bootReason) {}
 
     /**
      * @brief
@@ -142,17 +153,6 @@ public:
 class DiagnosticDataProvider
 {
 public:
-    enum BootReasonType : uint8_t
-    {
-        Unspecified             = 0,
-        PowerOnReboot           = 1,
-        BrownOutReset           = 2,
-        SoftwareWatchdogReset   = 3,
-        HardwareWatchdogReset   = 4,
-        SoftwareUpdateCompleted = 5,
-        SoftwareReset           = 6,
-    };
-
     void SetGeneralDiagnosticsDelegate(GeneralDiagnosticsDelegate * delegate) { mGeneralDiagnosticsDelegate = delegate; }
     GeneralDiagnosticsDelegate * GetGeneralDiagnosticsDelegate() const { return mGeneralDiagnosticsDelegate; }
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -298,7 +298,10 @@ void GenericPlatformManagerImpl<ImplClass>::HandleDeviceRebooted(intptr_t arg)
 
     if (generalDiagnosticsDelegate != nullptr)
     {
-        generalDiagnosticsDelegate->OnDeviceRebooted();
+        uint8_t bootReason;
+
+        if (GetDiagnosticDataProvider().GetBootReason(bootReason) == CHIP_NO_ERROR)
+            generalDiagnosticsDelegate->OnDeviceRebooted(bootReason);
     }
 
     // The StartUp event SHALL be emitted by a Node after completing a boot or reboot process
@@ -306,8 +309,8 @@ void GenericPlatformManagerImpl<ImplClass>::HandleDeviceRebooted(intptr_t arg)
     {
         uint32_t softwareVersion;
 
-        ReturnOnFailure(ConfigurationMgr().GetSoftwareVersion(softwareVersion));
-        platformManagerDelegate->OnStartUp(softwareVersion);
+        if (ConfigurationMgr().GetSoftwareVersion(softwareVersion) == CHIP_NO_ERROR)
+            platformManagerDelegate->OnStartUp(softwareVersion);
     }
 }
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -301,7 +301,7 @@ void GenericPlatformManagerImpl<ImplClass>::HandleDeviceRebooted(intptr_t arg)
         uint8_t bootReason;
 
         if (GetDiagnosticDataProvider().GetBootReason(bootReason) == CHIP_NO_ERROR)
-            generalDiagnosticsDelegate->OnDeviceRebooted(bootReason);
+            generalDiagnosticsDelegate->OnDeviceRebooted(static_cast<BootReasonType>(bootReason));
     }
 
     // The StartUp event SHALL be emitted by a Node after completing a boot or reboot process

--- a/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.cpp
@@ -35,6 +35,8 @@
 #include <system/SystemError.h>
 #include <system/SystemLayer.h>
 
+#include <sys/reboot.h>
+
 #define DEFAULT_MIN_SLEEP_PERIOD (60 * 60 * 24 * 30) // Month [sec]
 
 namespace chip {
@@ -46,6 +48,7 @@ System::LayerSocketsLoop & SystemLayerSocketsLoop()
 {
     return static_cast<System::LayerSocketsLoop &>(DeviceLayer::SystemLayer());
 }
+
 } // anonymous namespace
 
 // Fully instantiate the generic implementation class in whatever compilation unit includes this file.
@@ -106,7 +109,12 @@ CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_StopEventLoopTask(void
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_Shutdown(void)
 {
+#if CONFIG_REBOOT
+    sys_reboot(SYS_REBOOT_WARM);
+    return CHIP_NO_ERROR;
+#else
     return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif
 }
 
 template <class ImplClass>

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -80,7 +80,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
     if (!AmebaConfig::ConfigValueExists(AmebaConfig::kCounterKey_BootReason))
     {
-        err = StoreBootReason(DiagnosticDataProvider::BootReasonType::Unspecified);
+        err = StoreBootReason(BootReasonType::Unspecified);
         SuccessOrExit(err);
     }
 

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -160,7 +160,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
     if (!PosixConfig::ConfigValueExists(PosixConfig::kCounterKey_BootReason))
     {
-        ReturnErrorOnFailure(StoreBootReason(DiagnosticDataProvider::BootReasonType::Unspecified));
+        ReturnErrorOnFailure(StoreBootReason(BootReasonType::Unspecified));
     }
 
     if (!PosixConfig::ConfigValueExists(PosixConfig::kConfigKey_RegulatoryLocation))

--- a/src/platform/EFR32/ConfigurationManagerImpl.cpp
+++ b/src/platform/EFR32/ConfigurationManagerImpl.cpp
@@ -111,50 +111,50 @@ uint32_t ConfigurationManagerImpl::GetBootReason(void)
 #if defined(_SILICON_LABS_32B_SERIES_1)
     if (rebootCause & RMU_RSTCAUSE_PORST || rebootCause & RMU_RSTCAUSE_EXTRST) // PowerOn or External pin reset
     {
-        matterBootCause = DiagnosticDataProvider::BootReasonType::PowerOnReboot;
+        matterBootCause = BootReasonType::PowerOnReboot;
     }
     else if (rebootCause & RMU_RSTCAUSE_AVDDBOD || rebootCause & RMU_RSTCAUSE_DVDDBOD || rebootCause & RMU_RSTCAUSE_DECBOD)
     {
-        matterBootCause = DiagnosticDataProvider::BootReasonType::BrownOutReset;
+        matterBootCause = BootReasonType::BrownOutReset;
     }
     else if (rebootCause & RMU_RSTCAUSE_SYSREQRST)
     {
-        matterBootCause = DiagnosticDataProvider::BootReasonType::SoftwareReset;
+        matterBootCause = BootReasonType::SoftwareReset;
     }
     else if (rebootCause & RMU_RSTCAUSE_WDOGRST)
     {
-        matterBootCause = DiagnosticDataProvider::BootReasonType::SoftwareWatchdogReset;
+        matterBootCause = BootReasonType::SoftwareWatchdogReset;
     }
     else
     {
-        matterBootCause = DiagnosticDataProvider::BootReasonType::Unspecified;
+        matterBootCause = BootReasonType::Unspecified;
     }
     // Not tracked HARDWARE_WATCHDOG_RESET && SOFTWARE_UPDATE_COMPLETED
 #elif defined(_SILICON_LABS_32B_SERIES_2)
     if (rebootCause & EMU_RSTCAUSE_POR || rebootCause & EMU_RSTCAUSE_PIN) // PowerOn or External pin reset
     {
-        matterBootCause = DiagnosticDataProvider::BootReasonType::PowerOnReboot;
+        matterBootCause = BootReasonType::PowerOnReboot;
     }
     else if (rebootCause & EMU_RSTCAUSE_AVDDBOD || rebootCause & EMU_RSTCAUSE_DVDDBOD || rebootCause & EMU_RSTCAUSE_DECBOD ||
              rebootCause & EMU_RSTCAUSE_VREGIN || rebootCause & EMU_RSTCAUSE_IOVDD0BOD || rebootCause & EMU_RSTCAUSE_DVDDLEBOD)
     {
-        matterBootCause = DiagnosticDataProvider::BootReasonType::BrownOutReset;
+        matterBootCause = BootReasonType::BrownOutReset;
     }
     else if (rebootCause & EMU_RSTCAUSE_SYSREQ)
     {
-        matterBootCause = DiagnosticDataProvider::BootReasonType::SoftwareReset;
+        matterBootCause = BootReasonType::SoftwareReset;
     }
     else if (rebootCause & EMU_RSTCAUSE_WDOG0 || rebootCause & EMU_RSTCAUSE_WDOG1)
     {
-        matterBootCause = DiagnosticDataProvider::BootReasonType::SoftwareWatchdogReset;
+        matterBootCause = BootReasonType::SoftwareWatchdogReset;
     }
     else
     {
-        matterBootCause = DiagnosticDataProvider::BootReasonType::Unspecified;
+        matterBootCause = BootReasonType::Unspecified;
     }
     // Not tracked HARDWARE_WATCHDOG_RESET && SOFTWARE_UPDATE_COMPLETED
 #else
-    matterBootCause = DiagnosticDataProvider::BootReasonType::Unspecified;
+    matterBootCause = BootReasonType::Unspecified;
 #endif
 
     return matterBootCause;

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -88,7 +88,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
     if (!PosixConfig::ConfigValueExists(PosixConfig::kCounterKey_BootReason))
     {
-        err = StoreBootReason(DiagnosticDataProvider::BootReasonType::Unspecified);
+        err = StoreBootReason(BootReasonType::Unspecified);
         SuccessOrExit(err);
     }
 

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -36,8 +36,6 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 
-#include <power/reboot.h>
-
 namespace chip {
 namespace DeviceLayer {
 
@@ -204,9 +202,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     ThreadStackMgr().ErasePersistentInfo();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
-#if CONFIG_REBOOT
-    sys_reboot(SYS_REBOOT_WARM);
-#endif
+    PlatformMgr().Shutdown();
 }
 
 } // namespace DeviceLayer

--- a/src/platform/Zephyr/ConfigurationManagerImpl.h
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.h
@@ -81,7 +81,12 @@ inline bool ConfigurationManagerImpl::CanFactoryReset()
 
 inline CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
-    return Internal::ZephyrConfig::ReadConfigValueCounter(key, value);
+    CHIP_ERROR err = Internal::ZephyrConfig::ReadConfigValueCounter(key, value);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+    return err;
 }
 
 inline CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)


### PR DESCRIPTION
#### Problem
Zephyr platform doesn't support generating all mandatory events from Basic and General Diagnostics clusters.

#### Change overview
Generic changes:
* Added generating BootReason event
* Added Server::FactoryReset method to dispatch necessary events and flush pending events before
factory reset
* Added dispatching shutdown event on factory reset
* Added DeleteAllFabrics in FactoryReset to emit Leave event.
* Added flushing events on factory reset
* Added for all examples to call Server FactoryReset instead of platform InitiateFactoryReset

Zephyr platform changes:
* Fixed bug in persisted storage read implementation that returned wrong error code and it resulted in PersistedCounter initialization failure.
* Added calling Shutdown after factory reset

#### Testing
Tested using nrfconnect lock-app example and chip-tool that:

- After subscribing to `Shutdown` event it is sent by the accessory just before factory reset and received in the controller
- After subscribing to `Leave` event it is sent by the accessory just before factory reset and received in the controller
- Boot reason event is emitted after device boot
