### PR TITLE
[nwprov] Make it possible to notify network commissioning cluster for autonomous connection

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -81,16 +81,6 @@ private:
 
     ConcreteCommandPath mPath = ConcreteCommandPath(0, 0, 0);
 
-    // Last* attributes
-    // Setting these values don't have to care about parallel requests, since we will reject other requests when there is another
-    // request ongoing.
-    DataModel::Nullable<NetworkCommissioningStatus> mLastNetworkingStatusValue;
-    DataModel::Nullable<Attributes::LastConnectErrorValue::TypeInfo::Type> mLastConnectErrorValue;
-    uint8_t mConnectingNetworkID[DeviceLayer::NetworkCommissioning::kMaxNetworkIDLen];
-    uint8_t mConnectingNetworkIDLen = 0;
-    uint8_t mLastNetworkID[DeviceLayer::NetworkCommissioning::kMaxNetworkIDLen];
-    uint8_t mLastNetworkIDLen = 0;
-
     // Actual handlers of the commands
     void HandleScanNetworks(HandlerContext & ctx, const Commands::ScanNetworks::DecodableType & req);
     void HandleAddOrUpdateWiFiNetwork(HandlerContext & ctx, const Commands::AddOrUpdateWiFiNetwork::DecodableType & req);

--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -36,6 +36,7 @@ namespace NetworkCommissioning {
 // TODO: Use macro to disable some wifi or thread
 class Instance : public CommandHandlerInterface,
                  public AttributeAccessInterface,
+                 public DeviceLayer::NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback,
                  public DeviceLayer::NetworkCommissioning::Internal::WirelessDriver::ConnectCallback,
                  public DeviceLayer::NetworkCommissioning::WiFiDriver::ScanCallback,
                  public DeviceLayer::NetworkCommissioning::ThreadDriver::ScanCallback
@@ -53,6 +54,10 @@ public:
     // AttributeAccessInterface
     CHIP_ERROR Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder) override;
     CHIP_ERROR Write(const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder) override;
+
+    // BaseDriver::NetworkStatusChangeCallback
+    void OnNetworkingStatusChange(DeviceLayer::NetworkCommissioning::Status aCommissioningError, Optional<ByteSpan> aNetworkId,
+                                  Optional<int32_t> aConnectStatus) override;
 
     // WirelessDriver::ConnectCallback
     void OnResult(DeviceLayer::NetworkCommissioning::Status commissioningError, CharSpan errorText,
@@ -80,6 +85,17 @@ private:
     app::CommandHandler::Handle mAsyncCommandHandle;
 
     ConcreteCommandPath mPath = ConcreteCommandPath(0, 0, 0);
+
+    // Last* attributes
+    // Setting these values don't have to care about parallel requests, since we will reject other requests when there is another
+    // request ongoing.
+    // These values can be updated via OnNetworkingStatusChange callback, ScanCallback::OnFinished and ConnectCallback::OnResult.
+    DataModel::Nullable<NetworkCommissioningStatus> mLastNetworkingStatusValue;
+    Attributes::LastConnectErrorValue::TypeInfo::Type mLastConnectErrorValue;
+    uint8_t mConnectingNetworkID[DeviceLayer::NetworkCommissioning::kMaxNetworkIDLen];
+    uint8_t mConnectingNetworkIDLen = 0;
+    uint8_t mLastNetworkID[DeviceLayer::NetworkCommissioning::kMaxNetworkIDLen];
+    uint8_t mLastNetworkIDLen = 0;
 
     // Actual handlers of the commands
     void HandleScanNetworks(HandlerContext & ctx, const Commands::ScanNetworks::DecodableType & req);

--- a/src/controller/python/test/test_scripts/network_commissioning.py
+++ b/src/controller/python/test/test_scripts/network_commissioning.py
@@ -116,13 +116,6 @@ class NetworkCommissioningTests:
         if res.networkingStatus != Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatus.kSuccess:
             raise AssertionError(f"Unexpected result: {res.networkingStatus}")
 
-        # Verify Last* attributes
-        logger.info(f"Read Last* attributes")
-        res = await self.readLastNetworkingStateAttributes(endpointId=endpointId)
-        if (res.lastNetworkID != NullValue) or (res.lastNetworkingStatus == NullValue) or (res.lastConnectErrorValue != NullValue):
-            raise AssertionError(
-                f"LastNetworkID and LastConnectErrorValue should be Null and LastNetworkingStatus should not be Null")
-
         # Remove existing network
         logger.info(f"Check network list")
         res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)], returnClusterObject=True)
@@ -220,13 +213,6 @@ class NetworkCommissioningTests:
         logger.info(f"Received response: {res}")
         if res.networkingStatus != Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatus.kSuccess:
             raise AssertionError(f"Unexpected result: {res.networkingStatus}")
-
-        # Verify Last* attributes
-        logger.info(f"Read Last* attributes")
-        res = await self.readLastNetworkingStateAttributes(endpointId=endpointId)
-        if (res.lastNetworkID != NullValue) or (res.lastNetworkingStatus == NullValue) or (res.lastConnectErrorValue != NullValue):
-            raise AssertionError(
-                f"LastNetworkID and LastConnectErrorValue should be Null and LastNetworkingStatus should not be Null")
 
         # Remove existing network
         logger.info(f"Check network list")

