### PR TITLE
[Android] Fix optional encode/decode

### DIFF
--- a/src/controller/java/templates/partials/decode_value.zapt
+++ b/src/controller/java/templates/partials/decode_value.zapt
@@ -5,7 +5,9 @@ jobject {{target}};
 if (!{{source}}.HasValue()) {
   chip::JniReferences::GetInstance().CreateOptional(nullptr, {{target}});
 } else {
-  {{>decode_value target=target source=(concat source ".Value()") cluster=cluster depth=(incrementDepth depth) isOptional=false omitDeclaration=true earlyReturn=earlyReturn}}
+  jobject {{target}}InsideOptional;
+  {{>decode_value target=(concat target "InsideOptional") source=(concat source ".Value()") cluster=cluster depth=(incrementDepth depth) isOptional=false omitDeclaration=true earlyReturn=earlyReturn}}
+  chip::JniReferences::GetInstance().CreateOptional({{target}}InsideOptional, {{target}});
 }
 {{else if isNullable}}
 if ({{source}}.IsNull()) {

--- a/src/controller/java/templates/partials/encode_value.zapt
+++ b/src/controller/java/templates/partials/encode_value.zapt
@@ -2,8 +2,10 @@
   if ({{source}} != nullptr) {
     jobject optionalValue_{{depth}};
     chip::JniReferences::GetInstance().GetOptionalValue({{source}}, optionalValue_{{depth}});
-    auto & definedValue_{{depth}} = {{target}}.Emplace();
-    {{>encode_value target=(concat "definedValue_" depth) source=(concat "optionalValue_" depth) cluster=cluster depth=(incrementDepth depth) isOptional=false}}
+    if (optionalValue_{{depth}} != nullptr) {
+      auto & definedValue_{{depth}} = {{target}}.Emplace();
+      {{>encode_value target=(concat "definedValue_" depth) source=(concat "optionalValue_" depth) cluster=cluster depth=(incrementDepth depth) isOptional=false}}
+    }
   }
 {{else if isNullable}}
   if ({{source}} == nullptr) {

--- a/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
+++ b/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
@@ -900,11 +900,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    std::string value_endpointClassName     = "java/lang/Integer";
-                    std::string value_endpointCtorSignature = "(I)V";
+                    jobject value_endpointInsideOptional;
+                    std::string value_endpointInsideOptionalClassName     = "java/lang/Integer";
+                    std::string value_endpointInsideOptionalCtorSignature = "(I)V";
                     chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
-                        value_endpointClassName.c_str(), value_endpointCtorSignature.c_str(), cppValue.Value().endpoint.Value(),
-                        value_endpoint);
+                        value_endpointInsideOptionalClassName.c_str(), value_endpointInsideOptionalCtorSignature.c_str(),
+                        cppValue.Value().endpoint.Value(), value_endpointInsideOptional);
+                    chip::JniReferences::GetInstance().CreateOptional(value_endpointInsideOptional, value_endpoint);
                 }
 
                 jclass applicationEPStructClass;
@@ -1864,11 +1866,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    std::string newElement_0_nodeClassName     = "java/lang/Long";
-                    std::string newElement_0_nodeCtorSignature = "(J)V";
-                    chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(newElement_0_nodeClassName.c_str(),
-                                                                                   newElement_0_nodeCtorSignature.c_str(),
-                                                                                   entry_0.node.Value(), newElement_0_node);
+                    jobject newElement_0_nodeInsideOptional;
+                    std::string newElement_0_nodeInsideOptionalClassName     = "java/lang/Long";
+                    std::string newElement_0_nodeInsideOptionalCtorSignature = "(J)V";
+                    chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(
+                        newElement_0_nodeInsideOptionalClassName.c_str(), newElement_0_nodeInsideOptionalCtorSignature.c_str(),
+                        entry_0.node.Value(), newElement_0_nodeInsideOptional);
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_nodeInsideOptional, newElement_0_node);
                 }
                 jobject newElement_0_group;
                 if (!entry_0.group.HasValue())
@@ -1877,11 +1881,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    std::string newElement_0_groupClassName     = "java/lang/Integer";
-                    std::string newElement_0_groupCtorSignature = "(I)V";
-                    chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(newElement_0_groupClassName.c_str(),
-                                                                                   newElement_0_groupCtorSignature.c_str(),
-                                                                                   entry_0.group.Value(), newElement_0_group);
+                    jobject newElement_0_groupInsideOptional;
+                    std::string newElement_0_groupInsideOptionalClassName     = "java/lang/Integer";
+                    std::string newElement_0_groupInsideOptionalCtorSignature = "(I)V";
+                    chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
+                        newElement_0_groupInsideOptionalClassName.c_str(), newElement_0_groupInsideOptionalCtorSignature.c_str(),
+                        entry_0.group.Value(), newElement_0_groupInsideOptional);
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_groupInsideOptional, newElement_0_group);
                 }
                 jobject newElement_0_endpoint;
                 if (!entry_0.endpoint.HasValue())
@@ -1890,11 +1896,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    std::string newElement_0_endpointClassName     = "java/lang/Integer";
-                    std::string newElement_0_endpointCtorSignature = "(I)V";
-                    chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(newElement_0_endpointClassName.c_str(),
-                                                                                   newElement_0_endpointCtorSignature.c_str(),
-                                                                                   entry_0.endpoint.Value(), newElement_0_endpoint);
+                    jobject newElement_0_endpointInsideOptional;
+                    std::string newElement_0_endpointInsideOptionalClassName     = "java/lang/Integer";
+                    std::string newElement_0_endpointInsideOptionalCtorSignature = "(I)V";
+                    chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
+                        newElement_0_endpointInsideOptionalClassName.c_str(),
+                        newElement_0_endpointInsideOptionalCtorSignature.c_str(), entry_0.endpoint.Value(),
+                        newElement_0_endpointInsideOptional);
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_endpointInsideOptional, newElement_0_endpoint);
                 }
                 jobject newElement_0_cluster;
                 if (!entry_0.cluster.HasValue())
@@ -1903,11 +1912,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    std::string newElement_0_clusterClassName     = "java/lang/Long";
-                    std::string newElement_0_clusterCtorSignature = "(J)V";
-                    chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0_clusterClassName.c_str(),
-                                                                                   newElement_0_clusterCtorSignature.c_str(),
-                                                                                   entry_0.cluster.Value(), newElement_0_cluster);
+                    jobject newElement_0_clusterInsideOptional;
+                    std::string newElement_0_clusterInsideOptionalClassName     = "java/lang/Long";
+                    std::string newElement_0_clusterInsideOptionalCtorSignature = "(J)V";
+                    chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
+                        newElement_0_clusterInsideOptionalClassName.c_str(),
+                        newElement_0_clusterInsideOptionalCtorSignature.c_str(), entry_0.cluster.Value(),
+                        newElement_0_clusterInsideOptional);
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_clusterInsideOptional, newElement_0_cluster);
                 }
 
                 jclass targetStructStructClass;
@@ -2719,8 +2731,10 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    newElement_0_name =
+                    jobject newElement_0_nameInsideOptional;
+                    newElement_0_nameInsideOptional =
                         env->NewStringUTF(std::string(entry_0.name.Value().data(), entry_0.name.Value().size()).c_str());
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_nameInsideOptional, newElement_0_name);
                 }
                 jobject newElement_0_callSign;
                 if (!entry_0.callSign.HasValue())
@@ -2729,8 +2743,10 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    newElement_0_callSign =
+                    jobject newElement_0_callSignInsideOptional;
+                    newElement_0_callSignInsideOptional =
                         env->NewStringUTF(std::string(entry_0.callSign.Value().data(), entry_0.callSign.Value().size()).c_str());
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_callSignInsideOptional, newElement_0_callSign);
                 }
                 jobject newElement_0_affiliateCallSign;
                 if (!entry_0.affiliateCallSign.HasValue())
@@ -2739,8 +2755,11 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    newElement_0_affiliateCallSign = env->NewStringUTF(
+                    jobject newElement_0_affiliateCallSignInsideOptional;
+                    newElement_0_affiliateCallSignInsideOptional = env->NewStringUTF(
                         std::string(entry_0.affiliateCallSign.Value().data(), entry_0.affiliateCallSign.Value().size()).c_str());
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_affiliateCallSignInsideOptional,
+                                                                      newElement_0_affiliateCallSign);
                 }
 
                 jclass channelInfoStructClass;
@@ -2792,9 +2811,11 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    value_lineupName = env->NewStringUTF(
+                    jobject value_lineupNameInsideOptional;
+                    value_lineupNameInsideOptional = env->NewStringUTF(
                         std::string(cppValue.Value().lineupName.Value().data(), cppValue.Value().lineupName.Value().size())
                             .c_str());
+                    chip::JniReferences::GetInstance().CreateOptional(value_lineupNameInsideOptional, value_lineupName);
                 }
                 jobject value_postalCode;
                 if (!cppValue.Value().postalCode.HasValue())
@@ -2803,9 +2824,11 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    value_postalCode = env->NewStringUTF(
+                    jobject value_postalCodeInsideOptional;
+                    value_postalCodeInsideOptional = env->NewStringUTF(
                         std::string(cppValue.Value().postalCode.Value().data(), cppValue.Value().postalCode.Value().size())
                             .c_str());
+                    chip::JniReferences::GetInstance().CreateOptional(value_postalCodeInsideOptional, value_postalCode);
                 }
                 jobject value_lineupInfoType;
                 std::string value_lineupInfoTypeClassName     = "java/lang/Integer";
@@ -2870,8 +2893,10 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    value_name = env->NewStringUTF(
+                    jobject value_nameInsideOptional;
+                    value_nameInsideOptional = env->NewStringUTF(
                         std::string(cppValue.Value().name.Value().data(), cppValue.Value().name.Value().size()).c_str());
+                    chip::JniReferences::GetInstance().CreateOptional(value_nameInsideOptional, value_name);
                 }
                 jobject value_callSign;
                 if (!cppValue.Value().callSign.HasValue())
@@ -2880,8 +2905,10 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    value_callSign = env->NewStringUTF(
+                    jobject value_callSignInsideOptional;
+                    value_callSignInsideOptional = env->NewStringUTF(
                         std::string(cppValue.Value().callSign.Value().data(), cppValue.Value().callSign.Value().size()).c_str());
+                    chip::JniReferences::GetInstance().CreateOptional(value_callSignInsideOptional, value_callSign);
                 }
                 jobject value_affiliateCallSign;
                 if (!cppValue.Value().affiliateCallSign.HasValue())
@@ -2890,9 +2917,13 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    value_affiliateCallSign = env->NewStringUTF(std::string(cppValue.Value().affiliateCallSign.Value().data(),
-                                                                            cppValue.Value().affiliateCallSign.Value().size())
-                                                                    .c_str());
+                    jobject value_affiliateCallSignInsideOptional;
+                    value_affiliateCallSignInsideOptional =
+                        env->NewStringUTF(std::string(cppValue.Value().affiliateCallSign.Value().data(),
+                                                      cppValue.Value().affiliateCallSign.Value().size())
+                                              .c_str());
+                    chip::JniReferences::GetInstance().CreateOptional(value_affiliateCallSignInsideOptional,
+                                                                      value_affiliateCallSign);
                 }
 
                 jclass channelInfoStructClass;
@@ -6229,8 +6260,10 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    newElement_0_groupName =
+                    jobject newElement_0_groupNameInsideOptional;
+                    newElement_0_groupNameInsideOptional =
                         env->NewStringUTF(std::string(entry_0.groupName.Value().data(), entry_0.groupName.Value().size()).c_str());
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_groupNameInsideOptional, newElement_0_groupName);
                 }
 
                 jclass groupInfoMapStructStructClass;
@@ -11914,11 +11947,15 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    std::string newElement_0_optionalIntClassName     = "java/lang/Integer";
-                    std::string newElement_0_optionalIntCtorSignature = "(I)V";
+                    jobject newElement_0_optionalIntInsideOptional;
+                    std::string newElement_0_optionalIntInsideOptionalClassName     = "java/lang/Integer";
+                    std::string newElement_0_optionalIntInsideOptionalCtorSignature = "(I)V";
                     chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
-                        newElement_0_optionalIntClassName.c_str(), newElement_0_optionalIntCtorSignature.c_str(),
-                        entry_0.optionalInt.Value(), newElement_0_optionalInt);
+                        newElement_0_optionalIntInsideOptionalClassName.c_str(),
+                        newElement_0_optionalIntInsideOptionalCtorSignature.c_str(), entry_0.optionalInt.Value(),
+                        newElement_0_optionalIntInsideOptional);
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_optionalIntInsideOptional,
+                                                                      newElement_0_optionalInt);
                 }
                 jobject newElement_0_nullableOptionalInt;
                 if (!entry_0.nullableOptionalInt.HasValue())
@@ -11927,19 +11964,22 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
+                    jobject newElement_0_nullableOptionalIntInsideOptional;
                     if (entry_0.nullableOptionalInt.Value().IsNull())
                     {
-                        newElement_0_nullableOptionalInt = nullptr;
+                        newElement_0_nullableOptionalIntInsideOptional = nullptr;
                     }
                     else
                     {
-                        std::string newElement_0_nullableOptionalIntClassName     = "java/lang/Integer";
-                        std::string newElement_0_nullableOptionalIntCtorSignature = "(I)V";
+                        std::string newElement_0_nullableOptionalIntInsideOptionalClassName     = "java/lang/Integer";
+                        std::string newElement_0_nullableOptionalIntInsideOptionalCtorSignature = "(I)V";
                         chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
-                            newElement_0_nullableOptionalIntClassName.c_str(),
-                            newElement_0_nullableOptionalIntCtorSignature.c_str(), entry_0.nullableOptionalInt.Value().Value(),
-                            newElement_0_nullableOptionalInt);
+                            newElement_0_nullableOptionalIntInsideOptionalClassName.c_str(),
+                            newElement_0_nullableOptionalIntInsideOptionalCtorSignature.c_str(),
+                            entry_0.nullableOptionalInt.Value().Value(), newElement_0_nullableOptionalIntInsideOptional);
                     }
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_nullableOptionalIntInsideOptional,
+                                                                      newElement_0_nullableOptionalInt);
                 }
                 jobject newElement_0_nullableString;
                 if (entry_0.nullableString.IsNull())
@@ -11958,8 +11998,11 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    newElement_0_optionalString = env->NewStringUTF(
+                    jobject newElement_0_optionalStringInsideOptional;
+                    newElement_0_optionalStringInsideOptional = env->NewStringUTF(
                         std::string(entry_0.optionalString.Value().data(), entry_0.optionalString.Value().size()).c_str());
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_optionalStringInsideOptional,
+                                                                      newElement_0_optionalString);
                 }
                 jobject newElement_0_nullableOptionalString;
                 if (!entry_0.nullableOptionalString.HasValue())
@@ -11968,17 +12011,20 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
+                    jobject newElement_0_nullableOptionalStringInsideOptional;
                     if (entry_0.nullableOptionalString.Value().IsNull())
                     {
-                        newElement_0_nullableOptionalString = nullptr;
+                        newElement_0_nullableOptionalStringInsideOptional = nullptr;
                     }
                     else
                     {
-                        newElement_0_nullableOptionalString =
+                        newElement_0_nullableOptionalStringInsideOptional =
                             env->NewStringUTF(std::string(entry_0.nullableOptionalString.Value().Value().data(),
                                                           entry_0.nullableOptionalString.Value().Value().size())
                                                   .c_str());
                     }
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_nullableOptionalStringInsideOptional,
+                                                                      newElement_0_nullableOptionalString);
                 }
                 jobject newElement_0_nullableStruct;
                 if (entry_0.nullableStruct.IsNull())
