### PR TITLE
[EFR32] Adding shell commands to light-switch example

### DIFF
--- a/examples/light-switch-app/efr32/include/binding-handler.h
+++ b/examples/light-switch-app/efr32/include/binding-handler.h
@@ -16,7 +16,17 @@
  */
 #pragma once
 
+#include "app-common/zap-generated/ids/Clusters.h"
+#include "app-common/zap-generated/ids/Commands.h"
 #include "lib/core/CHIPError.h"
 
 CHIP_ERROR InitBindingHandler();
 void SwitchToggleOnOff(intptr_t context);
+void SwitchOnOffOn(intptr_t context);
+void SwitchOnOffOff(intptr_t context);
+
+struct BindingCommandData
+{
+    chip::CommandId commandId;
+    chip::ClusterId clusterId;
+};

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -142,8 +142,7 @@ void SwitchToggleOnOff(intptr_t context)
     data->clusterId = Clusters::OnOff::Id;
     data->commandId = Clusters::OnOff::Commands::Toggle::Id;
 
-    BindingManager::GetInstance().NotifyBoundClusterChanged(1 /* endpointId */, Clusters::OnOff::Id,
-                                                                  static_cast<void *>(data));
+    BindingManager::GetInstance().NotifyBoundClusterChanged(1 /* endpointId */, Clusters::OnOff::Id, static_cast<void *>(data));
 }
 
 void SwitchOnOffOn(intptr_t context)
@@ -154,8 +153,7 @@ void SwitchOnOffOn(intptr_t context)
     data->clusterId = Clusters::OnOff::Id;
     data->commandId = Clusters::OnOff::Commands::On::Id;
 
-    BindingManager::GetInstance().NotifyBoundClusterChanged(1 /* endpointId */, Clusters::OnOff::Id,
-                                                                  static_cast<void *>(data));
+    BindingManager::GetInstance().NotifyBoundClusterChanged(1 /* endpointId */, Clusters::OnOff::Id, static_cast<void *>(data));
 }
 
 void SwitchOnOffOff(intptr_t context)
@@ -166,8 +164,7 @@ void SwitchOnOffOff(intptr_t context)
     data->clusterId = Clusters::OnOff::Id;
     data->commandId = Clusters::OnOff::Commands::Off::Id;
 
-    BindingManager::GetInstance().NotifyBoundClusterChanged(1 /* endpointId */, Clusters::OnOff::Id,
-                                                                  static_cast<void *>(data));
+    BindingManager::GetInstance().NotifyBoundClusterChanged(1 /* endpointId */, Clusters::OnOff::Id, static_cast<void *>(data));
 }
 
 CHIP_ERROR InitBindingHandler()

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -25,19 +25,21 @@
 
 #if defined(ENABLE_CHIP_SHELL)
 #include "lib/shell/Engine.h"
-
-using chip::Shell::Engine;
-using chip::Shell::shell_command_t;
-using chip::Shell::streamer_get;
-using chip::Shell::streamer_printf;
-#endif // defined(ENABLE_CHIP_SHELL)
+#endif // ENABLE_CHIP_SHELL
 
 using namespace chip;
 using namespace chip::app;
 
+#if defined(ENABLE_CHIP_SHELL)
+using Shell::Engine;
+using Shell::shell_command_t;
+using Shell::streamer_get;
+using Shell::streamer_printf;
+#endif // defined(ENABLE_CHIP_SHELL)
+
 namespace {
 
-void ProcessOnOffBindingCommand(chip::CommandId commandId, const EmberBindingTableEntry & binding, chip::DeviceProxy * peer_device)
+void ProcessOnOffBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding, DeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
         ChipLogProgress(NotSpecified, "OnOff command succeeds");
@@ -73,7 +75,7 @@ void ProcessOnOffBindingCommand(chip::CommandId commandId, const EmberBindingTab
     }
 }
 
-void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, chip::DeviceProxy * peer_device, void * context)
+void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DeviceProxy * peer_device, void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "Invalid context for Light switch handler"););
     BindingCommandData * data = static_cast<BindingCommandData *>(context);
@@ -97,7 +99,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, chip::Dev
         }
     }
 
