### PR TITLE
Add a sanity check for attestation challenge length before returning

### DIFF
--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -598,6 +598,7 @@ JNI_METHOD(jbyteArray, getAttestationChallenge)
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
     err                                      = wrapper->Controller()->GetAttestationChallenge(attestationChallenge);
     SuccessOrExit(err);
+    VerifyOrExit(attestationChallenge.size() == 16, err = CHIP_ERROR_INVALID_ARGUMENT);
 
     err = JniReferences::GetInstance().N2J_ByteArray(env, attestationChallenge.data(), attestationChallenge.size(),
                                                      attestationChallengeJbytes);


### PR DESCRIPTION
The challenge should always be exactly 16 bytes.

Relates to the previous PR: https://github.com/project-chip/connectedhomeip/pull/15420

This just adds a sanity check to ensure a valid value is being returned.

#### Testing
Tested locally on Java and verified I was still able to retrieve the attestation challenge