### PR TITLE
Fix wrong remove from list during operational lookup failure

### DIFF
--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -243,7 +243,7 @@ void Resolver::OnOperationalNodeResolutionFailed(const PeerId & peerId, CHIP_ERR
         }
 
         current->GetListener()->OnNodeAddressResolutionFailed(peerId, error);
-        mActiveLookups.Erase(it);
+        mActiveLookups.Erase(current);
     }
     ReArmTimer();
 }


### PR DESCRIPTION
#### Problem
The iterator `it` is assumed to always be valid since it is incremented, so need to erase the existing item instead of the iterating one.

#### Change overview
Switched an erase from `it` to `current`.

#### Testing
CI will validate some unit tests. Change is trivial.