### PR TITLE
[OTA] Requestor API clean up

### DIFF
--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -239,7 +239,7 @@ EmberAfStatus OTARequestor::HandleAnnounceOTAProvider(app::CommandHandler * comm
                                                 .providerNodeID = commandData.providerNodeId,
                                                 .endpoint       = commandData.endpoint };
 
-    SetDefaultProviderLocation(providerLocation);
+    SetCurrentProviderLocation(providerLocation);
 
     ChipLogProgress(SoftwareUpdate, "OTA Requestor received AnnounceOTAProvider");
     ChipLogDetail(SoftwareUpdate, "  FabricIndex: %u", providerLocation.fabricIndex);
@@ -484,7 +484,7 @@ CHIP_ERROR OTARequestor::AddDefaultOtaProvider(const ProviderLocation::Type & pr
     iterator = mDefaultOtaProviderList.Begin();
     while (iterator.Next())
     {
-        SetDefaultProviderLocation(iterator.GetValue());
+        SetCurrentProviderLocation(iterator.GetValue());
         break;
     }
 
@@ -517,7 +517,7 @@ void OTARequestor::OnUpdateProgressChanged(Nullable<uint8_t> percent)
     OtaRequestorServerSetUpdateStateProgress(percent);
 }
 
-bool OTARequestor::SetDefaultProviderLocation(const ProviderLocationType & providerLocation)
+bool OTARequestor::SetCurrentProviderLocation(const ProviderLocationType & providerLocation)
 {
     // Provider location cannot be modified if there is an OTA update in progress
     if (mCurrentUpdateState != OTAUpdateStateEnum::kIdle)
@@ -529,7 +529,7 @@ bool OTARequestor::SetDefaultProviderLocation(const ProviderLocationType & provi
     return true;
 }
 
-bool OTARequestor::ClearDefaultProviderLocation(void)
+bool OTARequestor::ClearCurrentProviderLocation(void)
 {
     // Provider location cannot be modified if there is an OTA update in progress
     if (mCurrentUpdateState != OTAUpdateStateEnum::kIdle)
@@ -568,7 +568,7 @@ void OTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeRe
     // Provider location should not exist if no OTA update in progress
     if (mCurrentUpdateState == OTAUpdateStateEnum::kIdle)
     {
-        ClearDefaultProviderLocation();
+        ClearCurrentProviderLocation();
     }
 }
 

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -128,9 +128,16 @@ public:
      */
     void SetRequestorCanConsent(bool requestorCanConsent) { mRequestorCanConsent.SetValue(requestorCanConsent); }
 
-    // Application notifies the Requestor on the user consent action, TRUE if consent is given,
-    // FALSE otherwise
-    void OnUserConsent(bool result);
+    /**
+     * Set the OTA provider location to use for the next query
+     */
+    bool
+    SetCurrentProviderLocation(const app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type & providerLocation);
+
+    /**
+     * Clear the OTA provider location to indicate no OTA update may be in progress
+     */
+    bool ClearCurrentProviderLocation(void);
 
 private:
     using QueryImageResponseDecodableType  = app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType;
@@ -203,16 +210,6 @@ private:
         chip::Messaging::ExchangeContext * mExchangeCtx;
         chip::BDXDownloader * mDownloader;
     };
-
-    /**
-     * Set the cached default OTA provider location to use for the next query
-     */
-    bool SetDefaultProviderLocation(const ProviderLocationType & providerLocation);
-
-    /**
-     * Clear the cached default OTA provider location to indicate no OTA update may be in progress
-     */
-    bool ClearDefaultProviderLocation(void);
 
     /**
      * Record the new update state by updating the corresponding server attribute and logging a StateTransition event

--- a/src/include/platform/OTARequestorInterface.h
+++ b/src/include/platform/OTARequestorInterface.h
@@ -17,8 +17,7 @@
  */
 
 /* This file contains the declaration for the OTA Requestor interface.
- * Any implementation of the OTA Requestor (e.g. the OTARequestor class) must implement
- * this interface.
+ * Any implementation of the OTA Requestor must implement this interface.
  */
 
 #include <app-common/zap-generated/cluster-objects.h>
@@ -140,7 +139,7 @@ private:
 };
 
 // Interface class to connect the OTA Software Update Requestor cluster command processing
-// with the core OTA Requestor logic. The OTARequestor class implements this interface
+// with the core OTA Requestor logic
 class OTARequestorInterface
 {
 public:
@@ -155,12 +154,6 @@ public:
     virtual EmberAfStatus HandleAnnounceOTAProvider(
         chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
         const chip::app::Clusters::OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::DecodableType & commandData) = 0;
-
-    // TBD: This probably doesn't need to be a method OTARequestorInterface as the response handler is
-    // explicitly supplied at command invocation
-    // Handler for the QueryImageResponse command
-    // virtual bool
-    // HandleQueryImageResponse(chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType) = 0;
 
     // Destructor
     virtual ~OTARequestorInterface() = default;


### PR DESCRIPTION
#### Problem
There are some APIs that are not needed in OTA Requestor

Fixes: https://github.com/project-chip/connectedhomeip/issues/15277

#### Change overview
- Remove unused APIs
- Clean up naming of some APIs

#### Testing
No functional change, tree compiles
