### PR TITLE
[Telink]: BLE commissioning (docker part)

### DIFF
--- a/integrations/docker/images/chip-build-doxygen/Dockerfile
+++ b/integrations/docker/images/chip-build-doxygen/Dockerfile
@@ -3,5 +3,5 @@ FROM alpine:3.15
 RUN apk --no-cache add \
   doxygen=1.9.2-r1 \
   graphviz=2.49.3-r0 \
-  bash=5.1.8-r0 \
+  bash=5.1.16-r0 \
   git=2.34.1-r0

--- a/integrations/docker/images/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/chip-build-telink/Dockerfile
@@ -17,7 +17,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=b522ea774ab31c3e636f25da374b43855e9d4e60
+ARG ZEPHYR_REVISION=148e7967fb6062555f69de8cbcdc997f826b241c
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \

--- a/integrations/docker/images/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/chip-build-telink/Dockerfile
@@ -21,13 +21,13 @@ ARG ZEPHYR_REVISION=b522ea774ab31c3e636f25da374b43855e9d4e60
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \
-    west==0.11.1 \
+    west==0.12.0 \
     && git clone https://github.com/rikorsev/zephyr \
     && cd zephyr \
     && git reset ${ZEPHYR_REVISION} --hard \
     && west init -l \
     && cd .. \
-    && west update \
+    && west update -o=--depth=1 -n -f smart \
     && cd modules/hal/telink \
     && git remote add telink https://github.com/rikorsev/hal_telink \
     && git fetch telink telink_crypto \
@@ -58,6 +58,21 @@ RUN set -x \
     pyelftools==0.27 \
     && pip3 install --no-cache-dir --user -r /opt/telink/zephyrproject/zephyr/scripts/requirements.txt \
     && : # last line
+
+# Setup Telink tools required for "west flash"
+ARG TELINK_TOOLS_BASE=/opt/telink/tools
+RUN wget http://wiki.telink-semi.cn/tools_and_sdk/Tools/IDE/telink_riscv_ice_flash_tool.zip -O /opt/telink/tools.zip \
+    && unzip /opt/telink/tools.zip -d ${TELINK_TOOLS_BASE} \
+    && rm /opt/telink/tools.zip \
+    && mv ${TELINK_TOOLS_BASE}/telink_riscv_linux_toolchain/* ${TELINK_TOOLS_BASE} \
+    && rm -rf ${TELINK_TOOLS_BASE}/telink_riscv_linux_toolchain \
+    && chmod +x ${TELINK_TOOLS_BASE}/flash/bin/SPI_burn \
+    && chmod +x ${TELINK_TOOLS_BASE}/ice/ICEman \
+    && : # last line
+
+# Add path to Telink tools
+ENV PATH="${TELINK_TOOLS_BASE}/flash/bin:${PATH}"
+ENV PATH="${TELINK_TOOLS_BASE}/ice:${PATH}"
 
 ARG ZEPHYR_PROJECT_DIR=/opt/telink/zephyrproject
 ENV TELINK_ZEPHYR_BASE=${ZEPHYR_PROJECT_DIR}/zephyr

--- a/integrations/docker/images/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/chip-build-telink/Dockerfile
@@ -11,33 +11,37 @@ RUN set -x \
 
 # Setup toolchain
 RUN set -x \
-    && wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.13.0/zephyr-toolchain-riscv64-0.13.0-linux-x86_64-setup.run -O /tmp/zephyr-toolchain-riscv64-setup.run \
+    && wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.13.2/zephyr-toolchain-riscv64-0.13.2-linux-x86_64-setup.run -O /tmp/zephyr-toolchain-riscv64-setup.run \
     && chmod +x /tmp/zephyr-toolchain-riscv64-setup.run \
-    && /tmp/zephyr-toolchain-riscv64-setup.run -- -d /opt/telink/zephyr-sdk-0.13.0 \
+    && /tmp/zephyr-toolchain-riscv64-setup.run -- -d /opt/telink/zephyr-sdk-0.13.2 \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=19c519eb05d6d24a23fd084a3ab6c1a78edf5536
+ARG ZEPHYR_REVISION=b522ea774ab31c3e636f25da374b43855e9d4e60
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \
     west==0.11.1 \
-    && git clone https://github.com/zephyrproject-rtos/zephyr \
+    && git clone https://github.com/rikorsev/zephyr \
     && cd zephyr \
     && git reset ${ZEPHYR_REVISION} --hard \
     && west init -l \
     && cd .. \
     && west update \
+    && cd modules/hal/telink \
+    && git remote add telink https://github.com/rikorsev/hal_telink \
+    && git fetch telink telink_crypto \
+    && git checkout telink_crypto \
     && west zephyr-export \
     && : # last line
 
 FROM connectedhomeip/chip-build:${VERSION}
 
-COPY --from=build /opt/telink/zephyr-sdk-0.13.0/ /opt/telink/zephyr-sdk-0.13.0/
+COPY --from=build /opt/telink/zephyr-sdk-0.13.2/ /opt/telink/zephyr-sdk-0.13.2/
 COPY --from=build /opt/telink/zephyrproject/ /opt/telink/zephyrproject/
 
 ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-ENV ZEPHYR_SDK_INSTALL_DIR=/opt/telink/zephyr-sdk-0.13.0
+ENV ZEPHYR_SDK_INSTALL_DIR=/opt/telink/zephyr-sdk-0.13.2
 
 RUN set -x \
     && apt-get update \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.58 Version bump reason: Update nRF Connect SDK
+0.5.59 Version bump reason: Update Telink Docker


### PR DESCRIPTION
#### Problem
Currently Zephyr OS does not contain implemented Telink BLE controller yet.
So that, BLE functionality for Matter project is implemented with Telink BLE SDK.
This PR contains update of docker image with Zephyr that adapt Telink Radio module work in 
both BLE and Thread modes (not concurrently). 
The PR is closely related to: https://github.com/project-chip/connectedhomeip/pull/15723

#### Change overview
Updates in Telink docker image that contains late Zephyr source code with modifications in Telink radio driver

#### Testing
Tested manually.
Steps: 
* Build image
* Run docker
* Check if Telink lighting-app example able to be built successfully
