### PR TITLE
Correct link to python controller advanced usage document

### DIFF
--- a/src/controller/python/README.md
+++ b/src/controller/python/README.md
@@ -8,4 +8,4 @@ To learn more about the tool, how to build it and use its commands and advanced
 features, read the following guides:
 
 -   [Working with Python CHIP Controller](../../../docs/guides/python_chip_controller_building.md)
--   [Using Python CHIP Controller advanced features](../../../docs/guides/ADVANCED_USAGE.md)
+-   [Using Python CHIP Controller advanced features](../../../docs/guides/python_chip_controller_advanced_usage.md)


### PR DESCRIPTION
#### Problem
Link is 404ing

#### Change overview
Link to existing Markdown file.

#### Testing
Clicked the link in the preview.