### PR TITLE
[OTA] Serve the file specified by the file designator

### DIFF
--- a/examples/ota-provider-app/esp32/main/include/ota-provider-common/BdxOtaSender.h
+++ b/examples/ota-provider-app/esp32/main/include/ota-provider-common/BdxOtaSender.h
@@ -89,9 +89,6 @@ public:
      */
     uint64_t GetTransferLength(void);
 
-    /* ota-provider-common/OTAProviderExample.cpp requires this */
-    void SetFilepath(const char * path) {}
-
 private:
     // Inherited from bdx::TransferFacilitator
     void HandleTransferSessionOutput(chip::bdx::TransferSession::OutputEvent & event) override;

--- a/examples/ota-provider-app/ota-provider-common/BdxOtaSender.h
+++ b/examples/ota-provider-app/ota-provider-common/BdxOtaSender.h
@@ -25,16 +25,14 @@ class BdxOtaSender : public chip::bdx::Responder
 public:
     BdxOtaSender();
 
-    void SetFilepath(const char * path);
-
 private:
     // Inherited from bdx::TransferFacilitator
     void HandleTransferSessionOutput(chip::bdx::TransferSession::OutputEvent & event) override;
 
     void Reset();
 
-    static constexpr size_t kFilepathMaxLength = 256;
-    char mFilepath[kFilepathMaxLength];
+    // Null-terminated string representing file designator
+    char mFileDesignator[chip::bdx::kMaxFileDesignatorLen];
 
     uint32_t mNumBytesSent = 0;
 };

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -261,7 +261,6 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
         ChipLogDetail(SoftwareUpdate, "Generated URI: %.*s", static_cast<int>(uri.size()), uri.data());
 
         // Initialize the transfer session in prepartion for a BDX transfer
-        mBdxOtaSender.SetFilepath(otaFilePath);
         BitFlags<TransferControlFlags> bdxFlags;
         bdxFlags.Set(TransferControlFlags::kReceiverDrive);
         CHIP_ERROR err = mBdxOtaSender.PrepareForTransfer(&chip::DeviceLayer::SystemLayer(), chip::bdx::TransferRole::kSender,

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -287,8 +287,10 @@ private:
     BDXMessenger mBdxMessenger;                          // TODO: ideally this is held by the application
     uint8_t mUpdateTokenBuffer[kMaxUpdateTokenLen];
     ByteSpan mUpdateToken;
-    uint32_t mCurrentVersion               = 0;
-    uint32_t mTargetVersion                = 0;
+    uint32_t mCurrentVersion = 0;
+    uint32_t mTargetVersion  = 0;
+    char mFileDesignatorBuffer[bdx::kMaxFileDesignatorLen];
+    CharSpan mFileDesignator;
     OTAUpdateStateEnum mCurrentUpdateState = OTAUpdateStateEnum::kIdle;
     Server * mServer                       = nullptr;
     chip::Optional<bool> mRequestorCanConsent;

--- a/src/include/platform/OTARequestorDriver.h
+++ b/src/include/platform/OTARequestorDriver.h
@@ -33,7 +33,8 @@ namespace chip {
 // The set of parameters needed for starting a BDX download.
 struct UpdateDescription
 {
-    CharSpan imageURI;
+    NodeId nodeId;
+    CharSpan fileDesignator;
     uint32_t softwareVersion;
     CharSpan softwareVersionStr;
     ByteSpan updateToken;

--- a/src/protocols/bdx/BdxMessages.cpp
+++ b/src/protocols/bdx/BdxMessages.cpp
@@ -31,8 +31,7 @@
 #include <utility>
 
 namespace {
-constexpr uint8_t kVersionMask          = 0x0F;
-constexpr uint8_t kMaxFileDesignatorLen = 32;
+constexpr uint8_t kVersionMask = 0x0F;
 } // namespace
 
 using namespace chip;

--- a/src/protocols/bdx/BdxMessages.h
+++ b/src/protocols/bdx/BdxMessages.h
@@ -32,6 +32,8 @@
 namespace chip {
 namespace bdx {
 
+constexpr uint16_t kMaxFileDesignatorLen = 0xFF;
+
 enum class MessageType : uint8_t
 {
     SendInit           = 0x01,

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -298,6 +298,11 @@ public:
     uint64_t GetTransferLength() const { return mTransferLength; }
     uint16_t GetTransferBlockSize() const { return mTransferMaxBlockSize; }
     size_t GetNumBytesProcessed() const { return mNumBytesProcessed; }
+    const uint8_t * GetFileDesignator(uint16_t & fileDesignatorLen) const
+    {
+        fileDesignatorLen = mTransferRequestData.FileDesLength;
+        return mTransferRequestData.FileDesignator;
+    }
 
     TransferSession();
 


### PR DESCRIPTION
#### Problem
Currently, the OTA Requestor sets the file designator as a hard coded value `test.txt` in the current location where the application is launched. Also, the OTA Provider is serving the image file specified by the command line arg when the ota-provider-app is launched.

The Requestor should set the file designator appropriately during the BDX transfer. The Provider should be using the file designator field in the `ReceiveInit` message to serve the image file

#### Change overview
- OTA Requestor caches the file designator and pass this in when starting a BDX transfer
- OTA Provider caches the file designator in `ReceiveInit` message when BDX transfer begins and uses this filepath to serve the image in `BlockQuery` messages
- Remove `BdxOtaSender::SetFilepath` as the image file path should be set by the file designator and not by external caller

#### Testing
- Verify that basic happy path of file transfer succeeds
- Manually force the image URI file designator to point to a location different from the file specified from ota-provider-app command line and verified that the file specified by the file designator is the one served