### PR TITLE
Allow application inject PersistentStorageDelegate

### DIFF
--- a/src/app/server/BUILD.gn
+++ b/src/app/server/BUILD.gn
@@ -39,6 +39,8 @@ static_library("server") {
   sources = [
     "CommissioningWindowManager.cpp",
     "CommissioningWindowManager.h",
+    "DefaultFabricStorage.cpp",
+    "DefaultPersistentStorageDelegate.cpp",
     "Dnssd.cpp",
     "Dnssd.h",
     "EchoHandler.cpp",

--- a/src/app/server/DefaultFabricStorage.cpp
+++ b/src/app/server/DefaultFabricStorage.cpp
@@ -1,0 +1,49 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/server/Server.h>
+#include <credentials/FabricTable.h>
+
+namespace chip {
+
+class DefaultFabricStorage : public FabricStorage
+{
+public:
+    DefaultFabricStorage(PersistentStorageDelegate & storage) : mStorage(storage) {}
+
+    CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override
+    {
+        return mStorage.SyncSetKeyValue(key, buffer, size);
+    };
+
+    CHIP_ERROR SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) override
+    {
+        return mStorage.SyncGetKeyValue(key, buffer, size);
+    };
+
+    CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override { return mStorage.SyncDeleteKeyValue(key); };
+
+private:
+    PersistentStorageDelegate & mStorage;
+};
+
+FabricStorage & __attribute__((weak)) Server::GetFabricStorage()
+{
+    static DefaultFabricStorage fabricStorage(GetPersistentStorageDelegate());
+    return fabricStorage;
+}
+
+} // namespace chip

--- a/src/app/server/DefaultPersistentStorageDelegate.cpp
+++ b/src/app/server/DefaultPersistentStorageDelegate.cpp
@@ -1,0 +1,55 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/server/Server.h>
+#include <platform/KeyValueStoreManager.h>
+
+namespace chip {
+
+class DefaultStorageDelegate : public PersistentStorageDelegate
+{
+public:
+    CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
+    {
+        size_t bytesRead = 0;
+        CHIP_ERROR err   = DeviceLayer::PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size, &bytesRead);
+
+        if (err == CHIP_NO_ERROR)
+        {
+            ChipLogProgress(AppServer, "Retrieved from server storage: %s", key);
+        }
+        size = static_cast<uint16_t>(bytesRead);
+        return err;
+    }
+
+    CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override
+    {
+        return DeviceLayer::PersistedStorage::KeyValueStoreMgr().Put(key, value, size);
+    }
+
+    CHIP_ERROR SyncDeleteKeyValue(const char * key) override
+    {
+        return DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key);
+    }
+};
+
+PersistentStorageDelegate & __attribute__((weak)) Server::GetPersistentStorageDelegate()
+{
+    static DefaultStorageDelegate storage;
+    return storage;
+}
+
+} // namespace chip

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -112,8 +112,8 @@ Server::Server() :
         .dnsCache          = nullptr,
         .devicePool        = &mDevicePool,
         .dnsResolver       = nullptr,
-    }), mCommissioningWindowManager(this), mGroupsProvider(mDeviceStorage),
-    mAttributePersister(mDeviceStorage), mAccessControl(Access::Examples::GetAccessControlDelegate(&mDeviceStorage))
+    }), mCommissioningWindowManager(this), mGroupsProvider(GetPersistentStorageDelegate()),
+    mAttributePersister(GetPersistentStorageDelegate()), mAccessControl(Access::Examples::GetAccessControlDelegate(&GetPersistentStorageDelegate()))
 {}
 
 CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint16_t unsecureServicePort,
@@ -136,19 +136,19 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
 
     InitDataModelHandler(&mExchangeMgr);
 
-    err = mFabrics.Init(&mDeviceStorage);
+    err = mFabrics.Init(&GetFabricStorage());
     SuccessOrExit(err);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
     app::DnssdServer::Instance().SetFabricTable(&mFabrics);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
 
-    // Group data provider must be initialized after mDeviceStorage
+    // Group data provider must be initialized after PersistedStorage
     err = mGroupsProvider.Init();
     SuccessOrExit(err);
     SetGroupDataProvider(&mGroupsProvider);
 
-    // Access control must be initialized after mDeviceStorage.
+    // Access control must be initialized after PersistedStorage.
     err = mAccessControl.Init();
     SuccessOrExit(err);
     Access::SetAccessControl(mAccessControl);
@@ -182,7 +182,7 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
 #endif
     SuccessOrExit(err);
 
-    err = mSessions.Init(&DeviceLayer::SystemLayer(), &mTransports, &mMessageCounterManager, &mDeviceStorage);
+    err = mSessions.Init(&DeviceLayer::SystemLayer(), &mTransports, &mMessageCounterManager, &GetPersistentStorageDelegate());
     SuccessOrExit(err);
 
     err = mExchangeMgr.Init(&mSessions);


### PR DESCRIPTION
#### Problem
Fixes #12276

#### Change overview
Introduce 2 weak symbol `Server::GetPersistentStorageDelegate` and `Server::GetFabricStorage` which can be overwritten by applications to inject a `PersistentStorageDelegate`

#### Testing
Passed unit-tests