### PR TITLE
[EFR32] Add default boot time for efr32 platform

### DIFF
--- a/src/platform/EFR32/PlatformManagerImpl.cpp
+++ b/src/platform/EFR32/PlatformManagerImpl.cpp
@@ -25,6 +25,7 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include <platform/EFR32/DiagnosticDataProviderImpl.h>
+#include <platform/FreeRTOS/SystemTimeSupport.h>
 #include <platform/PlatformManager.h>
 #include <platform/internal/GenericPlatformManagerImpl_FreeRTOS.cpp>
 
@@ -50,6 +51,8 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 
     // Initialize LwIP.
     tcpip_init(NULL, NULL);
+
+    ReturnErrorOnFailure(System::Clock::InitClock_RealTime());
 
     // Call _InitChipStack() on the generic implementation base class
     // to finish the initialization process.

--- a/src/platform/FreeRTOS/SystemTimeSupport.cpp
+++ b/src/platform/FreeRTOS/SystemTimeSupport.cpp
@@ -151,6 +151,15 @@ CHIP_ERROR ClockImpl::SetClock_RealTime(Clock::Microseconds64 aNewCurTime)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR InitClock_RealTime()
+{
+    Clock::Microseconds64 curTime =
+        Clock::Microseconds64((static_cast<uint64_t>(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD) * UINT64_C(1000000)));
+    // Use CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD as the initial value of RealTime.
+    // Then the RealTime obtained from GetClock_RealTime will be always valid.
+    return System::SystemClock().SetClock_RealTime(curTime);
+}
+
 } // namespace Clock
 } // namespace System
 } // namespace chip

--- a/src/platform/FreeRTOS/SystemTimeSupport.h
+++ b/src/platform/FreeRTOS/SystemTimeSupport.h
@@ -1,0 +1,28 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/support/TimeUtils.h>
+
+namespace chip {
+namespace System {
+namespace Clock {
+
+CHIP_ERROR InitClock_RealTime();
+
+} // namespace Clock
+} // namespace System
+} // namespace chip


### PR DESCRIPTION
#### Problem
Boot time was not initialized which caused `CHIP_ERROR_REAL_TIME_NOT_SYNCED` at every `GetClock_RealTime(MS)`

#### Change overview
Added time init to SystemTime and Platform init

#### Testing
Manual tests on MG12 and MG24