-    chip::Platform::Delete(data);
+    Platform::Delete(data);
 }
 
 #ifdef ENABLE_CHIP_SHELL
@@ -105,15 +107,15 @@ CHIP_ERROR SwitchCommandHandler(int argc, char ** argv)
 {
     if (argc == 1 && strcmp(argv[0], "on") == 0)
     {
-        chip::DeviceLayer::PlatformMgr().ScheduleWork(SwitchOnOffOn, 0);
+        DeviceLayer::PlatformMgr().ScheduleWork(SwitchOnOffOn, 0);
     }
     else if (argc == 1 && strcmp(argv[0], "off") == 0)
     {
-        chip::DeviceLayer::PlatformMgr().ScheduleWork(SwitchOnOffOff, 0);
+        DeviceLayer::PlatformMgr().ScheduleWork(SwitchOnOffOff, 0);
     }
     else if (argc == 1 && strcmp(argv[0], "toggle") == 0)
     {
-        chip::DeviceLayer::PlatformMgr().ScheduleWork(SwitchToggleOnOff, 0);
+        DeviceLayer::PlatformMgr().ScheduleWork(SwitchToggleOnOff, 0);
     }
     else
     {
@@ -134,44 +136,44 @@ static void RegisterSwitchCommands()
 
 void SwitchToggleOnOff(intptr_t context)
 {
-    BindingCommandData * data = chip::Platform::New<BindingCommandData>();
+    BindingCommandData * data = Platform::New<BindingCommandData>();
     VerifyOrReturn(data != nullptr, ChipLogError(NotSpecified, "SwitchToggleOnOff -  Out of Memory of work data"));
 
-    data->clusterId = chip::app::Clusters::OnOff::Id;
-    data->commandId = chip::app::Clusters::OnOff::Commands::Toggle::Id;
+    data->clusterId = Clusters::OnOff::Id;
+    data->commandId = Clusters::OnOff::Commands::Toggle::Id;
 
-    chip::BindingManager::GetInstance().NotifyBoundClusterChanged(1 /* endpointId */, chip::app::Clusters::OnOff::Id,
+    BindingManager::GetInstance().NotifyBoundClusterChanged(1 /* endpointId */, Clusters::OnOff::Id,
                                                                   static_cast<void *>(data));
 }
 
 void SwitchOnOffOn(intptr_t context)
 {
-    BindingCommandData * data = chip::Platform::New<BindingCommandData>();
+    BindingCommandData * data = Platform::New<BindingCommandData>();
     VerifyOrReturn(data != nullptr, ChipLogError(NotSpecified, "SwitchOnOffOn -  Out of Memory of work data"));
 
-    data->clusterId = chip::app::Clusters::OnOff::Id;
-    data->commandId = chip::app::Clusters::OnOff::Commands::On::Id;
+    data->clusterId = Clusters::OnOff::Id;
+    data->commandId = Clusters::OnOff::Commands::On::Id;
 
-    chip::BindingManager::GetInstance().NotifyBoundClusterChanged(1 /* endpointId */, chip::app::Clusters::OnOff::Id,
+    BindingManager::GetInstance().NotifyBoundClusterChanged(1 /* endpointId */, Clusters::OnOff::Id,
                                                                   static_cast<void *>(data));
 }
 
 void SwitchOnOffOff(intptr_t context)
 {
-    BindingCommandData * data = chip::Platform::New<BindingCommandData>();
+    BindingCommandData * data = Platform::New<BindingCommandData>();
     VerifyOrReturn(data != nullptr, ChipLogError(NotSpecified, "SwitchOnOffOff -  Out of Memory of work data"));
 
-    data->clusterId = chip::app::Clusters::OnOff::Id;
-    data->commandId = chip::app::Clusters::OnOff::Commands::Off::Id;
+    data->clusterId = Clusters::OnOff::Id;
+    data->commandId = Clusters::OnOff::Commands::Off::Id;
 
-    chip::BindingManager::GetInstance().NotifyBoundClusterChanged(1 /* endpointId */, chip::app::Clusters::OnOff::Id,
+    BindingManager::GetInstance().NotifyBoundClusterChanged(1 /* endpointId */, Clusters::OnOff::Id,
                                                                   static_cast<void *>(data));
 }
 
 CHIP_ERROR InitBindingHandler()
 {
-    chip::BindingManager::GetInstance().SetAppServer(&chip::Server::GetInstance());
-    chip::BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
+    BindingManager::GetInstance().SetAppServer(&Server::GetInstance());
+    BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
 
 #if defined(ENABLE_CHIP_SHELL)
     RegisterSwitchCommands();

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -18,60 +18,164 @@
 #include "binding-handler.h"
 
 #include "AppConfig.h"
-#include "app-common/zap-generated/ids/Clusters.h"
-#include "app-common/zap-generated/ids/Commands.h"
 #include "app/CommandSender.h"
 #include "app/clusters/bindings/BindingManager.h"
 #include "app/server/Server.h"
 #include "controller/InvokeInteraction.h"
 
+#if defined(ENABLE_CHIP_SHELL)
+#include "lib/shell/Engine.h"
+
+using chip::Shell::Engine;
+using chip::Shell::shell_command_t;
+using chip::Shell::streamer_get;
+using chip::Shell::streamer_printf;
+#endif // defined(ENABLE_CHIP_SHELL)
+
+using namespace chip;
+using namespace chip::app;
+
 namespace {
-void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, chip::DeviceProxy * peer_device, void * context)
+
+void ProcessOnOffBindingCommand(chip::CommandId commandId, const EmberBindingTableEntry & binding, chip::DeviceProxy * peer_device)
 {
-    using namespace chip;
-    using namespace chip::app;
-
-    VerifyOrReturn(context != nullptr, return );
-
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
         ChipLogProgress(NotSpecified, "OnOff command succeeds");
     };
+
     auto onFailure = [](CHIP_ERROR error) {
         ChipLogError(NotSpecified, "OnOff command failed: %" CHIP_ERROR_FORMAT, error.Format());
     };
 
+    switch (commandId)
+    {
+    case Clusters::OnOff::Commands::Toggle::Id:
+        Clusters::OnOff::Commands::Toggle::Type toggleCommand;
+        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+                                         toggleCommand, onSuccess, onFailure);
+        break;
+
+    case Clusters::OnOff::Commands::On::Id:
+        Clusters::OnOff::Commands::On::Type onCommand;
+        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+                                         onCommand, onSuccess, onFailure);
+        break;
+
+    case Clusters::OnOff::Commands::Off::Id:
+        Clusters::OnOff::Commands::Off::Type offCommand;
+        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
+                                         offCommand, onSuccess, onFailure);
+        break;
+
+    default:
+        ChipLogError(NotSpecified, "Invalid binding command data - commandId is not supported");
+        break;
+    }
+}
+
+void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, chip::DeviceProxy * peer_device, void * context)
+{
+    VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "Invalid context for Light switch handler"););
+    BindingCommandData * data = static_cast<BindingCommandData *>(context);
+
     if (binding.type == EMBER_MULTICAST_BINDING)
     {
         ChipLogError(NotSpecified, "Group binding is not supported now");
-        return;
     }
