### PR TITLE
Ensure memory shutdown is done in tests

### DIFF
--- a/examples/platform/nrfconnect/util/test/TestInetCommon.cpp
+++ b/examples/platform/nrfconnect/util/test/TestInetCommon.cpp
@@ -76,6 +76,11 @@ void InitTestInetCommon()
     chip::Platform::MemoryInit();
 }
 
+void ShutdownTestInetCommon()
+{
+    chip::Platform::MemoryShutdown();
+}
+
 void InitSystemLayer()
 {
     gSystemLayer.Init();

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -63,6 +63,7 @@ public:
     virtual ~CASESessionManager() { mDNSResolver.Shutdown(); }
 
     CHIP_ERROR Init();
+    void Shutdown() { mDNSResolver.Shutdown(); }
 
     /**
      * Find an existing session for the given node ID, or trigger a new session request.

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -344,6 +344,7 @@ void Server::Shutdown()
     mSessions.Shutdown();
     mTransports.Close();
     mCommissioningWindowManager.Shutdown();
+    mCASESessionManager.Shutdown();
     chip::Platform::MemoryShutdown();
 }
 

--- a/src/app/tests/TestCommissionManager.cpp
+++ b/src/app/tests/TestCommissionManager.cpp
@@ -17,6 +17,7 @@
 
 #include <app/server/CommissioningWindowManager.h>
 #include <app/server/Server.h>
+#include <lib/dnssd/Advertiser.h>
 #include <lib/support/Span.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <messaging/tests/echo/common.h>
@@ -50,6 +51,20 @@ void InitializeChip(nlTestSuite * suite)
     NL_TEST_ASSERT(suite, err == CHIP_NO_ERROR);
     Server::GetInstance().GetCommissioningWindowManager().CloseCommissioningWindow();
     chip::DeviceLayer::PlatformMgr().StartEventLoopTask();
+}
+
+void ShutdownChipTest()
+{
+    chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
+    chip::DeviceLayer::PlatformMgr().Shutdown();
+
+    auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
+    mdnsAdvertiser.RemoveServices();
+    mdnsAdvertiser.Shutdown();
+
+    Server::GetInstance().Shutdown();
+
+    chip::Platform::MemoryShutdown();
 }
 
 void CheckCommissioningWindowManagerBasicWindowOpenCloseTask(intptr_t context)
@@ -182,9 +197,7 @@ int TestCommissioningWindowManager()
     // TODO: The platform memory was intentionally left not deinitialized so that minimal mdns can destruct
     chip::DeviceLayer::PlatformMgr().ScheduleWork(TearDownTask, 0);
     sleep(kTestTaskWaitSeconds);
-    chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
-    chip::DeviceLayer::PlatformMgr().Shutdown();
-    chip::Platform::MemoryShutdown();
+    ShutdownChipTest();
 
     return (nlTestRunnerStats(&theSuite));
 }

--- a/src/app/tests/TestCommissionManager.cpp
+++ b/src/app/tests/TestCommissionManager.cpp
@@ -62,8 +62,6 @@ void ShutdownChipTest()
     mdnsAdvertiser.RemoveServices();
     mdnsAdvertiser.Shutdown();
 
-    Server::GetInstance().Shutdown();
-
     // TODO: At this point UDP endpoits still seem leaked and the sanitizer
     // builds will attempt a memory free. As a result, we keep Memory initialized
     // so that the global UDPManager can still be destructed without a coredump.
@@ -71,6 +69,7 @@ void ShutdownChipTest()
     // This is likely either a missing shutdown or an actual UDP endpoint leak
     // which I have not been able to track down yet.
     //
+    // Server::GetInstance().Shutdown();
     // chip::Platform::MemoryShutdown();
 }
 

--- a/src/app/tests/TestCommissionManager.cpp
+++ b/src/app/tests/TestCommissionManager.cpp
@@ -184,6 +184,7 @@ int TestCommissioningWindowManager()
     sleep(kTestTaskWaitSeconds);
     chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
     chip::DeviceLayer::PlatformMgr().Shutdown();
+    chip::Platform::MemoryShutdown();
 
     return (nlTestRunnerStats(&theSuite));
 }

--- a/src/app/tests/TestCommissionManager.cpp
+++ b/src/app/tests/TestCommissionManager.cpp
@@ -64,7 +64,14 @@ void ShutdownChipTest()
 
     Server::GetInstance().Shutdown();
 
-    chip::Platform::MemoryShutdown();
+    // TODO: At this point UDP endpoits still seem leaked and the sanitizer
+    // builds will attempt a memory free. As a result, we keep Memory initialized
+    // so that the global UDPManager can still be destructed without a coredump.
+    //
+    // This is likely either a missing shutdown or an actual UDP endpoint leak
+    // which I have not been able to track down yet.
+    //
+    // chip::Platform::MemoryShutdown();
 }
 
 void CheckCommissioningWindowManagerBasicWindowOpenCloseTask(intptr_t context)

--- a/src/app/tests/TestCommissionManager.cpp
+++ b/src/app/tests/TestCommissionManager.cpp
@@ -62,6 +62,8 @@ void ShutdownChipTest()
     mdnsAdvertiser.RemoveServices();
     mdnsAdvertiser.Shutdown();
 
+    // Server shudown will be called in TearDownTask
+
     // TODO: At this point UDP endpoits still seem leaked and the sanitizer
     // builds will attempt a memory free. As a result, we keep Memory initialized
     // so that the global UDPManager can still be destructed without a coredump.
@@ -69,7 +71,6 @@ void ShutdownChipTest()
     // This is likely either a missing shutdown or an actual UDP endpoint leak
     // which I have not been able to track down yet.
     //
-    // Server::GetInstance().Shutdown();
     // chip::Platform::MemoryShutdown();
 }
 

--- a/src/inet/tests/TestInetCommon.h
+++ b/src/inet/tests/TestInetCommon.h
@@ -62,6 +62,7 @@ extern bool gDone;
 void InitTestInetCommon();
 void InitSystemLayer();
 void ShutdownSystemLayer();
+void ShutdownTestInetCommon();
 void InetFailError(CHIP_ERROR err, const char * msg);
 
 void InitNetwork();

--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -154,6 +154,11 @@ void InitTestInetCommon()
     UseStdoutLineBuffering();
 }
 
+void ShutdownTestInetCommon()
+{
+    chip::Platform::MemoryShutdown();
+}
+
 void InitSystemLayer()
 {
 #if CHIP_SYSTEM_CONFIG_USE_LWIP

--- a/src/inet/tests/TestInetLayer.cpp
+++ b/src/inet/tests/TestInetLayer.cpp
@@ -320,6 +320,8 @@ shutdown:
 
     lSuccessful = Common::WasSuccessful(sTestState.mStatus);
 
+    ShutdownTestInetCommon();
+
 exit:
     return (lSuccessful ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
@@ -559,7 +559,10 @@ int TestAdvertiser(void)
     nlTestRunner(&theSuite, &server);
     server.Shutdown();
     context.Shutdown();
+    mdnsAdvertiser.RemoveServices();
+    mdnsAdvertiser.Shutdown();
     chip::Platform::MemoryShutdown();
+
     return nlTestRunnerStats(&theSuite);
 }
 

--- a/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
@@ -559,6 +559,7 @@ int TestAdvertiser(void)
     nlTestRunner(&theSuite, &server);
     server.Shutdown();
     context.Shutdown();
+    chip::Platform::MemoryShutdown();
     return nlTestRunnerStats(&theSuite);
 }
 

--- a/src/lib/dnssd/minimal_mdns/tests/TestMinimalMdnsAllocator.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestMinimalMdnsAllocator.cpp
@@ -306,12 +306,22 @@ const nlTest sTests[] = {
     NL_TEST_SENTINEL() //
 };
 
+int TestSetup(void * inContext)
+{
+    return chip::Platform::MemoryInit() == CHIP_NO_ERROR ? SUCCESS : FAILURE;
+}
+
+int TestTeardown(void * inContext)
+{
+    chip::Platform::MemoryShutdown();
+    return SUCCESS;
+}
+
 } // namespace
 
 int TestMinimalMdnsAllocator(void)
 {
-    chip::Platform::MemoryInit();
-    nlTestSuite theSuite = { "MinimalMdnsAllocator", &sTests[0], nullptr, nullptr };
+    nlTestSuite theSuite = { "MinimalMdnsAllocator", &sTests[0], &TestSetup, &TestTeardown };
     nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
@@ -354,12 +354,22 @@ const nlTest sTests[] = {
     NL_TEST_SENTINEL() //
 };
 
+int TestSetup(void * inContext)
+{
+    return chip::Platform::MemoryInit() == CHIP_NO_ERROR ? SUCCESS : FAILURE;
+}
+
+int TestTeardown(void * inContext)
+{
+    chip::Platform::MemoryShutdown();
+    return SUCCESS;
+}
+
 } // namespace
 
 int TestResponseSender(void)
 {
-    chip::Platform::MemoryInit();
-    nlTestSuite theSuite = { "RecordData", sTests, nullptr, nullptr };
+    nlTestSuite theSuite = { "RecordData", sTests, &TestSetup, &TestTeardown };
     nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/lib/dnssd/platform/tests/TestPlatform.cpp
+++ b/src/lib/dnssd/platform/tests/TestPlatform.cpp
@@ -221,7 +221,12 @@ void TestCommissionableNode(nlTestSuite * inSuite, void * inContext)
 
 int TestSetup(void * inContext)
 {
-    chip::Platform::MemoryInit();
+    return chip::Platform::MemoryInit() == CHIP_NO_ERROR ? SUCCESS : FAILURE;
+}
+
+int TestTeardown(void * inContext)
+{
+    chip::Platform::MemoryShutdown();
     return SUCCESS;
 }
 
@@ -236,7 +241,7 @@ const nlTest sTests[] = {
 
 int TestDnssdPlatform(void)
 {
-    nlTestSuite theSuite = { "DnssdPlatform", &sTests[0], &TestSetup, nullptr };
+    nlTestSuite theSuite = { "DnssdPlatform", &sTests[0], &TestSetup, &TestTeardown };
     nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/lib/support/tests/TestCHIPArgParser.cpp
+++ b/src/lib/support/tests/TestCHIPArgParser.cpp
@@ -788,6 +788,8 @@ int TestCHIPArgParser(void)
 
     printf("All tests succeeded\n");
 
+    chip::Platform::MemoryShutdown();
+
     return (EXIT_SUCCESS);
 }
 #else  // CHIP_CONFIG_ENABLE_ARG_PARSER

--- a/src/platform/tests/TestCHIPoBLEStackMgr.cpp
+++ b/src/platform/tests/TestCHIPoBLEStackMgr.cpp
@@ -52,8 +52,8 @@ int TestCHIPoBLEStackManager()
     ChipLogProgress(DeviceLayer, "Start Chip Over Ble stack Done");
 
     chip::DeviceLayer::PlatformMgrImpl().RunEventLoop();
-    ChipLogProgress(DeviceLayer, "Start EventLoop");
-
+    ChipLogProgress(DeviceLayer, "RunEventLoop completed");
+    chip::Platform::MemoryShutdown();
     return 0;
 }
 

--- a/src/platform/tests/TestThreadStackMgr.cpp
+++ b/src/platform/tests/TestThreadStackMgr.cpp
@@ -46,6 +46,7 @@ void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg
     {
         if (event->ThreadConnectivityChange.Result == chip::DeviceLayer::ConnectivityChange::kConnectivity_Established)
         {
+            chip::Platform::MemoryShutdown();
             exit(0);
         }
     }
@@ -76,6 +77,7 @@ int TestThreadStackManager()
     printf("Start Thread task done\n");
 
     chip::DeviceLayer::PlatformMgrImpl().RunEventLoop();
+    chip::Platform::MemoryShutdown();
 
     return -1;
 }

--- a/src/protocols/secure_channel/tests/TestMessageCounterManager.cpp
+++ b/src/protocols/secure_channel/tests/TestMessageCounterManager.cpp
@@ -170,6 +170,7 @@ int Finalize(void * aContext)
 {
     CHIP_ERROR err = reinterpret_cast<TestContext *>(aContext)->Shutdown();
     gIOContext.Shutdown();
+    chip::Platform::MemoryShutdown();
     return (err == CHIP_NO_ERROR) ? SUCCESS : FAILURE;
 }
 

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -235,6 +235,8 @@ int PacketBufferTest::TestTeardown(void * inContext)
     if (err != CHIP_NO_ERROR && err != CHIP_ERROR_NOT_IMPLEMENTED)
         return FAILURE;
 
+    chip::Platform::MemoryShutdown();
+
     return SUCCESS;
 }
 


### PR DESCRIPTION
#### Problem

Memory init/shutdown should be done in pairs: shutdown may do some dmalloc checks which are helpful in finding leaks.

#### Change overview
Fixed several tests that had a 'MemoryInit' but never "MemoryShutdown'
Fixed inability to fully shutdown Server (CASESessionManager was only doing mdns resolve shutdown in the destructor).

#### Testing
Manually ran tests and fixed until they passed.