### PR TITLE
[IM] Reject conflict WriteRequests

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -533,7 +533,7 @@ bool InteractionModelEngine::HasConflictWriteRequests(const WriteHandler * apWri
         {
             continue;
         }
-        if (writeHandler.IsConflictWrite(aPath))
+        if (writeHandler.IsCurrentlyProcessingWritePath(aPath))
         {
             return true;
         }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -525,6 +525,22 @@ bool InteractionModelEngine::InActiveReadClientList(ReadClient * apReadClient)
     return false;
 }
 
+bool InteractionModelEngine::HasConflictWriteRequests(const WriteHandler * apWriteHandler, const ConcreteAttributePath & aPath)
+{
+    for (auto & writeHandler : mWriteHandlers)
+    {
+        if (writeHandler.IsFree() || &writeHandler == apWriteHandler)
+        {
+            continue;
+        }
+        if (writeHandler.IsConflictWrite(aPath))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 void InteractionModelEngine::ReleaseClusterInfoList(ClusterInfo *& aClusterInfo)
 {
     ClusterInfo * current = aClusterInfo;

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -178,6 +178,8 @@ public:
      */
     size_t GetNumActiveReadClients();
 
+    bool HasConflictWriteRequests(const WriteHandler * apWriteHandler, const ConcreteAttributePath & aPath);
+
 #if CONFIG_IM_BUILD_FOR_UNIT_TEST
     //
     // Get direct access to the underlying read handler pool

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -178,6 +178,10 @@ public:
      */
     size_t GetNumActiveReadClients();
 
+    /**
+     * Returns whether the write operation to the given path is conflict with another write operations. (i.e. another write
+     * transaction is in the middle of processing the chunked value of the given path.)
+     */
     bool HasConflictWriteRequests(const WriteHandler * apWriteHandler, const ConcreteAttributePath & aPath);
 
 #if CONFIG_IM_BUILD_FOR_UNIT_TEST

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -39,6 +39,7 @@ CHIP_ERROR WriteHandler::Init()
     MoveToState(State::Initialized);
 
     mACLCheckCache.ClearValue();
+    mProcessingAttributePath.ClearValue();
 
     return CHIP_NO_ERROR;
 }
@@ -244,7 +245,17 @@ CHIP_ERROR WriteHandler::ProcessAttributeDataIBs(TLV::TLVReader & aAttributeData
             dataAttributePath.mListOp = ConcreteDataAttributePath::ListOperation::ReplaceAll;
         }
 
+        if (InteractionModelEngine::GetInstance()->HasConflictWriteRequests(this, dataAttributePath) ||
+            // Per chunking protocol, we are processing the list entries, but the initial empty list is not processed, so we reject
+            // it with Busy status code.
+            (dataAttributePath.IsListItemOperation() &&
+             (!mProcessingAttributePath.HasValue() || mProcessingAttributePath.Value() != dataAttributePath)))
         {
+            err = AddStatus(dataAttributePath, StatusIB(Protocols::InteractionModel::Status::Busy));
+        }
+        else
+        {
+            mProcessingAttributePath.SetValue(dataAttributePath);
             MatterPreAttributeWriteCallback(dataAttributePath);
             TLV::TLVWriter backup;
             DataVersion version = 0;

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -112,7 +112,7 @@ public:
         return mACLCheckCache.HasValue() && mACLCheckCache.Value() == aToken;
     }
 
-    bool IsConflictWrite(const ConcreteAttributePath & aPath)
+    bool IsCurrentlyProcessingWritePath(const ConcreteAttributePath & aPath)
     {
         return mProcessingAttributePath.HasValue() && mProcessingAttributePath.Value() == aPath;
     }

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -112,6 +112,11 @@ public:
         return mACLCheckCache.HasValue() && mACLCheckCache.Value() == aToken;
     }
 
+    bool IsConflictWrite(const ConcreteAttributePath & aPath)
+    {
+        return mProcessingAttributePath.HasValue() && mProcessingAttributePath.Value() == aPath;
+    }
+
 private:
     enum class State
     {
@@ -143,9 +148,10 @@ private: // ExchangeDelegate
 private:
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
     WriteResponseMessage::Builder mWriteResponseBuilder;
-    State mState                                  = State::Uninitialized;
-    bool mIsTimedRequest                          = false;
-    bool mHasMoreChunks                           = false;
+    State mState         = State::Uninitialized;
+    bool mIsTimedRequest = false;
+    bool mHasMoreChunks  = false;
+    Optional<ConcreteAttributePath> mProcessingAttributePath;
     Optional<AttributeAccessToken> mACLCheckCache = NullOptional;
 };
 } // namespace app


### PR DESCRIPTION
#### Problem

Fixes #15120

Reject Write Requests if one is already outstanding, when the paths are being written by another write transaction.

#### Change overview

- `InteractionModel::Status::Busy` will be returned in this case.

#### Testing

Updated `src/controller/tests/TestWriteChunking.cpp` to cover this