### PR TITLE
Update media cluster for spec 1.0

### DIFF
--- a/examples/tv-app/android/java/ChannelManager.cpp
+++ b/examples/tv-app/android/java/ChannelManager.cpp
@@ -27,6 +27,7 @@
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters::Channel;
+using namespace chip::Uint8;
 
 /** @brief Channel  Cluster Init
  *
@@ -245,8 +246,7 @@ void ChannelManager::HandleChangeChannel(CommandResponseHelper<ChangeChannelResp
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
 
     ChangeChannelResponseType response;
-    response.channelMatch.majorNumber = 0;
-    response.channelMatch.minorNumber = 0;
+    response.data = chip::MakeOptional(CharSpan::fromCharString("data response"));
 
     ChipLogProgress(Zcl, "Received ChannelManager::HandleChangeChannel name %s", name.c_str());
     VerifyOrExit(mChannelManagerObject != nullptr, ChipLogError(Zcl, "mChannelManagerObject null"));
@@ -270,37 +270,6 @@ void ChannelManager::HandleChangeChannel(CommandResponseHelper<ChangeChannelResp
         jfieldID getStatusField = env->GetFieldID(channelClass, "status", "I");
         jint jstatus            = env->GetIntField(channelObject, getStatusField);
         response.status         = static_cast<app::Clusters::Channel::StatusEnum>(jstatus);
-
-        jfieldID getCallSignField = env->GetFieldID(channelClass, "callSign", "Ljava/lang/String;");
-        jstring jcallSign         = static_cast<jstring>(env->GetObjectField(channelObject, getCallSignField));
-        if (jcallSign != NULL)
-        {
-            JniUtfString callsign(env, jcallSign);
-            response.channelMatch.callSign = Optional<CharSpan>(callsign.charSpan());
-        }
-
-        jfieldID getNameField = env->GetFieldID(channelClass, "name", "Ljava/lang/String;");
-        jstring jname         = static_cast<jstring>(env->GetObjectField(channelObject, getNameField));
-        if (jname != NULL)
-        {
-            JniUtfString junitname(env, jname);
-            response.channelMatch.name = Optional<CharSpan>(junitname.charSpan());
-        }
-        jfieldID getJaffiliateCallSignField = env->GetFieldID(channelClass, "affiliateCallSign", "Ljava/lang/String;");
-        jstring jaffiliateCallSign          = static_cast<jstring>(env->GetObjectField(channelObject, getJaffiliateCallSignField));
-        if (jaffiliateCallSign != NULL)
-        {
-            JniUtfString affiliateCallSign(env, jaffiliateCallSign);
-            response.channelMatch.affiliateCallSign = Optional<CharSpan>(affiliateCallSign.charSpan());
-        }
-
-        jfieldID majorNumField            = env->GetFieldID(channelClass, "majorNumber", "I");
-        jint jmajorNum                    = env->GetIntField(channelObject, majorNumField);
-        response.channelMatch.majorNumber = static_cast<uint16_t>(jmajorNum);
-
-        jfieldID minorNumField            = env->GetFieldID(channelClass, "minorNumber", "I");
-        jint jminorNum                    = env->GetIntField(channelObject, minorNumField);
-        response.channelMatch.minorNumber = static_cast<uint16_t>(jminorNum);
 
         helper.Success(response);
     }

--- a/examples/tv-app/android/java/MediaPlaybackManager.cpp
+++ b/examples/tv-app/android/java/MediaPlaybackManager.cpp
@@ -30,6 +30,8 @@ using namespace chip;
 using namespace chip::app;
 using namespace chip::app::DataModel;
 using namespace chip::app::Clusters::MediaPlayback;
+using namespace chip::Uint8;
+using chip::CharSpan;
 
 /** @brief Media PlayBack Cluster Init
  *

--- a/examples/tv-app/linux/include/channel/ChannelManager.cpp
+++ b/examples/tv-app/linux/include/channel/ChannelManager.cpp
@@ -133,10 +133,10 @@ void ChannelManager::HandleChangeChannel(CommandResponseHelper<ChangeChannelResp
     }
     else
     {
-        response.status       = chip::app::Clusters::Channel::StatusEnum::kSuccess;
-        response.data         = chip::MakeOptional(CharSpan::fromCharString("data response"));
-        mCurrentChannel       = matchedChannels[0];
-        mCurrentChannelIndex  = index;
+        response.status      = chip::app::Clusters::Channel::StatusEnum::kSuccess;
+        response.data        = chip::MakeOptional(CharSpan::fromCharString("data response"));
+        mCurrentChannel      = matchedChannels[0];
+        mCurrentChannelIndex = index;
         helper.Success(response);
     }
 }

--- a/examples/tv-app/linux/include/channel/ChannelManager.cpp
+++ b/examples/tv-app/linux/include/channel/ChannelManager.cpp
@@ -21,6 +21,7 @@
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters::Channel;
+using namespace chip::Uint8;
 
 ChannelManager::ChannelManager()
 {
@@ -133,7 +134,7 @@ void ChannelManager::HandleChangeChannel(CommandResponseHelper<ChangeChannelResp
     else
     {
         response.status       = chip::app::Clusters::Channel::StatusEnum::kSuccess;
-        response.channelMatch = matchedChannels[0];
+        response.data         = chip::MakeOptional(CharSpan::fromCharString("data response"));
         mCurrentChannel       = matchedChannels[0];
         mCurrentChannelIndex  = index;
         helper.Success(response);

--- a/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
+++ b/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
@@ -20,6 +20,8 @@
 using namespace std;
 using namespace chip::app::DataModel;
 using namespace chip::app::Clusters::MediaPlayback;
+using namespace chip::Uint8;
+using chip::CharSpan;
 
 PlaybackStateEnum MediaPlaybackManager::HandleGetCurrentState()
 {
@@ -61,6 +63,7 @@ void MediaPlaybackManager::HandlePlay(CommandResponseHelper<Commands::PlaybackRe
     // TODO: Insert code here
     mCurrentState = PlaybackStateEnum::kPlaying;
     Commands::PlaybackResponse::Type response;
+    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
 }
@@ -70,6 +73,7 @@ void MediaPlaybackManager::HandlePause(CommandResponseHelper<Commands::PlaybackR
     // TODO: Insert code here
     mCurrentState = PlaybackStateEnum::kPaused;
     Commands::PlaybackResponse::Type response;
+    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
 }
@@ -79,6 +83,7 @@ void MediaPlaybackManager::HandleStop(CommandResponseHelper<Commands::PlaybackRe
     // TODO: Insert code here
     mCurrentState = PlaybackStateEnum::kNotPlaying;
     Commands::PlaybackResponse::Type response;
+    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
 }
@@ -87,6 +92,7 @@ void MediaPlaybackManager::HandleFastForward(CommandResponseHelper<Commands::Pla
 {
     // TODO: Insert code here
     Commands::PlaybackResponse::Type response;
+    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
 }
@@ -96,6 +102,7 @@ void MediaPlaybackManager::HandlePrevious(CommandResponseHelper<Commands::Playba
     // TODO: Insert code here
     mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(0) };
     Commands::PlaybackResponse::Type response;
+    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
 }
@@ -105,6 +112,7 @@ void MediaPlaybackManager::HandleRewind(CommandResponseHelper<Commands::Playback
     // TODO: Insert code here
     mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(0) };
     Commands::PlaybackResponse::Type response;
+    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
 }
@@ -117,6 +125,7 @@ void MediaPlaybackManager::HandleSkipBackward(CommandResponseHelper<Commands::Pl
     mPlaybackPosition    = { 0, chip::app::DataModel::Nullable<uint64_t>(newPosition) };
 
     Commands::PlaybackResponse::Type response;
+    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
 }
@@ -130,6 +139,7 @@ void MediaPlaybackManager::HandleSkipForward(CommandResponseHelper<Commands::Pla
     mPlaybackPosition    = { 0, chip::app::DataModel::Nullable<uint64_t>(newPosition) };
 
     Commands::PlaybackResponse::Type response;
+    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
 }
@@ -141,6 +151,7 @@ void MediaPlaybackManager::HandleSeek(CommandResponseHelper<Commands::PlaybackRe
     if (positionMilliseconds > mDuration)
     {
         Commands::PlaybackResponse::Type response;
+        response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
         response.status = StatusEnum::kSeekOutOfRange;
         helper.Success(response);
     }
@@ -149,6 +160,7 @@ void MediaPlaybackManager::HandleSeek(CommandResponseHelper<Commands::PlaybackRe
         mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(positionMilliseconds) };
 
         Commands::PlaybackResponse::Type response;
+        response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
         response.status = StatusEnum::kSuccess;
         helper.Success(response);
     }
@@ -158,6 +170,7 @@ void MediaPlaybackManager::HandleNext(CommandResponseHelper<Commands::PlaybackRe
 {
     // TODO: Insert code here
     Commands::PlaybackResponse::Type response;
+    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
 }
@@ -167,6 +180,7 @@ void MediaPlaybackManager::HandleStartOver(CommandResponseHelper<Commands::Playb
     // TODO: Insert code here
     mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(0) };
     Commands::PlaybackResponse::Type response;
+    response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
     response.status = StatusEnum::kSuccess;
     helper.Success(response);
 }

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -347,8 +347,8 @@ server cluster Channel = 1284 {
   }
 
   response struct ChangeChannelResponse {
-    ChannelInfo channelMatch = 0;
-    StatusEnum status = 1;
+    StatusEnum status = 0;
+    optional CHAR_STRING data = 1;
   }
 
   command ChangeChannel(ChangeChannelRequest): ChangeChannelResponse = 0;
@@ -1064,6 +1064,7 @@ server cluster MediaPlayback = 1286 {
 
   response struct PlaybackResponse {
     StatusEnum status = 0;
+    optional CHAR_STRING data = 1;
   }
 
   command FastForward(): PlaybackResponse = 7;

--- a/src/app/tests/suites/TV_ChannelCluster.yaml
+++ b/src/app/tests/suites/TV_ChannelCluster.yaml
@@ -97,17 +97,10 @@ tests:
                 value: "PBS"
       response:
           values:
+              - name: "data"
+                value: "data response"
               - name: "status"
                 value: 0
-              - name: "channelMatch"
-                value:
-                    {
-                        majorNumber: 9,
-                        minorNumber: 1,
-                        name: "PBS",
-                        callSign: "KCTS-TV",
-                        affiliateCallSign: "KCTS",
-                    }
 
     - label: "Change Channel By Number Command"
       command: "changeChannelByNumber"

--- a/src/app/tests/suites/TV_MediaPlaybackCluster.yaml
+++ b/src/app/tests/suites/TV_MediaPlaybackCluster.yaml
@@ -79,7 +79,6 @@ tests:
               - name: "status"
                 value: 0
 
-
     - label: "Media Playback Pause Command"
       command: "pause"
       response:
@@ -88,7 +87,6 @@ tests:
                 value: "data response"
               - name: "status"
                 value: 0
-
 
     - label: "Media Playback Stop Command"
       command: "stopPlayback"
@@ -99,7 +97,6 @@ tests:
               - name: "status"
                 value: 0
 
-
     - label: "Media Playback Start Over Command"
       command: "startOver"
       response:
@@ -108,7 +105,6 @@ tests:
                 value: "data response"
               - name: "status"
                 value: 0
-
 
     - label: "Media Playback Previous Command"
       command: "previous"
@@ -119,7 +115,6 @@ tests:
               - name: "status"
                 value: 0
 
-
     - label: "Media Playback Next Command"
       command: "next"
       response:
@@ -128,7 +123,6 @@ tests:
                 value: "data response"
               - name: "status"
                 value: 0
-
 
     - label: "Media Playback Rewind Command"
       command: "rewind"
@@ -139,7 +133,6 @@ tests:
               - name: "status"
                 value: 0
 
-
     - label: "Media Playback Fast Forward Command"
       command: "fastForward"
       response:
@@ -148,7 +141,6 @@ tests:
                 value: "data response"
               - name: "status"
                 value: 0
-
 
     - label: "Media Playback Skip Forward Command"
       command: "skipForward"
@@ -162,7 +154,6 @@ tests:
                 value: "data response"
               - name: "status"
                 value: 0
-
 
     - label: "Read attribute position after skip forward"
       command: "readAttribute"
@@ -183,7 +174,6 @@ tests:
               - name: "status"
                 value: 0
 
-
     - label: "Read attribute position after skip backward"
       command: "readAttribute"
       attribute: "SampledPosition"
@@ -202,7 +192,6 @@ tests:
                 value: "data response"
               - name: "status"
                 value: 0
-
 
     - label: "Read attribute position after seek"
       command: "readAttribute"

--- a/src/app/tests/suites/TV_MediaPlaybackCluster.yaml
+++ b/src/app/tests/suites/TV_MediaPlaybackCluster.yaml
@@ -74,57 +74,81 @@ tests:
       command: "play"
       response:
           values:
+              - name: "data"
+                value: "data response"
               - name: "status"
                 value: 0
+
 
     - label: "Media Playback Pause Command"
       command: "pause"
       response:
           values:
+              - name: "data"
+                value: "data response"
               - name: "status"
                 value: 0
+
 
     - label: "Media Playback Stop Command"
       command: "stopPlayback"
       response:
           values:
+              - name: "data"
+                value: "data response"
               - name: "status"
                 value: 0
+
 
     - label: "Media Playback Start Over Command"
       command: "startOver"
       response:
           values:
+              - name: "data"
+                value: "data response"
               - name: "status"
                 value: 0
+
 
     - label: "Media Playback Previous Command"
       command: "previous"
       response:
           values:
+              - name: "data"
+                value: "data response"
               - name: "status"
                 value: 0
+
 
     - label: "Media Playback Next Command"
       command: "next"
       response:
           values:
+              - name: "data"
+                value: "data response"
               - name: "status"
                 value: 0
+
 
     - label: "Media Playback Rewind Command"
       command: "rewind"
       response:
           values:
+              - name: "data"
+                value: "data response"
               - name: "status"
                 value: 0
+
 
     - label: "Media Playback Fast Forward Command"
       command: "fastForward"
       response:
           values:
+              - name: "data"
+                value: "data response"
               - name: "status"
                 value: 0
+
 
     - label: "Media Playback Skip Forward Command"
       command: "skipForward"
@@ -134,8 +158,11 @@ tests:
                 value: 500
       response:
           values:
+              - name: "data"
+                value: "data response"
               - name: "status"
                 value: 0
+
 
     - label: "Read attribute position after skip forward"
       command: "readAttribute"
@@ -151,8 +178,11 @@ tests:
                 value: 100
       response:
           values:
+              - name: "data"
+                value: "data response"
               - name: "status"
                 value: 0
+
 
     - label: "Read attribute position after skip backward"
       command: "readAttribute"
@@ -168,8 +198,11 @@ tests:
                 value: 1000
       response:
           values:
+              - name: "data"
+                value: "data response"
               - name: "status"
                 value: 0
+
 
     - label: "Read attribute position after seek"
       command: "readAttribute"

--- a/src/app/zap-templates/zcl/data-model/chip/channel-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/channel-cluster.xml
@@ -46,8 +46,8 @@ limitations under the License.
 
     <command source="server" code="0x01" name="ChangeChannelResponse" optional="false">
       <description>Upon receipt, this SHALL display the active status of the input list on screen.</description>
-      <arg name="channelMatch" type="ChannelInfo"/>
-      <arg name="status"       type="StatusEnum"/>
+      <arg name="status" type="StatusEnum"/>
+      <arg name="data"   type="CHAR_STRING" optional="true"/>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/media-playback-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-playback-cluster.xml
@@ -84,6 +84,7 @@ limitations under the License.
     <command source="server" code="0x0A" name="PlaybackResponse" optional="false">
       <description>This command SHALL be generated in response to various Playback Request commands.</description>
       <arg name="status" type="StatusEnum"/>
+      <arg name="data"   type="CHAR_STRING" optional="true"/>
     </command>
 
   </cluster>
@@ -91,24 +92,24 @@ limitations under the License.
   <struct name="PlaybackPosition">
     <cluster code="0x0506"/>
     <item name="updatedAt" type="INT64U"/>
-    <item name="position" type="INT64U" isNullable="true"/>    
+    <item name="position"  type="INT64U" isNullable="true"/>    
   </struct>
 
   <enum name="PlaybackStateEnum" type="ENUM8">
     <cluster code="0x0506"/>
-    <item name="Playing" value="0x00"/>
-    <item name="Paused" value="0x01"/>
+    <item name="Playing"    value="0x00"/>
+    <item name="Paused"     value="0x01"/>
     <item name="NotPlaying" value="0x02"/>
-    <item name="Buffering" value="0x03"/>
+    <item name="Buffering"  value="0x03"/>
   </enum>
 
   <enum name="StatusEnum" type="ENUM8">
     <cluster code="0x0506"/>
-    <item name="Success" value="0x00"/>
+    <item name="Success"                value="0x00"/>
     <item name="InvalidStateForCommand" value="0x01"/>
-    <item name="NotAllowed" value="0x02"/>
-    <item name="NotActive" value="0x03"/>
-    <item name="SpeedOutOfRange" value="0x04"/>
-    <item name="SeekOutOfRange" value="0x05"/>
+    <item name="NotAllowed"             value="0x02"/>
+    <item name="NotActive"              value="0x03"/>
+    <item name="SpeedOutOfRange"        value="0x04"/>
+    <item name="SeekOutOfRange"         value="0x05"/>
   </enum>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/target-navigator-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/target-navigator-cluster.xml
@@ -30,26 +30,26 @@ limitations under the License.
     <command source="client" code="0x00" name="NavigateTarget" response="NavigateTargetResponse" optional="false">
       <description>Upon receipt, this SHALL navigation the UX to the target identified.</description>
       <arg name="target" type="INT8U"/>
-      <arg name="data" type="CHAR_STRING" optional="true"/>
+      <arg name="data"   type="CHAR_STRING" optional="true"/>
     </command>
 
     <command source="server" code="0x01" name="NavigateTargetResponse" optional="false">
       <description>This command SHALL be generated in response to NavigateTarget commands.</description>
       <arg name="status" type="StatusEnum"/>
-      <arg name="data" type="CHAR_STRING" optional="true"/>
+      <arg name="data"   type="CHAR_STRING" optional="true"/>
     </command>
   </cluster>
 
   <enum name="StatusEnum" type="ENUM8">
     <cluster code="0x0505"/>
-    <item name="Success" value="0x00"/>
+    <item name="Success"        value="0x00"/>
     <item name="TargetNotFound" value="0x01"/>
-    <item name="NotAllowed" value="0x02"/>
+    <item name="NotAllowed"     value="0x02"/>
   </enum>
 
   <struct name="TargetInfo">
     <cluster code="0x0505"/>
     <item name="identifier" type="INT8U"/>
-    <item name="name" type="CHAR_STRING" length="32"/>
+    <item name="name"       type="CHAR_STRING" length="32"/>
   </struct>
 </configurator>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -596,8 +596,8 @@ client cluster Channel = 1284 {
   }
 
   response struct ChangeChannelResponse {
-    ChannelInfo channelMatch = 0;
-    StatusEnum status = 1;
+    StatusEnum status = 0;
+    optional CHAR_STRING data = 1;
   }
 
   command ChangeChannel(ChangeChannelRequest): ChangeChannelResponse = 0;
@@ -2334,6 +2334,7 @@ client cluster MediaPlayback = 1286 {
 
   response struct PlaybackResponse {
     StatusEnum status = 0;
+    optional CHAR_STRING data = 1;
   }
 
   command FastForward(): PlaybackResponse = 7;

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -3307,7 +3307,7 @@ public class ChipClusters {
         @Nullable Integer timedInvokeTimeoutMs);
 
     public interface ChangeChannelResponseCallback {
-      void onSuccess(ChipStructs.ChannelClusterChannelInfo channelMatch, Integer status);
+      void onSuccess(Integer status, Optional<String> data);
 
       void onError(Exception error);
     }
@@ -10761,7 +10761,7 @@ public class ChipClusters {
         @Nullable Integer timedInvokeTimeoutMs);
 
     public interface PlaybackResponseCallback {
-      void onSuccess(Integer status);
+      void onSuccess(Integer status, Optional<String> data);
 
       void onError(Exception error);
     }

--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
@@ -1427,12 +1427,12 @@ public class ClusterInfoMapping {
     }
 
     @Override
-    public void onSuccess(ChipStructs.ChannelClusterChannelInfo channelMatch, Integer status) {
+    public void onSuccess(Integer status, Optional<String> data) {
       Map<CommandResponseInfo, Object> responseValues = new LinkedHashMap<>();
-      // channelMatch: Struct ChannelInfo
-      // Conversion from this type to Java is not properly implemented yet
       CommandResponseInfo statusResponseValue = new CommandResponseInfo("status", "Integer");
       responseValues.put(statusResponseValue, status);
+      CommandResponseInfo dataResponseValue = new CommandResponseInfo("data", "Optional<String>");
+      responseValues.put(dataResponseValue, data);
       callback.onSuccess(responseValues);
     }
 
@@ -3883,10 +3883,12 @@ public class ClusterInfoMapping {
     }
 
     @Override
-    public void onSuccess(Integer status) {
+    public void onSuccess(Integer status, Optional<String> data) {
       Map<CommandResponseInfo, Object> responseValues = new LinkedHashMap<>();
       CommandResponseInfo statusResponseValue = new CommandResponseInfo("status", "Integer");
       responseValues.put(statusResponseValue, status);
+      CommandResponseInfo dataResponseValue = new CommandResponseInfo("data", "Optional<String>");
+      responseValues.put(dataResponseValue, data);
       callback.onSuccess(responseValues);
     }
 

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -31399,12 +31399,12 @@ class Channel(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="channelMatch", Tag=0, Type=Channel.Structs.ChannelInfo),
-                            ClusterObjectFieldDescriptor(Label="status", Tag=1, Type=Channel.Enums.StatusEnum),
+                            ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=Channel.Enums.StatusEnum),
+                            ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=typing.Optional[str]),
                     ])
 
-            channelMatch: 'Channel.Structs.ChannelInfo' = field(default_factory=lambda: Channel.Structs.ChannelInfo())
             status: 'Channel.Enums.StatusEnum' = 0
+            data: 'typing.Optional[str]' = None
 
         @dataclass
         class ChangeChannelByNumber(ClusterCommand):
@@ -31982,9 +31982,11 @@ class MediaPlayback(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=MediaPlayback.Enums.StatusEnum),
+                            ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=typing.Optional[str]),
                     ])
 
             status: 'MediaPlayback.Enums.StatusEnum' = 0
+            data: 'typing.Optional[str]' = None
 
         @dataclass
         class Seek(ClusterCommand):

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -10150,34 +10150,16 @@ void CHIPChannelClusterChangeChannelResponseCallbackBridge::OnSuccessFn(
 {
     auto * response = [CHIPChannelClusterChangeChannelResponseParams new];
     {
-        response.channelMatch = [CHIPChannelClusterChannelInfo new];
-        response.channelMatch.majorNumber = [NSNumber numberWithUnsignedShort:data.channelMatch.majorNumber];
-        response.channelMatch.minorNumber = [NSNumber numberWithUnsignedShort:data.channelMatch.minorNumber];
-        if (data.channelMatch.name.HasValue()) {
-            response.channelMatch.name = [[NSString alloc] initWithBytes:data.channelMatch.name.Value().data()
-                                                                  length:data.channelMatch.name.Value().size()
-                                                                encoding:NSUTF8StringEncoding];
-        } else {
-            response.channelMatch.name = nil;
-        }
-        if (data.channelMatch.callSign.HasValue()) {
-            response.channelMatch.callSign = [[NSString alloc] initWithBytes:data.channelMatch.callSign.Value().data()
-                                                                      length:data.channelMatch.callSign.Value().size()
-                                                                    encoding:NSUTF8StringEncoding];
-        } else {
-            response.channelMatch.callSign = nil;
-        }
-        if (data.channelMatch.affiliateCallSign.HasValue()) {
-            response.channelMatch.affiliateCallSign =
-                [[NSString alloc] initWithBytes:data.channelMatch.affiliateCallSign.Value().data()
-                                         length:data.channelMatch.affiliateCallSign.Value().size()
-                                       encoding:NSUTF8StringEncoding];
-        } else {
-            response.channelMatch.affiliateCallSign = nil;
-        }
+        response.status = [NSNumber numberWithUnsignedChar:chip::to_underlying(data.status)];
     }
     {
-        response.status = [NSNumber numberWithUnsignedChar:chip::to_underlying(data.status)];
+        if (data.data.HasValue()) {
+            response.data = [[NSString alloc] initWithBytes:data.data.Value().data()
+                                                     length:data.data.Value().size()
+                                                   encoding:NSUTF8StringEncoding];
+        } else {
+            response.data = nil;
+        }
     }
     DispatchSuccess(context, response);
 };
@@ -10659,6 +10641,15 @@ void CHIPMediaPlaybackClusterPlaybackResponseCallbackBridge::OnSuccessFn(
     auto * response = [CHIPMediaPlaybackClusterPlaybackResponseParams new];
     {
         response.status = [NSNumber numberWithUnsignedChar:chip::to_underlying(data.status)];
+    }
+    {
+        if (data.data.HasValue()) {
+            response.data = [[NSString alloc] initWithBytes:data.data.Value().data()
+                                                     length:data.data.Value().size()
+                                                   encoding:NSUTF8StringEncoding];
+        } else {
+            response.data = nil;
+        }
     }
     DispatchSuccess(context, response);
 };

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
@@ -1525,8 +1525,8 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface CHIPChannelClusterChangeChannelResponseParams : NSObject
-@property (strong, nonatomic) CHIPChannelClusterChannelInfo * _Nonnull channelMatch;
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSString * _Nullable data;
 - (instancetype)init;
 @end
 
@@ -1565,6 +1565,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPMediaPlaybackClusterPlaybackResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSString * _Nullable data;
 - (instancetype)init;
 @end
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
@@ -3241,9 +3241,9 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
 
-        _channelMatch = [CHIPChannelClusterChannelInfo new];
-
         _status = @(0);
+
+        _data = nil;
     }
     return self;
 }
@@ -3327,6 +3327,8 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super init]) {
 
         _status = @(0);
+
+        _data = nil;
     }
     return self;
 }

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -14788,9 +14788,8 @@ bool emberAfChannelClusterChangeChannelCallback(
 /**
  * @brief Channel Cluster ChangeChannelResponse Command callback (from server)
  */
