### PR TITLE
Add persistent storage for DefaultOTAProviders attribute

### DIFF
--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -43,6 +43,7 @@
 #include "app/clusters/ota-requestor/OTARequestor.h"
 #include "platform/Ameba/AmebaOTAImageProcessor.h"
 #include "platform/GenericOTARequestorDriver.h"
+#include "platform/GenericOTARequestorStorage.h"
 #endif
 
 #if CONFIG_ENABLE_PW_RPC
@@ -93,6 +94,7 @@ static DeviceCallbacks EchoCallbacks;
 OTARequestor gRequestorCore;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
+GenericOTARequestorStorage gStorage;
 AmebaOTAImageProcessor gImageProcessor;
 #endif
 
@@ -116,7 +118,7 @@ static void InitOTARequestor(void)
     SetRequestorInstance(&gRequestorCore);
 
     // Set server instance used for session establishment
-    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader, &gStorage);
 
     // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at
     // the beginning of program execution. We're using hardcoded values here for now since this is a reference application.

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -73,6 +73,7 @@
 #include <platform/ESP32/NetworkCommissioningDriver.h>
 #include <platform/ESP32/OTAImageProcessorImpl.h>
 #include <platform/GenericOTARequestorDriver.h>
+#include <platform/GenericOTARequestorStorage.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 
@@ -135,6 +136,7 @@ std::vector<gpio_num_t> button_gpios = { BUTTON_1_GPIO_NUM, BUTTON_2_GPIO_NUM, B
 OTARequestor gRequestorCore;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
+GenericOTARequestorStorage gStorage;
 OTAImageProcessorImpl gImageProcessor;
 #endif
 
@@ -613,7 +615,7 @@ static void InitOTARequestor(void)
 {
 #if CONFIG_ENABLE_OTA_REQUESTOR
     SetRequestorInstance(&gRequestorCore);
-    gRequestorCore.Init(&Server::GetInstance(), &gRequestorUser, &gDownloader);
+    gRequestorCore.Init(&Server::GetInstance(), &gRequestorUser, &gDownloader, &gStorage);
     gImageProcessor.SetOTADownloader(&gDownloader);
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -46,6 +46,7 @@
 #include "app/clusters/ota-requestor/OTARequestor.h"
 #include "platform/Ameba/AmebaOTAImageProcessor.h"
 #include "platform/GenericOTARequestorDriver.h"
+#include <platform/GenericOTARequestorStorage.h>
 #endif
 
 using namespace ::chip;
@@ -78,6 +79,7 @@ static DeviceCallbacks EchoCallbacks;
 OTARequestor gRequestorCore;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
+GenericOTARequestorStorage gStorage;
 AmebaOTAImageProcessor gImageProcessor;
 #endif
 
@@ -101,7 +103,7 @@ static void InitOTARequestor(void)
     SetRequestorInstance(&gRequestorCore);
 
     // Set server instance used for session establishment
-    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader, &gStorage);
 
     // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at
     // the beginning of program execution. We're using hardcoded values here for now since this is a reference application.

--- a/examples/lighting-app/esp32/main/main.cpp
+++ b/examples/lighting-app/esp32/main/main.cpp
@@ -36,6 +36,7 @@
 #include <platform/ESP32/NetworkCommissioningDriver.h>
 #include <platform/ESP32/OTAImageProcessorImpl.h>
 #include <platform/GenericOTARequestorDriver.h>
+#include <platform/GenericOTARequestorStorage.h>
 
 using namespace ::chip;
 using namespace ::chip::Credentials;
@@ -46,6 +47,7 @@ using namespace ::chip::DeviceLayer;
 OTARequestor gRequestorCore;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
+GenericOTARequestorStorage gStorage;
 OTAImageProcessorImpl gImageProcessor;
 #endif
 
@@ -64,7 +66,7 @@ static void InitOTARequestor(void)
 {
 #if CONFIG_ENABLE_OTA_REQUESTOR
     SetRequestorInstance(&gRequestorCore);
-    gRequestorCore.Init(&Server::GetInstance(), &gRequestorUser, &gDownloader);
+    gRequestorCore.Init(&Server::GetInstance(), &gRequestorUser, &gDownloader, &gStorage);
     gImageProcessor.SetOTADownloader(&gDownloader);
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -43,6 +43,7 @@
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/GenericOTARequestorDriver.h>
+#include <platform/GenericOTARequestorStorage.h>
 #include <platform/nrfconnect/OTAImageProcessorImpl.h>
 #endif
 
@@ -85,6 +86,7 @@ GenericOTARequestorDriver sOTARequestorDriver;
 OTAImageProcessorImpl sOTAImageProcessor;
 chip::BDXDownloader sBDXDownloader;
 chip::OTARequestor sOTARequestor;
+chip::GenericOTARequestorStorage sStorage;
 #endif
 
 } // namespace
@@ -188,7 +190,7 @@ void AppTask::InitOTARequestor()
     sOTAImageProcessor.SetOTADownloader(&sBDXDownloader);
     sBDXDownloader.SetImageProcessorDelegate(&sOTAImageProcessor);
     sOTARequestorDriver.Init(&sOTARequestor, &sOTAImageProcessor);
-    sOTARequestor.Init(&chip::Server::GetInstance(), &sOTARequestorDriver, &sBDXDownloader);
+    sOTARequestor.Init(&chip::Server::GetInstance(), &sOTARequestorDriver, &sBDXDownloader, &sStorage);
     chip::SetRequestorInstance(&sOTARequestor);
 #endif
 }

