### PR TITLE
Change domain to CHIP

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/basic-information-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/basic-information-cluster.xml
@@ -18,7 +18,7 @@ limitations under the License.
   <domain name="CHIP"/>
   <cluster singleton="true">
     <name>Basic</name>
-    <domain>General</domain>
+    <domain>CHIP</domain>
     <code>0x0028</code>
     <define>BASIC_CLUSTER</define>
     <description>This cluster provides attributes and events for determining basic information about Nodes, which supports both

--- a/src/app/zap-templates/zcl/data-model/chip/unit-localization-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/unit-localization-cluster.xml
@@ -23,7 +23,7 @@ limitations under the License.
     <item name="Kelvin" value="0x02"/>
   </enum>
   <cluster>
-    <domain>General</domain>
+    <domain>CHIP</domain>
     <name>Unit Localization</name>
     <code>0x002d</code>
     <define>UNIT_LOCALIZATION_CLUSTER</define>


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Basic Information and Unit Localization clusters still had domain listed as General.

#### Change overview
Change to CHIP.

#### Testing
How was this tested? (at least one bullet point required)
* None
