### PR TITLE
Use ReturnErrorOnFailure() instead of SuccessOrExit() in ESP examples

### DIFF
--- a/examples/all-clusters-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/all-clusters-app/esp32/main/CHIPDeviceManager.cpp
@@ -56,16 +56,13 @@ void CHIPDeviceManager::CommonDeviceEventHandler(const ChipDeviceEvent * event, 
  */
 CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
 {
-    CHIP_ERROR err;
     mCB                              = cb;
     RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
 
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(Platform::MemoryInit());
 
     // Initialize the CHIP stack.
-    err = PlatformMgr().InitChipStack();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(PlatformMgr().InitChipStack());
 
     if (flags.Has(RendezvousInformationFlag::kBLE))
     {
@@ -89,11 +86,7 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     PlatformMgr().AddEventHandler(CHIPDeviceManager::CommonDeviceEventHandler, reinterpret_cast<intptr_t>(cb));
 
     // Start a task to run the CHIP Device event loop.
-    err = PlatformMgr().StartEventLoopTask();
-    SuccessOrExit(err);
-
-exit:
-    return err;
+    return PlatformMgr().StartEventLoopTask();
 }
 } // namespace DeviceManager
 } // namespace chip

--- a/examples/bridge-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/bridge-app/esp32/main/CHIPDeviceManager.cpp
@@ -51,16 +51,13 @@ void CHIPDeviceManager::CommonDeviceEventHandler(const ChipDeviceEvent * event, 
 
 CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
 {
-    CHIP_ERROR err;
     mCB                              = cb;
     RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
 
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(Platform::MemoryInit());
 
     // Initialize the CHIP stack.
-    err = PlatformMgr().InitChipStack();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(PlatformMgr().InitChipStack());
 
     if (flags.Has(RendezvousInformationFlag::kBLE))
     {
@@ -84,11 +81,7 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     PlatformMgr().AddEventHandler(CHIPDeviceManager::CommonDeviceEventHandler, reinterpret_cast<intptr_t>(cb));
 
     // Start a task to run the CHIP Device event loop.
-    err = PlatformMgr().StartEventLoopTask();
-    SuccessOrExit(err);
-
-exit:
-    return err;
+    return PlatformMgr().StartEventLoopTask();
 }
 } // namespace DeviceManager
 } // namespace chip

--- a/examples/lighting-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/lighting-app/esp32/main/CHIPDeviceManager.cpp
@@ -51,16 +51,13 @@ void CHIPDeviceManager::CommonDeviceEventHandler(const ChipDeviceEvent * event, 
 
 CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
 {
-    CHIP_ERROR err;
     mCB                              = cb;
     RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
 
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(Platform::MemoryInit());
 
     // Initialize the CHIP stack.
-    err = PlatformMgr().InitChipStack();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(PlatformMgr().InitChipStack());
 
     if (flags.Has(RendezvousInformationFlag::kBLE))
     {
@@ -84,11 +81,7 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     PlatformMgr().AddEventHandler(CHIPDeviceManager::CommonDeviceEventHandler, reinterpret_cast<intptr_t>(cb));
 
     // Start a task to run the CHIP Device event loop.
-    err = PlatformMgr().StartEventLoopTask();
-    SuccessOrExit(err);
-
-exit:
-    return err;
+    return PlatformMgr().StartEventLoopTask();
 }
 } // namespace DeviceManager
 } // namespace chip

--- a/examples/lock-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/lock-app/esp32/main/CHIPDeviceManager.cpp
@@ -51,16 +51,13 @@ void CHIPDeviceManager::CommonDeviceEventHandler(const ChipDeviceEvent * event, 
 
 CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
 {
-    CHIP_ERROR err;
     mCB                              = cb;
     RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
 
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(Platform::MemoryInit());
 
     // Initialize the CHIP stack.
-    err = PlatformMgr().InitChipStack();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(PlatformMgr().InitChipStack());
 
     if (flags.Has(RendezvousInformationFlag::kBLE))
     {
@@ -84,11 +81,7 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     PlatformMgr().AddEventHandler(CHIPDeviceManager::CommonDeviceEventHandler, reinterpret_cast<intptr_t>(cb));
 
     // Start a task to run the CHIP Device event loop.
-    err = PlatformMgr().StartEventLoopTask();
-    SuccessOrExit(err);
-
-exit:
-    return err;
+    return PlatformMgr().StartEventLoopTask();
 }
 } // namespace DeviceManager
 } // namespace chip