-bool emberAfChannelClusterChangeChannelResponseCallback(
-    chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-    chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType channelMatch, uint8_t status);
+bool emberAfChannelClusterChangeChannelResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
+                                                        uint8_t status, chip::CharSpan data);
 /**
  * @brief Channel Cluster ChangeChannelByNumber Command callback (from client)
  */
@@ -14878,7 +14877,7 @@ bool emberAfMediaPlaybackClusterSkipBackwardCallback(
  * @brief Media Playback Cluster PlaybackResponse Command callback (from server)
  */
 bool emberAfMediaPlaybackClusterPlaybackResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                         uint8_t status);
+                                                         uint8_t status, chip::CharSpan data);
 /**
  * @brief Media Playback Cluster Seek Command callback (from client)
  */

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -20275,8 +20275,8 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kChannelMatch)), channelMatch));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kStatus)), status));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kData)), data));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
@@ -20292,11 +20292,11 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         VerifyOrReturnError(TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
         switch (TLV::TagNumFromTag(reader.GetTag()))
         {
-        case to_underlying(Fields::kChannelMatch):
-            ReturnErrorOnFailure(DataModel::Decode(reader, channelMatch));
-            break;
         case to_underlying(Fields::kStatus):
             ReturnErrorOnFailure(DataModel::Decode(reader, status));
+            break;
+        case to_underlying(Fields::kData):
+            ReturnErrorOnFailure(DataModel::Decode(reader, data));
             break;
         default:
             break;
@@ -20947,6 +20947,7 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kStatus)), status));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kData)), data));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
@@ -20964,6 +20965,9 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         {
         case to_underlying(Fields::kStatus):
             ReturnErrorOnFailure(DataModel::Decode(reader, status));
+            break;
+        case to_underlying(Fields::kData):
+            ReturnErrorOnFailure(DataModel::Decode(reader, data));
             break;
         default:
             break;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -31964,8 +31964,8 @@ public:
 namespace ChangeChannelResponse {
 enum class Fields
 {
-    kChannelMatch = 0,
-    kStatus       = 1,
+    kStatus = 0,
+    kData   = 1,
 };
 
 struct Type
@@ -31975,8 +31975,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ChangeChannelResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Channel::Id; }
 
-    Structs::ChannelInfo::Type channelMatch;
     StatusEnum status = static_cast<StatusEnum>(0);
+    Optional<chip::CharSpan> data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -31991,8 +31991,8 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ChangeChannelResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Channel::Id; }
 
