### PR TITLE
Generated content is out of sync

### DIFF
--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
@@ -7265,6 +7265,10 @@ typedef NS_OPTIONS(NSUInteger, CHIPOnOffControl) {
     CHIPOnOffControlAcceptOnlyWhenOn = 0x1,
 };
 
+typedef NS_OPTIONS(NSUInteger, CHIPOnOffFeature) {
+    CHIPOnOffFeatureLighting = 0x1,
+};
+
 typedef NS_ENUM(NSInteger, CHIPLevelControlMoveMode) {
     CHIPLevelControlMoveModeUp = 0x00,
     CHIPLevelControlMoveModeDown = 0x01,


### PR DESCRIPTION
#### Problem

ToT is red because the generated content if out of sync (again).
