### PR TITLE
Make group session ephemeral

### DIFF
--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -126,15 +126,8 @@ public:
         VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_NO_MEMORY);
         ReturnErrorOnFailure(commandSender->AddRequestDataNoTimedCheck(commandPath, value, mTimedInteractionTimeoutMs));
 
-        chip::Optional<chip::SessionHandle> session =
-            exchangeManager->GetSessionManager()->CreateGroupSession(groupId, fabricIndex, senderNodeId);
-        if (!session.HasValue())
-        {
-            return CHIP_ERROR_NO_MEMORY;
-        }
-        CHIP_ERROR err = commandSender->SendGroupCommandRequest(session.Value());
-        exchangeManager->GetSessionManager()->RemoveGroupSession(session.Value()->AsGroupSession());
-        ReturnErrorOnFailure(err);
+        chip::Transport::OutgoingGroupSession session(groupId, fabricIndex, senderNodeId);
+        ReturnErrorOnFailure(commandSender->SendGroupCommandRequest(chip::SessionHandle(session)));
         commandSender.release();
 
         return CHIP_NO_ERROR;

--- a/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
+++ b/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
@@ -128,15 +128,8 @@ public:
         VerifyOrReturnError(writeClient != nullptr, CHIP_ERROR_NO_MEMORY);
         ReturnErrorOnFailure(writeClient->EncodeAttribute(attributePathParams, value, mDataVersion));
 
-        chip::Optional<chip::SessionHandle> session =
-            exchangeManager->GetSessionManager()->CreateGroupSession(groupId, fabricIndex, senderNodeId);
-        if (!session.HasValue())
-        {
-            return CHIP_ERROR_NO_MEMORY;
-        }
-        CHIP_ERROR err = writeClient->SendWriteRequest(session.Value());
-        exchangeManager->GetSessionManager()->RemoveGroupSession(session.Value()->AsGroupSession());
-        ReturnErrorOnFailure(err);
+        chip::Transport::OutgoingGroupSession session(groupId, fabricIndex, senderNodeId);
+        ReturnErrorOnFailure(writeClient->SendWriteRequest(chip::SessionHandle(session)));
         writeClient.release();
 
         return CHIP_NO_ERROR;

--- a/examples/chip-tool/commands/common/CommandInvoker.h
+++ b/examples/chip-tool/commands/common/CommandInvoker.h
@@ -117,19 +117,14 @@ public:
 
         ReturnErrorOnFailure(commandSender->AddRequestData(commandPath, aRequestData));
 
-        Optional<SessionHandle> session = exchangeManager->GetSessionManager()->CreateGroupSession(groupId, fabric, sourceNodeId);
-        if (!session.HasValue())
-        {
-            return CHIP_ERROR_NO_MEMORY;
-        }
+        Transport::OutgoingGroupSession session(groupId, fabric, sourceNodeId);
 
         // this (invoker) and commandSender will be deleted by the onDone call before the return of SendGroupCommandRequest
         // this (invoker) should not be used after the SendGroupCommandRequest call
-        ReturnErrorOnFailure(commandSender->SendGroupCommandRequest(session.Value()));
+        ReturnErrorOnFailure(commandSender->SendGroupCommandRequest(SessionHandle(session)));
 
         // this (invoker) and commandSender are already deleted and are not to be used
         commandSender.release();
-        exchangeManager->GetSessionManager()->RemoveGroupSession(session.Value()->AsGroupSession());
 
         return CHIP_NO_ERROR;
     }

--- a/examples/shell/shell_common/cmd_server.cpp
+++ b/examples/shell/shell_common/cmd_server.cpp
@@ -128,9 +128,15 @@ static bool PrintServerSession(void * context, SessionHandle & session)
         break;
     }
 
