### PR TITLE
[chip-tool] Rely on the readclient/writeclient/commandsender onDone c…

### DIFF
--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -65,7 +65,7 @@ public:
         if (CHIP_NO_ERROR != error)
         {
             ChipLogError(chipTool, "Response Failure: %s", chip::ErrorStr(error));
-            SetCommandExitStatus(error);
+            mError = error;
             return;
         }
 
@@ -75,7 +75,7 @@ public:
             if (CHIP_NO_ERROR != error)
             {
                 ChipLogError(chipTool, "Response Failure: Can not decode Data");
-                SetCommandExitStatus(error);
+                mError = error;
                 return;
             }
         }
@@ -84,13 +84,13 @@ public:
     virtual void OnError(const chip::app::CommandSender * client, CHIP_ERROR error) override
     {
         ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(error));
-        SetCommandExitStatus(error);
+        mError = error;
     }
 
     virtual void OnDone(chip::app::CommandSender * client) override
     {
         mCommandSender.reset();
-        SetCommandExitStatus(CHIP_NO_ERROR);
+        SetCommandExitStatus(mError);
     }
 
     template <class T>
@@ -112,6 +112,7 @@ private:
     chip::CommandId mCommandId;
     chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
 
+    CHIP_ERROR mError = CHIP_NO_ERROR;
     CustomArgument mPayload;
     std::unique_ptr<chip::app::CommandSender> mCommandSender;
 };

--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -41,14 +41,14 @@ public:
         if (CHIP_NO_ERROR != error)
         {
             ChipLogError(chipTool, "Response Failure: %s", chip::ErrorStr(error));
-            SetCommandExitStatus(error);
+            mError = error;
             return;
         }
 
         if (data == nullptr)
         {
             ChipLogError(chipTool, "Response Failure: No Data");
-            SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            mError = CHIP_ERROR_INTERNAL;
             return;
         }
 
@@ -56,7 +56,7 @@ public:
         if (CHIP_NO_ERROR != error)
         {
             ChipLogError(chipTool, "Response Failure: Can not decode Data");
-            SetCommandExitStatus(error);
+            mError = error;
             return;
         }
     }
@@ -70,7 +70,7 @@ public:
             if (CHIP_NO_ERROR != error)
             {
                 ChipLogError(chipTool, "Response Failure: %s", chip::ErrorStr(error));
-                SetCommandExitStatus(error);
+                mError = error;
                 return;
             }
         }
@@ -78,7 +78,7 @@ public:
         if (data == nullptr)
         {
             ChipLogError(chipTool, "Response Failure: No Data");
-            SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            mError = CHIP_ERROR_INTERNAL;
             return;
         }
 
@@ -86,7 +86,7 @@ public:
         if (CHIP_NO_ERROR != error)
         {
             ChipLogError(chipTool, "Response Failure: Can not decode Data");
-            SetCommandExitStatus(error);
+            mError = error;
             return;
         }
     }
@@ -94,13 +94,13 @@ public:
     void OnError(CHIP_ERROR error) override
     {
         ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(error));
-        SetCommandExitStatus(error);
+        mError = error;
     }
 
     void OnDone() override
     {
         mReadClient.reset();
-        SetCommandExitStatus(CHIP_NO_ERROR);
+        SetCommandExitStatus(mError);
     }
 
     void OnSubscriptionEstablished(uint64_t subscriptionId) override { OnAttributeSubscription(); }
@@ -177,6 +177,8 @@ protected:
     // mFabricFiltered is really only used by the attribute commands, but we end
     // up needing it in our class's shared code.
     chip::Optional<bool> mFabricFiltered;
+
+    CHIP_ERROR mError = CHIP_NO_ERROR;
 };
 
 class ReadAttribute : public ReportCommand

--- a/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
+++ b/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
@@ -68,21 +68,20 @@ public:
         if (CHIP_NO_ERROR != error)
         {
             ChipLogError(chipTool, "Response Failure: %s", chip::ErrorStr(error));
-            SetCommandExitStatus(error);
-            return;
+            mError = error;
         }
     }
 
     void OnError(const chip::app::WriteClient * client, CHIP_ERROR error) override
     {
         ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(error));
-        SetCommandExitStatus(error);
+        mError = error;
     }
 
     void OnDone(chip::app::WriteClient * client) override
     {
         mWriteClient.reset();
-        SetCommandExitStatus(CHIP_NO_ERROR);
+        SetCommandExitStatus(mError);
     }
 
     template <class T>
@@ -109,6 +108,7 @@ public:
 private:
     chip::ClusterId mClusterId;
     chip::AttributeId mAttributeId;
+    CHIP_ERROR mError = CHIP_NO_ERROR;
     chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
     chip::Optional<chip::DataVersion> mDataVersion = chip::NullOptional;
     CustomArgument mAttributeValue;

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -62,7 +62,7 @@ CHIP_ERROR CHIPCommand::Run()
     ReturnLogErrorOnFailure(InitializeCommissioner(kIdentityGamma, kIdentityGammaFabricId, trustStore));
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(RunQueuedCommand, reinterpret_cast<intptr_t>(this));
-    ReturnLogErrorOnFailure(StartWaiting(GetWaitDuration()));
+    CHIP_ERROR err = StartWaiting(GetWaitDuration());
 
     Shutdown();
 
@@ -77,7 +77,7 @@ CHIP_ERROR CHIPCommand::Run()
     ReturnLogErrorOnFailure(ShutdownCommissioner(kIdentityGamma));
 
     StopTracing();
-    return CHIP_NO_ERROR;
+    return err;
 }
 
 void CHIPCommand::StartTracing()


### PR DESCRIPTION
…allback to be called for returning any errors

#### Problem

`chip-tool` exit on the first error when using a wildcard. 
See #14896

#### Change overview
* Wait for `onDone` delegates method before exiting

#### Testing
It was manually tested doing: ```./out/debug/standalone/chip-tool any read-by-id 0xFFFFFFFF 0xFFFFFFFF 0x12344321 3```