### PR TITLE
Updated iOS CHIP tool README and qr scanner to indicate requirement >…

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/RootViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/RootViewController.m
@@ -70,7 +70,7 @@
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
     switch (indexPath.row) {
     case 0:
-        [self pushQRCodeScanner];
+        [self pushQRCodeScannerWithSkipCheck:NO];
         break;
     case 1:
         [self pushEnumeration];
@@ -125,10 +125,35 @@
     [self.navigationController pushViewController:controller animated:YES];
 }
 
-- (void)pushQRCodeScanner
+- (void)pushQRCodeScannerWithSkipCheck:(BOOL)skipIosCheck
 {
-    QRCodeViewController * controller = [QRCodeViewController new];
-    [self.navigationController pushViewController:controller animated:YES];
+    if (skipIosCheck) {
+        QRCodeViewController * controller = [QRCodeViewController new];
+        [self.navigationController pushViewController:controller animated:YES];
+    } else {
+        if (@available(iOS 15.4, *)) {
+            // Device using the required iOS version (>= 15.4)
+            [self pushQRCodeScannerWithSkipCheck:YES];
+        } else {
+            // Device NOT using the required iOS version (< 15.4)
+            // Show a warning, but let the user continue
+            UIAlertController * alertController =
+                [UIAlertController alertControllerWithTitle:@"Warning"
+                                                    message:@"QRCode scanner to pair a matter device requires iOS >= 15.4"
+                                             preferredStyle:UIAlertControllerStyleAlert];
+            __weak typeof(self) weakSelf = self;
+            [alertController
+                addAction:[UIAlertAction actionWithTitle:@"I understand"
+                                                   style:UIAlertActionStyleDefault
+                                                 handler:^(UIAlertAction * action) {
+                                                     typeof(self) strongSelf = weakSelf;
+                                                     if (strongSelf) {
+                                                         [strongSelf pushQRCodeScannerWithSkipCheck:YES];
+                                                     }
+                                                 }]];
+            [self presentViewController:alertController animated:YES completion:nil];
+        }
+    }
 }
 
 - (void)pushEnumeration

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/RootViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/RootViewController.m
@@ -142,15 +142,14 @@
                                                     message:@"QRCode scanner to pair a matter device requires iOS >= 15.4"
                                              preferredStyle:UIAlertControllerStyleAlert];
             __weak typeof(self) weakSelf = self;
-            [alertController
-                addAction:[UIAlertAction actionWithTitle:@"I understand"
-                                                   style:UIAlertActionStyleDefault
-                                                 handler:^(UIAlertAction * action) {
-                                                     typeof(self) strongSelf = weakSelf;
-                                                     if (strongSelf) {
-                                                         [strongSelf pushQRCodeScannerWithSkipCheck:YES];
-                                                     }
-                                                 }]];
+            [alertController addAction:[UIAlertAction actionWithTitle:@"I understand"
+                                                                style:UIAlertActionStyleDefault
+                                                              handler:^(UIAlertAction * action) {
+                                                                  typeof(self) strongSelf = weakSelf;
+                                                                  if (strongSelf) {
+                                                                      [strongSelf pushQRCodeScannerWithSkipCheck:YES];
+                                                                  }
+                                                              }]];
             [self presentViewController:alertController animated:YES completion:nil];
         }
     }

--- a/src/darwin/CHIPTool/README.md
+++ b/src/darwin/CHIPTool/README.md
@@ -13,6 +13,11 @@ control.
 
 ---
 
+## Prerequisites
+
+-  Requires building and running the app to a physical device on iOS >= 15.4.
+    -  At time of writing 15.4 is in beta and the current active iOS version is 15.3.1. For detailed instructions on how to install the iOS 15.4 beta onto your device visit [beta.apple.com](https://beta.apple.com/sp/betaprogram/enroll#ios)
+
 ## Building the Application
 
 CHIPTool iOS can be built with the latest Xcode releases.

--- a/src/darwin/CHIPTool/README.md
+++ b/src/darwin/CHIPTool/README.md
@@ -15,8 +15,11 @@ control.
 
 ## Prerequisites
 
--  Requires building and running the app to a physical device on iOS >= 15.4.
-    -  At time of writing 15.4 is in beta and the current active iOS version is 15.3.1. For detailed instructions on how to install the iOS 15.4 beta onto your device visit [beta.apple.com](https://beta.apple.com/sp/betaprogram/enroll#ios)
+-   Requires building and running the app to a physical device on iOS >= 15.4.
+    -   At time of writing 15.4 is in beta and the current active iOS version is
+        15.3.1. For detailed instructions on how to install the iOS 15.4 beta
+        onto your device visit
+        [beta.apple.com](https://beta.apple.com/sp/betaprogram/enroll#ios)
 
 ## Building the Application
 


### PR DESCRIPTION
…= iOS 15.4 (#15640)

#### Problem
* The iOS (Darwin) CHIP tool to pair a matter device requires >= iOS 15.4 (currently in beta).

#### Change overview
Updated the README to indicate this requirement to prevent further support tickets being raised. Also display an alert for any user on less than iOS 15.4 to indicate this requirement