@@ -12065,52 +12111,59 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    jobject newElement_0_optionalStruct_a;
-                    std::string newElement_0_optionalStruct_aClassName     = "java/lang/Integer";
-                    std::string newElement_0_optionalStruct_aCtorSignature = "(I)V";
+                    jobject newElement_0_optionalStructInsideOptional;
+                    jobject newElement_0_optionalStructInsideOptional_a;
+                    std::string newElement_0_optionalStructInsideOptional_aClassName     = "java/lang/Integer";
+                    std::string newElement_0_optionalStructInsideOptional_aCtorSignature = "(I)V";
                     chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-                        newElement_0_optionalStruct_aClassName.c_str(), newElement_0_optionalStruct_aCtorSignature.c_str(),
-                        entry_0.optionalStruct.Value().a, newElement_0_optionalStruct_a);
-                    jobject newElement_0_optionalStruct_b;
-                    std::string newElement_0_optionalStruct_bClassName     = "java/lang/Boolean";
-                    std::string newElement_0_optionalStruct_bCtorSignature = "(Z)V";
+                        newElement_0_optionalStructInsideOptional_aClassName.c_str(),
+                        newElement_0_optionalStructInsideOptional_aCtorSignature.c_str(), entry_0.optionalStruct.Value().a,
+                        newElement_0_optionalStructInsideOptional_a);
+                    jobject newElement_0_optionalStructInsideOptional_b;
+                    std::string newElement_0_optionalStructInsideOptional_bClassName     = "java/lang/Boolean";
+                    std::string newElement_0_optionalStructInsideOptional_bCtorSignature = "(Z)V";
                     chip::JniReferences::GetInstance().CreateBoxedObject<bool>(
-                        newElement_0_optionalStruct_bClassName.c_str(), newElement_0_optionalStruct_bCtorSignature.c_str(),
-                        entry_0.optionalStruct.Value().b, newElement_0_optionalStruct_b);
-                    jobject newElement_0_optionalStruct_c;
-                    std::string newElement_0_optionalStruct_cClassName     = "java/lang/Integer";
-                    std::string newElement_0_optionalStruct_cCtorSignature = "(I)V";
+                        newElement_0_optionalStructInsideOptional_bClassName.c_str(),
+                        newElement_0_optionalStructInsideOptional_bCtorSignature.c_str(), entry_0.optionalStruct.Value().b,
+                        newElement_0_optionalStructInsideOptional_b);
+                    jobject newElement_0_optionalStructInsideOptional_c;
+                    std::string newElement_0_optionalStructInsideOptional_cClassName     = "java/lang/Integer";
+                    std::string newElement_0_optionalStructInsideOptional_cCtorSignature = "(I)V";
                     chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-                        newElement_0_optionalStruct_cClassName.c_str(), newElement_0_optionalStruct_cCtorSignature.c_str(),
-                        static_cast<uint8_t>(entry_0.optionalStruct.Value().c), newElement_0_optionalStruct_c);
-                    jobject newElement_0_optionalStruct_d;
-                    jbyteArray newElement_0_optionalStruct_dByteArray =
+                        newElement_0_optionalStructInsideOptional_cClassName.c_str(),
+                        newElement_0_optionalStructInsideOptional_cCtorSignature.c_str(),
+                        static_cast<uint8_t>(entry_0.optionalStruct.Value().c), newElement_0_optionalStructInsideOptional_c);
+                    jobject newElement_0_optionalStructInsideOptional_d;
+                    jbyteArray newElement_0_optionalStructInsideOptional_dByteArray =
                         env->NewByteArray(static_cast<jsize>(entry_0.optionalStruct.Value().d.size()));
-                    env->SetByteArrayRegion(newElement_0_optionalStruct_dByteArray, 0,
+                    env->SetByteArrayRegion(newElement_0_optionalStructInsideOptional_dByteArray, 0,
                                             static_cast<jsize>(entry_0.optionalStruct.Value().d.size()),
                                             reinterpret_cast<const jbyte *>(entry_0.optionalStruct.Value().d.data()));
-                    newElement_0_optionalStruct_d = newElement_0_optionalStruct_dByteArray;
-                    jobject newElement_0_optionalStruct_e;
-                    newElement_0_optionalStruct_e = env->NewStringUTF(
+                    newElement_0_optionalStructInsideOptional_d = newElement_0_optionalStructInsideOptional_dByteArray;
+                    jobject newElement_0_optionalStructInsideOptional_e;
+                    newElement_0_optionalStructInsideOptional_e = env->NewStringUTF(
                         std::string(entry_0.optionalStruct.Value().e.data(), entry_0.optionalStruct.Value().e.size()).c_str());
-                    jobject newElement_0_optionalStruct_f;
-                    std::string newElement_0_optionalStruct_fClassName     = "java/lang/Integer";
-                    std::string newElement_0_optionalStruct_fCtorSignature = "(I)V";
+                    jobject newElement_0_optionalStructInsideOptional_f;
+                    std::string newElement_0_optionalStructInsideOptional_fClassName     = "java/lang/Integer";
+                    std::string newElement_0_optionalStructInsideOptional_fCtorSignature = "(I)V";
                     chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-                        newElement_0_optionalStruct_fClassName.c_str(), newElement_0_optionalStruct_fCtorSignature.c_str(),
-                        entry_0.optionalStruct.Value().f.Raw(), newElement_0_optionalStruct_f);
-                    jobject newElement_0_optionalStruct_g;
-                    std::string newElement_0_optionalStruct_gClassName     = "java/lang/Float";
-                    std::string newElement_0_optionalStruct_gCtorSignature = "(F)V";
+                        newElement_0_optionalStructInsideOptional_fClassName.c_str(),
+                        newElement_0_optionalStructInsideOptional_fCtorSignature.c_str(), entry_0.optionalStruct.Value().f.Raw(),
+                        newElement_0_optionalStructInsideOptional_f);
+                    jobject newElement_0_optionalStructInsideOptional_g;
+                    std::string newElement_0_optionalStructInsideOptional_gClassName     = "java/lang/Float";
+                    std::string newElement_0_optionalStructInsideOptional_gCtorSignature = "(F)V";
                     chip::JniReferences::GetInstance().CreateBoxedObject<float>(
-                        newElement_0_optionalStruct_gClassName.c_str(), newElement_0_optionalStruct_gCtorSignature.c_str(),
-                        entry_0.optionalStruct.Value().g, newElement_0_optionalStruct_g);
-                    jobject newElement_0_optionalStruct_h;
-                    std::string newElement_0_optionalStruct_hClassName     = "java/lang/Double";
-                    std::string newElement_0_optionalStruct_hCtorSignature = "(D)V";
+                        newElement_0_optionalStructInsideOptional_gClassName.c_str(),
+                        newElement_0_optionalStructInsideOptional_gCtorSignature.c_str(), entry_0.optionalStruct.Value().g,
+                        newElement_0_optionalStructInsideOptional_g);
+                    jobject newElement_0_optionalStructInsideOptional_h;
+                    std::string newElement_0_optionalStructInsideOptional_hClassName     = "java/lang/Double";
+                    std::string newElement_0_optionalStructInsideOptional_hCtorSignature = "(D)V";
                     chip::JniReferences::GetInstance().CreateBoxedObject<double>(
-                        newElement_0_optionalStruct_hClassName.c_str(), newElement_0_optionalStruct_hCtorSignature.c_str(),
-                        entry_0.optionalStruct.Value().h, newElement_0_optionalStruct_h);
+                        newElement_0_optionalStructInsideOptional_hClassName.c_str(),
+                        newElement_0_optionalStructInsideOptional_hCtorSignature.c_str(), entry_0.optionalStruct.Value().h,
+                        newElement_0_optionalStructInsideOptional_h);
 
                     jclass simpleStructStructClass;
                     err = chip::JniReferences::GetInstance().GetClassRef(
@@ -12130,11 +12183,14 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         return nullptr;
                     }
 
-                    newElement_0_optionalStruct =
-                        env->NewObject(simpleStructStructClass, simpleStructStructCtor, newElement_0_optionalStruct_a,
-                                       newElement_0_optionalStruct_b, newElement_0_optionalStruct_c, newElement_0_optionalStruct_d,
-                                       newElement_0_optionalStruct_e, newElement_0_optionalStruct_f, newElement_0_optionalStruct_g,
-                                       newElement_0_optionalStruct_h);
+                    newElement_0_optionalStructInsideOptional =
+                        env->NewObject(simpleStructStructClass, simpleStructStructCtor, newElement_0_optionalStructInsideOptional_a,
+                                       newElement_0_optionalStructInsideOptional_b, newElement_0_optionalStructInsideOptional_c,
+                                       newElement_0_optionalStructInsideOptional_d, newElement_0_optionalStructInsideOptional_e,
+                                       newElement_0_optionalStructInsideOptional_f, newElement_0_optionalStructInsideOptional_g,
+                                       newElement_0_optionalStructInsideOptional_h);
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_optionalStructInsideOptional,
+                                                                      newElement_0_optionalStruct);
                 }
                 jobject newElement_0_nullableOptionalStruct;
                 if (!entry_0.nullableOptionalStruct.HasValue())
@@ -12143,68 +12199,71 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
+                    jobject newElement_0_nullableOptionalStructInsideOptional;
                     if (entry_0.nullableOptionalStruct.Value().IsNull())
                     {
-                        newElement_0_nullableOptionalStruct = nullptr;
+                        newElement_0_nullableOptionalStructInsideOptional = nullptr;
                     }
                     else
                     {
-                        jobject newElement_0_nullableOptionalStruct_a;
-                        std::string newElement_0_nullableOptionalStruct_aClassName     = "java/lang/Integer";
-                        std::string newElement_0_nullableOptionalStruct_aCtorSignature = "(I)V";
+                        jobject newElement_0_nullableOptionalStructInsideOptional_a;
+                        std::string newElement_0_nullableOptionalStructInsideOptional_aClassName     = "java/lang/Integer";
+                        std::string newElement_0_nullableOptionalStructInsideOptional_aCtorSignature = "(I)V";
                         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-                            newElement_0_nullableOptionalStruct_aClassName.c_str(),
-                            newElement_0_nullableOptionalStruct_aCtorSignature.c_str(),
-                            entry_0.nullableOptionalStruct.Value().Value().a, newElement_0_nullableOptionalStruct_a);
-                        jobject newElement_0_nullableOptionalStruct_b;
-                        std::string newElement_0_nullableOptionalStruct_bClassName     = "java/lang/Boolean";
-                        std::string newElement_0_nullableOptionalStruct_bCtorSignature = "(Z)V";
+                            newElement_0_nullableOptionalStructInsideOptional_aClassName.c_str(),
+                            newElement_0_nullableOptionalStructInsideOptional_aCtorSignature.c_str(),
+                            entry_0.nullableOptionalStruct.Value().Value().a, newElement_0_nullableOptionalStructInsideOptional_a);
+                        jobject newElement_0_nullableOptionalStructInsideOptional_b;
+                        std::string newElement_0_nullableOptionalStructInsideOptional_bClassName     = "java/lang/Boolean";
+                        std::string newElement_0_nullableOptionalStructInsideOptional_bCtorSignature = "(Z)V";
                         chip::JniReferences::GetInstance().CreateBoxedObject<bool>(
-                            newElement_0_nullableOptionalStruct_bClassName.c_str(),
-                            newElement_0_nullableOptionalStruct_bCtorSignature.c_str(),
-                            entry_0.nullableOptionalStruct.Value().Value().b, newElement_0_nullableOptionalStruct_b);
-                        jobject newElement_0_nullableOptionalStruct_c;
-                        std::string newElement_0_nullableOptionalStruct_cClassName     = "java/lang/Integer";
-                        std::string newElement_0_nullableOptionalStruct_cCtorSignature = "(I)V";
+                            newElement_0_nullableOptionalStructInsideOptional_bClassName.c_str(),
+                            newElement_0_nullableOptionalStructInsideOptional_bCtorSignature.c_str(),
+                            entry_0.nullableOptionalStruct.Value().Value().b, newElement_0_nullableOptionalStructInsideOptional_b);
+                        jobject newElement_0_nullableOptionalStructInsideOptional_c;
+                        std::string newElement_0_nullableOptionalStructInsideOptional_cClassName     = "java/lang/Integer";
+                        std::string newElement_0_nullableOptionalStructInsideOptional_cCtorSignature = "(I)V";
                         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-                            newElement_0_nullableOptionalStruct_cClassName.c_str(),
-                            newElement_0_nullableOptionalStruct_cCtorSignature.c_str(),
+                            newElement_0_nullableOptionalStructInsideOptional_cClassName.c_str(),
+                            newElement_0_nullableOptionalStructInsideOptional_cCtorSignature.c_str(),
                             static_cast<uint8_t>(entry_0.nullableOptionalStruct.Value().Value().c),
-                            newElement_0_nullableOptionalStruct_c);
-                        jobject newElement_0_nullableOptionalStruct_d;
-                        jbyteArray newElement_0_nullableOptionalStruct_dByteArray =
+                            newElement_0_nullableOptionalStructInsideOptional_c);
+                        jobject newElement_0_nullableOptionalStructInsideOptional_d;
+                        jbyteArray newElement_0_nullableOptionalStructInsideOptional_dByteArray =
                             env->NewByteArray(static_cast<jsize>(entry_0.nullableOptionalStruct.Value().Value().d.size()));
                         env->SetByteArrayRegion(
-                            newElement_0_nullableOptionalStruct_dByteArray, 0,
+                            newElement_0_nullableOptionalStructInsideOptional_dByteArray, 0,
                             static_cast<jsize>(entry_0.nullableOptionalStruct.Value().Value().d.size()),
                             reinterpret_cast<const jbyte *>(entry_0.nullableOptionalStruct.Value().Value().d.data()));
-                        newElement_0_nullableOptionalStruct_d = newElement_0_nullableOptionalStruct_dByteArray;
-                        jobject newElement_0_nullableOptionalStruct_e;
-                        newElement_0_nullableOptionalStruct_e =
+                        newElement_0_nullableOptionalStructInsideOptional_d =
+                            newElement_0_nullableOptionalStructInsideOptional_dByteArray;
+                        jobject newElement_0_nullableOptionalStructInsideOptional_e;
+                        newElement_0_nullableOptionalStructInsideOptional_e =
                             env->NewStringUTF(std::string(entry_0.nullableOptionalStruct.Value().Value().e.data(),
                                                           entry_0.nullableOptionalStruct.Value().Value().e.size())
                                                   .c_str());
-                        jobject newElement_0_nullableOptionalStruct_f;
-                        std::string newElement_0_nullableOptionalStruct_fClassName     = "java/lang/Integer";
-                        std::string newElement_0_nullableOptionalStruct_fCtorSignature = "(I)V";
+                        jobject newElement_0_nullableOptionalStructInsideOptional_f;
+                        std::string newElement_0_nullableOptionalStructInsideOptional_fClassName     = "java/lang/Integer";
+                        std::string newElement_0_nullableOptionalStructInsideOptional_fCtorSignature = "(I)V";
                         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-                            newElement_0_nullableOptionalStruct_fClassName.c_str(),
