### PR TITLE
Align unicast message counters with the spec.

### DIFF
--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -517,6 +517,106 @@ void CheckDuplicateMessageClosedExchange(nlTestSuite * inSuite, void * inContext
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
 }
 
+void CheckDuplicateOldMessageClosedExchange(nlTestSuite * inSuite, void * inContext)
+{
+    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+
+    chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
+    NL_TEST_ASSERT(inSuite, !buffer.IsNull());
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    MockAppDelegate mockReceiver;
+    err = ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest, &mockReceiver);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    mockReceiver.mTestSuite = inSuite;
+
+    MockAppDelegate mockSender;
+    ExchangeContext * exchange = ctx.NewExchangeToAlice(&mockSender);
+    NL_TEST_ASSERT(inSuite, exchange != nullptr);
+
+    ReliableMessageMgr * rm = ctx.GetExchangeManager().GetReliableMessageMgr();
+    NL_TEST_ASSERT(inSuite, rm != nullptr);
+
+    exchange->GetSessionHandle()->AsSecureSession()->SetMRPConfig({
+        64_ms32, // CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL
+        64_ms32, // CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL
+    });
+
+    // Let's not drop the message. Expectation is that it is received by the peer, but the ack is dropped
+    gLoopback.mSentMessageCount    = 0;
+    gLoopback.mNumMessagesToDrop   = 0;
+    gLoopback.mDroppedMessageCount = 0;
+
+    // Drop the ack, and also close the peer exchange
+    mockReceiver.mDropAckResponse = true;
+    mockReceiver.mRetainExchange  = false;
+
+    // Ensure the retransmit table is empty right now
+    NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
+
+    err = exchange->SendMessage(Echo::MsgType::EchoRequest, std::move(buffer));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    ctx.DrainAndServiceIO();
+
+    // Ensure the message was sent
+    // The ack was dropped, and message was added to the retransmit table
+    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 1);
+
+    // Make sure we don't accidentally retransmit before we are done with our
+    // message counter incrementing.
+    rm->StopTimer();
+
+    // Now send CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE + 2 messages to make
+    // sure our original message is out of the message counter window.  These
+    // messages can be sent withour MRP, because we are not expecting acks for
+    // them anyway.
+    size_t extraMessages = CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE + 2;
+    for (size_t i = 0; i < extraMessages; ++i)
+    {
+        buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
+        NL_TEST_ASSERT(inSuite, !buffer.IsNull());
+
+        ExchangeContext * newExchange = ctx.NewExchangeToAlice(&mockSender);
+        NL_TEST_ASSERT(inSuite, newExchange != nullptr);
+
+        mockReceiver.mRetainExchange = false;
+
+        // Ensure the retransmit table has our one message right now
+        NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 1);
+
+        // Send without MRP.
+        err = newExchange->SendMessage(Echo::MsgType::EchoRequest, std::move(buffer), SendMessageFlags::kNoAutoRequestAck);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        ctx.DrainAndServiceIO();
+
+        // Ensure the message was sent, but not added to the retransmit table.
+        NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1 + (i + 1));
+        NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+        NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 1);
+    }
+
+    // Let's not drop the duplicate message's ack.
+    mockReceiver.mDropAckResponse = false;
+
+    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Wait for the first re-transmit and ack (should take 64ms)
+    rm->StartTimer();
+    ctx.GetIOContext().DriveIOUntil(1000_ms32, [extraMessages] { return gLoopback.mSentMessageCount >= 3 + extraMessages; });
+    ctx.DrainAndServiceIO();
+
+    // Ensure the retransmit message was sent and the ack was sent
+    // and retransmit table was cleared
+    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 3 + extraMessages);
+    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
+}
+
 void CheckResendSessionEstablishmentMessageWithPeerExchange(nlTestSuite * inSuite, void * inContext)
 {
     // Making this static to reduce stack usage, as some platforms have limits on stack size.
@@ -1382,6 +1482,7 @@ const nlTest sTests[] =
     NL_TEST_DEF("Test ReliableMessageMgr::CheckResendSessionEstablishmentMessageWithPeerExchange", CheckResendSessionEstablishmentMessageWithPeerExchange),
     NL_TEST_DEF("Test ReliableMessageMgr::CheckDuplicateMessage", CheckDuplicateMessage),
     NL_TEST_DEF("Test ReliableMessageMgr::CheckDuplicateMessageClosedExchange", CheckDuplicateMessageClosedExchange),
+    NL_TEST_DEF("Test ReliableMessageMgr::CheckDuplicateOldMessageClosedExchange", CheckDuplicateOldMessageClosedExchange),
     NL_TEST_DEF("Test that a reply after a standalone ack comes through correctly", CheckReceiveAfterStandaloneAck),
     NL_TEST_DEF("Test that a reply to a non-MRP message piggybacks an ack if there were MRP things happening on the context before", CheckPiggybackAfterPiggyback),
     NL_TEST_DEF("Test sending an unsolicited ack-soliciting 'standalone ack' message", CheckSendUnsolicitedStandaloneAckMessage),

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -81,17 +81,7 @@ public:
 
     /**
      * @brief
-     *   Get the value of peer session counter which is synced during session establishment
-     */
-    virtual uint32_t GetPeerCounter()
-    {
-        // TODO(#6652): This is a stub implementation, should be replaced by the real one when CASE and PASE is completed
-        return LocalSessionMessageCounter::kInitialSyncValue;
-    }
-
-    /**
-     * @brief
-     *   Get the value of peer session counter which is synced during session establishment
+     *   Get the MRP config that was communicated during the session establishment.
      */
     virtual const ReliableMessageProtocolConfig & GetMRPConfig() const { return mMRPConfig; }
 

--- a/src/transport/PeerMessageCounter.h
+++ b/src/transport/PeerMessageCounter.h
@@ -96,97 +96,28 @@ public:
      * considered duplicate if the corresponding bit offset is set to true.
      *
      */
-    CHIP_ERROR VerifyGroupCounter(uint32_t counter)
+    CHIP_ERROR VerifyGroup(uint32_t counter) const
     {
         if (mStatus != Status::Synced)
         {
             return CHIP_ERROR_INCORRECT_STATE;
         }
 
-        // 1. Check whether the new counter value falls in the spec's "valid future counter value" window.
-        uint32_t counterIncrease          = counter - mSynced.mMaxCounter;
-        uint32_t groupFutureCounterWindow = (static_cast<uint32_t>(1 << 31)) - 1;
-        if (counterIncrease >= 1 && counterIncrease <= (groupFutureCounterWindow))
-        {
-            return CHIP_NO_ERROR;
-        }
-
-        // 2. Counter Window check
-        uint32_t offset = mSynced.mMaxCounter - counter;
-        if (offset <= CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE)
-        {
-            if ((offset == 0) || mSynced.mWindow.test(offset - 1))
-            {
-                return CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED; // duplicated, in window
-            }
-        }
-        else
-        {
-            return CHIP_ERROR_MESSAGE_COUNTER_OUT_OF_WINDOW;
-        }
-
-        return CHIP_NO_ERROR;
+        Position pos = ClassifyWithRollover(counter);
+        return VerifyPositionEncrypted(pos, counter);
     }
 
-    CHIP_ERROR VerifyUnicast(uint32_t counter) const
-    {
-        if (mStatus != Status::Synced)
-        {
-            return CHIP_ERROR_INCORRECT_STATE;
-        }
-
-        if (counter == mSynced.mMaxCounter)
-        {
-            return CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED;
-        }
-
-        if (counter < mSynced.mMaxCounter)
-        {
-            uint32_t offset = mSynced.mMaxCounter - counter;
-
-            if (offset > CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE)
-            {
-                return CHIP_ERROR_MESSAGE_COUNTER_OUT_OF_WINDOW; // outside valid range
-            }
-
-            if (mSynced.mWindow.test(offset - 1))
-            {
-                return CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED; // duplicated, in window
-            }
-        }
-
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR Verify(uint32_t counter, bool useGroupAlgorithm = false)
-    {
-        if (useGroupAlgorithm)
-        {
-            return VerifyGroupCounter(counter);
-        }
-        return VerifyUnicast(counter);
-    }
-
-    CHIP_ERROR VerifyOrTrustFirst(uint32_t counter, bool useGroupAlgorithm = false)
+    CHIP_ERROR VerifyOrTrustFirstGroup(uint32_t counter)
     {
         switch (mStatus)
         {
-        case Status::NotSynced:
+        case Status::NotSynced: {
             // Trust and set the counter when not synced
             SetCounter(counter);
             return CHIP_NO_ERROR;
+        }
         case Status::Synced: {
-            CHIP_ERROR err = Verify(counter, true);
-            if (err == CHIP_ERROR_MESSAGE_COUNTER_OUT_OF_WINDOW && !useGroupAlgorithm)
-            {
-                // According to chip spec, when global unencrypted message
-                // counter is out of window, the peer may have reset and is
-                // using another randomize initial value. Trust the new
-                // counter here.
-                SetCounter(counter);
-                err = CHIP_NO_ERROR;
-            }
-            return err;
+            return VerifyGroup(counter);
         }
         default:
             VerifyOrDie(false);
@@ -196,40 +127,22 @@ public:
 
     /**
      * @brief
-     *    With the counter verified and the packet MIC also verified by the secure key, we can trust the packet and adjust
-     *    counter states including possible Rollover for Groups communications.
+     *    With the group counter verified and the packet MIC also verified by the secure key, we can trust the packet and adjust
+     *    counter states.
      *
-     * @pre Verify(counter) == CHIP_NO_ERROR
+     * @pre counter has been verified via VerifyGroup or VerifyOrTrustFirstGroup
      */
-    void CommitWithRollOver(uint32_t counter)
-    {
-        uint32_t offset = mSynced.mMaxCounter - counter;
-        if (offset <= CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE)
-        {
+    void CommitGroup(uint32_t counter) { CommitWithRollover(counter); }
 
-            // Make sure that offset is never 0.
-            // This should not happen but we cannot guarantee it
-            // since this class doesn't own the call to this function
-            if (offset != 0)
-            {
-                mSynced.mWindow.set(offset - 1);
-            }
-        }
-        else
+    CHIP_ERROR VerifyEncryptedUnicast(uint32_t counter) const
+    {
+        if (mStatus != Status::Synced)
         {
-            // Not a bit inside the window.  Since we are committing, this is a new mMaxCounter value.
-            mSynced.mMaxCounter = counter;
-            uint32_t shift      = -offset;
-            if (shift > CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE)
-            {
-                mSynced.mWindow.reset();
-            }
-            else
-            {
-                mSynced.mWindow <<= shift;
-                mSynced.mWindow.set(shift - 1);
-            }
+            return CHIP_ERROR_INCORRECT_STATE;
         }
+
+        Position pos = ClassifyWithoutRollover(counter);
+        return VerifyPositionEncrypted(pos, counter);
     }
 
     /**
@@ -237,36 +150,38 @@ public:
      *    With the counter verified and the packet MIC also verified by the secure key, we can trust the packet and adjust
      *    counter states.
      *
-     * @pre Verify(counter) == CHIP_NO_ERROR
+     * @pre counter has been verified via VerifyEncryptedUnicast
      */
-    void Commit(uint32_t counter)
+    void CommitEncryptedUnicast(uint32_t counter) { CommitWithoutRollover(counter); }
+
+    CHIP_ERROR VerifyUnencrypted(uint32_t counter)
     {
-        if (counter < mSynced.mMaxCounter)
+        switch (mStatus)
         {
-            uint32_t offset = mSynced.mMaxCounter - counter;
-            mSynced.mWindow.set(offset - 1);
+        case Status::NotSynced: {
+            // Trust and set the counter when not synced
+            SetCounter(counter);
+            return CHIP_NO_ERROR;
         }
-        else if (counter == mSynced.mMaxCounter)
-        {
-            // No action needed.  We already trusted this counter when the
-            // VerifyOrTrustFirst call happened.
+        case Status::Synced: {
+            Position pos = ClassifyWithRollover(counter);
+            return VerifyPositionUnencrypted(pos, counter);
         }
-        else
-        {
-            uint32_t offset = counter - mSynced.mMaxCounter;
-            // advance max counter by `offset`
-            mSynced.mMaxCounter = counter;
-            if (offset <= CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE)
-            {
-                mSynced.mWindow <<= offset;
-                mSynced.mWindow.set(offset - 1);
-            }
-            else
-            {
-                mSynced.mWindow.reset();
-            }
+        default: {
+            VerifyOrDie(false);
+            return CHIP_ERROR_INTERNAL;
+        }
         }
     }
+
+    /**
+     * @brief
+     *    With the unencrypted counter verified we can trust the packet and adjust
+     *    counter states.
+     *
+     * @pre counter has been verified via VerifyUnencrypted
+     */
+    void CommitUnencrypted(uint32_t counter) { CommitWithRollover(counter); }
 
     void SetCounter(uint32_t value)
     {
@@ -280,6 +195,175 @@ public:
     uint32_t GetCounter() { return mSynced.mMaxCounter; }
 
 private:
+    // Counter position indicator with respect to our current
+    // mSynced.mMaxCounter.
+    enum class Position
+    {
+        BeforeWindow,
+        InWindow,
+        MaxCounter,
+        FutureCounter,
+    };
+
+    // Classify an incoming counter value's position.  Must be used only if
+    // mStatus is Status::Synced.
+    Position ClassifyWithoutRollover(uint32_t counter) const
+    {
+        if (counter > mSynced.mMaxCounter)
+        {
+            return Position::FutureCounter;
+        }
+
+        return ClassifyNonFutureCounter(counter);
+    }
+
+    /**
+     * Classify an incoming counter value's position for the cases when counters
+     * are allowed to roll over.  Must be used only if mStatus is
+     * Status::Synced.
+     *
+     * This can be used as the basis for implementing section 4.5.4.2 in the
+     * spec:
+     *
+     * For encrypted messages of Group Session Type, any arriving message with a counter in the range
+     * [(max_message_counter + 1) to (max_message_counter + 2^31 - 1)] (modulo 2^32) SHALL be considered
+     * new, and cause the max_message_counter value to be updated. Messages with counters from
+     * [(max_message_counter - 2^31) to (max_message_counter - MSG_COUNTER_WINDOW_SIZE - 1)] (modulo 2^
+     * 32) SHALL be considered duplicate. Message counters within the range of the bitmap SHALL be
+     * considered duplicate if the corresponding bit offset is set to true.
+     */
+    Position ClassifyWithRollover(uint32_t counter) const
+    {
+        uint32_t counterIncrease               = counter - mSynced.mMaxCounter;
+        constexpr uint32_t futureCounterWindow = (static_cast<uint32_t>(1 << 31)) - 1;
+
+        if (counterIncrease >= 1 && counterIncrease <= futureCounterWindow)
+        {
+            return Position::FutureCounter;
+        }
+
+        return ClassifyNonFutureCounter(counter);
+    }
+
+    /**
+     * Classify a counter that's known to not be future counter.  This works
+     * identically whether we are doing rollover or not.
+     */
+    Position ClassifyNonFutureCounter(uint32_t counter) const
+    {
+        if (counter == mSynced.mMaxCounter)
+        {
+            return Position::MaxCounter;
+        }
+
+        uint32_t offset = mSynced.mMaxCounter - counter;
+        if (offset <= CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE)
+        {
+            return Position::InWindow;
+        }
+
+        return Position::BeforeWindow;
+    }
+
+    /**
+     * Given an encrypted (group or unicast) counter position and the counter
+     * value, verify whether we should accept it.
+     */
+    CHIP_ERROR VerifyPositionEncrypted(Position position, uint32_t counter) const
+    {
+        switch (position)
+        {
+        case Position::FutureCounter:
+            return CHIP_NO_ERROR;
+        case Position::InWindow: {
+            uint32_t offset = mSynced.mMaxCounter - counter;
+            if (mSynced.mWindow.test(offset - 1))
+            {
+                return CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED;
+            }
+            return CHIP_NO_ERROR;
+        }
+        default: {
+            // Equal to max counter, or before window.
+            return CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED;
+        }
+        }
+    }
+
+    /**
+     * Given an unencrypted counter position and value, verify whether we should
+     * accept it.
+     */
+    CHIP_ERROR VerifyPositionUnencrypted(Position position, uint32_t counter) const
+    {
+        switch (position)
+        {
+        case Position::MaxCounter:
+            return CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED;
+        case Position::InWindow: {
+            uint32_t offset = mSynced.mMaxCounter - counter;
+            if (mSynced.mWindow.test(offset - 1))
+            {
+                return CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED;
+            }
+            return CHIP_NO_ERROR;
+        }
+        default: {
+            // Future counter or before window; all of these are accepted.  The
+            // before-window case is accepted because the peer may have reset
+            // and is using a new randomized initial value.
+            return CHIP_NO_ERROR;
+        }
+        }
+    }
+
+    void CommitWithRollover(uint32_t counter)
+    {
+        Position pos = ClassifyWithRollover(counter);
+        CommitWithPosition(pos, counter);
+    }
+
+    void CommitWithoutRollover(uint32_t counter)
+    {
+        Position pos = ClassifyWithoutRollover(counter);
+        CommitWithPosition(pos, counter);
+    }
+
+    /**
+     * Commit a counter value that is known to be at the given position with
+     * respect to our max counter.
+     */
+    void CommitWithPosition(Position position, uint32_t counter)
+    {
+        switch (position)
+        {
+        case Position::InWindow: {
+            uint32_t offset = mSynced.mMaxCounter - counter;
+            mSynced.mWindow.set(offset - 1);
+            break;
+        }
+        case Position::MaxCounter: {
+            // Nothing to do
+            break;
+        }
+        default: {
+            // Since we are committing, this becomes a new max-counter value.
+            uint32_t shift      = counter - mSynced.mMaxCounter;
+            mSynced.mMaxCounter = counter;
+            if (shift > CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE)
+            {
+                mSynced.mWindow.reset();
+            }
+            else
+            {
+                mSynced.mWindow <<= shift;
+                mSynced.mWindow.set(shift - 1);
+            }
+            break;
+        }
+        }
+    }
+
     enum class Status
     {
         NotSynced,     // No state associated

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -502,8 +502,8 @@ void SessionManager::UnauthenticatedMessageDispatch(const PacketHeader & packetH
     ReturnOnFailure(payloadHeader.DecodeAndConsume(msg));
 
     // Verify message counter
-    CHIP_ERROR err = unsecuredSession->GetPeerMessageCounter().VerifyOrTrustFirst(packetHeader.GetMessageCounter());
-    if (err == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED || err == CHIP_ERROR_MESSAGE_COUNTER_OUT_OF_WINDOW)
+    CHIP_ERROR err = unsecuredSession->GetPeerMessageCounter().VerifyUnencrypted(packetHeader.GetMessageCounter());
+    if (err == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED)
     {
         ChipLogDetail(Inet,
                       "Received a duplicate message with MessageCounter:" ChipLogFormatMessageCounter
@@ -514,9 +514,9 @@ void SessionManager::UnauthenticatedMessageDispatch(const PacketHeader & packetH
     }
     else
     {
-        // VerifyOrTrustFirst always returns one of CHIP_NO_ERROR,
-        // CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED, or CHIP_ERROR_MESSAGE_COUNTER_OUT_OF_WINDOW
-        unsecuredSession->GetPeerMessageCounter().CommitWithRollOver(packetHeader.GetMessageCounter());
+        // VerifyUnencrypted always returns one of CHIP_NO_ERROR or
+        // CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED.
+        unsecuredSession->GetPeerMessageCounter().CommitUnencrypted(packetHeader.GetMessageCounter());
     }
 
     if (mCB != nullptr)
@@ -557,8 +557,9 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & packetHea
         return;
     }
 
-    err = secureSession->GetSessionMessageCounter().GetPeerMessageCounter().Verify(packetHeader.GetMessageCounter());
-    if (err == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED || err == CHIP_ERROR_MESSAGE_COUNTER_OUT_OF_WINDOW)
+    err =
+        secureSession->GetSessionMessageCounter().GetPeerMessageCounter().VerifyEncryptedUnicast(packetHeader.GetMessageCounter());
+    if (err == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED)
     {
         ChipLogDetail(Inet,
                       "Received a duplicate message with MessageCounter:" ChipLogFormatMessageCounter
@@ -584,7 +585,7 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & packetHea
 
     if (isDuplicate == SessionMessageDelegate::DuplicateMessage::No)
     {
-        secureSession->GetSessionMessageCounter().GetPeerMessageCounter().Commit(packetHeader.GetMessageCounter());
+        secureSession->GetSessionMessageCounter().GetPeerMessageCounter().CommitEncryptedUnicast(packetHeader.GetMessageCounter());
     }
 
     // TODO: once mDNS address resolution is available reconsider if this is required
@@ -692,7 +693,7 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
 
         if (Credentials::GroupDataProvider::SecurityPolicy::kLowLatency == groupContext.security_policy)
         {
-            err = counter->VerifyOrTrustFirst(packetHeader.GetMessageCounter(), true);
+            err = counter->VerifyOrTrustFirstGroup(packetHeader.GetMessageCounter());
         }
         else
         {
@@ -702,7 +703,7 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
             return;
 
             // cache and sync
-            // err = counter->Verify(packetHeader.GetMessageCounter(), true);
+            // err = counter->VerifyGroup(packetHeader.GetMessageCounter());
         }
 
         if (err != CHIP_NO_ERROR)
@@ -719,7 +720,7 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
         return;
     }
 
-    counter->CommitWithRollOver(packetHeader.GetMessageCounter());
+    counter->CommitGroup(packetHeader.GetMessageCounter());
 
     if (mCB != nullptr)
     {

--- a/src/transport/tests/TestGroupMessageCounter.cpp
+++ b/src/transport/tests/TestGroupMessageCounter.cpp
@@ -200,20 +200,20 @@ void CounterCommitRolloverTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, counter != nullptr);
 
-    err = counter->VerifyOrTrustFirst(UINT32_MAX, true);
+    err = counter->VerifyOrTrustFirstGroup(UINT32_MAX);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    counter->CommitWithRollOver(UINT32_MAX);
+    counter->CommitGroup(UINT32_MAX);
 
-    err = counter->VerifyOrTrustFirst(0, true);
+    err = counter->VerifyOrTrustFirstGroup(0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    counter->CommitWithRollOver(0);
+    counter->CommitGroup(0);
 
-    err = counter->VerifyOrTrustFirst(1, true);
+    err = counter->VerifyOrTrustFirstGroup(1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    counter->CommitWithRollOver(1);
+    counter->CommitGroup(1);
 }
 
 void CounterTrustFirstTest(nlTestSuite * inSuite, void * inContext)
@@ -226,27 +226,27 @@ void CounterTrustFirstTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, counter != nullptr);
 
-    err = counter->VerifyOrTrustFirst(5656, true);
+    err = counter->VerifyOrTrustFirstGroup(5656);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    counter->CommitWithRollOver(5656);
+    counter->CommitGroup(5656);
 
-    err = counter->VerifyOrTrustFirst(5756, true);
+    err = counter->VerifyOrTrustFirstGroup(5756);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    counter->CommitWithRollOver(5756);
-    err = counter->VerifyOrTrustFirst(4756, true);
+    counter->CommitGroup(5756);
+    err = counter->VerifyOrTrustFirstGroup(4756);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 
     // test sequential reception
-    err = counter->VerifyOrTrustFirst(5757, true);
+    err = counter->VerifyOrTrustFirstGroup(5757);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    counter->CommitWithRollOver(5757);
+    counter->CommitGroup(5757);
 
-    err = counter->VerifyOrTrustFirst(5758, true);
+    err = counter->VerifyOrTrustFirstGroup(5758);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    counter->CommitWithRollOver(5758);
+    counter->CommitGroup(5758);
 
-    err = counter->VerifyOrTrustFirst(5756, true);
+    err = counter->VerifyOrTrustFirstGroup(5756);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 
     // Test Roll over
@@ -254,39 +254,39 @@ void CounterTrustFirstTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, counter != nullptr);
 
-    err = counter->VerifyOrTrustFirst(UINT32_MAX - 6, true);
+    err = counter->VerifyOrTrustFirstGroup(UINT32_MAX - 6);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    counter->CommitWithRollOver(UINT32_MAX - 6);
+    counter->CommitGroup(UINT32_MAX - 6);
 
-    err = counter->VerifyOrTrustFirst(UINT32_MAX - 1, true);
+    err = counter->VerifyOrTrustFirstGroup(UINT32_MAX - 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    counter->CommitWithRollOver(UINT32_MAX - 1);
+    counter->CommitGroup(UINT32_MAX - 1);
 
-    err = counter->VerifyOrTrustFirst(UINT32_MAX, true);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    err = counter->VerifyOrTrustFirst(0, true);
+    err = counter->VerifyOrTrustFirstGroup(UINT32_MAX);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = counter->VerifyOrTrustFirst(1, true);
+    err = counter->VerifyOrTrustFirstGroup(0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = counter->VerifyOrTrustFirst(2, true);
+    err = counter->VerifyOrTrustFirstGroup(1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = counter->VerifyOrTrustFirst(3, true);
+    err = counter->VerifyOrTrustFirstGroup(2);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = counter->VerifyOrTrustFirst(4, true);
+    err = counter->VerifyOrTrustFirstGroup(3);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = counter->VerifyOrTrustFirst(5, true);
+    err = counter->VerifyOrTrustFirstGroup(4);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = counter->VerifyOrTrustFirst(6, true);
+    err = counter->VerifyOrTrustFirstGroup(5);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = counter->VerifyOrTrustFirst(7, true);
+    err = counter->VerifyOrTrustFirstGroup(6);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = counter->VerifyOrTrustFirstGroup(7);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
@@ -344,11 +344,11 @@ void ReorderFabricRemovalTest(nlTestSuite * inSuite, void * inContext)
     err = mGroupPeerMsgCounter.FindOrAddPeer(8, 1, false, counter);
     err = mGroupPeerMsgCounter.FindOrAddPeer(9, 1, false, counter);
 
-    err = counter->VerifyOrTrustFirst(5656, true);
+    err = counter->VerifyOrTrustFirstGroup(5656);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    counter->CommitWithRollOver(5656);
+    counter->CommitGroup(5656);
 
-    err = counter->VerifyOrTrustFirst(4756, true);
+    err = counter->VerifyOrTrustFirstGroup(4756);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 
     err = mGroupPeerMsgCounter.FindOrAddPeer(10, 1, false, counter);
@@ -377,7 +377,7 @@ void ReorderFabricRemovalTest(nlTestSuite * inSuite, void * inContext)
     // Validate that counter value were moved around correctly
     err = mGroupPeerMsgCounter.FindOrAddPeer(9, 1, false, counter);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    err = counter->VerifyOrTrustFirst(4756, true);
+    err = counter->VerifyOrTrustFirstGroup(4756);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 }
 #endif // CHIP_CONFIG_MAX_FABRICS > 12

--- a/src/transport/tests/TestPeerMessageCounter.cpp
+++ b/src/transport/tests/TestPeerMessageCounter.cpp
@@ -43,23 +43,16 @@ void GroupRollOverTest(nlTestSuite * inSuite, void * inContext)
         for (uint32_t k = 1; k <= 2 * CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE; k++)
         {
             chip::Transport::PeerMessageCounter counter;
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n, true) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirstGroup(n) == CHIP_NO_ERROR);
 
-            counter.CommitWithRollOver(n);
+            counter.CommitGroup(n);
 
             // 1. A counter value of N + k comes in, we detect it as valid and commit it.
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n + k, true) == CHIP_NO_ERROR);
-            counter.CommitWithRollOver(n + k);
+            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirstGroup(n + k) == CHIP_NO_ERROR);
+            counter.CommitGroup(n + k);
 
             // 2. A counter value of N comes in, we detect it as duplicate.
-            if (k <= CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE)
-            {
-                NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n, true) == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED);
-            }
-            else
-            {
-                NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n, true) == CHIP_ERROR_MESSAGE_COUNTER_OUT_OF_WINDOW);
-            }
+            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirstGroup(n) == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED);
 
             // 3. A counter value between N - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE and
             //    N + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE (but not including
@@ -67,19 +60,19 @@ void GroupRollOverTest(nlTestSuite * inSuite, void * inContext)
             for (uint32_t i = n - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE; i != (n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE);
                  i++)
             {
-                NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(i, true) != CHIP_NO_ERROR);
+                NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirstGroup(i) != CHIP_NO_ERROR);
             }
 
             // 4. A counter value of N + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE comes in, is treated as valid.
             if (k != CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE)
             {
-                NL_TEST_ASSERT(
-                    inSuite, counter.VerifyOrTrustFirst((n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE), true) == CHIP_NO_ERROR);
+                NL_TEST_ASSERT(inSuite,
+                               counter.VerifyOrTrustFirstGroup(n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) == CHIP_NO_ERROR);
             }
             else
             {
-                NL_TEST_ASSERT(
-                    inSuite, counter.VerifyOrTrustFirst((n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE), true) != CHIP_NO_ERROR);
+                NL_TEST_ASSERT(inSuite,
+                               counter.VerifyOrTrustFirstGroup(n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) != CHIP_NO_ERROR);
             }
         }
     }