-    Structs::ChannelInfo::DecodableType channelMatch;
     StatusEnum status = static_cast<StatusEnum>(0);
+    Optional<chip::CharSpan> data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ChangeChannelResponse
@@ -32795,6 +32795,7 @@ namespace PlaybackResponse {
 enum class Fields
 {
     kStatus = 0,
+    kData   = 1,
 };
 
 struct Type
@@ -32805,6 +32806,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     StatusEnum status = static_cast<StatusEnum>(0);
+    Optional<chip::CharSpan> data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -32820,6 +32822,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     StatusEnum status = static_cast<StatusEnum>(0);
+    Optional<chip::CharSpan> data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace PlaybackResponse

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
@@ -3510,8 +3510,8 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
                                      const Channel::Commands::ChangeChannelResponse::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
-    ReturnErrorOnFailure(DataModelLogger::LogValue("channelMatch", indent + 1, value.channelMatch));
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
+    ReturnErrorOnFailure(DataModelLogger::LogValue("data", indent + 1, value.data));
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }
@@ -3819,6 +3819,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 {
     DataModelLogger::LogString(label, indent, "{");
     ReturnErrorOnFailure(DataModelLogger::LogValue("status", indent + 1, value.status));
+    ReturnErrorOnFailure(DataModelLogger::LogValue("data", indent + 1, value.data));
     DataModelLogger::LogString(indent, "}");
     return CHIP_NO_ERROR;
 }

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -52978,7 +52978,7 @@ private:
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_8(data.status);
+            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_8(data.status, data.data);
         };
 
         auto failure = [](void * context, CHIP_ERROR error) {
@@ -52995,9 +52995,12 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_8(chip::app::Clusters::MediaPlayback::StatusEnum status)
+    void OnSuccessResponse_8(chip::app::Clusters::MediaPlayback::StatusEnum status, const chip::Optional<chip::CharSpan> & data)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
+
+        VerifyOrReturn(CheckValuePresent("data", data));
+        VerifyOrReturn(CheckValueAsString("data.Value()", data.Value(), chip::CharSpan("data response", 13)));
 
         NextTest();
     }
