### PR TITLE
ACL/Transport: Add structured subject

### DIFF
--- a/src/access/Subjects.h
+++ b/src/access/Subjects.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include <access/AuthMode.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/InPlace.h>
@@ -27,9 +29,8 @@ namespace Access {
 
 struct PaseSubject
 {
-    PaseSubject(uint16_t aPasscodeId) : passcodeId(aPasscodeId) {}
-    uint16_t passcodeId;
-    bool operator==(const PaseSubject & that) const { return this->passcodeId == that.passcodeId; }
+    static constexpr uint16_t kPasscodeId = 0;
+    bool operator==(const PaseSubject & that) const { return true; }
 };
 
 struct NodeSubject
@@ -108,7 +109,7 @@ public:
     {
         if (mSubject.Is<PaseSubject>())
         {
-            return static_cast<uint64_t>(mSubject.Get<PaseSubject>().passcodeId) << 48;
+            return static_cast<uint64_t>(mSubject.Get<PaseSubject>().kPasscodeId) << 48;
         }
         else if (mSubject.Is<NodeSubject>())
         {
@@ -120,7 +121,7 @@ public:
         }
         else
         {
-            return -1ull;
+            return std::numeric_limits<uint64_t>::max();
         }
     }
 
@@ -150,6 +151,12 @@ public:
     static Subject Create(FabricIndex fabricIndex, Args &&... args)
     {
         return Subject(fabricIndex, InPlaceTemplate<T>, std::forward<Args>(args)...);
+    }
+
+    static Subject CreatePaseSubject()
+    {
+        // Return a unique subject for all PASE sessions.
+        return Subject(kUndefinedFabricIndex, InPlaceTemplate<PaseSubject>);
     }
 
     FabricIndex GetFabricIndex() const { return mFabricIndex; }

--- a/src/access/Subjects.h
+++ b/src/access/Subjects.h
@@ -37,14 +37,14 @@ struct NodeSubject
 {
     NodeSubject(NodeId aNodeId) : nodeId(aNodeId) {}
     NodeId nodeId;
-    bool operator==(const NodeSubject & that) const { return this->nodeId == that.nodeId; }
+    bool operator==(const NodeSubject & that) const { return nodeId == that.nodeId; }
 };
 
 struct GroupSubject
 {
     GroupSubject(GroupId aGroupId) : groupId(aGroupId) {}
     GroupId groupId;
-    bool operator==(const GroupSubject & that) const { return this->groupId == that.groupId; }
+    bool operator==(const GroupSubject & that) const { return groupId == that.groupId; }
 };
 
 class OperationalNodeId;
@@ -125,14 +125,14 @@ public:
         }
     }
 
