### PR TITLE
Add document to clarify all platform delegates have process lifetime

### DIFF
--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -208,7 +208,8 @@ extern ConfigurationManager & ConfigurationMgr();
  * Sets a reference to a ConfigurationManager object.
  *
  * This must be called before any calls to ConfigurationMgr. If a nullptr is passed in,
- * no changes will be made.
+ * no changes will be made. ConfigurationManager object gets set only once during the
+ * lifetime of per process execution.
  */
 extern void SetConfigurationMgr(ConfigurationManager * configurationManager);
 

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -154,6 +154,11 @@ public:
 
     struct SEDPollingConfig;
 
+    /**
+     * ConnectivityManager delegate object should have process lifetime, and can outlive shutdown process
+     * on all platforms. ConnectivityManager delegate object should be able to keep its state even after
+     * PlatformManager is shut down and restarted.
+     */
     void SetDelegate(ConnectivityManagerDelegate * delegate) { mDelegate = delegate; }
     ConnectivityManagerDelegate * GetDelegate() const { return mDelegate; }
 

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -153,6 +153,11 @@ public:
 class DiagnosticDataProvider
 {
 public:
+    /*
+     * DiagnosticDataProvider delegate objects should have process lifetime, and can outlive shutdown process
+     * on all platforms. DiagnosticDataProvider delegate objects should be able to keep their state even after
+     * PlatformManager is shut down and restarted.
+     */
     void SetGeneralDiagnosticsDelegate(GeneralDiagnosticsDelegate * delegate) { mGeneralDiagnosticsDelegate = delegate; }
     GeneralDiagnosticsDelegate * GetGeneralDiagnosticsDelegate() const { return mGeneralDiagnosticsDelegate; }
 
@@ -255,7 +260,8 @@ DiagnosticDataProvider & GetDiagnosticDataProvider();
  * Sets a reference to a DiagnosticDataProvider object.
  *
  * This must be called before any calls to GetDiagnosticDataProvider. If a nullptr is passed in,
- * no changes will be made.
+ * no changes will be made. DiagnosticDataProvider object gets set only once during the lifetime
+ * of per process execution.
  */
 void SetDiagnosticDataProvider(DiagnosticDataProvider * diagnosticDataProvider);
 

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -114,6 +114,12 @@ public:
     CHIP_ERROR InitChipStack();
     CHIP_ERROR AddEventHandler(EventHandlerFunct handler, intptr_t arg = 0);
     void RemoveEventHandler(EventHandlerFunct handler, intptr_t arg = 0);
+
+    /**
+     * PlatformManager delegate object should have process lifetime, and can outlive shutdown process
+     * on all platforms. PlatformManager delegate object should be able to keep its state even after
+     * PlatformManager is shut down and restarted.
+     */
     void SetDelegate(PlatformManagerDelegate * delegate) { mDelegate = delegate; }
     PlatformManagerDelegate * GetDelegate() const { return mDelegate; }
 

--- a/src/platform/Linux/DiagnosticDataProviderImpl.h
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.h
@@ -30,14 +30,14 @@ namespace chip {
 namespace DeviceLayer {
 
 /**
- * Concrete implementation of the PlatformManager singleton object for Linux platforms.
+ * Concrete implementation of the DiagnosticDataProvider singleton object for Linux platforms.
  */
 class DiagnosticDataProviderImpl : public DiagnosticDataProvider
 {
 public:
     static DiagnosticDataProviderImpl & GetDefaultInstance();
 
-    // ===== Methods that implement the PlatformManager abstract interface.
+    // ===== Methods that implement the DiagnosticDataProvider abstract interface.
 
     CHIP_ERROR GetCurrentHeapFree(uint64_t & currentHeapFree) override;
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, the Matter*PluginServerInitCallback functions are implemented as if they are called once per process lifetime to avoid loops in the linked list, and presumably infinite loops during attr reads after that. (https://github.com/project-chip/connectedhomeip/issues/11352).

* That means we don't call SetDelegate again as things stand. If the CHIP stack is shut down and restarted (e.g. via PlatformManager::Shutdown and then a new InitChipStack, etc).

* Right now, shutting down the stack does not unregister delegate, so after PlatformManager::Shutdown and then a new InitChipStack, the delegate is still there until another SetDelegate is called, we need to make sure this is clearly documented to make sure these delegates are correctly set up on new platforms.

* Fixes #11568

#### Change overview
Add document to clarify all platform delegates have process lifetime

#### Testing
How was this tested? (at least one bullet point required)
* Document update only