### PR TITLE
RPC: Add RPC to ESP temperature example

### DIFF
--- a/examples/platform/esp32/Rpc.cpp
+++ b/examples/platform/esp32/Rpc.cpp
@@ -34,7 +34,9 @@
 #endif // defined(PW_RPC_ATTRIBUTE_SERVICE) && PW_RPC_ATTRIBUTE_SERVICE
 
 #if defined(PW_RPC_BUTTON_SERVICE) && PW_RPC_BUTTON_SERVICE
+#if CONFIG_DEVICE_TYPE_M5STACK
 #include "ScreenManager.h"
+#endif // CONFIG_DEVICE_TYPE_M5STACK
 #include "pigweed/rpc_services/Button.h"
 #endif // defined(PW_RPC_BUTTON_SERVICE) && PW_RPC_BUTTON_SERVICE
 

--- a/examples/temperature-measurement-app/esp32/CMakeLists.txt
+++ b/examples/temperature-measurement-app/esp32/CMakeLists.txt
@@ -33,7 +33,7 @@ set(EXTRA_COMPONENT_DIRS
 )
 
 project(chip-temperature-measurement-app)
-idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
+idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++17;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
 # For the C3, project_include.cmake sets -Wno-format, but does not clear various
 # flags that depend on -Wformat
