### PR TITLE
Fix example code using stale peer fabric index after CommissioningCom…

### DIFF
--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -216,7 +216,13 @@ void DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * event, intptr_t ar
 {
     if (event->Type == DeviceLayer::DeviceEventType::kCommissioningComplete)
     {
-        chip::FabricIndex peerFabricIndex = chip::DeviceLayer::DeviceControlServer::DeviceControlSvr().GetFabricIndex();
+        if (event->CommissioningComplete.Status != CHIP_NO_ERROR)
+        {
+            ChipLogError(AppServer, "Commissioning is not successfully Complete");
+            return;
+        }
+
+        chip::FabricIndex peerFabricIndex = event->CommissioningComplete.PeerFabricIndex;
 
         Server * server           = &(chip::Server::GetInstance());
         chip::FabricInfo * fabric = server->GetFabricTable().FindFabricWithIndex(peerFabricIndex);

--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -150,9 +150,8 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(
      * Once bindings are implemented, this may no longer be needed.
      */
     SessionHandle handle = commandObj->GetExchangeContext()->GetSessionHandle();
-    server->SetFabricIndex(handle->GetFabricIndex());
 
-    CheckSuccess(server->CommissioningComplete(handle->AsSecureSession()->GetPeerNodeId()), Failure);
+    CheckSuccess(server->CommissioningComplete(handle->AsSecureSession()->GetPeerNodeId(), handle->GetFabricIndex()), Failure);
 
     Commands::CommissioningCompleteResponse::Type response;
     response.errorCode = CommissioningError::kOk;

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -25,6 +25,8 @@
 #pragma once
 #include <stdint.h>
 
+#include <lib/core/DataModelTypes.h>
+
 namespace chip {
 namespace DeviceLayer {
 namespace DeviceEventType {
@@ -441,6 +443,7 @@ struct ChipDeviceEvent final
         {
             CHIP_ERROR Status;
             uint64_t PeerNodeId;
+            FabricIndex PeerFabricIndex;
         } CommissioningComplete;
 
         struct

--- a/src/include/platform/DeviceControlServer.h
+++ b/src/include/platform/DeviceControlServer.h
@@ -89,13 +89,10 @@ public:
 
     CHIP_ERROR ArmFailSafe(System::Clock::Timeout expiryLength);
     CHIP_ERROR DisarmFailSafe();
-    CHIP_ERROR CommissioningComplete(NodeId peerNodeId);
+    CHIP_ERROR CommissioningComplete(NodeId peerNodeId, FabricIndex accessingFabricIndex);
     CHIP_ERROR SetRegulatoryConfig(uint8_t location, const CharSpan & countryCode, uint64_t breadcrumb);
-
     CHIP_ERROR ConnectNetworkForOperational(ByteSpan networkID);
 
-    inline FabricIndex GetFabricIndex() { return mFabric; }
-    inline void SetFabricIndex(FabricIndex fabricId) { mFabric = fabricId; }
     void SetSwitchDelegate(SwitchDeviceControlDelegate * delegate) { mSwitchDelegate = delegate; }
     SwitchDeviceControlDelegate * GetSwitchDelegate() const { return mSwitchDelegate; }
 
@@ -118,8 +115,6 @@ private:
     DeviceControlServer(const DeviceControlServer &)  = delete;
     DeviceControlServer(const DeviceControlServer &&) = delete;
     DeviceControlServer & operator=(const DeviceControlServer &) = delete;
-
-    FabricIndex mFabric = 0;
 };
 
 } // namespace DeviceLayer

--- a/src/platform/DeviceControlServer.cpp
+++ b/src/platform/DeviceControlServer.cpp
@@ -64,13 +64,14 @@ CHIP_ERROR DeviceControlServer::DisarmFailSafe()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DeviceControlServer::CommissioningComplete(NodeId peerNodeId)
+CHIP_ERROR DeviceControlServer::CommissioningComplete(NodeId peerNodeId, FabricIndex accessingFabricIndex)
 {
     VerifyOrReturnError(CHIP_NO_ERROR == DisarmFailSafe(), CHIP_ERROR_INTERNAL);
     ChipDeviceEvent event;
-    event.Type                             = DeviceEventType::kCommissioningComplete;
-    event.CommissioningComplete.PeerNodeId = peerNodeId;
-    event.CommissioningComplete.Status     = CHIP_NO_ERROR;
+    event.Type                                  = DeviceEventType::kCommissioningComplete;
+    event.CommissioningComplete.PeerNodeId      = peerNodeId;
+    event.CommissioningComplete.PeerFabricIndex = accessingFabricIndex;
+    event.CommissioningComplete.Status          = CHIP_NO_ERROR;
     return PlatformMgr().PostEvent(&event);
 }
 


### PR DESCRIPTION
…plete

#### Problem
What is being fixed?  Examples:
* When TV example app handle DeviceEventType::kCommissioningComplete, it gets the peer fabric index from device server, since this logic is running async after CommissioningComplete, the failsafe context has been torn down. The fabric index there is stale data, and could in fact be a different fabric index by now.

* Fixes #15547 

#### Change overview
putting the fabric index into the event itself, along with status.

#### Testing
How was this tested? (at least one bullet point required)
* Pair TV examples
1. Run ./chip-tv-casting-app on server
2. ./chip-tool pairing onnetwork 12344321 20202021

Confirmed the PeerFabricIndex is correctly passed from event