### PR TITLE
The printing of onboarding code spec compliant

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -209,6 +209,14 @@ int ChipLinuxAppInit(int argc, char ** argv, OptionSet * customOptions)
 
     PrintOnboardingCodes(LinuxDeviceOptions::GetInstance().payload);
 
+    // For testing of manual pairing code with custom commissioning flow
+    err = GetSetupPayload(LinuxDeviceOptions::GetInstance().payload, rendezvousFlags);
+    SuccessOrExit(err);
+
+    LinuxDeviceOptions::GetInstance().payload.commissioningFlow = chip::CommissioningFlow::kCustom;
+
+    PrintOnboardingCodes(LinuxDeviceOptions::GetInstance().payload);
+
 #if defined(PW_RPC_ENABLED)
     rpc::Init();
     ChipLogProgress(NotSpecified, "PW_RPC initialized.");

--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -78,16 +78,6 @@ void PrintOnboardingCodes(const chip::SetupPayload & payload)
     {
         ChipLogError(AppServer, "Getting manual pairing code failed!");
     }
-
-    // Hand a copy of the payload to GetLongManualPairingCode.
-    if (GetLongManualPairingCode(manualPairingCode, chip::SetupPayload(payload)) == CHIP_NO_ERROR)
-    {
-        ChipLogProgress(AppServer, "Long manual pairing code: [%s]", manualPairingCode.c_str());
-    }
-    else
-    {
-        ChipLogError(AppServer, "Getting long manual pairing code failed!");
-    }
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_NFC

--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -183,35 +183,6 @@ CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, chip::Rendezvo
     return GetManualPairingCode(aManualPairingCode, payload);
 }
 
-CHIP_ERROR GetLongManualPairingCode(std::string & aLongManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags)
-{
-    chip::SetupPayload payload;
-
-    CHIP_ERROR err = GetSetupPayload(payload, aRendezvousFlags);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogProgress(AppServer, "GetSetupPayload() failed: %s", chip::ErrorStr(err));
-        return err;
-    }
-    return GetLongManualPairingCode(aLongManualPairingCode, std::move(payload));
-}
-
-CHIP_ERROR GetLongManualPairingCode(std::string & aLongManualPairingCode, chip::SetupPayload && payload)
-{
-    // To get payloadDecimalStringRepresentation to produce a long manual
-    // pairing code, the commissioning flow in the payload needs to be kCustom.
-    payload.commissioningFlow = chip::CommissioningFlow::kCustom;
-
-    CHIP_ERROR err = chip::ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(aLongManualPairingCode);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogProgress(AppServer, "Generating long manual pairing code failed: %s", chip::ErrorStr(err));
-        return err;
-    }
-
-    return CHIP_NO_ERROR;
-}
-
 CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, const chip::SetupPayload & payload)
 {
     CHIP_ERROR err = chip::ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(aManualPairingCode);

--- a/src/app/server/OnboardingCodesUtil.h
+++ b/src/app/server/OnboardingCodesUtil.h
@@ -26,8 +26,6 @@ CHIP_ERROR GetQRCode(std::string & aQRCode, chip::RendezvousInformationFlags aRe
 CHIP_ERROR GetQRCode(std::string & aQRCode, const chip::SetupPayload & payload);
 CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, const std::string & aQRCode);
 CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags);
-CHIP_ERROR GetLongManualPairingCode(std::string & aLongManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags);
-CHIP_ERROR GetLongManualPairingCode(std::string & aLongManualPairingCode, chip::SetupPayload && payload);
 CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, const chip::SetupPayload & payload);
 CHIP_ERROR GetSetupPayload(chip::SetupPayload & aSetupPayload, chip::RendezvousInformationFlags aRendezvousFlags);
 

--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -46,7 +46,7 @@ static uint32_t chunk1PayloadRepresentation(const PayloadContents & payload)
                   "Discriminator won't fit");
 
     uint32_t discriminatorChunk = (payload.discriminator >> kDiscriminatorShift) & kDiscriminatorMask;
-    uint32_t vidPidPresentFlag  = payload.commissioningFlow == CommissioningFlow::kCustom ? 1 : 0;
+    uint32_t vidPidPresentFlag  = payload.commissioningFlow != CommissioningFlow::kStandard ? 1 : 0;
 
     uint32_t result = (discriminatorChunk << kManualSetupChunk1DiscriminatorMsbitsPos) |
         (vidPidPresentFlag << kManualSetupChunk1VidPidPresentBitPos);
@@ -115,7 +115,7 @@ CHIP_ERROR ManualSetupPayloadGenerator::payloadDecimalStringRepresentation(Mutab
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    bool useLongCode = (mPayloadContents.commissioningFlow == CommissioningFlow::kCustom);
+    bool useLongCode = (mPayloadContents.commissioningFlow != CommissioningFlow::kStandard);
 
     // Add two for the check digit and null terminator.
     if ((useLongCode && outBuffer.size() < kManualSetupLongCodeCharLength + 2) ||

--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -115,7 +115,6 @@ CHIP_ERROR ManualSetupPayloadGenerator::payloadDecimalStringRepresentation(Mutab
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-
     bool useLongCode = (mPayloadContents.commissioningFlow != CommissioningFlow::kStandard);
 
     // Add two for the check digit and null terminator.

--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -115,6 +115,7 @@ CHIP_ERROR ManualSetupPayloadGenerator::payloadDecimalStringRepresentation(Mutab
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
+
     bool useLongCode = (mPayloadContents.commissioningFlow != CommissioningFlow::kStandard);
 
     // Add two for the check digit and null terminator.


### PR DESCRIPTION
Problem
* Ability to generate long manual pairing code only when commissioning flow is set to custom.
* Long and short manual pairing codes both are printed in many application. 
* Fixes #15076 

Change overview
* Generate long manual pairing code for custom and user intent commissioning flow
* Either long or short manual pairing code will print in application.

Testing
* Manually tested all clusters linux  app.
* With custom and user intent commissioning flow
[1645769935519] [6658:71085] CHIP: [SVR] Manual pairing code: [749701123365521327694]
* With standard commissioning flow
[1645769935519] [6658:71085] CHIP: [SVR] Manual pairing code: [34970112332]