### PR TITLE
[QPG] Fix shell app

### DIFF
--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -65,31 +65,16 @@ jobs:
                   path: |
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
-            - name: Build example QPG6105 Lock App
+            - name: Build QPG6105 example apps
               timeout-minutes: 5
               run: |
-                  scripts/examples/gn_build_example.sh examples/lock-app/qpg out/lock_app_debug qpg_target_ic=\"qpg6105\"
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    qpg qpg6105+debug lock-app \
-                    out/lock_app_debug/chip-qpg6105-lock-example.out \
-                    /tmp/bloat_reports/
-            - name: Build example QPG6105 Lighting App
-              timeout-minutes: 5
-              run: |
-                  scripts/examples/gn_build_example.sh examples/lighting-app/qpg out/lighting_app_debug qpg_target_ic=\"qpg6105\"
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    qpg qpg6105+debug lighting-app \
-                    out/lighting_app_debug/chip-qpg6105-lighting-example.out \
-                    /tmp/bloat_reports/
-            - name: Build example QPG6105 persistent-storage
-              timeout-minutes: 5
-              run: |
-                  scripts/examples/gn_build_example.sh examples/persistent-storage/qpg out/persistent-storage_app_debug \
-                    qpg_target_ic=\"qpg6105\"
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    qpg qpg6105+debug persistent-storage-app \
-                    out/persistent-storage_app_debug/chip-qpg6105-persistent_storage-example.out \
-                    /tmp/bloat_reports/
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --enable-flashbundle \
+                        --target-glob 'qpg6105-{lock,light,shell,persistent-storage}' \
+                        build \
+                        --copy-artifacts-to out/artifacts \
+                     "
             - name: Build Matter SDK library
               timeout-minutes: 5
               run: |

--- a/config/qpg/chip-gn/args.gni
+++ b/config/qpg/chip-gn/args.gni
@@ -36,8 +36,9 @@ chip_mdns = "platform"
 # INCLUDE_xSemaphoreGetMutexHolder
 chip_stack_lock_tracking = "none"
 
-chip_project_config_include_dirs =
-    [ "//examples/platform/qpg/project_include/" ]
+# Using lighting-app as template config
+# Application specific override to be done as cmd line arg
+chip_project_config_include_dirs = [ "//examples/lighting-app/qpg/include" ]
 chip_project_config_include = "<CHIPProjectConfig.h>"
 chip_system_project_config_include = "<CHIPProjectConfig.h>"
 chip_ble_project_config_include = ""

