### PR TITLE
Fix SessionHandle for UnauthenticatedSession may dangling

### DIFF
--- a/src/transport/SessionHolder.cpp
+++ b/src/transport/SessionHolder.cpp
@@ -19,6 +19,11 @@
 
 namespace chip {
 
+SessionHolder::SessionHolder(const SessionHandle & session) : mSession(InPlace, session.mSession)
+{
+    session->AddHolder(*this);
+}
+
 SessionHolder::~SessionHolder()
 {
     Release();

--- a/src/transport/SessionHolder.h
+++ b/src/transport/SessionHolder.h
@@ -32,6 +32,7 @@ class SessionHolder : public SessionReleaseDelegate, public IntrusiveListNodeBas
 {
 public:
     SessionHolder() {}
+    SessionHolder(const SessionHandle & session);
     ~SessionHolder();
 
     SessionHolder(const SessionHolder &);

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -527,6 +527,7 @@ void SessionManager::UnauthenticatedMessageDispatch(const PacketHeader & packetH
     if (mCB != nullptr)
     {
         CHIP_TRACE_MESSAGE_RECEIVED(payloadHeader, packetHeader, unsecuredSession, peerAddress, msg->Start(), msg->TotalLength());
+        SessionHolder holder(session);
         mCB->OnMessageReceived(packetHeader, payloadHeader, session, peerAddress, isDuplicate, std::move(msg));
     }
 }


### PR DESCRIPTION
#### Problem
Partial fixes #14849

The `UnauthenticatedSession` can be removed inside `OnMessageReceived`, which makes the `SessionHandle` dangling

#### Change overview
Add a `SessionHolder` to lock the session entry.

#### Testing
Passed unit-tests