### PR TITLE
Fix member name for address resolve address pick

### DIFF
--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -109,13 +109,13 @@ void NodeLookupHandle::LookupResult(const ResolveResult & result)
         mBestResult       = result;
         mBestAddressScore = newScore;
 
-        if (!mBestPeerAddress.GetIPAddress().IsIPv6LinkLocal())
+        if (!mBestResult.address.GetIPAddress().IsIPv6LinkLocal())
         {
             // Only use the DNS-SD resolution's InterfaceID for addresses that are IPv6 LLA.
             // For all other addresses, we should rely on the device's routing table to route messages sent.
             // Forcing messages down an InterfaceId might fail. For example, in bridged networks like Thread,
             // mDNS advertisements are not usually received on the same interface the peer is reachable on.
-            mBestPeerAddress.SetInterface(Inet::InterfaceId::Null());
+            mBestResult.address.SetInterface(Inet::InterfaceId::Null());
             ChipLogDetail(Discovery, "Lookup clearing interface for non LL address");
         }
 


### PR DESCRIPTION
#### Problem
Racy merge resulted in ToT breakage

#### Change overview
Fix member names

#### Testing
Compile checked locally.