-                            newElement_0_nullableOptionalStruct_fCtorSignature.c_str(),
-                            entry_0.nullableOptionalStruct.Value().Value().f.Raw(), newElement_0_nullableOptionalStruct_f);
-                        jobject newElement_0_nullableOptionalStruct_g;
-                        std::string newElement_0_nullableOptionalStruct_gClassName     = "java/lang/Float";
-                        std::string newElement_0_nullableOptionalStruct_gCtorSignature = "(F)V";
+                            newElement_0_nullableOptionalStructInsideOptional_fClassName.c_str(),
+                            newElement_0_nullableOptionalStructInsideOptional_fCtorSignature.c_str(),
+                            entry_0.nullableOptionalStruct.Value().Value().f.Raw(),
+                            newElement_0_nullableOptionalStructInsideOptional_f);
+                        jobject newElement_0_nullableOptionalStructInsideOptional_g;
+                        std::string newElement_0_nullableOptionalStructInsideOptional_gClassName     = "java/lang/Float";
+                        std::string newElement_0_nullableOptionalStructInsideOptional_gCtorSignature = "(F)V";
                         chip::JniReferences::GetInstance().CreateBoxedObject<float>(
-                            newElement_0_nullableOptionalStruct_gClassName.c_str(),
-                            newElement_0_nullableOptionalStruct_gCtorSignature.c_str(),
-                            entry_0.nullableOptionalStruct.Value().Value().g, newElement_0_nullableOptionalStruct_g);
-                        jobject newElement_0_nullableOptionalStruct_h;
-                        std::string newElement_0_nullableOptionalStruct_hClassName     = "java/lang/Double";
-                        std::string newElement_0_nullableOptionalStruct_hCtorSignature = "(D)V";
+                            newElement_0_nullableOptionalStructInsideOptional_gClassName.c_str(),
+                            newElement_0_nullableOptionalStructInsideOptional_gCtorSignature.c_str(),
+                            entry_0.nullableOptionalStruct.Value().Value().g, newElement_0_nullableOptionalStructInsideOptional_g);
+                        jobject newElement_0_nullableOptionalStructInsideOptional_h;
+                        std::string newElement_0_nullableOptionalStructInsideOptional_hClassName     = "java/lang/Double";
+                        std::string newElement_0_nullableOptionalStructInsideOptional_hCtorSignature = "(D)V";
                         chip::JniReferences::GetInstance().CreateBoxedObject<double>(
-                            newElement_0_nullableOptionalStruct_hClassName.c_str(),
-                            newElement_0_nullableOptionalStruct_hCtorSignature.c_str(),
-                            entry_0.nullableOptionalStruct.Value().Value().h, newElement_0_nullableOptionalStruct_h);
+                            newElement_0_nullableOptionalStructInsideOptional_hClassName.c_str(),
+                            newElement_0_nullableOptionalStructInsideOptional_hCtorSignature.c_str(),
+                            entry_0.nullableOptionalStruct.Value().Value().h, newElement_0_nullableOptionalStructInsideOptional_h);
 
                         jclass simpleStructStructClass;
                         err = chip::JniReferences::GetInstance().GetClassRef(
@@ -12224,13 +12283,18 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             return nullptr;
                         }
 
-                        newElement_0_nullableOptionalStruct =
-                            env->NewObject(simpleStructStructClass, simpleStructStructCtor, newElement_0_nullableOptionalStruct_a,
-                                           newElement_0_nullableOptionalStruct_b, newElement_0_nullableOptionalStruct_c,
-                                           newElement_0_nullableOptionalStruct_d, newElement_0_nullableOptionalStruct_e,
-                                           newElement_0_nullableOptionalStruct_f, newElement_0_nullableOptionalStruct_g,
-                                           newElement_0_nullableOptionalStruct_h);
+                        newElement_0_nullableOptionalStructInsideOptional = env->NewObject(
+                            simpleStructStructClass, simpleStructStructCtor, newElement_0_nullableOptionalStructInsideOptional_a,
+                            newElement_0_nullableOptionalStructInsideOptional_b,
+                            newElement_0_nullableOptionalStructInsideOptional_c,
+                            newElement_0_nullableOptionalStructInsideOptional_d,
+                            newElement_0_nullableOptionalStructInsideOptional_e,
+                            newElement_0_nullableOptionalStructInsideOptional_f,
+                            newElement_0_nullableOptionalStructInsideOptional_g,
+                            newElement_0_nullableOptionalStructInsideOptional_h);
                     }
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_nullableOptionalStructInsideOptional,
+                                                                      newElement_0_nullableOptionalStruct);
                 }
                 jobject newElement_0_nullableList;
                 if (entry_0.nullableList.IsNull())
@@ -12261,20 +12325,23 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
-                    chip::JniReferences::GetInstance().CreateArrayList(newElement_0_optionalList);
+                    jobject newElement_0_optionalListInsideOptional;
+                    chip::JniReferences::GetInstance().CreateArrayList(newElement_0_optionalListInsideOptional);
 
-                    auto iter_newElement_0_optionalList_NaN = entry_0.optionalList.Value().begin();
-                    while (iter_newElement_0_optionalList_NaN.Next())
+                    auto iter_newElement_0_optionalListInsideOptional_NaN = entry_0.optionalList.Value().begin();
+                    while (iter_newElement_0_optionalListInsideOptional_NaN.Next())
                     {
-                        auto & entry_NaN = iter_newElement_0_optionalList_NaN.GetValue();
+                        auto & entry_NaN = iter_newElement_0_optionalListInsideOptional_NaN.GetValue();
                         jobject newElement_NaN;
                         std::string newElement_NaNClassName     = "java/lang/Integer";
                         std::string newElement_NaNCtorSignature = "(I)V";
                         chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
                             newElement_NaNClassName.c_str(), newElement_NaNCtorSignature.c_str(), static_cast<uint8_t>(entry_NaN),
                             newElement_NaN);
-                        chip::JniReferences::GetInstance().AddToList(newElement_0_optionalList, newElement_NaN);
+                        chip::JniReferences::GetInstance().AddToList(newElement_0_optionalListInsideOptional, newElement_NaN);
                     }
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_optionalListInsideOptional,
+                                                                      newElement_0_optionalList);
                 }
                 jobject newElement_0_nullableOptionalList;
                 if (!entry_0.nullableOptionalList.HasValue())
@@ -12283,27 +12350,32 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
                 else
                 {
+                    jobject newElement_0_nullableOptionalListInsideOptional;
                     if (entry_0.nullableOptionalList.Value().IsNull())
                     {
-                        newElement_0_nullableOptionalList = nullptr;
+                        newElement_0_nullableOptionalListInsideOptional = nullptr;
                     }
                     else
                     {
-                        chip::JniReferences::GetInstance().CreateArrayList(newElement_0_nullableOptionalList);
+                        chip::JniReferences::GetInstance().CreateArrayList(newElement_0_nullableOptionalListInsideOptional);
 
-                        auto iter_newElement_0_nullableOptionalList_NaN = entry_0.nullableOptionalList.Value().Value().begin();
-                        while (iter_newElement_0_nullableOptionalList_NaN.Next())
+                        auto iter_newElement_0_nullableOptionalListInsideOptional_NaN =
+                            entry_0.nullableOptionalList.Value().Value().begin();
+                        while (iter_newElement_0_nullableOptionalListInsideOptional_NaN.Next())
                         {
-                            auto & entry_NaN = iter_newElement_0_nullableOptionalList_NaN.GetValue();
+                            auto & entry_NaN = iter_newElement_0_nullableOptionalListInsideOptional_NaN.GetValue();
                             jobject newElement_NaN;
                             std::string newElement_NaNClassName     = "java/lang/Integer";
                             std::string newElement_NaNCtorSignature = "(I)V";
                             chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
                                 newElement_NaNClassName.c_str(), newElement_NaNCtorSignature.c_str(),
                                 static_cast<uint8_t>(entry_NaN), newElement_NaN);
-                            chip::JniReferences::GetInstance().AddToList(newElement_0_nullableOptionalList, newElement_NaN);
+                            chip::JniReferences::GetInstance().AddToList(newElement_0_nullableOptionalListInsideOptional,
+                                                                         newElement_NaN);
                         }
                     }
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_nullableOptionalListInsideOptional,
+                                                                      newElement_0_nullableOptionalList);
                 }
 
                 jclass nullablesAndOptionalsStructStructClass;

--- a/src/controller/java/zap-generated/CHIPClustersWrite-JNI.cpp
+++ b/src/controller/java/zap-generated/CHIPClustersWrite-JNI.cpp
@@ -619,9 +619,12 @@ JNI_METHOD(void, BindingCluster, writeBindingAttribute)
                 {
                     jobject optionalValue_2;
                     chip::JniReferences::GetInstance().GetOptionalValue(element_0_nodeItem_1, optionalValue_2);
-                    auto & definedValue_2 = listHolder_0->mList[i_0].node.Emplace();
-                    definedValue_2        = static_cast<std::remove_reference_t<decltype(definedValue_2)>>(
-                        chip::JniReferences::GetInstance().LongToPrimitive(optionalValue_2));
+                    if (optionalValue_2 != nullptr)
+                    {
+                        auto & definedValue_2 = listHolder_0->mList[i_0].node.Emplace();
+                        definedValue_2        = static_cast<std::remove_reference_t<decltype(definedValue_2)>>(
+                            chip::JniReferences::GetInstance().LongToPrimitive(optionalValue_2));
+                    }
                 }
                 jobject element_0_groupItem_1;
                 chip::JniReferences::GetInstance().GetObjectField(element_0, "group", "Ljava/util/Optional;",
@@ -630,9 +633,12 @@ JNI_METHOD(void, BindingCluster, writeBindingAttribute)
                 {
                     jobject optionalValue_2;
                     chip::JniReferences::GetInstance().GetOptionalValue(element_0_groupItem_1, optionalValue_2);
-                    auto & definedValue_2 = listHolder_0->mList[i_0].group.Emplace();
-                    definedValue_2        = static_cast<std::remove_reference_t<decltype(definedValue_2)>>(
-                        chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2));
+                    if (optionalValue_2 != nullptr)
+                    {
+                        auto & definedValue_2 = listHolder_0->mList[i_0].group.Emplace();
+                        definedValue_2        = static_cast<std::remove_reference_t<decltype(definedValue_2)>>(
+                            chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2));
+                    }
                 }
                 jobject element_0_endpointItem_1;
                 chip::JniReferences::GetInstance().GetObjectField(element_0, "endpoint", "Ljava/util/Optional;",
@@ -641,9 +647,12 @@ JNI_METHOD(void, BindingCluster, writeBindingAttribute)
                 {
                     jobject optionalValue_2;
                     chip::JniReferences::GetInstance().GetOptionalValue(element_0_endpointItem_1, optionalValue_2);
-                    auto & definedValue_2 = listHolder_0->mList[i_0].endpoint.Emplace();
-                    definedValue_2        = static_cast<std::remove_reference_t<decltype(definedValue_2)>>(
-                        chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2));
+                    if (optionalValue_2 != nullptr)
+                    {
+                        auto & definedValue_2 = listHolder_0->mList[i_0].endpoint.Emplace();
+                        definedValue_2        = static_cast<std::remove_reference_t<decltype(definedValue_2)>>(
+                            chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2));
+                    }
                 }
                 jobject element_0_clusterItem_1;
                 chip::JniReferences::GetInstance().GetObjectField(element_0, "cluster", "Ljava/util/Optional;",
@@ -652,9 +661,12 @@ JNI_METHOD(void, BindingCluster, writeBindingAttribute)
                 {
                     jobject optionalValue_2;
                     chip::JniReferences::GetInstance().GetOptionalValue(element_0_clusterItem_1, optionalValue_2);
-                    auto & definedValue_2 = listHolder_0->mList[i_0].cluster.Emplace();
-                    definedValue_2        = static_cast<std::remove_reference_t<decltype(definedValue_2)>>(
-                        chip::JniReferences::GetInstance().LongToPrimitive(optionalValue_2));
+                    if (optionalValue_2 != nullptr)
+                    {
+                        auto & definedValue_2 = listHolder_0->mList[i_0].cluster.Emplace();
+                        definedValue_2        = static_cast<std::remove_reference_t<decltype(definedValue_2)>>(
+                            chip::JniReferences::GetInstance().LongToPrimitive(optionalValue_2));
+                    }
                 }
             }
             cppValue = ListType_0(listHolder_0->mList, valueSize);
@@ -5044,9 +5056,12 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                 {
                     jobject optionalValue_2;
                     chip::JniReferences::GetInstance().GetOptionalValue(element_0_optionalIntItem_1, optionalValue_2);
-                    auto & definedValue_2 = listHolder_0->mList[i_0].optionalInt.Emplace();
-                    definedValue_2        = static_cast<std::remove_reference_t<decltype(definedValue_2)>>(
-                        chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2));
+                    if (optionalValue_2 != nullptr)
+                    {
+                        auto & definedValue_2 = listHolder_0->mList[i_0].optionalInt.Emplace();
+                        definedValue_2        = static_cast<std::remove_reference_t<decltype(definedValue_2)>>(
+                            chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2));
+                    }
                 }
                 jobject element_0_nullableOptionalIntItem_1;
                 chip::JniReferences::GetInstance().GetObjectField(element_0, "nullableOptionalInt", "Ljava/util/Optional;",
@@ -5055,16 +5070,19 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                 {
                     jobject optionalValue_2;
                     chip::JniReferences::GetInstance().GetOptionalValue(element_0_nullableOptionalIntItem_1, optionalValue_2);
-                    auto & definedValue_2 = listHolder_0->mList[i_0].nullableOptionalInt.Emplace();
-                    if (optionalValue_2 == nullptr)
+                    if (optionalValue_2 != nullptr)
                     {
-                        definedValue_2.SetNull();
-                    }
-                    else
-                    {
-                        auto & nonNullValue_3 = definedValue_2.SetNonNull();
-                        nonNullValue_3        = static_cast<std::remove_reference_t<decltype(nonNullValue_3)>>(
-                            chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2));
+                        auto & definedValue_2 = listHolder_0->mList[i_0].nullableOptionalInt.Emplace();
+                        if (optionalValue_2 == nullptr)
+                        {
+                            definedValue_2.SetNull();
+                        }
+                        else
+                        {
+                            auto & nonNullValue_3 = definedValue_2.SetNonNull();
+                            nonNullValue_3        = static_cast<std::remove_reference_t<decltype(nonNullValue_3)>>(
+                                chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2));
+                        }
                     }
                 }
                 jobject element_0_nullableStringItem_1;
@@ -5088,10 +5106,13 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                 {
                     jobject optionalValue_2;
                     chip::JniReferences::GetInstance().GetOptionalValue(element_0_optionalStringItem_1, optionalValue_2);
-                    auto & definedValue_2 = listHolder_0->mList[i_0].optionalString.Emplace();
-                    cleanupStrings.push_back(
-                        chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_2)));
-                    definedValue_2 = cleanupStrings.back()->charSpan();
+                    if (optionalValue_2 != nullptr)
+                    {
+                        auto & definedValue_2 = listHolder_0->mList[i_0].optionalString.Emplace();
+                        cleanupStrings.push_back(
+                            chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_2)));
+                        definedValue_2 = cleanupStrings.back()->charSpan();
+                    }
                 }
                 jobject element_0_nullableOptionalStringItem_1;
                 chip::JniReferences::GetInstance().GetObjectField(element_0, "nullableOptionalString", "Ljava/util/Optional;",
@@ -5100,17 +5121,20 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                 {
                     jobject optionalValue_2;
                     chip::JniReferences::GetInstance().GetOptionalValue(element_0_nullableOptionalStringItem_1, optionalValue_2);
-                    auto & definedValue_2 = listHolder_0->mList[i_0].nullableOptionalString.Emplace();
-                    if (optionalValue_2 == nullptr)
+                    if (optionalValue_2 != nullptr)
                     {
-                        definedValue_2.SetNull();
-                    }
-                    else
-                    {
-                        auto & nonNullValue_3 = definedValue_2.SetNonNull();
-                        cleanupStrings.push_back(
-                            chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_2)));
-                        nonNullValue_3 = cleanupStrings.back()->charSpan();
+                        auto & definedValue_2 = listHolder_0->mList[i_0].nullableOptionalString.Emplace();
+                        if (optionalValue_2 == nullptr)
+                        {
+                            definedValue_2.SetNull();
+                        }
+                        else
+                        {
+                            auto & nonNullValue_3 = definedValue_2.SetNonNull();
+                            cleanupStrings.push_back(
+                                chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_2)));
+                            nonNullValue_3 = cleanupStrings.back()->charSpan();
+                        }
                     }
                 }
                 jobject element_0_nullableStructItem_1;
