### PR TITLE
[nrfconnect] Fix flashing script

### DIFF
--- a/scripts/flashing/nrfconnect_firmware_utils.py
+++ b/scripts/flashing/nrfconnect_firmware_utils.py
@@ -130,7 +130,7 @@ class Flasher(firmware_utils.Flasher):
 
     def reset(self):
         """Reset the device."""
-        return self.run_tool('nrfjprog', ['--pinresetenable'], name='Enable pin reset')
+        return self.run_tool('nrfjprog', ['--reset'], name='Reset')
 
     def actions(self):
         """Perform actions on the device according to self.option."""


### PR DESCRIPTION
#### Problem
Flashing script uses only `--pinresetenable` flag which doesn't reset the board.

#### Change overview
`--reset` flash should be used to reset the board after flashing a firmware.

#### Testing
Ran the script and tested it programs a firmware and resets the board correctly.