-    bool operator==(const ScopedSubject & that) const { return this->mSubject == that.mSubject; }
+    bool operator==(const ScopedSubject & that) const { return mSubject == that.mSubject; }
 
 private:
     Variant<PaseSubject, NodeSubject, GroupSubject> mSubject;
 };
 
 /**
- * A subject is a global unique identifier. It suite 2 purpose:
+ * A subject is a global unique identifier. It serves 2 purposes:
  *
  *  1. Identify an entity. operator== can be used to check if 2 subjects are identical.
  *  2. Associate to ACL entries to grant privileges
@@ -164,7 +164,7 @@ public:
 
     bool operator==(const Subject & that) const
     {
-        return this->mFabricIndex == that.mFabricIndex && this->mScopedSubject == that.mScopedSubject;
+        return mFabricIndex == that.mFabricIndex && mScopedSubject == that.mScopedSubject;
     }
 
 private:
@@ -193,7 +193,7 @@ private:
 
     bool operator==(const OperationalNodeId & that) const
     {
-        return this->mFabricIndex == that.mFabricIndex && this->mNodeId == that.mNodeId;
+        return mFabricIndex == that.mFabricIndex && mNodeId == that.mNodeId;
     }
 
     friend bool operator==(const Subject &, const OperationalNodeId &);

--- a/src/access/Subjects.h
+++ b/src/access/Subjects.h
@@ -1,0 +1,201 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <access/AuthMode.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/core/InPlace.h>
+#include <lib/core/NodeId.h>
+#include <lib/support/Variant.h>
+
+namespace chip {
+namespace Access {
+
+struct PaseSubject
+{
+    PaseSubject(uint16_t aPasscodeId) : passcodeId(aPasscodeId) {}
+    uint16_t passcodeId;
+    bool operator==(const PaseSubject & that) const { return this->passcodeId == that.passcodeId; }
+};
+
+struct NodeSubject
+{
+    NodeSubject(NodeId aNodeId) : nodeId(aNodeId) {}
+    NodeId nodeId;
+    bool operator==(const NodeSubject & that) const { return this->nodeId == that.nodeId; }
+};
+
+struct GroupSubject
+{
+    GroupSubject(GroupId aGroupId) : groupId(aGroupId) {}
+    GroupId groupId;
+    bool operator==(const GroupSubject & that) const { return this->groupId == that.groupId; }
+};
+
+class OperationalNodeId;
+
+/** A scoped subject is a unique identifier with-in a fabric scope. */
+class ScopedSubject
+{
+public:
+    ScopedSubject() {}
+
+    template <typename T, class... Args>
+    constexpr explicit ScopedSubject(InPlaceTemplateType<T>, Args &&... args) :
+        mSubject(InPlaceTemplate<T>, std::forward<Args>(args)...)
+    {}
+
+    template <typename T, typename... Args>
+    static ScopedSubject Create(Args &&... args)
+    {
+        return ScopedSubject(InPlaceTemplate<T>, std::forward<Args>(args)...);
+    }
+
+    Access::AuthMode GetAuthMode() const
+    {
+        if (mSubject.Is<PaseSubject>())
+        {
+            return Access::AuthMode::kPase;
+        }
+        else if (mSubject.Is<NodeSubject>())
+        {
+            return Access::AuthMode::kCase;
+        }
+        else if (mSubject.Is<GroupSubject>())
+        {
+            return Access::AuthMode::kGroup;
+        }
+        else
+        {
+            return Access::AuthMode::kNone;
+        }
+    }
+
+#if CHIP_DETAIL_LOGGING
+    const char * GetAuthModeString() const
+    {
+        switch (GetAuthMode())
+        {
+        case Access::AuthMode::kPase:
+            return "Pase";
+        case Access::AuthMode::kCase:
+            return "Case";
+        case Access::AuthMode::kGroup:
+            return "Group";
+        case Access::AuthMode::kNone:
+        default:
+            return "None";
+        }
+    }
+#endif // CHIP_DETAIL_LOGGING
+
+    /** Return subject value described in spec */
+    uint64_t GetValue() const
+    {
+        if (mSubject.Is<PaseSubject>())
+        {
+            return static_cast<uint64_t>(mSubject.Get<PaseSubject>().passcodeId) << 48;
+        }
+        else if (mSubject.Is<NodeSubject>())
+        {
+            return mSubject.Get<NodeSubject>().nodeId;
+        }
+        else if (mSubject.Is<GroupSubject>())
+        {
+            return static_cast<uint64_t>(mSubject.Get<GroupSubject>().groupId) << 48;
+        }
+        else
+        {
+            return -1ull;
+        }
+    }
+
+    bool operator==(const ScopedSubject & that) const { return this->mSubject == that.mSubject; }
+
+private:
+    Variant<PaseSubject, NodeSubject, GroupSubject> mSubject;
+};
+
+/**
+ * A subject is a global unique identifier. It suite 2 purpose:
+ *
+ *  1. Identify an entity. operator== can be used to check if 2 subjects are identical.
+ *  2. Associate to ACL entries to grant privileges
+ */
+class Subject
+{
+public:
+    Subject() : mFabricIndex(kUndefinedFabricIndex) {}
+
+    template <typename T, class... Args>
+    constexpr explicit Subject(FabricIndex fabricIndex, InPlaceTemplateType<T>, Args &&... args) :
+        mFabricIndex(fabricIndex), mScopedSubject(InPlaceTemplate<T>, std::forward<Args>(args)...)
+    {}
+
+    template <typename T, typename... Args>
+    static Subject Create(FabricIndex fabricIndex, Args &&... args)
+    {
+        return Subject(fabricIndex, InPlaceTemplate<T>, std::forward<Args>(args)...);
+    }
+
+    FabricIndex GetFabricIndex() const { return mFabricIndex; }
+    const ScopedSubject & GetScopedSubject() const { return mScopedSubject; }
+
+    bool operator==(const Subject & that) const
+    {
+        return this->mFabricIndex == that.mFabricIndex && this->mScopedSubject == that.mScopedSubject;
+    }
+
+private:
+    FabricIndex mFabricIndex;
+    ScopedSubject mScopedSubject;
+
+    friend bool operator==(const Subject &, const OperationalNodeId &);
+};
+
+/**
+ * OperationalNodeId identifies an individual Node on a Fabric. It is a special type of Subject targeting to NodeSubject. It is
+ * interchangeable with the generic Subject type but uses less memory.
+ */
+class OperationalNodeId
+{
+public:
+    OperationalNodeId(FabricIndex fabricIndex, NodeId nodeId) : mFabricIndex(fabricIndex), mNodeId(nodeId) {}
+    Subject ToSubject() { return Subject::Create<NodeSubject>(mFabricIndex, mNodeId); }
+
+    FabricIndex GetFabricIndex() const { return mFabricIndex; }
+    NodeId GetNodeId() const { return mNodeId; }
+
+private:
+    FabricIndex mFabricIndex;
+    NodeId mNodeId;
+
+    bool operator==(const OperationalNodeId & that) const
+    {
+        return this->mFabricIndex == that.mFabricIndex && this->mNodeId == that.mNodeId;
+    }
+
+    friend bool operator==(const Subject &, const OperationalNodeId &);
+};
+
+inline bool operator==(const Subject & subject, const OperationalNodeId & node)
+{
+    return subject.mFabricIndex == node.mFabricIndex && subject.mScopedSubject == ScopedSubject::Create<NodeSubject>(node.mNodeId);
+}
+
+} // namespace Access
+} // namespace chip

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -378,5 +378,12 @@ bool IsCategoryEnabled(uint8_t category);
  */
 #define ChipLogFormatMessageType "0x%x"
 
