### PR TITLE
Enable reset watermark for software diagnostics on Window cover app

### DIFF
--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -719,6 +719,8 @@ server cluster SoftwareDiagnostics = 52 {
   readonly attribute int64u currentHeapHighWatermark = 3;
   readonly global attribute bitmap32 featureMap = 65532;
   readonly global attribute int16u clusterRevision = 65533;
+
+  command ResetWatermarks(): DefaultSuccess = 0;
 }
 
 server cluster ThreadNetworkDiagnostics = 53 {

--- a/examples/window-app/common/window-app.zap
+++ b/examples/window-app/common/window-app.zap
@@ -2053,7 +2053,7 @@
               "code": 0,
               "mfgCode": null,
               "source": "client",
-              "incoming": 0,
+              "incoming": 1,
               "outgoing": 1
             }
           ],


### PR DESCRIPTION
#### Problem
* ResetWatermarks for SoftwareDiagnostics was not enabled on window cover app

#### Change overview
* Enable ResetWatermarks on the window cover app

#### Testing
* Manual tests running the command on efr32 mg12