### PR TITLE
[Mbed] Real time support

### DIFF
--- a/src/platform/mbed/PlatformManagerImpl.cpp
+++ b/src/platform/mbed/PlatformManagerImpl.cpp
@@ -7,6 +7,7 @@
 #include <platform/ScopedLock.h>
 #include <platform/internal/GenericPlatformManagerImpl.cpp>
 #include <platform/mbed/DiagnosticDataProviderImpl.h>
+#include <platform/mbed/SystemTimeSupport.h>
 #include <rtos/ThisThread.h>
 
 #include "MbedEventTimeout.h"
@@ -94,8 +95,11 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
     SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 
+    auto err = System::Clock::InitClock_RealTime();
+    SuccessOrExit(err);
+
     // Call up to the base class _InitChipStack() to perform the bulk of the initialization.
-    auto err = GenericPlatformManagerImpl<ImplClass>::_InitChipStack();
+    err = GenericPlatformManagerImpl<ImplClass>::_InitChipStack();
     SuccessOrExit(err);
     mInitialized = true;
 

--- a/src/platform/mbed/SystemTimeSupport.h
+++ b/src/platform/mbed/SystemTimeSupport.h
@@ -1,0 +1,28 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/support/TimeUtils.h>
+
+namespace chip {
+namespace System {
+namespace Clock {
+
+CHIP_ERROR InitClock_RealTime();
+
+} // namespace Clock
+} // namespace System
+} // namespace chip


### PR DESCRIPTION
#### Problem
Mbed implementation does not support the RTC clock in the System Time Support module.
Mbed-os contains an RTC time driver which can be used for it.

#### Change overview
Add real-time implementation in system time support

#### Testing
Build and run mbed examples
