### PR TITLE
[Python] Provide a user friendly API for getting data versions

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -776,7 +776,7 @@ class ChipDeviceController():
             nodeid, [(endpoint, attributeType)]))
         path = ClusterAttribute.AttributePath(
             EndpointId=endpoint, Attribute=attributeType)
-        return im.AttributeReadResult(path=im.AttributePath(nodeId=nodeid, endpointId=path.EndpointId, clusterId=path.ClusterId, attributeId=path.AttributeId), status=0, value=result[0][endpoint][clusterType][attributeType])
+        return im.AttributeReadResult(path=im.AttributePath(nodeId=nodeid, endpointId=path.EndpointId, clusterId=path.ClusterId, attributeId=path.AttributeId), status=0, value=result[endpoint][clusterType][attributeType])
 
     def ZCLWriteAttribute(self, cluster: str, attribute: str, nodeid, endpoint, groupid, value, dataVersion=0, blocking=True):
         req = None

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -320,6 +320,13 @@ class SubscriptionParameters:
     MaxReportIntervalCeilingSeconds: int
 
 
+class DataVersion:
+    '''
+    A helper class as a key for getting cluster data version when reading attributes without returnClusterObject.
+    '''
+    pass
+
+
 @dataclass
 class AttributeCache:
     ''' A cache that stores data & errors returned in read/subscribe reports, but organizes it topologically
@@ -358,23 +365,18 @@ class AttributeCache:
             self.versionList[path.EndpointId] = {}
 
         endpointCache = self.attributeTLVCache[path.EndpointId]
-        endpoint = self.versionList[path.EndpointId]
+        endpointVersion = self.versionList[path.EndpointId]
         if (path.ClusterId not in endpointCache):
             endpointCache[path.ClusterId] = {}
 
-        if (path.ClusterId not in endpoint):
-            endpoint[path.ClusterId] = {}
+        # All attributes from the same cluster instance should have the same dataVersion, so we can set the dataVersion of the cluster to the dataVersion with a random attribute.
+        endpointVersion[path.ClusterId] = dataVersion
 
         clusterCache = endpointCache[path.ClusterId]
-        cluster = endpoint[path.ClusterId]
         if (path.AttributeId not in clusterCache):
             clusterCache[path.AttributeId] = None
 
-        if (path.AttributeId not in cluster):
-            cluster[path.AttributeId] = None
-
         clusterCache[path.AttributeId] = data
-        cluster[path.AttributeId] = dataVersion
 
     def UpdateCachedData(self):
         ''' This converts the raw TLV data into a cluster object format.
@@ -409,12 +411,16 @@ class AttributeCache:
                     endpointCache[clusterType] = {}
 
                 clusterCache = endpointCache[clusterType]
+                clusterDataVersion = self.versionList.get(
+                    endpoint, {}).get(cluster, None)
 
                 if (self.returnClusterObject):
                     try:
                         # Since the TLV data is already organized by attribute tags, we can trivially convert to a cluster object representation.
                         endpointCache[clusterType] = clusterType.FromDict(
                             data=clusterType.descriptor.TagDictToLabelDict([], tlvCache[endpoint][cluster]))
+                        endpointCache[clusterType].SetDataVersion(
+                            clusterDataVersion)
                     except Exception as ex:
                         logging.error(
                             f"Error converting TLV to Cluster Object for path: Endpoint = {endpoint}, cluster = {str(clusterType)}")
@@ -423,6 +429,7 @@ class AttributeCache:
                             tlvCache[endpoint][cluster], ex)
                         endpointCache[clusterType] = decodedValue
                 else:
+                    clusterCache[DataVersion] = clusterDataVersion
                     for attribute in tlvCache[endpoint][cluster]:
                         value = tlvCache[endpoint][cluster][attribute]
 
@@ -680,14 +687,12 @@ class AsyncReadTransaction:
             if (self._transactionType == TransactionType.READ_EVENTS):
                 self._future.set_result(self._events)
             else:
-                self._future.set_result(
-                    (self._cache.attributeCache, self._cache.versionList))
+                self._future.set_result(self._cache.attributeCache)
 
     def handleDone(self):
         self._event_loop.call_soon_threadsafe(self._handleDone)
 
     def handleReportBegin(self):
-        self._cache.versionList.clear()
         pass
 
     def handleReportEnd(self):

