### PR TITLE
CI split between master (full) and PR (smoke) for Android

### DIFF
--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -1,0 +1,76 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Full builds - Android
+
+on:
+    push:
+    workflow_dispatch:
+
+concurrency:
+    group: full-${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
+    cancel-in-progress: true
+
+jobs:
+    android:
+        name: Run
+        timeout-minutes: 75
+
+        env:
+            JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64/
+
+        runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io[bot]'
+
+        container:
+            image: connectedhomeip/chip-build-android:0.5.56
+            volumes:
+                - "/tmp/log_output:/tmp/test_logs"
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  submodules: true
+            - name: Bootstrap
+              timeout-minutes: 10
+              run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }} && ${{ !env.ACT }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
+            - name: Build Android CHIPTool and CHIPTest (ARM)
+              run: |
+                ./scripts/run_in_build_env.sh \
+                  "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-arm-chip-*' build"
+            - name: Clean out build output
+              run: rm -rf ./out
+            - name: Build Android CHIPTool and CHIPTest (ARM64)
+              run: |
+                ./scripts/run_in_build_env.sh \
+                  "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-arm64-chip-*' build"
+            - name: Run Android build rule tests
+              run: |
+                ./scripts/run_in_build_env.sh \
+                  "ninja -C out/android-arm64-chip-tool build/chip/java/tests:java_build_test.tests"
+            - name: Clean out build output
+              run: rm -rf ./out
+            # - name: Build Android Studio build (arm64 only)
+            #   run: |
+            #     ./scripts/run_in_build_env.sh \
+            #       "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-androidstudio-arm64-chip-tool' build"

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -57,7 +57,7 @@ jobs:
             - name: Build Android CHIPTool and CHIPTest (ARM64)
               run: |
                 ./scripts/run_in_build_env.sh \
-                  "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-arm64-chip-*' build"
+                  "./scripts/build/build_examples.py --no-log-timestamps --target android-arm64-chip-tool build"
             - name: Run Android build rule tests
               run: |
                 ./scripts/run_in_build_env.sh \

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Android
+name: Smoke test - Android
 
 on:
-    push:
     pull_request:
+    workflow_dispatch:
 
 concurrency:
-    group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
+    group: smoke-${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
 jobs:
     android:
-        name: Build Android
-        timeout-minutes: 75
+        name: Run
+        timeout-minutes: 45
 
         env:
             JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64/
@@ -54,23 +54,11 @@ jobs:
                   path: |
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
-            - name: Build Android CHIPTool and CHIPTest (ARM)
-              run: |
-                ./scripts/run_in_build_env.sh \
-                  "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-arm-chip-*' build"
             - name: Clean out build output
               run: rm -rf ./out
             - name: Build Android CHIPTool and CHIPTest (ARM64)
               run: |
                 ./scripts/run_in_build_env.sh \
                   "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-arm64-chip-*' build"
-            - name: Run Android build rule tests
-              run: |
-                ./scripts/run_in_build_env.sh \
-                  "ninja -C out/android-arm64-chip-tool build/chip/java/tests:java_build_test.tests"
             - name: Clean out build output
               run: rm -rf ./out
-            # - name: Build Android Studio build (arm64 only)
-            #   run: |
-            #     ./scripts/run_in_build_env.sh \
-            #       "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-androidstudio-arm64-chip-tool' build"

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
     android:
         name: Run
-        timeout-minutes: 45
+        timeout-minutes: 60
 
         env:
             JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64/
@@ -54,11 +54,11 @@ jobs:
                   path: |
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
-            - name: Clean out build output
-              run: rm -rf ./out
             - name: Build Android CHIPTool and CHIPTest (ARM64)
               run: |
                 ./scripts/run_in_build_env.sh \
                   "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-arm64-chip-*' build"
-            - name: Clean out build output
-              run: rm -rf ./out
+            - name: Run Android build rule tests
+              run: |
+                ./scripts/run_in_build_env.sh \
+                  "ninja -C out/android-arm64-chip-tool build/chip/java/tests:java_build_test.tests"


### PR DESCRIPTION
#### Problem
We spend a lot of time waiting for PR CI.

#### Change overview
Moved full Android into full builds (as before) to run on master and smoketest (arm64 only, no build rules unit tests).

As a future step, we can start enabling Studio builds on master only.

#### Testing
CI will validate.


