### PR TITLE
Address resolve: for non LL address, ignore interface id

### DIFF
--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -109,6 +109,16 @@ void NodeLookupHandle::LookupResult(const Transport::PeerAddress & addr)
         mBestPeerAddress  = addr;
         mBestAddressScore = newScore;
 
+        if (!mBestPeerAddress.GetIPAddress().IsIPv6LinkLocal())
+        {
+            // Only use the DNS-SD resolution's InterfaceID for addresses that are IPv6 LLA.
+            // For all other addresses, we should rely on the device's routing table to route messages sent.
+            // Forcing messages down an InterfaceId might fail. For example, in bridged networks like Thread,
+            // mDNS advertisements are not usually received on the same interface the peer is reachable on.
+            mBestPeerAddress.SetInterface(Inet::InterfaceId::Null());
+            ChipLogDetail(Discovery, "Lookup clearing interface for non LL address");
+        }
+
 #if CHIP_PROGRESS_LOGGING
         char addr_string[Transport::PeerAddress::kMaxToStringSize];
         mBestPeerAddress.ToString(addr_string);

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -73,7 +73,7 @@ struct ResolvedNodeData
 
         // Would be nice to log the interface id, but sorting out how to do so
         // across our differnet InterfaceId implementations is a pain.
-
+        ChipLogProgress(Discovery, "Node ID resolved for 0x" ChipLogFormatX64, ChipLogValueX64(mPeerId.GetNodeId()));
         for (unsigned i = 0; i < mNumIPs; ++i)
         {
             mAddress[i].ToString(addrBuffer);

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -73,7 +73,7 @@ struct ResolvedNodeData
 
         // Would be nice to log the interface id, but sorting out how to do so
         // across our differnet InterfaceId implementations is a pain.
-        ChipLogProgress(Discovery, "Node ID resolved for 0x" ChipLogFormatX64, ChipLogValueX64(mPeerId.GetNodeId()));
+
         for (unsigned i = 0; i < mNumIPs; ++i)
         {
             mAddress[i].ToString(addrBuffer);


### PR DESCRIPTION
#### Problem
Existing 'ToPeerAddress' logic drops InterfaceID from non-link-local addresses, so that things may be routed over any interface.

Fixes #15560 

#### Change overview
Null-out interface id if peer address is not link-local.

#### Testing
Ran address resolve tool manually, saw interface dropped from non-link-local address.