@@ -90,24 +83,24 @@ void GroupBackTrackTest(nlTestSuite * inSuite, void * inContext)
     for (auto n : counterValuesArray)
     {
         chip::Transport::PeerMessageCounter counter;
-        NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n, true) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirstGroup(n) == CHIP_NO_ERROR);
 
-        counter.CommitWithRollOver(n);
+        counter.CommitGroup(n);
         // 1.   Some set of values N - k come in, for 0 < k < CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE.
         //      All of those should be considered valid and committed.
         for (uint32_t k = 1; k * k < CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE; k++)
         {
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n - (k * k), true) == CHIP_NO_ERROR);
-            counter.CommitWithRollOver(n - (k * k));
+            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirstGroup(n - (k * k)) == CHIP_NO_ERROR);
+            counter.CommitGroup(n - (k * k));
         }
         // 2. Counter value N + 3 comes in
-        NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n + 3, true) == CHIP_NO_ERROR);
-        counter.CommitWithRollOver(n + 3);
+        NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirstGroup(n + 3) == CHIP_NO_ERROR);
+        counter.CommitGroup(n + 3);
 
         // 3. The same set of values N - k come in as in step (1) and are all considered duplicates/out of window.
         for (uint32_t k = 1; k * k < CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE; k++)
         {
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n - (k * k), true) != CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirstGroup(n - (k * k)) != CHIP_NO_ERROR);
         }
 
         // 4. The values that were not in the set in step (a) (but are at least N + 3 - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE)
