### PR TITLE
Update address resolve interface to only use OperationalDiscovery interface

### DIFF
--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -178,11 +178,11 @@ CHIP_ERROR Resolver::LookupNode(const NodeLookupRequest & request, Impl::NodeLoo
 CHIP_ERROR Resolver::Init(System::Layer * systemLayer)
 {
     mSystemLayer = systemLayer;
-    Dnssd::Resolver::Instance().SetResolverDelegate(this);
+    Dnssd::Resolver::Instance().SetOperationalDelegate(this);
     return CHIP_NO_ERROR;
 }
 
-void Resolver::OnNodeIdResolved(const Dnssd::ResolvedNodeData & nodeData)
+void Resolver::OnOperationalNodeResolved(const Dnssd::ResolvedNodeData & nodeData)
 {
     auto it = mActiveLookups.begin();
     while (it != mActiveLookups.end())
@@ -230,7 +230,7 @@ void Resolver::HandleTimer()
     ReArmTimer();
 }
 
-void Resolver::OnNodeIdResolutionFailed(const PeerId & peerId, CHIP_ERROR error)
+void Resolver::OnOperationalNodeResolutionFailed(const PeerId & peerId, CHIP_ERROR error)
 {
     auto it = mActiveLookups.begin();
     while (it != mActiveLookups.end())
@@ -286,15 +286,6 @@ void Resolver::ReArmTimer()
             it = mActiveLookups.begin();
         }
     }
-}
-
-void Resolver::OnNodeDiscoveryComplete(const Dnssd::DiscoveredNodeData & nodeData)
-{
-    // This is for Commissionable discovery and such lookup is not performed by
-    // the address resolver.
-    //
-    // Getting this callback likely means that linkages of delegates is not done correctly.
-    ChipLogError(Discovery, "UNEXPECTED/UNIMPLEMENTED commissionable discovery callback");
 }
 
 } // namespace Impl

--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.h
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.h
@@ -71,7 +71,7 @@ private:
     unsigned mBestAddressScore = 0;
 };
 
-class Resolver : public ::chip::AddressResolve::Resolver, public Dnssd::ResolverDelegate
+class Resolver : public ::chip::AddressResolve::Resolver, public Dnssd::OperationalResolveDelegate
 {
 public:
     virtual ~Resolver() = default;
@@ -81,11 +81,10 @@ public:
     CHIP_ERROR Init(System::Layer * systemLayer) override;
     CHIP_ERROR LookupNode(const NodeLookupRequest & request, Impl::NodeLookupHandle & handle) override;
 
-    // Dnssd::ResolverDelegate
+    // Dnssd::OperationalResolveDelegate
 
-    void OnNodeIdResolved(const Dnssd::ResolvedNodeData & nodeData) override;
-    void OnNodeIdResolutionFailed(const PeerId & peerId, CHIP_ERROR error) override;
-    void OnNodeDiscoveryComplete(const Dnssd::DiscoveredNodeData & nodeData) override;
+    void OnOperationalNodeResolved(const Dnssd::ResolvedNodeData & nodeData) override;
+    void OnOperationalNodeResolutionFailed(const PeerId & peerId, CHIP_ERROR error) override;
 
 private:
     static void OnResolveTimer(System::Layer * layer, void * context) { static_cast<Resolver *>(context)->HandleTimer(); }


### PR DESCRIPTION
#### Problem
DNSSD "resolver" interface is deprecated as it handles a single callback for two distinct address discovery methods: operational and commissionable.

#### Change overview
Update the addressresolve interface to only use 'operational' discovery interface (as the other commissionalbe callback was not used/implemented anyway)

#### Testing
Ran address resolve tool manually, observed that it works.