@@ -5174,48 +5198,51 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                 {
                     jobject optionalValue_2;
                     chip::JniReferences::GetInstance().GetOptionalValue(element_0_optionalStructItem_1, optionalValue_2);
-                    auto & definedValue_2 = listHolder_0->mList[i_0].optionalStruct.Emplace();
-                    jobject optionalValue_2_aItem_3;
-                    chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "a", "Ljava/lang/Integer;",
-                                                                      optionalValue_2_aItem_3);
-                    definedValue_2.a = static_cast<std::remove_reference_t<decltype(definedValue_2.a)>>(
-                        chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2_aItem_3));
-                    jobject optionalValue_2_bItem_3;
-                    chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "b", "Ljava/lang/Boolean;",
-                                                                      optionalValue_2_bItem_3);
-                    definedValue_2.b = static_cast<std::remove_reference_t<decltype(definedValue_2.b)>>(
-                        chip::JniReferences::GetInstance().BooleanToPrimitive(optionalValue_2_bItem_3));
-                    jobject optionalValue_2_cItem_3;
-                    chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "c", "Ljava/lang/Integer;",
-                                                                      optionalValue_2_cItem_3);
-                    definedValue_2.c = static_cast<std::remove_reference_t<decltype(definedValue_2.c)>>(
-                        chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2_cItem_3));
-                    jobject optionalValue_2_dItem_3;
-                    chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "d", "[B", optionalValue_2_dItem_3);
-                    cleanupByteArrays.push_back(
-                        chip::Platform::MakeUnique<chip::JniByteArray>(env, static_cast<jbyteArray>(optionalValue_2_dItem_3)));
-                    definedValue_2.d = cleanupByteArrays.back()->byteSpan();
-                    jobject optionalValue_2_eItem_3;
-                    chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "e", "Ljava/lang/String;",
-                                                                      optionalValue_2_eItem_3);
-                    cleanupStrings.push_back(
-                        chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_2_eItem_3)));
-                    definedValue_2.e = cleanupStrings.back()->charSpan();
-                    jobject optionalValue_2_fItem_3;
-                    chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "f", "Ljava/lang/Integer;",
-                                                                      optionalValue_2_fItem_3);
-                    definedValue_2.f = static_cast<std::remove_reference_t<decltype(definedValue_2.f)>>(
-                        chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2_fItem_3));
-                    jobject optionalValue_2_gItem_3;
-                    chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "g", "Ljava/lang/Float;",
-                                                                      optionalValue_2_gItem_3);
-                    definedValue_2.g = static_cast<std::remove_reference_t<decltype(definedValue_2.g)>>(
-                        chip::JniReferences::GetInstance().FloatToPrimitive(optionalValue_2_gItem_3));
-                    jobject optionalValue_2_hItem_3;
-                    chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "h", "Ljava/lang/Double;",
-                                                                      optionalValue_2_hItem_3);
-                    definedValue_2.h = static_cast<std::remove_reference_t<decltype(definedValue_2.h)>>(
-                        chip::JniReferences::GetInstance().DoubleToPrimitive(optionalValue_2_hItem_3));
+                    if (optionalValue_2 != nullptr)
+                    {
+                        auto & definedValue_2 = listHolder_0->mList[i_0].optionalStruct.Emplace();
+                        jobject optionalValue_2_aItem_3;
+                        chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "a", "Ljava/lang/Integer;",
+                                                                          optionalValue_2_aItem_3);
+                        definedValue_2.a = static_cast<std::remove_reference_t<decltype(definedValue_2.a)>>(
+                            chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2_aItem_3));
+                        jobject optionalValue_2_bItem_3;
+                        chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "b", "Ljava/lang/Boolean;",
+                                                                          optionalValue_2_bItem_3);
+                        definedValue_2.b = static_cast<std::remove_reference_t<decltype(definedValue_2.b)>>(
+                            chip::JniReferences::GetInstance().BooleanToPrimitive(optionalValue_2_bItem_3));
+                        jobject optionalValue_2_cItem_3;
+                        chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "c", "Ljava/lang/Integer;",
+                                                                          optionalValue_2_cItem_3);
+                        definedValue_2.c = static_cast<std::remove_reference_t<decltype(definedValue_2.c)>>(
+                            chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2_cItem_3));
+                        jobject optionalValue_2_dItem_3;
+                        chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "d", "[B", optionalValue_2_dItem_3);
+                        cleanupByteArrays.push_back(
+                            chip::Platform::MakeUnique<chip::JniByteArray>(env, static_cast<jbyteArray>(optionalValue_2_dItem_3)));
+                        definedValue_2.d = cleanupByteArrays.back()->byteSpan();
+                        jobject optionalValue_2_eItem_3;
+                        chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "e", "Ljava/lang/String;",
+                                                                          optionalValue_2_eItem_3);
+                        cleanupStrings.push_back(
+                            chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_2_eItem_3)));
+                        definedValue_2.e = cleanupStrings.back()->charSpan();
+                        jobject optionalValue_2_fItem_3;
+                        chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "f", "Ljava/lang/Integer;",
+                                                                          optionalValue_2_fItem_3);
+                        definedValue_2.f = static_cast<std::remove_reference_t<decltype(definedValue_2.f)>>(
+                            chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2_fItem_3));
+                        jobject optionalValue_2_gItem_3;
+                        chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "g", "Ljava/lang/Float;",
+                                                                          optionalValue_2_gItem_3);
+                        definedValue_2.g = static_cast<std::remove_reference_t<decltype(definedValue_2.g)>>(
+                            chip::JniReferences::GetInstance().FloatToPrimitive(optionalValue_2_gItem_3));
+                        jobject optionalValue_2_hItem_3;
+                        chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "h", "Ljava/lang/Double;",
+                                                                          optionalValue_2_hItem_3);
+                        definedValue_2.h = static_cast<std::remove_reference_t<decltype(definedValue_2.h)>>(
+                            chip::JniReferences::GetInstance().DoubleToPrimitive(optionalValue_2_hItem_3));
+                    }
                 }
                 jobject element_0_nullableOptionalStructItem_1;
                 chip::JniReferences::GetInstance().GetObjectField(element_0, "nullableOptionalStruct", "Ljava/util/Optional;",
@@ -5224,55 +5251,58 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                 {
                     jobject optionalValue_2;
                     chip::JniReferences::GetInstance().GetOptionalValue(element_0_nullableOptionalStructItem_1, optionalValue_2);
-                    auto & definedValue_2 = listHolder_0->mList[i_0].nullableOptionalStruct.Emplace();
-                    if (optionalValue_2 == nullptr)
+                    if (optionalValue_2 != nullptr)
                     {
-                        definedValue_2.SetNull();
-                    }
-                    else
-                    {
-                        auto & nonNullValue_3 = definedValue_2.SetNonNull();
-                        jobject optionalValue_2_aItem_4;
-                        chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "a", "Ljava/lang/Integer;",
-                                                                          optionalValue_2_aItem_4);
-                        nonNullValue_3.a = static_cast<std::remove_reference_t<decltype(nonNullValue_3.a)>>(
-                            chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2_aItem_4));
-                        jobject optionalValue_2_bItem_4;
-                        chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "b", "Ljava/lang/Boolean;",
-                                                                          optionalValue_2_bItem_4);
-                        nonNullValue_3.b = static_cast<std::remove_reference_t<decltype(nonNullValue_3.b)>>(
-                            chip::JniReferences::GetInstance().BooleanToPrimitive(optionalValue_2_bItem_4));
-                        jobject optionalValue_2_cItem_4;
-                        chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "c", "Ljava/lang/Integer;",
-                                                                          optionalValue_2_cItem_4);
-                        nonNullValue_3.c = static_cast<std::remove_reference_t<decltype(nonNullValue_3.c)>>(
-                            chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2_cItem_4));
-                        jobject optionalValue_2_dItem_4;
-                        chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "d", "[B", optionalValue_2_dItem_4);
-                        cleanupByteArrays.push_back(
-                            chip::Platform::MakeUnique<chip::JniByteArray>(env, static_cast<jbyteArray>(optionalValue_2_dItem_4)));
-                        nonNullValue_3.d = cleanupByteArrays.back()->byteSpan();
-                        jobject optionalValue_2_eItem_4;
-                        chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "e", "Ljava/lang/String;",
-                                                                          optionalValue_2_eItem_4);
-                        cleanupStrings.push_back(
-                            chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_2_eItem_4)));
-                        nonNullValue_3.e = cleanupStrings.back()->charSpan();
-                        jobject optionalValue_2_fItem_4;
-                        chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "f", "Ljava/lang/Integer;",
-                                                                          optionalValue_2_fItem_4);
-                        nonNullValue_3.f = static_cast<std::remove_reference_t<decltype(nonNullValue_3.f)>>(
-                            chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2_fItem_4));
-                        jobject optionalValue_2_gItem_4;
-                        chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "g", "Ljava/lang/Float;",
-                                                                          optionalValue_2_gItem_4);
-                        nonNullValue_3.g = static_cast<std::remove_reference_t<decltype(nonNullValue_3.g)>>(
-                            chip::JniReferences::GetInstance().FloatToPrimitive(optionalValue_2_gItem_4));
-                        jobject optionalValue_2_hItem_4;
-                        chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "h", "Ljava/lang/Double;",
-                                                                          optionalValue_2_hItem_4);
-                        nonNullValue_3.h = static_cast<std::remove_reference_t<decltype(nonNullValue_3.h)>>(
-                            chip::JniReferences::GetInstance().DoubleToPrimitive(optionalValue_2_hItem_4));
+                        auto & definedValue_2 = listHolder_0->mList[i_0].nullableOptionalStruct.Emplace();
+                        if (optionalValue_2 == nullptr)
+                        {
+                            definedValue_2.SetNull();
+                        }
+                        else
+                        {
+                            auto & nonNullValue_3 = definedValue_2.SetNonNull();
+                            jobject optionalValue_2_aItem_4;
+                            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "a", "Ljava/lang/Integer;",
+                                                                              optionalValue_2_aItem_4);
+                            nonNullValue_3.a = static_cast<std::remove_reference_t<decltype(nonNullValue_3.a)>>(
+                                chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2_aItem_4));
+                            jobject optionalValue_2_bItem_4;
+                            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "b", "Ljava/lang/Boolean;",
+                                                                              optionalValue_2_bItem_4);
+                            nonNullValue_3.b = static_cast<std::remove_reference_t<decltype(nonNullValue_3.b)>>(
+                                chip::JniReferences::GetInstance().BooleanToPrimitive(optionalValue_2_bItem_4));
+                            jobject optionalValue_2_cItem_4;
+                            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "c", "Ljava/lang/Integer;",
+                                                                              optionalValue_2_cItem_4);
+                            nonNullValue_3.c = static_cast<std::remove_reference_t<decltype(nonNullValue_3.c)>>(
+                                chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2_cItem_4));
+                            jobject optionalValue_2_dItem_4;
+                            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "d", "[B", optionalValue_2_dItem_4);
+                            cleanupByteArrays.push_back(chip::Platform::MakeUnique<chip::JniByteArray>(
+                                env, static_cast<jbyteArray>(optionalValue_2_dItem_4)));
+                            nonNullValue_3.d = cleanupByteArrays.back()->byteSpan();
+                            jobject optionalValue_2_eItem_4;
+                            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "e", "Ljava/lang/String;",
+                                                                              optionalValue_2_eItem_4);
+                            cleanupStrings.push_back(
+                                chip::Platform::MakeUnique<chip::JniUtfString>(env, static_cast<jstring>(optionalValue_2_eItem_4)));
+                            nonNullValue_3.e = cleanupStrings.back()->charSpan();
+                            jobject optionalValue_2_fItem_4;
+                            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "f", "Ljava/lang/Integer;",
+                                                                              optionalValue_2_fItem_4);
+                            nonNullValue_3.f = static_cast<std::remove_reference_t<decltype(nonNullValue_3.f)>>(
+                                chip::JniReferences::GetInstance().IntegerToPrimitive(optionalValue_2_fItem_4));
+                            jobject optionalValue_2_gItem_4;
+                            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "g", "Ljava/lang/Float;",
+                                                                              optionalValue_2_gItem_4);
+                            nonNullValue_3.g = static_cast<std::remove_reference_t<decltype(nonNullValue_3.g)>>(
+                                chip::JniReferences::GetInstance().FloatToPrimitive(optionalValue_2_gItem_4));
+                            jobject optionalValue_2_hItem_4;
+                            chip::JniReferences::GetInstance().GetObjectField(optionalValue_2, "h", "Ljava/lang/Double;",
+                                                                              optionalValue_2_hItem_4);
+                            nonNullValue_3.h = static_cast<std::remove_reference_t<decltype(nonNullValue_3.h)>>(
+                                chip::JniReferences::GetInstance().DoubleToPrimitive(optionalValue_2_hItem_4));
+                        }
                     }
                 }
                 jobject element_0_nullableListItem_1;
@@ -5318,29 +5348,33 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                 {
                     jobject optionalValue_2;
                     chip::JniReferences::GetInstance().GetOptionalValue(element_0_optionalListItem_1, optionalValue_2);
-                    auto & definedValue_2 = listHolder_0->mList[i_0].optionalList.Emplace();
+                    if (optionalValue_2 != nullptr)
                     {
-                        using ListType_3       = std::remove_reference_t<decltype(definedValue_2)>;
-                        using ListMemberType_3 = ListMemberTypeGetter<ListType_3>::Type;
-                        jint optionalValue_2Size;
-                        chip::JniReferences::GetInstance().GetListSize(optionalValue_2, optionalValue_2Size);
-                        if (optionalValue_2Size != 0)
+                        auto & definedValue_2 = listHolder_0->mList[i_0].optionalList.Emplace();
                         {
-                            auto * listHolder_3 = new ListHolder<ListMemberType_3>(optionalValue_2Size);
-                            listFreer.add(listHolder_3);
-
-                            for (size_t i_3 = 0; i_3 < static_cast<size_t>(optionalValue_2Size); ++i_3)
+                            using ListType_3       = std::remove_reference_t<decltype(definedValue_2)>;
+                            using ListMemberType_3 = ListMemberTypeGetter<ListType_3>::Type;
+                            jint optionalValue_2Size;
+                            chip::JniReferences::GetInstance().GetListSize(optionalValue_2, optionalValue_2Size);
+                            if (optionalValue_2Size != 0)
                             {
-                                jobject element_3;
-                                chip::JniReferences::GetInstance().GetListItem(optionalValue_2, i_3, element_3);
-                                listHolder_3->mList[i_3] = static_cast<std::remove_reference_t<decltype(listHolder_3->mList[i_3])>>(
-                                    chip::JniReferences::GetInstance().IntegerToPrimitive(element_3));
+                                auto * listHolder_3 = new ListHolder<ListMemberType_3>(optionalValue_2Size);
+                                listFreer.add(listHolder_3);
+
+                                for (size_t i_3 = 0; i_3 < static_cast<size_t>(optionalValue_2Size); ++i_3)
+                                {
+                                    jobject element_3;
+                                    chip::JniReferences::GetInstance().GetListItem(optionalValue_2, i_3, element_3);
+                                    listHolder_3->mList[i_3] =
+                                        static_cast<std::remove_reference_t<decltype(listHolder_3->mList[i_3])>>(
+                                            chip::JniReferences::GetInstance().IntegerToPrimitive(element_3));
+                                }
+                                definedValue_2 = ListType_3(listHolder_3->mList, optionalValue_2Size);
                             }
-                            definedValue_2 = ListType_3(listHolder_3->mList, optionalValue_2Size);
-                        }
-                        else
-                        {
-                            definedValue_2 = ListType_3();
+                            else
+                            {
+                                definedValue_2 = ListType_3();
+                            }
                         }
                     }
                 }