@@ -118,8 +111,8 @@ void GroupBackTrackTest(nlTestSuite * inSuite, void * inContext)
             {
                 continue;
             }
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(k, true) == CHIP_NO_ERROR);
-            counter.CommitWithRollOver(k);
+            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirstGroup(k) == CHIP_NO_ERROR);
+            counter.CommitGroup(k);
         }
     }
 }
@@ -131,16 +124,16 @@ void GroupBigLeapTest(nlTestSuite * inSuite, void * inContext)
         for (uint32_t k = (static_cast<uint32_t>(1 << 31) - 5); k <= (static_cast<uint32_t>(1 << 31) - 1); k++)
         {
             chip::Transport::PeerMessageCounter counter;
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n, true) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirstGroup(n) == CHIP_NO_ERROR);
 
-            counter.CommitWithRollOver(n);
+            counter.CommitGroup(n);
 
             // 1. A counter value of N + k comes in, we detect it as valid and commit it.
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n + k, true) == CHIP_NO_ERROR);
-            counter.CommitWithRollOver(n + k);
+            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirstGroup(n + k) == CHIP_NO_ERROR);
+            counter.CommitGroup(n + k);
 
             // 2. A counter value of N comes in, we detect it as duplicate.
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n, true) != CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirstGroup(n) != CHIP_NO_ERROR);
 
             // 3. A counter value between N and N + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE
             //    (but not including N + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) comes in, we treat it as duplicate.
