### PR TITLE
Use the correct size for attestation challenge when converting to Java

### DIFF
--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -599,7 +599,7 @@ JNI_METHOD(jbyteArray, getAttestationChallenge)
     err                                      = wrapper->Controller()->GetAttestationChallenge(attestationChallenge);
     SuccessOrExit(err);
 
-    err = JniReferences::GetInstance().N2J_ByteArray(env, attestationChallenge.data(), sizeof(attestationChallenge.data()),
+    err = JniReferences::GetInstance().N2J_ByteArray(env, attestationChallenge.data(), attestationChallenge.size(),
                                                      attestationChallengeJbytes);
     SuccessOrExit(err);
 


### PR DESCRIPTION
#### Problem

Fixes issue where the wrong number of bytes is returned from the Java API to return an attestation challenge.

#### Testing
* Tested locally, adding logging to C++ and Java side to ensure the correct value was seen on both sides.