@@ -5351,37 +5385,40 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                 {
                     jobject optionalValue_2;
                     chip::JniReferences::GetInstance().GetOptionalValue(element_0_nullableOptionalListItem_1, optionalValue_2);
-                    auto & definedValue_2 = listHolder_0->mList[i_0].nullableOptionalList.Emplace();
-                    if (optionalValue_2 == nullptr)
+                    if (optionalValue_2 != nullptr)
                     {
-                        definedValue_2.SetNull();
-                    }
-                    else
-                    {
-                        auto & nonNullValue_3 = definedValue_2.SetNonNull();
+                        auto & definedValue_2 = listHolder_0->mList[i_0].nullableOptionalList.Emplace();
+                        if (optionalValue_2 == nullptr)
                         {
-                            using ListType_4       = std::remove_reference_t<decltype(nonNullValue_3)>;
-                            using ListMemberType_4 = ListMemberTypeGetter<ListType_4>::Type;
-                            jint optionalValue_2Size;
-                            chip::JniReferences::GetInstance().GetListSize(optionalValue_2, optionalValue_2Size);
-                            if (optionalValue_2Size != 0)
+                            definedValue_2.SetNull();
+                        }
+                        else
+                        {
+                            auto & nonNullValue_3 = definedValue_2.SetNonNull();
                             {
-                                auto * listHolder_4 = new ListHolder<ListMemberType_4>(optionalValue_2Size);
-                                listFreer.add(listHolder_4);
-
-                                for (size_t i_4 = 0; i_4 < static_cast<size_t>(optionalValue_2Size); ++i_4)
+                                using ListType_4       = std::remove_reference_t<decltype(nonNullValue_3)>;
+                                using ListMemberType_4 = ListMemberTypeGetter<ListType_4>::Type;
+                                jint optionalValue_2Size;
+                                chip::JniReferences::GetInstance().GetListSize(optionalValue_2, optionalValue_2Size);
+                                if (optionalValue_2Size != 0)
                                 {
-                                    jobject element_4;
-                                    chip::JniReferences::GetInstance().GetListItem(optionalValue_2, i_4, element_4);
-                                    listHolder_4->mList[i_4] =
-                                        static_cast<std::remove_reference_t<decltype(listHolder_4->mList[i_4])>>(
-                                            chip::JniReferences::GetInstance().IntegerToPrimitive(element_4));
+                                    auto * listHolder_4 = new ListHolder<ListMemberType_4>(optionalValue_2Size);
+                                    listFreer.add(listHolder_4);
+
+                                    for (size_t i_4 = 0; i_4 < static_cast<size_t>(optionalValue_2Size); ++i_4)
+                                    {
+                                        jobject element_4;
+                                        chip::JniReferences::GetInstance().GetListItem(optionalValue_2, i_4, element_4);
+                                        listHolder_4->mList[i_4] =
+                                            static_cast<std::remove_reference_t<decltype(listHolder_4->mList[i_4])>>(
+                                                chip::JniReferences::GetInstance().IntegerToPrimitive(element_4));
+                                    }
+                                    nonNullValue_3 = ListType_4(listHolder_4->mList, optionalValue_2Size);
                                 }
-                                nonNullValue_3 = ListType_4(listHolder_4->mList, optionalValue_2Size);
-                            }
-                            else
-                            {
-                                nonNullValue_3 = ListType_4();
+                                else
+                                {
+                                    nonNullValue_3 = ListType_4();
+                                }
                             }
                         }
                     }

--- a/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPInvokeCallbacks.cpp
@@ -225,8 +225,10 @@ void CHIPChannelClusterChangeChannelResponseCallback::CallbackFn(
     }
     else
     {
-        channelMatch_name = env->NewStringUTF(
+        jobject channelMatch_nameInsideOptional;
+        channelMatch_nameInsideOptional = env->NewStringUTF(
             std::string(dataResponse.channelMatch.name.Value().data(), dataResponse.channelMatch.name.Value().size()).c_str());
+        chip::JniReferences::GetInstance().CreateOptional(channelMatch_nameInsideOptional, channelMatch_name);
     }
     jobject channelMatch_callSign;
     if (!dataResponse.channelMatch.callSign.HasValue())
@@ -235,9 +237,11 @@ void CHIPChannelClusterChangeChannelResponseCallback::CallbackFn(
     }
     else
     {
-        channelMatch_callSign = env->NewStringUTF(
+        jobject channelMatch_callSignInsideOptional;
+        channelMatch_callSignInsideOptional = env->NewStringUTF(
             std::string(dataResponse.channelMatch.callSign.Value().data(), dataResponse.channelMatch.callSign.Value().size())
                 .c_str());
+        chip::JniReferences::GetInstance().CreateOptional(channelMatch_callSignInsideOptional, channelMatch_callSign);
     }
     jobject channelMatch_affiliateCallSign;
     if (!dataResponse.channelMatch.affiliateCallSign.HasValue())
@@ -246,9 +250,13 @@ void CHIPChannelClusterChangeChannelResponseCallback::CallbackFn(
     }
     else
     {
-        channelMatch_affiliateCallSign = env->NewStringUTF(std::string(dataResponse.channelMatch.affiliateCallSign.Value().data(),
-                                                                       dataResponse.channelMatch.affiliateCallSign.Value().size())
-                                                               .c_str());
+        jobject channelMatch_affiliateCallSignInsideOptional;
+        channelMatch_affiliateCallSignInsideOptional =
+            env->NewStringUTF(std::string(dataResponse.channelMatch.affiliateCallSign.Value().data(),
+                                          dataResponse.channelMatch.affiliateCallSign.Value().size())
+                                  .c_str());
+        chip::JniReferences::GetInstance().CreateOptional(channelMatch_affiliateCallSignInsideOptional,
+                                                          channelMatch_affiliateCallSign);
     }
 
     jclass channelInfoStructClass;
@@ -342,7 +350,10 @@ void CHIPContentLauncherClusterLaunchResponseCallback::CallbackFn(
     }
     else
     {
-        data = env->NewStringUTF(std::string(dataResponse.data.Value().data(), dataResponse.data.Value().size()).c_str());
+        jobject dataInsideOptional;
+        dataInsideOptional =
+            env->NewStringUTF(std::string(dataResponse.data.Value().data(), dataResponse.data.Value().size()).c_str());
+        chip::JniReferences::GetInstance().CreateOptional(dataInsideOptional, data);
     }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, status, data);
@@ -799,10 +810,13 @@ void CHIPDoorLockClusterGetWeekDayScheduleResponseCallback::CallbackFn(
     }
     else
     {
-        std::string daysMaskClassName     = "java/lang/Integer";
-        std::string daysMaskCtorSignature = "(I)V";
-        chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(daysMaskClassName.c_str(), daysMaskCtorSignature.c_str(),
-                                                                      dataResponse.daysMask.Value().Raw(), daysMask);
+        jobject daysMaskInsideOptional;
+        std::string daysMaskInsideOptionalClassName     = "java/lang/Integer";
+        std::string daysMaskInsideOptionalCtorSignature = "(I)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(daysMaskInsideOptionalClassName.c_str(),
+                                                                      daysMaskInsideOptionalCtorSignature.c_str(),
+                                                                      dataResponse.daysMask.Value().Raw(), daysMaskInsideOptional);
+        chip::JniReferences::GetInstance().CreateOptional(daysMaskInsideOptional, daysMask);
     }
     jobject startHour;
     if (!dataResponse.startHour.HasValue())
@@ -811,10 +825,13 @@ void CHIPDoorLockClusterGetWeekDayScheduleResponseCallback::CallbackFn(
     }
     else
     {
-        std::string startHourClassName     = "java/lang/Integer";
-        std::string startHourCtorSignature = "(I)V";
-        chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(startHourClassName.c_str(), startHourCtorSignature.c_str(),
-                                                                      dataResponse.startHour.Value(), startHour);
+        jobject startHourInsideOptional;
+        std::string startHourInsideOptionalClassName     = "java/lang/Integer";
+        std::string startHourInsideOptionalCtorSignature = "(I)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(startHourInsideOptionalClassName.c_str(),
+                                                                      startHourInsideOptionalCtorSignature.c_str(),
+                                                                      dataResponse.startHour.Value(), startHourInsideOptional);
+        chip::JniReferences::GetInstance().CreateOptional(startHourInsideOptional, startHour);
     }
     jobject startMinute;
     if (!dataResponse.startMinute.HasValue())
@@ -823,10 +840,13 @@ void CHIPDoorLockClusterGetWeekDayScheduleResponseCallback::CallbackFn(
     }
     else
     {
-        std::string startMinuteClassName     = "java/lang/Integer";
-        std::string startMinuteCtorSignature = "(I)V";
-        chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-            startMinuteClassName.c_str(), startMinuteCtorSignature.c_str(), dataResponse.startMinute.Value(), startMinute);
+        jobject startMinuteInsideOptional;
+        std::string startMinuteInsideOptionalClassName     = "java/lang/Integer";
+        std::string startMinuteInsideOptionalCtorSignature = "(I)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(startMinuteInsideOptionalClassName.c_str(),
+                                                                      startMinuteInsideOptionalCtorSignature.c_str(),
+                                                                      dataResponse.startMinute.Value(), startMinuteInsideOptional);
+        chip::JniReferences::GetInstance().CreateOptional(startMinuteInsideOptional, startMinute);
     }
     jobject endHour;
     if (!dataResponse.endHour.HasValue())
@@ -835,10 +855,13 @@ void CHIPDoorLockClusterGetWeekDayScheduleResponseCallback::CallbackFn(
     }
     else
     {
-        std::string endHourClassName     = "java/lang/Integer";
-        std::string endHourCtorSignature = "(I)V";
-        chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(endHourClassName.c_str(), endHourCtorSignature.c_str(),
-                                                                      dataResponse.endHour.Value(), endHour);
+        jobject endHourInsideOptional;
+        std::string endHourInsideOptionalClassName     = "java/lang/Integer";
+        std::string endHourInsideOptionalCtorSignature = "(I)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(endHourInsideOptionalClassName.c_str(),
+                                                                      endHourInsideOptionalCtorSignature.c_str(),
+                                                                      dataResponse.endHour.Value(), endHourInsideOptional);
+        chip::JniReferences::GetInstance().CreateOptional(endHourInsideOptional, endHour);
     }
     jobject endMinute;
     if (!dataResponse.endMinute.HasValue())
@@ -847,10 +870,13 @@ void CHIPDoorLockClusterGetWeekDayScheduleResponseCallback::CallbackFn(
     }
     else
     {
-        std::string endMinuteClassName     = "java/lang/Integer";
-        std::string endMinuteCtorSignature = "(I)V";
-        chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(endMinuteClassName.c_str(), endMinuteCtorSignature.c_str(),
-                                                                      dataResponse.endMinute.Value(), endMinute);
+        jobject endMinuteInsideOptional;
+        std::string endMinuteInsideOptionalClassName     = "java/lang/Integer";
+        std::string endMinuteInsideOptionalCtorSignature = "(I)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(endMinuteInsideOptionalClassName.c_str(),
+                                                                      endMinuteInsideOptionalCtorSignature.c_str(),
+                                                                      dataResponse.endMinute.Value(), endMinuteInsideOptional);
+        chip::JniReferences::GetInstance().CreateOptional(endMinuteInsideOptional, endMinute);
     }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, weekDayIndex, userIndex, status, daysMask, startHour, startMinute, endHour,
@@ -932,11 +958,13 @@ void CHIPDoorLockClusterGetYearDayScheduleResponseCallback::CallbackFn(
     }
     else
     {
-        std::string localStartTimeClassName     = "java/lang/Long";
-        std::string localStartTimeCtorSignature = "(J)V";
-        chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(localStartTimeClassName.c_str(),
-                                                                       localStartTimeCtorSignature.c_str(),
-                                                                       dataResponse.localStartTime.Value(), localStartTime);
+        jobject localStartTimeInsideOptional;
+        std::string localStartTimeInsideOptionalClassName     = "java/lang/Long";
+        std::string localStartTimeInsideOptionalCtorSignature = "(J)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
+            localStartTimeInsideOptionalClassName.c_str(), localStartTimeInsideOptionalCtorSignature.c_str(),
+            dataResponse.localStartTime.Value(), localStartTimeInsideOptional);
+        chip::JniReferences::GetInstance().CreateOptional(localStartTimeInsideOptional, localStartTime);
     }
     jobject localEndTime;
     if (!dataResponse.localEndTime.HasValue())
@@ -945,10 +973,13 @@ void CHIPDoorLockClusterGetYearDayScheduleResponseCallback::CallbackFn(
     }
     else
     {
-        std::string localEndTimeClassName     = "java/lang/Long";
-        std::string localEndTimeCtorSignature = "(J)V";
+        jobject localEndTimeInsideOptional;
+        std::string localEndTimeInsideOptionalClassName     = "java/lang/Long";
+        std::string localEndTimeInsideOptionalCtorSignature = "(J)V";
         chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
-            localEndTimeClassName.c_str(), localEndTimeCtorSignature.c_str(), dataResponse.localEndTime.Value(), localEndTime);
+            localEndTimeInsideOptionalClassName.c_str(), localEndTimeInsideOptionalCtorSignature.c_str(),
+            dataResponse.localEndTime.Value(), localEndTimeInsideOptional);
+        chip::JniReferences::GetInstance().CreateOptional(localEndTimeInsideOptional, localEndTime);
     }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, yearDayIndex, userIndex, status, localStartTime, localEndTime);
