### PR TITLE
Add support for supplying OTA download file path

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -855,6 +855,7 @@ optionsOverride
 orgs
 OTA
 OTADownloader
+otaDownloadPath
 otaImageList
 OTAImageProcessorDriver
 OTAImageProcessorInterface

--- a/examples/ota-requestor-app/linux/README.md
+++ b/examples/ota-requestor-app/linux/README.md
@@ -21,6 +21,7 @@ following command line options are available for the OTA Requestor application.
 | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | -q/--delayQuery <Time in seconds> | From boot up, the amount of time to wait before triggering the QueryImage command. If none or zero is supplied, QueryImage will not be triggered automatically. At least one provider location must be written to the DefaultOTAProviders attribute. |
 | -c/--requestorCanConsent          | If supplied, the RequestorCanConsent field of the QueryImage command is set to true. Otherwise, the value is determined by the driver.                                                                                                               |
+| -f/--otaDownloadPath <file path>  | If supplied, the OTA image is downloaded to the given fully-qualified file-path. Otherwise, the value defaults to /tmp/test.bin.                                                                                                                     |
 
 ## Software Image Header
 
@@ -86,7 +87,7 @@ Follow instructions
 #### Run the OTA Requestor application:
 
 ```
-out/chip-ota-requestor-app --discriminator ${REQUESTOR_LONG_DISCRIMINATOR} --secured-device-port ${REQUESTOR_UDP_PORT} --KVS ${KVS_STORE_LOCATION} --delayQuery ${TIME_IN_SECONDS}
+out/chip-ota-requestor-app --discriminator ${REQUESTOR_LONG_DISCRIMINATOR} --secured-device-port ${REQUESTOR_UDP_PORT} --KVS ${KVS_STORE_LOCATION} --delayQuery ${TIME_IN_SECONDS} --otaDownloadPath ${OTA_FILE_PATH}
 ```
 
 -   `${REQUESTOR_LONG_DISCRIMINATOR}` is the long discriminator specified for
@@ -101,6 +102,8 @@ out/chip-ota-requestor-app --discriminator ${REQUESTOR_LONG_DISCRIMINATOR} --sec
     the value used by the OTA Provider application.
 -   `${TIME_IN_SECONDS}` is the amount of time to wait before triggering the
     QueryImage command specified by the DefaultOTAProviders attribute
+-   `${OTA_FILE_PATH}` is the fully-qualified path for the OTA file download
+    location
 
 #### Commission the OTA Requestor application
 
@@ -212,7 +215,7 @@ scripts/examples/gn_build_example.sh examples/ota-requestor-app/linux/ out chip_
 **Run the OTA Requestor application**
 
 ```
-out/chip-ota-requestor-app --discriminator 18 --secured-device-port 5560 --KVS /tmp/chip_kvs_requestor --delayQuery 30
+out/chip-ota-requestor-app --discriminator 18 --secured-device-port 5560 --KVS /tmp/chip_kvs_requestor --delayQuery 30 --otaDownloadPath /tmp/test.bin
 ```
 
 #### In terminal 3:
@@ -257,7 +260,7 @@ specified below:
 
 ```
 scripts/examples/gn_build_example.sh examples/ota-requestor-app/linux/ out chip_config_network_layer_ble=false
-out/chip-ota-requestor-app --discriminator 18 --secured-device-port 5560 --KVS /tmp/chip_kvs_requestor
+out/chip-ota-requestor-app --discriminator 18 --secured-device-port 5560 --KVS /tmp/chip_kvs_requestor --otaDownloadPath /tmp/test.bin
 ```
 
 **Commission to the first fabric**
@@ -297,6 +300,3 @@ out/chip-tool otasoftwareupdaterequestor read default-ota-providers 0x858 0 --co
 ```
 
 ## Limitations
-
--   Stores the downloaded file in the directory this reference app is launched
-    from

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -56,13 +56,17 @@ void OnStartDelayTimerHandler(Layer * systemLayer, void * appState);
 
 constexpr uint16_t kOptionDelayQuery          = 'q';
 constexpr uint16_t kOptionRequestorCanConsent = 'c';
+constexpr uint16_t kOptionOtaDownloadPath     = 'f';
+constexpr size_t kMaxFilePathSize             = 256;
 
 uint16_t delayQueryTimeInSec = 0;
 chip::Optional<bool> gRequestorCanConsent;
+static char gOtaDownloadPath[kMaxFilePathSize] = "/tmp/test.bin";
 
 OptionDef cmdLineOptionsDef[] = {
     { "delayQuery", chip::ArgParser::kArgumentRequired, kOptionDelayQuery },
     { "requestorCanConsent", chip::ArgParser::kNoArgument, kOptionRequestorCanConsent },
+    { "otaDownloadPath", chip::ArgParser::kArgumentRequired, kOptionOtaDownloadPath },
     {},
 };
 
@@ -73,7 +77,10 @@ OptionSet cmdLineOptions = { HandleOptions, cmdLineOptionsDef, "PROGRAM OPTIONS"
                              "least one provider location must be written to the DefaultOTAProviders attribute.\n"
                              "  -c/--requestorCanConsent\n"
                              "        If supplied, the RequestorCanConsent field of the QueryImage command is set to true.\n"
-                             "        Otherwise, the value is determined by the driver.\n " };
+                             "        Otherwise, the value is determined by the driver.\n "
+                             "  -f/--otaDownloadPath <file path>\n"
+                             "        If supplied, the OTA image is downloaded to the given fully-qualified file-path.\n"
+                             "        Otherwise, the value defaults to /tmp/test.bin.\n " };
 
 OptionSet * allOptions[] = { &cmdLineOptions, nullptr };
 
@@ -87,10 +94,8 @@ static void InitOTARequestor(void)
 
     // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at
     // the beginning of program execution. We're using hardcoded values here for now since this is a reference application.
-    // TODO: instatiate and initialize these values when QueryImageResponse tells us an image is available
-    // TODO: add API for OTARequestor to pass QueryImageResponse info to the application to use for OTADownloader init
     OTAImageProcessorParams ipParams;
-    ipParams.imageFile = CharSpan("test.txt");
+    ipParams.imageFile = CharSpan::fromCharString(gOtaDownloadPath);
     gImageProcessor.SetOTAImageProcessorParams(ipParams);
     gImageProcessor.SetOTADownloader(&gDownloader);
 
@@ -109,6 +114,9 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
         break;
     case kOptionRequestorCanConsent:
         gRequestorCanConsent.SetValue(true);
+        break;
+    case kOptionOtaDownloadPath:
+        chip::Platform::CopyString(gOtaDownloadPath, aValue);
         break;
     default:
         PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", aProgram, aName);


### PR DESCRIPTION
#### Problem
Add support to the Linux OTA-requestor for supplying a fully-qualified destination path for the OTA file to be downloaded to

#### Change overview
Added a simple command line option for the same

#### Testing
Tested by running an OTA on a Linux machine and verifying that the file path was chosen successfully.
