### PR TITLE
Fix ForEachCluster missing return

### DIFF
--- a/src/app/AttributeCache.h
+++ b/src/app/AttributeCache.h
@@ -306,6 +306,7 @@ public:
                 ReturnErrorOnFailure(func(clusterIter.first));
             }
         }
+        return CHIP_NO_ERROR;
     }
 
 private:


### PR DESCRIPTION
#### Problem
* Fix the missing return state from a template method

#### Change overview
A missing return statement was added.

#### Testing
* No test was added for the issue is apparent: Use of the method would cause a compile time error. The method is being used in a separate feature development.