### PR TITLE
[flashing scripts] Log errors from subprocesses

### DIFF
--- a/scripts/flashing/firmware_utils.py
+++ b/scripts/flashing/firmware_utils.py
@@ -221,7 +221,15 @@ class Flasher:
                     capture_output=True)
             else:
                 result = self
-                self.err = subprocess.call(command)
+                self.error = subprocess.check_call(command)
+        except subprocess.CalledProcessError as exception:
+            self.err = exception.returncode
+            if capture_output:
+                self.log(fail_level, '--- stdout ---')
+                self.log(fail_level, exception.stdout)
+                self.log(fail_level, '--- stderr ---')
+                self.log(fail_level, exception.stderr)
+                self.log(fail_level, '---')
         except FileNotFoundError as exception:
             self.err = exception.errno
             if self.err == errno.ENOENT:


### PR DESCRIPTION
#### Problem

It's difficult to troubleshoot errors frome external commands
run by the flashing scripts, because their output is captured
and not reported.

#### Change overview

Log command stdout and stderr in case of failure.

#### Testing

Manual run.