+/**
+ * Logging helpers for Subject
+ */
+#define ChipLogFormatSubject "< %u, %s, " ChipLogFormatX64 ">"
+#define ChipLogValueSubject(subject)                                                                                               \
+    subject.GetFabricIndex(), subject.GetScopedSubject().GetAuthModeString(), ChipLogValueX64(subject.GetScopedSubject().GetValue())
+
 } // namespace Logging
 } // namespace chip

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -383,7 +383,8 @@ bool IsCategoryEnabled(uint8_t category);
  */
 #define ChipLogFormatSubject "< %u, %s, " ChipLogFormatX64 ">"
 #define ChipLogValueSubject(subject)                                                                                               \
-    subject.GetFabricIndex(), subject.GetScopedSubject().GetAuthModeString(), ChipLogValueX64(subject.GetScopedSubject().GetValue())
+    subject.GetFabricIndex(), subject.GetScopedSubject().GetAuthModeString(),                                                      \
+        ChipLogValueX64(subject.GetScopedSubject().GetSubjectId())
 
 } // namespace Logging
 } // namespace chip

--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -38,6 +38,11 @@ public:
     const char * GetSessionTypeString() const override { return "secure"; };
 #endif
 
+    Access::Subject GetSubject() const override
+    {
+        return Access::Subject::Create<Access::GroupSubject>(GetFabricIndex(), mGroupId);
+    }
+
     Access::SubjectDescriptor GetSubjectDescriptor() const override
     {
         Access::SubjectDescriptor subjectDescriptor;

--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -43,6 +43,16 @@ public:
         return Access::Subject::Create<Access::GroupSubject>(GetFabricIndex(), mGroupId);
     }
 
+    bool MatchSubject(const Access::Subject & subject) const override
+    {
+        return Access::Subject::Create<Access::GroupSubject>(GetFabricIndex(), mGroupId).Match(subject);
+    }
+
+    bool MatchSubject(const Access::ScopedSubject & scopedSubject) const override
+    {
+        return Access::ScopedSubject::Create<Access::GroupSubject>(mGroupId).Match(scopedSubject);
+    }
+
     Access::SubjectDescriptor GetSubjectDescriptor() const override
     {
         Access::SubjectDescriptor subjectDescriptor;

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -37,6 +37,37 @@ Access::Subject SecureSession::GetSubject() const
     }
 }
 