@@ -2134,12 +2165,13 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallback::CallbackFn(
     }
     else
     {
-        chip::JniReferences::GetInstance().CreateArrayList(WiFiScanResults);
+        jobject WiFiScanResultsInsideOptional;
+        chip::JniReferences::GetInstance().CreateArrayList(WiFiScanResultsInsideOptional);
 
-        auto iter_WiFiScanResults_1 = dataResponse.wiFiScanResults.Value().begin();
-        while (iter_WiFiScanResults_1.Next())
+        auto iter_WiFiScanResultsInsideOptional_1 = dataResponse.wiFiScanResults.Value().begin();
+        while (iter_WiFiScanResultsInsideOptional_1.Next())
         {
-            auto & entry_1 = iter_WiFiScanResults_1.GetValue();
+            auto & entry_1 = iter_WiFiScanResultsInsideOptional_1.GetValue();
             jobject newElement_1;
             jobject newElement_1_security;
             std::string newElement_1_securityClassName     = "java/lang/Integer";
@@ -2196,8 +2228,9 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallback::CallbackFn(
             newElement_1 = env->NewObject(wiFiInterfaceScanResultStructClass, wiFiInterfaceScanResultStructCtor,
                                           newElement_1_security, newElement_1_ssid, newElement_1_bssid, newElement_1_channel,
                                           newElement_1_wiFiBand, newElement_1_rssi);
-            chip::JniReferences::GetInstance().AddToList(WiFiScanResults, newElement_1);
+            chip::JniReferences::GetInstance().AddToList(WiFiScanResultsInsideOptional, newElement_1);
         }
+        chip::JniReferences::GetInstance().CreateOptional(WiFiScanResultsInsideOptional, WiFiScanResults);
     }
     jobject ThreadScanResults;
     if (!dataResponse.threadScanResults.HasValue())
@@ -2206,12 +2239,13 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallback::CallbackFn(
     }
     else
     {
-        chip::JniReferences::GetInstance().CreateArrayList(ThreadScanResults);
+        jobject ThreadScanResultsInsideOptional;
+        chip::JniReferences::GetInstance().CreateArrayList(ThreadScanResultsInsideOptional);
 
-        auto iter_ThreadScanResults_1 = dataResponse.threadScanResults.Value().begin();
-        while (iter_ThreadScanResults_1.Next())
+        auto iter_ThreadScanResultsInsideOptional_1 = dataResponse.threadScanResults.Value().begin();
+        while (iter_ThreadScanResultsInsideOptional_1.Next())
         {
-            auto & entry_1 = iter_ThreadScanResults_1.GetValue();
+            auto & entry_1 = iter_ThreadScanResultsInsideOptional_1.GetValue();
             jobject newElement_1;
             jobject newElement_1_panId;
             std::string newElement_1_panIdClassName     = "java/lang/Long";
@@ -2279,8 +2313,9 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallback::CallbackFn(
                 env->NewObject(threadInterfaceScanResultStructClass, threadInterfaceScanResultStructCtor, newElement_1_panId,
                                newElement_1_extendedPanId, newElement_1_networkName, newElement_1_channel, newElement_1_version,
                                newElement_1_extendedAddress, newElement_1_rssi, newElement_1_lqi);
-            chip::JniReferences::GetInstance().AddToList(ThreadScanResults, newElement_1);
+            chip::JniReferences::GetInstance().AddToList(ThreadScanResultsInsideOptional, newElement_1);
         }
+        chip::JniReferences::GetInstance().CreateOptional(ThreadScanResultsInsideOptional, ThreadScanResults);
     }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, NetworkingStatus, DebugText, WiFiScanResults, ThreadScanResults);
@@ -2424,11 +2459,13 @@ void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallback::CallbackFn(
     }
     else
     {
-        std::string delayedActionTimeClassName     = "java/lang/Long";
-        std::string delayedActionTimeCtorSignature = "(J)V";
-        chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(delayedActionTimeClassName.c_str(),
-                                                                       delayedActionTimeCtorSignature.c_str(),
-                                                                       dataResponse.delayedActionTime.Value(), delayedActionTime);
+        jobject delayedActionTimeInsideOptional;
+        std::string delayedActionTimeInsideOptionalClassName     = "java/lang/Long";
+        std::string delayedActionTimeInsideOptionalCtorSignature = "(J)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
+            delayedActionTimeInsideOptionalClassName.c_str(), delayedActionTimeInsideOptionalCtorSignature.c_str(),
+            dataResponse.delayedActionTime.Value(), delayedActionTimeInsideOptional);
+        chip::JniReferences::GetInstance().CreateOptional(delayedActionTimeInsideOptional, delayedActionTime);
     }
     jobject imageURI;
     if (!dataResponse.imageURI.HasValue())
@@ -2437,8 +2474,10 @@ void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallback::CallbackFn(
     }
     else
     {
-        imageURI =
+        jobject imageURIInsideOptional;
+        imageURIInsideOptional =
             env->NewStringUTF(std::string(dataResponse.imageURI.Value().data(), dataResponse.imageURI.Value().size()).c_str());
+        chip::JniReferences::GetInstance().CreateOptional(imageURIInsideOptional, imageURI);
     }
     jobject softwareVersion;
     if (!dataResponse.softwareVersion.HasValue())
@@ -2447,11 +2486,13 @@ void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallback::CallbackFn(
     }
     else
     {
-        std::string softwareVersionClassName     = "java/lang/Long";
-        std::string softwareVersionCtorSignature = "(J)V";
-        chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(softwareVersionClassName.c_str(),
-                                                                       softwareVersionCtorSignature.c_str(),
-                                                                       dataResponse.softwareVersion.Value(), softwareVersion);
+        jobject softwareVersionInsideOptional;
+        std::string softwareVersionInsideOptionalClassName     = "java/lang/Long";
+        std::string softwareVersionInsideOptionalCtorSignature = "(J)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
+            softwareVersionInsideOptionalClassName.c_str(), softwareVersionInsideOptionalCtorSignature.c_str(),
+            dataResponse.softwareVersion.Value(), softwareVersionInsideOptional);
+        chip::JniReferences::GetInstance().CreateOptional(softwareVersionInsideOptional, softwareVersion);
     }
     jobject softwareVersionString;
     if (!dataResponse.softwareVersionString.HasValue())
@@ -2460,9 +2501,11 @@ void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallback::CallbackFn(
     }
     else
     {
-        softwareVersionString = env->NewStringUTF(
+        jobject softwareVersionStringInsideOptional;
+        softwareVersionStringInsideOptional = env->NewStringUTF(
             std::string(dataResponse.softwareVersionString.Value().data(), dataResponse.softwareVersionString.Value().size())
                 .c_str());
+        chip::JniReferences::GetInstance().CreateOptional(softwareVersionStringInsideOptional, softwareVersionString);
     }
     jobject updateToken;
     if (!dataResponse.updateToken.HasValue())
@@ -2471,10 +2514,13 @@ void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallback::CallbackFn(
     }
     else
     {
-        jbyteArray updateTokenByteArray = env->NewByteArray(static_cast<jsize>(dataResponse.updateToken.Value().size()));
-        env->SetByteArrayRegion(updateTokenByteArray, 0, static_cast<jsize>(dataResponse.updateToken.Value().size()),
+        jobject updateTokenInsideOptional;
+        jbyteArray updateTokenInsideOptionalByteArray =
+            env->NewByteArray(static_cast<jsize>(dataResponse.updateToken.Value().size()));
+        env->SetByteArrayRegion(updateTokenInsideOptionalByteArray, 0, static_cast<jsize>(dataResponse.updateToken.Value().size()),
                                 reinterpret_cast<const jbyte *>(dataResponse.updateToken.Value().data()));
-        updateToken = updateTokenByteArray;
+        updateTokenInsideOptional = updateTokenInsideOptionalByteArray;
+        chip::JniReferences::GetInstance().CreateOptional(updateTokenInsideOptional, updateToken);
     }
     jobject userConsentNeeded;
     if (!dataResponse.userConsentNeeded.HasValue())
@@ -2483,11 +2529,13 @@ void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallback::CallbackFn(
     }
     else
     {
-        std::string userConsentNeededClassName     = "java/lang/Boolean";
-        std::string userConsentNeededCtorSignature = "(Z)V";
-        chip::JniReferences::GetInstance().CreateBoxedObject<bool>(userConsentNeededClassName.c_str(),
-                                                                   userConsentNeededCtorSignature.c_str(),
-                                                                   dataResponse.userConsentNeeded.Value(), userConsentNeeded);
+        jobject userConsentNeededInsideOptional;
+        std::string userConsentNeededInsideOptionalClassName     = "java/lang/Boolean";
+        std::string userConsentNeededInsideOptionalCtorSignature = "(Z)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<bool>(
+            userConsentNeededInsideOptionalClassName.c_str(), userConsentNeededInsideOptionalCtorSignature.c_str(),
+            dataResponse.userConsentNeeded.Value(), userConsentNeededInsideOptional);
+        chip::JniReferences::GetInstance().CreateOptional(userConsentNeededInsideOptional, userConsentNeeded);
     }
     jobject metadataForRequestor;
     if (!dataResponse.metadataForRequestor.HasValue())
@@ -2496,12 +2544,14 @@ void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallback::CallbackFn(
     }
     else
     {
-        jbyteArray metadataForRequestorByteArray =
+        jobject metadataForRequestorInsideOptional;
+        jbyteArray metadataForRequestorInsideOptionalByteArray =
             env->NewByteArray(static_cast<jsize>(dataResponse.metadataForRequestor.Value().size()));
-        env->SetByteArrayRegion(metadataForRequestorByteArray, 0,
+        env->SetByteArrayRegion(metadataForRequestorInsideOptionalByteArray, 0,
                                 static_cast<jsize>(dataResponse.metadataForRequestor.Value().size()),
                                 reinterpret_cast<const jbyte *>(dataResponse.metadataForRequestor.Value().data()));
-        metadataForRequestor = metadataForRequestorByteArray;
+        metadataForRequestorInsideOptional = metadataForRequestorInsideOptionalByteArray;
+        chip::JniReferences::GetInstance().CreateOptional(metadataForRequestorInsideOptional, metadataForRequestor);
     }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, status, delayedActionTime, imageURI, softwareVersion, softwareVersionString,
@@ -2766,10 +2816,13 @@ void CHIPOperationalCredentialsClusterNOCResponseCallback::CallbackFn(
     }
     else
     {
-        std::string FabricIndexClassName     = "java/lang/Integer";
-        std::string FabricIndexCtorSignature = "(I)V";
-        chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-            FabricIndexClassName.c_str(), FabricIndexCtorSignature.c_str(), dataResponse.fabricIndex.Value(), FabricIndex);
+        jobject FabricIndexInsideOptional;
+        std::string FabricIndexInsideOptionalClassName     = "java/lang/Integer";
+        std::string FabricIndexInsideOptionalCtorSignature = "(I)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(FabricIndexInsideOptionalClassName.c_str(),
+                                                                      FabricIndexInsideOptionalCtorSignature.c_str(),
+                                                                      dataResponse.fabricIndex.Value(), FabricIndexInsideOptional);
+        chip::JniReferences::GetInstance().CreateOptional(FabricIndexInsideOptional, FabricIndex);
     }
     jobject DebugText;
     if (!dataResponse.debugText.HasValue())
@@ -2778,8 +2831,10 @@ void CHIPOperationalCredentialsClusterNOCResponseCallback::CallbackFn(
     }
     else
     {
-        DebugText =
+        jobject DebugTextInsideOptional;
+        DebugTextInsideOptional =
             env->NewStringUTF(std::string(dataResponse.debugText.Value().data(), dataResponse.debugText.Value().size()).c_str());
+        chip::JniReferences::GetInstance().CreateOptional(DebugTextInsideOptional, DebugText);
     }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, StatusCode, FabricIndex, DebugText);
@@ -3340,7 +3395,10 @@ void CHIPTargetNavigatorClusterNavigateTargetResponseCallback::CallbackFn(
     }
     else
     {
-        data = env->NewStringUTF(std::string(dataResponse.data.Value().data(), dataResponse.data.Value().size()).c_str());
+        jobject dataInsideOptional;
+        dataInsideOptional =
+            env->NewStringUTF(std::string(dataResponse.data.Value().data(), dataResponse.data.Value().size()).c_str());
+        chip::JniReferences::GetInstance().CreateOptional(dataInsideOptional, data);
     }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, status, data);
@@ -3842,10 +3900,13 @@ void CHIPTestClusterClusterTestNullableOptionalResponseCallback::CallbackFn(
     }
     else
     {
-        std::string wasNullClassName     = "java/lang/Boolean";
-        std::string wasNullCtorSignature = "(Z)V";
-        chip::JniReferences::GetInstance().CreateBoxedObject<bool>(wasNullClassName.c_str(), wasNullCtorSignature.c_str(),
-                                                                   dataResponse.wasNull.Value(), wasNull);
+        jobject wasNullInsideOptional;
+        std::string wasNullInsideOptionalClassName     = "java/lang/Boolean";
+        std::string wasNullInsideOptionalCtorSignature = "(Z)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<bool>(wasNullInsideOptionalClassName.c_str(),
+                                                                   wasNullInsideOptionalCtorSignature.c_str(),
+                                                                   dataResponse.wasNull.Value(), wasNullInsideOptional);
+        chip::JniReferences::GetInstance().CreateOptional(wasNullInsideOptional, wasNull);
     }
     jobject value;
     if (!dataResponse.value.HasValue())
@@ -3854,10 +3915,13 @@ void CHIPTestClusterClusterTestNullableOptionalResponseCallback::CallbackFn(
     }
     else
     {
-        std::string valueClassName     = "java/lang/Integer";
-        std::string valueCtorSignature = "(I)V";
-        chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(valueClassName.c_str(), valueCtorSignature.c_str(),
-                                                                      dataResponse.value.Value(), value);
+        jobject valueInsideOptional;
+        std::string valueInsideOptionalClassName     = "java/lang/Integer";
+        std::string valueInsideOptionalCtorSignature = "(I)V";
+        chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(valueInsideOptionalClassName.c_str(),
+                                                                      valueInsideOptionalCtorSignature.c_str(),
+                                                                      dataResponse.value.Value(), valueInsideOptional);
+        chip::JniReferences::GetInstance().CreateOptional(valueInsideOptional, value);
     }
     jobject originalValue;
     if (!dataResponse.originalValue.HasValue())
@@ -3866,18 +3930,20 @@ void CHIPTestClusterClusterTestNullableOptionalResponseCallback::CallbackFn(
     }
     else
     {
+        jobject originalValueInsideOptional;
         if (dataResponse.originalValue.Value().IsNull())
         {
-            originalValue = nullptr;
+            originalValueInsideOptional = nullptr;
         }
         else
         {
-            std::string originalValueClassName     = "java/lang/Integer";
-            std::string originalValueCtorSignature = "(I)V";
+            std::string originalValueInsideOptionalClassName     = "java/lang/Integer";
+            std::string originalValueInsideOptionalCtorSignature = "(I)V";
             chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-                originalValueClassName.c_str(), originalValueCtorSignature.c_str(), dataResponse.originalValue.Value().Value(),
-                originalValue);
+                originalValueInsideOptionalClassName.c_str(), originalValueInsideOptionalCtorSignature.c_str(),
+                dataResponse.originalValue.Value().Value(), originalValueInsideOptional);
         }
+        chip::JniReferences::GetInstance().CreateOptional(originalValueInsideOptional, originalValue);
     }
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, wasPresent, wasNull, value, originalValue);

--- a/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
@@ -3315,11 +3315,13 @@ void CHIPBindingBindingAttributeCallback::CallbackFn(
         }
         else
         {
-            std::string newElement_0_nodeClassName     = "java/lang/Long";
-            std::string newElement_0_nodeCtorSignature = "(J)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(newElement_0_nodeClassName.c_str(),
-                                                                           newElement_0_nodeCtorSignature.c_str(),
-                                                                           entry_0.node.Value(), newElement_0_node);
+            jobject newElement_0_nodeInsideOptional;
+            std::string newElement_0_nodeInsideOptionalClassName     = "java/lang/Long";
+            std::string newElement_0_nodeInsideOptionalCtorSignature = "(J)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(newElement_0_nodeInsideOptionalClassName.c_str(),
+                                                                           newElement_0_nodeInsideOptionalCtorSignature.c_str(),
+                                                                           entry_0.node.Value(), newElement_0_nodeInsideOptional);
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_nodeInsideOptional, newElement_0_node);
         }
         jobject newElement_0_group;
         if (!entry_0.group.HasValue())
@@ -3328,11 +3330,13 @@ void CHIPBindingBindingAttributeCallback::CallbackFn(
         }
         else
         {
-            std::string newElement_0_groupClassName     = "java/lang/Integer";
-            std::string newElement_0_groupCtorSignature = "(I)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(newElement_0_groupClassName.c_str(),
-                                                                           newElement_0_groupCtorSignature.c_str(),
-                                                                           entry_0.group.Value(), newElement_0_group);
+            jobject newElement_0_groupInsideOptional;
+            std::string newElement_0_groupInsideOptionalClassName     = "java/lang/Integer";
+            std::string newElement_0_groupInsideOptionalCtorSignature = "(I)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(newElement_0_groupInsideOptionalClassName.c_str(),
+                                                                           newElement_0_groupInsideOptionalCtorSignature.c_str(),
+                                                                           entry_0.group.Value(), newElement_0_groupInsideOptional);
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_groupInsideOptional, newElement_0_group);
         }
         jobject newElement_0_endpoint;
         if (!entry_0.endpoint.HasValue())