@@ -53010,7 +53013,7 @@ private:
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_9(data.status);
+            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_9(data.status, data.data);
         };
 
         auto failure = [](void * context, CHIP_ERROR error) {
@@ -53027,9 +53030,12 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_9(chip::app::Clusters::MediaPlayback::StatusEnum status)
+    void OnSuccessResponse_9(chip::app::Clusters::MediaPlayback::StatusEnum status, const chip::Optional<chip::CharSpan> & data)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
+
+        VerifyOrReturn(CheckValuePresent("data", data));
+        VerifyOrReturn(CheckValueAsString("data.Value()", data.Value(), chip::CharSpan("data response", 13)));
 
         NextTest();
     }
@@ -53042,7 +53048,7 @@ private:
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_10(data.status);
+            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_10(data.status, data.data);
         };
 
         auto failure = [](void * context, CHIP_ERROR error) {
@@ -53059,9 +53065,12 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_10(chip::app::Clusters::MediaPlayback::StatusEnum status)
+    void OnSuccessResponse_10(chip::app::Clusters::MediaPlayback::StatusEnum status, const chip::Optional<chip::CharSpan> & data)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
+
+        VerifyOrReturn(CheckValuePresent("data", data));
+        VerifyOrReturn(CheckValueAsString("data.Value()", data.Value(), chip::CharSpan("data response", 13)));
 
         NextTest();
     }