--- a/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -37,6 +37,7 @@
 #include "OTAImageProcessorImpl.h"
 #include "OtaSupport.h"
 #include "platform/GenericOTARequestorDriver.h"
+#include "platform/GenericOTARequestorStorage.h"
 #include "src/app/clusters/ota-requestor/BDXDownloader.h"
 #include "src/app/clusters/ota-requestor/OTARequestor.h"
 
@@ -87,6 +88,7 @@ AppTask AppTask::sAppTask;
 static OTARequestor gRequestorCore;
 DeviceLayer::GenericOTARequestorDriver gRequestorUser;
 static BDXDownloader gDownloader;
+static GenericOTARequestorStorage gStorage;
 static OTAImageProcessorImpl gImageProcessor;
 
 CHIP_ERROR AppTask::StartAppTask()
@@ -121,7 +123,7 @@ CHIP_ERROR AppTask::Init()
     // Initialize and interconnect the Requestor and Image Processor objects -- START
     SetRequestorInstance(&gRequestorCore);
 
-    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader, &gStorage);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 
     // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at

--- a/examples/lock-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/lock-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -34,6 +34,7 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPPlatformMemory.h>
 #include <platform/GenericOTARequestorDriver.h>
+#include <platform/GenericOTARequestorStorage.h>
 #include <platform/cc13x2_26x2/OTAImageProcessorImpl.h>
 
 #include <app/server/OnboardingCodesUtil.h>
@@ -65,6 +66,7 @@ AppTask AppTask::sAppTask;
 static OTARequestor sRequestorCore;
 static GenericOTARequestorDriver sRequestorUser;
 static BDXDownloader sDownloader;
+static GenericOTARequestorStorage sStorage;
 static OTAImageProcessorImpl sImageProcessor;
 
 void InitializeOTARequestor(void)
@@ -72,7 +74,7 @@ void InitializeOTARequestor(void)
     // Initialize and interconnect the Requestor and Image Processor objects
     SetRequestorInstance(&sRequestorCore);
 
-    sRequestorCore.Init(&Server::GetInstance(), &sRequestorUser, &sDownloader);
+    sRequestorCore.Init(&Server::GetInstance(), &sRequestorUser, &sDownloader, &sStorage);
     sImageProcessor.SetOTADownloader(&sDownloader);
     sDownloader.SetImageProcessorDelegate(&sImageProcessor);
     sRequestorUser.Init(&sRequestorCore, &sImageProcessor);

--- a/examples/ota-requestor-app/ameba/main/chipinterface.cpp
+++ b/examples/ota-requestor-app/ameba/main/chipinterface.cpp
@@ -36,6 +36,7 @@
 #include "app/clusters/ota-requestor/OTARequestor.h"
 #include "platform/Ameba/AmebaOTAImageProcessor.h"
 #include "platform/GenericOTARequestorDriver.h"
+#include "platform/GenericOTARequestorStorage.h"
 
 void * __dso_handle = 0;
 
