### PR TITLE
Do not link group for iOS builds.

### DIFF
--- a/build/toolchain/gcc_toolchain.gni
+++ b/build/toolchain/gcc_toolchain.gni
@@ -41,7 +41,8 @@ template("gcc_toolchain") {
     }
 
     is_host_toolchain = invoker_toolchain_args.current_os == host_os
-    link_group = invoker_toolchain_args.current_os != "mac"
+    link_group = invoker_toolchain_args.current_os != "mac" &&
+                 invoker_toolchain_args.current_os != "ios"
 
     defaults = {
       forward_variables_from(invoker_toolchain_args, "*")


### PR DESCRIPTION
#### Problem
When linking groups in IOS the linker fails, because it is not supported on iOS or MacOS.

#### Change overview
If iOS as well, do not link group.

#### Testing
Compiled successfully. 
