### PR TITLE
Make sure unit test buffers are initialized for message header tests

### DIFF
--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -219,8 +219,8 @@ void TestPayloadHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
 void TestPacketHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)
 {
     PacketHeader header;
-    uint8_t buffer[64];
-    uint16_t unusedLen;
+    uint8_t buffer[64] = {};
+    uint16_t unusedLen = 0;
 
     for (uint16_t shortLen = 0; shortLen < 8; shortLen++)
     {
@@ -294,8 +294,8 @@ void TestPacketHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)
 void TestPayloadHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)
 {
     PayloadHeader header;
-    uint8_t buffer[64];
-    uint16_t unusedLen;
+    uint8_t buffer[64] = {};
+    uint16_t unusedLen = 0;
 
     for (uint16_t shortLen = 0; shortLen < 6; shortLen++)
     {


### PR DESCRIPTION
#### Problem
Partially parsed message header is reused when encoding, however that reuse may result in invalid values (e.g. invalid session id): https://github.com/project-chip/connectedhomeip/runs/5307914529?check_suite_focus=true

#### Change overview
0-initialize memory buffers and sizes in the unit test.

#### Testing
Ran under valgrind, had no more 'uninitialized value' jump complains.