### PR TITLE
Enable Python CHIP Controller on Raspbian

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -36,7 +36,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
   declare_args() {
     chip_enable_python_modules =
         (current_os == "mac" || current_os == "linux") &&
-        (host_cpu == "x64" || host_cpu == "arm64")
+        (host_cpu == "x64" || host_cpu == "arm64" || host_cpu == "arm")
     enable_pylib = false
   }
 

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -213,6 +213,8 @@ pw_python_action("python") {
     cpu_tag = "x86_64"
   } else if (current_cpu == "arm64" && current_os == "linux") {
     cpu_tag = "aarch64"
+  } else if (current_cpu == "arm" && current_os == "linux") {
+    cpu_tag = "armv7l"
   } else {
     cpu_tag = current_cpu
   }

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -135,7 +135,8 @@ try:
         'stringcase',
         'pyyaml',
         'ipdb',
-        'ipykernel'
+        'ipykernel',
+        'deprecation'
     ]
 
     if platform.system() == "Darwin":


### PR DESCRIPTION
#### Problem
* Make Python CHIP Controller build and run on Raspberry Pi 4 with Raspbian

#### Change overview
Minor build changes that was made to make it build and start on Raspbian

#### Testing
* Sections "Building and installing" and "Running the tool" from:
https://github.com/project-chip/connectedhomeip/blob/e5bd5f3703b45b43b4cee4a5178586ca9fc01610/docs/guides/python_chip_controller_building.md
