### PR TITLE
Remove PublishProvisionedDevice/PublishUnprovisionedDevice from Disco…

### DIFF
--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -68,8 +68,6 @@ private:
     DiscoveryImplPlatform & operator=(const DiscoveryImplPlatform &) = delete;
 
     CHIP_ERROR InitImpl();
-    CHIP_ERROR PublishUnprovisionedDevice(chip::Inet::IPAddressType addressType, chip::Inet::InterfaceId interface);
-    CHIP_ERROR PublishProvisionedDevice(chip::Inet::IPAddressType addressType, chip::Inet::InterfaceId interface);
 
     static void HandleDnssdInit(void * context, CHIP_ERROR initError);
     static void HandleDnssdError(void * context, CHIP_ERROR initError);


### PR DESCRIPTION
…very_ImplPlatform.h since they seems unused

#### Problem
While working on [Tests_OptionaInterfaceIdArgument](https://github.com/vivien-apple/connectedhomeip-1/tree/Tests_OptionaInterfaceIdArgument) I stumble on those 2 methods that seems old leftovers.

#### Change overview
* Remove them
