### PR TITLE
Stop using sync message delivery in AppContext.

### DIFF
--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -634,6 +634,14 @@ CHIP_ERROR Engine::SetDirty(ClusterInfo & aClusterInfo)
         *clusterInfo = aClusterInfo;
     }
 
+    // Schedule work to run asynchronously on the CHIP thread. The scheduled
+    // work won't execute until the current execution context has
+    // completed. This ensures that we can 'gather up' multiple attribute
+    // changes that have occurred in the same execution context without
+    // requiring any explicit 'start' or 'end' change calls into the engine to
+    // book-end the change.
+    ScheduleRun();
+
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/tests/AppTestContext.h
+++ b/src/app/tests/AppTestContext.h
@@ -30,6 +30,9 @@ class AppContext : public LoopbackMessagingContext<>
     typedef LoopbackMessagingContext<> Super;
 
 public:
+    // Disallow initialization as a sync loopback context.
+    static void Initialize(void *) = delete;
+
     /// Initialize the underlying layers.
     CHIP_ERROR Init() override;
 

--- a/src/app/tests/TestAttributeCache.cpp
+++ b/src/app/tests/TestAttributeCache.cpp
@@ -539,7 +539,7 @@ nlTestSuite theSuite =
 {
     "TestAttributeCache",
     &sTests[0],
-    TestContext::Initialize,
+    TestContext::InitializeAsync,
     TestContext::Finalize
 };
 

