### PR TITLE
[ESP] Fix boot crash issue

### DIFF
--- a/examples/all-clusters-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/all-clusters-app/esp32/main/CHIPDeviceManager.cpp
@@ -60,6 +60,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     mCB                              = cb;
     RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
 
+    err = Platform::MemoryInit();
+    SuccessOrExit(err);
+
     // Initialize the CHIP stack.
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
@@ -80,9 +83,6 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
         // be communicated with via its SoftAP as needed.
         ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_Enabled);
     }
-
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
 
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.

--- a/examples/bridge-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/bridge-app/esp32/main/CHIPDeviceManager.cpp
@@ -55,12 +55,12 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     mCB                              = cb;
     RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
 
+    err = Platform::MemoryInit();
+    SuccessOrExit(err);
+
     // Initialize the CHIP stack.
     err = PlatformMgr().InitChipStack();
-    if (err != CHIP_NO_ERROR)
-    {
-        return err;
-    }
+    SuccessOrExit(err);
 
     if (flags.Has(RendezvousInformationFlag::kBLE))
     {
@@ -79,23 +79,16 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
         ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_Enabled);
     }
 
-    err = Platform::MemoryInit();
-    if (err != CHIP_NO_ERROR)
-    {
-        return err;
-    }
-
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.
     PlatformMgr().AddEventHandler(CHIPDeviceManager::CommonDeviceEventHandler, reinterpret_cast<intptr_t>(cb));
 
     // Start a task to run the CHIP Device event loop.
     err = PlatformMgr().StartEventLoopTask();
-    if (err != CHIP_NO_ERROR)
-    {
-        return err;
-    }
-    return CHIP_NO_ERROR;
+    SuccessOrExit(err);
+
+exit:
+    return err;
 }
 } // namespace DeviceManager
 } // namespace chip

--- a/examples/lighting-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/lighting-app/esp32/main/CHIPDeviceManager.cpp
@@ -55,6 +55,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     mCB                              = cb;
     RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
 
+    err = Platform::MemoryInit();
+    SuccessOrExit(err);
+
     // Initialize the CHIP stack.
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
@@ -75,9 +78,6 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
         // be communicated with via its SoftAP as needed.
         ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_Enabled);
     }
-
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
 
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.

--- a/examples/lock-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/lock-app/esp32/main/CHIPDeviceManager.cpp
@@ -55,6 +55,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     mCB                              = cb;
     RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
 
+    err = Platform::MemoryInit();
+    SuccessOrExit(err);
+
     // Initialize the CHIP stack.
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
@@ -75,9 +78,6 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
         // be communicated with via its SoftAP as needed.
         ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_Enabled);
     }
-
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
 
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.

--- a/examples/ota-provider-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/ota-provider-app/esp32/main/CHIPDeviceManager.cpp
@@ -55,6 +55,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     mCB                              = cb;
     RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
 
+    err = Platform::MemoryInit();
+    SuccessOrExit(err);
+
     // Initialize the CHIP stack.
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
@@ -75,9 +78,6 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
         // be communicated with via its SoftAP as needed.
         ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_Enabled);
     }
-
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
 
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.

--- a/examples/ota-requestor-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/ota-requestor-app/esp32/main/CHIPDeviceManager.cpp
@@ -55,6 +55,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     mCB                              = cb;
     RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
 
+    err = Platform::MemoryInit();
+    SuccessOrExit(err);
+
     // Initialize the CHIP stack.
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
@@ -75,9 +78,6 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
         // be communicated with via its SoftAP as needed.
         ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_Enabled);
     }
-
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
 
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.

--- a/examples/temperature-measurement-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/temperature-measurement-app/esp32/main/CHIPDeviceManager.cpp
@@ -58,6 +58,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     mCB                              = cb;
     RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
 
+    err = Platform::MemoryInit();
+    SuccessOrExit(err);
+
     // Initialize the CHIP stack.
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
@@ -78,9 +81,6 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
         // be communicated with via its SoftAP as needed.
         ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_Enabled);
     }
-
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
 
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.


### PR DESCRIPTION
#### Problem
Since #15031, it will do `MemoryCalloc()` in `InitChipStack()`. But `MemoryInit()` are called after `InitChipStack()` in ESP examples, so all boot crash at here: [CHIPMem-Malloc.cpp](https://github.com/project-chip/connectedhomeip/blob/master/src/lib/support/CHIPMem-Malloc.cpp#L60)

#### Change overview
move `MemoryInit()` to the front of `InitChipStack()`.

#### Testing
Verified with all-clusters-app and lighting-app on esp32
