### PR TITLE
Disable the second network commissioning endpoint for ESP32 all-clusters-app

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -628,12 +628,17 @@ public:
 
 AppCallbacks sCallbacks;
 
+constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
+
 } // namespace
 
 static void InitServer(intptr_t context)
 {
     // Init ZCL Data Model and CHIP App Server
     chip::Server::GetInstance().Init(&sCallbacks);
+
+    // We only have network commissioning on endpoint 0.
+    emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());


### PR DESCRIPTION
We don't use that endpoint, and should not be enabling it.

#### Problem
Extra endpoint visible.

#### Change overview
Disable it on esp32.

#### Testing
Checked that it not longer shows up in Descriptor.