### PR TITLE
[CI] Enable test discovery again

### DIFF
--- a/examples/chip-tool/templates/tests/tests.js
+++ b/examples/chip-tool/templates/tests/tests.js
@@ -18,7 +18,6 @@
 function getManualTests()
 {
   const DeviceDiscovery = [
-    'TestDiscovery',
     'Test_TC_DD_1_5',
     'Test_TC_DD_1_6',
     'Test_TC_DD_1_7',
@@ -449,6 +448,7 @@ function getTests()
     'TestClusterComplexTypes',
     'TestConstraints',
     'TestDelayCommands',
+    'TestDiscovery',
     'TestLogCommands',
     'TestSaveAs',
     'TestConfigVariables',

--- a/src/app/tests/suites/TestDiscovery.yaml
+++ b/src/app/tests/suites/TestDiscovery.yaml
@@ -56,10 +56,6 @@ tests:
               - name: "CommissioningTimeout"
                 value: 120
 
-    - label: "Wait Commissionable advertisement"
-      cluster: "DelayCommands"
-      command: "WaitForCommissionableAdvertisement"
-
     - label: "Check Instance Name"
       cluster: "DiscoveryCommands"
       command: "FindCommissionable"
@@ -296,10 +292,6 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 120
-
-    - label: "Wait Commissionable advertisement"
-      cluster: "DelayCommands"
-      command: "WaitForCommissionableAdvertisement"
 
     - label: "Check Instance Name"
       cluster: "DiscoveryCommands"


### PR DESCRIPTION
#### Problem

This PR tries to moves back `TestDiscovery` to the list of tests that are automatically runs on CI now that https://github.com/project-chip/connectedhomeip/pull/15411 has landed and it should limit the scope of the mdns advertisements.

#### Change overview
* Move `TestDiscovery` to the list of tests automatically runned
* Update `TestDiscovery` to not wait for the device advertisement itself before browsing, that should makes it clearer if #15411 works properly or not.

#### Testing
`TestDiscovery` will run automatically .