### PR TITLE
Remove PeerNodeId from DeviceControlServer and pass it via event directly

### DIFF
--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -216,7 +216,6 @@ void DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * event, intptr_t ar
 {
     if (event->Type == DeviceLayer::DeviceEventType::kCommissioningComplete)
     {
-        chip::NodeId tvNodeId             = chip::DeviceLayer::DeviceControlServer::DeviceControlSvr().GetPeerNodeId();
         chip::FabricIndex peerFabricIndex = chip::DeviceLayer::DeviceControlServer::DeviceControlSvr().GetFabricIndex();
 
         Server * server           = &(chip::Server::GetInstance());
@@ -235,7 +234,7 @@ void DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * event, intptr_t ar
             .clientPool     = &gCASEClientPool,
         };
 
-        PeerId peerID = fabric->GetPeerIdForNode(tvNodeId);
+        PeerId peerID = fabric->GetPeerIdForNode(event->CommissioningComplete.PeerNodeId);
         chip::OperationalDeviceProxy * operationalDeviceProxy =
             chip::Platform::New<chip::OperationalDeviceProxy>(initParams, peerID);
         if (operationalDeviceProxy == nullptr)
@@ -244,7 +243,7 @@ void DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * event, intptr_t ar
             return;
         }
 
-        SessionHandle handle = server->GetSecureSessionManager().FindSecureSessionForNode(tvNodeId);
+        SessionHandle handle = server->GetSecureSessionManager().FindSecureSessionForNode(event->CommissioningComplete.PeerNodeId);
         operationalDeviceProxy->SetConnectedSession(handle);
 
         ContentLauncherCluster cluster;

