### PR TITLE
[clang-tidy] Fix a clang-analyzer-valist.Unterminated instance in CHIPTLVWriter

### DIFF
--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -309,12 +309,13 @@ CHIP_ERROR TLVWriter::VPutStringF(Tag tag, const char * fmt, va_list ap)
     va_copy(aq, ap);
 
     dataLen = static_cast<size_t>(vsnprintf(nullptr, 0, fmt, aq));
+
+    va_end(aq);
+
     if (!CanCastTo<uint32_t>(dataLen))
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
-
-    va_end(aq);
 
     if (dataLen <= UINT8_MAX)
         lenFieldSize = kTLVFieldSize_1Byte;


### PR DESCRIPTION
#### Problem

While trying to get `clang-tidy` up and running in CI in https://github.com/project-chip/connectedhomeip/pull/15563  I found a leak in `TVLWriter.cpp` some `bugprone-argument-comment` errors. 


#### Change overview
 * Close the va list