-    case Session::SessionType::kGroup: {
-        GroupSession * groupSession = session->AsGroupSession();
-        streamer_printf(streamer_get(), "session type=GROUP id=0x%04x fabricIdx=%d\r\n", groupSession->GetGroupId(),
+    case Session::SessionType::kGroupIncoming: {
+        IncomingGroupSession * groupSession = session->AsIncomingGroupSession();
+        streamer_printf(streamer_get(), "session type=GROUP INCOMING id=0x%04x fabricIdx=%d\r\n", groupSession->GetGroupId(),
+                        groupSession->GetFabricIndex());
+        break;
+    }
+    case Session::SessionType::kGroupOutgoing: {
+        OutgoingGroupSession * groupSession = session->AsOutgoingGroupSession();
+        streamer_printf(streamer_get(), "session type=GROUP OUTGOING id=0x%04x fabricIdx=%d\r\n", groupSession->GetGroupId(),
                         groupSession->GetFabricIndex());
         break;
     }

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -344,7 +344,7 @@ CHIP_ERROR CommandHandler::ProcessGroupCommandDataIB(CommandDataIB::Parser & aCo
     err = commandPath.GetCommandId(&commandId);
     SuccessOrExit(err);
 
-    groupId = mpExchangeCtx->GetSessionHandle()->AsGroupSession()->GetGroupId();
+    groupId = mpExchangeCtx->GetSessionHandle()->AsIncomingGroupSession()->GetGroupId();
     fabric  = GetAccessingFabricIndex();
 
     ChipLogDetail(DataManagement,

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -295,7 +295,8 @@ CHIP_ERROR WriteHandler::ProcessGroupAttributeDataIBs(TLV::TLVReader & aAttribut
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     ReturnErrorCodeIf(mpExchangeCtx == nullptr, CHIP_ERROR_INTERNAL);
-    const Access::SubjectDescriptor subjectDescriptor = mpExchangeCtx->GetSessionHandle()->AsGroupSession()->GetSubjectDescriptor();
+    const Access::SubjectDescriptor subjectDescriptor =
+        mpExchangeCtx->GetSessionHandle()->AsIncomingGroupSession()->GetSubjectDescriptor();
 
     while (CHIP_NO_ERROR == (err = aAttributeDataIBsReader.Next()))
     {
@@ -329,7 +330,7 @@ CHIP_ERROR WriteHandler::ProcessGroupAttributeDataIBs(TLV::TLVReader & aAttribut
         err = attributePath.GetListIndex(dataAttributePath);
         SuccessOrExit(err);
 
-        groupId = mpExchangeCtx->GetSessionHandle()->AsGroupSession()->GetGroupId();
+        groupId = mpExchangeCtx->GetSessionHandle()->AsIncomingGroupSession()->GetGroupId();
         fabric  = GetAccessingFabricIndex();
 
         err = element.GetData(&dataReader);

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -316,7 +316,7 @@ bool OnOffServer::offWithEffectCommand(app::CommandHandler * commandObj, const a
             GroupId groupId = ZCL_SCENES_GLOBAL_SCENE_GROUP_ID;
             if (commandObj->GetExchangeContext()->IsGroupExchangeContext())
             {
-                groupId = commandObj->GetExchangeContext()->GetSessionHandle()->AsGroupSession()->GetGroupId();
+                groupId = commandObj->GetExchangeContext()->GetSessionHandle()->AsIncomingGroupSession()->GetGroupId();
             }
 
             emberAfScenesClusterStoreCurrentSceneCallback(fabric, endpoint, groupId, ZCL_SCENES_GLOBAL_SCENE_SCENE_ID);
@@ -383,7 +383,7 @@ bool OnOffServer::OnWithRecallGlobalSceneCommand(app::CommandHandler * commandOb
     GroupId groupId = ZCL_SCENES_GLOBAL_SCENE_GROUP_ID;
     if (commandObj->GetExchangeContext()->IsGroupExchangeContext())
     {
-        groupId = commandObj->GetExchangeContext()->GetSessionHandle()->AsGroupSession()->GetGroupId();
+        groupId = commandObj->GetExchangeContext()->GetSessionHandle()->AsIncomingGroupSession()->GetGroupId();
     }
 
     emberAfScenesClusterRecallSavedSceneCallback(fabric, endpoint, groupId, ZCL_SCENES_GLOBAL_SCENE_SCENE_ID);

--- a/src/controller/CHIPCluster.cpp
+++ b/src/controller/CHIPCluster.cpp
@@ -45,34 +45,10 @@ CHIP_ERROR ClusterBase::Associate(DeviceProxy * device, EndpointId endpoint)
 CHIP_ERROR ClusterBase::AssociateWithGroup(DeviceProxy * device, GroupId groupId)
 {
     // TODO Update this function to work in all possible conditions Issue #11850
-
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    mDevice = device;
-    if (mDevice->GetSecureSession().HasValue())
-    {
-        // Local copy to preserve original SessionHandle for future Unicast communication.
-        Optional<SessionHandle> session = mDevice->GetExchangeManager()->GetSessionManager()->CreateGroupSession(
-            groupId, mDevice->GetSecureSession().Value()->GetFabricIndex(), mDevice->GetDeviceId());
-
-        // Sanity check
-        if (!session.HasValue() || !session.Value()->IsGroupSession())
-        {
-            err = CHIP_ERROR_INCORRECT_STATE;
-        }
-
-        mGroupSession.Grab(session.Value());
-    }
-    else
-    {
-        // something fishy is going on
-        err = CHIP_ERROR_INCORRECT_STATE;
-    }
-
-    // Set to 0 for now.
-    mEndpoint = 0;
-
-    return err;
+    mDevice   = device;
+    mEndpoint = 0; // Set to 0 for now.
+    mGroupId.SetValue(groupId);
+    return CHIP_NO_ERROR;
 }
 
 void ClusterBase::Dissociate()

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1205,17 +1205,6 @@
 #endif // CHIP_CONFIG_UNAUTHENTICATED_CONNECTION_POOL_SIZE
 
 /**
- * @def CHIP_CONFIG_GROUP_CONNECTION_POOL_SIZE
- *
- * @brief Define the size of the pool used for tracking CHIP groups.
- *        Given the ephemeral nature of groups session, no need to support
- *        a large pool size.
- */
-#ifndef CHIP_CONFIG_GROUP_CONNECTION_POOL_SIZE
-#define CHIP_CONFIG_GROUP_CONNECTION_POOL_SIZE 4
-#endif // CHIP_CONFIG_GROUP_CONNECTION_POOL_SIZE
-
-/**
  * @def CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE
  *
  * @brief Define the size of the pool used for tracking CHIP

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -79,10 +79,7 @@ public:
 
     bool IsEncryptionRequired() const { return mDispatch.IsEncryptionRequired(); }
 
-    bool IsGroupExchangeContext() const
-    {
-        return (mSession && mSession->GetSessionType() == Transport::Session::SessionType::kGroup);
-    }
+    bool IsGroupExchangeContext() const { return mSession && mSession->IsGroupSession(); }
 
     // Implement SessionReleaseDelegate
     void OnSessionReleased() override;

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -83,7 +83,7 @@ CHIP_ERROR MessagingContext::CreateSessionAliceToBob()
 
 CHIP_ERROR MessagingContext::CreateSessionBobToFriends()
 {
-    mSessionBobToFriends.Grab(mSessionManager.CreateGroupSession(GetFriendsGroupId(), mSrcFabricIndex, GetBobNodeId()).Value());
+    mSessionBobToFriends.Emplace(GetFriendsGroupId(), mSrcFabricIndex, GetBobNodeId());
     return CHIP_NO_ERROR;
 }
 
@@ -99,7 +99,7 @@ SessionHandle MessagingContext::GetSessionAliceToBob()
 
 SessionHandle MessagingContext::GetSessionBobToFriends()
 {
-    return mSessionBobToFriends.Get();
+    return SessionHandle(mSessionBobToFriends.Value());
 }
 
 void MessagingContext::ExpireSessionBobToAlice()
@@ -114,7 +114,7 @@ void MessagingContext::ExpireSessionAliceToBob()
 
 void MessagingContext::ExpireSessionBobToFriends()
 {
-    mSessionManager.RemoveGroupSession(mSessionBobToFriends.Get()->AsGroupSession());
+    mSessionBobToFriends.ClearValue();
 }
 
 Messaging::ExchangeContext * MessagingContext::NewUnauthenticatedExchangeToAlice(Messaging::ExchangeDelegate * delegate)

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -160,7 +160,7 @@ private:
     SecurePairingUsingTestSecret mPairingBobToAlice;
     SessionHolder mSessionAliceToBob;
     SessionHolder mSessionBobToAlice;
-    SessionHolder mSessionBobToFriends;
+    Optional<Transport::OutgoingGroupSession> mSessionBobToFriends;
     FabricIndex mSrcFabricIndex  = 1;
     FabricIndex mDestFabricIndex = 1;
 };

--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -224,8 +224,7 @@ CHIP_ERROR MessageCounterManager::SendMsgCounterSyncResp(Messaging::ExchangeCont
     System::PacketBufferHandle msgBuf;
     VerifyOrDie(exchangeContext->HasSessionHandle());
 
-    VerifyOrReturnError(exchangeContext->GetSessionHandle()->GetSessionType() == Transport::Session::SessionType::kGroup,
-                        CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(exchangeContext->GetSessionHandle()->IsGroupSession(), CHIP_ERROR_INVALID_ARGUMENT);
 
     // NOTE: not currently implemented. When implementing, the following should be done:
     //    - allocate a new buffer: MessagePacketBuffer::New

--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -36,6 +36,9 @@ public:
 
 class IncomingGroupSession : public Session
 #ifndef NDEBUG
+    // The group session is ephemeral, its lifespan is controller by who using it. To prevent the object being destroyed while there
+    // are still SessionHandle or SessionHolder pointing to it, we enforce a reference counter check at its destruction in debug
+    // build.
     ,
                              public ReferenceCounted<IncomingGroupSession, GroupSessionDeleter, 0>
 #endif
@@ -98,6 +101,9 @@ private:
 
 class OutgoingGroupSession : public Session
 #ifndef NDEBUG
+    // The group session is ephemeral, its lifespan is controller by who using it. To prevent the object being destroyed while there
+    // are still SessionHandle or SessionHolder pointing to it, we enforce a reference counter check at its destruction in debug
+    // build.
     ,
                              public ReferenceCounted<OutgoingGroupSession, GroupSessionDeleter, 0>
 #endif

--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -36,9 +36,9 @@ public:
 
 class IncomingGroupSession : public Session
 #ifndef NDEBUG
-    // The group session is ephemeral, its lifespan is controller by who using it. To prevent the object being destroyed while there
-    // are still SessionHandle or SessionHolder pointing to it, we enforce a reference counter check at its destruction in debug
-    // build.
+    // The group session is ephemeral, its lifespan is controlled by whoever is using it. To prevent the object being destroyed
+    // while there are still SessionHandle or SessionHolder pointing to it, we enforce a reference counter check at its destruction
+    // in debug build.
     ,
                              public ReferenceCounted<IncomingGroupSession, GroupSessionDeleter, 0>
 #endif
@@ -101,9 +101,9 @@ private:
 
 class OutgoingGroupSession : public Session
 #ifndef NDEBUG
-    // The group session is ephemeral, its lifespan is controller by who using it. To prevent the object being destroyed while there
-    // are still SessionHandle or SessionHolder pointing to it, we enforce a reference counter check at its destruction in debug
-    // build.
+    // The group session is ephemeral, its lifespan is controlled by whoever is using it. To prevent the object being destroyed
+    // while there are still SessionHandle or SessionHolder pointing to it, we enforce a reference counter check at its destruction
+    // in debug build.
     ,
                              public ReferenceCounted<OutgoingGroupSession, GroupSessionDeleter, 0>
 #endif

--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -18,24 +18,49 @@
 
 #include <app/util/basic-types.h>
 #include <lib/core/GroupId.h>
+#include <lib/core/ReferenceCounted.h>
 #include <lib/support/Pool.h>
 #include <transport/Session.h>
 
 namespace chip {
 namespace Transport {
 
-class GroupSession : public Session
+#ifndef NDEBUG
+class GroupSessionDeleter
 {
 public:
-    GroupSession(GroupId group, FabricIndex fabricIndex, NodeId sourceNodeId) : mGroupId(group), mSourceNodeId(sourceNodeId)
+    static void Release(IncomingGroupSession * entry) {}
+    static void Release(OutgoingGroupSession * entry) {}
+};
+#endif
+
+class IncomingGroupSession : public Session
+#ifndef NDEBUG
+    ,
+                             public ReferenceCounted<IncomingGroupSession, GroupSessionDeleter, 0>
+#endif
+{
+public:
+    IncomingGroupSession(GroupId group, FabricIndex fabricIndex, NodeId sourceNodeId) : mGroupId(group), mSourceNodeId(sourceNodeId)
     {
         SetFabricIndex(fabricIndex);
     }
-    ~GroupSession() { NotifySessionReleased(); }
+    ~IncomingGroupSession()
+    {
+        NotifySessionReleased();
+#ifndef NDEBUG
+        VerifyOrDie(GetReferenceCount() == 0);
+#endif
+    }
 
-    Session::SessionType GetSessionType() const override { return Session::SessionType::kGroup; }
+#ifndef NDEBUG
+    void Retain() override { ReferenceCounted<IncomingGroupSession, GroupSessionDeleter, 0>::Retain(); }
+    void Release() override { ReferenceCounted<IncomingGroupSession, GroupSessionDeleter, 0>::Release(); }
+#endif
+
+    Session::SessionType GetSessionType() const override { return Session::SessionType::kGroupIncoming; }
 #if CHIP_PROGRESS_LOGGING
-    const char * GetSessionTypeString() const override { return "secure"; };
+    const char * GetSessionTypeString() const override { return "incoming group"; };
 #endif
 
     Access::SubjectDescriptor GetSubjectDescriptor() const override
@@ -71,69 +96,62 @@ private:
     const NodeId mSourceNodeId;
 };
 
-/*
- * @brief
- *   An table which manages GroupSessions
- */
-template <size_t kMaxSessionCount>
-class GroupSessionTable
+class OutgoingGroupSession : public Session
+#ifndef NDEBUG
+    ,
+                             public ReferenceCounted<OutgoingGroupSession, GroupSessionDeleter, 0>
+#endif
 {
 public:
-    ~GroupSessionTable() { mEntries.ReleaseAll(); }
-
-    /**
-     * Get a session given the peer address. If the session doesn't exist in the cache, allocate a new entry for it.
-     *
-     * @return the session found or allocated, nullptr if not found and allocation failed.
-     */
-    CHECK_RETURN_VALUE
-    Optional<SessionHandle> AllocEntry(GroupId group, FabricIndex fabricIndex, NodeId sourceNodeId)
+    OutgoingGroupSession(GroupId group, FabricIndex fabricIndex, NodeId sourceNodeId) : mGroupId(group), mSourceNodeId(sourceNodeId)
     {
-        GroupSession * entry = mEntries.CreateObject(group, fabricIndex, sourceNodeId);
-        if (entry != nullptr)
-        {
-            return MakeOptional<SessionHandle>(*entry);
-        }
-        else
-        {
-            return Optional<SessionHandle>::Missing();
-        }
+        SetFabricIndex(fabricIndex);
+    }
+    ~OutgoingGroupSession()
+    {
+        NotifySessionReleased();
+#ifndef NDEBUG
+        VerifyOrDie(GetReferenceCount() == 0);
+#endif
     }
 
-    /**
-     * Get a session using given GroupId
-     */
-    CHECK_RETURN_VALUE
-    Optional<SessionHandle> FindEntry(GroupId group, FabricIndex fabricIndex)
+#ifndef NDEBUG
+    void Retain() override { ReferenceCounted<OutgoingGroupSession, GroupSessionDeleter, 0>::Retain(); }
+    void Release() override { ReferenceCounted<OutgoingGroupSession, GroupSessionDeleter, 0>::Release(); }
+#endif
+
+    Session::SessionType GetSessionType() const override { return Session::SessionType::kGroupOutgoing; }
+#if CHIP_PROGRESS_LOGGING
+    const char * GetSessionTypeString() const override { return "outgoing group"; };
+#endif
+
+    Access::SubjectDescriptor GetSubjectDescriptor() const override
     {
-        GroupSession * result = nullptr;
-        mEntries.ForEachActiveObject([&](GroupSession * entry) {
-            if (entry->GetGroupId() == group && entry->GetFabricIndex() == fabricIndex)
-            {
-                result = entry;
-                return Loop::Break;
-            }
-            return Loop::Continue;
-        });
-        if (result != nullptr)
-        {
-            return MakeOptional<SessionHandle>(*result);
-        }
-        else
-        {
-            return Optional<SessionHandle>::Missing();
-        }
+        return Access::SubjectDescriptor(); // no subject exists for outgoing group session.
     }
 
-    /**
-     * @brief Deletes an entry from the object pool
-     *
-     * @param entry The GroupSession entry to delete
-     */
-    void DeleteEntry(GroupSession * entry) { mEntries.ReleaseObject(entry); }
+    bool RequireMRP() const override { return false; }
+
+    const ReliableMessageProtocolConfig & GetMRPConfig() const override
+    {
+        static const ReliableMessageProtocolConfig cfg(GetLocalMRPConfig());
+        VerifyOrDie(false);
+        return cfg;
+    }
+
+    System::Clock::Milliseconds32 GetAckTimeout() const override
+    {
+        VerifyOrDie(false);
+        return System::Clock::Timeout();
+    }
+
+    GroupId GetGroupId() const { return mGroupId; }
+
+    NodeId GetSourceNodeId() { return mSourceNodeId; }
 
 private:
-    BitMapObjectPool<GroupSession, kMaxSessionCount> mEntries;
+    const GroupId mGroupId;
+    const NodeId mSourceNodeId;
 };
 
 } // namespace Transport

--- a/src/transport/Session.cpp
+++ b/src/transport/Session.cpp
@@ -34,10 +34,16 @@ UnauthenticatedSession * Session::AsUnauthenticatedSession()
     return static_cast<UnauthenticatedSession *>(this);
 }
 
-GroupSession * Session::AsGroupSession()
+IncomingGroupSession * Session::AsIncomingGroupSession()
 {
-    VerifyOrDie(GetSessionType() == SessionType::kGroup);
-    return static_cast<GroupSession *>(this);
+    VerifyOrDie(GetSessionType() == SessionType::kGroupIncoming);
+    return static_cast<IncomingGroupSession *>(this);
+}
+
+OutgoingGroupSession * Session::AsOutgoingGroupSession()
+{
+    VerifyOrDie(GetSessionType() == SessionType::kGroupOutgoing);
+    return static_cast<OutgoingGroupSession *>(this);
 }
 
 } // namespace Transport

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -27,7 +27,8 @@ namespace Transport {
 
 class SecureSession;
 class UnauthenticatedSession;
-class GroupSession;
+class IncomingGroupSession;
+class OutgoingGroupSession;
 
 class Session
 {
@@ -39,7 +40,8 @@ public:
         kUndefined       = 0,
         kUnauthenticated = 1,
         kSecure          = 2,
-        kGroup           = 3,
+        kGroupIncoming   = 3,
+        kGroupOutgoing   = 4,
     };
 
     virtual SessionType GetSessionType() const = 0;
@@ -72,9 +74,13 @@ public:
 
     SecureSession * AsSecureSession();
     UnauthenticatedSession * AsUnauthenticatedSession();
-    GroupSession * AsGroupSession();
+    IncomingGroupSession * AsIncomingGroupSession();
+    OutgoingGroupSession * AsOutgoingGroupSession();
 
-    bool IsGroupSession() const { return GetSessionType() == SessionType::kGroup; }
+    bool IsGroupSession() const
+    {
+        return GetSessionType() == SessionType::kGroupIncoming || GetSessionType() == SessionType::kGroupOutgoing;
+    }
 
 protected:
     // This should be called by sub-classes at the very beginning of the destructor, before any data field is disposed, such that

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -727,7 +727,7 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
         // TODO : When MCSP is done, clean up session creation logic
         Transport::IncomingGroupSession groupSession(groupContext.group_id, groupContext.fabric_index,
                                                      packetHeader.GetSourceNodeId().Value());
-        CHIP_TRACE_MESSAGE_RECEIVED(payloadHeader, packetHeader, groupSession, peerAddress, msg->Start(), msg->TotalLength());
+        CHIP_TRACE_MESSAGE_RECEIVED(payloadHeader, packetHeader, &groupSession, peerAddress, msg->Start(), msg->TotalLength());
         mCB->OnMessageReceived(packetHeader, payloadHeader, SessionHandle(groupSession), peerAddress,
                                SessionMessageDelegate::DuplicateMessage::No, std::move(msg));
     }

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -27,6 +27,7 @@
 
 #include <utility>
 
+#include <credentials/FabricTable.h>
 #include <crypto/RandUtils.h>
 #include <inet/IPAddress.h>
 #include <lib/core/CHIPCore.h>
@@ -219,16 +220,6 @@ public:
         return mUnauthenticatedSessions.AllocInitiator(ephemeralInitiatorNodeID, peerAddress, config);
     }
 
-    Optional<SessionHandle> CreateGroupSession(GroupId group, chip::FabricIndex fabricIndex, NodeId sourceNodeId)
-    {
-        return mGroupSessions.AllocEntry(group, fabricIndex, sourceNodeId);
-    }
-    Optional<SessionHandle> FindGroupSession(GroupId group, chip::FabricIndex fabricIndex)
-    {
-        return mGroupSessions.FindEntry(group, fabricIndex);
-    }
-    void RemoveGroupSession(Transport::GroupSession * session) { mGroupSessions.DeleteEntry(session); }
-
     // TODO: this is a temporary solution for legacy tests which use nodeId to send packets
     // and tv-casting-app that uses the TV's node ID to find the associated secure session
     SessionHandle FindSecureSessionForNode(NodeId peerNodeId);
@@ -255,7 +246,6 @@ private:
     System::Layer * mSystemLayer = nullptr;
     Transport::UnauthenticatedSessionTable<CHIP_CONFIG_UNAUTHENTICATED_CONNECTION_POOL_SIZE> mUnauthenticatedSessions;
     Transport::SecureSessionTable<CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE> mSecureSessions;
-    Transport::GroupSessionTable<CHIP_CONFIG_GROUP_CONNECTION_POOL_SIZE> mGroupSessions;
     State mState; // < Initialization state of the object
     chip::Transport::GroupOutgoingCounters mGroupClientCounter;
 


### PR DESCRIPTION
#### Problem
Fixes #13507

#### Change overview
Make group session ephemeral

Change the group session class into 2 classes:
* IncomingGroupSession
* OutgoingGroupSession
Although they shares save member fields, but their usage doesn't overlap, and `GetIncomingSubjectDescriptor` have different meaning for these 2 objects. Using 2 different classes can prevent people using the wrong object.

#### Testing
Passed unit-tests.