@@ -156,16 +149,16 @@ void GroupBigLeapTest(nlTestSuite * inSuite, void * inContext)
             testValues.push_back(static_cast<uint32_t>(n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE - 1));
 
             // Will be inside the valid window of counter + (2^31 -1)
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE, true) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirstGroup(n - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) == CHIP_NO_ERROR);
 
             for (auto it : testValues)
             {
-                NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(it, true) != CHIP_NO_ERROR);
+                NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirstGroup(it) != CHIP_NO_ERROR);
             }
 
             // 4. A counter value of N + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE comes in, is treated as valid.
             NL_TEST_ASSERT(inSuite,
-                           counter.VerifyOrTrustFirst((n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE), true) == CHIP_NO_ERROR);
+                           counter.VerifyOrTrustFirstGroup(n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) == CHIP_NO_ERROR);
         }
     }
 }
@@ -177,12 +170,12 @@ void GroupOutOfWindow(nlTestSuite * inSuite, void * inContext)
         for (uint32_t k = (static_cast<uint32_t>(1 << 31)); k <= (static_cast<uint32_t>(1 << 31) + 2); k++)
         {
             chip::Transport::PeerMessageCounter counter;
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n, true) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirstGroup(n) == CHIP_NO_ERROR);
 
-            counter.CommitWithRollOver(n);
+            counter.CommitGroup(n);
 
