### PR TITLE
[clang-tidy] Fix some bugprone-argument-comment errors

### DIFF
--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -156,7 +156,7 @@ public:
 
     CHIP_ERROR ProcessInvokeRequest(System::PacketBufferHandle && payload, bool isTimedInvoke);
     CHIP_ERROR PrepareCommand(const ConcreteCommandPath & aCommandPath, bool aStartDataStruct = true);
-    CHIP_ERROR FinishCommand(bool aStartDataStruct = true);
+    CHIP_ERROR FinishCommand(bool aEndDataStruct = true);
     CHIP_ERROR PrepareStatus(const ConcreteCommandPath & aCommandPath);
     CHIP_ERROR FinishStatus();
     TLV::TLVWriter * GetCommandDataIBTLVWriter();

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -971,7 +971,7 @@ bool emberAfEndpointEnableDisable(EndpointId endpoint, bool enable)
         // TODO: Once endpoints are in parts lists other than that of endpoint
         // 0, something more complicated might need to happen here.
 
-        MatterReportingAttributeChangeCallback(/* EndpointId = */ 0, app::Clusters::Descriptor::Id,
+        MatterReportingAttributeChangeCallback(/* endpoint = */ 0, app::Clusters::Descriptor::Id,
                                                app::Clusters::Descriptor::Attributes::PartsList::Id);
     }
 


### PR DESCRIPTION
#### Problem

While trying to get `clang-tidy` up and running in CI I found some `bugprone-argument-comment` errors. Not a big deal but I would like to make the list in https://github.com/project-chip/connectedhomeip/pull/15563 smaller.


#### Change overview
* Fix some `bugprone-argument-comment` found by clang-tidy