### PR TITLE
[IM] Ensure we reject operations on fabric scoped attributes when using PASE session before AddNOC

### DIFF
--- a/src/app/AttributeAccessInterface.h
+++ b/src/app/AttributeAccessInterface.h
@@ -337,8 +337,9 @@ public:
     CHIP_ERROR Decode(T & aArg)
     {
         mTriedDecode = true;
-        // TODO: We may want to reject kUndefinedFabricIndex for writing fabric scoped data. mAccessingFabricIndex will be
-        // kUndefinedFabricIndex on PASE sessions.
+        // The WriteRequest comes with no fabric index, this will happen when receiving a write request on a PASE session before
+        // AddNOC.
+        VerifyOrReturnError(AccessingFabricIndex() != kUndefinedFabricIndex, CHIP_IM_GLOBAL_STATUS(UnsupportedAccess));
         ReturnErrorOnFailure(DataModel::Decode(mReader, aArg));
         aArg.SetFabricIndex(AccessingFabricIndex());
         return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem

Fixes #14586 

#### Change overview

Addes a check to AttributeAccessInterface.h

#### Testing

The testing session comes with a fabric id,. so we add a override when accessing testing attribute.
