### PR TITLE
If IPv4 is disabled, force avahi to use ipv6

### DIFF
--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -44,15 +44,14 @@ namespace {
 
 AvahiProtocol ToAvahiProtocol(chip::Inet::IPAddressType addressType)
 {
+#if INET_CONFIG_ENABLE_IPV4
     AvahiProtocol protocol;
 
     switch (addressType)
     {
-#if INET_CONFIG_ENABLE_IPV4
     case chip::Inet::IPAddressType::kIPv4:
         protocol = AVAHI_PROTO_INET;
         break;
-#endif
     case chip::Inet::IPAddressType::kIPv6:
         protocol = AVAHI_PROTO_INET6;
         break;
@@ -62,6 +61,11 @@ AvahiProtocol ToAvahiProtocol(chip::Inet::IPAddressType addressType)
     }
 
     return protocol;
+#else
+    // We only support IPV6, never tell AVAHI about INET4 or UNSPEC because
+    // UNSPEC may actually return IPv4 data.
+    return AVAHI_PROTO_INET6;
+#endif
 }
 
 chip::Inet::IPAddressType ToAddressType(AvahiProtocol protocol)


### PR DESCRIPTION
#### Problem
Avahi is passed 'UNSPEC' for IPADDRANY during discovery even for ipv6only builds, which makes it return IPv4 addresses as well.

#### Change overview
Force IPv6 discovery when IPv4 is disabled.

#### Testing
Used `./out/linux-x64-address-resolve-tool-platform-mdns-ipv6only/address-resolve-tool` to test (resolve failed after this, was failing before)