@@ -80,6 +81,7 @@ static DeviceCallbacks EchoCallbacks;
 OTARequestor gRequestorCore;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
+GenericOTARequestorStorage gStorage;
 AmebaOTAImageProcessor gImageProcessor;
 
 extern "C" void amebaQueryImageCmdHandler()
@@ -101,7 +103,7 @@ static void InitOTARequestor(void)
     SetRequestorInstance(&gRequestorCore);
 
     // Set server instance used for session establishment
-    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader, &gStorage);
 
     // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at
     // the beginning of program execution. We're using hardcoded values here for now since this is a reference application.

--- a/examples/ota-requestor-app/cyw30739/src/main.cpp
+++ b/examples/ota-requestor-app/cyw30739/src/main.cpp
@@ -27,6 +27,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/CYW30739/OTAImageProcessorImpl.h>
 #include <platform/GenericOTARequestorDriver.h>
+#include <platform/GenericOTARequestorStorage.h>
 #include <protocols/secure_channel/PASESession.h>
 #include <sparcommon.h>
 #include <stdio.h>
@@ -44,6 +45,7 @@ static void InitApp(intptr_t args);
 OTARequestor gRequestorCore;
 DeviceLayer::GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
+GenericOTARequestorStorage gStorage;
 OTAImageProcessorImpl gImageProcessor;
 
 APPLICATION_START()
@@ -129,7 +131,7 @@ void InitApp(intptr_t args)
     // Initialize and interconnect the Requestor and Image Processor objects -- START
     SetRequestorInstance(&gRequestorCore);
 
-    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader, &gStorage);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 
     gImageProcessor.SetOTADownloader(&gDownloader);

--- a/examples/ota-requestor-app/efr32/src/AppTask.cpp
+++ b/examples/ota-requestor-app/efr32/src/AppTask.cpp
@@ -36,6 +36,7 @@
 #include "app/clusters/ota-requestor/OTARequestor.h"
 #include "platform/EFR32/OTAImageProcessorImpl.h"
 #include "platform/GenericOTARequestorDriver.h"
+#include "platform/GenericOTARequestorStorage.h"
 
 #include <assert.h>
 
@@ -100,6 +101,7 @@ using namespace ::chip::DeviceLayer;
 OTARequestor gRequestorCore;
 DeviceLayer::GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
+GenericOTARequestorStorage gStorage;
 OTAImageProcessorImpl gImageProcessor;
 
 AppTask AppTask::sAppTask;
@@ -533,7 +535,7 @@ void AppTask::InitOTARequestor()
     // Initialize and interconnect the Requestor and Image Processor objects -- START
     SetRequestorInstance(&gRequestorCore);
 
-    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader, &gStorage);
 
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 

--- a/examples/ota-requestor-app/esp32/main/main.cpp
+++ b/examples/ota-requestor-app/esp32/main/main.cpp
@@ -41,6 +41,7 @@
 
 #include "OTAImageProcessorImpl.h"
 #include "platform/GenericOTARequestorDriver.h"
+#include "platform/GenericOTARequestorStorage.h"
 #include "platform/OTARequestorInterface.h"
 
 using namespace ::chip;
@@ -56,6 +57,7 @@ static DeviceCallbacks EchoCallbacks;
 OTARequestor gRequestorCore;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
+GenericOTARequestorStorage gStorage;
 OTAImageProcessorImpl gImageProcessor;
 
 app::Clusters::NetworkCommissioning::Instance
@@ -71,7 +73,7 @@ static void InitServer(intptr_t context)
     sWiFiNetworkCommissioningInstance.Init();
 
     SetRequestorInstance(&gRequestorCore);
-    gRequestorCore.Init(&(Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorCore.Init(&(Server::GetInstance()), &gRequestorUser, &gDownloader, &gStorage);
     gImageProcessor.SetOTADownloader(&gDownloader);
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -20,6 +20,7 @@
 #include "app/clusters/ota-requestor/BDXDownloader.h"
 #include "app/clusters/ota-requestor/OTARequestor.h"
 #include "platform/GenericOTARequestorDriver.h"
+#include "platform/GenericOTARequestorStorage.h"
 #include "platform/Linux/OTAImageProcessorImpl.h"
 
 using chip::BDXDownloader;
@@ -49,6 +50,7 @@ using namespace chip::app::Clusters::OtaSoftwareUpdateProvider::Commands;
 OTARequestor gRequestorCore;
 DeviceLayer::GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
+GenericOTARequestorStorage gStorage;
 OTAImageProcessorImpl gImageProcessor;
 
 bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue);
@@ -82,7 +84,7 @@ static void InitOTARequestor(void)
     // Set the global instance of the OTA requestor core component
     SetRequestorInstance(&gRequestorCore);
 
-    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader, &gStorage);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 
     // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at

