### PR TITLE
Switch cloudbuild to 0.5.56 image after #15453 requires new nrf SDK

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.5.52"
+    - name: "connectedhomeip/chip-build-vscode:0.5.56"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -12,7 +12,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.52"
+    - name: "connectedhomeip/chip-build-vscode:0.5.56"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -28,7 +28,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.52"
+    - name: "connectedhomeip/chip-build-vscode:0.5.56"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -45,7 +45,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.52"
+    - name: "connectedhomeip/chip-build-vscode:0.5.56"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -62,7 +62,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.52"
+    - name: "connectedhomeip/chip-build-vscode:0.5.56"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -79,7 +79,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.52"
+    - name: "connectedhomeip/chip-build-vscode:0.5.56"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.5.52"
+    - name: "connectedhomeip/chip-build-vscode:0.5.56"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -12,7 +12,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.52"
+    - name: "connectedhomeip/chip-build-vscode:0.5.56"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
#### Problem
Cloudbuild fails to compile since new NRF SDK is required for compilation

#### Change overview
switch cloudbuild config from 0.5.52 to 0.5.56

#### Testing
Cloudbuild change will be validated during cloudbuild compilation