--- a/src/controller/python/chip/clusters/ClusterObjects.py
+++ b/src/controller/python/chip/clusters/ClusterObjects.py
@@ -219,10 +219,16 @@ class ClusterCommand(ClusterObject):
 
 
 class Cluster(ClusterObject):
-    ''' This class does nothing, but a convenient class that generated clusters can inherit from.
-    This gives the ability that the users can use issubclass(X, Cluster) to determine if the class represnents a Cluster.
     '''
-    pass
+    When send read requests with returnClusterObject=True, we will set the dataVersion property of the object.
+    Otherwise the [endpoint][cluster][Clusters.DataVersion] will be set to the DataVersion of the cluster.
+    '''
+    @ChipUtility.classproperty
+    def dataVersion(self) -> int:
+        return self._dataVersion
+
+    def SetDataVersion(self, version: int) -> None:
+        self._dataVersion = version
 
 
 class ClusterAttributeDescriptor:

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -190,8 +190,8 @@ class BaseTestHelper:
         data2 = await devCtrl2.ReadAttribute(nodeid, [(Clusters.OperationalCredentials.Attributes.NOCs)], fabricFiltered=False)
 
         # Read out noclist from each fabric, and each should contain two NOCs.
-        nocList1 = data1[0][0][Clusters.OperationalCredentials][Clusters.OperationalCredentials.Attributes.NOCs]
-        nocList2 = data2[0][0][Clusters.OperationalCredentials][Clusters.OperationalCredentials.Attributes.NOCs]
+        nocList1 = data1[0][Clusters.OperationalCredentials][Clusters.OperationalCredentials.Attributes.NOCs]
+        nocList2 = data2[0][Clusters.OperationalCredentials][Clusters.OperationalCredentials.Attributes.NOCs]
 
         if (len(nocList1) != 2 or len(nocList2) != 2):
             self.logger.error("Got back invalid nocList")
@@ -201,8 +201,8 @@ class BaseTestHelper:
         data2 = await devCtrl2.ReadAttribute(nodeid, [(Clusters.OperationalCredentials.Attributes.CurrentFabricIndex)], fabricFiltered=False)
 
         # Read out current fabric from each fabric, and both should be different.
-        currentFabric1 = data1[0][0][Clusters.OperationalCredentials][Clusters.OperationalCredentials.Attributes.CurrentFabricIndex]
-        currentFabric2 = data2[0][0][Clusters.OperationalCredentials][Clusters.OperationalCredentials.Attributes.CurrentFabricIndex]
+        currentFabric1 = data1[0][Clusters.OperationalCredentials][Clusters.OperationalCredentials.Attributes.CurrentFabricIndex]
+        currentFabric2 = data2[0][Clusters.OperationalCredentials][Clusters.OperationalCredentials.Attributes.CurrentFabricIndex]
         if (currentFabric1 == currentFabric2):
             self.logger.error(
                 "Got back fabric indices that match for two different fabrics!")

--- a/src/controller/python/test/test_scripts/cluster_objects.py
+++ b/src/controller/python/test/test_scripts/cluster_objects.py
@@ -195,7 +195,8 @@ class ClusterObjectTests:
             (0, Clusters.Basic.Attributes.HardwareVersion),
         ]
         res = await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=req)
-        if ((0 not in res) or (Clusters.Basic not in res[0]) or (len(res[0][Clusters.Basic]) != 3)):
+        if ((0 not in res) or (Clusters.Basic not in res[0]) or (len(res[0][Clusters.Basic]) != 4)):
+            # 3 attribute data + DataVersion
             raise AssertionError(
                 f"Got back {len(res)} data items instead of 3")
         VerifyDecodeSuccess(res)

--- a/src/controller/python/test/test_scripts/network_commissioning.py
+++ b/src/controller/python/test/test_scripts/network_commissioning.py
@@ -66,7 +66,7 @@ class NetworkCommissioningTests:
         res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.LastConnectErrorValue),
                                                                                  (endpointId, Clusters.NetworkCommissioning.Attributes.LastNetworkID),
                                                                                  (endpointId, Clusters.NetworkCommissioning.Attributes.LastNetworkingStatus)], returnClusterObject=True)
-        values = res[0][endpointId][Clusters.NetworkCommissioning]
+        values = res[endpointId][Clusters.NetworkCommissioning]
         logger.info(f"Got values: {values}")
         return values
 
@@ -97,7 +97,7 @@ class NetworkCommissioningTests:
             (endpointId, Clusters.NetworkCommissioning.Attributes.FeatureMap)],
             returnClusterObject=True)
         self.log_interface_basic_info(
-            res[0][endpointId][Clusters.NetworkCommissioning])
+            res[endpointId][Clusters.NetworkCommissioning])
         logger.info(f"Finished getting basic information of the endpoint")
 
         # Read Last* attributes
@@ -126,7 +126,7 @@ class NetworkCommissioningTests:
         # Remove existing network
         logger.info(f"Check network list")
         res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)], returnClusterObject=True)
-        networkList = res[0][endpointId][Clusters.NetworkCommissioning].networks
+        networkList = res[endpointId][Clusters.NetworkCommissioning].networks
         logger.info(f"Got network list: {networkList}")
         if len(networkList) != 0:
             logger.info(f"Removing existing network")
@@ -149,7 +149,7 @@ class NetworkCommissioningTests:
 
         logger.info(f"Check network list")
         res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)], returnClusterObject=True)
-        networkList = res[0][endpointId][Clusters.NetworkCommissioning].networks
+        networkList = res[endpointId][Clusters.NetworkCommissioning].networks
         logger.info(f"Got network list: {networkList}")
         if len(networkList) != 1:
             raise AssertionError(
@@ -172,7 +172,7 @@ class NetworkCommissioningTests:
 
         logger.info(f"Check network is connected")
         res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)], returnClusterObject=True)
-        networkList = res[0][endpointId][Clusters.NetworkCommissioning].networks
+        networkList = res[endpointId][Clusters.NetworkCommissioning].networks
         logger.info(f"Got network list: {networkList}")
         if len(networkList) != 1:
             raise AssertionError(
@@ -202,7 +202,7 @@ class NetworkCommissioningTests:
             (endpointId, Clusters.NetworkCommissioning.Attributes.FeatureMap)],
             returnClusterObject=True)
         self.log_interface_basic_info(
-            res[0][endpointId][Clusters.NetworkCommissioning])
+            res[endpointId][Clusters.NetworkCommissioning])
         logger.info(f"Finished getting basic information of the endpoint")
 
         # Read Last* attributes
@@ -231,7 +231,7 @@ class NetworkCommissioningTests:
         # Remove existing network
         logger.info(f"Check network list")
         res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)], returnClusterObject=True)
-        networkList = res[0][endpointId][Clusters.NetworkCommissioning].networks
+        networkList = res[endpointId][Clusters.NetworkCommissioning].networks
         logger.info(f"Got network list: {networkList}")
         if len(networkList) != 0:
             logger.info(f"Removing existing network")
@@ -254,7 +254,7 @@ class NetworkCommissioningTests:
 
         logger.info(f"Check network list")
         res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)], returnClusterObject=True)
-        networkList = res[0][endpointId][Clusters.NetworkCommissioning].networks
+        networkList = res[endpointId][Clusters.NetworkCommissioning].networks
         logger.info(f"Got network list: {networkList}")
         if len(networkList) != 1:
             raise AssertionError(
@@ -297,7 +297,6 @@ class NetworkCommissioningTests:
         try:
             endpoints = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(Clusters.NetworkCommissioning.Attributes.FeatureMap)], returnClusterObject=True)
             logger.info(endpoints)
-            endpoints = endpoints[0]
             for endpoint, obj in endpoints.items():
                 clus = obj[Clusters.NetworkCommissioning]
                 if clus.featureMap == WIFI_NETWORK_FEATURE_MAP:

--- a/src/controller/python/test/test_scripts/network_commissioning.py
+++ b/src/controller/python/test/test_scripts/network_commissioning.py
@@ -281,7 +281,7 @@ class NetworkCommissioningTests:
 
         logger.info(f"Check network list")
         res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)], returnClusterObject=True)
-        networkList = res[0][endpointId][Clusters.NetworkCommissioning].networks
+        networkList = res[endpointId][Clusters.NetworkCommissioning].networks
         logger.info(f"Got network list: {networkList}")
         if len(networkList) != 1:
             raise AssertionError(


### PR DESCRIPTION
#### Problem
res[0] and res[1] is not user friendly, and data version is the same for all attributes under the same cluster

#### Change overview
Add a mock "DataVersion" key to read attribute response.

#### Testing
Test script is updated
