### PR TITLE
[clang-tidy] Fix -clang-analyzer-nullability.NullPassedToNonnull erro…

### DIFF
--- a/src/platform/Darwin/BlePlatformDelegateImpl.mm
+++ b/src/platform/Darwin/BlePlatformDelegateImpl.mm
@@ -45,17 +45,14 @@ namespace DeviceLayer {
             BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId)
         {
             bool found = false;
-            CBUUID * serviceId = nil;
-            CBUUID * characteristicId = nil;
+
+            if (NULL == svcId || NULL == charId) {
+                return found;
+            }
+
+            CBUUID * serviceId = [UUIDHelper GetShortestServiceUUID:svcId];
+            CBUUID * characteristicId = [CBUUID UUIDWithData:[NSData dataWithBytes:charId->bytes length:sizeof(charId->bytes)]];
             CBPeripheral * peripheral = (__bridge CBPeripheral *) connObj;
-
-            if (NULL != svcId) {
-                serviceId = [UUIDHelper GetShortestServiceUUID:svcId];
-            }
-
-            if (NULL != charId) {
-                characteristicId = [CBUUID UUIDWithData:[NSData dataWithBytes:charId->bytes length:sizeof(charId->bytes)]];
-            }
 
             for (CBService * service in peripheral.services) {
                 if ([service.UUID.data isEqualToData:serviceId.data]) {
@@ -76,16 +73,14 @@ namespace DeviceLayer {
             BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId)
         {
             bool found = false;
-            CBUUID * serviceId = nil;
-            CBUUID * characteristicId = nil;
-            CBPeripheral * peripheral = (__bridge CBPeripheral *) connObj;
+            if (NULL == svcId || NULL == charId) {
+                return found;
+            }
 
-            if (NULL != svcId) {
-                serviceId = [UUIDHelper GetShortestServiceUUID:svcId];
-            }
-            if (NULL != charId) {
-                characteristicId = [CBUUID UUIDWithData:[NSData dataWithBytes:charId->bytes length:sizeof(charId->bytes)]];
-            }
+            CBUUID * serviceId = [UUIDHelper GetShortestServiceUUID:svcId];
+            CBUUID * characteristicId = characteristicId = [CBUUID UUIDWithData:[NSData dataWithBytes:charId->bytes
+                                                                                               length:sizeof(charId->bytes)]];
+            CBPeripheral * peripheral = (__bridge CBPeripheral *) connObj;
 
             for (CBService * service in peripheral.services) {
                 if ([service.UUID.data isEqualToData:serviceId.data]) {
@@ -135,20 +130,14 @@ namespace DeviceLayer {
             BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId, PacketBufferHandle pBuf)
         {
             bool found = false;
-            CBUUID * serviceId = nil;
-            CBUUID * characteristicId = nil;
-            NSData * data = nil;
-            CBPeripheral * peripheral = (__bridge CBPeripheral *) connObj;
+            if (NULL == svcId || NULL == charId || pBuf.IsNull()) {
+                return found;
+            }
 
-            if (NULL != svcId) {
-                serviceId = [UUIDHelper GetShortestServiceUUID:svcId];
-            }
-            if (NULL != charId) {
-                characteristicId = [CBUUID UUIDWithData:[NSData dataWithBytes:charId->bytes length:sizeof(charId->bytes)]];
-            }
-            if (!pBuf.IsNull()) {
-                data = [NSData dataWithBytes:pBuf->Start() length:pBuf->DataLength()];
-            }
+            CBUUID * serviceId = [UUIDHelper GetShortestServiceUUID:svcId];
+            CBUUID * characteristicId = [CBUUID UUIDWithData:[NSData dataWithBytes:charId->bytes length:sizeof(charId->bytes)]];
+            NSData * data = [NSData dataWithBytes:pBuf->Start() length:pBuf->DataLength()];
+            CBPeripheral * peripheral = (__bridge CBPeripheral *) connObj;
 
             for (CBService * service in peripheral.services) {
                 if ([service.UUID.data isEqualToData:serviceId.data]) {


### PR DESCRIPTION
…r in src/platform/Darwin/BlePlatformDelegateImpl.mm

#### Problem

`clang-tidy` complains because a null can be passed to a method that expects non-null.

#### Change overview
 * Update the code so it does not happens