--- a/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.zap
+++ b/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.zap
@@ -1297,7 +1297,7 @@
               "mfgCode": null,
               "side": "server",
               "included": 1,
-              "storageOption": "External",
+              "storageOption": "NVM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0",

--- a/examples/platform/efr32/OTAConfig.cpp
+++ b/examples/platform/efr32/OTAConfig.cpp
@@ -64,6 +64,7 @@ __attribute__((used)) ApplicationProperties_t sl_app_properties = {
 chip::OTARequestor gRequestorCore;
 chip::DeviceLayer::GenericOTARequestorDriver gRequestorUser;
 chip::BDXDownloader gDownloader;
+chip::GenericOTARequestorStorage gStorage;
 chip::OTAImageProcessorImpl gImageProcessor;
 
 void OTAConfig::Init()
@@ -71,7 +72,7 @@ void OTAConfig::Init()
     // Initialize and interconnect the Requestor and Image Processor objects -- START
     SetRequestorInstance(&gRequestorCore);
 
-    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader, &gStorage);
 
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 

--- a/examples/platform/qpg/ota/ota.cpp
+++ b/examples/platform/qpg/ota/ota.cpp
@@ -30,6 +30,7 @@
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/GenericOTARequestorDriver.h>
+#include <platform/GenericOTARequestorStorage.h>
 #include <platform/qpg/OTAImageProcessorImpl.h>
 
 using namespace chip;
@@ -42,6 +43,7 @@ using namespace chip::DeviceLayer;
 OTARequestor gRequestorCore;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
+GenericOTARequestorStorage gStorage;
 OTAImageProcessorImpl gImageProcessor;
 
 /*****************************************************************************
@@ -53,7 +55,7 @@ void InitializeOTARequestor(void)
     // Initialize and interconnect the Requestor and Image Processor objects
     SetRequestorInstance(&gRequestorCore);
 
-    gRequestorCore.Init(&Server::GetInstance(), &gRequestorUser, &gDownloader);
+    gRequestorCore.Init(&Server::GetInstance(), &gRequestorUser, &gDownloader, &gStorage);
     gImageProcessor.SetOTADownloader(&gDownloader);
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -479,6 +479,8 @@ CHIP_ERROR OTARequestor::AddDefaultOtaProvider(const ProviderLocation::Type & pr
     }
 
     ReturnErrorOnFailure(mDefaultOtaProviderList.Add(providerLocation));
+    // Store in KVS
+    ReturnErrorOnFailure(StoreDefaultOtaProvidersList());
 
     // Should be removed when periodic queries is implemented
     iterator = mDefaultOtaProviderList.Begin();

--- a/src/app/clusters/ota-requestor/OTARequestorStorage.h
+++ b/src/app/clusters/ota-requestor/OTARequestorStorage.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2022 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,18 +16,20 @@
  *    limitations under the License.
  */
 
+/* This file contains the Storage interface for the OTARequestor
+ */
+
 #pragma once
 
-#include "app/clusters/ota-requestor/BDXDownloader.h"
-#include "app/clusters/ota-requestor/OTARequestor.h"
-#include "platform/EFR32/OTAImageProcessorImpl.h"
-#include "platform/GenericOTARequestorDriver.h"
-#include "platform/GenericOTARequestorStorage.h"
-
-class OTAConfig
+namespace chip {
+class OTARequestorStorage : public PersistentStorageDelegate
 {
 public:
-    OTAConfig(){};
+    virtual ~OTARequestorStorage() = default;
 
-    static void Init();
+    // Reads a KVS value from an offset if desired and returns number of bytes read
+    // TODO: Move to PersistentStorageDelegate interface ideally
+    virtual CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size, size_t * read_bytes_size,
+                                       size_t offset_bytes) = 0;
 };
