### PR TITLE
Modify the default value for window covering cluster

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -10898,7 +10898,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x00",
+              "defaultValue": "0x17",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,


### PR DESCRIPTION
Currently the window covering cluster's feature map has a
default value of 0x0.

#### Problem
As per matter spec, window covering cluster's feature map should have a non-zero default value.

#### Change overview
Modified the window covering cluster's feature map to have have default value of 0x17, same as on master branch, as
back porting the CL on master is not required.

#### Testing
Verified that all-cluster-app on m5stack is able to report the cluster information correctly and is parsed correctly on the receiving end as well, without any attribute errors.
