### PR TITLE
[Ameba] Fix boot abort issue

### DIFF
--- a/examples/all-clusters-app/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/all-clusters-app/ameba/main/CHIPDeviceManager.cpp
@@ -54,6 +54,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     CHIP_ERROR err;
     mCB = cb;
 
+    err = Platform::MemoryInit();
+    SuccessOrExit(err);
+
     // Initialize the CHIP stack.
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
@@ -62,9 +65,6 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     {
         ConnectivityMgr().SetBLEAdvertisingEnabled(true);
     }
-
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
 
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.

--- a/examples/lighting-app/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/lighting-app/ameba/main/CHIPDeviceManager.cpp
@@ -63,6 +63,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     CHIP_ERROR err;
     mCB = cb;
 
+    err = Platform::MemoryInit();
+    SuccessOrExit(err);
+
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
 
@@ -71,21 +74,11 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
         ConnectivityMgr().SetBLEAdvertisingEnabled(true);
     }
 
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
-
     PlatformMgr().AddEventHandler(CHIPDeviceManager::CommonDeviceEventHandler, reinterpret_cast<intptr_t>(cb));
 
     // // Start a task to run the CHIP Device event loop.
     err = PlatformMgr().StartEventLoopTask();
-    if (err != CHIP_NO_ERROR)
-    {
-        printf("StartEventLoopTask() - ERROR!\r\n");
-    }
-    else
-    {
-        printf("StartEventLoopTask() - OK\r\n");
-    }
+    SuccessOrExit(err);
 
 exit:
     return err;

--- a/examples/ota-requestor-app/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/ota-requestor-app/ameba/main/CHIPDeviceManager.cpp
@@ -54,6 +54,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     CHIP_ERROR err;
     mCB = cb;
 
+    err = Platform::MemoryInit();
+    SuccessOrExit(err);
+
     // Initialize the CHIP stack.
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
@@ -62,9 +65,6 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     {
         ConnectivityMgr().SetBLEAdvertisingEnabled(true);
     }
-
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
 
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.


### PR DESCRIPTION
#### Problem
After #15031, it will use MemoryCalloc() in InitChipStack()

#### Change overview
Move MemoryInit() before InitChipStack()

#### Testing
Tested all-clusters-app, lighting-app