--- a/src/app/tests/TestBufferedReadCallback.cpp
+++ b/src/app/tests/TestBufferedReadCallback.cpp
@@ -609,7 +609,7 @@ nlTestSuite theSuite =
 {
     "TestBufferedReadCallback",
     &sTests[0],
-    TestContext::Initialize,
+    TestContext::InitializeAsync,
     TestContext::Finalize
 };
 

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -429,6 +429,8 @@ void TestCommandInteraction::TestCommandSenderWithSendCommand(nlTestSuite * apSu
     err = commandSender.SendCommandRequest(ctx.GetSessionBobToAlice());
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
+    ctx.DrainAndServiceIO();
+
     GenerateInvokeResponse(apSuite, apContext, buf, true /*aNeedCommandData*/);
     err = commandSender.ProcessInvokeResponse(std::move(buf));
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -616,6 +618,9 @@ void TestCommandInteraction::TestCommandSenderCommandSuccessResponseFlow(nlTestS
     err = commandSender.SendCommandRequest(ctx.GetSessionBobToAlice());
 
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    ctx.DrainAndServiceIO();
+
     NL_TEST_ASSERT(apSuite,
                    mockCommandSenderDelegate.onResponseCalledTimes == 1 && mockCommandSenderDelegate.onFinalCalledTimes == 1 &&
                        mockCommandSenderDelegate.onErrorCalledTimes == 0);
@@ -637,6 +642,9 @@ void TestCommandInteraction::TestCommandSenderCommandAsyncSuccessResponseFlow(nl
     err          = commandSender.SendCommandRequest(ctx.GetSessionBobToAlice());
 
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    ctx.DrainAndServiceIO();
+
     NL_TEST_ASSERT(apSuite,
                    mockCommandSenderDelegate.onResponseCalledTimes == 0 && mockCommandSenderDelegate.onFinalCalledTimes == 0 &&
                        mockCommandSenderDelegate.onErrorCalledTimes == 0);
@@ -646,6 +654,9 @@ void TestCommandInteraction::TestCommandSenderCommandAsyncSuccessResponseFlow(nl
 
     // Decrease CommandHandler refcount and send response
     asyncCommandHandle = nullptr;
+
+    ctx.DrainAndServiceIO();
+
     NL_TEST_ASSERT(apSuite,
                    mockCommandSenderDelegate.onResponseCalledTimes == 1 && mockCommandSenderDelegate.onFinalCalledTimes == 1 &&
                        mockCommandSenderDelegate.onErrorCalledTimes == 0);
@@ -666,6 +677,9 @@ void TestCommandInteraction::TestCommandSenderCommandSpecificResponseFlow(nlTest
     err = commandSender.SendCommandRequest(ctx.GetSessionBobToAlice());
 
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    ctx.DrainAndServiceIO();
+
     NL_TEST_ASSERT(apSuite,
                    mockCommandSenderDelegate.onResponseCalledTimes == 1 && mockCommandSenderDelegate.onFinalCalledTimes == 1 &&
                        mockCommandSenderDelegate.onErrorCalledTimes == 0);
@@ -685,7 +699,12 @@ void TestCommandInteraction::TestCommandSenderCommandFailureResponseFlow(nlTestS
     AddInvokeRequestData(apSuite, apContext, &commandSender, kTestNonExistCommandId);
     err = commandSender.SendCommandRequest(ctx.GetSessionBobToAlice());
 
+    ctx.DrainAndServiceIO();
+
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    ctx.DrainAndServiceIO();
+
     NL_TEST_ASSERT(apSuite,
                    mockCommandSenderDelegate.onResponseCalledTimes == 0 && mockCommandSenderDelegate.onFinalCalledTimes == 1 &&
                        mockCommandSenderDelegate.onErrorCalledTimes == 1);
@@ -714,6 +733,8 @@ void TestCommandInteraction::TestCommandSenderAbruptDestruction(nlTestSuite * ap
         err = commandSender.SendCommandRequest(ctx.GetSessionBobToAlice());
 
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        ctx.DrainAndServiceIO();
 
         //
         // No callbacks should be invoked yet - let's validate that.
@@ -766,7 +787,7 @@ nlTestSuite sSuite =
 {
     "TestCommandInteraction",
     &sTests[0],
-    TestContext::Initialize,
+    TestContext::InitializeAsync,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/app/tests/TestEventLogging.cpp
+++ b/src/app/tests/TestEventLogging.cpp
@@ -60,9 +60,9 @@ static chip::app::CircularEventBuffer gCircularEventBuffer[3];
 class TestContext : public chip::Test::AppContext
 {
 public:
-    static int Initialize(void * context)
+    static int InitializeAsync(void * context)
     {
-        if (AppContext::Initialize(context) != SUCCESS)
+        if (AppContext::InitializeAsync(context) != SUCCESS)
             return FAILURE;
 
         auto * ctx = static_cast<TestContext *>(context);
@@ -294,7 +294,7 @@ nlTestSuite sSuite =
 {
     "EventLogging",
     &sTests[0],
-    TestContext::Initialize,
+    TestContext::InitializeAsync,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -107,7 +107,7 @@ nlTestSuite sSuite =
 {
     "TestInteractionModelEngine",
     &sTests[0],
-    TestContext::Initialize,
+    TestContext::InitializeAsync,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -159,7 +159,7 @@ nlTestSuite sSuite =
 {
     "TestReportingEngine",
     &sTests[0],
-    TestContext::Initialize,
+    TestContext::InitializeAsync,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -226,6 +226,8 @@ void TestWriteInteraction::TestWriteClient(nlTestSuite * apSuite, void * apConte
     err = writeClient.SendWriteRequest(ctx.GetSessionBobToAlice());
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
+    ctx.DrainAndServiceIO();
+
     GenerateWriteResponse(apSuite, apContext, buf);
 
     err = writeClient.ProcessWriteResponseMessage(std::move(buf));
@@ -255,6 +257,9 @@ void TestWriteInteraction::TestWriteClientGroup(nlTestSuite * apSuite, void * ap
     err = writeClient.SendWriteRequest(groupSession);
 
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    ctx.DrainAndServiceIO();
+
     // The WriteClient should be shutdown once we SendWriteRequest for group.
     NL_TEST_ASSERT(apSuite, writeClient.mState == WriteClient::State::AwaitingDestruction);
 }
@@ -380,6 +385,8 @@ void TestWriteInteraction::TestWriteRoundtripWithClusterObjects(nlTestSuite * ap
     err = writeClient.SendWriteRequest(ctx.GetSessionBobToAlice());
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
+    ctx.DrainAndServiceIO();
+
     NL_TEST_ASSERT(apSuite, callback.mOnSuccessCalled == 1);
 
     {
@@ -429,6 +436,8 @@ void TestWriteInteraction::TestWriteRoundtrip(nlTestSuite * apSuite, void * apCo
     err = writeClient.SendWriteRequest(ctx.GetSessionBobToAlice());
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
+    ctx.DrainAndServiceIO();
+
     NL_TEST_ASSERT(apSuite, callback.mOnSuccessCalled == 1 && callback.mOnErrorCalled == 0 && callback.mOnDoneCalled == 1);
 
     // By now we should have closed all exchanges and sent all pending acks, so
@@ -468,7 +477,7 @@ int Test_Setup(void * inContext)
 {
     VerifyOrReturnError(CHIP_NO_ERROR == chip::Platform::MemoryInit(), FAILURE);
 
-    VerifyOrReturnError(TestContext::Initialize(inContext) == SUCCESS, FAILURE);
+    VerifyOrReturnError(TestContext::InitializeAsync(inContext) == SUCCESS, FAILURE);
 
     VerifyOrReturnError(CHIP_NO_ERROR == chip::GroupTesting::InitGroupData(), FAILURE);
 

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -1028,11 +1028,6 @@ void MatterReportingAttributeChangeCallback(EndpointId endpoint, ClusterId clust
 
     IncreaseClusterDataVersion(ConcreteClusterPath(endpoint, clusterId));
     InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(info);
-
-    // Schedule work to run asynchronously on the CHIP thread. The scheduled work won't execute until the current execution context
-    // has completed. This ensures that we can 'gather up' multiple attribute changes that have occurred in the same execution
-    // context without requiring any explicit 'start' or 'end' change calls into the engine to book-end the change.
-    InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
 }
 
 void MatterReportingAttributeChangeCallback(const ConcreteAttributePath & aPath)

--- a/src/controller/tests/TestReadChunking.cpp
+++ b/src/controller/tests/TestReadChunking.cpp
@@ -267,17 +267,8 @@ void TestCommandInteraction::TestChunking(nlTestSuite * apSuite, void * apContex
 
         NL_TEST_ASSERT(apSuite, readClient.SendRequest(readParams) == CHIP_NO_ERROR);
 
-        //
-        // Service the IO + Engine till we get a ReportEnd callback on the client.
-        // Since bugs can happen, we don't want this test to never stop, so create a ceiling for how many
-        // times this can run without seeing expected results.
-        //
-        for (int j = 0; j < 20 && !readCallback.mOnReportEnd; j++)
-        {
-            ctx.DrainAndServiceIO();
-            chip::app::InteractionModelEngine::GetInstance()->GetReportingEngine().Run();
-            ctx.DrainAndServiceIO();
-        }
+        ctx.DrainAndServiceIO();
+        NL_TEST_ASSERT(apSuite, readCallback.mOnReportEnd);
 
         //
         // Always returns the same number of attributes read (5 + revision +
@@ -341,17 +332,8 @@ void TestCommandInteraction::TestListChunking(nlTestSuite * apSuite, void * apCo
 
         NL_TEST_ASSERT(apSuite, readClient.SendRequest(readParams) == CHIP_NO_ERROR);
 
-        //
-        // Service the IO + Engine till we get a ReportEnd callback on the client.
-        // Since bugs can happen, we don't want this test to never stop, so create a ceiling for how many
-        // times this can run without seeing expected results.
-        //
-        for (int j = 0; j < 10 && !readCallback.mOnReportEnd; j++)
-        {
-            ctx.DrainAndServiceIO();
-            chip::app::InteractionModelEngine::GetInstance()->GetReportingEngine().Run();
-            ctx.DrainAndServiceIO();
-        }
+        ctx.DrainAndServiceIO();
+        NL_TEST_ASSERT(apSuite, readCallback.mOnReportEnd);
 
         //
         // Always returns the same number of attributes read (merged by buffered read callback). The content is checked in
@@ -402,20 +384,15 @@ void TestCommandInteraction::TestBadChunking(nlTestSuite * apSuite, void * apCon
 
         NL_TEST_ASSERT(apSuite, readClient.SendRequest(readParams) == CHIP_NO_ERROR);
 
-        //
-        // Service the IO + Engine till we get a ReportEnd callback on the client.
+        ctx.DrainAndServiceIO();
+
         // The server should return an empty list as attribute data for the first report (for list chunking), and encodes nothing
         // (then shuts down the read handler) for the second report.
         //
-        for (int j = 0; j < 2; j++)
-        {
-            ctx.DrainAndServiceIO();
-            chip::app::InteractionModelEngine::GetInstance()->GetReportingEngine().Run();
-            ctx.DrainAndServiceIO();
-        }
 
         // Nothing is actually encoded. buffered callback does not handle the message to us.
         NL_TEST_ASSERT(apSuite, readCallback.mAttributeCount == 0);
+        NL_TEST_ASSERT(apSuite, !readCallback.mOnReportEnd);
 
         // The server should shutted down, while the client is still alive (pending for the attribute data.)
         NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -244,15 +244,15 @@ CHIP_ERROR SessionManager::SendPreparedMessage(const SessionHandle & sessionHand
     VerifyOrReturnError(mState == State::kInitialized, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(!preparedMessage.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
 
+    Transport::PeerAddress multicastAddress; // Only used for the group case
     const Transport::PeerAddress * destination;
 
     switch (sessionHandle->GetSessionType())
     {
     case Transport::Session::SessionType::kGroup: {
         auto groupSession = sessionHandle->AsGroupSession();
-        Transport::PeerAddress multicastAddress =
-            Transport::PeerAddress::Multicast(groupSession->GetFabricIndex(), groupSession->GetGroupId());
-        destination = &multicastAddress; // XXX: this is dangling pointer, must be fixed
+        multicastAddress  = Transport::PeerAddress::Multicast(groupSession->GetFabricIndex(), groupSession->GetGroupId());
+        destination       = &multicastAddress;
         char addressStr[Transport::PeerAddress::kMaxToStringSize];
         multicastAddress.ToString(addressStr, Transport::PeerAddress::kMaxToStringSize);
 


### PR DESCRIPTION
Switches various interaction model tests to async delivery.

Fixes https://github.com/project-chip/connectedhomeip/issues/15402

#### Problem
We are doing sync message delivery and manual reporting Run() calls to cover up for that.

#### Change overview
1. Make sure that we schedule a reporting run whenever a path is marked dirty.
2. Disallow initializing Test::AppContext for sync message delivery.
3. Remove all manual `Run()` calls for reporting from tests.
4. Add `DrainAndServiceIO()` calls in the places where we want to deliver messages.
5. Fix existing dangling pointer issue in `SessionManager::SendPreparedMessage` that is now getting caught because the loopback transport actually does something with the PeerAddress now instead of just passing it along as a reference.

The chunking bits in `TestReadChunking.cpp` required some complexity in the delegate to keep testing the thing we used to be testing.

#### Testing
The tests all pass with async message delivery.