### PR TITLE
fix BLE commissioning on commissionable Matter TVs

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1333,13 +1333,7 @@ CHIP_ERROR DeviceCommissioner::OnOperationalCredentialsProvisioningCompletion(Co
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 void DeviceCommissioner::ConnectBleTransportToSelf()
 {
-#if INET_CONFIG_ENABLE_IPV4
-    static const size_t kBleTupleIndex = 2;
-#else  // INET_CONFIG_ENABLE_IPV4
-    static const size_t kBleTupleIndex = 1;
-#endif // INET_CONFIG_ENABLE_IPV4
-
-    Transport::BLEBase & transport = mSystemState->TransportMgr()->GetTransport().GetImplAtIndex<kBleTupleIndex>();
+    Transport::BLEBase & transport = std::get<Transport::BLE<1>>(mSystemState->TransportMgr()->GetTransport().GetTransports());
     if (!transport.IsBleLayerTransportSetToSelf())
     {
         transport.SetBleLayerTransportToSelf();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -774,7 +774,7 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
     {
 #if CONFIG_NETWORK_LAYER_BLE
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
-        PrepareBleTransport();
+        ConnectBleTransportToSelf();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
         if (!params.HasBleLayer())
         {
@@ -1331,9 +1331,13 @@ CHIP_ERROR DeviceCommissioner::OnOperationalCredentialsProvisioningCompletion(Co
 
 #if CONFIG_NETWORK_LAYER_BLE
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
-void DeviceCommissioner::PrepareBleTransport()
+void DeviceCommissioner::ConnectBleTransportToSelf()
 {
-    Transport::BLEBase transport = mSystemState->TransportMgr()->GetTransport().template GetImplAtIndex<2>();
+    // The following returns error on Linux builds:
+    // /usr/include/c++/9/tuple:1303:25: error: static assertion failed: tuple index is in range
+    // static_assert(__i < tuple_size<tuple<>>::value,
+    // Transport::BLEBase transport = mSystemState->TransportMgr()->GetTransport().template GetImplAtIndex<2>();
+    Transport::BLEBase transport = mSystemState->TransportMgr()->GetTransport().GetImplAtIndex<2>();
     if (!transport.IsBleLayerTransportSetToSelf())
     {
         transport.SetBleLayerTransportToSelf();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1333,11 +1333,13 @@ CHIP_ERROR DeviceCommissioner::OnOperationalCredentialsProvisioningCompletion(Co
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 void DeviceCommissioner::ConnectBleTransportToSelf()
 {
-    // The following returns error on Linux builds:
-    // /usr/include/c++/9/tuple:1303:25: error: static assertion failed: tuple index is in range
-    // static_assert(__i < tuple_size<tuple<>>::value,
-    // Transport::BLEBase transport = mSystemState->TransportMgr()->GetTransport().template GetImplAtIndex<2>();
-    Transport::BLEBase transport = mSystemState->TransportMgr()->GetTransport().GetImplAtIndex<2>();
+#if INET_CONFIG_ENABLE_IPV4
+    static const size_t kBleTupleIndex = 2;
+#else  // INET_CONFIG_ENABLE_IPV4
+    static const size_t kBleTupleIndex = 1;
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    Transport::BLEBase & transport = mSystemState->TransportMgr()->GetTransport().GetImplAtIndex<kBleTupleIndex>();
     if (!transport.IsBleLayerTransportSetToSelf())
     {
         transport.SetBleLayerTransportToSelf();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -773,6 +773,9 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
         params.GetPeerAddress().GetTransportType() == Transport::Type::kUndefined)
     {
 #if CONFIG_NETWORK_LAYER_BLE
+#if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+        PrepareBleTransport();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
         if (!params.HasBleLayer())
         {
             params.SetPeerAddress(Transport::PeerAddress::BLE());
@@ -1327,6 +1330,17 @@ CHIP_ERROR DeviceCommissioner::OnOperationalCredentialsProvisioningCompletion(Co
 }
 
 #if CONFIG_NETWORK_LAYER_BLE
+#if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+void DeviceCommissioner::PrepareBleTransport()
+{
+    Transport::BLEBase transport = mSystemState->TransportMgr()->GetTransport().template GetImplAtIndex<2>();
+    if (!transport.IsBleLayerTransportSetToSelf())
+    {
+        transport.SetBleLayerTransportToSelf();
+    }
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+
 CHIP_ERROR DeviceCommissioner::CloseBleConnection()
 {
     // It is fine since we can only commission one device at the same time.

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -602,7 +602,7 @@ public:
      *   Prior to commissioning, the Controller should make sure the BleLayer transport
      *   is set to the Commissioner transport and not the Server transport.
      */
-    void PrepareBleTransport();
+    void ConnectBleTransportToSelf();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
     /**

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -596,6 +596,15 @@ public:
                                CommissioningDelegate::CommissioningReport report = CommissioningDelegate::CommissioningReport());
 
 #if CONFIG_NETWORK_LAYER_BLE
+#if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+    /**
+     * @brief
+     *   Prior to commissioning, the Controller should make sure the BleLayer transport
+     *   is set to the Commissioner transport and not the Server transport.
+     */
+    void PrepareBleTransport();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+
     /**
      * @brief
      *   Once we have finished all commissioning work, the Controller should close the BLE

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -87,7 +87,7 @@ CHIP_ERROR SetUpCodePairer::StartDiscoverOverBle(SetupPayload & payload)
 #if CONFIG_NETWORK_LAYER_BLE
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
     VerifyOrReturnError(mCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    mCommissioner->PrepareBleTransport();
+    mCommissioner->ConnectBleTransportToSelf();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
     VerifyOrReturnError(mBleLayer != nullptr, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
     return mBleLayer->NewBleConnectionByDiscriminator(payload.discriminator, this, OnDiscoveredDeviceOverBleSuccess,

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -85,6 +85,10 @@ CHIP_ERROR SetUpCodePairer::Connect(SetupPayload & payload)
 CHIP_ERROR SetUpCodePairer::StartDiscoverOverBle(SetupPayload & payload)
 {
 #if CONFIG_NETWORK_LAYER_BLE
+#if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+    VerifyOrReturnError(mCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    mCommissioner->PrepareBleTransport();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
     VerifyOrReturnError(mBleLayer != nullptr, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
     return mBleLayer->NewBleConnectionByDiscriminator(payload.discriminator, this, OnDiscoveredDeviceOverBleSuccess,
                                                       OnDiscoveredDeviceOverBleError);

--- a/src/transport/raw/BLE.cpp
+++ b/src/transport/raw/BLE.cpp
@@ -47,6 +47,7 @@ void BLEBase::ClearState()
     {
         mBleLayer->CancelBleIncompleteConnection();
         mBleLayer->OnChipBleConnectReceived = nullptr;
+        mBleLayer->mBleTransport            = nullptr;
         mBleLayer                           = nullptr;
     }
 
@@ -66,8 +67,16 @@ CHIP_ERROR BLEBase::Init(const BleListenParameters & param)
     VerifyOrReturnError(mState == State::kNotReady, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(bleLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    mBleLayer                           = bleLayer;
-    mBleLayer->mBleTransport            = this;
+    mBleLayer = bleLayer;
+    if (mBleLayer->mBleTransport == nullptr || !param.PreserveExistingBleLayerTransport())
+    {
+        mBleLayer->mBleTransport = this;
+        ChipLogDetail(Inet, "BLEBase::Init - setting/overriding transport");
+    }
+    else
+    {
+        ChipLogDetail(Inet, "BLEBase::Init - not overriding transport");
+    }
     mBleLayer->OnChipBleConnectReceived = nullptr;
 
     mState = State::kInitialized;

--- a/src/transport/raw/Tuple.h
+++ b/src/transport/raw/Tuple.h
@@ -281,6 +281,8 @@ public:
     {
         return std::get<i>(mTransports);
     }
+
+    std::tuple<TransportTypes...> & GetTransports() { return mTransports; }
 };
 
 } // namespace Transport


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fixes #15012: CHIP-TOOL can't provision CHIP-TV using BLE

#### Change overview
By default, when there is more than one BleBase transport, the second to initialize overrides the global BleLayer transport with itself. This fix adds Ble transport initialization parameters so that this override behavior can be managed, and the default behavior is to only set the global BleLayer transport if it is not already set.

#### Testing
* Tested by commissioning the tv-app using BLE
