### PR TITLE
Remove unnecessary debug logs

### DIFF
--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -306,10 +306,6 @@ CHIP_ERROR BasicAttrAccess::Write(const ConcreteDataAttributePath & aPath, Attri
     case Location::Id: {
         CHIP_ERROR err = WriteLocation(aDecoder);
 
-#ifdef CHIP_DEVICE_LAYER_TARGET_DARWIN
-        // TODO: Attempt to diagnose Darwin CI, REMOVE ONCE FIXED
-        ChipLogError(Zcl, "WriteLocation status: %" CHIP_ERROR_FORMAT, err.Format());
-#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
         return err;
     }
     default:
@@ -325,11 +321,6 @@ CHIP_ERROR BasicAttrAccess::WriteLocation(AttributeValueDecoder & aDecoder)
 
     ReturnErrorOnFailure(aDecoder.Decode(location));
 
-#ifdef CHIP_DEVICE_LAYER_TARGET_DARWIN
-    // TODO: Attempt to diagnose Darwin CI, REMOVE ONCE FIXED
-    ChipLogError(Zcl, "WriteLocation received, size %zu, location '%.*s'", location.size(), (int) location.size(), location.data());
-#endif
-
     bool isValidLength = location.size() == DeviceLayer::ConfigurationManager::kMaxLocationLength;
     VerifyOrReturnError(isValidLength, StatusIB(Protocols::InteractionModel::Status::InvalidValue).ToChipError());
 
@@ -338,7 +329,7 @@ CHIP_ERROR BasicAttrAccess::WriteLocation(AttributeValueDecoder & aDecoder)
 
 class PlatformMgrDelegate : public DeviceLayer::PlatformManagerDelegate
 {
-    // Gets called by the current Node after completing a boot or reboot process.
+    // Gets called by the current Node after completing a boot or reboot process
     void OnStartUp(uint32_t softwareVersion) override
     {
         ChipLogProgress(Zcl, "PlatformMgrDelegate: OnStartUp");

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -305,8 +305,11 @@ CHIP_ERROR BasicAttrAccess::Write(const ConcreteDataAttributePath & aPath, Attri
     {
     case Location::Id: {
         CHIP_ERROR err = WriteLocation(aDecoder);
+
+#ifdef CHIP_DEVICE_LAYER_TARGET_DARWIN
         // TODO: Attempt to diagnose Darwin CI, REMOVE ONCE FIXED
         ChipLogError(Zcl, "WriteLocation status: %" CHIP_ERROR_FORMAT, err.Format());
+#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
         return err;
     }
     default:
@@ -322,8 +325,10 @@ CHIP_ERROR BasicAttrAccess::WriteLocation(AttributeValueDecoder & aDecoder)
 
     ReturnErrorOnFailure(aDecoder.Decode(location));
 
+#ifdef CHIP_DEVICE_LAYER_TARGET_DARWIN
     // TODO: Attempt to diagnose Darwin CI, REMOVE ONCE FIXED
     ChipLogError(Zcl, "WriteLocation received, size %zu, location '%.*s'", location.size(), (int) location.size(), location.data());
+#endif
 
     bool isValidLength = location.size() == DeviceLayer::ConfigurationManager::kMaxLocationLength;
     VerifyOrReturnError(isValidLength, StatusIB(Protocols::InteractionModel::Status::InvalidValue).ToChipError());


### PR DESCRIPTION
#### Problem
* Debug logs present but unnecessary. Where added in #13885
* `%zu` causes hardfault on MG24

#### Change overview
* Removed logs

#### Testing
* Manual test with MG24