@@ -53074,7 +53083,7 @@ private:
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_11(data.status);
+            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_11(data.status, data.data);
         };
 
         auto failure = [](void * context, CHIP_ERROR error) {
@@ -53091,9 +53100,12 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_11(chip::app::Clusters::MediaPlayback::StatusEnum status)
+    void OnSuccessResponse_11(chip::app::Clusters::MediaPlayback::StatusEnum status, const chip::Optional<chip::CharSpan> & data)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
+
+        VerifyOrReturn(CheckValuePresent("data", data));
+        VerifyOrReturn(CheckValueAsString("data.Value()", data.Value(), chip::CharSpan("data response", 13)));
 
         NextTest();
     }
@@ -53106,7 +53118,7 @@ private:
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_12(data.status);
+            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_12(data.status, data.data);
         };
 
         auto failure = [](void * context, CHIP_ERROR error) {
@@ -53123,9 +53135,12 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_12(chip::app::Clusters::MediaPlayback::StatusEnum status)
+    void OnSuccessResponse_12(chip::app::Clusters::MediaPlayback::StatusEnum status, const chip::Optional<chip::CharSpan> & data)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
+
+        VerifyOrReturn(CheckValuePresent("data", data));
+        VerifyOrReturn(CheckValueAsString("data.Value()", data.Value(), chip::CharSpan("data response", 13)));
 
         NextTest();
     }
