### PR TITLE
Add extra logging to address resolve.

### DIFF
--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -103,6 +103,11 @@ void NodeLookupHandle::ResetForLookup(System::Clock::Timestamp now, const NodeLo
 
 void NodeLookupHandle::LookupResult(const ResolveResult & result)
 {
+#if CHIP_PROGRESS_LOGGING
+    char addr_string[Transport::PeerAddress::kMaxToStringSize];
+    result.address.ToString(addr_string);
+#endif
+
     unsigned newScore = ScoreValue(ScoreIpAddress(result.address.GetIPAddress(), result.address.GetInterface()));
     if (newScore > mBestAddressScore)
     {
@@ -120,9 +125,11 @@ void NodeLookupHandle::LookupResult(const ResolveResult & result)
         }
 
 #if CHIP_PROGRESS_LOGGING
-        char addr_string[Transport::PeerAddress::kMaxToStringSize];
-        mBestResult.address.ToString(addr_string);
-        ChipLogProgress(Discovery, "Address %s is scored at %u", addr_string, mBestAddressScore);
+        ChipLogProgress(Discovery, "%s: new best score: %u", addr_string, mBestAddressScore);
+    }
+    else
+    {
+        ChipLogProgress(Discovery, "%s: score has not improved: %u", addr_string, newScore);
 #endif
     }
 }


### PR DESCRIPTION
#### Problem
Feedback in #15544 - want to ensure we log all IP addresses when testing address resolution.

#### Change overview
Ensure all addresses are logged in the address resolver.

#### Testing
Ran a resolve manually. Logs now look like:

```
CHIP:DIS: Node ID resolved for 0x000000000001E1B9
CHIP:DIS:     Addr 0: [fe80::ea68:e7ff:fe31:1684]:5540
CHIP:DIS:     Addr 1: [2607:fea8:1fdf:1001:ea68:e7ff:fe31:1684]:5540
CHIP:DIS:     Addr 2: [10.30.0.157]:5540
CHIP:DIS: Lookup clearing interface for non LL address
CHIP:DIS: UDP:[2607:fea8:1fdf:1001:ea68:e7ff:fe31:1684%enp58s0]:5540: new best score: 7
CHIP:DIS: UDP:[fe80::ea68:e7ff:fe31:1684%enp58s0]:5540: score has not improved: 3
CHIP:DIS: UDP:10.30.0.157%enp58s0:5540: score has not improved: 2
CHIP:DIS: Checking node lookup status after 126 ms
CHIP:DIS: Keeping DNSSD lookup active
CHIP:DIS: Discovered node without a pending query
CHIP:DIS: Node ID resolved for 0x000000000001E1B9
CHIP:DIS:     Addr 0: [fe80::ea68:e7ff:fe31:1684]:5540
CHIP:DIS:     Addr 1: [2607:fea8:1fdf:1001:ea68:e7ff:fe31:1684]:5540
CHIP:DIS:     Addr 2: [10.30.0.157]:5540
CHIP:DIS: UDP:[2607:fea8:1fdf:1001:ea68:e7ff:fe31:1684%enp58s0]:5540: score has not improved: 7
CHIP:DIS: UDP:[fe80::ea68:e7ff:fe31:1684%enp58s0]:5540: score has not improved: 3
CHIP:DIS: UDP:10.30.0.157%enp58s0:5540: score has not improved: 2
CHIP:DIS: Checking node lookup status after 126 ms
CHIP:DIS: Keeping DNSSD lookup active
```

and for chip-tool I have:

```
[1646074720.179543][647777:647790] CHIP:DIS: Node ID resolved for 0x000000000001E1B9
[1646074720.179553][647777:647790] CHIP:DIS:     Addr 0: [fe80::ea68:e7ff:fe31:1684]:5540
[1646074720.179556][647777:647790] CHIP:DIS:     Addr 1: [2607:fea8:1fdf:1001:ea68:e7ff:fe31:1684]:5540
[1646074720.179558][647777:647790] CHIP:DIS:     Addr 2: [10.30.0.157]:5540
[1646074720.179862][647777:647790] CHIP:DIS: Lookup clearing interface for non LL address
[1646074720.179866][647777:647790] CHIP:DIS: UDP:[2607:fea8:1fdf:1001:ea68:e7ff:fe31:1684%enp58s0]:5540: new best score: 7
[1646074720.179872][647777:647790] CHIP:DIS: UDP:[fe80::ea68:e7ff:fe31:1684%enp58s0]:5540: score has not improved: 3
[1646074720.179877][647777:647790] CHIP:DIS: UDP:10.30.0.157%enp58s0:5540: score has not improved: 2
[1646074720.179878][647777:647790] CHIP:DIS: Checking node lookup status after 88 ms
[1646074720.179880][647777:647790] CHIP:DIS: Keeping DNSSD lookup active
[1646074720.185761][647777:647790] CHIP:DIS: Discovered node without a pending query
[1646074720.185770][647777:647790] CHIP:DIS: Node ID resolved for 0x000000000001E1B9
[1646074720.185774][647777:647790] CHIP:DIS:     Addr 0: [fe80::ea68:e7ff:fe31:1684]:5540
[1646074720.185777][647777:647790] CHIP:DIS:     Addr 1: [2607:fea8:1fdf:1001:ea68:e7ff:fe31:1684]:5540
[1646074720.185780][647777:647790] CHIP:DIS:     Addr 2: [10.30.0.157]:5540
[1646074720.186058][647777:647790] CHIP:DIS: UDP:[2607:fea8:1fdf:1001:ea68:e7ff:fe31:1684%wlp57s0]:5540: score has not improved: 7
[1646074720.186067][647777:647790] CHIP:DIS: UDP:[fe80::ea68:e7ff:fe31:1684%wlp57s0]:5540: score has not improved: 3
[1646074720.186074][647777:647790] CHIP:DIS: UDP:10.30.0.157%wlp57s0:5540: score has not improved: 2
[1646074720.186077][647777:647790] CHIP:DIS: Checking node lookup status after 94 ms
```
