### PR TITLE
[YAML] Make busyWait a dedicated method instead of always generating it

### DIFF
--- a/examples/chip-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_cluster.zapt
@@ -288,13 +288,8 @@ class {{filename}}: public TestCommand
 
         {{~#*inline "maybeWait"}}
           {{#if busyWaitMs}}
-          {
-            using namespace chip::System::Clock::Literals;
-            // Busy-wait for {{busyWaitMs}} milliseconds.
-            auto & clock = chip::System::SystemClock();
-            auto start = clock.GetMonotonicTimestamp();
-            while (clock.GetMonotonicTimestamp() - start < {{busyWaitMs}}_ms);
-          }
+          using namespace chip::System::Clock::Literals;
+          BusyWaitFor({{busyWaitMs}}_ms);
           {{/if}}
         {{/inline~}}
 

--- a/src/app/tests/suites/commands/delay/DelayCommands.cpp
+++ b/src/app/tests/suites/commands/delay/DelayCommands.cpp
@@ -63,3 +63,14 @@ CHIP_ERROR DelayCommands::RunInternal(const char * command)
     VerifyOrReturnError(system(command) == 0, CHIP_ERROR_INTERNAL);
     return ContinueOnChipMainThread(CHIP_NO_ERROR);
 }
+
+CHIP_ERROR DelayCommands::BusyWaitFor(chip::System::Clock::Milliseconds32 durationInMs)
+{
+    auto & clock = chip::System::SystemClock();
+    auto start   = clock.GetMonotonicTimestamp();
+    while (clock.GetMonotonicTimestamp() - start < durationInMs)
+    {
+        // nothing to do.
+    };
+    return CHIP_NO_ERROR;
+}

--- a/src/app/tests/suites/commands/delay/DelayCommands.h
+++ b/src/app/tests/suites/commands/delay/DelayCommands.h
@@ -37,6 +37,9 @@ public:
     CHIP_ERROR WaitForCommissionableAdvertisement();
     CHIP_ERROR WaitForOperationalAdvertisement();
 
+    // Busy-wait for a given duration in milliseconds
+    CHIP_ERROR BusyWaitFor(chip::System::Clock::Milliseconds32 durationInMs);
+
 private:
     static void OnWaitForMsFn(chip::System::Layer * systemLayer, void * context);
     CHIP_ERROR RunInternal(const char * command);

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -73539,14 +73539,8 @@ private:
 
         ReturnErrorOnFailure(
             chip::Controller::InvokeCommand(mDevices[kIdentityAlpha], this, success, failure, endpoint, request, 1));
-        {
-            using namespace chip::System::Clock::Literals;
-            // Busy-wait for 100 milliseconds.
-            auto & clock = chip::System::SystemClock();
-            auto start   = clock.GetMonotonicTimestamp();
-            while (clock.GetMonotonicTimestamp() - start < 100_ms)
-                ;
-        }
+        using namespace chip::System::Clock::Literals;
+        BusyWaitFor(100_ms);
         return CHIP_NO_ERROR;
     }
 
@@ -73604,14 +73598,8 @@ private:
 
         ReturnErrorOnFailure(
             chip::Controller::InvokeCommand(mDevices[kIdentityAlpha], this, success, failure, endpoint, request, 1));
-        {
-            using namespace chip::System::Clock::Literals;
-            // Busy-wait for 100 milliseconds.
-            auto & clock = chip::System::SystemClock();
-            auto start   = clock.GetMonotonicTimestamp();
-            while (clock.GetMonotonicTimestamp() - start < 100_ms)
-                ;
-        }
+        using namespace chip::System::Clock::Literals;
+        BusyWaitFor(100_ms);
         return CHIP_NO_ERROR;
     }
 
@@ -73706,14 +73694,8 @@ private:
 
         ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::TimedWriteBoolean::TypeInfo>(
             timedWriteBooleanArgument, this, OnSuccessCallback_10, OnFailureCallback_10, 1));
-        {
-            using namespace chip::System::Clock::Literals;
-            // Busy-wait for 100 milliseconds.
-            auto & clock = chip::System::SystemClock();
-            auto start   = clock.GetMonotonicTimestamp();
-            while (clock.GetMonotonicTimestamp() - start < 100_ms)
-                ;
-        }
+        using namespace chip::System::Clock::Literals;
+        BusyWaitFor(100_ms);
         return CHIP_NO_ERROR;
     }
 
@@ -73853,14 +73835,8 @@ private:
 
         ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(
             booleanArgument, this, OnSuccessCallback_16, OnFailureCallback_16, 1));
-        {
-            using namespace chip::System::Clock::Literals;
-            // Busy-wait for 100 milliseconds.
-            auto & clock = chip::System::SystemClock();
-            auto start   = clock.GetMonotonicTimestamp();
-            while (clock.GetMonotonicTimestamp() - start < 100_ms)
-                ;
-        }
+        using namespace chip::System::Clock::Literals;
+        BusyWaitFor(100_ms);
         return CHIP_NO_ERROR;
     }
 


### PR DESCRIPTION
#### Problem

The code to keep busy the event loop for testing timed interaction is generated multiple times while it could just be a method.

#### Change overview
* Convert it to a method