@@ -53138,7 +53153,7 @@ private:
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_13(data.status);
+            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_13(data.status, data.data);
         };
 
         auto failure = [](void * context, CHIP_ERROR error) {
@@ -53155,9 +53170,12 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_13(chip::app::Clusters::MediaPlayback::StatusEnum status)
+    void OnSuccessResponse_13(chip::app::Clusters::MediaPlayback::StatusEnum status, const chip::Optional<chip::CharSpan> & data)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
+
+        VerifyOrReturn(CheckValuePresent("data", data));
+        VerifyOrReturn(CheckValueAsString("data.Value()", data.Value(), chip::CharSpan("data response", 13)));
 
         NextTest();
     }
@@ -53170,7 +53188,7 @@ private:
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_14(data.status);
+            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_14(data.status, data.data);
         };
 
         auto failure = [](void * context, CHIP_ERROR error) {
@@ -53187,9 +53205,12 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_14(chip::app::Clusters::MediaPlayback::StatusEnum status)
+    void OnSuccessResponse_14(chip::app::Clusters::MediaPlayback::StatusEnum status, const chip::Optional<chip::CharSpan> & data)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
+
+        VerifyOrReturn(CheckValuePresent("data", data));
+        VerifyOrReturn(CheckValueAsString("data.Value()", data.Value(), chip::CharSpan("data response", 13)));
 
         NextTest();
     }