@@ -3341,11 +3345,13 @@ void CHIPBindingBindingAttributeCallback::CallbackFn(
         }
         else
         {
-            std::string newElement_0_endpointClassName     = "java/lang/Integer";
-            std::string newElement_0_endpointCtorSignature = "(I)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(newElement_0_endpointClassName.c_str(),
-                                                                           newElement_0_endpointCtorSignature.c_str(),
-                                                                           entry_0.endpoint.Value(), newElement_0_endpoint);
+            jobject newElement_0_endpointInsideOptional;
+            std::string newElement_0_endpointInsideOptionalClassName     = "java/lang/Integer";
+            std::string newElement_0_endpointInsideOptionalCtorSignature = "(I)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
+                newElement_0_endpointInsideOptionalClassName.c_str(), newElement_0_endpointInsideOptionalCtorSignature.c_str(),
+                entry_0.endpoint.Value(), newElement_0_endpointInsideOptional);
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_endpointInsideOptional, newElement_0_endpoint);
         }
         jobject newElement_0_cluster;
         if (!entry_0.cluster.HasValue())
@@ -3354,11 +3360,13 @@ void CHIPBindingBindingAttributeCallback::CallbackFn(
         }
         else
         {
-            std::string newElement_0_clusterClassName     = "java/lang/Long";
-            std::string newElement_0_clusterCtorSignature = "(J)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0_clusterClassName.c_str(),
-                                                                           newElement_0_clusterCtorSignature.c_str(),
-                                                                           entry_0.cluster.Value(), newElement_0_cluster);
+            jobject newElement_0_clusterInsideOptional;
+            std::string newElement_0_clusterInsideOptionalClassName     = "java/lang/Long";
+            std::string newElement_0_clusterInsideOptionalCtorSignature = "(J)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
+                newElement_0_clusterInsideOptionalClassName.c_str(), newElement_0_clusterInsideOptionalCtorSignature.c_str(),
+                entry_0.cluster.Value(), newElement_0_clusterInsideOptional);
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_clusterInsideOptional, newElement_0_cluster);
         }
 
         jclass targetStructStructClass;
@@ -4612,7 +4620,10 @@ void CHIPChannelChannelListAttributeCallback::CallbackFn(
         }
         else
         {
-            newElement_0_name = env->NewStringUTF(std::string(entry_0.name.Value().data(), entry_0.name.Value().size()).c_str());
+            jobject newElement_0_nameInsideOptional;
+            newElement_0_nameInsideOptional =
+                env->NewStringUTF(std::string(entry_0.name.Value().data(), entry_0.name.Value().size()).c_str());
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_nameInsideOptional, newElement_0_name);
         }
         jobject newElement_0_callSign;
         if (!entry_0.callSign.HasValue())
@@ -4621,8 +4632,10 @@ void CHIPChannelChannelListAttributeCallback::CallbackFn(
         }
         else
         {
-            newElement_0_callSign =
+            jobject newElement_0_callSignInsideOptional;
+            newElement_0_callSignInsideOptional =
                 env->NewStringUTF(std::string(entry_0.callSign.Value().data(), entry_0.callSign.Value().size()).c_str());
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_callSignInsideOptional, newElement_0_callSign);
         }
         jobject newElement_0_affiliateCallSign;
         if (!entry_0.affiliateCallSign.HasValue())
@@ -4631,8 +4644,11 @@ void CHIPChannelChannelListAttributeCallback::CallbackFn(
         }
         else
         {
-            newElement_0_affiliateCallSign = env->NewStringUTF(
+            jobject newElement_0_affiliateCallSignInsideOptional;
+            newElement_0_affiliateCallSignInsideOptional = env->NewStringUTF(
                 std::string(entry_0.affiliateCallSign.Value().data(), entry_0.affiliateCallSign.Value().size()).c_str());
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_affiliateCallSignInsideOptional,
+                                                              newElement_0_affiliateCallSign);
         }
 
         jclass channelInfoStructClass;
@@ -8792,8 +8808,10 @@ void CHIPGroupKeyManagementGroupTableAttributeCallback::CallbackFn(
         }
         else
         {
-            newElement_0_groupName =
+            jobject newElement_0_groupNameInsideOptional;
+            newElement_0_groupNameInsideOptional =
                 env->NewStringUTF(std::string(entry_0.groupName.Value().data(), entry_0.groupName.Value().size()).c_str());
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_groupNameInsideOptional, newElement_0_groupName);
         }
 
         jclass groupInfoMapStructStructClass;
@@ -17113,11 +17131,14 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
         }
         else
         {
-            std::string newElement_0_optionalIntClassName     = "java/lang/Integer";
-            std::string newElement_0_optionalIntCtorSignature = "(I)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(newElement_0_optionalIntClassName.c_str(),
-                                                                           newElement_0_optionalIntCtorSignature.c_str(),
-                                                                           entry_0.optionalInt.Value(), newElement_0_optionalInt);
+            jobject newElement_0_optionalIntInsideOptional;
+            std::string newElement_0_optionalIntInsideOptionalClassName     = "java/lang/Integer";
+            std::string newElement_0_optionalIntInsideOptionalCtorSignature = "(I)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
+                newElement_0_optionalIntInsideOptionalClassName.c_str(),
+                newElement_0_optionalIntInsideOptionalCtorSignature.c_str(), entry_0.optionalInt.Value(),
+                newElement_0_optionalIntInsideOptional);
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_optionalIntInsideOptional, newElement_0_optionalInt);
         }
         jobject newElement_0_nullableOptionalInt;
         if (!entry_0.nullableOptionalInt.HasValue())
@@ -17126,18 +17147,22 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
         }
         else
         {
+            jobject newElement_0_nullableOptionalIntInsideOptional;
             if (entry_0.nullableOptionalInt.Value().IsNull())
             {
-                newElement_0_nullableOptionalInt = nullptr;
+                newElement_0_nullableOptionalIntInsideOptional = nullptr;
             }
             else
             {
-                std::string newElement_0_nullableOptionalIntClassName     = "java/lang/Integer";
-                std::string newElement_0_nullableOptionalIntCtorSignature = "(I)V";
+                std::string newElement_0_nullableOptionalIntInsideOptionalClassName     = "java/lang/Integer";
+                std::string newElement_0_nullableOptionalIntInsideOptionalCtorSignature = "(I)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>(
-                    newElement_0_nullableOptionalIntClassName.c_str(), newElement_0_nullableOptionalIntCtorSignature.c_str(),
-                    entry_0.nullableOptionalInt.Value().Value(), newElement_0_nullableOptionalInt);
+                    newElement_0_nullableOptionalIntInsideOptionalClassName.c_str(),
+                    newElement_0_nullableOptionalIntInsideOptionalCtorSignature.c_str(),
+                    entry_0.nullableOptionalInt.Value().Value(), newElement_0_nullableOptionalIntInsideOptional);
             }
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_nullableOptionalIntInsideOptional,
+                                                              newElement_0_nullableOptionalInt);
         }
         jobject newElement_0_nullableString;
         if (entry_0.nullableString.IsNull())
@@ -17156,8 +17181,11 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
         }
         else
         {
-            newElement_0_optionalString = env->NewStringUTF(
+            jobject newElement_0_optionalStringInsideOptional;
+            newElement_0_optionalStringInsideOptional = env->NewStringUTF(
                 std::string(entry_0.optionalString.Value().data(), entry_0.optionalString.Value().size()).c_str());
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_optionalStringInsideOptional,
+                                                              newElement_0_optionalString);
         }
         jobject newElement_0_nullableOptionalString;
         if (!entry_0.nullableOptionalString.HasValue())
@@ -17166,17 +17194,20 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
         }
         else
         {
+            jobject newElement_0_nullableOptionalStringInsideOptional;
             if (entry_0.nullableOptionalString.Value().IsNull())
             {
-                newElement_0_nullableOptionalString = nullptr;
+                newElement_0_nullableOptionalStringInsideOptional = nullptr;
             }
             else
             {
-                newElement_0_nullableOptionalString =
+                newElement_0_nullableOptionalStringInsideOptional =
                     env->NewStringUTF(std::string(entry_0.nullableOptionalString.Value().Value().data(),
                                                   entry_0.nullableOptionalString.Value().Value().size())
                                           .c_str());
             }
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_nullableOptionalStringInsideOptional,
+                                                              newElement_0_nullableOptionalString);
         }
         jobject newElement_0_nullableStruct;
         if (entry_0.nullableStruct.IsNull())
@@ -17262,52 +17293,59 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
         }
         else
         {
-            jobject newElement_0_optionalStruct_a;
-            std::string newElement_0_optionalStruct_aClassName     = "java/lang/Integer";
-            std::string newElement_0_optionalStruct_aCtorSignature = "(I)V";
+            jobject newElement_0_optionalStructInsideOptional;
+            jobject newElement_0_optionalStructInsideOptional_a;
+            std::string newElement_0_optionalStructInsideOptional_aClassName     = "java/lang/Integer";
+            std::string newElement_0_optionalStructInsideOptional_aCtorSignature = "(I)V";
             chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-                newElement_0_optionalStruct_aClassName.c_str(), newElement_0_optionalStruct_aCtorSignature.c_str(),
-                entry_0.optionalStruct.Value().a, newElement_0_optionalStruct_a);
-            jobject newElement_0_optionalStruct_b;
-            std::string newElement_0_optionalStruct_bClassName     = "java/lang/Boolean";
-            std::string newElement_0_optionalStruct_bCtorSignature = "(Z)V";
+                newElement_0_optionalStructInsideOptional_aClassName.c_str(),
+                newElement_0_optionalStructInsideOptional_aCtorSignature.c_str(), entry_0.optionalStruct.Value().a,
+                newElement_0_optionalStructInsideOptional_a);
+            jobject newElement_0_optionalStructInsideOptional_b;
+            std::string newElement_0_optionalStructInsideOptional_bClassName     = "java/lang/Boolean";
+            std::string newElement_0_optionalStructInsideOptional_bCtorSignature = "(Z)V";
             chip::JniReferences::GetInstance().CreateBoxedObject<bool>(
-                newElement_0_optionalStruct_bClassName.c_str(), newElement_0_optionalStruct_bCtorSignature.c_str(),
-                entry_0.optionalStruct.Value().b, newElement_0_optionalStruct_b);
-            jobject newElement_0_optionalStruct_c;
-            std::string newElement_0_optionalStruct_cClassName     = "java/lang/Integer";
-            std::string newElement_0_optionalStruct_cCtorSignature = "(I)V";
+                newElement_0_optionalStructInsideOptional_bClassName.c_str(),
+                newElement_0_optionalStructInsideOptional_bCtorSignature.c_str(), entry_0.optionalStruct.Value().b,
+                newElement_0_optionalStructInsideOptional_b);
+            jobject newElement_0_optionalStructInsideOptional_c;
+            std::string newElement_0_optionalStructInsideOptional_cClassName     = "java/lang/Integer";
+            std::string newElement_0_optionalStructInsideOptional_cCtorSignature = "(I)V";
             chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-                newElement_0_optionalStruct_cClassName.c_str(), newElement_0_optionalStruct_cCtorSignature.c_str(),
-                static_cast<uint8_t>(entry_0.optionalStruct.Value().c), newElement_0_optionalStruct_c);
-            jobject newElement_0_optionalStruct_d;
-            jbyteArray newElement_0_optionalStruct_dByteArray =
+                newElement_0_optionalStructInsideOptional_cClassName.c_str(),
+                newElement_0_optionalStructInsideOptional_cCtorSignature.c_str(),
+                static_cast<uint8_t>(entry_0.optionalStruct.Value().c), newElement_0_optionalStructInsideOptional_c);
+            jobject newElement_0_optionalStructInsideOptional_d;
+            jbyteArray newElement_0_optionalStructInsideOptional_dByteArray =
                 env->NewByteArray(static_cast<jsize>(entry_0.optionalStruct.Value().d.size()));
-            env->SetByteArrayRegion(newElement_0_optionalStruct_dByteArray, 0,
+            env->SetByteArrayRegion(newElement_0_optionalStructInsideOptional_dByteArray, 0,
                                     static_cast<jsize>(entry_0.optionalStruct.Value().d.size()),
                                     reinterpret_cast<const jbyte *>(entry_0.optionalStruct.Value().d.data()));
-            newElement_0_optionalStruct_d = newElement_0_optionalStruct_dByteArray;
-            jobject newElement_0_optionalStruct_e;
-            newElement_0_optionalStruct_e = env->NewStringUTF(
+            newElement_0_optionalStructInsideOptional_d = newElement_0_optionalStructInsideOptional_dByteArray;
+            jobject newElement_0_optionalStructInsideOptional_e;
+            newElement_0_optionalStructInsideOptional_e = env->NewStringUTF(
                 std::string(entry_0.optionalStruct.Value().e.data(), entry_0.optionalStruct.Value().e.size()).c_str());
-            jobject newElement_0_optionalStruct_f;
-            std::string newElement_0_optionalStruct_fClassName     = "java/lang/Integer";
-            std::string newElement_0_optionalStruct_fCtorSignature = "(I)V";
+            jobject newElement_0_optionalStructInsideOptional_f;
+            std::string newElement_0_optionalStructInsideOptional_fClassName     = "java/lang/Integer";
+            std::string newElement_0_optionalStructInsideOptional_fCtorSignature = "(I)V";
             chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-                newElement_0_optionalStruct_fClassName.c_str(), newElement_0_optionalStruct_fCtorSignature.c_str(),
-                entry_0.optionalStruct.Value().f.Raw(), newElement_0_optionalStruct_f);
-            jobject newElement_0_optionalStruct_g;
-            std::string newElement_0_optionalStruct_gClassName     = "java/lang/Float";
-            std::string newElement_0_optionalStruct_gCtorSignature = "(F)V";
+                newElement_0_optionalStructInsideOptional_fClassName.c_str(),
+                newElement_0_optionalStructInsideOptional_fCtorSignature.c_str(), entry_0.optionalStruct.Value().f.Raw(),
+                newElement_0_optionalStructInsideOptional_f);
+            jobject newElement_0_optionalStructInsideOptional_g;
+            std::string newElement_0_optionalStructInsideOptional_gClassName     = "java/lang/Float";
+            std::string newElement_0_optionalStructInsideOptional_gCtorSignature = "(F)V";
             chip::JniReferences::GetInstance().CreateBoxedObject<float>(
-                newElement_0_optionalStruct_gClassName.c_str(), newElement_0_optionalStruct_gCtorSignature.c_str(),
-                entry_0.optionalStruct.Value().g, newElement_0_optionalStruct_g);
-            jobject newElement_0_optionalStruct_h;
-            std::string newElement_0_optionalStruct_hClassName     = "java/lang/Double";
-            std::string newElement_0_optionalStruct_hCtorSignature = "(D)V";
+                newElement_0_optionalStructInsideOptional_gClassName.c_str(),
+                newElement_0_optionalStructInsideOptional_gCtorSignature.c_str(), entry_0.optionalStruct.Value().g,
+                newElement_0_optionalStructInsideOptional_g);
+            jobject newElement_0_optionalStructInsideOptional_h;
+            std::string newElement_0_optionalStructInsideOptional_hClassName     = "java/lang/Double";
+            std::string newElement_0_optionalStructInsideOptional_hCtorSignature = "(D)V";
             chip::JniReferences::GetInstance().CreateBoxedObject<double>(
-                newElement_0_optionalStruct_hClassName.c_str(), newElement_0_optionalStruct_hCtorSignature.c_str(),
-                entry_0.optionalStruct.Value().h, newElement_0_optionalStruct_h);
+                newElement_0_optionalStructInsideOptional_hClassName.c_str(),
+                newElement_0_optionalStructInsideOptional_hCtorSignature.c_str(), entry_0.optionalStruct.Value().h,
+                newElement_0_optionalStructInsideOptional_h);
 
             jclass simpleStructStructClass;
             err = chip::JniReferences::GetInstance().GetClassRef(
@@ -17327,10 +17365,14 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
                 return;
             }
 
