### PR TITLE
Move chip tool resolve command to address_resolver

### DIFF
--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -22,57 +22,47 @@
 #include "DiscoverCommissionablesCommand.h"
 #include "DiscoverCommissionersCommand.h"
 #include <controller/DeviceAddressUpdateDelegate.h>
-#include <lib/dnssd/Resolver.h>
+#include <lib/address_resolve/AddressResolve.h>
 
-class Resolve : public DiscoverCommand, public chip::Dnssd::OperationalResolveDelegate
+class Resolve : public DiscoverCommand, public chip::AddressResolve::NodeListener
 {
 public:
-    Resolve(CredentialIssuerCommands * credsIssuerConfig) : DiscoverCommand("resolve", credsIssuerConfig) {}
+    Resolve(CredentialIssuerCommands * credsIssuerConfig) : DiscoverCommand("resolve", credsIssuerConfig)
+    {
+        mNodeLookupHandle.SetListener(this);
+    }
 
     /////////// DiscoverCommand Interface /////////
     CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) override
     {
-        ReturnErrorOnFailure(mDNSResolver.Init(chip::DeviceLayer::UDPEndPointManager()));
-        mDNSResolver.SetOperationalDelegate(this);
-        ChipLogProgress(chipTool, "Dnssd: Searching for NodeId: %" PRIx64 " FabricId: %" PRIx64 " ...", remoteId, fabricId);
-        return mDNSResolver.ResolveNodeId(chip::PeerId().SetNodeId(remoteId).SetCompressedFabricId(fabricId),
-                                          chip::Inet::IPAddressType::kAny);
+        ReturnErrorOnFailure(chip::AddressResolve::Resolver::Instance().Init(&chip::DeviceLayer::SystemLayer()));
+
+        return chip::AddressResolve::Resolver::Instance().LookupNode(
+            chip::AddressResolve::NodeLookupRequest(chip::PeerId().SetNodeId(remoteId).SetCompressedFabricId(fabricId)),
+            mNodeLookupHandle);
     }
 
-    void OnOperationalNodeResolved(const chip::Dnssd::ResolvedNodeData & nodeData) override
+    void OnNodeAddressResolved(const PeerId & peerId, const chip::AddressResolve::ResolveResult & result) override
     {
         char addrBuffer[chip::Transport::PeerAddress::kMaxToStringSize];
 
-        ChipLogProgress(chipTool, "NodeId Resolution: %" PRIu64 " Port: %" PRIu16, nodeData.mPeerId.GetNodeId(), nodeData.mPort);
-        ChipLogProgress(chipTool, "    Hostname: %s", nodeData.mHostName);
-        for (size_t i = 0; i < nodeData.mNumIPs; ++i)
-        {
-            nodeData.mAddress[i].ToString(addrBuffer);
-            ChipLogProgress(chipTool, "    addr %zu: %s", i, addrBuffer);
-        }
+        result.address.ToString(addrBuffer);
 
-        auto retryInterval = nodeData.GetMrpRetryIntervalIdle();
-
-        if (retryInterval.HasValue())
-            ChipLogProgress(chipTool, "   MRP retry interval (idle): %" PRIu32 "ms", retryInterval.Value().count());
-
-        retryInterval = nodeData.GetMrpRetryIntervalActive();
-
-        if (retryInterval.HasValue())
-            ChipLogProgress(chipTool, "   MRP retry interval (active): %" PRIu32 "ms", retryInterval.Value().count());
-
-        ChipLogProgress(chipTool, "   Supports TCP: %s", nodeData.mSupportsTcp ? "yes" : "no");
+        ChipLogProgress(chipTool, "NodeId Resolution: %" PRIu64 " at %s", peerId.GetNodeId(), addrBuffer);
+        ChipLogProgress(chipTool, "   MRP retry interval (idle): %" PRIu32 "ms", result.mrpConfig.mIdleRetransTimeout.count());
+        ChipLogProgress(chipTool, "   MRP retry interval (active): %" PRIu32 "ms", result.mrpConfig.mActiveRetransTimeout.count());
+        ChipLogProgress(chipTool, "   Supports TCP: %s", result.supportsTcp ? "yes" : "no");
         SetCommandExitStatus(CHIP_NO_ERROR);
     }
 
