### PR TITLE
[ota] User consent handling in OTA Requestor

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/BUILD.gn
+++ b/examples/ota-provider-app/ota-provider-common/BUILD.gn
@@ -33,7 +33,6 @@ chip_data_model("ota-provider-common") {
     "DefaultUserConsentProvider.h",
     "OTAProviderExample.cpp",
     "OTAProviderExample.h",
-    "UserConsentDelegate.h",
   ]
 
   deps = [ "${chip_root}/src/protocols/bdx" ]

--- a/examples/ota-provider-app/ota-provider-common/DefaultUserConsentProvider.cpp
+++ b/examples/ota-provider-app/ota-provider-common/DefaultUserConsentProvider.cpp
@@ -15,29 +15,14 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <lib/support/logging/CHIPLogging.h>
 #include <ota-provider-common/DefaultUserConsentProvider.h>
 
 namespace chip {
 namespace ota {
 
-void DefaultUserConsentProvider::LogUserConsentSubject(const UserConsentSubject & subject)
-{
-    ChipLogDetail(SoftwareUpdate, "User consent request for:");
-    ChipLogDetail(SoftwareUpdate, ":  FabricIndex: %u", subject.fabricIndex);
-    ChipLogDetail(SoftwareUpdate, ":  RequestorNodeId: " ChipLogFormatX64, ChipLogValueX64(subject.requestorNodeId));
-    ChipLogDetail(SoftwareUpdate, ":  ProviderEndpointId: %" PRIu16, subject.providerEndpointId);
-    ChipLogDetail(SoftwareUpdate, ":  RequestorVendorId: %" PRIu16, subject.requestorVendorId);
-    ChipLogDetail(SoftwareUpdate, ":  RequestorProductId: %" PRIu16, subject.requestorProductId);
-    ChipLogDetail(SoftwareUpdate, ":  RequestorCurrentVersion: %" PRIu32, subject.requestorCurrentVersion);
-    ChipLogDetail(SoftwareUpdate, ":  RequestorTargetVersion: %" PRIu32, subject.requestorTargetVersion);
-    ChipLogDetail(SoftwareUpdate, ":  Metadata:");
-    ChipLogByteSpan(SoftwareUpdate, subject.metadata);
-}
-
 UserConsentState DefaultUserConsentProvider::GetUserConsentState(const UserConsentSubject & subject)
 {
-    LogUserConsentSubject(subject);
+    subject.Log();
 
     if (mUseGlobalConsent)
     {

--- a/examples/ota-provider-app/ota-provider-common/DefaultUserConsentProvider.h
+++ b/examples/ota-provider-app/ota-provider-common/DefaultUserConsentProvider.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <lib/core/CHIPError.h>
-#include <ota-provider-common/UserConsentDelegate.h>
+#include <platform/UserConsentDelegate.h>
 
 namespace chip {
 namespace ota {
@@ -30,7 +30,7 @@ public:
 
     ~DefaultUserConsentProvider() = default;
 
-    // This method returns kGranted unless explicitly denied by the user by calling RevokeUserConsent()
+    // This method returns kGranted unless explicitly set by the user by calling SetGlobalUserConsentState()
     UserConsentState GetUserConsentState(const UserConsentSubject & subject) override;
 
     // If this is set to true, all the user consent requests will be replied with global consent.
@@ -54,8 +54,6 @@ private:
     bool mUseGlobalConsent = false;
 
     UserConsentState mGlobalConsentState = UserConsentState::kGranted;
-
-    void LogUserConsentSubject(const UserConsentSubject & subject);
 };
 
 } // namespace ota

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -203,7 +203,8 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
             }
         }
 
-        if (queryStatus == OTAQueryStatus::kUpdateAvailable && mUserConsentDelegate != nullptr)
+        // If requestor is capable of taking user consent then delegate obtaining user consent to the requestor
+        if (requestorCanConsent == false && queryStatus == OTAQueryStatus::kUpdateAvailable && mUserConsentDelegate != nullptr)
         {
             UserConsentState state = mUserConsentDelegate->GetUserConsentState(
                 GetUserConsentSubject(commandObj, commandPath, commandData, newSoftwareVersion));
@@ -279,7 +280,7 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
 
     response.status = queryStatus;
     response.delayedActionTime.Emplace(delayedActionTimeSec);
-    if (mUserConsentNeeded && requestorCanConsent)
+    if (mUserConsentNeeded || requestorCanConsent)
     {
         response.userConsentNeeded.Emplace(true);
     }

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -203,8 +203,10 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
             }
         }
 
-        // If requestor is capable of taking user consent then delegate obtaining user consent to the requestor
-        if (requestorCanConsent == false && queryStatus == OTAQueryStatus::kUpdateAvailable && mUserConsentDelegate != nullptr)
+        // If mUserConsentNeeded (set by the CLI) is true and requestor is capable of taking user consent
+        // then delegate obtaining user consent to the requestor
+        if (mUserConsentDelegate && queryStatus == OTAQueryStatus::kUpdateAvailable
+                && (requestorCanConsent && mUserConsentNeeded) == false)
         {
             UserConsentState state = mUserConsentDelegate->GetUserConsentState(
                 GetUserConsentSubject(commandObj, commandPath, commandData, newSoftwareVersion));
@@ -280,7 +282,7 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
 
     response.status = queryStatus;
     response.delayedActionTime.Emplace(delayedActionTimeSec);
-    if (mUserConsentNeeded || requestorCanConsent)
+    if (mUserConsentNeeded && requestorCanConsent)
     {
         response.userConsentNeeded.Emplace(true);
     }

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -205,8 +205,8 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
 
         // If mUserConsentNeeded (set by the CLI) is true and requestor is capable of taking user consent
         // then delegate obtaining user consent to the requestor
-        if (mUserConsentDelegate && queryStatus == OTAQueryStatus::kUpdateAvailable
-                && (requestorCanConsent && mUserConsentNeeded) == false)
+        if (mUserConsentDelegate && queryStatus == OTAQueryStatus::kUpdateAvailable &&
+            (requestorCanConsent && mUserConsentNeeded) == false)
         {
             UserConsentState state = mUserConsentDelegate->GetUserConsentState(
                 GetUserConsentSubject(commandObj, commandPath, commandData, newSoftwareVersion));

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
@@ -22,7 +22,7 @@
 #include <app/CommandHandler.h>
 #include <app/clusters/ota-provider/ota-provider-delegate.h>
 #include <ota-provider-common/BdxOtaSender.h>
-#include <ota-provider-common/UserConsentDelegate.h>
+#include <platform/UserConsentDelegate.h>
 #include <vector>
 
 /**

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -18,8 +18,9 @@
 
 #include "AppMain.h"
 #include "app/clusters/ota-requestor/BDXDownloader.h"
+#include "app/clusters/ota-requestor/DefaultOTARequestorUserConsentProvider.h"
 #include "app/clusters/ota-requestor/OTARequestor.h"
-#include "platform/GenericOTARequestorDriver.h"
+#include "platform/ExtendedOTARequestorDriver.h"
 #include "platform/Linux/OTAImageProcessorImpl.h"
 
 using chip::BDXDownloader;
@@ -47,12 +48,15 @@ using namespace chip::Messaging;
 using namespace chip::app::Clusters::OtaSoftwareUpdateProvider::Commands;
 
 OTARequestor gRequestorCore;
-DeviceLayer::GenericOTARequestorDriver gRequestorUser;
+DeviceLayer::ExtendedOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
+chip::ota::DefaultOTARequestorUserConsentProvider gUserConsentProvider;
+static chip::ota::UserConsentState gUserConsentState = chip::ota::UserConsentState::kUnknown;
 
 bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue);
 
+constexpr uint16_t kOptionUserConsentState     = 'u';
 constexpr uint16_t kOptionPeriodicQueryTimeout = 'p';
 constexpr uint16_t kOptionRequestorCanConsent  = 'c';
 constexpr uint16_t kOptionOtaDownloadPath      = 'f';
@@ -66,6 +70,7 @@ OptionDef cmdLineOptionsDef[] = {
     { "periodicQueryTimeout", chip::ArgParser::kArgumentRequired, kOptionPeriodicQueryTimeout },
     { "requestorCanConsent", chip::ArgParser::kNoArgument, kOptionRequestorCanConsent },
     { "otaDownloadPath", chip::ArgParser::kArgumentRequired, kOptionOtaDownloadPath },
+    { "userConsentState", chip::ArgParser::kArgumentRequired, kOptionUserConsentState },
     {},
 };
 
@@ -78,7 +83,11 @@ OptionSet cmdLineOptions = { HandleOptions, cmdLineOptionsDef, "PROGRAM OPTIONS"
                              "        Otherwise, the value is determined by the driver.\n "
                              "  -f/--otaDownloadPath <file path>\n"
                              "        If supplied, the OTA image is downloaded to the given fully-qualified file-path.\n"
-                             "        Otherwise, the value defaults to /tmp/test.bin.\n " };
+                             "        Otherwise, the value defaults to /tmp/test.bin.\n "
+                             "  -u/--userConsentState <granted | denied | deferred>\n"
+                             "        granted: Authorize OTA requestor to download an OTA image\n"
+                             "        denied: Forbid OTA requestor to download an OTA image\n"
+                             "        deferred: Defer obtaining user consent \n" };
 
 OptionSet * allOptions[] = { &cmdLineOptions, nullptr };
 
@@ -100,6 +109,12 @@ static void InitOTARequestor(void)
 
     // Set the image processor instance used for handling image being downloaded
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
+
+    if (gUserConsentState != chip::ota::UserConsentState::kUnknown)
+    {
+        gUserConsentProvider.SetUserConsentState(gUserConsentState);
+        gRequestorUser.SetUserConsentDelegate(&gUserConsentProvider);
+    }
 }
 
 bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue)
@@ -116,6 +131,30 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
         break;
     case kOptionOtaDownloadPath:
         chip::Platform::CopyString(gOtaDownloadPath, aValue);
+        break;
+    case kOptionUserConsentState:
+        if (aValue == NULL)
+        {
+            PrintArgError("%s: ERROR: NULL UserConsent parameter\n", aProgram);
+            retval = false;
+        }
+        else if (strcmp(aValue, "granted") == 0)
+        {
+            gUserConsentState = chip::ota::UserConsentState::kGranted;
+        }
+        else if (strcmp(aValue, "denied") == 0)
+        {
+            gUserConsentState = chip::ota::UserConsentState::kDenied;
+        }
+        else if (strcmp(aValue, "deferred") == 0)
+        {
+            gUserConsentState = chip::ota::UserConsentState::kObtaining;
+        }
+        else
+        {
+            PrintArgError("%s: ERROR: Invalid UserConsent parameter:  %s\n", aProgram, aValue);
+            retval = false;
+        }
         break;
     default:
         PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", aProgram, aName);

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -131,6 +131,7 @@ template("chip_data_model") {
           "${_app_root}/clusters/${cluster}/${cluster}-server.cpp",
           "${_app_root}/clusters/${cluster}/BDXDownloader.cpp",
           "${_app_root}/clusters/${cluster}/BDXDownloader.h",
+          "${_app_root}/clusters/${cluster}/DefaultOTARequestorUserConsentProvider.h",
           "${_app_root}/clusters/${cluster}/OTARequestor.cpp",
         ]
       } else if (cluster == "bindings") {

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorUserConsentProvider.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorUserConsentProvider.h
@@ -1,0 +1,49 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <platform/OTARequestorUserConsentDelegate.h>
+
+namespace chip {
+namespace ota {
+
+class DefaultOTARequestorUserConsentProvider : public OTARequestorUserConsentDelegate
+{
+public:
+    DefaultOTARequestorUserConsentProvider() = default;
+
+    ~DefaultOTARequestorUserConsentProvider() = default;
+
+    // This method returns kGranted unless explicitly set by the user by calling SetUserConsentState()
+    UserConsentState GetUserConsentState(const UserConsentSubject & subject) override
+    {
+        subject.Log();
+        return mUserConsentState;
+    }
+
+    UserConsentState CheckDeferredUserConsentState() override { return mUserConsentState; }
+
+    void SetUserConsentState(UserConsentState state) { mUserConsentState = state; }
+
+private:
+    UserConsentState mUserConsentState = UserConsentState::kGranted;
+};
+
+} // namespace ota
+} // namespace chip

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -446,6 +446,11 @@ void OTARequestor::DownloadUpdate()
     ConnectToProvider(kDownload);
 }
 
+void OTARequestor::DownloadUpdateDelayedOnUserConsent()
+{
+    RecordNewUpdateState(OTAUpdateStateEnum::kDelayedOnUserConsent, OTAChangeReasonEnum::kSuccess);
+}
+
 void OTARequestor::ApplyUpdate()
 {
     RecordNewUpdateState(OTAUpdateStateEnum::kApplying, OTAChangeReasonEnum::kSuccess);

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -54,6 +54,9 @@ public:
     // Initiate download of the new image
     void DownloadUpdate() override;
 
+    // Set the requestor state to kDelayedOnUserConsent
+    void DownloadUpdateDelayedOnUserConsent() override;
+
     // Initiate the session to send ApplyUpdateRequest command
     void ApplyUpdate() override;
 

--- a/src/include/platform/OTARequestorDriver.h
+++ b/src/include/platform/OTARequestorDriver.h
@@ -51,6 +51,7 @@ enum class UpdateFailureState
     kApplying,
     kNotifying,
     kAwaitingNextAction,
+    kDelayedOnUserConsent,
 };
 
 enum class UpdateNotFoundReason

--- a/src/include/platform/OTARequestorInterface.h
+++ b/src/include/platform/OTARequestorInterface.h
@@ -172,6 +172,9 @@ public:
     // Download image
     virtual void DownloadUpdate() = 0;
 
+    // Image download delayed on user consent
+    virtual void DownloadUpdateDelayedOnUserConsent() = 0;
+
     // Initiate the session to send ApplyUpdateRequest command
     virtual void ApplyUpdate() = 0;
 

--- a/src/include/platform/OTARequestorUserConsentDelegate.h
+++ b/src/include/platform/OTARequestorUserConsentDelegate.h
@@ -1,0 +1,37 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+#include <platform/UserConsentDelegate.h>
+
+namespace chip {
+namespace ota {
+
+class OTARequestorUserConsentDelegate : public UserConsentDelegate
+{
+public:
+    virtual ~OTARequestorUserConsentDelegate() = default;
+
+    virtual UserConsentState GetUserConsentState(const UserConsentSubject & subject) = 0;
+
+    // When GetUserConsentState() returns kObtaining this will be called to
+    // check if the user consent is granted or denied.
+    virtual UserConsentState CheckDeferredUserConsentState() = 0;
+};
+
+} // namespace ota
+} // namespace chip

--- a/src/include/platform/UserConsentDelegate.h
+++ b/src/include/platform/UserConsentDelegate.h
@@ -19,6 +19,7 @@
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/NodeId.h>
 #include <lib/support/Span.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 namespace chip {
 namespace ota {
@@ -64,6 +65,20 @@ struct UserConsentSubject
     // This data is not owned by UserConsentSubject and therefore any user of this field
     // has to copy the data and own it if not immediately used from an argument having a UserConsentSubject
     ByteSpan metadata;
+
+    void Log() const
+    {
+        ChipLogDetail(SoftwareUpdate, "User consent request for:");
+        ChipLogDetail(SoftwareUpdate, ":  FabricIndex: %u", this->fabricIndex);
+        ChipLogDetail(SoftwareUpdate, ":  RequestorNodeId: " ChipLogFormatX64, ChipLogValueX64(this->requestorNodeId));
+        ChipLogDetail(SoftwareUpdate, ":  ProviderEndpointId: %" PRIu16, this->providerEndpointId);
+        ChipLogDetail(SoftwareUpdate, ":  RequestorVendorId: %" PRIu16, this->requestorVendorId);
+        ChipLogDetail(SoftwareUpdate, ":  RequestorProductId: %" PRIu16, this->requestorProductId);
+        ChipLogDetail(SoftwareUpdate, ":  RequestorCurrentVersion: %" PRIu32, this->requestorCurrentVersion);
+        ChipLogDetail(SoftwareUpdate, ":  RequestorTargetVersion: %" PRIu32, this->requestorTargetVersion);
+        ChipLogDetail(SoftwareUpdate, ":  Metadata:");
+        ChipLogByteSpan(SoftwareUpdate, this->metadata);
+    }
 };
 
 class UserConsentDelegate

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -318,6 +318,8 @@ if (chip_device_platform != "none") {
 
     if (chip_enable_ota_requestor) {
       sources += [
+        "ExtendedOTARequestorDriver.cpp",
+        "ExtendedOTARequestorDriver.h",
         "GenericOTARequestorDriver.cpp",
         "GenericOTARequestorDriver.h",
       ]

--- a/src/platform/ExtendedOTARequestorDriver.cpp
+++ b/src/platform/ExtendedOTARequestorDriver.cpp
@@ -1,0 +1,127 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <platform/ExtendedOTARequestorDriver.h>
+#include <platform/OTARequestorInterface.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+namespace {
+
+constexpr System::Clock::Seconds32 kUserConsentPollInterval = System::Clock::Seconds32(30);
+
+} // namespace
+
+void ExtendedOTARequestorDriver::UpdateAvailable(const UpdateDescription & update, System::Clock::Seconds32 delay)
+{
+    VerifyOrDie(mRequestor != nullptr);
+
+    if (update.userConsentNeeded == true && mUserConsentDelegate)
+    {
+        bool localConfigDisabled = false;
+        VerifyOrdo(DeviceLayer::ConfigurationMgr().GetLocalConfigDisabled(localConfigDisabled) == CHIP_NO_ERROR,
+                   ChipLogProgress(SoftwareUpdate, "Failed to get local config disabled, using as false"));
+
+        if (localConfigDisabled == false)
+        {
+            chip::ota::UserConsentSubject subject;
+            CHIP_ERROR err = GetUserConsentSubject(subject, update);
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(SoftwareUpdate, "Failed to get user consent subject");
+                return;
+            }
+
+            mDelayedActionTime = delay;
+            HandleUserConsentState(mUserConsentDelegate->GetUserConsentState(subject));
+            return;
+        }
+    }
+
+    ScheduleDelayedAction(
+        delay,
+        [](System::Layer *, void * context) { static_cast<ExtendedOTARequestorDriver *>(context)->mRequestor->DownloadUpdate(); },
+        this);
+}
+
+void ExtendedOTARequestorDriver::PollUserConsentState()
+{
+    HandleUserConsentState(mUserConsentDelegate->CheckDeferredUserConsentState());
+}
+
+CHIP_ERROR ExtendedOTARequestorDriver::GetUserConsentSubject(chip::ota::UserConsentSubject & subject,
+                                                             const UpdateDescription & update)
+{
+    // mLastUsedProvider has the provider fabric index and endpoint id
+    subject.fabricIndex        = mLastUsedProvider.fabricIndex;
+    subject.providerEndpointId = mLastUsedProvider.endpoint;
+
+    // TODO: As we cannot use the src/app/Server.h in here so, figure out a way to get the node id.
+
+    ReturnErrorOnFailure(DeviceLayer::ConfigurationMgr().GetVendorId(subject.requestorVendorId));
+    ReturnErrorOnFailure(DeviceLayer::ConfigurationMgr().GetProductId(subject.requestorProductId));
+    ReturnErrorOnFailure(DeviceLayer::ConfigurationMgr().GetSoftwareVersion(subject.requestorCurrentVersion));
+    subject.requestorTargetVersion = update.softwareVersion;
+    subject.metadata               = update.metadataForRequestor;
+
+    return CHIP_NO_ERROR;
+}
+
+void ExtendedOTARequestorDriver::HandleUserConsentState(chip::ota::UserConsentState userConsentState)
+{
+    ChipLogDetail(SoftwareUpdate, "User consent state: %s", mUserConsentDelegate->UserConsentStateToString(userConsentState));
+
+    switch (userConsentState)
+    {
+    case chip::ota::UserConsentState::kGranted:
+        ScheduleDelayedAction(
+            mDelayedActionTime,
+            [](System::Layer *, void * context) {
+                static_cast<ExtendedOTARequestorDriver *>(context)->mRequestor->DownloadUpdate();
+            },
+            this);
+        break;
+
+    case chip::ota::UserConsentState::kDenied:
+        ScheduleDelayedAction(
+            mDelayedActionTime,
+            [](System::Layer *, void * context) {
+                static_cast<ExtendedOTARequestorDriver *>(context)->mRequestor->CancelImageUpdate();
+            },
+            this);
+        break;
+
+    case chip::ota::UserConsentState::kObtaining:
+        SystemLayer().ScheduleWork(
+            [](System::Layer *, void * context) {
+                static_cast<ExtendedOTARequestorDriver *>(context)->mRequestor->DownloadUpdateDelayedOnUserConsent();
+            },
+            this);
+
+        ScheduleDelayedAction(
+            kUserConsentPollInterval,
+            [](System::Layer *, void * context) { static_cast<ExtendedOTARequestorDriver *>(context)->PollUserConsentState(); },
+            this);
+        break;
+
+    default:
+        break;
+    }
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/ExtendedOTARequestorDriver.h
+++ b/src/platform/ExtendedOTARequestorDriver.h
@@ -29,6 +29,8 @@ namespace DeviceLayer {
 class ExtendedOTARequestorDriver : public GenericOTARequestorDriver
 {
 public:
+    bool CanConsent() override;
+
     void UpdateAvailable(const UpdateDescription & update, System::Clock::Seconds32 delay) override;
 
     /**

--- a/src/platform/ExtendedOTARequestorDriver.h
+++ b/src/platform/ExtendedOTARequestorDriver.h
@@ -1,0 +1,52 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/GenericOTARequestorDriver.h>
+#include <platform/OTARequestorUserConsentDelegate.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+/**
+ * This extends the GenericOTARequestorDriver and provides optional
+ * features. For now, it adds support for the handling user consent.
+ */
+class ExtendedOTARequestorDriver : public GenericOTARequestorDriver
+{
+public:
+    void UpdateAvailable(const UpdateDescription & update, System::Clock::Seconds32 delay) override;
+
+    /**
+     * Set delegate for requesting user consent
+     */
+    void SetUserConsentDelegate(chip::ota::OTARequestorUserConsentDelegate * delegate) { mUserConsentDelegate = delegate; }
+
+private:
+    System::Clock::Seconds32 mDelayedActionTime;
+
+    chip::ota::OTARequestorUserConsentDelegate * mUserConsentDelegate = nullptr;
+
+    void PollUserConsentState();
+
+    CHIP_ERROR GetUserConsentSubject(chip::ota::UserConsentSubject & subject, const UpdateDescription & update);
+
+    void HandleUserConsentState(chip::ota::UserConsentState userConsentState);
+};
+
+} // namespace DeviceLayer
+} // namespace chip


### PR DESCRIPTION
#### Problem
* Fixes #13817 

#### Change overview
In case of stored consent, the file transfer will take place or will be canceled based on the user consent state.
In case of deferred consent, generic OTA requestor driver will poll for the user consent state every 30 seconds and take appropriate action when user consent is granted/denied.

* Added an OTARequestorUserConsentDelegate and the default implementation for the same
* Extended the GenericOTARequestorDriver and implemented the user consent handling in ExtendedOTARequestorDriver
* CLI option to specify the user consent state to set

#### Testing
* Tested manually the granted, denied, and deferred state by using `-u`.