@@ -53202,7 +53223,7 @@ private:
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_15(data.status);
+            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_15(data.status, data.data);
         };
 
         auto failure = [](void * context, CHIP_ERROR error) {
@@ -53219,9 +53240,12 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_15(chip::app::Clusters::MediaPlayback::StatusEnum status)
+    void OnSuccessResponse_15(chip::app::Clusters::MediaPlayback::StatusEnum status, const chip::Optional<chip::CharSpan> & data)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
+
+        VerifyOrReturn(CheckValuePresent("data", data));
+        VerifyOrReturn(CheckValueAsString("data.Value()", data.Value(), chip::CharSpan("data response", 13)));
 
         NextTest();
     }
@@ -53235,7 +53259,7 @@ private:
         request.deltaPositionMilliseconds = 500ULL;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_16(data.status);
+            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_16(data.status, data.data);
         };
 
         auto failure = [](void * context, CHIP_ERROR error) {
@@ -53252,9 +53276,12 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_16(chip::app::Clusters::MediaPlayback::StatusEnum status)
+    void OnSuccessResponse_16(chip::app::Clusters::MediaPlayback::StatusEnum status, const chip::Optional<chip::CharSpan> & data)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
+
+        VerifyOrReturn(CheckValuePresent("data", data));
+        VerifyOrReturn(CheckValueAsString("data.Value()", data.Value(), chip::CharSpan("data response", 13)));
 
         NextTest();
     }
