### PR TITLE
Bump up darwin compile time

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
     darwin:
         name: Build Darwin
-        timeout-minutes: 75
+        timeout-minutes: 120 
 
         if: github.actor != 'restyled-io[bot]'
         runs-on: macos-latest


### PR DESCRIPTION
#### Problem
Frequent darwin timeouts - 75 minutes seems not enough anymore (guessing more tests take longer or a test time increase):

https://github.com/project-chip/connectedhomeip/runs/5363136535?check_suite_focus=true

#### Change overview
Change 75 minutes to 120 minutes

#### Testing
CI will validate, but trivial change in general.