### PR TITLE
[ESP32] Fix flashing_script dependency on partition table

### DIFF
--- a/examples/common/cmake/idf_flashing.cmake
+++ b/examples/common/cmake/idf_flashing.cmake
@@ -84,6 +84,7 @@ macro(flashing_script)
             --use-sdkconfig ${project_path}/sdkconfig
     WORKING_DIRECTORY ${build_dir}
     DEPENDS "${build_dir}/${board_firmware_utils}"
+            "${build_dir}/${partition_table}"
             "${build_dir}/firmware_utils.py"
             "${build_dir_deps}"
     COMMENT "To flash ${build_dir}/${CMAKE_PROJECT_NAME}.bin run ./build/${CMAKE_PROJECT_NAME}.flash.py"


### PR DESCRIPTION
#### Problem

`gen_flashing_script.py` for ESP32 occasionally fails; it turns out
that there is no dependency declared on the partition table, which
is a required input.

#### Change overview

Add the depencency.

#### Testing

Manual build works (but may have merely won the race).
