### PR TITLE
ESP32: Fix onnetwork pairing when disabling CHIPoBLE

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -68,7 +68,7 @@ chip_gn_arg_append("esp32_cxx"             "\"${CMAKE_CXX_COMPILER}\"")
 chip_gn_arg_append("esp32_cpu"             "\"esp32\"")
 chip_gn_arg_bool("is_debug"                ${is_debug})
 
-if(CONFIG_BT_ENABLED)
+if(CONFIG_ENABLE_CHIPOBLE)
 chip_gn_arg_append("chip_config_network_layer_ble"           "true")
 else()
 chip_gn_arg_append("chip_config_network_layer_ble"           "false")


### PR DESCRIPTION
#### Problem
Onnetwork commissioning will fail on ESP32 when we disable config `ENABLE_CHIPOBLE` in menuconfig . 

#### Change overview
Fix the bug

#### Testing
Test all-clusters-app on ESP32C3 after disabling `ENABLE_CHIPOBLE`, using `matter wifi connect ssid password` to connect ESP32C3 to an AP, then using chip-tool to finish on-network commissioning.
