### PR TITLE
Fix use of config variables in Darwin YAML expected values.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/tests/partials/check_test_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/tests/partials/check_test_value.zapt
@@ -1,4 +1,7 @@
-{{#if isOptional}}
+{{#if (chip_tests_config_has expected)}}
+  {{! Just replace the value's name with the actual value in the rest of the processing~}}
+  {{>check_test_value target=target expected=(chip_tests_config_get_default_value expected) cluster=cluster depth=depth}}
+{{else if isOptional}}
   {{! This just means we expect a non-nil value.  Go ahead and check the value,
       stripping the optionality off. }}
   {{>check_test_value actual=actual expected=expected cluster=cluster isOptional=false}}


### PR DESCRIPTION
We were just putting in the variable name, not the config value.

#### Problem
Config vars used in expected values in YAML do not compile on Darwin.

#### Change overview
Fix that.

#### Testing
Looked at generated code for #15451 with these changes.