-            // 1. A counter value of N + k comes in, we detect it as out of window
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n + k, true) == CHIP_ERROR_MESSAGE_COUNTER_OUT_OF_WINDOW);
+            // 1. A counter value of N + k comes in, we detect it as duplicate.
+            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirstGroup(n + k) == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED);
         }
     }
 }
@@ -195,10 +188,10 @@ void UnicastSmallStepTest(nlTestSuite * inSuite, void * inContext)
         {
             chip::Transport::PeerMessageCounter counter;
             counter.SetCounter(LocalSessionMessageCounter::kInitialSyncValue);
-            if (counter.VerifyUnicast(n) == CHIP_NO_ERROR)
+            if (counter.VerifyEncryptedUnicast(n) == CHIP_NO_ERROR)
             {
                 // Act like we got this counter value on the wire.
-                counter.Commit(n);
+                counter.CommitEncryptedUnicast(n);
             }
             else
             {
@@ -208,29 +201,22 @@ void UnicastSmallStepTest(nlTestSuite * inSuite, void * inContext)
             }
 
             // A counter value of N comes in, we detect it as duplicate.
-            NL_TEST_ASSERT(inSuite, counter.VerifyUnicast(n) == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED);
+            NL_TEST_ASSERT(inSuite, counter.VerifyEncryptedUnicast(n) == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED);
 
             // A counter value of N + k comes in, we detect it as valid only if it would not
             // overflow, and commit it.
             if (k > UINT32_MAX - n)
             {
-                NL_TEST_ASSERT(inSuite, counter.VerifyUnicast(n + k) == CHIP_ERROR_MESSAGE_COUNTER_OUT_OF_WINDOW);
+                NL_TEST_ASSERT(inSuite, counter.VerifyEncryptedUnicast(n + k) == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED);
                 // The other tests make no sense if we did not commit N+k as the new max counter.
                 continue;
             }
 
-            NL_TEST_ASSERT(inSuite, counter.VerifyUnicast(n + k) == CHIP_NO_ERROR);
-            counter.Commit(n + k);
+            NL_TEST_ASSERT(inSuite, counter.VerifyEncryptedUnicast(n + k) == CHIP_NO_ERROR);
+            counter.CommitEncryptedUnicast(n + k);
 
             // A counter value of N comes in, we detect it as duplicate.
-            if (k <= CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE)
-            {
-                NL_TEST_ASSERT(inSuite, counter.VerifyUnicast(n) == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED);
-            }
-            else
-            {
-                NL_TEST_ASSERT(inSuite, counter.VerifyUnicast(n) == CHIP_ERROR_MESSAGE_COUNTER_OUT_OF_WINDOW);
-            }
+            NL_TEST_ASSERT(inSuite, counter.VerifyEncryptedUnicast(n) == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED);
 
             // A counter value between N - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE and
             // N + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE (but not including
@@ -243,7 +229,7 @@ void UnicastSmallStepTest(nlTestSuite * inSuite, void * inContext)
                 (n + k >= CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) ? (n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) : 0;
             for (uint32_t i = outOfWindowStart; i < outOfWindowEnd; i++)
             {
-                NL_TEST_ASSERT(inSuite, counter.VerifyUnicast(i) != CHIP_NO_ERROR);
+                NL_TEST_ASSERT(inSuite, counter.VerifyEncryptedUnicast(i) != CHIP_NO_ERROR);
             }
 
             // A counter value of N + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE (if that does not
@@ -253,13 +239,13 @@ void UnicastSmallStepTest(nlTestSuite * inSuite, void * inContext)
             {
                 if ((k != CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) && (n + k != CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE))
                 {
-                    NL_TEST_ASSERT(inSuite,
-                                   counter.VerifyUnicast(n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) == CHIP_NO_ERROR);
+                    NL_TEST_ASSERT(
+                        inSuite, counter.VerifyEncryptedUnicast(n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) == CHIP_NO_ERROR);
                 }
                 else
                 {
-                    NL_TEST_ASSERT(inSuite,
-                                   counter.VerifyUnicast(n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) != CHIP_NO_ERROR);
+                    NL_TEST_ASSERT(
+                        inSuite, counter.VerifyEncryptedUnicast(n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) != CHIP_NO_ERROR);
                 }
             }
         }
