### PR TITLE
Remove unused key id persistence.

### DIFF
--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -365,8 +365,6 @@ protected:
     CHIP_ERROR SetPairedDeviceList(ByteSpan pairedDeviceSerializedSet);
     ControllerDeviceInitParams GetControllerDeviceInitParams();
 
-    void PersistNextKeyId();
-
     OperationalCredentialsDelegate * mOperationalCredentialsDelegate;
 
     SessionIDAllocator mIDAllocator;
@@ -691,8 +689,6 @@ private:
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
     void SetupCluster(ClusterBase & base, DeviceProxy * proxy, EndpointId endpoint, Optional<System::Clock::Timeout> timeout);
-
-    void FreeRendezvousSession();
 
     CHIP_ERROR LoadKeyId(PersistentStorageDelegate * delegate, uint16_t & out);
 

--- a/src/lib/support/PersistentStorageMacros.h
+++ b/src/lib/support/PersistentStorageMacros.h
@@ -29,7 +29,6 @@ namespace chip {
 
 constexpr const char kPairedDeviceListKeyPrefix[] = "ListPairedDevices";
 constexpr const char kPairedDeviceKeyPrefix[]     = "PairedDevice";
-constexpr const char kNextAvailableKeyID[]        = "StartKeyID";
 
 // This macro generates a key for storage using a node ID and a key prefix, and performs the given action
 // on that key.


### PR DESCRIPTION
We are writing the key ids, but never reading them.  And there is no
real reason to persist these; they should just be ephemeral as long as
the sessions are not being persisted.

#### Problem
Dead code writing key ids that never get read.

#### Change overview
Remove it.

#### Testing
Should be no behavior changes; it's dead code.