### PR TITLE
[ota] Add OTA requestor storage interface

### DIFF
--- a/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
@@ -1,0 +1,141 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "DefaultOTARequestorStorage.h"
+#include "OTARequestorInterface.h"
+
+#include <lib/core/CHIPConfig.h>
+#include <lib/core/CHIPPersistentStorageDelegate.h>
+#include <lib/core/CHIPTLV.h>
+#include <lib/support/DefaultStorageKeyAllocator.h>
+
+#include <limits>
+
+namespace chip {
+
+// Calculated with Python code:
+//   w = TLVWriter()
+//   s = {1:uint(0xffffffffffffffff), 2:uint(0xffff), 254:uint(0xff)}
+//   w.put(None, s)
+//   len(w.encoding)
+constexpr size_t kProviderMaxSerializedSize = 19u;
+
+// Multiply the serialized provider size by the maximum number of fabrics and add 2 bytes for the array start and end.
+constexpr size_t kProviderListMaxSerializedSize = kProviderMaxSerializedSize * CHIP_CONFIG_MAX_FABRICS + 2;
+
+CHIP_ERROR DefaultOTARequestorStorage::StoreDefaultProviders(const ProviderLocationList & providers)
+{
+    uint8_t buffer[kProviderListMaxSerializedSize];
+    TLV::TLVWriter writer;
+    TLV::TLVType outerType;
+
+    writer.Init(buffer);
+    ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, outerType));
+
+    for (auto providerIter = providers.Begin(); providerIter.Next();)
+    {
+        const auto & provider = providerIter.GetValue();
+        ReturnErrorOnFailure(provider.EncodeForRead(writer, TLV::AnonymousTag(), provider.fabricIndex));
+    }
+
+    ReturnErrorOnFailure(writer.EndContainer(outerType));
+
+    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator().OTADefaultProviders(), buffer,
+                                               static_cast<uint16_t>(writer.GetLengthWritten()));
+}
+
+CHIP_ERROR DefaultOTARequestorStorage::LoadDefaultProviders(ProviderLocationList & providers)
+{
+    uint8_t buffer[kProviderListMaxSerializedSize];
+    uint16_t size = sizeof(buffer);
+
+    ReturnErrorOnFailure(mPersistentStorage->SyncGetKeyValue(DefaultStorageKeyAllocator().OTADefaultProviders(), buffer, size));
+
+    TLV::TLVReader reader;
+    TLV::TLVType outerType;
+
+    reader.Init(buffer, size);
+    ReturnErrorOnFailure(reader.Next(TLV::TLVType::kTLVType_Array, TLV::AnonymousTag()));
+    ReturnErrorOnFailure(reader.EnterContainer(outerType));
+
+    while (reader.Next() != CHIP_ERROR_END_OF_TLV)
+    {
+        ProviderLocationType provider;
+        ReturnErrorOnFailure(provider.Decode(reader));
+        providers.Add(provider);
+    }
+
+    ReturnErrorOnFailure(reader.ExitContainer(outerType));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DefaultOTARequestorStorage::StoreCurrentProviderLocation(const ProviderLocationType & provider)
+{
+    uint8_t buffer[kProviderMaxSerializedSize];
+    TLV::TLVWriter writer;
+
+    writer.Init(buffer);
+    ReturnErrorOnFailure(provider.EncodeForRead(writer, TLV::AnonymousTag(), provider.fabricIndex));
+
+    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator().OTACurrentProvider(), buffer,
+                                               static_cast<uint16_t>(writer.GetLengthWritten()));
+}
+
+CHIP_ERROR DefaultOTARequestorStorage::ClearCurrentProviderLocation()
+{
+    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator().OTACurrentProvider());
+}
+
+CHIP_ERROR DefaultOTARequestorStorage::LoadCurrentProviderLocation(ProviderLocationType & provider)
+{
+    uint8_t buffer[kProviderMaxSerializedSize];
+    uint16_t size = sizeof(buffer);
+
+    ReturnErrorOnFailure(mPersistentStorage->SyncGetKeyValue(DefaultStorageKeyAllocator().OTACurrentProvider(), buffer, size));
+
+    TLV::TLVReader reader;
+
+    reader.Init(buffer, size);
+    ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag()));
+    ReturnErrorOnFailure(provider.Decode(reader));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DefaultOTARequestorStorage::StoreUpdateToken(ByteSpan updateToken)
+{
+    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator().OTAUpdateToken(), updateToken.data(),
+                                               static_cast<uint16_t>(updateToken.size()));
+}
+
+CHIP_ERROR DefaultOTARequestorStorage::ClearUpdateToken()
+{
+    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator().OTAUpdateToken());
+}
+
+CHIP_ERROR DefaultOTARequestorStorage::LoadUpdateToken(MutableByteSpan & updateToken)
+{
+    uint16_t size    = static_cast<uint16_t>(updateToken.size());
+    CHIP_ERROR error = mPersistentStorage->SyncGetKeyValue(DefaultStorageKeyAllocator().OTAUpdateToken(), updateToken.data(), size);
+
+    updateToken.reduce_size(size);
+    return error;
+}
+
+} // namespace chip

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.h
@@ -1,0 +1,47 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "OTARequestorStorage.h"
+
+namespace chip {
+
+class PersistentStorageDelegate;
+
+class DefaultOTARequestorStorage : public OTARequestorStorage
+{
+public:
+    void Init(PersistentStorageDelegate & persistentStorage) { mPersistentStorage = &persistentStorage; }
+
+    CHIP_ERROR StoreDefaultProviders(const ProviderLocationList & provider) override;
+    CHIP_ERROR LoadDefaultProviders(ProviderLocationList & providers) override;
+
+    CHIP_ERROR StoreCurrentProviderLocation(const ProviderLocationType & provider) override;
+    CHIP_ERROR ClearCurrentProviderLocation() override;
+    CHIP_ERROR LoadCurrentProviderLocation(ProviderLocationType & provider) override;
+
+    CHIP_ERROR StoreUpdateToken(ByteSpan updateToken) override;
+    CHIP_ERROR ClearUpdateToken() override;
+    CHIP_ERROR LoadUpdateToken(MutableByteSpan & updateToken) override;
+
+private:
+    PersistentStorageDelegate * mPersistentStorage = nullptr;
+};
+
+} // namespace chip