--- a/examples/ota-provider-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/ota-provider-app/esp32/main/CHIPDeviceManager.cpp
@@ -51,16 +51,13 @@ void CHIPDeviceManager::CommonDeviceEventHandler(const ChipDeviceEvent * event, 
 
 CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
 {
-    CHIP_ERROR err;
     mCB                              = cb;
     RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
 
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(Platform::MemoryInit());
 
     // Initialize the CHIP stack.
-    err = PlatformMgr().InitChipStack();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(PlatformMgr().InitChipStack());
 
     if (flags.Has(RendezvousInformationFlag::kBLE))
     {
@@ -84,11 +81,7 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     PlatformMgr().AddEventHandler(CHIPDeviceManager::CommonDeviceEventHandler, reinterpret_cast<intptr_t>(cb));
 
     // Start a task to run the CHIP Device event loop.
-    err = PlatformMgr().StartEventLoopTask();
-    SuccessOrExit(err);
-
-exit:
-    return err;
+    return PlatformMgr().StartEventLoopTask();
 }
 } // namespace DeviceManager
 } // namespace chip

--- a/examples/ota-requestor-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/ota-requestor-app/esp32/main/CHIPDeviceManager.cpp
@@ -51,16 +51,13 @@ void CHIPDeviceManager::CommonDeviceEventHandler(const ChipDeviceEvent * event, 
 
 CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
 {
-    CHIP_ERROR err;
     mCB                              = cb;
     RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
 
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(Platform::MemoryInit());
 
     // Initialize the CHIP stack.
-    err = PlatformMgr().InitChipStack();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(PlatformMgr().InitChipStack());
 
     if (flags.Has(RendezvousInformationFlag::kBLE))
     {
@@ -84,11 +81,7 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     PlatformMgr().AddEventHandler(CHIPDeviceManager::CommonDeviceEventHandler, reinterpret_cast<intptr_t>(cb));
 
     // Start a task to run the CHIP Device event loop.
-    err = PlatformMgr().StartEventLoopTask();
-    SuccessOrExit(err);
-
-exit:
-    return err;
+    return PlatformMgr().StartEventLoopTask();
 }
 } // namespace DeviceManager
 } // namespace chip

--- a/examples/temperature-measurement-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/temperature-measurement-app/esp32/main/CHIPDeviceManager.cpp
@@ -54,16 +54,13 @@ void CHIPDeviceManager::CommonDeviceEventHandler(const ChipDeviceEvent * event, 
  */
 CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
 {
-    CHIP_ERROR err;
     mCB                              = cb;
     RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
 
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(Platform::MemoryInit());
 
     // Initialize the CHIP stack.
-    err = PlatformMgr().InitChipStack();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(PlatformMgr().InitChipStack());
 
     if (flags.Has(RendezvousInformationFlag::kBLE))
     {
@@ -87,11 +84,7 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     PlatformMgr().AddEventHandler(CHIPDeviceManager::CommonDeviceEventHandler, reinterpret_cast<intptr_t>(cb));
 
     // Start a task to run the CHIP Device event loop.
-    err = PlatformMgr().StartEventLoopTask();
-    SuccessOrExit(err);
-
-exit:
-    return err;
+    return PlatformMgr().StartEventLoopTask();
 }
 } // namespace DeviceManager
 } // namespace chip


### PR DESCRIPTION
#### Problem
Address a followup comment in: https://github.com/project-chip/connectedhomeip/pull/15507

> Use ReturnErrorOnFailure(Platform::MemoryInit()) here and for the below call as well. Prefer to not use goto exit since it forces code readers to scroll down to see the goto exit side as well for sideffects instead of relying on RAII and clear exit path.

#### Change overview
Use ReturnErrorOnFailure() instead of SuccessOrExit() in ESP examples

#### Testing
Verified lighting-app on esp32