--- a/src/controller/python/test/test_scripts/network_commissioning.py
+++ b/src/controller/python/test/test_scripts/network_commissioning.py
@@ -187,9 +187,9 @@ class NetworkCommissioningTests:
         # Verify Last* attributes
         logger.info(f"Read Last* attributes")
         res = await self.readLastNetworkingStateAttributes(endpointId=endpointId)
-        if (res.lastNetworkID == NullValue) or (res.lastNetworkingStatus == NullValue) or (res.lastConnectErrorValue == NullValue):
+        if (res.lastNetworkID == NullValue) or (res.lastNetworkingStatus == NullValue) or (res.lastConnectErrorValue != NullValue):
             raise AssertionError(
-                f"LastNetworkID, LastConnectErrorValue and LastNetworkingStatus should not be Null")
+                f"LastNetworkID, LastNetworkingStatus should not be Null, LastConnectErrorValue should be Null for a successful network provision.")
 
     async def test_thread(self, endpointId):
         logger.info(f"Get basic information of the endpoint")
@@ -275,9 +275,9 @@ class NetworkCommissioningTests:
         # Verify Last* attributes
         logger.info(f"Read Last* attributes")
         res = await self.readLastNetworkingStateAttributes(endpointId=endpointId)
-        if (res.lastNetworkID == NullValue) or (res.lastNetworkingStatus == NullValue) or (res.lastConnectErrorValue == NullValue):
+        if (res.lastNetworkID == NullValue) or (res.lastNetworkingStatus == NullValue) or (res.lastConnectErrorValue != NullValue):
             raise AssertionError(
-                f"LastNetworkID, LastConnectErrorValue and LastNetworkingStatus should not be Null")
+                f"LastNetworkID, LastNetworkingStatus should not be Null, LastConnectErrorValue should be Null for a successful network provision.")
 
         logger.info(f"Check network list")
         res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)], returnClusterObject=True)

--- a/src/include/platform/NetworkCommissioning.h
+++ b/src/include/platform/NetworkCommissioning.h
@@ -176,6 +176,25 @@ public:
     virtual NetworkIterator * GetNetworks() = 0;
 
     /**
+     * @brief Returns the status of last network operations (i.e. scan and attach attempts.) If no such attempts are conducted,
+     * CHIP_ERROR_KEY_NOT_FOUND will be returned.
+     */
+    virtual CHIP_ERROR GetLastNetworkingStatus(Status & status) { return CHIP_ERROR_KEY_NOT_FOUND; }
+
+    /**
+     * @brief Returns the Network ID of the last attach attempts. If no such attempts are conducted, CHIP_ERROR_KEY_NOT_FOUND will
+     * be returned. The callee can assume netwokrIDLen equals to or larger than kMaxNetworkIDLen, and should set it to the actual
+     * length of the network id.
+     */
+    virtual CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) { return CHIP_ERROR_KEY_NOT_FOUND; }
+
+    /**
+     * @brief Returns the driver specific error value of the last attach attempt. If no such attempts are conducted, or last attach
+     * attempt successfully finished, CHIP_ERROR_KEY_NOT_FOUND will be returned.
+     */
+    virtual CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) { return CHIP_ERROR_KEY_NOT_FOUND; }
+
+    /**
      * @brief Sets the status of the interface, this is an optional feature of a network driver.
      */
     virtual CHIP_ERROR SetEnabled(bool enabled) { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }

--- a/src/include/platform/NetworkCommissioning.h
+++ b/src/include/platform/NetworkCommissioning.h
@@ -179,20 +179,20 @@ public:
      * @brief Returns the status of last network operations (i.e. scan and attach attempts.) If no such attempts are conducted,
      * CHIP_ERROR_KEY_NOT_FOUND will be returned.
      */
-    virtual CHIP_ERROR GetLastNetworkingStatus(Status & status) { return CHIP_ERROR_KEY_NOT_FOUND; }
+    virtual CHIP_ERROR GetLastNetworkingStatus(Status & status) = 0;
 
     /**
      * @brief Returns the Network ID of the last attach attempts. If no such attempts are conducted, CHIP_ERROR_KEY_NOT_FOUND will
      * be returned. The callee can assume netwokrIDLen equals to or larger than kMaxNetworkIDLen, and should set it to the actual
      * length of the network id.
      */
-    virtual CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) { return CHIP_ERROR_KEY_NOT_FOUND; }
+    virtual CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) = 0;
 
     /**
      * @brief Returns the driver specific error value of the last attach attempt. If no such attempts are conducted, or last attach
      * attempt successfully finished, CHIP_ERROR_KEY_NOT_FOUND will be returned.
      */
