### PR TITLE
[EFR32] Enable openthread udpEndpoint

### DIFF
--- a/examples/lock-app/efr32/args.gni
+++ b/examples/lock-app/efr32/args.gni
@@ -23,5 +23,6 @@ declare_args() {
 }
 
 chip_enable_openthread = true
+chip_system_config_use_open_thread_udp = true
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"

--- a/examples/window-app/efr32/args.gni
+++ b/examples/window-app/efr32/args.gni
@@ -26,3 +26,4 @@ declare_args() {
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"
 chip_enable_openthread = true
+chip_system_config_use_open_thread_udp = true


### PR DESCRIPTION
#### Problem
OpenThreadUDPEndpoint isn't used on all examples for efr32

#### Change overview
enable it

#### Testing
CI
