### PR TITLE
Set Expiry time on DNS SD resolved data

### DIFF
--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -61,8 +61,9 @@ private:
     NodeData & mNodeData;
 };
 
-constexpr size_t kMdnsMaxPacketSize = 1024;
-constexpr uint16_t kMdnsPort        = 5353;
+constexpr size_t kMdnsMaxPacketSize   = 1024;
+constexpr uint16_t kMdnsPort          = 5353;
+constexpr uint16_t kDefaultTtlSeconds = 120;
 
 using namespace mdns::Minimal;
 using DnssdCacheType = Dnssd::DnssdCache<CHIP_CONFIG_MDNS_CACHE_SIZE>;
@@ -340,6 +341,9 @@ void PacketDataReporter::OnComplete(ActiveResolveAttempts & activeAttempts)
         activeAttempts.Complete(mNodeData.mPeerId);
         mNodeData.LogNodeIdResolved();
         mNodeData.PrioritizeAddresses();
+
+        const System::Clock::Timestamp currentTime = System::SystemClock().GetMonotonicTimestamp();
+        mNodeData.mExpiryTime                      = currentTime + System::Clock::Seconds16(kDefaultTtlSeconds);
 
         if (mOperationalDelegate != nullptr)
         {

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -342,6 +342,9 @@ void PacketDataReporter::OnComplete(ActiveResolveAttempts & activeAttempts)
         mNodeData.LogNodeIdResolved();
         mNodeData.PrioritizeAddresses();
 
+        //
+        // This is a quick fix to address some failing tests. Issue #15489 tracks the correct fix here.
+        //
         const System::Clock::Timestamp currentTime = System::SystemClock().GetMonotonicTimestamp();
         mNodeData.mExpiryTime                      = currentTime + System::Clock::Seconds16(kDefaultTtlSeconds);
 


### PR DESCRIPTION
The expiry time wasn't being set properly on DNS resolution results in
the Minimal mDNS impl. This was causing some of the Cirque tests to
fail to resolve at times:

```
CRITICAL:PythonMatterControllerTEST:Testfail: Failed to resolve nodeid
Node address has been updated
Node address has been updated
Established CASE with Device
2022-02-18 00:04:00,125 [PythonMatterControllerTEST] CRITICAL Testfail: Failed to resolve nodeid
```

Tests:
Repro'ed the failure and validated that the change fixed it.
