### PR TITLE
Remove log only delegate bridge from darwin chip controller

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -198,7 +198,7 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
         params.fabricStorage = _fabricStorage;
         params.fabricIndependentStorage = _persistentStorageDelegateBridge;
         commissionerParams.storageDelegate = _persistentStorageDelegateBridge;
-        commissionerParams.deviceAddressUpdateDelegate = _pairingDelegateBridge;
+        commissionerParams.deviceAddressUpdateDelegate = nullptr;
         commissionerParams.pairingDelegate = _pairingDelegateBridge;
 
         commissionerParams.operationalCredentialsDelegate = _operationalCredentialsDelegate;

--- a/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.h
@@ -23,8 +23,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-class CHIPDevicePairingDelegateBridge : public chip::Controller::DevicePairingDelegate,
-                                        public chip::Controller::DeviceAddressUpdateDelegate
+class CHIPDevicePairingDelegateBridge : public chip::Controller::DevicePairingDelegate
 {
 public:
     CHIPDevicePairingDelegateBridge();
@@ -39,8 +38,6 @@ public:
     void OnPairingDeleted(CHIP_ERROR error) override;
 
     void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR error) override;
-
-    void OnAddressUpdateComplete(chip::NodeId nodeId, CHIP_ERROR error) override;
 
 private:
     id<CHIPDevicePairingDelegate> mDelegate;

--- a/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.mm
@@ -110,8 +110,3 @@ void CHIPDevicePairingDelegateBridge::OnCommissioningComplete(chip::NodeId nodeI
     }
 }
 
-void CHIPDevicePairingDelegateBridge::OnAddressUpdateComplete(chip::NodeId nodeId, CHIP_ERROR error)
-{
-    // Todo, is there any benefit of exposing this anymore?
-    NSLog(@"OnAddressUpdateComplete. Status %s", chip::ErrorStr(error));
-}

--- a/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.mm
@@ -109,4 +109,3 @@ void CHIPDevicePairingDelegateBridge::OnCommissioningComplete(chip::NodeId nodeI
         }
     }
 }
-


### PR DESCRIPTION
#### Problem
Controller is only interested on 'Device commissioning done' and not in 'address update done'. There was already a todo of 'is this really required?'

#### Change overview
Removed the log-only method (and todo as a result)

#### Testing
Darwin build and CI should be sufficient.