@@ -46,3 +46,20 @@ idf_build_set_property(COMPILE_OPTIONS "-Wno-format-nonliteral;-Wno-format-secur
 idf_build_set_property(COMPILE_OPTIONS "-Wno-error=maybe-uninitialized" APPEND)
 
 flashing_script()
+
+if (CONFIG_ENABLE_PW_RPC)
+get_filename_component(CHIP_ROOT ./third_party/connectedhomeip REALPATH)
+include(third_party/connectedhomeip/third_party/pigweed/repo/pw_build/pigweed.cmake)
+pw_set_backend(pw_log pw_log_basic)
+pw_set_backend(pw_assert pw_assert_log)
+pw_set_backend(pw_sys_io pw_sys_io.esp32)
+
+add_subdirectory(third_party/connectedhomeip/third_party/pigweed/repo)
+add_subdirectory(third_party/connectedhomeip/third_party/nanopb/repo)
+add_subdirectory(third_party/connectedhomeip/examples/platform/esp32/pw_sys_io)
+
+get_target_property(_target_cxx_flags pw_build.cpp17 INTERFACE_COMPILE_OPTIONS)
+list(REMOVE_ITEM _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>)
+list(APPEND _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++17>)
+set_target_properties(pw_build.cpp17 PROPERTIES INTERFACE_COMPILE_OPTIONS "${_target_cxx_flags}")
+endif(CONFIG_ENABLE_PW_RPC)

--- a/examples/temperature-measurement-app/esp32/main/CMakeLists.txt
+++ b/examples/temperature-measurement-app/esp32/main/CMakeLists.txt
@@ -16,11 +16,12 @@
 #
 #
 # (Uses default behaviour of compiling all source files in directory, adding 'include' to include path.)
-idf_component_register(PRIV_INCLUDE_DIRS
+set(PRIV_INCLUDE_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/zzz_generated/temperature-measurement-app/"
                       "${CMAKE_CURRENT_LIST_DIR}/include"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32"
-                      SRC_DIRS
+)
+set(SRC_DIRS_LIST
                       "${CMAKE_CURRENT_LIST_DIR}"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/zzz_generated/temperature-measurement-app/zap-generated"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/zzz_generated/app-common/app-common/zap-generated/attributes"
@@ -49,7 +50,131 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/network-commissioning"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/operational-credentials-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/route_hook"
-                      PRIV_REQUIRES chip QRCode bt)
+)
 
-set_property(TARGET ${COMPONENT_LIB} PROPERTY CXX_STANDARD 14)
+set(PRIV_REQUIRES_LIST chip QRCode bt)
+
+if (CONFIG_ENABLE_PW_RPC)
+# Append additional directories for RPC build
+set(PRIV_INCLUDE_DIRS_LIST  "${PRIV_INCLUDE_DIRS_LIST}"
+                     "${CMAKE_SOURCE_DIR}/../../platform/esp32/pw_sys_io/public"
+                     "${CMAKE_SOURCE_DIR}/../../common"
+                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
+                     "${CMAKE_SOURCE_DIR}/../../../src/lib/support"
+                     "${IDF_PATH}/components/freertos/include/freertos"
+)
+set(SRC_DIRS_LIST  "${SRC_DIRS_LIST}"
+                     "${CMAKE_SOURCE_DIR}/../../platform/esp32"
+                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
+)
+endif (CONFIG_ENABLE_PW_RPC)
+
+idf_component_register(PRIV_INCLUDE_DIRS ${PRIV_INCLUDE_DIRS_LIST}
+                       SRC_DIRS ${SRC_DIRS_LIST}
+                       PRIV_REQUIRES ${PRIV_REQUIRES_LIST})
+
+set_property(TARGET ${COMPONENT_LIB} PROPERTY CXX_STANDARD 17)
 target_compile_options(${COMPONENT_LIB} PRIVATE "-DLWIP_IPV6_SCOPES=0" "-DCHIP_HAVE_CONFIG_H")
+
+if (CONFIG_ENABLE_PW_RPC)
+
+get_filename_component(CHIP_ROOT ../third_party/connectedhomeip REALPATH)
+
+set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")
+include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)
+include(${PIGWEED_ROOT}/pw_protobuf_compiler/proto.cmake)
+set(dir_pw_third_party_nanopb "${CHIP_ROOT}/third_party/nanopb/repo" CACHE STRING "" FORCE)
+
+pw_proto_library(attributes_service
+  SOURCES
+    ${CHIP_ROOT}/examples/common/pigweed/protos/attributes_service.proto
+  INPUTS
+    ${CHIP_ROOT}/examples/common/pigweed/protos/attributes_service.options
+  PREFIX
+    attributes_service
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_protos
+)
+
+pw_proto_library(button_service
+  SOURCES
+    ${CHIP_ROOT}/examples/common/pigweed/protos/button_service.proto
+  PREFIX
+    button_service
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_protos
+)
+
+pw_proto_library(descriptor_service
+  SOURCES
+    ${CHIP_ROOT}/examples/common/pigweed/protos/descriptor_service.proto
+  PREFIX
+    descriptor_service
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_protos
+)
+
+pw_proto_library(device_service
+  SOURCES
+    ${CHIP_ROOT}/examples/common/pigweed/protos/device_service.proto
+  INPUTS
+    ${CHIP_ROOT}/examples/common/pigweed/protos/device_service.options
+  PREFIX
+    device_service
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_protos
+)
+
+pw_proto_library(wifi_service
+  SOURCES
+    ${CHIP_ROOT}/examples/common/pigweed/protos/wifi_service.proto
+  INPUTS
+    ${CHIP_ROOT}/examples/common/pigweed/protos/wifi_service.options
+  PREFIX
+    wifi_service
+  DEPS
+    pw_protobuf.common_protos
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/common/pigweed/protos
+)
+
+target_link_libraries(${COMPONENT_LIB} PUBLIC
+  attributes_service.nanopb_rpc
+  button_service.nanopb_rpc
+  descriptor_service.nanopb_rpc
+  device_service.nanopb_rpc
+  wifi_service.nanopb_rpc
+  pw_checksum
+  pw_hdlc
+  pw_log
+  pw_rpc.server
+  pw_trace_tokenized
+  pw_trace_tokenized.trace_buffer
+  pw_trace_tokenized.rpc_service
+  pw_trace_tokenized.protos.nanopb_rpc
+)
+
+target_link_options(${COMPONENT_LIB}
+  PUBLIC
+    "-T${PIGWEED_ROOT}/pw_tokenizer/pw_tokenizer_linker_sections.ld"
+)
+
+target_compile_options(${COMPONENT_LIB} PRIVATE
+                       "-DPW_RPC_ATTRIBUTE_SERVICE=1"
+                       "-DPW_RPC_BUTTON_SERVICE=1"
+                       "-DPW_RPC_DESCRIPTOR_SERVICE=1"
+                       "-DPW_RPC_DEVICE_SERVICE=1"
+                       "-DPW_RPC_TRACING_SERVICE=1"
+                       "-DPW_RPC_WIFI_SERVICE=1")
+
+endif (CONFIG_ENABLE_PW_RPC)

--- a/examples/temperature-measurement-app/esp32/main/Kconfig.projbuild
+++ b/examples/temperature-measurement-app/esp32/main/Kconfig.projbuild
@@ -62,3 +62,41 @@ menu "Demo"
        default 8 if RENDEZVOUS_MODE_ETHERNET
 
 endmenu
