### PR TITLE
Fix kvs in linux

### DIFF
--- a/src/platform/Linux/PosixConfig.cpp
+++ b/src/platform/Linux/PosixConfig.cpp
@@ -103,8 +103,7 @@ ChipLinuxStorage * PosixConfig::GetStorageForNamespace(Key key)
 
 CHIP_ERROR PosixConfig::Init()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    return err;
+    return PersistedStorage::KeyValueStoreMgrImpl().Init(CHIP_CONFIG_KVS_PATH);
 }
 
 CHIP_ERROR PosixConfig::ReadConfigValue(Key key, bool & val)


### PR DESCRIPTION
#### Problem
PR #15644 fixed a silent failure in the SessionManager Init.

In short if the KVS impl isn't initialized before calling the SessionManager.Init() GroupMessageCounter wouldn't be initialized correctly.

Turns out that by adding this error check within the SessionManager Init function, it highlighted the fact that the KVS isn't initialized when running Unit test in Linux platform.

#### Change overview
Add KVS init in PosixConfig for Linux (same as for Darwin)

#### Testing
Unit test and test suite
