### PR TITLE
Add MRP data for address resolution

### DIFF
--- a/src/lib/address_resolve/AddressResolve.h
+++ b/src/lib/address_resolve/AddressResolve.h
@@ -26,10 +26,14 @@
 namespace chip {
 namespace AddressResolve {
 
+/// Contains resolve information received from nodes. Contains all information
+/// bits that are considered useful but does not contain a full DNSSD data
+/// structure since not all DNSSD data is useful during operational processing.
 struct ResolveResult
 {
     Transport::PeerAddress address;
     ReliableMessageProtocolConfig mrpConfig;
+    bool supportsTcp = false;
 
     ResolveResult() : address(Transport::Type::kUdp), mrpConfig(GetLocalMRPConfig()) {}
 };

--- a/src/lib/address_resolve/AddressResolve.h
+++ b/src/lib/address_resolve/AddressResolve.h
@@ -18,12 +18,21 @@
 
 #include <lib/core/PeerId.h>
 #include <lib/support/IntrusiveList.h>
+#include <messaging/ReliableMessageProtocolConfig.h>
 #include <system/SystemClock.h>
 #include <system/SystemLayer.h>
 #include <transport/raw/PeerAddress.h>
 
 namespace chip {
 namespace AddressResolve {
+
+struct ResolveResult
+{
+    Transport::PeerAddress address;
+    ReliableMessageProtocolConfig mrpConfig;
+
+    ResolveResult() : address(Transport::Type::kUdp), mrpConfig(GetLocalMRPConfig()) {}
+};
 
 /// Represents an object intersted in callbacks for a resolve operation.
 class NodeListener
@@ -37,7 +46,7 @@ public:
     ///
     /// The callback is expected to be executed within the chip event loop
     /// thread.
-    virtual void OnNodeAddressResolved(const PeerId & peerId, const Transport::PeerAddress & address) = 0;
+    virtual void OnNodeAddressResolved(const PeerId & peerId, const ResolveResult & result) = 0;
 
     /// Node resolution failure - occurs only once for a lookup, when an address
     /// could not be resolved - generally due to a timeout or due to DNSSD

--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -95,23 +95,24 @@ IpScore ScoreIpAddress(const Inet::IPAddress & ip, Inet::InterfaceId interfaceId
 
 void NodeLookupHandle::ResetForLookup(System::Clock::Timestamp now, const NodeLookupRequest & request)
 {
-    mRequestStartTime = now;
-    mRequest          = request;
-    mBestPeerAddress  = Transport::PeerAddress();
-    mBestAddressScore = ScoreValue(IpScore::kInvalid);
+    mRequestStartTime     = now;
+    mRequest              = request;
+    mBestResult.address   = Transport::PeerAddress();
+    mBestResult.mrpConfig = GetLocalMRPConfig();
+    mBestAddressScore     = ScoreValue(IpScore::kInvalid);
 }
 
-void NodeLookupHandle::LookupResult(const Transport::PeerAddress & addr)
+void NodeLookupHandle::LookupResult(const ResolveResult & result)
 {
-    unsigned newScore = ScoreValue(ScoreIpAddress(addr.GetIPAddress(), addr.GetInterface()));
+    unsigned newScore = ScoreValue(ScoreIpAddress(result.address.GetIPAddress(), result.address.GetInterface()));
     if (newScore > mBestAddressScore)
     {
-        mBestPeerAddress  = addr;
+        mBestResult       = result;
         mBestAddressScore = newScore;
 
 #if CHIP_PROGRESS_LOGGING
         char addr_string[Transport::PeerAddress::kMaxToStringSize];
-        mBestPeerAddress.ToString(addr_string);
+        mBestResult.address.ToString(addr_string);
         ChipLogProgress(Discovery, "Address %s is scored at %u", addr_string, mBestAddressScore);
 #endif
     }
@@ -152,7 +153,7 @@ NodeLookupAction NodeLookupHandle::NextAction(System::Clock::Timestamp now)
     // Minimal time to search reached. If any Ip available, ready to return it.
     if (mBestAddressScore > ScoreValue(IpScore::kInvalid))
     {
-        GetListener()->OnNodeAddressResolved(GetRequest().GetPeerId(), mBestPeerAddress);
+        GetListener()->OnNodeAddressResolved(GetRequest().GetPeerId(), mBestResult);
         return NodeLookupAction::kStopSearching;
     }
 
@@ -194,15 +195,16 @@ void Resolver::OnOperationalNodeResolved(const Dnssd::ResolvedNodeData & nodeDat
             continue;
         }
 
-        // Assume we only search for UDP addresses for now
-        Transport::PeerAddress address(Transport::Type::kUdp);
-        address.SetPort(nodeData.mPort);
-        address.SetInterface(nodeData.mInterfaceId);
+        ResolveResult result;
+
+        result.address.SetPort(nodeData.mPort);
+        result.address.SetInterface(nodeData.mInterfaceId);
+        result.mrpConfig = nodeData.GetMRPConfig();
 
         for (size_t i = 0; i < nodeData.mNumIPs; i++)
         {
-            address.SetIPAddress(nodeData.mAddress[i]);
-            current->LookupResult(address);
+            result.address.SetIPAddress(nodeData.mAddress[i]);
+            current->LookupResult(result);
         }
 
         if (current->NextAction(mTimeSource.GetMonotonicTimestamp()) == NodeLookupAction::kStopSearching)

--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -95,11 +95,10 @@ IpScore ScoreIpAddress(const Inet::IPAddress & ip, Inet::InterfaceId interfaceId
 
 void NodeLookupHandle::ResetForLookup(System::Clock::Timestamp now, const NodeLookupRequest & request)
 {
-    mRequestStartTime     = now;
-    mRequest              = request;
-    mBestResult.address   = Transport::PeerAddress();
-    mBestResult.mrpConfig = GetLocalMRPConfig();
-    mBestAddressScore     = ScoreValue(IpScore::kInvalid);
+    mRequestStartTime = now;
+    mRequest          = request;
+    mBestResult       = ResolveResult();
+    mBestAddressScore = ScoreValue(IpScore::kInvalid);
 }
 
 void NodeLookupHandle::LookupResult(const ResolveResult & result)
@@ -199,7 +198,8 @@ void Resolver::OnOperationalNodeResolved(const Dnssd::ResolvedNodeData & nodeDat
 
         result.address.SetPort(nodeData.mPort);
         result.address.SetInterface(nodeData.mInterfaceId);
-        result.mrpConfig = nodeData.GetMRPConfig();
+        result.mrpConfig   = nodeData.GetMRPConfig();
+        result.supportsTcp = nodeData.mSupportsTcp;
 
         for (size_t i = 0; i < nodeData.mNumIPs; i++)
         {

--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.h
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.h
@@ -47,7 +47,7 @@ public:
     void ResetForLookup(System::Clock::Timestamp now, const NodeLookupRequest & request);
 
     /// Mark that a specific IP address has been found
-    void LookupResult(const Transport::PeerAddress & addr);
+    void LookupResult(const ResolveResult & result);
 
     /// Called after timeouts or after a series of IP addresses have been
     /// marked as found.
@@ -67,7 +67,7 @@ public:
 private:
     System::Clock::Timestamp mRequestStartTime;
     NodeLookupRequest mRequest; // active request to process
-    Transport::PeerAddress mBestPeerAddress;
+    AddressResolve::ResolveResult mBestResult;
     unsigned mBestAddressScore = 0;
 };
 

--- a/src/lib/address_resolve/BUILD.gn
+++ b/src/lib/address_resolve/BUILD.gn
@@ -36,6 +36,7 @@ static_library("address_resolve") {
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/dnssd",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/messaging",
     "${chip_root}/src/transport/raw",
   ]
 

--- a/src/lib/address_resolve/tool.cpp
+++ b/src/lib/address_resolve/tool.cpp
@@ -47,12 +47,14 @@ class PrintOutNodeListener : public chip::AddressResolve::NodeListener
 public:
     PrintOutNodeListener() { mSelfHandle.SetListener(this); }
 
-    void OnNodeAddressResolved(const PeerId & peerId, const PeerAddress & address) override
+    void OnNodeAddressResolved(const PeerId & peerId, const AddressResolve::ResolveResult & result) override
     {
         char addr_string[PeerAddress::kMaxToStringSize];
-        address.ToString(addr_string);
+        result.address.ToString(addr_string);
 
         ChipLogProgress(Discovery, "Resolve completed: %s", addr_string);
+        ChipLogProgress(Discovery, "   MRP IDLE retransmit timeout:   %u ms", result.mrpConfig.mIdleRetransTimeout.count());
+        ChipLogProgress(Discovery, "   MRP ACTIVE retransmit timeout: %u ms", result.mrpConfig.mActiveRetransTimeout.count());
         NotifyDone();
     }
 

--- a/src/lib/address_resolve/tool.cpp
+++ b/src/lib/address_resolve/tool.cpp
@@ -53,6 +53,7 @@ public:
         result.address.ToString(addr_string);
 
         ChipLogProgress(Discovery, "Resolve completed: %s", addr_string);
+        ChipLogProgress(Discovery, "   Supports TCP:                  %s", result.supportsTcp ? "YES" : "NO");
         ChipLogProgress(Discovery, "   MRP IDLE retransmit timeout:   %u ms", result.mrpConfig.mIdleRetransTimeout.count());
         ChipLogProgress(Discovery, "   MRP ACTIVE retransmit timeout: %u ms", result.mrpConfig.mActiveRetransTimeout.count());
         NotifyDone();


### PR DESCRIPTION
#### Problem
Resolving operational nodes generally requires both address and MRP data. Ensure that our 'find best address' logic returns full information.

#### Change overview
Make the resolution callback take a 'ResolveResult' that we can change as needed
Add MRP info to resolve result.
Print out mrp data in the resolve tool.

#### Testing
Ran `address-resolve-tool` and observed reasonable MRP data shown from a devkitc device.

Specifically did a build and run:

```
./scripts/build/build_examples.py --target linux-x64-address-resolve-tool build
# ......
# ......
./out/linux-x64-address-resolve-tool/address-resolve-tool node 0x000000000001E1B9 0x116362B9D227A22A
```

