### PR TITLE
Move Init in casesessionmanager in cpp, remove minmdns dssdcache

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -21,6 +21,17 @@
 
 namespace chip {
 
+CHIP_ERROR CASESessionManager::Init()
+{
+    if (mConfig.dnsResolver == nullptr)
+    {
+        ReturnErrorOnFailure(mDNSResolver.Init(DeviceLayer::UDPEndPointManager()));
+        mDNSResolver.SetOperationalDelegate(this);
+        mConfig.dnsResolver = &mDNSResolver;
+    }
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR CASESessionManager::FindOrEstablishSession(PeerId peerId, Callback::Callback<OnDeviceConnected> * onConnection,
                                                       Callback::Callback<OnDeviceConnectionFailure> * onFailure)
 {

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -60,18 +60,9 @@ public:
         mConfig = params;
     }
 
-    CHIP_ERROR Init()
-    {
-        if (mConfig.dnsResolver == nullptr)
-        {
-            ReturnErrorOnFailure(mDNSResolver.Init(DeviceLayer::UDPEndPointManager()));
-            mDNSResolver.SetOperationalDelegate(this);
-            mConfig.dnsResolver = &mDNSResolver;
-        }
-        return CHIP_NO_ERROR;
-    }
-
     virtual ~CASESessionManager() { mDNSResolver.Shutdown(); }
+
+    CHIP_ERROR Init();
 
     /**
      * Find an existing session for the given node ID, or trigger a new session request.

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 
-#include "DnssdCache.h"
 #include "Resolver.h"
 
 #include <limits>
@@ -66,14 +65,12 @@ constexpr uint16_t kMdnsPort          = 5353;
 constexpr uint16_t kDefaultTtlSeconds = 120;
 
 using namespace mdns::Minimal;
-using DnssdCacheType = Dnssd::DnssdCache<CHIP_CONFIG_MDNS_CACHE_SIZE>;
 
 class PacketDataReporter : public ParserDelegate
 {
 public:
     PacketDataReporter(OperationalResolveDelegate * opDelegate, CommissioningResolveDelegate * commissionDelegate,
-                       chip::Inet::InterfaceId interfaceId, DiscoveryType discoveryType, const BytesRange & packet,
-                       DnssdCacheType & mdnsCache) :
+                       chip::Inet::InterfaceId interfaceId, DiscoveryType discoveryType, const BytesRange & packet) :
         mOperationalDelegate(opDelegate),
         mCommissioningDelegate(commissionDelegate), mDiscoveryType(discoveryType), mPacketRange(packet)
     {
@@ -406,9 +403,6 @@ private:
     }
     static constexpr int kMaxQnameSize = 100;
     char qnameStorage[kMaxQnameSize];
-    // should this be static?
-    // original version had:    static Dnssd::IPCache<CHIP_CONFIG_IPCACHE_SIZE, CHIP_CONFIG_TTL_MS> sIPCache;
-    DnssdCacheType sDnssdCache;
 };
 
 void MinMdnsResolver::OnMdnsPacketData(const BytesRange & data, const chip::Inet::IPPacketInfo * info)

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -412,7 +412,7 @@ void MinMdnsResolver::OnMdnsPacketData(const BytesRange & data, const chip::Inet
         return;
     }
 
-    PacketDataReporter reporter(mOperationalDelegate, mCommissioningDelegate, info->Interface, mDiscoveryType, data, sDnssdCache);
+    PacketDataReporter reporter(mOperationalDelegate, mCommissioningDelegate, info->Interface, mDiscoveryType, data);
 
     if (!ParsePacket(data, &reporter))
     {


### PR DESCRIPTION
#### Problem

Init of CaseSessionManager is likely better placed in c++ file instead of header (has a few lines, I expect some more logic as we move to address resolution).

Minmdns does not use a dnssd cache at all, remove the references to it (this will save some RAM hopefully).

#### Change overview
Trivial method move from header to cpp
Remove unused dnssd cache.

#### Testing
CI will validate, changes are trivial.