### PR TITLE
Enable FreeRTOS mutex holder tracking for chip_stack_lock_tracking

### DIFF
--- a/src/platform/cc13x2_26x2/FreeRTOSConfig.h
+++ b/src/platform/cc13x2_26x2/FreeRTOSConfig.h
@@ -168,7 +168,7 @@
 #define INCLUDE_xTaskResumeFromISR 0
 #define INCLUDE_xTaskGetCurrentTaskHandle 1
 #define INCLUDE_xTaskGetSchedulerState 1
-#define INCLUDE_xSemaphoreGetMutexHolder 0
+#define INCLUDE_xSemaphoreGetMutexHolder 1
 #define INCLUDE_xTimerPendFunctionCall 0
 
 /* Cortex-M3/4 interrupt priority configuration follows...................... */


### PR DESCRIPTION
#### Problem

Fixes #15524

#### Change overview

Sets INCLUDE_xSemaphoreGetMutexHolder FreeRTOS config for the cc13x2x7_cc26x2x7 platform

#### Testing

Build tested