### PR TITLE
Fix include path after movement of attestation verifier

### DIFF
--- a/src/tools/chip-cert/Cmd_ValidateAttCert.cpp
+++ b/src/tools/chip-cert/Cmd_ValidateAttCert.cpp
@@ -25,9 +25,7 @@
 
 #include "chip-cert.h"
 
-//#include "vector"
-
-#include <credentials/DeviceAttestationVerifier.h>
+#include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
 
 namespace {
 


### PR DESCRIPTION
#### Problem
TOT compilation broken.

#### Change overview
Update an include path.

#### Testing
Compiled chip cert locally and it passed.