--- a/examples/lighting-app/qpg/BUILD.gn
+++ b/examples/lighting-app/qpg/BUILD.gn
@@ -34,15 +34,14 @@ if (chip_enable_pw_rpc) {
 
 assert(current_os == "freertos")
 
+qpg_project_dir = "${chip_root}/examples/lighting-app/qpg"
 examples_plat_dir = "${chip_root}/examples/platform/qpg"
 
 qpg_sdk("sdk") {
-  sources = [ "${examples_plat_dir}/project_include/CHIPProjectConfig.h" ]
-
   include_dirs = [
     "${chip_root}/src/platform/qpg",
     "${examples_plat_dir}",
-    "${examples_plat_dir}/project_include",
+    "${qpg_project_dir}/include",
   ]
 
   if (chip_enable_pw_rpc) {

--- a/examples/lighting-app/qpg/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/qpg/include/CHIPProjectConfig.h
@@ -29,11 +29,12 @@
 #pragma once
 
 // Use a default setup PIN code if one hasn't been provisioned in flash.
+#ifndef CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021
+#endif
+#ifndef CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
-
-// Use a default pairing code if one hasn't been provisioned in flash.
-#define CHIP_DEVICE_CONFIG_USE_TEST_PAIRING_CODE "CHIPUS"
+#endif
 
 // For convenience, enable Chip Security Test Mode and disable the requirement for
 // authentication in various protocols.
@@ -42,19 +43,19 @@
 //    including message encryption. Because of this they MUST NEVER BE ENABLED IN PRODUCTION BUILDS.
 //
 #define CHIP_CONFIG_SECURITY_TEST_MODE 0
-#define CHIP_CONFIG_REQUIRE_AUTH 0
+#define CHIP_CONFIG_REQUIRE_AUTH 1
 
 /**
  * CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID
  *
- * 0xFFF1: Test vendor
+ * 0xFFF1: Test vendor.
  */
 #define CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID 0xFFF1
 
 /**
  * CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID
  *
- * 0x8005: example lighting-app
+ * 0x8005: example lighting app
  */
 #define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID 0x8005
 

--- a/examples/lock-app/qpg/BUILD.gn
+++ b/examples/lock-app/qpg/BUILD.gn
@@ -34,15 +34,14 @@ if (chip_enable_pw_rpc) {
 
 assert(current_os == "freertos")
 
+qpg_project_dir = "${chip_root}/examples/lock-app/qpg"
 examples_plat_dir = "${chip_root}/examples/platform/qpg"
 
 qpg_sdk("sdk") {
-  sources = [ "${examples_plat_dir}/project_include/CHIPProjectConfig.h" ]
-
   include_dirs = [
     "${chip_root}/src/platform/qpg",
     "${examples_plat_dir}",
-    "${examples_plat_dir}/project_include",
+    "${qpg_project_dir}/include",
   ]
 
   if (chip_enable_pw_rpc) {

--- a/examples/lock-app/qpg/include/CHIPProjectConfig.h
+++ b/examples/lock-app/qpg/include/CHIPProjectConfig.h
@@ -1,0 +1,183 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2019 Google LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Example project configuration file for CHIP.
+ *
+ *          This is a place to put application or project-specific overrides
+ *          to the default configuration values for general CHIP features.
+ *
+ */
+
+#pragma once
+
+// Use a default setup PIN code if one hasn't been provisioned in flash.
+#ifndef CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE
+#define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021
+#endif
+#define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
+
+// For convenience, enable Chip Security Test Mode and disable the requirement for
+// authentication in various protocols.
+//
+//    WARNING: These options make it possible to circumvent basic Chip security functionality,
+//    including message encryption. Because of this they MUST NEVER BE ENABLED IN PRODUCTION BUILDS.
+//
+#define CHIP_CONFIG_SECURITY_TEST_MODE 0
+#define CHIP_CONFIG_REQUIRE_AUTH 1
+
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID
+ *
+ * 0xFFF1: Test vendor.
+ */
+#define CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID 0xFFF1
+
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID
+ *
+ * 0x8006: example lock-app
+ */
+#define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID 0x8006
+
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION
+ *
+ * The hardware version number assigned to device or product by the device vendor.  This
+ * number is scoped to the device product id, and typically corresponds to a revision of the
+ * physical device, a change to its packaging, and/or a change to its marketing presentation.
+ * This value is generally *not* incremented for device software versions.
+ */
+#define CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION 1
+
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING
+ *
+ * A string identifying the software version running on the device.
+ * CHIP service currently expects the software version to be in the format
+ * {MAJOR_VERSION}.0d{MINOR_VERSION}
+ */
+#ifndef CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING
+#define CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING "0.1ALPHA"
+#endif
+/**
+ * CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+ *
+ * Enable support for Chip-over-BLE (CHIPoBLE).
+ */
+#define CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE 1
+
+/**
+ * CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC
+ *
+ * Enables synchronizing the device's real time clock with a remote Chip Time service
+ * using the Chip Time Sync protocol.
+ */
+#define CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC 0
+
+/**
+ * CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER
+ *
+ * Enables the use of a hard-coded default serial number if none
+ * is found in Chip NV storage.
+ */
+#define CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER "TEST_SN"
+
+/**
+ * CHIP_DEVICE_CONFIG_EVENT_LOGGING_DEBUG_BUFFER_SIZE
+ *
+ * A size, in bytes, of the individual debug event logging buffer.
+ */
+#define CHIP_DEVICE_CONFIG_EVENT_LOGGING_DEBUG_BUFFER_SIZE (512)
+
+/**
+ * CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
+ *
+ * Enable Thread CLI interface at initialisation.
+ */
+#define CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI 1
+
+/**
+ *  @def CHIP_CONFIG_MAX_FABRICS
+ *
+ *  @brief
+ *    Maximum number of fabrics the device can participate in.  Each fabric can
+ *    provision the device with its unique operational credentials and manage
+ *    its own access control lists.
+ */
+#define CHIP_CONFIG_MAX_FABRICS 4 // 3 fabrics + 1 for rotation slack
+
+/**
+ *  @name Interaction Model object pool configuration.
+ *
+ *  @brief
+ *    The following definitions sets the maximum number of corresponding interaction model object pool size.
+ *
+ *      * #CHIP_IM_MAX_NUM_COMMAND_HANDLER
+ *      * #CHIP_IM_MAX_NUM_READ_HANDLER
+ *      * #CHIP_IM_MAX_REPORTS_IN_FLIGHT
+ *      * #CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
+ *      * #CHIP_IM_MAX_NUM_WRITE_HANDLER
+ *      * #CHIP_IM_MAX_NUM_WRITE_CLIENT
+ *
+ *  @{
+ */
+
+/**
+ * @def CHIP_IM_MAX_NUM_COMMAND_HANDLER
+ *
+ * @brief Defines the maximum number of CommandHandler, limits the number of active commands transactions on server.
+ */
+#define CHIP_IM_MAX_NUM_COMMAND_HANDLER 2
+
+/**
+ * @def CHIP_IM_MAX_NUM_READ_HANDLER
+ *
+ * @brief Defines the maximum number of ReadHandler, limits the number of active read transactions on server.
+ */
+#define CHIP_IM_MAX_NUM_READ_HANDLER 3
+
+/**
+ * @def CHIP_IM_MAX_REPORTS_IN_FLIGHT
+ *
+ * @brief Defines the maximum number of Reports, limits the traffic of read and subscription transactions.
+ */
+#define CHIP_IM_MAX_REPORTS_IN_FLIGHT 2
+
+/**
+ * @def CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
+ *
+ * @brief Defines the maximum number of path objects, limits the number of attributes being read or subscribed at the same time.
+ */
+#define CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS 9
+
+/**
+ * @def CHIP_IM_MAX_NUM_WRITE_HANDLER
+ *
+ * @brief Defines the maximum number of WriteHandler, limits the number of active write transactions on server.
+ */
+#define CHIP_IM_MAX_NUM_WRITE_HANDLER 2
+
+/**
+ * @def CHIP_IM_MAX_NUM_WRITE_CLIENT
+ *
+ * @brief Defines the maximum number of WriteClient, limits the number of active write transactions on client.
+ */
+#define CHIP_IM_MAX_NUM_WRITE_CLIENT 2

--- a/examples/persistent-storage/qpg/BUILD.gn
+++ b/examples/persistent-storage/qpg/BUILD.gn
@@ -29,17 +29,12 @@ examples_plat_dir = "${chip_root}/examples/platform/qpg"
 qpg_sdk("sdk") {
   include_dirs = [
     "${chip_root}/src/platform/qpg",
-    "${examples_plat_dir}/project_include",
+    "${qpg_project_dir}/include",
   ]
-
-  sources = [ "${examples_plat_dir}/project_include/CHIPProjectConfig.h" ]
-
-  defines = []
 }
 
-qpg_executable("persistent_storage") {
+qpg_executable("persistent_storage_app") {
   include_dirs = [ "${qpg_project_dir}/.." ]
-  defines = []
   output_name = "chip-${qpg_target_ic}-persistent_storage-example.out"
 
   deps = []
@@ -70,7 +65,7 @@ qpg_executable("persistent_storage") {
 }
 
 group("qpg") {
-  deps = [ ":persistent_storage" ]
+  deps = [ ":persistent_storage_app" ]
 }
 
 group("default") {

--- a/examples/persistent-storage/qpg/include/CHIPProjectConfig.h
+++ b/examples/persistent-storage/qpg/include/CHIPProjectConfig.h
@@ -1,0 +1,181 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2019 Google LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Example project configuration file for CHIP.
+ *
+ *          This is a place to put application or project-specific overrides
+ *          to the default configuration values for general CHIP features.
+ *
+ */
+
+#pragma once
+
+// Use a default setup PIN code if one hasn't been provisioned in flash.
+#define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021
+#define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
+
+// For convenience, enable Chip Security Test Mode and disable the requirement for
+// authentication in various protocols.
+//
+//    WARNING: These options make it possible to circumvent basic Chip security functionality,
+//    including message encryption. Because of this they MUST NEVER BE ENABLED IN PRODUCTION BUILDS.
+//
+#define CHIP_CONFIG_SECURITY_TEST_MODE 0
+#define CHIP_CONFIG_REQUIRE_AUTH 1
+
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID
+ *
+ * 0xFFF1: Test vendor.
+ */
+#define CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID 0xFFF1
+
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID
+ *
+ * 0x8009: example persistent-storage
+ */
+#define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID 0x8009
+
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION
+ *
+ * The hardware version number assigned to device or product by the device vendor.  This
+ * number is scoped to the device product id, and typically corresponds to a revision of the
+ * physical device, a change to its packaging, and/or a change to its marketing presentation.
+ * This value is generally *not* incremented for device software versions.
+ */
+#define CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION 1
+
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING
+ *
+ * A string identifying the software version running on the device.
+ * CHIP service currently expects the software version to be in the format
+ * {MAJOR_VERSION}.0d{MINOR_VERSION}
+ */
+#ifndef CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING
+#define CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING "0.1ALPHA"
+#endif
+/**
+ * CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+ *
+ * Enable support for Chip-over-BLE (CHIPoBLE).
+ */
+#define CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE 1
+
+/**
+ * CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC
+ *
+ * Enables synchronizing the device's real time clock with a remote Chip Time service
+ * using the Chip Time Sync protocol.
+ */
+#define CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC 0
+
+/**
+ * CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER
+ *
+ * Enables the use of a hard-coded default serial number if none
+ * is found in Chip NV storage.
+ */
+#define CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER "TEST_SN"
+
+/**
+ * CHIP_DEVICE_CONFIG_EVENT_LOGGING_DEBUG_BUFFER_SIZE
+ *
+ * A size, in bytes, of the individual debug event logging buffer.
+ */
+#define CHIP_DEVICE_CONFIG_EVENT_LOGGING_DEBUG_BUFFER_SIZE (512)
+
+/**
+ * CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
+ *
+ * Enable Thread CLI interface at initialisation.
+ */
+#define CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI 1
+
+/**
+ *  @def CHIP_CONFIG_MAX_FABRICS
+ *
+ *  @brief
+ *    Maximum number of fabrics the device can participate in.  Each fabric can
+ *    provision the device with its unique operational credentials and manage
+ *    its own access control lists.
+ */
+#define CHIP_CONFIG_MAX_FABRICS 4 // 3 fabrics + 1 for rotation slack
+
+/**
+ *  @name Interaction Model object pool configuration.
+ *
+ *  @brief
+ *    The following definitions sets the maximum number of corresponding interaction model object pool size.
+ *
+ *      * #CHIP_IM_MAX_NUM_COMMAND_HANDLER
+ *      * #CHIP_IM_MAX_NUM_READ_HANDLER
+ *      * #CHIP_IM_MAX_REPORTS_IN_FLIGHT
+ *      * #CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
+ *      * #CHIP_IM_MAX_NUM_WRITE_HANDLER
+ *      * #CHIP_IM_MAX_NUM_WRITE_CLIENT
+ *
+ *  @{
+ */
+
+/**
+ * @def CHIP_IM_MAX_NUM_COMMAND_HANDLER
+ *
+ * @brief Defines the maximum number of CommandHandler, limits the number of active commands transactions on server.
+ */
+#define CHIP_IM_MAX_NUM_COMMAND_HANDLER 2
+
+/**
+ * @def CHIP_IM_MAX_NUM_READ_HANDLER
+ *
+ * @brief Defines the maximum number of ReadHandler, limits the number of active read transactions on server.
+ */
+#define CHIP_IM_MAX_NUM_READ_HANDLER 3
+
+/**
+ * @def CHIP_IM_MAX_REPORTS_IN_FLIGHT
+ *
+ * @brief Defines the maximum number of Reports, limits the traffic of read and subscription transactions.
+ */
+#define CHIP_IM_MAX_REPORTS_IN_FLIGHT 2
+
+/**
+ * @def CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
+ *
+ * @brief Defines the maximum number of path objects, limits the number of attributes being read or subscribed at the same time.
+ */
+#define CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS 9
+
+/**
+ * @def CHIP_IM_MAX_NUM_WRITE_HANDLER
+ *
+ * @brief Defines the maximum number of WriteHandler, limits the number of active write transactions on server.
+ */
+#define CHIP_IM_MAX_NUM_WRITE_HANDLER 2
+
+/**
+ * @def CHIP_IM_MAX_NUM_WRITE_CLIENT
+ *
+ * @brief Defines the maximum number of WriteClient, limits the number of active write transactions on client.
+ */
+#define CHIP_IM_MAX_NUM_WRITE_CLIENT 2

--- a/examples/platform/qpg/args.gni
+++ b/examples/platform/qpg/args.gni
@@ -18,7 +18,6 @@ import("${chip_root}/src/platform/qpg/args.gni")
 
 chip_enable_openthread = true
 chip_openthread_ftd = false
-chip_system_config_use_open_thread_udp = true
 openthread_project_core_config_file = "OpenThreadConfig.h"
 openthread_core_config_deps = []
 openthread_core_config_deps = [

--- a/examples/shell/qpg/BUILD.gn
+++ b/examples/shell/qpg/BUILD.gn
@@ -14,7 +14,6 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-import("//build_overrides/openthread.gni")
 import("//build_overrides/qpg_sdk.gni")
 
 import("${build_root}/config/defaults.gni")
@@ -24,19 +23,17 @@ import("${qpg_sdk_build_root}/qpg_sdk.gni")
 
 assert(current_os == "freertos")
 
+qpg_project_dir = "${chip_root}/examples/shell/qpg"
 examples_plat_dir = "${chip_root}/examples/platform/qpg"
 
 qpg_sdk("sdk") {
   include_dirs = [
     "${chip_root}/src/platform/qpg",
-    "${examples_plat_dir}/project_include",
+    "${qpg_project_dir}/include",
     "${examples_plat_dir}",
   ]
 
-  defines = [
-    "OPENTHREAD_CONFIG_CLI_TRANSPORT=OT_CLI_TRANSPORT_CONSOLE",
-    "ENABLE_CHIP_SHELL",
-  ]
+  defines = [ "OPENTHREAD_CONFIG_CLI_TRANSPORT=OT_CLI_TRANSPORT_CONSOLE" ]
 }
 
 qpg_executable("shell_app") {
@@ -57,10 +54,7 @@ qpg_executable("shell_app") {
     "${examples_plat_dir}:qpg-matter-shell",
   ]
 
-  include_dirs = [
-    "include",
-    "${examples_plat_dir}/shell_common",
-  ]
+  include_dirs = [ "include" ]
 
   defines = []
 

--- a/examples/shell/qpg/args.gni
+++ b/examples/shell/qpg/args.gni
@@ -21,3 +21,7 @@ qpg_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"
 chip_build_libshell = true
+
+# Disable lock tracking, since our FreeRTOS configuration does not set
+# INCLUDE_xSemaphoreGetMutexHolder
+chip_stack_lock_tracking = "none"

--- a/examples/shell/qpg/include/CHIPProjectConfig.h
+++ b/examples/shell/qpg/include/CHIPProjectConfig.h
@@ -1,0 +1,187 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2019 Google LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Example project configuration file for CHIP.
+ *
+ *          This is a place to put application or project-specific overrides
+ *          to the default configuration values for general CHIP features.
+ *
+ */
+
+#pragma once
+
+// Use a default setup PIN code if one hasn't been provisioned in flash.
+#ifndef CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE
+#define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021
+#endif
+#define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
+
+// shell app uses openthread but does not have the NETWORK_COMMISSIONING cluster or zap config
+// Do not instantiate the NETWORK_COMMISSIONING thread driver
+#define _NO_NETWORK_COMMISSIONING_DRIVER_
+
+// For convenience, enable Chip Security Test Mode and disable the requirement for
+// authentication in various protocols.
+//
+//    WARNING: These options make it possible to circumvent basic Chip security functionality,
+//    including message encryption. Because of this they MUST NEVER BE ENABLED IN PRODUCTION BUILDS.
+//
+#define CHIP_CONFIG_SECURITY_TEST_MODE 0
+#define CHIP_CONFIG_REQUIRE_AUTH 1
+
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID
+ *
+ * 0xFFF1: Test vendor.
+ */
+#define CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID 0xFFF1
+
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID
+ *
+ * 0x8009: example shell
+ */
+#define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID 0x8012
+
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION
+ *
+ * The hardware version number assigned to device or product by the device vendor.  This
+ * number is scoped to the device product id, and typically corresponds to a revision of the
+ * physical device, a change to its packaging, and/or a change to its marketing presentation.
+ * This value is generally *not* incremented for device software versions.
+ */
+#define CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION 1
+
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING
+ *
+ * A string identifying the software version running on the device.
+ * CHIP service currently expects the software version to be in the format
+ * {MAJOR_VERSION}.0d{MINOR_VERSION}
+ */
+#ifndef CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING
+#define CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING "0.1ALPHA"
+#endif
+/**
+ * CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+ *
+ * Enable support for Chip-over-BLE (CHIPoBLE).
+ */
+#define CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE 1
+
+/**
+ * CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC
+ *
+ * Enables synchronizing the device's real time clock with a remote Chip Time service
+ * using the Chip Time Sync protocol.
+ */
+#define CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC 0
+
+/**
+ * CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER
+ *
+ * Enables the use of a hard-coded default serial number if none
+ * is found in Chip NV storage.
+ */
+#define CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER "TEST_SN"
+
+/**
+ * CHIP_DEVICE_CONFIG_EVENT_LOGGING_DEBUG_BUFFER_SIZE
+ *
+ * A size, in bytes, of the individual debug event logging buffer.
+ */
+#define CHIP_DEVICE_CONFIG_EVENT_LOGGING_DEBUG_BUFFER_SIZE (512)
+
+/**
+ * CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
+ *
+ * Enable Thread CLI interface at initialisation.
+ */
+#define CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI 1
+
+/**
+ *  @def CHIP_CONFIG_MAX_FABRICS
+ *
+ *  @brief
+ *    Maximum number of fabrics the device can participate in.  Each fabric can
+ *    provision the device with its unique operational credentials and manage
+ *    its own access control lists.
+ */
+#define CHIP_CONFIG_MAX_FABRICS 4 // 3 fabrics + 1 for rotation slack
+
+/**
+ *  @name Interaction Model object pool configuration.
+ *
+ *  @brief
+ *    The following definitions sets the maximum number of corresponding interaction model object pool size.
+ *
+ *      * #CHIP_IM_MAX_NUM_COMMAND_HANDLER
+ *      * #CHIP_IM_MAX_NUM_READ_HANDLER
+ *      * #CHIP_IM_MAX_REPORTS_IN_FLIGHT
+ *      * #CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
+ *      * #CHIP_IM_MAX_NUM_WRITE_HANDLER
+ *      * #CHIP_IM_MAX_NUM_WRITE_CLIENT
+ *
+ *  @{
+ */
+
+/**
+ * @def CHIP_IM_MAX_NUM_COMMAND_HANDLER
+ *
+ * @brief Defines the maximum number of CommandHandler, limits the number of active commands transactions on server.
+ */
+#define CHIP_IM_MAX_NUM_COMMAND_HANDLER 2
+
+/**
+ * @def CHIP_IM_MAX_NUM_READ_HANDLER
+ *
+ * @brief Defines the maximum number of ReadHandler, limits the number of active read transactions on server.
+ */
+#define CHIP_IM_MAX_NUM_READ_HANDLER 3
+
+/**
+ * @def CHIP_IM_MAX_REPORTS_IN_FLIGHT
+ *
+ * @brief Defines the maximum number of Reports, limits the traffic of read and subscription transactions.
+ */
+#define CHIP_IM_MAX_REPORTS_IN_FLIGHT 2
+
+/**
+ * @def CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
+ *
+ * @brief Defines the maximum number of path objects, limits the number of attributes being read or subscribed at the same time.
+ */
+#define CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS 9
+
+/**
+ * @def CHIP_IM_MAX_NUM_WRITE_HANDLER
+ *
+ * @brief Defines the maximum number of WriteHandler, limits the number of active write transactions on server.
+ */
+#define CHIP_IM_MAX_NUM_WRITE_HANDLER 2
+
+/**
+ * @def CHIP_IM_MAX_NUM_WRITE_CLIENT
+ *
+ * @brief Defines the maximum number of WriteClient, limits the number of active write transactions on client.
+ */
+#define CHIP_IM_MAX_NUM_WRITE_CLIENT 2

--- a/scripts/build/README.md
+++ b/scripts/build/README.md
@@ -54,7 +54,7 @@ Usage examples:
    argument order (artifact copying is an argument for the build command)
 
     ```
-    ./scripts/build/build_examples.py --target qpg-qpg6100-lock build --copy-artifacts-to /tmp/artifacts
+    ./scripts/build/build_examples.py --target qpg-lock build --copy-artifacts-to /tmp/artifacts
     ```
 
 5. Find out all possible targets for compiling the 'light' app:

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -27,7 +27,7 @@ from builders.infineon import InfineonBuilder, InfineonApp, InfineonBoard
 from builders.k32w import K32WApp, K32WBuilder
 from builders.mbed import MbedApp, MbedBoard, MbedProfile, MbedBuilder
 from builders.nrf import NrfApp, NrfBoard, NrfConnectBuilder
-from builders.qpg import QpgBuilder
+from builders.qpg import QpgApp, QpgBoard, QpgBuilder
 from builders.telink import TelinkApp, TelinkBoard, TelinkBuilder
 from builders.tizen import TizenApp, TizenBoard, TizenBuilder
 
@@ -379,6 +379,15 @@ def Cyw30739Targets():
     yield Target('cyw30739-cyw930739m2evb_01-ota-requestor', Cyw30739Builder, board=Cyw30739Board.CYW930739M2EVB_01, app=Cyw30739App.OTA_REQUESTOR)
 
 
+def QorvoTargets():
+    target = Target('qpg', QpgBuilder)
+
+    yield target.Extend('lock', board=QpgBoard.QPG6105, app=QpgApp.LOCK)
+    yield target.Extend('light', board=QpgBoard.QPG6105, app=QpgApp.LIGHT)
+    yield target.Extend('shell', board=QpgBoard.QPG6105, app=QpgApp.SHELL)
+    yield target.Extend('persistent-storage', board=QpgBoard.QPG6105, app=QpgApp.PERSISTENT_STORAGE)
+
+
 ALL = []
 
 target_generators = [
@@ -392,6 +401,7 @@ target_generators = [
     AmebaTargets(),
     K32WTargets(),
     Cyw30739Targets(),
+    QorvoTargets(),
 ]
 
 for generator in target_generators:
@@ -399,7 +409,6 @@ for generator in target_generators:
         ALL.append(target)
 
 # Simple targets added one by one
-ALL.append(Target('qpg-qpg6100-lock', QpgBuilder))
 ALL.append(Target('telink-tlsr9518adk80d-light', TelinkBuilder,
                   board=TelinkBoard.TLSR9518ADK80D, app=TelinkApp.LIGHT))
 ALL.append(Target('tizen-arm-light', TizenBuilder,

--- a/scripts/build/builders/qpg.py
+++ b/scripts/build/builders/qpg.py
@@ -13,21 +13,99 @@
 # limitations under the License.
 
 import os
+from enum import Enum, auto
 
 from .gn import GnBuilder
 
 
+class QpgApp(Enum):
+    LIGHT = auto()
+    LOCK = auto()
+    SHELL = auto()
+    PERSISTENT_STORAGE = auto()
+
+    def ExampleName(self):
+        if self == QpgApp.LIGHT:
+            return 'lighting-app'
+        elif self == QpgApp.LOCK:
+            return 'lock-app'
+        elif self == QpgApp.SHELL:
+            return 'shell'
+        elif self == QpgApp.PERSISTENT_STORAGE:
+            return 'persistent-storage'
+        else:
+            raise Exception('Unknown app type: %r' % self)
+
+    def AppNamePrefix(self):
+        if self == QpgApp.LIGHT:
+            return 'chip-qpg6105-lighting-example'
+        elif self == QpgApp.LOCK:
+            return 'chip-qpg6105-lock-example'
+        elif self == QpgApp.SHELL:
+            return 'chip-qpg6105-shell-example'
+        elif self == QpgApp.PERSISTENT_STORAGE:
+            return 'chip-qpg6105-persistent_storage-example'
+        else:
+            raise Exception('Unknown app type: %r' % self)
+
+    def FlashBundleName(self):
+        if self == QpgApp.LIGHT:
+            return 'lighting_app.out.flashbundle.txt'
+        elif self == QpgApp.LOCK:
+            return 'lock_app.out.flashbundle.txt'
+        elif self == QpgApp.SHELL:
+            return 'shell_app.out.flashbundle.txt'
+        elif self == QpgApp.PERSISTENT_STORAGE:
+            return 'persistent_storage_app.out.flashbundle.txt'
+        else:
+            raise Exception('Unknown app type: %r' % self)
+
+    def BuildRoot(self, root):
+        return os.path.join(root, 'examples', self.ExampleName(), 'qpg')
+
+
+class QpgBoard(Enum):
+    QPG6105 = 1
+
+    def GnArgName(self):
+        if self == QpgBoard.QPG6105:
+            return 'qpg6105'
+        else:
+            raise Exception('Unknown board #: %r' % self)
+
+
 class QpgBuilder(GnBuilder):
 
-    def __init__(self, root, runner):
+    def __init__(self,
+                 root,
+                 runner,
+                 app: QpgApp = QpgApp.LIGHT,
+                 board: QpgBoard = QpgBoard.QPG6105,
+                 enable_rpcs: bool = False):
         super(QpgBuilder, self).__init__(
-            root=os.path.join(root, 'examples/lock-app/qpg/'),
+            root=app.BuildRoot(root),
             runner=runner)
+        self.app = app
+        self.board = board
+        self.enable_rpcs = enable_rpcs
+
+    def GnBuildArgs(self):
+        args = ['qpg_target_ic=\"%s\"' % self.board.GnArgName()]
+        if self.enable_rpcs:
+            args.append('import("//with_pw_rpc.gni")')
+        return args
 
     def build_outputs(self):
-        return {
-            'chip-qpg-lock-example.out':
-                os.path.join(self.output_dir, 'chip-qpg6105-lock-example.out'),
-            'chip-qpg-lock-example.out.map':
-                os.path.join(self.output_dir, 'chip-qpg6105-lock-example.out.map'),
-        }
+        items = {}
+        for extension in ["out", "out.map", "out.hex"]:
+            name = '%s.%s' % (self.app.AppNamePrefix(), extension)
+            items[name] = os.path.join(self.output_dir, name)
+
+        # Figure out flash bundle files and build accordingly
+        with open(os.path.join(self.output_dir, self.app.FlashBundleName())) as f:
+            for line in f.readlines():
+                name = line.strip()
+                items['flashbundle/%s' %
+                      name] = os.path.join(self.output_dir, name)
+
+        return items

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -124,6 +124,9 @@ nrf-nrf5340dk-lock
 nrf-nrf5340dk-pump
 nrf-nrf5340dk-pump-controller
 nrf-nrf5340dk-shell
-qpg-qpg6100-lock
+qpg-light
+qpg-lock
+qpg-persistent-storage
+qpg-shell
 telink-tlsr9518adk80d-light
 tizen-arm-light

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -697,8 +697,17 @@ bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_ARM_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf5340dk-shell -b nrf5340dk_nrf5340_cpuapp {root}/examples/shell/nrfconnect'
 
-# Generating qpg-qpg6100-lock
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lock-app/qpg {out}/qpg-qpg6100-lock
+# Generating qpg-light
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/qpg '--args=qpg_target_ic="qpg6105"' {out}/qpg-light
+
+# Generating qpg-lock
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lock-app/qpg '--args=qpg_target_ic="qpg6105"' {out}/qpg-lock
+
+# Generating qpg-persistent-storage
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/persistent-storage/qpg '--args=qpg_target_ic="qpg6105"' {out}/qpg-persistent-storage
+
+# Generating qpg-shell
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/qpg '--args=qpg_target_ic="qpg6105"' {out}/qpg-shell
 
 # Generating telink-tlsr9518adk80d-light
 bash -c 'export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
@@ -1354,8 +1363,17 @@ ninja -C {out}/nrf-nrf5340dk-pump-controller
 # Building nrf-nrf5340dk-shell
 ninja -C {out}/nrf-nrf5340dk-shell
 
-# Building qpg-qpg6100-lock
-ninja -C {out}/qpg-qpg6100-lock
+# Building qpg-light
+ninja -C {out}/qpg-light
+
+# Building qpg-lock
+ninja -C {out}/qpg-lock
+
+# Building qpg-persistent-storage
+ninja -C {out}/qpg-persistent-storage
+
+# Building qpg-shell
+ninja -C {out}/qpg-shell
 
 # Building telink-tlsr9518adk80d-light
 ninja -C {out}/telink-tlsr9518adk80d-light

--- a/scripts/build/testdata/glob_star_targets_except_host.txt
+++ b/scripts/build/testdata/glob_star_targets_except_host.txt
@@ -62,6 +62,9 @@ nrf-nrf5340dk-lock
 nrf-nrf5340dk-pump
 nrf-nrf5340dk-pump-controller
 nrf-nrf5340dk-shell
-qpg-qpg6100-lock
+qpg-light
+qpg-lock
+qpg-persistent-storage
+qpg-shell
 telink-tlsr9518adk80d-light
 tizen-arm-light

--- a/third_party/qpg_sdk/qpg_executable.gni
+++ b/third_party/qpg_sdk/qpg_executable.gni
@@ -14,23 +14,51 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-import("//build_overrides/pigweed.gni")
 
 import("${build_root}/toolchain/flashable_executable.gni")
 import("${chip_root}/src/platform/device.gni")
-import("${dir_pw_build}/python.gni")
+import("qpg_sdk.gni")
+
+# Run the generator script that takes a .HEX file and adds the OTA header to it.
+#
+# This requires a Python script, given by ota_header_generator,
+# to construct the resulting image containing the OTA header,
+# do any optional adjustments (like image compression) and produce
+# the end result, given by ota_header_script_name.
+#
+# As used by qpg_executable(), the generator script requires three arguments,
+#   chip_root       - The path to the root tree of Matter
+#   in_hex          - The HEX file to be patched with OTA header
+#   out_ota         - The out file, containing the OTA header in front
+#                     of the original HEX binary data
+template("gen_ota_header") {
+  forward_variables_from(invoker,
+                         [
+                           "ota_header_generator",
+                           "ota_header_script_name",
+                           "ota_header_options",
+                           "deps",
+                           "data_deps",
+                         ])
+
+  action(target_name) {
+    outputs = [ ota_header_script_name ]
+
+    args = ota_header_options
+    script = ota_header_generator
+  }
+}
 
 template("qpg_executable") {
   output_base_name = get_path_info(invoker.output_name, "name")
 
   qpg_target_name = target_name
   executable_target_name = "${target_name}.out"
+
+  # The executable is the final target.
   if (chip_enable_ota_requestor) {
-    # Generate OTA image after executable
-    ota_target_name = "${target_name}_ota"
-    final_target = ota_target_name
+    final_target = "$executable_target_name.ota"
   } else {
-    # The executable is the final target.
     final_target = executable_target_name
   }
 
@@ -66,19 +94,17 @@ template("qpg_executable") {
 
   # If OTA requestor is enabled, generate OTA image from HEX
   if (chip_enable_ota_requestor) {
-    pw_python_action(ota_target_name) {
-      public_deps = [ ":${qpg_target_name}.out.image" ]
-      sources = [ "${root_out_dir}/${objcopy_image_name}" ]
-      outputs = [ "${root_out_dir}/${objcopy_image_name}.ota" ]
-      script =
-          "${chip_root}/third_party/qpg_sdk/repo/Tools/ota/generate_ota_img.py"
+    gen_ota_header("$executable_target_name.ota") {
+      ota_header_script_name = "${root_out_dir}/${executable_target_name}.ota"
       out_dir = rebase_path(root_out_dir, root_build_dir)
+      ota_header_generator = "${qpg_sdk_root}/Tools/ota/generate_ota_img.py"
 
-      args = [
+      ota_header_options = [
         rebase_path(chip_root, root_build_dir),
         "${out_dir}/${invoker.output_name}.hex",
         "${out_dir}/${invoker.output_name}.ota",
       ]
+      deps = [ ":$executable_target_name" ]
     }
   }
 


### PR DESCRIPTION
Problem

Shell app build fails for QPG.

Change overview

fix shell app failure by defining necessary parameter
move CHIP Project config files to each example folder (needed to define a PID based on the application type)
add Shell app to CI
Testing

The changes were tested by compiling each app (lighting-app, lock-app, persistent-storage, shell)