### PR TITLE
DiableDebug and chip_stack_lock_tracking

### DIFF
--- a/examples/pump-app/cc13x2x7_26x2x7/args.gni
+++ b/examples/pump-app/cc13x2x7_26x2x7/args.gni
@@ -23,7 +23,7 @@ ti_simplelink_board = "LP_CC2652R7"
 
 # Size Optimizations
 # use -Os instead of -Og, LWIP release build
-#is_debug = false
+is_debug = false
 
 # Disable CHIP Logging
 #chip_progress_logging = false
@@ -33,3 +33,7 @@ ti_simplelink_board = "LP_CC2652R7"
 # BLE options
 chip_config_network_layer_ble = true
 chip_bypass_rendezvous = false
+
+# Disable lock tracking, since our FreeRTOS configuration does not set
+# INCLUDE_xSemaphoreGetMutexHolder
+chip_stack_lock_tracking = "none"

--- a/examples/pump-controller-app/cc13x2x7_26x2x7/args.gni
+++ b/examples/pump-controller-app/cc13x2x7_26x2x7/args.gni
@@ -23,7 +23,7 @@ ti_simplelink_board = "LP_CC2652R7"
 
 # Size Optimizations
 # use -Os instead of -Og, LWIP release build
-#is_debug = false
+is_debug = false
 
 # Disable CHIP Logging
 #chip_progress_logging = false
@@ -33,3 +33,7 @@ ti_simplelink_board = "LP_CC2652R7"
 # BLE options
 chip_config_network_layer_ble = true
 chip_bypass_rendezvous = false
+
+# Disable lock tracking, since our FreeRTOS configuration does not set
+# INCLUDE_xSemaphoreGetMutexHolder
+chip_stack_lock_tracking = "none"


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* pump-controller-app
* pump-app 

#### Change overview
Examples are not able to compile and run without disabling Debug and chip_stack_lock_tracking

#### Testing
How was this tested? (at least one bullet point required)
* Examples compiled. It is tested with chip-tool on physical demonstrator