+
+menu "PW RPC Debug channel"
+depends on ENABLE_PW_RPC
+    config EXAMPLE_UART_PORT_NUM
+        int "UART port number"
+        range 0 2 if IDF_TARGET_ESP32
+        range 0 1 if IDF_TARGET_ESP32C3
+        default 0
+        help
+            UART communication port number for the example.
+            See UART documentation for available port numbers.
+
+    config EXAMPLE_UART_BAUD_RATE
+        int "UART communication speed"
+        range 1200 115200
+        default 115200
+        help
+            UART communication speed for Modbus example.
+
+    config EXAMPLE_UART_RXD
+        int "UART RXD pin number"
+        range 0 34 if IDF_TARGET_ESP32
+        range 0 19 if IDF_TARGET_ESP32C3
+        default 5
+        help
+            GPIO number for UART RX pin. See UART documentation for more information
+            about available pin numbers for UART.
+
+    config EXAMPLE_UART_TXD
+        int "UART TXD pin number"
+        range 0 34 if IDF_TARGET_ESP32
+        range 0 19 if IDF_TARGET_ESP32C3
+        default 4
+        help
+            GPIO number for UART TX pin. See UART documentation for more information
+            about available pin numbers for UART.
+
+endmenu

--- a/examples/temperature-measurement-app/esp32/main/main.cpp
+++ b/examples/temperature-measurement-app/esp32/main/main.cpp
@@ -40,6 +40,10 @@
 
 #include <lib/support/ErrorStr.h>
 
+#if CONFIG_ENABLE_PW_RPC
+#include "Rpc.h"
+#endif
+
 using namespace ::chip;
 using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
