### PR TITLE
Make the iOS CHIPTool reboot the Matter stack prior to each pairing

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -788,10 +788,21 @@
     return peripheralFullName;
 }
 
+- (void)_restartMatterStack
+{
+    NSLog(@"Shutting down the stack");
+    [self.chipController shutdown];
+    NSLog(@"Starting up the stack");
+    [self.chipController startup:nil vendorId:0 nocSigner:nil];
+}
+
 - (void)handleRendezVousDefault:(NSString *)payload
 {
     NSError * error;
     uint64_t deviceID = CHIPGetNextAvailableDeviceID();
+
+    // restart the Matter Stack before pairing (for reliability + testing restarts)
+    [self _restartMatterStack];
 
     if ([self.chipController pairDevice:deviceID onboardingPayload:payload error:&error]) {
         deviceID++;


### PR DESCRIPTION
#### Problem
Need a way to exercise the restart mechanism via CHIPTool. 

#### Change overview
Added the Matter stack restart as a pre-pairing step. Now the stack gets restarted just before each pairing.

#### Testing
manually, with CHIPTool on iOS
