### PR TITLE
CI split between master (full) and PR (smoke) for NRF

### DIFF
--- a/.github/workflows/full-nrfconnect.yaml
+++ b/.github/workflows/full-nrfconnect.yaml
@@ -16,20 +16,16 @@ name: Build example - nRF Connect SDK
 
 on:
     push:
-    pull_request:
+    workflow_dispatch:
 
 concurrency:
-    group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
+    group: full-${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
 jobs:
     nrfconnect:
         name: nRF Connect SDK
         timeout-minutes: 120
-
-        env:
-            BUILD_TYPE: nrfconnect
-
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
 

--- a/.github/workflows/smoketest-nrfconnect.yaml
+++ b/.github/workflows/smoketest-nrfconnect.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
     nrfconnect:
         name: Run
-        timeout-minutes: 45
+        timeout-minutes: 30
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
 
@@ -68,18 +68,6 @@ jobs:
                     nrfconnect nrf52840dk_nrf52840 lock-app \
                     examples/lock-app/nrfconnect/build/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
-            - name: Run unit tests for Zephyr native_posix_64 platform
-              timeout-minutes: 10
-              run: |
-                  scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target nrf-native-posix-64-tests build"
-            - name: Uploading Failed Test Logs
-              uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
-              with:
-                  name: test-log
-                  path: |
-                      src/test_driver/nrfconnect/build/Testing/Temporary/LastTest.log
-
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}

--- a/.github/workflows/smoketest-nrfconnect.yaml
+++ b/.github/workflows/smoketest-nrfconnect.yaml
@@ -1,0 +1,89 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Smoke test - nRF Connect SDK
+
+on:
+    pull_request:
+    workflow_dispatch:
+
+concurrency:
+    group: smoke-${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
+    cancel-in-progress: true
+
+jobs:
+    nrfconnect:
+        name: Run
+        timeout-minutes: 45
+        runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io[bot]'
+
+        container:
+            image: connectedhomeip/chip-build-nrf-platform:0.5.56
+            volumes:
+                - "/tmp/bloat_reports:/tmp/bloat_reports"
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  submodules: true
+
+            - name: Set up environment for size reports
+              if: ${{ !env.ACT }}
+              env:
+                  GH_CONTEXT: ${{ toJson(github) }}
+              run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
+
+            - name: Bootstrap
+              timeout-minutes: 25
+              run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }} && ${{ !env.ACT }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
+            - name: Update nRF Connect SDK revision to the currently recommended.
+              timeout-minutes: 10
+              run: scripts/run_in_build_env.sh "python3 scripts/setup/nrfconnect/update_ncs.py --update --shallow"
+            - name: Build example nRF Connect SDK Lock App on nRF52840 DK
+              timeout-minutes: 10
+              run: |
+                  scripts/examples/nrfconnect_example.sh lock-app nrf52840dk_nrf52840
+                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+                    nrfconnect nrf52840dk_nrf52840 lock-app \
+                    examples/lock-app/nrfconnect/build/zephyr/zephyr.elf \
+                    /tmp/bloat_reports/
+            - name: Run unit tests for Zephyr native_posix_64 platform
+              timeout-minutes: 10
+              run: |
+                  scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target nrf-native-posix-64-tests build"
+            - name: Uploading Failed Test Logs
+              uses: actions/upload-artifact@v2
+              if: ${{ failure() }} && ${{ !env.ACT }}
+              with:
+                  name: test-log
+                  path: |
+                      src/test_driver/nrfconnect/build/Testing/Temporary/LastTest.log
+
+            - name: Uploading Size Reports
+              uses: actions/upload-artifact@v2
+              if: ${{ !env.ACT }}
+              with:
+                  name: Size,nRFConnect-Examples,${{ env.GH_EVENT_PR }},${{ env.GH_EVENT_HASH }},${{ env.GH_EVENT_PARENT }},${{ github.event_name }}
+                  path: |
+                      /tmp/bloat_reports/

--- a/.github/workflows/smoketest-nrfconnect.yaml
+++ b/.github/workflows/smoketest-nrfconnect.yaml
@@ -63,10 +63,10 @@ jobs:
             - name: Build example nRF Connect SDK Lock App on nRF52840 DK
               timeout-minutes: 10
               run: |
-                  scripts/examples/nrfconnect_example.sh lock-app nrf52840dk_nrf52840
+                  scripts/examples/nrfconnect_example.sh all-clusters-app nrf52840dk_nrf52840 -DBUILD_WITH_DFU=1
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    nrfconnect nrf52840dk_nrf52840 lock-app \
-                    examples/lock-app/nrfconnect/build/zephyr/zephyr.elf \
+                    nrfconnect nrf52840dk_nrf52840 all-clusters-app \
+                    examples/all-clusters-app/nrfconnect/build/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2


### PR DESCRIPTION
#### Problem
We spend a lot of time waiting for PR CI.

#### Change overview
Moved full NRF into master builds only, moved the PR builds as a "smoke test" only that is expected to finish faster (under 30 min).

PR smoke test will only do an app compile. Master pushes will compile all apps and run zephyr unit tests.

#### Testing
CI will validate.