@@ -53297,7 +53324,7 @@ private:
         request.deltaPositionMilliseconds = 100ULL;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_18(data.status);
+            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_18(data.status, data.data);
         };
 
         auto failure = [](void * context, CHIP_ERROR error) {
@@ -53314,9 +53341,12 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_18(chip::app::Clusters::MediaPlayback::StatusEnum status)
+    void OnSuccessResponse_18(chip::app::Clusters::MediaPlayback::StatusEnum status, const chip::Optional<chip::CharSpan> & data)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
+
+        VerifyOrReturn(CheckValuePresent("data", data));
+        VerifyOrReturn(CheckValueAsString("data.Value()", data.Value(), chip::CharSpan("data response", 13)));
 
         NextTest();
     }
@@ -53359,7 +53389,7 @@ private:
         request.position = 1000ULL;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_20(data.status);
+            (static_cast<TV_MediaPlaybackClusterSuite *>(context))->OnSuccessResponse_20(data.status, data.data);
         };
 
         auto failure = [](void * context, CHIP_ERROR error) {
@@ -53376,9 +53406,12 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_20(chip::app::Clusters::MediaPlayback::StatusEnum status)
+    void OnSuccessResponse_20(chip::app::Clusters::MediaPlayback::StatusEnum status, const chip::Optional<chip::CharSpan> & data)
     {
         VerifyOrReturn(CheckValue("status", status, 0));
+
+        VerifyOrReturn(CheckValuePresent("data", data));
+        VerifyOrReturn(CheckValueAsString("data.Value()", data.Value(), chip::CharSpan("data response", 13)));
 
         NextTest();
     }
@@ -53705,7 +53738,7 @@ private:
         request.match = chip::Span<const char>("PBSgarbage: not in length on purpose", 3);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TV_ChannelClusterSuite *>(context))->OnSuccessResponse_4(data.channelMatch, data.status);
+            (static_cast<TV_ChannelClusterSuite *>(context))->OnSuccessResponse_4(data.status, data.data);
         };
 
         auto failure = [](void * context, CHIP_ERROR error) {
@@ -53722,21 +53755,12 @@ private:
         ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_4(const chip::app::Clusters::Channel::Structs::ChannelInfo::DecodableType & channelMatch,
-                             chip::app::Clusters::Channel::StatusEnum status)
+    void OnSuccessResponse_4(chip::app::Clusters::Channel::StatusEnum status, const chip::Optional<chip::CharSpan> & data)
     {
-        VerifyOrReturn(CheckValue("channelMatch.majorNumber", channelMatch.majorNumber, 9U));
-        VerifyOrReturn(CheckValue("channelMatch.minorNumber", channelMatch.minorNumber, 1U));
-        VerifyOrReturn(CheckValuePresent("channelMatch.name", channelMatch.name));
-        VerifyOrReturn(CheckValueAsString("channelMatch.name.Value()", channelMatch.name.Value(), chip::CharSpan("PBS", 3)));
-        VerifyOrReturn(CheckValuePresent("channelMatch.callSign", channelMatch.callSign));
-        VerifyOrReturn(
-            CheckValueAsString("channelMatch.callSign.Value()", channelMatch.callSign.Value(), chip::CharSpan("KCTS-TV", 7)));
-        VerifyOrReturn(CheckValuePresent("channelMatch.affiliateCallSign", channelMatch.affiliateCallSign));
-        VerifyOrReturn(CheckValueAsString("channelMatch.affiliateCallSign.Value()", channelMatch.affiliateCallSign.Value(),
-                                          chip::CharSpan("KCTS", 4)));
-
         VerifyOrReturn(CheckValue("status", status, 0));
+
+        VerifyOrReturn(CheckValuePresent("data", data));
+        VerifyOrReturn(CheckValueAsString("data.Value()", data.Value(), chip::CharSpan("data response", 13)));
 
         NextTest();
     }


### PR DESCRIPTION
#### Problem
- ChangeChannelResponse data structure is changed, changeChannel is replaced with data
- MediaPlaybackResponse is missing data parameter 

#### Change overview
see above

#### Testing
Run `./scripts/run_in_build_env.sh \  
                  "./scripts/tests/run_test_suite.py \
                     --chip-tool ./out/debug/standalone/chip-tool \
                     run \
                     --iterations 1 \
                     --all-clusters-app ./out/debug/standalone/chip-all-clusters-app \
                     --tv-app ./out/debug/standalone/chip-tv-app \
                  "`