@@ -64,6 +68,10 @@ static void InitServer(intptr_t context)
 
 extern "C" void app_main()
 {
+#if CONFIG_ENABLE_PW_RPC
+    chip::rpc::Init();
+#endif
+
     ESP_LOGI(TAG, "Temperature sensor!");
 
     /* Print chip information */

--- a/examples/temperature-measurement-app/esp32/sdkconfig_rpc.defaults
+++ b/examples/temperature-measurement-app/esp32/sdkconfig_rpc.defaults
@@ -1,0 +1,93 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#    Copyright (c) 2018 Nest Labs, Inc.
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#    Description:
+#      Some useful defaults for the demo app configuration.
+#
+
+
+# Default to 921600 baud when flashing and monitoring device
+CONFIG_ESPTOOLPY_BAUD_921600B=y
+CONFIG_ESPTOOLPY_BAUD=921600
+CONFIG_ESPTOOLPY_COMPRESSED=y
+CONFIG_ESPTOOLPY_MONITOR_BAUD_115200B=y
+CONFIG_ESPTOOLPY_MONITOR_BAUD=115200
+
+#enable BT
+CONFIG_BT_ENABLED=y
+CONFIG_BT_NIMBLE_ENABLED=y
+
+#enable lwip ipv6 autoconfig
+CONFIG_LWIP_IPV6_AUTOCONFIG=y
+
+# Use a custom partition table
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
+
+# Compiler options
+CONFIG_COMPILER_OPTIMIZATION_SIZE=y
+CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLE=y
+
+# Bluetooth controller
+CONFIG_BTDM_CTRL_BLE_MAX_CONN=1
+CONFIG_BTDM_CTRL_BLE_MAX_CONN_EFF=1
+
+# NimBLE Options 
+CONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
+
+# Wi-Fi
+CONFIG_ESP32_WIFI_STATIC_RX_BUFFER_NUM=4
+CONFIG_ESP32_WIFI_DYNAMIC_RX_BUFFER_NUM=8
+CONFIG_ESP32_WIFI_DYNAMIC_TX_BUFFER_NUM=16
+
+# FreeRTOS
+CONFIG_FREERTOS_UNICORE=y
+
+# Add RTC memory to system heap
+CONFIG_ESP_SYSTEM_ALLOW_RTC_FAST_MEM_AS_HEAP=y
+
+# LWIP
+CONFIG_LWIP_TCPIP_RECVMBOX_SIZE=16
+
+# TCP
+CONFIG_LWIP_TCP_SYNMAXRTX=6
+
+# Compatibility options
+CONFIG_BTDM_CONTROLLER_BLE_MAX_CONN=1
+CONFIG_BTDM_CONTROLLER_BLE_MAX_CONN_EFF=1
+CONFIG_NIMBLE_MAX_CONNECTIONS=1
+CONFIG_TCPIP_RECVMBOX_SIZE=16
+CONFIG_TCP_SYNMAXRTX=6
+
+# Product id
+CONFIG_DEVICE_VENDOR_ID=0xFFF1
+CONFIG_DEVICE_PRODUCT_ID=0x800D
+
+# Main task needs a bit more stack than the default
+# default is 3584, bump this up to 4k.
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=4096
+
+#enable lwIP route hooks
+CONFIG_LWIP_HOOK_IP6_ROUTE_DEFAULT=y
+CONFIG_LWIP_HOOK_ND6_GET_GW_DEFAULT=y
+
+# PW RPC Debug channel
+CONFIG_EXAMPLE_UART_PORT_NUM=0
+CONFIG_EXAMPLE_UART_BAUD_RATE=115200
+CONFIG_EXAMPLE_UART_RXD=3
+CONFIG_EXAMPLE_UART_TXD=1
+CONFIG_ENABLE_PW_RPC=y

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -231,6 +231,7 @@ def Esp32Targets():
     yield devkitc.Extend('lock', app=Esp32App.LOCK)
     yield devkitc.Extend('bridge', app=Esp32App.BRIDGE)
     yield devkitc.Extend('temperature-measurement', app=Esp32App.TEMPERATURE_MEASUREMENT)
+    yield devkitc.Extend('temperature-measurement-rpc', app=Esp32App.TEMPERATURE_MEASUREMENT, enable_rpcs=True)
 
     yield esp32_target.Extend('qemu-tests', board=Esp32Board.QEMU, app=Esp32App.TESTS)
 

--- a/scripts/build/builders/esp32.py
+++ b/scripts/build/builders/esp32.py
@@ -96,7 +96,7 @@ class Esp32App(Enum):
 def DefaultsFileName(board: Esp32Board, app: Esp32App, enable_rpcs: bool):
     if app == Esp32App.TESTS:
         return 'sdkconfig_qemu.defaults'
-    elif app != Esp32App.ALL_CLUSTERS:
+    elif app != Esp32App.ALL_CLUSTERS and app != Esp32App.TEMPERATURE_MEASUREMENT:
         return 'sdkconfig.defaults'
 
     rpc = "_rpc" if enable_rpcs else ""

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -81,6 +81,7 @@ esp32-devkitc-light
 esp32-devkitc-lock
 esp32-devkitc-shell
 esp32-devkitc-temperature-measurement
+esp32-devkitc-temperature-measurement-rpc
 esp32-m5stack-all-clusters
 esp32-m5stack-all-clusters-ipv6only
 esp32-m5stack-all-clusters-rpc

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -433,6 +433,17 @@ bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh;
 export SDKCONFIG_DEFAULTS={out}/esp32-devkitc-temperature-measurement/sdkconfig.defaults
 idf.py -C examples/temperature-measurement-app/esp32 -B {out}/esp32-devkitc-temperature-measurement reconfigure'
 
+# Generating esp32-devkitc-temperature-measurement-rpc
+mkdir -p {out}/esp32-devkitc-temperature-measurement-rpc
+
+cp examples/temperature-measurement-app/esp32/sdkconfig_rpc.defaults {out}/esp32-devkitc-temperature-measurement-rpc/sdkconfig.defaults
+
+rm -f examples/temperature-measurement-app/esp32/sdkconfig
+
+bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh; 
+export SDKCONFIG_DEFAULTS={out}/esp32-devkitc-temperature-measurement-rpc/sdkconfig.defaults
+idf.py -C examples/temperature-measurement-app/esp32 -B {out}/esp32-devkitc-temperature-measurement-rpc reconfigure'
+
 # Generating esp32-m5stack-all-clusters
 mkdir -p {out}/esp32-m5stack-all-clusters
 
@@ -1141,6 +1152,13 @@ rm -f examples/temperature-measurement-app/esp32/sdkconfig
 bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh; 
 export SDKCONFIG_DEFAULTS={out}/esp32-devkitc-temperature-measurement/sdkconfig.defaults
 idf.py -C examples/temperature-measurement-app/esp32 -B {out}/esp32-devkitc-temperature-measurement build'
+
+rm -f examples/temperature-measurement-app/esp32/sdkconfig
+
+# Building esp32-devkitc-temperature-measurement-rpc
+bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh; 
+export SDKCONFIG_DEFAULTS={out}/esp32-devkitc-temperature-measurement-rpc/sdkconfig.defaults
+idf.py -C examples/temperature-measurement-app/esp32 -B {out}/esp32-devkitc-temperature-measurement-rpc build'
 
 rm -f examples/all-clusters-app/esp32/sdkconfig
 

--- a/scripts/build/testdata/glob_star_targets_except_host.txt
+++ b/scripts/build/testdata/glob_star_targets_except_host.txt
@@ -32,6 +32,7 @@ esp32-devkitc-light
 esp32-devkitc-lock
 esp32-devkitc-shell
 esp32-devkitc-temperature-measurement
+esp32-devkitc-temperature-measurement-rpc
 esp32-m5stack-all-clusters
 esp32-m5stack-all-clusters-ipv6only
 esp32-m5stack-all-clusters-rpc


### PR DESCRIPTION
#### Problem
RPC variant of the temperature app is needed for testing.

#### Change overview
- Add Attribute, Button, Descriptor, Device, and Wifi RPC services to the temperature app (when built with RPCs)
- Add new RPC build target for temp app.

#### Testing
Built the RPC variant for DevC board, flashed and verified the RPCs worked with the console.