-    virtual CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) { return CHIP_ERROR_KEY_NOT_FOUND; }
+    virtual CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) = 0;
 
     /**
      * @brief Sets the status of the interface, this is an optional feature of a network driver.
@@ -309,7 +309,14 @@ public:
 
 class EthernetDriver : public Internal::BaseDriver
 {
+public:
     // Ethernet driver does not have any special operations.
+    // Default EthernetDriver will always return NULL for these attributes.
+    CHIP_ERROR GetLastNetworkingStatus(Status & status) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+    CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+    CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+
+    virtual ~EthernetDriver() {}
 };
 
 } // namespace NetworkCommissioning

--- a/src/platform/Ameba/NetworkCommissioningDriver.h
+++ b/src/platform/Ameba/NetworkCommissioningDriver.h
@@ -92,6 +92,11 @@ public:
     CHIP_ERROR Init() override;
     CHIP_ERROR Shutdown() override;
 
+    // TODO: Implement this.
+    CHIP_ERROR GetLastNetworkingStatus(Status & status) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+    CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+    CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return kMaxWiFiNetworks; }
     uint8_t GetScanNetworkTimeoutSeconds() override { return kWiFiScanNetworksTimeOutSeconds; }

--- a/src/platform/Ameba/NetworkCommissioningDriver.h
+++ b/src/platform/Ameba/NetworkCommissioningDriver.h
@@ -89,13 +89,8 @@ public:
 
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
-    CHIP_ERROR Init() override;
+    CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback) override;
     CHIP_ERROR Shutdown() override;
-
-    // TODO(#15700): Implement this.
-    CHIP_ERROR GetLastNetworkingStatus(Status & status) override { return CHIP_ERROR_KEY_NOT_FOUND; }
-    CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override { return CHIP_ERROR_KEY_NOT_FOUND; }
-    CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override { return CHIP_ERROR_KEY_NOT_FOUND; }
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return kMaxWiFiNetworks; }

--- a/src/platform/Ameba/NetworkCommissioningDriver.h
+++ b/src/platform/Ameba/NetworkCommissioningDriver.h
@@ -92,7 +92,7 @@ public:
     CHIP_ERROR Init() override;
     CHIP_ERROR Shutdown() override;
 
-    // TODO: Implement this.
+    // TODO(#15700): Implement this.
     CHIP_ERROR GetLastNetworkingStatus(Status & status) override { return CHIP_ERROR_KEY_NOT_FOUND; }
     CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override { return CHIP_ERROR_KEY_NOT_FOUND; }
     CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override { return CHIP_ERROR_KEY_NOT_FOUND; }

--- a/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
@@ -35,7 +35,7 @@ constexpr char kWiFiSSIDKeyName[]        = "wifi-ssid";
 constexpr char kWiFiCredentialsKeyName[] = "wifi-pass";
 } // namespace
 
-CHIP_ERROR AmebaWiFiDriver::Init()
+CHIP_ERROR AmebaWiFiDriver::Init(NetworkStatusChangeCallback *)
 {
     CHIP_ERROR err;
     size_t ssidLen        = 0;

--- a/src/platform/EFR32/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/EFR32/NetworkCommissioningWiFiDriver.cpp
@@ -35,7 +35,7 @@ NetworkCommissioning::WiFiScanResponse * sScanResult;
 SlScanResponseIterator<NetworkCommissioning::WiFiScanResponse> mScanResponseIter(sScanResult);
 } // namespace
 
-CHIP_ERROR SlWiFiDriver::Init()
+CHIP_ERROR SlWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChangeCallback)
 {
     CHIP_ERROR err;
     size_t ssidLen        = 0;

--- a/src/platform/EFR32/NetworkCommissioningWiFiDriver.h
+++ b/src/platform/EFR32/NetworkCommissioningWiFiDriver.h
@@ -132,12 +132,7 @@ public:
 
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
-    CHIP_ERROR Init() override;
-
-    // TODO(#15700): Implement this.
-    CHIP_ERROR GetLastNetworkingStatus(Status & status) override { return CHIP_ERROR_KEY_NOT_FOUND; }
-    CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override { return CHIP_ERROR_KEY_NOT_FOUND; }
-    CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+    CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback) override;
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return kMaxWiFiNetworks; }

--- a/src/platform/EFR32/NetworkCommissioningWiFiDriver.h
+++ b/src/platform/EFR32/NetworkCommissioningWiFiDriver.h
@@ -134,7 +134,7 @@ public:
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
     CHIP_ERROR Init() override;
 
-    // TODO: Implement this.
+    // TODO(#15700): Implement this.
     CHIP_ERROR GetLastNetworkingStatus(Status & status) override { return CHIP_ERROR_KEY_NOT_FOUND; }
     CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override { return CHIP_ERROR_KEY_NOT_FOUND; }
     CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override { return CHIP_ERROR_KEY_NOT_FOUND; }

--- a/src/platform/EFR32/NetworkCommissioningWiFiDriver.h
+++ b/src/platform/EFR32/NetworkCommissioningWiFiDriver.h
@@ -134,6 +134,11 @@ public:
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
     CHIP_ERROR Init() override;
 
+    // TODO: Implement this.
+    CHIP_ERROR GetLastNetworkingStatus(Status & status) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+    CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+    CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return kMaxWiFiNetworks; }
     uint8_t GetScanNetworkTimeoutSeconds() override { return kWiFiScanNetworksTimeOutSeconds; }

--- a/src/platform/ESP32/NetworkCommissioningDriver.h
+++ b/src/platform/ESP32/NetworkCommissioningDriver.h
@@ -91,7 +91,7 @@ public:
     CHIP_ERROR Init() override;
     CHIP_ERROR Shutdown() override;
 
-    // TODO: Implement this.
+    // TODO(#15700): Implement this.
     CHIP_ERROR GetLastNetworkingStatus(Status & status) override { return CHIP_ERROR_KEY_NOT_FOUND; }
     CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override { return CHIP_ERROR_KEY_NOT_FOUND; }
     CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override { return CHIP_ERROR_KEY_NOT_FOUND; }

--- a/src/platform/ESP32/NetworkCommissioningDriver.h
+++ b/src/platform/ESP32/NetworkCommissioningDriver.h
@@ -91,6 +91,11 @@ public:
     CHIP_ERROR Init() override;
     CHIP_ERROR Shutdown() override;
 
+    // TODO: Implement this.
+    CHIP_ERROR GetLastNetworkingStatus(Status & status) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+    CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+    CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return kMaxWiFiNetworks; }
     uint8_t GetScanNetworkTimeoutSeconds() override { return kWiFiScanNetworksTimeOutSeconds; }

--- a/src/platform/ESP32/NetworkCommissioningDriver.h
+++ b/src/platform/ESP32/NetworkCommissioningDriver.h
@@ -88,13 +88,8 @@ public:
 
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
-    CHIP_ERROR Init() override;
+    CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback) override;
     CHIP_ERROR Shutdown() override;
-
-    // TODO(#15700): Implement this.
-    CHIP_ERROR GetLastNetworkingStatus(Status & status) override { return CHIP_ERROR_KEY_NOT_FOUND; }
-    CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override { return CHIP_ERROR_KEY_NOT_FOUND; }
-    CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override { return CHIP_ERROR_KEY_NOT_FOUND; }
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return kMaxWiFiNetworks; }

--- a/src/platform/ESP32/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/ESP32/NetworkCommissioningWiFiDriver.cpp
@@ -38,7 +38,7 @@ constexpr char kWiFiCredentialsKeyName[] = "wifi-pass";
 static uint8_t WiFiSSIDStr[DeviceLayer::Internal::kMaxWiFiSSIDLength];
 } // namespace
 
-CHIP_ERROR ESPWiFiDriver::Init()
+CHIP_ERROR ESPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChangeCallback)
 {
     CHIP_ERROR err;
     size_t ssidLen        = 0;

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -114,6 +114,11 @@ class ConnectivityManagerImpl final : public ConnectivityManager,
 public:
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     CHIP_ERROR ProvisionWiFiNetwork(const char * ssid, const char * key);
+    void
+    SetNetworkStatusChangeCallback(NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * statusChangeCallback)
+    {
+        mpStatusChangeCallback = statusChangeCallback;
+    }
     CHIP_ERROR ConnectWiFiNetworkAsync(ByteSpan ssid, ByteSpan credentials,
                                        NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback);
     void PostNetworkConnect();
@@ -122,7 +127,7 @@ public:
 
     void StartWiFiManagement();
     bool IsWiFiManagementStarted();
-    uint32_t GetDisconnectReason();
+    int32_t GetDisconnectReason();
     CHIP_ERROR GetWiFiBssId(ByteSpan & value);
     CHIP_ERROR GetWiFiSecurityType(uint8_t & securityType);
     CHIP_ERROR GetWiFiVersion(uint8_t & wiFiVersion);
@@ -175,6 +180,7 @@ private:
     void _MaintainOnDemandWiFiAP();
     System::Clock::Timeout _GetWiFiAPIdleTimeout();
     void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
+    void UpdateNetworkStatus();
     static CHIP_ERROR StopAutoScan();
 
     static void _OnWpaProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
@@ -194,6 +200,8 @@ private:
     static BitFlags<ConnectivityFlags> mConnectivityFlag;
     static struct GDBusWpaSupplicant mWpaSupplicant;
     static std::mutex mWpaSupplicantMutex;
+
+    NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
 #endif
 
     // ==================== ConnectivityManager Private Methods ====================

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -122,10 +122,11 @@ public:
 
     void StartWiFiManagement();
     bool IsWiFiManagementStarted();
+    uint32_t GetDisconnectReason();
     CHIP_ERROR GetWiFiBssId(ByteSpan & value);
     CHIP_ERROR GetWiFiSecurityType(uint8_t & securityType);
     CHIP_ERROR GetWiFiVersion(uint8_t & wiFiVersion);
-    CHIP_ERROR GetConnectedNetwork(NetworkCommissioning::Network & network);
+    CHIP_ERROR GetConfiguredNetwork(NetworkCommissioning::Network & network);
     CHIP_ERROR StartWiFiScan(ByteSpan ssid, NetworkCommissioning::WiFiDriver::ScanCallback * callback);
 #endif
 

--- a/src/platform/Linux/NetworkCommissioningDriver.h
+++ b/src/platform/Linux/NetworkCommissioningDriver.h
@@ -82,6 +82,10 @@ public:
     CHIP_ERROR Init() override;
     CHIP_ERROR Shutdown() override { return CHIP_NO_ERROR; } // Nothing to do on linux for shutdown.
 
+    CHIP_ERROR GetLastNetworkingStatus(Status & status) override;
+    CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override;
+    CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override;
+
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return 1; }
     uint8_t GetScanNetworkTimeoutSeconds() override { return 10; }
@@ -134,6 +138,9 @@ public:
     uint8_t GetMaxNetworks() override { return 1; }
     uint8_t GetScanNetworkTimeoutSeconds() override { return 10; }
     uint8_t GetConnectNetworkTimeoutSeconds() override { return 20; }
+    CHIP_ERROR GetLastNetworkingStatus(Status & status) override;
+    CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override;
+    CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override;
 
     CHIP_ERROR CommitConfiguration() override;
     CHIP_ERROR RevertConfiguration() override;

--- a/src/platform/Linux/NetworkCommissioningThreadDriver.cpp
+++ b/src/platform/Linux/NetworkCommissioningThreadDriver.cpp
@@ -112,7 +112,7 @@ CHIP_ERROR LinuxThreadDriver::GetLastConnectErrorValue(uint32_t & value)
     // Thread is not enabled, then we are not trying to connect to the network.
     VerifyOrReturnError(ThreadStackMgrImpl().IsThreadEnabled(), CHIP_ERROR_KEY_NOT_FOUND);
     // Thread is enabled, but is already attached, thus return null to indicate a success state.
-    VerifyOrReturnError(ThreadStackMgrImpl().IsThreadAttached(), CHIP_ERROR_KEY_NOT_FOUND);
+    ReturnErrorCodeIf(ThreadStackMgrImpl().IsThreadAttached(), CHIP_ERROR_KEY_NOT_FOUND);
 
     // Then we tell the client that the network is detached.
     value = OT_ERROR_DETACHED;

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -36,6 +36,12 @@ class ThreadStackManagerImpl : public ThreadStackManager
 public:
     ThreadStackManagerImpl();
 
+    void
+    SetNetworkStatusChangeCallback(NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * statusChangeCallback)
+    {
+        mpStatusChangeCallback = statusChangeCallback;
+    }
+
     CHIP_ERROR _InitThreadStack();
     void _ProcessThreadActivity();
 
@@ -70,6 +76,8 @@ public:
     CHIP_ERROR _SetThreadEnabled(bool val);
 
     void _OnThreadAttachFinished(void);
+
+    void _UpdateNetworkStatus();
 
     static void _OnThreadBrAttachFinished(GObject * source_object, GAsyncResult * res, gpointer user_data);
 
@@ -144,6 +152,7 @@ private:
 
     NetworkCommissioning::ThreadDriver::ScanCallback * mpScanCallback;
     NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * mpConnectCallback;
+    NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
 
     bool mAttached;
 };

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -66,6 +66,25 @@ CHIP_ERROR GenericThreadDriver::GetLastNetworkingStatus(Status & status)
 {
     // Thread is not enabled, then we are not trying to connect to the network.
     VerifyOrReturnError(ThreadStackMgrImpl().IsThreadEnabled(), CHIP_ERROR_KEY_NOT_FOUND);
+
+    ByteSpan datasetTLV;
+    // If we have not provisioned any Thread network, return the status from last network scan,
+    // If we have provisioned a network, we assume the ot-br-posix is activitely connecting to that network.
+    CHIP_ERROR err = ThreadStackMgrImpl().GetThreadProvision(datasetTLV);
+    if (err == CHIP_ERROR_KEY_NOT_FOUND || datasetTLV.size() == 0)
+    {
+        if (mScanStatus.HasValue())
+        {
+            status = mScanStatus.Value();
+            return CHIP_NO_ERROR;
+        }
+        return CHIP_ERROR_KEY_NOT_FOUND;
+    }
+    else if (err != CHIP_NO_ERROR)
+    {
+        return err;
+    }
+
     // We have already connected to the network, thus return success.
     if (ThreadStackMgrImpl().IsThreadAttached())
     {
@@ -198,7 +217,13 @@ void GenericThreadDriver::ScanNetworks(ThreadDriver::ScanCallback * callback)
     CHIP_ERROR err = DeviceLayer::ThreadStackMgrImpl().StartThreadScan(callback);
     if (err != CHIP_NO_ERROR)
     {
+        mScanStatus.SetValue(Status::kUnknownError);
         callback->OnFinished(Status::kUnknownError, CharSpan(), nullptr);
+    }
+    else
+    {
+        // OpenThread's "scan" will always success once started, so we can set the value of scan result here.
+        mScanStatus.SetValue(Status::kSuccess);
     }
 }
 

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -35,15 +35,23 @@ namespace NetworkCommissioning {
 // load the network config from thread persistent info, and loads it into both mSavedNetwork and mStagingNetwork. When updating the
 // networks, all changes are made on the staging network. When validated we can commit it and save it to the persistent info
 
-CHIP_ERROR GenericThreadDriver::Init()
+CHIP_ERROR GenericThreadDriver::Init(Internal::BaseDriver::NetworkStatusChangeCallback * statusChangeCallback)
 {
     ByteSpan currentProvision;
+    ThreadStackMgrImpl().SetNetworkStatusChangeCallback(statusChangeCallback);
+
     VerifyOrReturnError(ThreadStackMgrImpl().IsThreadAttached(), CHIP_NO_ERROR);
     VerifyOrReturnError(ThreadStackMgrImpl().GetThreadProvision(currentProvision) == CHIP_NO_ERROR, CHIP_NO_ERROR);
 
     mSavedNetwork.Init(currentProvision);
     mStagingNetwork.Init(currentProvision);
 
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GenericThreadDriver::Shutdown()
+{
+    ThreadStackMgrImpl().SetNetworkStatusChangeCallback(nullptr);
     return CHIP_NO_ERROR;
 }
 
@@ -59,73 +67,6 @@ CHIP_ERROR GenericThreadDriver::CommitConfiguration()
 CHIP_ERROR GenericThreadDriver::RevertConfiguration()
 {
     mStagingNetwork = mSavedNetwork;
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR GenericThreadDriver::GetLastNetworkingStatus(Status & status)
-{
-    // Thread is not enabled, then we are not trying to connect to the network.
-    VerifyOrReturnError(ThreadStackMgrImpl().IsThreadEnabled(), CHIP_ERROR_KEY_NOT_FOUND);
-
-    ByteSpan datasetTLV;
-    // If we have not provisioned any Thread network, return the status from last network scan,
-    // If we have provisioned a network, we assume the ot-br-posix is activitely connecting to that network.
-    CHIP_ERROR err = ThreadStackMgrImpl().GetThreadProvision(datasetTLV);
-    if (err == CHIP_ERROR_KEY_NOT_FOUND || datasetTLV.size() == 0)
-    {
-        if (mScanStatus.HasValue())
-        {
-            status = mScanStatus.Value();
-            return CHIP_NO_ERROR;
-        }
-        return CHIP_ERROR_KEY_NOT_FOUND;
-    }
-    else if (err != CHIP_NO_ERROR)
-    {
-        return err;
-    }
-
-    // We have already connected to the network, thus return success.
-    if (ThreadStackMgrImpl().IsThreadAttached())
-    {
-        status = Status::kSuccess;
-    }
-    else
-    {
-        status = Status::kNetworkNotFound;
-    }
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR GenericThreadDriver::GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen)
-{
-    ByteSpan datasetTLV;
-    Thread::OperationalDataset dataset;
-    uint8_t extpanid[kSizeExtendedPanId];
-
-    VerifyOrReturnError(networkIDLen != nullptr && networkID != nullptr && (*networkIDLen) >= kSizeExtendedPanId,
-                        CHIP_ERROR_INTERNAL);
-
-    // The Thread network is not actually enabled.
-    VerifyOrReturnError(ThreadStackMgrImpl().IsThreadEnabled(), CHIP_ERROR_KEY_NOT_FOUND);
-    VerifyOrReturnError(ThreadStackMgrImpl().GetThreadProvision(datasetTLV) == CHIP_NO_ERROR, CHIP_ERROR_KEY_NOT_FOUND);
-    VerifyOrReturnError(dataset.Init(datasetTLV) == CHIP_NO_ERROR, CHIP_ERROR_KEY_NOT_FOUND);
-    // The Thread network is not enabled, but has a different extended pan id.
-    VerifyOrReturnError(dataset.GetExtendedPanId(extpanid) == CHIP_NO_ERROR, CHIP_ERROR_KEY_NOT_FOUND);
-    memcpy(networkID, extpanid, kSizeExtendedPanId);
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR GenericThreadDriver::GetLastConnectErrorValue(uint32_t & value)
-{
-    // Thread is not enabled, then we are not trying to connect to the network.
-    VerifyOrReturnError(ThreadStackMgrImpl().IsThreadEnabled(), CHIP_ERROR_KEY_NOT_FOUND);
-    // Thread is enabled, but is already attached, thus return null to indicate a success state.
-    ReturnErrorCodeIf(ThreadStackMgrImpl().IsThreadAttached(), CHIP_ERROR_KEY_NOT_FOUND);
-
-    // Then we tell the client that the network is detached.
-    value = OT_ERROR_DETACHED;
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -84,7 +84,8 @@ CHIP_ERROR GenericThreadDriver::GetLastNetworkID(uint8_t * networkID, size_t * n
     Thread::OperationalDataset dataset;
     uint8_t extpanid[kSizeExtendedPanId];
 
-    VerifyOrReturnError(networkIDLen != nullptr && networkID != nullptr && (*networkIDLen) >= kSizeExtendedPanId);
+    VerifyOrReturnError(networkIDLen != nullptr && networkID != nullptr && (*networkIDLen) >= kSizeExtendedPanId,
+                        CHIP_ERROR_INTERNAL);
 
     // The Thread network is not actually enabled.
     VerifyOrReturnError(ThreadStackMgrImpl().IsThreadEnabled(), CHIP_ERROR_KEY_NOT_FOUND);
@@ -102,7 +103,7 @@ CHIP_ERROR GenericThreadDriver::GetLastConnectErrorValue(uint32_t & value)
     // Thread is not enabled, then we are not trying to connect to the network.
     VerifyOrReturnError(ThreadStackMgrImpl().IsThreadEnabled(), CHIP_ERROR_KEY_NOT_FOUND);
     // Thread is enabled, but is already attached, thus return null to indicate a success state.
-    VerifyOrReturnError(ThreadStackMgrImpl().IsThreadAttached(), CHIP_ERROR_KEY_NOT_FOUND);
+    ReturnErrorCodeIf(ThreadStackMgrImpl().IsThreadAttached(), CHIP_ERROR_KEY_NOT_FOUND);
 
     // Then we tell the client that the network is detached.
     value = OT_ERROR_DETACHED;

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
@@ -86,6 +86,9 @@ public:
     NetworkIterator * GetNetworks() override { return new ThreadNetworkIterator(this); }
     CHIP_ERROR Init() override;
     CHIP_ERROR Shutdown() override { return CHIP_NO_ERROR; } // Nothing to do on EFR32 for shutdown.
+    CHIP_ERROR GetLastNetworkingStatus(Status & status) override;
+    CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override;
+    CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override;
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return 1; }

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
@@ -84,11 +84,8 @@ public:
 
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new ThreadNetworkIterator(this); }
-    CHIP_ERROR Init() override;
-    CHIP_ERROR Shutdown() override { return CHIP_NO_ERROR; } // Nothing to do on EFR32 for shutdown.
-    CHIP_ERROR GetLastNetworkingStatus(Status & status) override;
-    CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override;
-    CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override;
+    CHIP_ERROR Init(Internal::BaseDriver::NetworkStatusChangeCallback * statusChangeCallback) override;
+    CHIP_ERROR Shutdown() override;
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return 1; }

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
@@ -104,12 +104,13 @@ public:
 
     // ThreadDriver
     Status AddOrUpdateNetwork(ByteSpan operationalDataset) override;
-    void ScanNetworks(ScanCallback * callback) override;
+    void ScanNetworks(ThreadDriver::ScanCallback * callback) override;
 
 private:
     ThreadNetworkIterator mThreadIterator      = ThreadNetworkIterator(this);
     Thread::OperationalDataset mSavedNetwork   = {};
     Thread::OperationalDataset mStagingNetwork = {};
+    Optional<Status> mScanStatus;
 };
 
 } // namespace NetworkCommissioning

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -70,6 +70,11 @@ public:
     otInstance * OTInstance() const;
     static void OnOpenThreadStateChange(uint32_t flags, void * context);
     inline void OverrunErrorTally(void);
+    void
+    SetNetworkStatusChangeCallback(NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * statusChangeCallback)
+    {
+        mpStatusChangeCallback = statusChangeCallback;
+    }
 
 protected:
     // ===== Methods that implement the ThreadStackManager abstract interface.
@@ -92,6 +97,7 @@ protected:
     CHIP_ERROR _StartThreadScan(NetworkCommissioning::ThreadDriver::ScanCallback * callback);
     static void _OnNetworkScanFinished(otActiveScanResult * aResult, void * aContext);
     void _OnNetworkScanFinished(otActiveScanResult * aResult);
+    void _UpdateNetworkStatus();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
     CHIP_ERROR _GetSEDPollingConfig(ConnectivityManager::SEDPollingConfig & pollingConfig);
@@ -148,6 +154,7 @@ private:
 
     NetworkCommissioning::ThreadDriver::ScanCallback * mpScanCallback;
     NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * mpConnectCallback;
+    NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
     ConnectivityManager::SEDPollingConfig mPollingConfig;

--- a/src/platform/P6/NetworkCommissioningDriver.h
+++ b/src/platform/P6/NetworkCommissioningDriver.h
@@ -91,13 +91,8 @@ public:
 
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
-    CHIP_ERROR Init() override;
+    CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback) override;
     CHIP_ERROR Shutdown() override;
-
-    // TODO(#15700): Implement this
-    CHIP_ERROR GetLastNetworkingStatus(Status & status) override { return CHIP_ERROR_KEY_NOT_FOUND; }
-    CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override { return CHIP_ERROR_KEY_NOT_FOUND; }
-    CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override { return CHIP_ERROR_KEY_NOT_FOUND; }
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return kMaxWiFiNetworks; }

--- a/src/platform/P6/NetworkCommissioningDriver.h
+++ b/src/platform/P6/NetworkCommissioningDriver.h
@@ -94,6 +94,11 @@ public:
     CHIP_ERROR Init() override;
     CHIP_ERROR Shutdown() override;
 
+    // TODO: Implement this
+    CHIP_ERROR GetLastNetworkingStatus(Status & status) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+    CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+    CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return kMaxWiFiNetworks; }
     uint8_t GetScanNetworkTimeoutSeconds() override { return kWiFiScanNetworksTimeOutSeconds; }

--- a/src/platform/P6/NetworkCommissioningDriver.h
+++ b/src/platform/P6/NetworkCommissioningDriver.h
@@ -94,7 +94,7 @@ public:
     CHIP_ERROR Init() override;
     CHIP_ERROR Shutdown() override;
 
-    // TODO: Implement this
+    // TODO(#15700): Implement this
     CHIP_ERROR GetLastNetworkingStatus(Status & status) override { return CHIP_ERROR_KEY_NOT_FOUND; }
     CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override { return CHIP_ERROR_KEY_NOT_FOUND; }
     CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override { return CHIP_ERROR_KEY_NOT_FOUND; }

--- a/src/platform/P6/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/P6/NetworkCommissioningWiFiDriver.cpp
@@ -39,7 +39,7 @@ constexpr char kWiFiCredentialsKeyName[] = "wifi-pass";
 cy_wcm_scan_result_t scan_result_list[kWiFiMaxNetworks];
 uint8_t NumAP; // no of network scanned
 
-CHIP_ERROR P6WiFiDriver::Init()
+CHIP_ERROR P6WiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChangeCallback)
 {
     CHIP_ERROR err;
     size_t ssidLen        = 0;

--- a/src/platform/Tizen/NetworkCommissioningDriver.h
+++ b/src/platform/Tizen/NetworkCommissioningDriver.h
@@ -52,7 +52,7 @@ public:
 
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
-    CHIP_ERROR Init() override;
+    CHIP_ERROR Init(BaseDriver::NetworkStatusChangeCallback * networkStatusChangeCallback) override;
     CHIP_ERROR Shutdown() override { return CHIP_NO_ERROR; }
 
     // WirelessDriver

--- a/src/platform/Tizen/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Tizen/NetworkCommissioningWiFiDriver.cpp
@@ -38,7 +38,7 @@ constexpr char kWiFiSSIDKeyName[]        = "wifi-ssid";
 constexpr char kWiFiCredentialsKeyName[] = "wifi-pass";
 } // namespace
 
-CHIP_ERROR TizenWiFiDriver::Init()
+CHIP_ERROR TizenWiFiDriver::Init(BaseDriver::NetworkStatusChangeCallback * networkStatusChangeCallback)
 {
     CHIP_ERROR err;
     size_t ssidLen        = 0;

--- a/src/platform/mbed/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/mbed/ConnectivityManagerImpl_WiFi.cpp
@@ -56,7 +56,7 @@ CHIP_ERROR ConnectivityManagerImpl::InitWiFi()
 #if CHIP_DEVICE_ENABLE_DATA_MODEL
     err = sWiFiNetworkCommissioningInstance.Init();
 #else
-    err = NetworkCommissioning::WiFiDriverImpl::GetInstance().Init();
+    err = NetworkCommissioning::WiFiDriverImpl::GetInstance().Init(nullptr);
 #endif
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "WiFi driver init failed: %s", chip::ErrorStr(err)));
 
@@ -116,7 +116,7 @@ CHIP_ERROR ConnectivityManagerImpl::_SetWiFiStationMode(WiFiStationMode val)
         {
             if (mWiFiStationMode == kWiFiStationMode_Enabled)
             {
-                NetworkCommissioning::WiFiDriverImpl::GetInstance().Init();
+                NetworkCommissioning::WiFiDriverImpl::GetInstance().Init(nullptr);
             }
             else if (mWiFiStationMode == kWiFiStationMode_Disabled)
             {

--- a/src/platform/mbed/NetworkCommissioningDriver.h
+++ b/src/platform/mbed/NetworkCommissioningDriver.h
@@ -96,6 +96,11 @@ public:
     CHIP_ERROR Init() override;
     CHIP_ERROR Shutdown() override;
 
+    // TODO: Implement this.
+    CHIP_ERROR GetLastNetworkingStatus(Status & status) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+    CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+    CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override { return CHIP_ERROR_KEY_NOT_FOUND; }
+
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return kMaxWiFiNetworks; }
     uint8_t GetScanNetworkTimeoutSeconds() override { return kWiFiScanNetworksTimeOutSeconds; }

--- a/src/platform/mbed/NetworkCommissioningDriver.h
+++ b/src/platform/mbed/NetworkCommissioningDriver.h
@@ -96,7 +96,7 @@ public:
     CHIP_ERROR Init() override;
     CHIP_ERROR Shutdown() override;
 
-    // TODO: Implement this.
+    // TODO(#15700): Implement this
     CHIP_ERROR GetLastNetworkingStatus(Status & status) override { return CHIP_ERROR_KEY_NOT_FOUND; }
     CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override { return CHIP_ERROR_KEY_NOT_FOUND; }
     CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override { return CHIP_ERROR_KEY_NOT_FOUND; }

--- a/src/platform/mbed/NetworkCommissioningDriver.h
+++ b/src/platform/mbed/NetworkCommissioningDriver.h
@@ -93,13 +93,8 @@ public:
 
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
-    CHIP_ERROR Init() override;
+    CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback) override;
     CHIP_ERROR Shutdown() override;
-
-    // TODO(#15700): Implement this
-    CHIP_ERROR GetLastNetworkingStatus(Status & status) override { return CHIP_ERROR_KEY_NOT_FOUND; }
-    CHIP_ERROR GetLastNetworkID(uint8_t * networkID, size_t * networkIDLen) override { return CHIP_ERROR_KEY_NOT_FOUND; }
-    CHIP_ERROR GetLastConnectErrorValue(uint32_t & value) override { return CHIP_ERROR_KEY_NOT_FOUND; }
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return kMaxWiFiNetworks; }

--- a/src/platform/mbed/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/mbed/NetworkCommissioningWiFiDriver.cpp
@@ -34,7 +34,7 @@ constexpr char kWiFiSSIDKeyName[]        = "wifi-ssid";
 constexpr char kWiFiCredentialsKeyName[] = "wifi-pass";
 } // namespace
 
-CHIP_ERROR WiFiDriverImpl::Init()
+CHIP_ERROR WiFiDriverImpl::Init(NetworkStatusChangeCallback * networkStatusChangeCallback)
 {
     size_t ssidLen        = 0;
     size_t credentialsLen = 0;


### PR DESCRIPTION
#### Problem
LastNetworkID, LastNetworkingStatus, LastConnectErrorValue should be handled by driver for returning "the last attempt to connect to an operational network, using this interface, whether by invocation of the ConnectNetwork command or by autonomous connection after loss of connectivity or during initial establishment."

#### Change overview
- Update DriverAPI
- Update Linux Driver and GenericThreadDriver

#### Testing
- Updated test
