### PR TITLE
Update step naming for smoke tests

### DIFF
--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
     android:
-        name: Run
+        name: Smoke Run - Android
         timeout-minutes: 60
 
         env:

--- a/.github/workflows/smoketest-mbed.yaml
+++ b/.github/workflows/smoketest-mbed.yaml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
     mbedos:
-        name: Run
+        name: Smoke Run - MbedOS
         timeout-minutes: 30
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'

--- a/.github/workflows/smoketest-nrfconnect.yaml
+++ b/.github/workflows/smoketest-nrfconnect.yaml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
     nrfconnect:
-        name: Run
+        name: Smoke Run - nRF Connect SDK
         timeout-minutes: 30
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'


### PR DESCRIPTION
#### Problem
Branch protection rules just use the job name to protect and a name of 'RUN' is not very user friendly.

#### Change overview
Chane the run name to be more explicit so I can use it in branch protection rules.

#### Testing
CI will validate (new names should be used).