### PR TITLE
Fix a memory leak in src/crypto/CHIPCryptoPALOpenSSL.cpp

### DIFF
--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -1204,6 +1204,11 @@ exit:
         X509_REQ_free(x509_req);
     }
 
+    if (ec_key != nullptr)
+    {
+        EC_KEY_free(ec_key);
+    }
+
     _logSSLError();
     return error;
 }


### PR DESCRIPTION
#### Problem

The `EC_KEY` is not freed.

#### Change overview
 * free it