@@ -274,10 +260,10 @@ void UnicastLargeStepTest(nlTestSuite * inSuite, void * inContext)
         {
             chip::Transport::PeerMessageCounter counter;
             counter.SetCounter(LocalSessionMessageCounter::kInitialSyncValue);
-            if (counter.VerifyUnicast(n) == CHIP_NO_ERROR)
+            if (counter.VerifyEncryptedUnicast(n) == CHIP_NO_ERROR)
             {
                 // Act like we got this counter value on the wire.
-                counter.Commit(n);
+                counter.CommitEncryptedUnicast(n);
             }
             else
             {
@@ -290,16 +276,16 @@ void UnicastLargeStepTest(nlTestSuite * inSuite, void * inContext)
             // if it would not overflow, and commit it.
             if (k > UINT32_MAX - n)
             {
-                NL_TEST_ASSERT(inSuite, counter.VerifyUnicast(n + k) == CHIP_ERROR_MESSAGE_COUNTER_OUT_OF_WINDOW);
+                NL_TEST_ASSERT(inSuite, counter.VerifyEncryptedUnicast(n + k) == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED);
                 // The other tests make no sense if we did not commit N+k as the new max counter.
                 continue;
             }
 
-            NL_TEST_ASSERT(inSuite, counter.VerifyUnicast(n + k) == CHIP_NO_ERROR);
-            counter.Commit(n + k);
+            NL_TEST_ASSERT(inSuite, counter.VerifyEncryptedUnicast(n + k) == CHIP_NO_ERROR);
+            counter.CommitEncryptedUnicast(n + k);
 
             // 2. A counter value of N comes in, we detect it as duplicate.
-            NL_TEST_ASSERT(inSuite, counter.VerifyUnicast(n) != CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, counter.VerifyEncryptedUnicast(n) != CHIP_NO_ERROR);
 
             // 3. A counter value between N and N + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE
             //    (but not including N + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) comes in, we treat it as duplicate.
@@ -317,16 +303,18 @@ void UnicastLargeStepTest(nlTestSuite * inSuite, void * inContext)
             // n - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE will be smaller than the current allowed counter values.
             if (n >= CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE)
             {
-                NL_TEST_ASSERT(inSuite, counter.VerifyUnicast(n - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) != CHIP_NO_ERROR);
+                NL_TEST_ASSERT(inSuite,
+                               counter.VerifyEncryptedUnicast(n - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) != CHIP_NO_ERROR);
             }
 
             for (auto it : testValues)
             {
-                NL_TEST_ASSERT(inSuite, counter.VerifyUnicast(it) != CHIP_NO_ERROR);
+                NL_TEST_ASSERT(inSuite, counter.VerifyEncryptedUnicast(it) != CHIP_NO_ERROR);
             }
 
             // 4. A counter value of N + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE comes in, is treated as valid.
-            NL_TEST_ASSERT(inSuite, counter.VerifyUnicast(n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite,
+                           counter.VerifyEncryptedUnicast(n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) == CHIP_NO_ERROR);
         }
     }
 }
@@ -338,36 +326,36 @@ void UnencryptedRollOverTest(nlTestSuite * inSuite, void * inContext)
         for (uint32_t k = 1; k <= 2 * CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE; k++)
         {
             chip::Transport::PeerMessageCounter counter;
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n, false) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(n) == CHIP_NO_ERROR);
 
