### PR TITLE
Fix PersistentStorageDelegate APIs to be consistent about error reporting

### DIFF
--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -104,7 +104,7 @@ CHIP_ERROR PersistentStorage::SyncGetKeyValue(const char * key, void * value, ui
 
     auto section = mConfig.sections[kDefaultSectionName];
     auto it      = section.find(key);
-    ReturnErrorCodeIf(it == section.end(), CHIP_ERROR_KEY_NOT_FOUND);
+    ReturnErrorCodeIf(it == section.end(), CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 
     ReturnErrorCodeIf(!inipp::extract(section[key], iniValue), CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -135,6 +135,9 @@ CHIP_ERROR PersistentStorage::SyncSetKeyValue(const char * key, const void * val
 CHIP_ERROR PersistentStorage::SyncDeleteKeyValue(const char * key)
 {
     auto section = mConfig.sections[kDefaultSectionName];
+    auto it      = section.find(key);
+    ReturnErrorCodeIf(it == section.end(), CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+
     section.erase(key);
 
     mConfig.sections[kDefaultSectionName] = section;

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -265,8 +265,16 @@ class MyServerStorageDelegate : public PersistentStorageDelegate
 {
     CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
     {
-        ChipLogProgress(AppServer, "Retrieved value from server storage.");
-        return PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size);
+        ChipLogProgress(AppServer, "Retrieving value from server storage.");
+        size_t bytesRead = 0;
+        CHIP_ERROR err   = PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size, &bytesRead);
+
+        if (err == CHIP_NO_ERROR)
+        {
+            ChipLogProgress(AppServer, "Retrieved value from server storage.");
+        }
+        size = static_cast<uint16_t>(bytesRead);
+        return err;
     }
 
     CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -115,16 +115,15 @@ private:
     {
         CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
         {
-            size_t bytesRead;
-            ReturnErrorOnFailure(DeviceLayer::PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size, &bytesRead));
-            if (!CanCastTo<uint16_t>(bytesRead))
+            size_t bytesRead = 0;
+            CHIP_ERROR err   = DeviceLayer::PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size, &bytesRead);
+
+            if (err == CHIP_NO_ERROR)
             {
-                ChipLogDetail(AppServer, "0x%" PRIx32 " is too big to fit in uint16_t", static_cast<uint32_t>(bytesRead));
-                return CHIP_ERROR_BUFFER_TOO_SMALL;
+                ChipLogProgress(AppServer, "Retrieved from server storage: %s", key);
             }
-            ChipLogProgress(AppServer, "Retrieved from server storage: %s", key);
             size = static_cast<uint16_t>(bytesRead);
-            return CHIP_NO_ERROR;
+            return err;
         }
 
         CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override

--- a/src/controller/python/ChipDeviceController-StorageDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.cpp
@@ -34,7 +34,7 @@ CHIP_ERROR PythonPersistentStorageDelegate::SyncGetKeyValue(const char * key, vo
     auto val = mStorage.find(key);
     if (val == mStorage.end())
     {
-        return CHIP_ERROR_KEY_NOT_FOUND;
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     }
 
     if (value == nullptr)
@@ -46,14 +46,14 @@ CHIP_ERROR PythonPersistentStorageDelegate::SyncGetKeyValue(const char * key, vo
     if (size == 0)
     {
         size = neededSize;
-        return CHIP_ERROR_NO_MEMORY;
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 
     if (size < neededSize)
     {
         memcpy(value, val->second.data(), size);
         size = neededSize;
-        return CHIP_ERROR_NO_MEMORY;
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 
     memcpy(value, val->second.data(), neededSize);
@@ -71,6 +71,12 @@ CHIP_ERROR PythonPersistentStorageDelegate::SyncSetKeyValue(const char * key, co
 
 CHIP_ERROR PythonPersistentStorageDelegate::SyncDeleteKeyValue(const char * key)
 {
+    auto val = mStorage.find(key);
+    if (val == mStorage.end())
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
     mStorage.erase(key);
     return CHIP_NO_ERROR;
 }
@@ -88,13 +94,13 @@ CHIP_ERROR StorageAdapter::SyncGetKeyValue(const char * key, void * value, uint1
     if (tmpSize == 0)
     {
         ChipLogDetail(Controller, "Key Not Found\n");
-        return CHIP_ERROR_KEY_NOT_FOUND;
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     }
     else if (size < tmpSize)
     {
         ChipLogDetail(Controller, "Buf not big enough\n");
         size = tmpSize;
-        return CHIP_ERROR_NO_MEMORY;
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
     else
     {
@@ -114,6 +120,14 @@ CHIP_ERROR StorageAdapter::SyncSetKeyValue(const char * key, const void * value,
 
 CHIP_ERROR StorageAdapter::SyncDeleteKeyValue(const char * key)
 {
+    uint8_t val[1];
+    uint16_t size  = 0;
+    CHIP_ERROR err = SyncGetKeyValue(key, val, size);
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    {
+        return err;
+    }
+
     mDeleteKeyCb(mContext, key);
     return CHIP_NO_ERROR;
 }

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -40,7 +40,10 @@ public:
     CHIP_ERROR
     SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
     {
-        return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size);
+        size_t bytesRead = 0;
+        CHIP_ERROR err   = chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size, &bytesRead);
+        size             = static_cast<uint16_t>(bytesRead);
+        return err;
     }
 
     CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -93,11 +93,12 @@ CHIP_ERROR CHIPPersistentStorageDelegateBridge::SyncGetKeyValue(const char * key
 
             if (decoded.length() > UINT16_MAX) {
                 error = CHIP_ERROR_BUFFER_TOO_SMALL;
+                size = 0;
             } else {
                 if (buffer != nullptr) {
                     memcpy(buffer, decoded.data(), std::min<size_t>(decoded.length(), size));
                     if (size < decoded.length()) {
-                        error = CHIP_ERROR_NO_MEMORY;
+                        error = CHIP_ERROR_BUFFER_TOO_SMALL;
                     }
                 } else {
                     error = CHIP_ERROR_NO_MEMORY;
@@ -105,7 +106,7 @@ CHIP_ERROR CHIPPersistentStorageDelegateBridge::SyncGetKeyValue(const char * key
                 size = static_cast<uint16_t>(decoded.length());
             }
         } else {
-            error = CHIP_ERROR_KEY_NOT_FOUND;
+            error = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
         }
     });
     return error;

--- a/src/lib/core/CHIPPersistentStorageDelegate.h
+++ b/src/lib/core/CHIPPersistentStorageDelegate.h
@@ -45,6 +45,18 @@ public:
      *                 The output length could be larger than input value. In
      *                 such cases, the user should allocate the buffer large
      *                 enough (>= output length), and call the API again.
+     *
+     * @return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND the key is unknown.
+     * @return CHIP_ERROR_BUFFER_TOO_SMALL the provided buffer is not big
+     *                                     enough.  In this case "size" will
+     *                                     indicate the needed buffer size.
+     *                                     Some data may or may not be placed
+     *                                     in "buffer" in this case; consumers
+     *                                     should not rely on that behavior.
+     *                                     CHIP_ERROR_BUFFER_TOO_SMALL combined
+     *                                     with setting "size" to 0 means the
+     *                                     actual size was too large to fit in
+     *                                     uint16_t.
      */
     virtual CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) = 0;
 
@@ -63,6 +75,8 @@ public:
      *   Deletes the value for the key
      *
      * @param[in] key Key to be deleted
+     *
+     * @return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND the key is unknown.
      */
     virtual CHIP_ERROR SyncDeleteKeyValue(const char * key) = 0;
 };

--- a/src/lib/support/TestPersistentStorageDelegate.h
+++ b/src/lib/support/TestPersistentStorageDelegate.h
@@ -57,6 +57,8 @@ public:
 
     CHIP_ERROR SyncDeleteKeyValue(const char * key) override
     {
+        bool contains = mStorage.find(key) != mStorage.end();
+        VerifyOrReturnError(contains, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
         mStorage.erase(key);
         return CHIP_NO_ERROR;
     }


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/15671

#### Problem
Storage delegate has unclear API contract, implementation violate parts of it anyway.

#### Change overview
Define contract more clearly, fix violations.

#### Testing
Should not affect existing code.  Should allow new code being added to not have to check for multiple possible error returns for the same situation.