--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -152,7 +152,7 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(
     SessionHandle handle = commandObj->GetExchangeContext()->GetSessionHandle();
     server->SetFabricIndex(handle->GetFabricIndex());
 
-    CheckSuccess(server->CommissioningComplete(), Failure);
+    CheckSuccess(server->CommissioningComplete(handle->AsSecureSession()->GetPeerNodeId()), Failure);
 
     Commands::CommissioningCompleteResponse::Type response;
     response.errorCode = CommissioningError::kOk;

--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -145,13 +145,12 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(
     DeviceControlServer * server = &DeviceLayer::DeviceControlServer::DeviceControlSvr();
 
     /*
-     * Pass fabric and nodeId of commissioner to DeviceControlSvr.
+     * Pass fabric of commissioner to DeviceControlSvr.
      * This allows device to send messages back to commissioner.
      * Once bindings are implemented, this may no longer be needed.
      */
     SessionHandle handle = commandObj->GetExchangeContext()->GetSessionHandle();
     server->SetFabricIndex(handle->GetFabricIndex());
-    server->SetPeerNodeId(handle->AsSecureSession()->GetPeerNodeId());
 
     CheckSuccess(server->CommissioningComplete(), Failure);
 

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -451,7 +451,7 @@ void Instance::_OnCommissioningComplete(const DeviceLayer::ChipDeviceEvent * eve
 {
     Instance * this_ = reinterpret_cast<Instance *>(arg);
     VerifyOrReturn(event->Type == DeviceLayer::DeviceEventType::kCommissioningComplete);
-    this_->OnCommissioningComplete(event->CommissioningComplete.status);
+    this_->OnCommissioningComplete(event->CommissioningComplete.Status);
 }
 
 void Instance::OnCommissioningComplete(CHIP_ERROR err)

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -54,7 +54,7 @@ void CommissioningWindowManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEv
 {
     if (event->Type == DeviceLayer::DeviceEventType::kCommissioningComplete)
     {
-        if (event->CommissioningComplete.status == CHIP_NO_ERROR)
+        if (event->CommissioningComplete.Status == CHIP_NO_ERROR)
         {
             ChipLogProgress(AppServer, "Commissioning completed successfully");
             Cleanup();
@@ -62,8 +62,8 @@ void CommissioningWindowManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEv
         else
         {
             ChipLogError(AppServer, "Commissioning failed with error %" CHIP_ERROR_FORMAT,
-                         event->CommissioningComplete.status.Format());
-            OnSessionEstablishmentError(event->CommissioningComplete.status);
+                         event->CommissioningComplete.Status.Format());
+            OnSessionEstablishmentError(event->CommissioningComplete.Status);
         }
     }
     else if (event->Type == DeviceLayer::DeviceEventType::kOperationalNetworkEnabled)

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -439,7 +439,8 @@ struct ChipDeviceEvent final
 
         struct
         {
-            CHIP_ERROR status;
+            CHIP_ERROR Status;
+            uint64_t PeerNodeId;
         } CommissioningComplete;
 
         struct

--- a/src/include/platform/DeviceControlServer.h
+++ b/src/include/platform/DeviceControlServer.h
@@ -89,7 +89,7 @@ public:
 
     CHIP_ERROR ArmFailSafe(System::Clock::Timeout expiryLength);
     CHIP_ERROR DisarmFailSafe();
-    CHIP_ERROR CommissioningComplete();
+    CHIP_ERROR CommissioningComplete(NodeId peerNodeId);
     CHIP_ERROR SetRegulatoryConfig(uint8_t location, const CharSpan & countryCode, uint64_t breadcrumb);
 
     CHIP_ERROR ConnectNetworkForOperational(ByteSpan networkID);

--- a/src/include/platform/DeviceControlServer.h
+++ b/src/include/platform/DeviceControlServer.h
@@ -96,8 +96,6 @@ public:
 
     inline FabricIndex GetFabricIndex() { return mFabric; }
     inline void SetFabricIndex(FabricIndex fabricId) { mFabric = fabricId; }
-    inline NodeId GetPeerNodeId() { return mPeerNodeId; }
-    inline void SetPeerNodeId(NodeId peerNodeId) { mPeerNodeId = peerNodeId; }
     void SetSwitchDelegate(SwitchDeviceControlDelegate * delegate) { mSwitchDelegate = delegate; }
     SwitchDeviceControlDelegate * GetSwitchDelegate() const { return mSwitchDelegate; }
 
@@ -121,7 +119,6 @@ private:
     DeviceControlServer(const DeviceControlServer &&) = delete;
     DeviceControlServer & operator=(const DeviceControlServer &) = delete;
 
-    NodeId mPeerNodeId  = 0;
     FabricIndex mFabric = 0;
 };
 

--- a/src/platform/DeviceControlServer.cpp
+++ b/src/platform/DeviceControlServer.cpp
@@ -44,7 +44,7 @@ void DeviceControlServer::CommissioningFailedTimerComplete()
 {
     ChipDeviceEvent event;
     event.Type                         = DeviceEventType::kCommissioningComplete;
-    event.CommissioningComplete.status = CHIP_ERROR_TIMEOUT;
+    event.CommissioningComplete.Status = CHIP_ERROR_TIMEOUT;
     CHIP_ERROR status                  = PlatformMgr().PostEvent(&event);
     if (status != CHIP_NO_ERROR)
     {
@@ -64,12 +64,13 @@ CHIP_ERROR DeviceControlServer::DisarmFailSafe()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DeviceControlServer::CommissioningComplete()
+CHIP_ERROR DeviceControlServer::CommissioningComplete(NodeId peerNodeId)
 {
     VerifyOrReturnError(CHIP_NO_ERROR == DisarmFailSafe(), CHIP_ERROR_INTERNAL);
     ChipDeviceEvent event;
-    event.Type                         = DeviceEventType::kCommissioningComplete;
-    event.CommissioningComplete.status = CHIP_NO_ERROR;
+    event.Type                             = DeviceEventType::kCommissioningComplete;
+    event.CommissioningComplete.PeerNodeId = peerNodeId;
+    event.CommissioningComplete.Status     = CHIP_NO_ERROR;
     return PlatformMgr().PostEvent(&event);
 }
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* PeerNodeId in DeviceControlServer is not used anywhere, we should clean it up together with its accessor APIs
* Fixes #15366

#### Change overview
Remove PeerNodeId from DeviceControlServer since it is not used

#### Testing
How was this tested? (at least one bullet point required)
* cleanup only, regression is covered by CI