-            counter.CommitWithRollOver(n);
+            counter.CommitUnencrypted(n);
 
             // 1. A counter value of N + k comes in, we detect it as valid and commit it.
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n + k, false) == CHIP_NO_ERROR);
-            counter.CommitWithRollOver(n + k);
+            NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(n + k) == CHIP_NO_ERROR);
+            counter.CommitUnencrypted(n + k);
 
             // 2. A counter value of N comes in, we detect it as duplicate if
             // it's in the window.
             if (k <= CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE)
             {
-                NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n, false) == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED);
+                NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(n) == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED);
             }
             else
             {
-                NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n, false) == CHIP_NO_ERROR);
+                NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(n) == CHIP_NO_ERROR);
                 // Don't commit here so we change our max counter value.
             }
 
             // 4. A counter value of N + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE comes in, is treated as valid.
             if (k != CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE)
             {
-                NL_TEST_ASSERT(
-                    inSuite, counter.VerifyOrTrustFirst((n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE), false) == CHIP_NO_ERROR);
+                NL_TEST_ASSERT(inSuite,
+                               counter.VerifyUnencrypted(n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) == CHIP_NO_ERROR);
             }
             else
             {
-                NL_TEST_ASSERT(
-                    inSuite, counter.VerifyOrTrustFirst((n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE), false) != CHIP_NO_ERROR);
+                NL_TEST_ASSERT(inSuite,
+                               counter.VerifyUnencrypted(n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) != CHIP_NO_ERROR);
             }
         }
     }
@@ -378,26 +366,26 @@ void UnencryptedBackTrackTest(nlTestSuite * inSuite, void * inContext)
     for (auto n : counterValuesArray)
     {
         chip::Transport::PeerMessageCounter counter;
-        NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n, false) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(n) == CHIP_NO_ERROR);
 
-        counter.CommitWithRollOver(n);
+        counter.CommitUnencrypted(n);
         // 1.   Some set of values N - k come in, for 0 < k < CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE.
         //      All of those should be considered valid and committed.
         for (uint32_t k = 1; k * k < CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE; k++)
         {
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n - (k * k), false) == CHIP_NO_ERROR);
-            counter.CommitWithRollOver(n - (k * k));
+            NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(n - (k * k)) == CHIP_NO_ERROR);
+            counter.CommitUnencrypted(n - (k * k));
         }
         // 2. Counter value N + 3 comes in
-        NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n + 3, false) == CHIP_NO_ERROR);
-        counter.CommitWithRollOver(n + 3);
+        NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(n + 3) == CHIP_NO_ERROR);
+        counter.CommitUnencrypted(n + 3);
 
         // 3. The same set of values N - k come in as in step (1) and are all considered duplicates.
         //    This test is valid because 25 + 3 < CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE, so none of these values
         //    are out of window, and 25 is the biggest k*k value we are dealing with.
         for (uint32_t k = 1; k * k < CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE; k++)
         {
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n - (k * k), false) != CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(n - (k * k)) != CHIP_NO_ERROR);
         }
 
         // 4. The values that were not in the set in step (a) (but are at least N + 3 - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE)
@@ -408,8 +396,8 @@ void UnencryptedBackTrackTest(nlTestSuite * inSuite, void * inContext)
             {
                 continue;
             }
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(k, false) == CHIP_NO_ERROR);
-            counter.CommitWithRollOver(k);
+            NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(k) == CHIP_NO_ERROR);
+            counter.CommitUnencrypted(k);
         }
     }
 }
@@ -421,17 +409,17 @@ void UnencryptedBigLeapTest(nlTestSuite * inSuite, void * inContext)
         for (uint32_t k = (static_cast<uint32_t>(1 << 31) - 5); k <= (static_cast<uint32_t>(1 << 31) - 1); k++)
         {
             chip::Transport::PeerMessageCounter counter;
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n, false) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(n) == CHIP_NO_ERROR);
 
-            counter.CommitWithRollOver(n);
+            counter.CommitUnencrypted(n);
 
             // 1. A counter value of N + k comes in, we detect it as valid and commit it.
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n + k, false) == CHIP_NO_ERROR);
-            counter.CommitWithRollOver(n + k);
+            NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(n + k) == CHIP_NO_ERROR);
+            counter.CommitUnencrypted(n + k);
 
             // 2. A counter value of N comes in, we detect it as valid, since
             // it's out of window.
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n, false) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(n) == CHIP_NO_ERROR);
             // Don't commit, though.
 
             // 3. A counter value between N and N + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE
@@ -449,17 +437,15 @@ void UnencryptedBigLeapTest(nlTestSuite * inSuite, void * inContext)
             testValues.push_back(static_cast<uint32_t>(n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE - 1));
 
             // Will be inside the valid window of counter + (2^31 -1)
-            NL_TEST_ASSERT(inSuite,
-                           counter.VerifyOrTrustFirst(n - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE, false) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(n - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) == CHIP_NO_ERROR);
 
             for (auto it : testValues)
             {
-                NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(it, false) == CHIP_NO_ERROR);
+                NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(it) == CHIP_NO_ERROR);
             }
 
             // 4. A counter value of N + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE comes in, is treated as valid.
-            NL_TEST_ASSERT(inSuite,
-                           counter.VerifyOrTrustFirst((n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE), false) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(n + k - CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE) == CHIP_NO_ERROR);
         }
     }
 }
@@ -471,13 +457,13 @@ void UnencryptedOutOfWindow(nlTestSuite * inSuite, void * inContext)
         for (uint32_t k = (static_cast<uint32_t>(1 << 31)); k <= (static_cast<uint32_t>(1 << 31) + 2); k++)
         {
             chip::Transport::PeerMessageCounter counter;
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n, false) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(n) == CHIP_NO_ERROR);
 
-            counter.CommitWithRollOver(n);
+            counter.CommitUnencrypted(n);
 
             // 1. A counter value of N + k comes in, we treat it as valid, since
             // it's out of window.
-            NL_TEST_ASSERT(inSuite, counter.VerifyOrTrustFirst(n + k, false) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, counter.VerifyUnencrypted(n + k) == CHIP_NO_ERROR);
         }
     }
 }

--- a/src/transport/tests/TestSessionManager.cpp
+++ b/src/transport/tests/TestSessionManager.cpp
@@ -465,6 +465,192 @@ void StaleConnectionDropTest(nlTestSuite * inSuite, void * inContext)
     sessionManager.Shutdown();
 }
 