+bool SecureSession::MatchSubject(const Access::Subject & subject) const
+{
+    return GetFabricIndex() == subject.GetFabricIndex() && MatchSubject(subject.GetScopedSubject());
+}
+
+bool SecureSession::MatchSubject(const Access::ScopedSubject & scopedSubject) const
+{
+    if (IsOperationalNodeId(mPeerNodeId))
+    {
+        if (Access::ScopedSubject::Create<Access::NodeSubject>(mPeerNodeId).Match(scopedSubject))
+        {
+            return true;
+        }
+    }
+    else if (IsPAKEKeyId(mPeerNodeId))
+    {
+        if (Access::ScopedSubject::Create<Access::PaseSubject>().Match(scopedSubject))
+        {
+            return true;
+        }
+    }
+    else
+    {
+        VerifyOrDie(false);
+        return false;
+    }
+
+    // TODO: match againse CATs
+    return false;
+}
+
 Access::SubjectDescriptor SecureSession::GetSubjectDescriptor() const
 {
     Access::SubjectDescriptor subjectDescriptor;

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -20,6 +20,23 @@
 namespace chip {
 namespace Transport {
 
+Access::Subject SecureSession::GetSubject() const
+{
+    if (IsOperationalNodeId(mPeerNodeId))
+    {
+        return Access::Subject::Create<Access::NodeSubject>(GetFabricIndex(), mPeerNodeId);
+    }
+    else if (IsPAKEKeyId(mPeerNodeId))
+    {
+        return Access::Subject::Create<Access::PaseSubject>(GetFabricIndex(), static_cast<uint16_t>(mPeerNodeId >> 48));
+    }
+    else
+    {
+        VerifyOrDie(false);
+        return Access::Subject();
+    }
+}
+
 Access::SubjectDescriptor SecureSession::GetSubjectDescriptor() const
 {
     Access::SubjectDescriptor subjectDescriptor;

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -28,7 +28,7 @@ Access::Subject SecureSession::GetSubject() const
     }
     else if (IsPAKEKeyId(mPeerNodeId))
     {
-        return Access::Subject::Create<Access::PaseSubject>(GetFabricIndex(), static_cast<uint16_t>(mPeerNodeId >> 48));
+        return Access::Subject::CreatePaseSubject();
     }
     else
     {

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -84,6 +84,8 @@ public:
 #endif
 
     Access::Subject GetSubject() const override;
+    bool MatchSubject(const Access::Subject & subject) const override;
+    bool MatchSubject(const Access::ScopedSubject & scopedSubject) const override;
     Access::SubjectDescriptor GetSubjectDescriptor() const override;
 
     bool RequireMRP() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kUdp; }

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -83,6 +83,7 @@ public:
     const char * GetSessionTypeString() const override { return "secure"; };
 #endif
 
+    Access::Subject GetSubject() const override;
     Access::SubjectDescriptor GetSubjectDescriptor() const override;
 
     bool RequireMRP() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kUdp; }

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -64,8 +64,11 @@ public:
     virtual void Retain() {}
     virtual void Release() {}
 
-    virtual Access::Subject GetSubject() const                         = 0;
-    virtual Access::SubjectDescriptor GetSubjectDescriptor() const     = 0;
+    virtual Access::Subject GetSubject() const                                   = 0;
+    virtual bool MatchSubject(const Access::Subject & subject) const             = 0;
+    virtual bool MatchSubject(const Access::ScopedSubject & scopedSubject) const = 0;
+    virtual Access::SubjectDescriptor GetSubjectDescriptor() const               = 0;
+
     virtual bool RequireMRP() const                                    = 0;
     virtual const ReliableMessageProtocolConfig & GetMRPConfig() const = 0;
     virtual System::Clock::Milliseconds32 GetAckTimeout() const        = 0;

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <access/Subjects.h>
 #include <credentials/FabricTable.h>
 #include <lib/core/CHIPConfig.h>
 #include <messaging/ReliableMessageProtocolConfig.h>
@@ -63,6 +64,7 @@ public:
     virtual void Retain() {}
     virtual void Release() {}
 
+    virtual Access::Subject GetSubject() const                         = 0;
     virtual Access::SubjectDescriptor GetSubjectDescriptor() const     = 0;
     virtual bool RequireMRP() const                                    = 0;
     virtual const ReliableMessageProtocolConfig & GetMRPConfig() const = 0;

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -75,6 +75,11 @@ public:
     void Release() override { ReferenceCounted<UnauthenticatedSession, UnauthenticatedSessionDeleter, 0>::Release(); }
 
     Access::Subject GetSubject() const override { return Access::Subject(); }
+
+    bool MatchSubject(const Access::Subject & subject) const override { return false; }
+
+    bool MatchSubject(const Access::ScopedSubject & scopedSubject) const override { return false; }
+
     Access::SubjectDescriptor GetSubjectDescriptor() const override
     {
         return Access::SubjectDescriptor(); // return an empty ISD for unauthenticated session.

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -74,6 +74,7 @@ public:
     void Retain() override { ReferenceCounted<UnauthenticatedSession, UnauthenticatedSessionDeleter, 0>::Retain(); }
     void Release() override { ReferenceCounted<UnauthenticatedSession, UnauthenticatedSessionDeleter, 0>::Release(); }
 
+    Access::Subject GetSubject() const override { return Access::Subject(); }
     Access::SubjectDescriptor GetSubjectDescriptor() const override
     {
         return Access::SubjectDescriptor(); // return an empty ISD for unauthenticated session.


### PR DESCRIPTION
#### Problem
SubjectDescriptor is not easy to use. Prepare to fix #13397

#### Change overview
* Add a new class `Subject` contains information about SubjectDescriptor
* Add a new class `OperationalNodeId` contains tuple `<FabricIndex, NodeId>`
* Add a new API `GetSubject` in session interface which returns a structured `SubjectDescriptor` object
* Introduce log maco `ChipLogFormatSubject` and `ChipLogValueSubject` to help print `Subject` structure

#### Testing
Passed unit-tests