### PR TITLE
Bridge app endpointid fix

### DIFF
--- a/examples/bridge-app/esp32/main/main.cpp
+++ b/examples/bridge-app/esp32/main/main.cpp
@@ -146,6 +146,7 @@ CHIP_ERROR AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, uint16_t de
     {
         if (NULL == gDevices[index])
         {
+            dev->SetEndpointId(gCurrentEndpointId);
             gDevices[index] = dev;
             EmberAfStatus ret;
             ret = emberAfSetDynamicEndpoint(index, gCurrentEndpointId, ep, deviceType, DEVICE_VERSION_DEFAULT, dataVersionStorage);

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -211,6 +211,7 @@ int AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, uint16_t deviceTyp
             EmberAfStatus ret;
             while (1)
             {
+                dev->SetEndpointId(gCurrentEndpointId);
                 ret = emberAfSetDynamicEndpoint(index, gCurrentEndpointId, ep, deviceType, DEVICE_VERSION_DEFAULT,
                                                 dataVersionStorage);
                 if (ret == EMBER_ZCL_STATUS_SUCCESS)

--- a/src/app/clusters/bridged-device-basic-information-server/bridged-device-basic-information-server.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/bridged-device-basic-information-server.cpp
@@ -56,7 +56,7 @@ void MatterBridgedDeviceBasicClusterServerAttributeChangedCallback(const Concret
 {
     if (attributePath.mClusterId != BridgedDeviceBasic::Id)
     {
-        // This shouldn't be.
+        ChipLogError(Zcl, "MatterBridgedDeviceBasicClusterServerAttributeChangedCallback: Incorrect cluster ID");
         return;
     }
 

--- a/src/app/clusters/bridged-device-basic-information-server/bridged-device-basic-information-server.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/bridged-device-basic-information-server.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
 #include <app/EventLogging.h>
 #include <app/util/af-enums.h>
 #include <app/util/basic-types.h>
@@ -28,6 +29,7 @@
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::BridgedDeviceBasic;
 
 namespace {
@@ -52,6 +54,12 @@ void ReachableChanged(EndpointId endpointId)
 
 void MatterBridgedDeviceBasicClusterServerAttributeChangedCallback(const ConcreteAttributePath & attributePath)
 {
+    if (attributePath.mClusterId != BridgedDeviceBasic::Id)
+    {
+        // This shouldn't be.
+        return;
+    }
+
     switch (attributePath.mAttributeId)
     {
     case Attributes::Reachable::Id:


### PR DESCRIPTION
#### Problem
* Endpoint ID was not being set on bridge-app Device objects.

#### Change overview
Set Endpoint ID on bridge-app Device objects.
Check Cluster ID in Bridged Device Basic Information server callback.

#### Testing
How was this tested? (at least one bullet point required)
* Temporarily hacked code to check that ReachableChanged event was being logged with no error, and that correct value of Reachable was being read.