+void SendPacketWithOldCounterTest(nlTestSuite * inSuite, void * inContext)
+{
+    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+
+    uint16_t payload_len = sizeof(PAYLOAD);
+
+    TestSessMgrCallback callback;
+    callback.LargeMessageSent = false;
+
+    chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, payload_len);
+    NL_TEST_ASSERT(inSuite, !buffer.IsNull());
+
+    IPAddress addr;
+    IPAddress::FromString("::1", addr);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    TransportMgr<LoopbackTransport> transportMgr;
+    SessionManager sessionManager;
+    secure_channel::MessageCounterManager gMessageCounterManager;
+    chip::TestPersistentStorageDelegate deviceStorage;
+
+    err = transportMgr.Init("LOOPBACK");
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = sessionManager.Init(&ctx.GetSystemLayer(), &transportMgr, &gMessageCounterManager, &deviceStorage);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    callback.mSuite = inSuite;
+
+    sessionManager.SetMessageDelegate(&callback);
+
+    Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
+    SessionHolder localToRemoteSession;
+    SessionHolder remoteToLocalSession;
+
+    SecurePairingUsingTestSecret pairing1(1, 2);
+    err =
+        sessionManager.NewPairing(localToRemoteSession, peer, kSourceNodeId, &pairing1, CryptoContext::SessionRole::kInitiator, 1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    SecurePairingUsingTestSecret pairing2(2, 1);
+    err = sessionManager.NewPairing(remoteToLocalSession, peer, kDestinationNodeId, &pairing2,
+                                    CryptoContext::SessionRole::kResponder, 0);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    callback.ReceiveHandlerCallCount = 0;
+
+    PayloadHeader payloadHeader;
+    EncryptedPacketBufferHandle preparedMessage;
+
+    // Set the exchange ID for this header.
+    payloadHeader.SetExchangeID(0);
+
+    // Set the protocol ID and message type for this header.
+    payloadHeader.SetMessageType(chip::Protocols::Echo::MsgType::EchoRequest);
+
+    payloadHeader.SetInitiator(true);
+
+    err = sessionManager.PrepareMessage(localToRemoteSession.Get(), payloadHeader, std::move(buffer), preparedMessage);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = sessionManager.SendPreparedMessage(localToRemoteSession.Get(), preparedMessage);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 1);
+
+    // Now advance our message counter by 5.
+    EncryptedPacketBufferHandle newMessage;
+    for (size_t i = 0; i < 5; ++i)
+    {
+        buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, payload_len);
+        NL_TEST_ASSERT(inSuite, !buffer.IsNull());
+
+        err = sessionManager.PrepareMessage(localToRemoteSession.Get(), payloadHeader, std::move(buffer), newMessage);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    err = sessionManager.SendPreparedMessage(localToRemoteSession.Get(), newMessage);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 2);
+
+    // Now resend our original message.  It should be rejected as a duplicate.
+
+    err = sessionManager.SendPreparedMessage(localToRemoteSession.Get(), preparedMessage);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 2);
+
+    sessionManager.Shutdown();
+}
+
+void SendPacketWithTooOldCounterTest(nlTestSuite * inSuite, void * inContext)
+{
+    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+
+    uint16_t payload_len = sizeof(PAYLOAD);
+
+    TestSessMgrCallback callback;
+    callback.LargeMessageSent = false;
+
+    chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, payload_len);
+    NL_TEST_ASSERT(inSuite, !buffer.IsNull());
+
+    IPAddress addr;
+    IPAddress::FromString("::1", addr);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    TransportMgr<LoopbackTransport> transportMgr;
+    SessionManager sessionManager;
+    secure_channel::MessageCounterManager gMessageCounterManager;
+    chip::TestPersistentStorageDelegate deviceStorage;
+
+    err = transportMgr.Init("LOOPBACK");
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = sessionManager.Init(&ctx.GetSystemLayer(), &transportMgr, &gMessageCounterManager, &deviceStorage);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    callback.mSuite = inSuite;
+
+    sessionManager.SetMessageDelegate(&callback);
+
+    Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
+    SessionHolder localToRemoteSession;
+    SessionHolder remoteToLocalSession;
+
+    SecurePairingUsingTestSecret pairing1(1, 2);
+    err =
+        sessionManager.NewPairing(localToRemoteSession, peer, kSourceNodeId, &pairing1, CryptoContext::SessionRole::kInitiator, 1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    SecurePairingUsingTestSecret pairing2(2, 1);
+    err = sessionManager.NewPairing(remoteToLocalSession, peer, kDestinationNodeId, &pairing2,
+                                    CryptoContext::SessionRole::kResponder, 0);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    callback.ReceiveHandlerCallCount = 0;
+
+    PayloadHeader payloadHeader;
+    EncryptedPacketBufferHandle preparedMessage;
+
+    // Set the exchange ID for this header.
+    payloadHeader.SetExchangeID(0);
+
+    // Set the protocol ID and message type for this header.
+    payloadHeader.SetMessageType(chip::Protocols::Echo::MsgType::EchoRequest);
+
+    payloadHeader.SetInitiator(true);
+
+    err = sessionManager.PrepareMessage(localToRemoteSession.Get(), payloadHeader, std::move(buffer), preparedMessage);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = sessionManager.SendPreparedMessage(localToRemoteSession.Get(), preparedMessage);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 1);
+
+    // Now advance our message counter by at least
+    // CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE + 2, so preparedMessage will be
+    // out of the window.
+    EncryptedPacketBufferHandle newMessage;
+    for (size_t i = 0; i < CHIP_CONFIG_MESSAGE_COUNTER_WINDOW_SIZE + 2; ++i)
+    {
+        buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, payload_len);
+        NL_TEST_ASSERT(inSuite, !buffer.IsNull());
+
+        err = sessionManager.PrepareMessage(localToRemoteSession.Get(), payloadHeader, std::move(buffer), newMessage);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    err = sessionManager.SendPreparedMessage(localToRemoteSession.Get(), newMessage);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 2);
+
+    // Now resend our original message.  It should be rejected as a duplicate.
+
+    err = sessionManager.SendPreparedMessage(localToRemoteSession.Get(), preparedMessage);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 2);
+
+    sessionManager.Shutdown();
+}
+
 // Test Suite
 
 /**
@@ -478,6 +664,8 @@ const nlTest sTests[] =
     NL_TEST_DEF("Send Encrypted Packet Test",     SendEncryptedPacketTest),
     NL_TEST_DEF("Send Bad Encrypted Packet Test", SendBadEncryptedPacketTest),
     NL_TEST_DEF("Drop stale connection Test",     StaleConnectionDropTest),
+    NL_TEST_DEF("Old counter Test",               SendPacketWithOldCounterTest),
+    NL_TEST_DEF("Too-old counter Test",           SendPacketWithTooOldCounterTest),
 
     NL_TEST_SENTINEL()
 };


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/15455

Fixes https://github.com/project-chip/connectedhomeip/issues/7108

#### Problem
Various issues:
1. Window size is off by 1.
2. Not correctly sending MRP acks for things that are duplicates due to being out of window.
3. Lack of tests.
4. Unencrypted message counters not doing rollover as they should per spec.

#### Change overview
Add some tests, fix the above.

#### Testing
See new tests being added.