-
-    if (binding.type == EMBER_UNICAST_BINDING && binding.local == 1 && binding.clusterId.HasValue() &&
-        binding.clusterId.Value() == Clusters::OnOff::Id)
+    else if (binding.type == EMBER_UNICAST_BINDING && binding.local == 1 &&
+             (!binding.clusterId.HasValue() || binding.clusterId.Value() == data->clusterId))
     {
-        CommandId commandId = *(static_cast<CommandId *>(context));
-        switch (commandId)
+
+        switch (data->clusterId)
         {
-        case Clusters::OnOff::Commands::Toggle::Id:
-            Clusters::OnOff::Commands::Toggle::Type command;
-            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
-                                             command, onSuccess, onFailure);
+        case Clusters::OnOff::Id:
+            ProcessOnOffBindingCommand(data->commandId, binding, peer_device);
+            break;
+        default:
+            ChipLogError(NotSpecified, "Invalid binding command data - clusterId is not supported");
             break;
         }
     }
+
+    chip::Platform::Delete(data);
 }
+
+#ifdef ENABLE_CHIP_SHELL
+CHIP_ERROR SwitchCommandHandler(int argc, char ** argv)
+{
+    if (argc == 1 && strcmp(argv[0], "on") == 0)
+    {
+        chip::DeviceLayer::PlatformMgr().ScheduleWork(SwitchOnOffOn, 0);
+    }
+    else if (argc == 1 && strcmp(argv[0], "off") == 0)
+    {
+        chip::DeviceLayer::PlatformMgr().ScheduleWork(SwitchOnOffOff, 0);
+    }
+    else if (argc == 1 && strcmp(argv[0], "toggle") == 0)
+    {
+        chip::DeviceLayer::PlatformMgr().ScheduleWork(SwitchToggleOnOff, 0);
+    }
+    else
+    {
+        streamer_printf(streamer_get(), "Usage: switch [on|off|toggle]");
+    }
+    return CHIP_NO_ERROR;
+}
+
+static void RegisterSwitchCommands()
+{
+    static const shell_command_t sSwitchCommand = { SwitchCommandHandler, "switch",
+                                                    "Switch commands. Usage: switch [on|off|toggle]" };
+    Engine::Root().RegisterCommands(&sSwitchCommand, 1);
+    return;
+}
+#endif // ENABLE_CHIP_SHELL
 } // namespace
 
 void SwitchToggleOnOff(intptr_t context)
 {
-    void * command = (void *) (&chip::app::Clusters::OnOff::Commands::Toggle::Id);
-    chip::BindingManager::GetInstance().NotifyBoundClusterChanged(1 /* endpointId */, chip::app::Clusters::OnOff::Id, command);
+    BindingCommandData * data = chip::Platform::New<BindingCommandData>();
+    VerifyOrReturn(data != nullptr, ChipLogError(NotSpecified, "SwitchToggleOnOff -  Out of Memory of work data"));
+
+    data->clusterId = chip::app::Clusters::OnOff::Id;
+    data->commandId = chip::app::Clusters::OnOff::Commands::Toggle::Id;
+
+    chip::BindingManager::GetInstance().NotifyBoundClusterChanged(1 /* endpointId */, chip::app::Clusters::OnOff::Id,
+                                                                  static_cast<void *>(data));
+}
+
+void SwitchOnOffOn(intptr_t context)
+{
+    BindingCommandData * data = chip::Platform::New<BindingCommandData>();
+    VerifyOrReturn(data != nullptr, ChipLogError(NotSpecified, "SwitchOnOffOn -  Out of Memory of work data"));
+
+    data->clusterId = chip::app::Clusters::OnOff::Id;
+    data->commandId = chip::app::Clusters::OnOff::Commands::On::Id;
+
+    chip::BindingManager::GetInstance().NotifyBoundClusterChanged(1 /* endpointId */, chip::app::Clusters::OnOff::Id,
+                                                                  static_cast<void *>(data));
+}
+
+void SwitchOnOffOff(intptr_t context)
+{
+    BindingCommandData * data = chip::Platform::New<BindingCommandData>();
+    VerifyOrReturn(data != nullptr, ChipLogError(NotSpecified, "SwitchOnOffOff -  Out of Memory of work data"));
+
+    data->clusterId = chip::app::Clusters::OnOff::Id;
+    data->commandId = chip::app::Clusters::OnOff::Commands::Off::Id;
+
+    chip::BindingManager::GetInstance().NotifyBoundClusterChanged(1 /* endpointId */, chip::app::Clusters::OnOff::Id,
+                                                                  static_cast<void *>(data));
 }
 
 CHIP_ERROR InitBindingHandler()
 {
     chip::BindingManager::GetInstance().SetAppServer(&chip::Server::GetInstance());
-    chip::BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(BoundDeviceChangedHandler);
+    chip::BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
+
+#if defined(ENABLE_CHIP_SHELL)
+    RegisterSwitchCommands();
+#endif
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Problem
* Limited fonctionnalities were available in the light-switch-example without shell commands
* Example did not support wildcard bindings

#### Change overview
* Added support for shell commands for basic OnOff cluster commands
* Fixes comment from #15431 

#### Testing
* Manual tests with light-switch example and lighting example with EFR32 MG12 and MG24
