### PR TITLE
Fixed Undefined VendoId Value is 0xFFFF (Not 0x0)

### DIFF
--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -236,7 +236,7 @@ public:
     void Reset()
     {
         mOperationalId  = PeerId();
-        mVendorId       = kUndefinedVendorId;
+        mVendorId       = VendorId::NotSpecified;
         mFabricLabel[0] = '\0';
 
         if (mOperationalKey != nullptr)
@@ -260,7 +260,7 @@ private:
     PeerId mOperationalId;
 
     FabricIndex mFabric                                 = kUndefinedFabricIndex;
-    uint16_t mVendorId                                  = kUndefinedVendorId;
+    uint16_t mVendorId                                  = VendorId::NotSpecified;
     char mFabricLabel[kFabricLabelMaxLengthInBytes + 1] = { '\0' };
 
 #ifdef ENABLE_HSM_CASE_OPS_KEY

--- a/src/lib/core/PeerId.h
+++ b/src/lib/core/PeerId.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ using FabricId           = uint64_t;
 constexpr CompressedFabricId kUndefinedCompressedFabricId = 0ULL;
 
 constexpr FabricId kUndefinedFabricId = 0ULL;
-constexpr uint16_t kUndefinedVendorId = 0U;
 
 /// A peer is identified by a node id within a compressed fabric ID
 class PeerId


### PR DESCRIPTION
#### Problem
In some places in the code the value 0 is used as Undefined Vendor Id, which is wrong. The correct value is 0xFFFF.

#### Change overview
fixed

#### Testing
All existing tests