-    void OnOperationalNodeResolutionFailed(const chip::PeerId & peerId, CHIP_ERROR error) override
+    void OnNodeAddressResolutionFailed(const chip::PeerId & peerId, CHIP_ERROR error) override
     {
-        ChipLogProgress(chipTool, "NodeId Resolution: failed!");
+        ChipLogProgress(chipTool, "NodeId %" PRIu64 " Resolution: failed!", peerId.GetNodeId());
         SetCommandExitStatus(CHIP_ERROR_INTERNAL);
     }
 
 private:
-    chip::Dnssd::ResolverProxy mDNSResolver;
+    chip::AddressResolve::NodeLookupHandle mNodeLookupHandle;
 };
 
 class Update : public DiscoverCommand

--- a/src/app/tests/suites/commands/discovery/BUILD.gn
+++ b/src/app/tests/suites/commands/discovery/BUILD.gn
@@ -26,7 +26,7 @@ static_library("discovery") {
   cflags = [ "-Wconversion" ]
 
   public_deps = [
-    "${chip_root}/src/lib/dnssd",
+    "${chip_root}/src/lib/address_resolve",
     "${chip_root}/src/lib/support",
   ]
 }

--- a/src/lib/address_resolve/AddressResolve.h
+++ b/src/lib/address_resolve/AddressResolve.h
@@ -26,10 +26,14 @@
 namespace chip {
 namespace AddressResolve {
 
+/// Contains resolve information received from nodes. Contains all information
+/// bits that are considered useful but does not contain a full DNSSD data
+/// structure since not all DNSSD data is useful during operational processing.
 struct ResolveResult
 {
     Transport::PeerAddress address;
     ReliableMessageProtocolConfig mrpConfig;
+    bool supportsTcp = false;
 
     ResolveResult() : address(Transport::Type::kUdp), mrpConfig(GetLocalMRPConfig()) {}
 };

--- a/src/lib/address_resolve/AddressResolve.h
+++ b/src/lib/address_resolve/AddressResolve.h
@@ -18,12 +18,21 @@
 
 #include <lib/core/PeerId.h>
 #include <lib/support/IntrusiveList.h>
+#include <messaging/ReliableMessageProtocolConfig.h>
 #include <system/SystemClock.h>
 #include <system/SystemLayer.h>
 #include <transport/raw/PeerAddress.h>
 
 namespace chip {
 namespace AddressResolve {
+
+struct ResolveResult
+{
+    Transport::PeerAddress address;
+    ReliableMessageProtocolConfig mrpConfig;
+
+    ResolveResult() : address(Transport::Type::kUdp), mrpConfig(GetLocalMRPConfig()) {}
+};
 
 /// Represents an object intersted in callbacks for a resolve operation.
 class NodeListener
@@ -37,7 +46,7 @@ public:
     ///
     /// The callback is expected to be executed within the chip event loop
     /// thread.
-    virtual void OnNodeAddressResolved(const PeerId & peerId, const Transport::PeerAddress & address) = 0;
+    virtual void OnNodeAddressResolved(const PeerId & peerId, const ResolveResult & result) = 0;
 
     /// Node resolution failure - occurs only once for a lookup, when an address
     /// could not be resolved - generally due to a timeout or due to DNSSD

--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -95,23 +95,24 @@ IpScore ScoreIpAddress(const Inet::IPAddress & ip, Inet::InterfaceId interfaceId
 
 void NodeLookupHandle::ResetForLookup(System::Clock::Timestamp now, const NodeLookupRequest & request)
 {
-    mRequestStartTime = now;
-    mRequest          = request;
-    mBestPeerAddress  = Transport::PeerAddress();
-    mBestAddressScore = ScoreValue(IpScore::kInvalid);
+    mRequestStartTime     = now;
+    mRequest              = request;
+    mBestResult.address   = Transport::PeerAddress();
+    mBestResult.mrpConfig = GetLocalMRPConfig();
+    mBestAddressScore     = ScoreValue(IpScore::kInvalid);
 }
 
-void NodeLookupHandle::LookupResult(const Transport::PeerAddress & addr)
+void NodeLookupHandle::LookupResult(const ResolveResult & result)
 {
-    unsigned newScore = ScoreValue(ScoreIpAddress(addr.GetIPAddress(), addr.GetInterface()));
+    unsigned newScore = ScoreValue(ScoreIpAddress(result.address.GetIPAddress(), result.address.GetInterface()));
     if (newScore > mBestAddressScore)
     {
-        mBestPeerAddress  = addr;
+        mBestResult       = result;
         mBestAddressScore = newScore;
 
 #if CHIP_PROGRESS_LOGGING
         char addr_string[Transport::PeerAddress::kMaxToStringSize];
-        mBestPeerAddress.ToString(addr_string);
+        mBestResult.address.ToString(addr_string);
         ChipLogProgress(Discovery, "Address %s is scored at %u", addr_string, mBestAddressScore);
 #endif
     }
@@ -152,7 +153,7 @@ NodeLookupAction NodeLookupHandle::NextAction(System::Clock::Timestamp now)
     // Minimal time to search reached. If any Ip available, ready to return it.
     if (mBestAddressScore > ScoreValue(IpScore::kInvalid))
     {
-        GetListener()->OnNodeAddressResolved(GetRequest().GetPeerId(), mBestPeerAddress);
+        GetListener()->OnNodeAddressResolved(GetRequest().GetPeerId(), mBestResult);
         return NodeLookupAction::kStopSearching;
     }
 
@@ -194,15 +195,16 @@ void Resolver::OnOperationalNodeResolved(const Dnssd::ResolvedNodeData & nodeDat
             continue;
         }
 
-        // Assume we only search for UDP addresses for now
-        Transport::PeerAddress address(Transport::Type::kUdp);
-        address.SetPort(nodeData.mPort);
-        address.SetInterface(nodeData.mInterfaceId);
+        ResolveResult result;
+
+        result.address.SetPort(nodeData.mPort);
+        result.address.SetInterface(nodeData.mInterfaceId);
+        result.mrpConfig = nodeData.GetMRPConfig();
 
         for (size_t i = 0; i < nodeData.mNumIPs; i++)
         {
-            address.SetIPAddress(nodeData.mAddress[i]);
-            current->LookupResult(address);
+            result.address.SetIPAddress(nodeData.mAddress[i]);
+            current->LookupResult(result);
         }
 
         if (current->NextAction(mTimeSource.GetMonotonicTimestamp()) == NodeLookupAction::kStopSearching)

--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -95,11 +95,10 @@ IpScore ScoreIpAddress(const Inet::IPAddress & ip, Inet::InterfaceId interfaceId
 
 void NodeLookupHandle::ResetForLookup(System::Clock::Timestamp now, const NodeLookupRequest & request)
 {
-    mRequestStartTime     = now;
-    mRequest              = request;
-    mBestResult.address   = Transport::PeerAddress();
-    mBestResult.mrpConfig = GetLocalMRPConfig();
-    mBestAddressScore     = ScoreValue(IpScore::kInvalid);
+    mRequestStartTime = now;
+    mRequest          = request;
+    mBestResult       = ResolveResult();
+    mBestAddressScore = ScoreValue(IpScore::kInvalid);
 }
 
 void NodeLookupHandle::LookupResult(const ResolveResult & result)
@@ -199,7 +198,8 @@ void Resolver::OnOperationalNodeResolved(const Dnssd::ResolvedNodeData & nodeDat
 
         result.address.SetPort(nodeData.mPort);
         result.address.SetInterface(nodeData.mInterfaceId);
-        result.mrpConfig = nodeData.GetMRPConfig();
+        result.mrpConfig   = nodeData.GetMRPConfig();
+        result.supportsTcp = nodeData.mSupportsTcp;
 
         for (size_t i = 0; i < nodeData.mNumIPs; i++)
         {

--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.h
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.h
@@ -47,7 +47,7 @@ public:
     void ResetForLookup(System::Clock::Timestamp now, const NodeLookupRequest & request);
 
     /// Mark that a specific IP address has been found
-    void LookupResult(const Transport::PeerAddress & addr);
+    void LookupResult(const ResolveResult & result);
 
     /// Called after timeouts or after a series of IP addresses have been
     /// marked as found.
@@ -67,7 +67,7 @@ public:
 private:
     System::Clock::Timestamp mRequestStartTime;
     NodeLookupRequest mRequest; // active request to process
-    Transport::PeerAddress mBestPeerAddress;
+    AddressResolve::ResolveResult mBestResult;
     unsigned mBestAddressScore = 0;
 };
 

--- a/src/lib/address_resolve/BUILD.gn
+++ b/src/lib/address_resolve/BUILD.gn
@@ -36,6 +36,7 @@ static_library("address_resolve") {
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/dnssd",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/messaging",
     "${chip_root}/src/transport/raw",
   ]
 

--- a/src/lib/address_resolve/tool.cpp
+++ b/src/lib/address_resolve/tool.cpp
@@ -47,12 +47,14 @@ class PrintOutNodeListener : public chip::AddressResolve::NodeListener
 public:
     PrintOutNodeListener() { mSelfHandle.SetListener(this); }
 
-    void OnNodeAddressResolved(const PeerId & peerId, const PeerAddress & address) override
+    void OnNodeAddressResolved(const PeerId & peerId, const AddressResolve::ResolveResult & result) override
     {
         char addr_string[PeerAddress::kMaxToStringSize];
-        address.ToString(addr_string);
+        result.address.ToString(addr_string);
 
         ChipLogProgress(Discovery, "Resolve completed: %s", addr_string);
+        ChipLogProgress(Discovery, "   MRP IDLE retransmit timeout:   %u ms", result.mrpConfig.mIdleRetransTimeout.count());
+        ChipLogProgress(Discovery, "   MRP ACTIVE retransmit timeout: %u ms", result.mrpConfig.mActiveRetransTimeout.count());
         NotifyDone();
     }
 

--- a/src/lib/address_resolve/tool.cpp
+++ b/src/lib/address_resolve/tool.cpp
@@ -53,6 +53,7 @@ public:
         result.address.ToString(addr_string);
 
         ChipLogProgress(Discovery, "Resolve completed: %s", addr_string);
+        ChipLogProgress(Discovery, "   Supports TCP:                  %s", result.supportsTcp ? "YES" : "NO");
         ChipLogProgress(Discovery, "   MRP IDLE retransmit timeout:   %u ms", result.mrpConfig.mIdleRetransTimeout.count());
         ChipLogProgress(Discovery, "   MRP ACTIVE retransmit timeout: %u ms", result.mrpConfig.mActiveRetransTimeout.count());
         NotifyDone();


### PR DESCRIPTION
#### Problem
Looking for a path to start using address resolution logic instead of ResolveProxy, since address resolution handles prioritization and timeouts as well as parallel search potential.

#### Change overview
Changed `chip-tool discovery resolve` to use addresss_resolve. This PR is a delta from #15536 (since it requires MRP and tcp data to display).

Since nodedata MRP parameters seem to NOT be optional, I updated the tool to always print out MRP settings that it would use. This means that it would not print out DNSSD data but rather the configuration that other CHIP operations would/should use.

#### Testing
Manually ran `./out/linux-x64-chip-tool/chip-tool discover resolve 0x000000000001E1B9 0x116362B9D227A22A` observed values were printed out.