+} // namespace chip

--- a/src/platform/GenericOTARequestorStorage.h
+++ b/src/platform/GenericOTARequestorStorage.h
@@ -1,0 +1,45 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+/* This file contains a generic implementation for the OTARequestorStorage
+ */
+#include <app/clusters/ota-requestor/OTARequestorStorage.h>
+
+namespace chip {
+class GenericOTARequestorStorage : public OTARequestorStorage
+{
+
+    CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
+    {
+        return DeviceLayer::PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size);
+    }
+
+    CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size, size_t * read_bytes_size, size_t offset_bytes)
+    {
+        return DeviceLayer::PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size, read_bytes_size, offset_bytes);
+    }
+
+    CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override
+    {
+        return DeviceLayer::PersistedStorage::KeyValueStoreMgr().Put(key, value, size);
+    }
+
+    CHIP_ERROR SyncDeleteKeyValue(const char * key) override
+    {
+        return DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key);
+    }
+};
+} // namespace chip

--- a/zzz_generated/ota-requestor-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/ota-requestor-app/zap-generated/endpoint_config.h
@@ -173,8 +173,8 @@
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(SINGLETON), ZAP_SIMPLE_DEFAULT(1) }, /* ClusterRevision */       \
                                                                                                                                    \
             /* Endpoint: 0, Cluster: OTA Software Update Requestor (server) */                                                     \
-            { 0x00000000, ZAP_TYPE(ARRAY), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE) | ZAP_ATTRIBUTE_MASK(WRITABLE),                 \
-              ZAP_EMPTY_DEFAULT() },                                                                 /* DefaultOtaProviders */     \
+            { 0x00000000, ZAP_TYPE(ARRAY), 2, ZAP_ATTRIBUTE_MASK(TOKENIZE) | ZAP_ATTRIBUTE_MASK(WRITABLE),                         \
+              ZAP_SIMPLE_DEFAULT(0) },                                                               /* DefaultOtaProviders */     \
             { 0x00000001, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(1) },                          /* UpdatePossible */          \
             { 0x00000002, ZAP_TYPE(ENUM8), 1, 0, ZAP_SIMPLE_DEFAULT(0) },                            /* UpdateState */             \
             { 0x00000003, ZAP_TYPE(INT8U), 1, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_SIMPLE_DEFAULT(0) }, /* UpdateStateProgress */     \
@@ -364,7 +364,7 @@
       .clusterId = 0x0000002A,  \
       .attributes = ZAP_ATTRIBUTE_INDEX(24), \
       .attributeCount = 5, \
-      .clusterSize = 5, \
+      .clusterSize = 7, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
       .clientGeneratedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 0 ) ,\
@@ -469,7 +469,7 @@
 // This is an array of EmberAfEndpointType structures.
 #define GENERATED_ENDPOINT_TYPES                                                                                                   \
     {                                                                                                                              \
-        { ZAP_CLUSTER_INDEX(0), 12, 178 },                                                                                         \
+        { ZAP_CLUSTER_INDEX(0), 12, 180 },                                                                                         \
     }
 
 // Largest attribute size is needed for various buffers
@@ -481,7 +481,7 @@ static_assert(ATTRIBUTE_LARGEST <= CHIP_CONFIG_MAX_ATTRIBUTE_STORE_ELEMENT_SIZE,
 #define ATTRIBUTE_SINGLETONS_SIZE (39)
 
 // Total size of attribute storage
-#define ATTRIBUTE_MAX_SIZE (178)
+#define ATTRIBUTE_MAX_SIZE (180)
 
 // Number of fixed endpoints
 #define FIXED_ENDPOINT_COUNT (1)


### PR DESCRIPTION
#### Problem
Added support for loading and storing the default OTA provider attribute

#### Change overview
- A generic storage interface for the OTA provider
- A generic implementation for the OTAStorageProvider
- Load/Store the defaultotaproviderList attribute in the KVS
- Removed the "Optional" nature of the ProviderLocationList class (mList var) to make it easier to copy buffers from/to the KVS, without having an intermediate buffer.

#### Testing
- Tested using chip-tool and REPL.
- Wrote defaultotaproviderList and ensured it was stored to the KVS and read-back from it
- Ensured the defaultotaproviderList value was read from KVS during bootup