--- a/src/app/clusters/ota-requestor/OTARequestorInterface.h
+++ b/src/app/clusters/ota-requestor/OTARequestorInterface.h
@@ -21,14 +21,17 @@
  */
 
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app/AttributeAccessInterface.h>
-#include <app/CommandHandler.h>
 #include <app/util/af-enums.h>
 #include <lib/core/ClusterEnums.h>
 
 #pragma once
 
 namespace chip {
+
+namespace app {
+class CommandHandler;
+struct ConcreteCommandPath;
+} // namespace app
 
 /**
  * A class to represent a list of the provider locations

--- a/src/app/clusters/ota-requestor/OTARequestorStorage.h
+++ b/src/app/clusters/ota-requestor/OTARequestorStorage.h
@@ -1,0 +1,47 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app-common/zap-generated/cluster-objects.h>
+#include <lib/support/Span.h>
+
+namespace chip {
+
+class ProviderLocationList;
+
+class OTARequestorStorage
+{
+public:
+    using ProviderLocationType = app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type;
+
+    virtual ~OTARequestorStorage() {}
+
+    virtual CHIP_ERROR StoreDefaultProviders(const ProviderLocationList & provider) = 0;
+    virtual CHIP_ERROR LoadDefaultProviders(ProviderLocationList & providers)       = 0;
+
+    virtual CHIP_ERROR StoreCurrentProviderLocation(const ProviderLocationType & provider) = 0;
+    virtual CHIP_ERROR ClearCurrentProviderLocation()                                      = 0;
+    virtual CHIP_ERROR LoadCurrentProviderLocation(ProviderLocationType & provider)        = 0;
+
+    virtual CHIP_ERROR StoreUpdateToken(ByteSpan updateToken)         = 0;
+    virtual CHIP_ERROR LoadUpdateToken(MutableByteSpan & updateToken) = 0;
+    virtual CHIP_ERROR ClearUpdateToken()                             = 0;
+};
+
+} // namespace chip

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -52,6 +52,19 @@ source_set("binding-test-srcs") {
   ]
 }
 
+source_set("ota-requestor-test-srcs") {
+  sources = [
+    "${chip_root}/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp",
+    "${chip_root}/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.h",
+    "${chip_root}/src/app/clusters/ota-requestor/OTARequestorStorage.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/app/common:cluster-objects",
+    "${chip_root}/src/lib/core",
+  ]
+}
+
 chip_test_suite("tests") {
   output_name = "libAppTests"
 
@@ -65,6 +78,7 @@ chip_test_suite("tests") {
     "TestCommandInteraction.cpp",
     "TestCommandPathParams.cpp",
     "TestDataModelSerialization.cpp",
+    "TestDefaultOTARequestorStorage.cpp",
     "TestEventLogging.cpp",
     "TestEventOverflow.cpp",
     "TestEventPathParams.cpp",
@@ -93,6 +107,7 @@ chip_test_suite("tests") {
 
   public_deps = [
     ":binding-test-srcs",
+    ":ota-requestor-test-srcs",
     "${chip_root}/src/app",
     "${chip_root}/src/app/common:cluster-objects",
     "${chip_root}/src/app/tests:helpers",

--- a/src/app/tests/TestDefaultOTARequestorStorage.cpp
+++ b/src/app/tests/TestDefaultOTARequestorStorage.cpp
@@ -1,0 +1,176 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
+#include <app/clusters/ota-requestor/OTARequestorInterface.h>
+#include <lib/core/CHIPPersistentStorageDelegate.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
+#include <lib/support/UnitTestRegistration.h>
+
+#include <nlunit-test.h>
+
+using namespace chip;
+using namespace chip::DeviceLayer;
+
+namespace {
+
+void TestDefaultProviders(nlTestSuite * inSuite, void * inContext)
+{
+    TestPersistentStorageDelegate persistentStorage;
+    DefaultOTARequestorStorage otaStorage;
+    otaStorage.Init(persistentStorage);
+
+    const auto makeProvider = [](FabricIndex fabric, NodeId nodeId, EndpointId endpointId) {
+        OTARequestorStorage::ProviderLocationType provider;
+        provider.fabricIndex    = fabric;
+        provider.providerNodeID = nodeId;
+        provider.endpoint       = endpointId;
+        return provider;
+    };
+
+    ProviderLocationList providers = {};
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == providers.Add(makeProvider(FabricIndex(1), NodeId(0x11111111), EndpointId(1))));
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == providers.Add(makeProvider(FabricIndex(2), NodeId(0x22222222), EndpointId(2))));
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == providers.Add(makeProvider(FabricIndex(3), NodeId(0x33333333), EndpointId(3))));
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == otaStorage.StoreDefaultProviders(providers));
+
+    providers = {};
+    NL_TEST_ASSERT(inSuite, !providers.Begin().Next());
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == otaStorage.LoadDefaultProviders(providers));
+
+    auto provider = providers.Begin();
+    bool hasNext;
+
+    NL_TEST_ASSERT(inSuite, hasNext = provider.Next());
+
+    if (hasNext)
+    {
+        NL_TEST_ASSERT(inSuite, provider.GetValue().fabricIndex == 1);
+        NL_TEST_ASSERT(inSuite, provider.GetValue().providerNodeID == 0x11111111);
+        NL_TEST_ASSERT(inSuite, provider.GetValue().endpoint == 1);
+    }
+
+    NL_TEST_ASSERT(inSuite, hasNext = provider.Next());
+
+    if (hasNext)
+    {
+        NL_TEST_ASSERT(inSuite, provider.GetValue().fabricIndex == 2);
+        NL_TEST_ASSERT(inSuite, provider.GetValue().providerNodeID == 0x22222222);
+        NL_TEST_ASSERT(inSuite, provider.GetValue().endpoint == 2);
+    }
+
+    NL_TEST_ASSERT(inSuite, hasNext = provider.Next());
+
+    if (hasNext)
+    {
+        NL_TEST_ASSERT(inSuite, provider.GetValue().fabricIndex == 3);
+        NL_TEST_ASSERT(inSuite, provider.GetValue().providerNodeID == 0x33333333);
+        NL_TEST_ASSERT(inSuite, provider.GetValue().endpoint == 3);
+    }
+
+    NL_TEST_ASSERT(inSuite, !provider.Next());
+}
+
+void TestDefaultProvidersEmpty(nlTestSuite * inSuite, void * inContext)
+{
+    TestPersistentStorageDelegate persistentStorage;
+    DefaultOTARequestorStorage otaStorage;
+    otaStorage.Init(persistentStorage);
+
+    ProviderLocationList providers = {};
+
+    NL_TEST_ASSERT(inSuite, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND == otaStorage.LoadDefaultProviders(providers));
+    NL_TEST_ASSERT(inSuite, !providers.Begin().Next());
+}
+
+void TestCurrentProviderLocation(nlTestSuite * inSuite, void * inContext)
+{
+    TestPersistentStorageDelegate persistentStorage;
+    DefaultOTARequestorStorage otaStorage;
+    otaStorage.Init(persistentStorage);
+
+    OTARequestorStorage::ProviderLocationType provider;
+    provider.fabricIndex    = 1;
+    provider.providerNodeID = 0x12344321;
+    provider.endpoint       = 10;
+
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == otaStorage.StoreCurrentProviderLocation(provider));
+
+    provider = {};
+
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == otaStorage.LoadCurrentProviderLocation(provider));
+    NL_TEST_ASSERT(inSuite, provider.fabricIndex == 1);
+    NL_TEST_ASSERT(inSuite, provider.providerNodeID == 0x12344321);
+    NL_TEST_ASSERT(inSuite, provider.endpoint == 10);
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == otaStorage.ClearCurrentProviderLocation());
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR != otaStorage.LoadCurrentProviderLocation(provider));
+}
+
+void TestUpdateToken(nlTestSuite * inSuite, void * inContext)
+{
+    TestPersistentStorageDelegate persistentStorage;
+    DefaultOTARequestorStorage otaStorage;
+    otaStorage.Init(persistentStorage);
+
+    constexpr size_t updateTokenLength = 32;
+    uint8_t updateTokenBuffer[updateTokenLength];
+    ByteSpan updateToken(updateTokenBuffer);
+
+    for (uint8_t i = 0; i < updateTokenLength; ++i)
+        updateTokenBuffer[i] = i;
+
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == otaStorage.StoreUpdateToken(updateToken));
+
+    uint8_t readBuffer[updateTokenLength + 10];
+    MutableByteSpan readUpdateToken(readBuffer);
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == otaStorage.LoadUpdateToken(readUpdateToken));
+    NL_TEST_ASSERT(inSuite, readUpdateToken.size() == updateTokenLength);
+
+    for (uint8_t i = 0; i < updateTokenLength; ++i)
+        NL_TEST_ASSERT(inSuite, readBuffer[i] == i);
+
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == otaStorage.ClearUpdateToken());
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR != otaStorage.LoadUpdateToken(readUpdateToken));
+}
+
+const nlTest sTests[] = { NL_TEST_DEF("Test default providers", TestDefaultProviders),
+                          NL_TEST_DEF("Test default providers (empty list)", TestDefaultProvidersEmpty),
+                          NL_TEST_DEF("Test current provider location", TestCurrentProviderLocation),
+                          NL_TEST_DEF("Test update token", TestUpdateToken), NL_TEST_SENTINEL() };
+
+int TestSetup(void * inContext)
+{
+    return SUCCESS;
+}
+
+int TestTearDown(void * inContext)
+{
+    return SUCCESS;
+}
+
+} // namespace
+
+int TestDefaultOTARequestorStorage()
+{
+    nlTestSuite theSuite = { "OTA Storage tests", &sTests[0], TestSetup, TestTearDown };
+
+    // Run test suit againt one context.
+    nlTestRunner(&theSuite, nullptr);
+    return nlTestRunnerStats(&theSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestDefaultOTARequestorStorage)

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -72,6 +72,10 @@ public:
     const char * BindingTable() { return Format("bt"); }
     const char * BindingTableEntry(uint8_t index) { return Format("bt/%x", index); }
 
+    const char * OTADefaultProviders() { return "o/dp"; }
+    const char * OTACurrentProvider() { return "o/pl"; }
+    const char * OTAUpdateToken() { return "o/ut"; }
+
 private:
     static const size_t kKeyLengthMax = 32;
 


### PR DESCRIPTION
#### Problem
We don't have an abstract OTA requestor storage interface.

#### Change overview
Add OTA requestor storage interface with methods for storing and loading:
* default OTA providers
* current OTA provider
* update token
Provide the default implementation based on the persistent storage delegate, `GenericOTARequestorStorage`, and add unit tests.
Prerequisite for #15401

#### Testing
Added unit tests.
