### PR TITLE
[clang-tidy] Fix some bugprone-use-after-move errors

### DIFF
--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -385,7 +385,7 @@ exit:
         }
         LogState();
 
-        if (!data.IsNull())
+        if (!data.IsNull()) // NOLINT(bugprone-use-after-move)
         {
             // Tack received data onto rx buffer, to be freed when end point resets protocol engine on close.
             if (!mRxBuf.IsNull())

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -4312,7 +4312,7 @@ static void CheckCHIPTLVScopedBuffer(nlTestSuite * inSuite, void * inContext)
     {
         ScopedBufferTLVWriter writer(std::move(buf), 64);
 
-        NL_TEST_ASSERT(inSuite, buf.Get() == nullptr);
+        NL_TEST_ASSERT(inSuite, buf.Get() == nullptr); // // NOLINT(bugprone-use-after-move)
 
         err = writer.Put(TLV::AnonymousTag(), (uint8_t) 33);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);

--- a/src/lib/support/tests/TestVariant.cpp
+++ b/src/lib/support/tests/TestVariant.cpp
@@ -178,7 +178,7 @@ void TestVariantMove(nlTestSuite * inSuite, void * inContext)
     Variant<Simple, Movable> v1;
     v1.Set<Movable>(5, 10);
     Variant<Simple, Movable> v2 = std::move(v1);
-    NL_TEST_ASSERT(inSuite, !v1.Valid());
+    NL_TEST_ASSERT(inSuite, !v1.Valid()); // NOLINT(bugprone-use-after-move)
     NL_TEST_ASSERT(inSuite, v2.Valid());
     NL_TEST_ASSERT(inSuite, v2.Get<Movable>().m1 == 5);
     NL_TEST_ASSERT(inSuite, v2.Get<Movable>().m2 == 10);
@@ -204,7 +204,7 @@ void TestVariantMoveAssign(nlTestSuite * inSuite, void * inContext)
     Variant<Simple, Pod> v2;
     v1.Set<Pod>(5, 10);
     v2 = std::move(v1);
-    NL_TEST_ASSERT(inSuite, !v1.Valid());
+    NL_TEST_ASSERT(inSuite, !v1.Valid()); // NOLINT(bugprone-use-after-move)
     NL_TEST_ASSERT(inSuite, v2.Valid());
     NL_TEST_ASSERT(inSuite, v2.Get<Pod>().m1 == 5);
     NL_TEST_ASSERT(inSuite, v2.Get<Pod>().m2 == 10);

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1470,7 +1470,7 @@ CHIP_ERROR CASESession::ParseSigma1(TLV::ContiguousBufferTLVReader & tlvReader, 
 }
 
 CHIP_ERROR CASESession::ValidateReceivedMessage(ExchangeContext * ec, const PayloadHeader & payloadHeader,
-                                                System::PacketBufferHandle & msg)
+                                                const System::PacketBufferHandle & msg)
 {
     VerifyOrReturnError(ec != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -229,7 +229,7 @@ private:
     CHIP_ERROR SetEffectiveTime();
 
     CHIP_ERROR ValidateReceivedMessage(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
-                                       System::PacketBufferHandle & msg);
+                                       const System::PacketBufferHandle & msg);
 
     SessionEstablishmentDelegate * mDelegate = nullptr;
 

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -856,7 +856,7 @@ CHIP_ERROR PASESession::OnFailureStatusReport(Protocols::SecureChannel::GeneralS
 }
 
 CHIP_ERROR PASESession::ValidateReceivedMessage(ExchangeContext * exchange, const PayloadHeader & payloadHeader,
-                                                System::PacketBufferHandle && msg)
+                                                const System::PacketBufferHandle & msg)
 {
     VerifyOrReturnError(exchange != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -886,7 +886,7 @@ CHIP_ERROR PASESession::ValidateReceivedMessage(ExchangeContext * exchange, cons
 CHIP_ERROR PASESession::OnMessageReceived(ExchangeContext * exchange, const PayloadHeader & payloadHeader,
                                           System::PacketBufferHandle && msg)
 {
-    CHIP_ERROR err = ValidateReceivedMessage(exchange, payloadHeader, std::move(msg));
+    CHIP_ERROR err = ValidateReceivedMessage(exchange, payloadHeader, msg);
     SuccessOrExit(err);
 
     switch (static_cast<MsgType>(payloadHeader.GetMessageType()))

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -210,7 +210,7 @@ private:
     CHIP_ERROR Init(uint16_t mySessionId, uint32_t setupCode, SessionEstablishmentDelegate * delegate);
 
     CHIP_ERROR ValidateReceivedMessage(Messaging::ExchangeContext * exchange, const PayloadHeader & payloadHeader,
-                                       System::PacketBufferHandle && msg);
+                                       const System::PacketBufferHandle & msg);
 
     CHIP_ERROR SetupSpake2p();
 

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -115,7 +115,7 @@ public:
      *
      */
 
-    CHIP_ERROR EncodeUDCMessage(System::PacketBufferHandle && payload);
+    CHIP_ERROR EncodeUDCMessage(const System::PacketBufferHandle & payload);
 };
 
 class DLL_EXPORT UserDirectedCommissioningServer : public TransportMgrDelegate

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
@@ -34,7 +34,7 @@ namespace UserDirectedCommissioning {
 CHIP_ERROR UserDirectedCommissioningClient::SendUDCMessage(TransportMgrBase * transportMgr, System::PacketBufferHandle && payload,
                                                            chip::Transport::PeerAddress peerAddress)
 {
-    CHIP_ERROR err = EncodeUDCMessage(std::move(payload));
+    CHIP_ERROR err = EncodeUDCMessage(payload);
     if (err != CHIP_NO_ERROR)
     {
         return err;
@@ -44,7 +44,7 @@ CHIP_ERROR UserDirectedCommissioningClient::SendUDCMessage(TransportMgrBase * tr
     // send UDC message 5 times per spec (no ACK on this message)
     for (unsigned int i = 0; i < 5; i++)
     {
-        err = transportMgr->SendMessage(peerAddress, std::move(payload));
+        err = transportMgr->SendMessage(peerAddress, payload.CloneData());
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(AppServer, "UDC SendMessage failed, err: %s\n", chip::ErrorStr(err));
@@ -56,7 +56,7 @@ CHIP_ERROR UserDirectedCommissioningClient::SendUDCMessage(TransportMgrBase * tr
     return err;
 }
 
-CHIP_ERROR UserDirectedCommissioningClient::EncodeUDCMessage(System::PacketBufferHandle && payload)
+CHIP_ERROR UserDirectedCommissioningClient::EncodeUDCMessage(const System::PacketBufferHandle & payload)
 {
     PayloadHeader payloadHeader;
     PacketHeader packetHeader;

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -142,7 +142,7 @@ void TestUDCServerInstanceNameResolver(nlTestSuite * inSuite, void * inContext)
     // encode our client message
     char nameBuffer[Dnssd::Commission::kInstanceNameMaxLength + 1] = "Chris";
     System::PacketBufferHandle payloadBuf = MessagePacketBuffer::NewWithData(nameBuffer, strlen(nameBuffer));
-    udcClient.EncodeUDCMessage(std::move(payloadBuf));
+    udcClient.EncodeUDCMessage(payloadBuf);
 
     // prepare peerAddress for handleMessage
     Inet::IPAddress commissioner;
@@ -165,8 +165,10 @@ void TestUDCServerInstanceNameResolver(nlTestSuite * inSuite, void * inContext)
     // same instance name is received, there is no callback
     testCallback.mFindCommissionableNodeCalled = false;
 
+    payloadBuf = MessagePacketBuffer::NewWithData(nameBuffer, strlen(nameBuffer));
+
     // reset the UDC message
-    udcClient.EncodeUDCMessage(std::move(payloadBuf));
+    udcClient.EncodeUDCMessage(payloadBuf);
 
     // test OnMessageReceived again
     mUdcTransportMgr->HandleMessageReceived(peerAddress, std::move(payloadBuf));
@@ -177,8 +179,10 @@ void TestUDCServerInstanceNameResolver(nlTestSuite * inSuite, void * inContext)
     // next, reset the cache state and confirm the callback
     udcServer.ResetUDCClientProcessingStates();
 
+    payloadBuf = MessagePacketBuffer::NewWithData(nameBuffer, strlen(nameBuffer));
+
     // reset the UDC message
-    udcClient.EncodeUDCMessage(std::move(payloadBuf));
+    udcClient.EncodeUDCMessage(payloadBuf);
 
     // test OnMessageReceived again
     mUdcTransportMgr->HandleMessageReceived(peerAddress, std::move(payloadBuf));
@@ -194,7 +198,7 @@ void TestUserDirectedCommissioningClientMessage(nlTestSuite * inSuite, void * in
     UserDirectedCommissioningClient udcClient;
 
     // obtain the UDC message
-    CHIP_ERROR err = udcClient.EncodeUDCMessage(std::move(payloadBuf));
+    CHIP_ERROR err = udcClient.EncodeUDCMessage(payloadBuf);
 
     // check the packet header fields
     PacketHeader packetHeader;


### PR DESCRIPTION
#### Problem

`clang-tidy` with `bugprone-use-after-move ` errors is complaining a little.

#### Change overview
 * Fix the different places where it complains