-            newElement_0_optionalStruct = env->NewObject(
-                simpleStructStructClass, simpleStructStructCtor, newElement_0_optionalStruct_a, newElement_0_optionalStruct_b,
-                newElement_0_optionalStruct_c, newElement_0_optionalStruct_d, newElement_0_optionalStruct_e,
-                newElement_0_optionalStruct_f, newElement_0_optionalStruct_g, newElement_0_optionalStruct_h);
+            newElement_0_optionalStructInsideOptional =
+                env->NewObject(simpleStructStructClass, simpleStructStructCtor, newElement_0_optionalStructInsideOptional_a,
+                               newElement_0_optionalStructInsideOptional_b, newElement_0_optionalStructInsideOptional_c,
+                               newElement_0_optionalStructInsideOptional_d, newElement_0_optionalStructInsideOptional_e,
+                               newElement_0_optionalStructInsideOptional_f, newElement_0_optionalStructInsideOptional_g,
+                               newElement_0_optionalStructInsideOptional_h);
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_optionalStructInsideOptional,
+                                                              newElement_0_optionalStruct);
         }
         jobject newElement_0_nullableOptionalStruct;
         if (!entry_0.nullableOptionalStruct.HasValue())
@@ -17339,66 +17381,68 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
         }
         else
         {
+            jobject newElement_0_nullableOptionalStructInsideOptional;
             if (entry_0.nullableOptionalStruct.Value().IsNull())
             {
-                newElement_0_nullableOptionalStruct = nullptr;
+                newElement_0_nullableOptionalStructInsideOptional = nullptr;
             }
             else
             {
-                jobject newElement_0_nullableOptionalStruct_a;
-                std::string newElement_0_nullableOptionalStruct_aClassName     = "java/lang/Integer";
-                std::string newElement_0_nullableOptionalStruct_aCtorSignature = "(I)V";
+                jobject newElement_0_nullableOptionalStructInsideOptional_a;
+                std::string newElement_0_nullableOptionalStructInsideOptional_aClassName     = "java/lang/Integer";
+                std::string newElement_0_nullableOptionalStructInsideOptional_aCtorSignature = "(I)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-                    newElement_0_nullableOptionalStruct_aClassName.c_str(),
-                    newElement_0_nullableOptionalStruct_aCtorSignature.c_str(), entry_0.nullableOptionalStruct.Value().Value().a,
-                    newElement_0_nullableOptionalStruct_a);
-                jobject newElement_0_nullableOptionalStruct_b;
-                std::string newElement_0_nullableOptionalStruct_bClassName     = "java/lang/Boolean";
-                std::string newElement_0_nullableOptionalStruct_bCtorSignature = "(Z)V";
+                    newElement_0_nullableOptionalStructInsideOptional_aClassName.c_str(),
+                    newElement_0_nullableOptionalStructInsideOptional_aCtorSignature.c_str(),
+                    entry_0.nullableOptionalStruct.Value().Value().a, newElement_0_nullableOptionalStructInsideOptional_a);
+                jobject newElement_0_nullableOptionalStructInsideOptional_b;
+                std::string newElement_0_nullableOptionalStructInsideOptional_bClassName     = "java/lang/Boolean";
+                std::string newElement_0_nullableOptionalStructInsideOptional_bCtorSignature = "(Z)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<bool>(
-                    newElement_0_nullableOptionalStruct_bClassName.c_str(),
-                    newElement_0_nullableOptionalStruct_bCtorSignature.c_str(), entry_0.nullableOptionalStruct.Value().Value().b,
-                    newElement_0_nullableOptionalStruct_b);
-                jobject newElement_0_nullableOptionalStruct_c;
-                std::string newElement_0_nullableOptionalStruct_cClassName     = "java/lang/Integer";
-                std::string newElement_0_nullableOptionalStruct_cCtorSignature = "(I)V";
+                    newElement_0_nullableOptionalStructInsideOptional_bClassName.c_str(),
+                    newElement_0_nullableOptionalStructInsideOptional_bCtorSignature.c_str(),
+                    entry_0.nullableOptionalStruct.Value().Value().b, newElement_0_nullableOptionalStructInsideOptional_b);
+                jobject newElement_0_nullableOptionalStructInsideOptional_c;
+                std::string newElement_0_nullableOptionalStructInsideOptional_cClassName     = "java/lang/Integer";
+                std::string newElement_0_nullableOptionalStructInsideOptional_cCtorSignature = "(I)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-                    newElement_0_nullableOptionalStruct_cClassName.c_str(),
-                    newElement_0_nullableOptionalStruct_cCtorSignature.c_str(),
-                    static_cast<uint8_t>(entry_0.nullableOptionalStruct.Value().Value().c), newElement_0_nullableOptionalStruct_c);
-                jobject newElement_0_nullableOptionalStruct_d;
-                jbyteArray newElement_0_nullableOptionalStruct_dByteArray =
+                    newElement_0_nullableOptionalStructInsideOptional_cClassName.c_str(),
+                    newElement_0_nullableOptionalStructInsideOptional_cCtorSignature.c_str(),
+                    static_cast<uint8_t>(entry_0.nullableOptionalStruct.Value().Value().c),
+                    newElement_0_nullableOptionalStructInsideOptional_c);
+                jobject newElement_0_nullableOptionalStructInsideOptional_d;
+                jbyteArray newElement_0_nullableOptionalStructInsideOptional_dByteArray =
                     env->NewByteArray(static_cast<jsize>(entry_0.nullableOptionalStruct.Value().Value().d.size()));
-                env->SetByteArrayRegion(newElement_0_nullableOptionalStruct_dByteArray, 0,
+                env->SetByteArrayRegion(newElement_0_nullableOptionalStructInsideOptional_dByteArray, 0,
                                         static_cast<jsize>(entry_0.nullableOptionalStruct.Value().Value().d.size()),
                                         reinterpret_cast<const jbyte *>(entry_0.nullableOptionalStruct.Value().Value().d.data()));
-                newElement_0_nullableOptionalStruct_d = newElement_0_nullableOptionalStruct_dByteArray;
-                jobject newElement_0_nullableOptionalStruct_e;
-                newElement_0_nullableOptionalStruct_e =
+                newElement_0_nullableOptionalStructInsideOptional_d = newElement_0_nullableOptionalStructInsideOptional_dByteArray;
+                jobject newElement_0_nullableOptionalStructInsideOptional_e;
+                newElement_0_nullableOptionalStructInsideOptional_e =
                     env->NewStringUTF(std::string(entry_0.nullableOptionalStruct.Value().Value().e.data(),
                                                   entry_0.nullableOptionalStruct.Value().Value().e.size())
                                           .c_str());
-                jobject newElement_0_nullableOptionalStruct_f;
-                std::string newElement_0_nullableOptionalStruct_fClassName     = "java/lang/Integer";
-                std::string newElement_0_nullableOptionalStruct_fCtorSignature = "(I)V";
+                jobject newElement_0_nullableOptionalStructInsideOptional_f;
+                std::string newElement_0_nullableOptionalStructInsideOptional_fClassName     = "java/lang/Integer";
+                std::string newElement_0_nullableOptionalStructInsideOptional_fCtorSignature = "(I)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-                    newElement_0_nullableOptionalStruct_fClassName.c_str(),
-                    newElement_0_nullableOptionalStruct_fCtorSignature.c_str(),
-                    entry_0.nullableOptionalStruct.Value().Value().f.Raw(), newElement_0_nullableOptionalStruct_f);
-                jobject newElement_0_nullableOptionalStruct_g;
-                std::string newElement_0_nullableOptionalStruct_gClassName     = "java/lang/Float";
-                std::string newElement_0_nullableOptionalStruct_gCtorSignature = "(F)V";
+                    newElement_0_nullableOptionalStructInsideOptional_fClassName.c_str(),
+                    newElement_0_nullableOptionalStructInsideOptional_fCtorSignature.c_str(),
+                    entry_0.nullableOptionalStruct.Value().Value().f.Raw(), newElement_0_nullableOptionalStructInsideOptional_f);
+                jobject newElement_0_nullableOptionalStructInsideOptional_g;
+                std::string newElement_0_nullableOptionalStructInsideOptional_gClassName     = "java/lang/Float";
+                std::string newElement_0_nullableOptionalStructInsideOptional_gCtorSignature = "(F)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<float>(
-                    newElement_0_nullableOptionalStruct_gClassName.c_str(),
-                    newElement_0_nullableOptionalStruct_gCtorSignature.c_str(), entry_0.nullableOptionalStruct.Value().Value().g,
-                    newElement_0_nullableOptionalStruct_g);
-                jobject newElement_0_nullableOptionalStruct_h;
-                std::string newElement_0_nullableOptionalStruct_hClassName     = "java/lang/Double";
-                std::string newElement_0_nullableOptionalStruct_hCtorSignature = "(D)V";
+                    newElement_0_nullableOptionalStructInsideOptional_gClassName.c_str(),
+                    newElement_0_nullableOptionalStructInsideOptional_gCtorSignature.c_str(),
+                    entry_0.nullableOptionalStruct.Value().Value().g, newElement_0_nullableOptionalStructInsideOptional_g);
+                jobject newElement_0_nullableOptionalStructInsideOptional_h;
+                std::string newElement_0_nullableOptionalStructInsideOptional_hClassName     = "java/lang/Double";
+                std::string newElement_0_nullableOptionalStructInsideOptional_hCtorSignature = "(D)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<double>(
-                    newElement_0_nullableOptionalStruct_hClassName.c_str(),
-                    newElement_0_nullableOptionalStruct_hCtorSignature.c_str(), entry_0.nullableOptionalStruct.Value().Value().h,
-                    newElement_0_nullableOptionalStruct_h);
+                    newElement_0_nullableOptionalStructInsideOptional_hClassName.c_str(),
+                    newElement_0_nullableOptionalStructInsideOptional_hCtorSignature.c_str(),
+                    entry_0.nullableOptionalStruct.Value().Value().h, newElement_0_nullableOptionalStructInsideOptional_h);
 
                 jclass simpleStructStructClass;
                 err = chip::JniReferences::GetInstance().GetClassRef(
@@ -17418,13 +17462,15 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
                     return;
                 }
 
-                newElement_0_nullableOptionalStruct =
-                    env->NewObject(simpleStructStructClass, simpleStructStructCtor, newElement_0_nullableOptionalStruct_a,
-                                   newElement_0_nullableOptionalStruct_b, newElement_0_nullableOptionalStruct_c,
-                                   newElement_0_nullableOptionalStruct_d, newElement_0_nullableOptionalStruct_e,
-                                   newElement_0_nullableOptionalStruct_f, newElement_0_nullableOptionalStruct_g,
-                                   newElement_0_nullableOptionalStruct_h);
+                newElement_0_nullableOptionalStructInsideOptional = env->NewObject(
+                    simpleStructStructClass, simpleStructStructCtor, newElement_0_nullableOptionalStructInsideOptional_a,
+                    newElement_0_nullableOptionalStructInsideOptional_b, newElement_0_nullableOptionalStructInsideOptional_c,
+                    newElement_0_nullableOptionalStructInsideOptional_d, newElement_0_nullableOptionalStructInsideOptional_e,
+                    newElement_0_nullableOptionalStructInsideOptional_f, newElement_0_nullableOptionalStructInsideOptional_g,
+                    newElement_0_nullableOptionalStructInsideOptional_h);
             }
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_nullableOptionalStructInsideOptional,
+                                                              newElement_0_nullableOptionalStruct);
         }
         jobject newElement_0_nullableList;
         if (entry_0.nullableList.IsNull())
@@ -17455,20 +17501,22 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
         }
         else
         {
-            chip::JniReferences::GetInstance().CreateArrayList(newElement_0_optionalList);
+            jobject newElement_0_optionalListInsideOptional;
+            chip::JniReferences::GetInstance().CreateArrayList(newElement_0_optionalListInsideOptional);
 
-            auto iter_newElement_0_optionalList_NaN = entry_0.optionalList.Value().begin();
-            while (iter_newElement_0_optionalList_NaN.Next())
+            auto iter_newElement_0_optionalListInsideOptional_NaN = entry_0.optionalList.Value().begin();
+            while (iter_newElement_0_optionalListInsideOptional_NaN.Next())
             {
-                auto & entry_NaN = iter_newElement_0_optionalList_NaN.GetValue();
+                auto & entry_NaN = iter_newElement_0_optionalListInsideOptional_NaN.GetValue();
                 jobject newElement_NaN;
                 std::string newElement_NaNClassName     = "java/lang/Integer";
                 std::string newElement_NaNCtorSignature = "(I)V";
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(newElement_NaNClassName.c_str(),
                                                                               newElement_NaNCtorSignature.c_str(),
                                                                               static_cast<uint8_t>(entry_NaN), newElement_NaN);
-                chip::JniReferences::GetInstance().AddToList(newElement_0_optionalList, newElement_NaN);
+                chip::JniReferences::GetInstance().AddToList(newElement_0_optionalListInsideOptional, newElement_NaN);
             }
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_optionalListInsideOptional, newElement_0_optionalList);
         }
         jobject newElement_0_nullableOptionalList;
         if (!entry_0.nullableOptionalList.HasValue())
@@ -17477,27 +17525,31 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
         }
         else
         {
+            jobject newElement_0_nullableOptionalListInsideOptional;
             if (entry_0.nullableOptionalList.Value().IsNull())
             {
-                newElement_0_nullableOptionalList = nullptr;
+                newElement_0_nullableOptionalListInsideOptional = nullptr;
             }
             else
             {
-                chip::JniReferences::GetInstance().CreateArrayList(newElement_0_nullableOptionalList);
+                chip::JniReferences::GetInstance().CreateArrayList(newElement_0_nullableOptionalListInsideOptional);
 
-                auto iter_newElement_0_nullableOptionalList_NaN = entry_0.nullableOptionalList.Value().Value().begin();
-                while (iter_newElement_0_nullableOptionalList_NaN.Next())
+                auto iter_newElement_0_nullableOptionalListInsideOptional_NaN =
+                    entry_0.nullableOptionalList.Value().Value().begin();
+                while (iter_newElement_0_nullableOptionalListInsideOptional_NaN.Next())
                 {
-                    auto & entry_NaN = iter_newElement_0_nullableOptionalList_NaN.GetValue();
+                    auto & entry_NaN = iter_newElement_0_nullableOptionalListInsideOptional_NaN.GetValue();
                     jobject newElement_NaN;
                     std::string newElement_NaNClassName     = "java/lang/Integer";
                     std::string newElement_NaNCtorSignature = "(I)V";
                     chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(newElement_NaNClassName.c_str(),
                                                                                   newElement_NaNCtorSignature.c_str(),
                                                                                   static_cast<uint8_t>(entry_NaN), newElement_NaN);
-                    chip::JniReferences::GetInstance().AddToList(newElement_0_nullableOptionalList, newElement_NaN);
+                    chip::JniReferences::GetInstance().AddToList(newElement_0_nullableOptionalListInsideOptional, newElement_NaN);
                 }
             }
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_nullableOptionalListInsideOptional,
+                                                              newElement_0_nullableOptionalList);
         }
 
         jclass nullablesAndOptionalsStructStructClass;


### PR DESCRIPTION
#### Problem
* Java optional encode breaks for struct within optional since it doesn't check for empty, and just relies on setting `nullptr`.
* Java optional decode is not properly wrapping non-empty values inside `java.util.Optional`

#### Change overview
* Check if optional is empty in encode, if so don't recurse.
* Wrap value in `Optional` for decode

#### Testing
* Checked `CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback`
