### PR TITLE
Issue #11760 - [ota-requestor-app] Abort query image download on timeout

### DIFF
--- a/src/app/clusters/ota-requestor/BDXDownloader.cpp
+++ b/src/app/clusters/ota-requestor/BDXDownloader.cpp
@@ -18,12 +18,12 @@
 
 #include "BDXDownloader.h"
 
-#include <platform/CHIPDeviceLayer.h>
 #include <app/data-model/Nullable.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/BufferReader.h>
 #include <lib/support/BytesToHex.h>
 #include <lib/support/CodeUtils.h>
+#include <platform/CHIPDeviceLayer.h>
 #include <protocols/bdx/BdxMessages.h>
 #include <system/SystemClock.h> /* TODO:(#12520) remove */
 #include <system/SystemPacketBuffer.h>
@@ -37,29 +37,30 @@ using chip::bdx::TransferSession;
 namespace chip {
 
 // Timeout value in seconds to abort the download if there's no progress in the transfer session.
-System::Clock::Timeout mTimeout           = System::Clock::kZero;
+System::Clock::Timeout mTimeout = System::Clock::kZero;
 
 static uint8_t prevPercentageComplete = 0;
 
 void StartTimeoutTimerHandler(System::Layer * systemLayer, void * appState)
 {
-    if( static_cast<BDXDownloader *>(appState)->CheckTransferTimeout() )
+    if (static_cast<BDXDownloader *>(appState)->CheckTransferTimeout())
     {
-        //End download if transfer timeout has been detected
-        static_cast<BDXDownloader *>(appState)->OnDownloadTimeout();  
+        // End download if transfer timeout has been detected
+        static_cast<BDXDownloader *>(appState)->OnDownloadTimeout();
     }
     else
     {
-       //Else restart the timer
-       systemLayer->StartTimer(mTimeout, StartTimeoutTimerHandler, appState);  
+        // Else restart the timer
+        systemLayer->StartTimer(mTimeout, StartTimeoutTimerHandler, appState);
     }
 }
 
 bool BDXDownloader::CheckTransferTimeout()
 {
-    uint8_t curPercentageComplete = mImageProcessor->GetPercentComplete().IsNull() ? 0 : mImageProcessor->GetPercentComplete().Value();
+    uint8_t curPercentageComplete =
+        mImageProcessor->GetPercentComplete().IsNull() ? 0 : mImageProcessor->GetPercentComplete().Value();
 
-    if( curPercentageComplete > prevPercentageComplete )
+    if (curPercentageComplete > prevPercentageComplete)
     {
         prevPercentageComplete = curPercentageComplete;
         return false;
@@ -86,10 +87,11 @@ void BDXDownloader::OnMessageReceived(const chip::PayloadHeader & payloadHeader,
     PollTransferSession();
 }
 
-CHIP_ERROR BDXDownloader::SetBDXParams(const chip::bdx::TransferSession::TransferInitData & bdxInitData, System::Clock::Timeout timeout)
+CHIP_ERROR BDXDownloader::SetBDXParams(const chip::bdx::TransferSession::TransferInitData & bdxInitData,
+                                       System::Clock::Timeout timeout)
 {
     mTimeout = timeout;
-    mState = State::kIdle;
+    mState   = State::kIdle;
     mBdxTransfer.Reset();
 
     VerifyOrReturnError(mState == State::kIdle, CHIP_ERROR_INCORRECT_STATE);
@@ -150,7 +152,7 @@ CHIP_ERROR BDXDownloader::FetchNextData()
 void BDXDownloader::OnDownloadTimeout()
 {
     prevPercentageComplete = 0;
-    DeviceLayer::SystemLayer().CancelTimer(StartTimeoutTimerHandler, this); 
+    DeviceLayer::SystemLayer().CancelTimer(StartTimeoutTimerHandler, this);
 
     if (mState == State::kInProgress)
     {

--- a/src/app/clusters/ota-requestor/BDXDownloader.cpp
+++ b/src/app/clusters/ota-requestor/BDXDownloader.cpp
@@ -60,7 +60,7 @@ System::Clock::Timeout BDXDownloader::GetTimeout()
 
 void BDXDownloader::Reset()
 {
-    prevPercentageComplete = 0;
+    mPrevPercentageComplete = 0;
     DeviceLayer::SystemLayer().StartTimer(mTimeout, TransferTimeoutCheckHandler, this);
 }
 
@@ -69,9 +69,9 @@ bool BDXDownloader::CheckTransferTimeout()
     uint8_t curPercentageComplete =
         mImageProcessor->GetPercentComplete().IsNull() ? 0 : mImageProcessor->GetPercentComplete().Value();
 
-    if (curPercentageComplete > prevPercentageComplete)
+    if (curPercentageComplete > mPrevPercentageComplete)
     {
-        prevPercentageComplete = curPercentageComplete;
+        mPrevPercentageComplete = curPercentageComplete;
         return false;
     }
     else
@@ -118,7 +118,7 @@ CHIP_ERROR BDXDownloader::BeginPrepareDownload()
     VerifyOrReturnError(mState == State::kIdle, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(mImageProcessor != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    prevPercentageComplete = 0;
+    mPrevPercentageComplete = 0;
     DeviceLayer::SystemLayer().StartTimer(mTimeout, TransferTimeoutCheckHandler, this);
 
     ReturnErrorOnFailure(mImageProcessor->PrepareDownload());

--- a/src/app/clusters/ota-requestor/BDXDownloader.h
+++ b/src/app/clusters/ota-requestor/BDXDownloader.h
@@ -75,6 +75,9 @@ public:
     CHIP_ERROR FetchNextData() override;
     // TODO: override SkipData
 
+    System::Clock::Timeout GetTimeout();
+    // If True, there's been a timeout in the transfer as measured by no download progress after 'mTimeout' seconds.
+    // If False, there's been progress in the transfer.
     bool CheckTransferTimeout();
 
 private:
@@ -85,6 +88,10 @@ private:
     chip::bdx::TransferSession mBdxTransfer;
     MessagingDelegate * mMsgDelegate = nullptr;
     StateDelegate * mStateDelegate   = nullptr;
+    // Timeout value in seconds to abort the download if there's no progress in the transfer session.
+    System::Clock::Timeout mTimeout = System::Clock::kZero;
+    // Tracks the percentage of transfer session complete from as of the previous check.
+    uint8_t prevPercentageComplete = 0;
 };
 
 } // namespace chip

--- a/src/app/clusters/ota-requestor/BDXDownloader.h
+++ b/src/app/clusters/ota-requestor/BDXDownloader.h
@@ -92,7 +92,7 @@ private:
     // Timeout value in seconds to abort the download if there's no progress in the transfer session.
     System::Clock::Timeout mTimeout = System::Clock::kZero;
     // Tracks the percentage of transfer session complete from as of the previous check.
-    uint8_t prevPercentageComplete = 0;
+    uint8_t mPrevPercentageComplete = 0;
 };
 
 } // namespace chip

--- a/src/app/clusters/ota-requestor/BDXDownloader.h
+++ b/src/app/clusters/ota-requestor/BDXDownloader.h
@@ -63,7 +63,7 @@ public:
     void SetStateDelegate(StateDelegate * delegate) { mStateDelegate = delegate; }
 
     // Initialize a BDX transfer session but will not proceed until OnPreparedForDownload() is called.
-    CHIP_ERROR SetBDXParams(const chip::bdx::TransferSession::TransferInitData & bdxInitData);
+    CHIP_ERROR SetBDXParams(const chip::bdx::TransferSession::TransferInitData & bdxInitData, System::Clock::Timeout timeout);
 
     // OTADownloader Overrides
     CHIP_ERROR BeginPrepareDownload() override;
@@ -74,6 +74,8 @@ public:
     void EndDownload(CHIP_ERROR reason = CHIP_NO_ERROR) override;
     CHIP_ERROR FetchNextData() override;
     // TODO: override SkipData
+
+    bool CheckTransferTimeout();
 
 private:
     void PollTransferSession();

--- a/src/app/clusters/ota-requestor/BDXDownloader.h
+++ b/src/app/clusters/ota-requestor/BDXDownloader.h
@@ -78,7 +78,7 @@ public:
     System::Clock::Timeout GetTimeout();
     // If True, there's been a timeout in the transfer as measured by no download progress after 'mTimeout' seconds.
     // If False, there's been progress in the transfer.
-    bool CheckTransferTimeout();
+    bool HasTransferTimedOut();
 
 private:
     void PollTransferSession();
@@ -91,8 +91,8 @@ private:
     StateDelegate * mStateDelegate   = nullptr;
     // Timeout value in seconds to abort the download if there's no progress in the transfer session.
     System::Clock::Timeout mTimeout = System::Clock::kZero;
-    // Tracks the percentage of transfer session complete from as of the previous check.
-    uint8_t mPrevPercentageComplete = 0;
+    // Tracks the last block counter used during the transfer session as of the previous check.
+    uint32_t mPrevBlockCounter = 0;
 };
 
 } // namespace chip

--- a/src/app/clusters/ota-requestor/BDXDownloader.h
+++ b/src/app/clusters/ota-requestor/BDXDownloader.h
@@ -84,6 +84,7 @@ private:
     void PollTransferSession();
     CHIP_ERROR HandleBdxEvent(const chip::bdx::TransferSession::OutputEvent & outEvent);
     void SetState(State state, app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
+    void Reset();
 
     chip::bdx::TransferSession mBdxTransfer;
     MessagingDelegate * mMsgDelegate = nullptr;

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -44,6 +44,9 @@ using bdx::TransferSession;
 // Global instance of the OTARequestorInterface.
 OTARequestorInterface * globalOTARequestorInstance = nullptr;
 
+// Abort the QueryImage download request if there's been no progress for 5 minutes
+static constexpr System::Clock::Timeout kDownloadTimeoutSec = chip::System::Clock::Seconds32(300);
+
 static void LogQueryImageResponse(const QueryImageResponse::DecodableType & response)
 {
     ChipLogDetail(SoftwareUpdate, "QueryImageResponse:");
@@ -701,7 +704,7 @@ CHIP_ERROR OTARequestor::StartDownload(OperationalDeviceProxy & deviceProxy)
     mBdxDownloader->SetMessageDelegate(&mBdxMessenger);
     mBdxDownloader->SetStateDelegate(this);
 
-    ReturnErrorOnFailure(mBdxDownloader->SetBDXParams(initOptions, mTimeoutSec));
+    ReturnErrorOnFailure(mBdxDownloader->SetBDXParams(initOptions, kDownloadTimeoutSec));
     return mBdxDownloader->BeginPrepareDownload();
 }
 

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -701,7 +701,7 @@ CHIP_ERROR OTARequestor::StartDownload(OperationalDeviceProxy & deviceProxy)
     mBdxDownloader->SetMessageDelegate(&mBdxMessenger);
     mBdxDownloader->SetStateDelegate(this);
 
-    ReturnErrorOnFailure(mBdxDownloader->SetBDXParams(initOptions));
+    ReturnErrorOnFailure(mBdxDownloader->SetBDXParams(initOptions, mTimeoutSec));
     return mBdxDownloader->BeginPrepareDownload();
 }
 

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -45,7 +45,7 @@ using bdx::TransferSession;
 OTARequestorInterface * globalOTARequestorInstance = nullptr;
 
 // Abort the QueryImage download request if there's been no progress for 5 minutes
-static constexpr System::Clock::Timeout kDownloadTimeoutSec = chip::System::Clock::Seconds32(300);
+static constexpr System::Clock::Timeout kDownloadTimeoutSec = chip::System::Clock::Seconds32(5 * 60);
 
 static void LogQueryImageResponse(const QueryImageResponse::DecodableType & response)
 {

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -306,7 +306,6 @@ private:
     char mFileDesignatorBuffer[bdx::kMaxFileDesignatorLen];
     CharSpan mFileDesignator;
     OTAUpdateStateEnum mCurrentUpdateState = OTAUpdateStateEnum::kUnknown;
-    System::Clock::Timeout mTimeoutSec     = chip::System::Clock::Seconds32(5*60); // Abort the QueryImage download request if there's been no progress for 5 minutes
     Server * mServer                       = nullptr;
     chip::Optional<bool> mRequestorCanConsent;
     ProviderLocationList mDefaultOtaProviderList;

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -306,6 +306,7 @@ private:
     char mFileDesignatorBuffer[bdx::kMaxFileDesignatorLen];
     CharSpan mFileDesignator;
     OTAUpdateStateEnum mCurrentUpdateState = OTAUpdateStateEnum::kUnknown;
+    System::Clock::Timeout mTimeoutSec     = chip::System::Clock::Seconds32(5*60); // Abort the QueryImage download request if there's been no progress for 5 minutes
     Server * mServer                       = nullptr;
     chip::Optional<bool> mRequestorCanConsent;
     ProviderLocationList mDefaultOtaProviderList;

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -297,6 +297,7 @@ public:
     uint64_t GetStartOffset() const { return mStartOffset; }
     uint64_t GetTransferLength() const { return mTransferLength; }
     uint16_t GetTransferBlockSize() const { return mTransferMaxBlockSize; }
+    uint32_t GetNextBlockNum() { return mNextBlockNum; };
     size_t GetNumBytesProcessed() const { return mNumBytesProcessed; }
     const uint8_t * GetFileDesignator(uint16_t & fileDesignatorLen) const
     {

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -297,7 +297,7 @@ public:
     uint64_t GetStartOffset() const { return mStartOffset; }
     uint64_t GetTransferLength() const { return mTransferLength; }
     uint16_t GetTransferBlockSize() const { return mTransferMaxBlockSize; }
-    uint32_t GetNextBlockNum() { return mNextBlockNum; };
+    uint32_t GetNextBlockNum() { return mNextBlockNum; }
     size_t GetNumBytesProcessed() const { return mNumBytesProcessed; }
     const uint8_t * GetFileDesignator(uint16_t & fileDesignatorLen) const
     {


### PR DESCRIPTION
#### Problem
Currently, if OTA-P crashes or somehow stops responding during a QueryImage download, OTA-R app waits forever.

Fixes: https://github.com/project-chip/connectedhomeip/issues/11760
Fixes: https://github.com/project-chip/connectedhomeip/issues/14854

#### Change overview
Added a 5 minute timer in BDX downloader which checks whether there's been progress made in the QueryImage download session.  If there's been progress, set the timer to check again.  If there's been no progress, that means OTA-P hasn't been responsive, so OTA-R will abort the session.

This change addresses this part of the spec:

Section 11.20.3.5 Pg 665: Idle time-out SHALL be no less than 5 minutes for either Receiver-Driver or Asynchronous mode, before aborting a transfer.

#### Testing
- Run OTA-P and OTA-R Linux apps and send QueryImage command.
- Subscribe to DownloadError event on OTA-R Linux app using chip-tool.
- While OTA image download is in progress, kill OTA-P app (via control-C).
- Wait at least 5 minutes and confirm that OTA-R has aborted the BDX transfer session and sends DownloadError event.

Example:

```
out/apps/ota-provider/chip-ota-provider-app -f ~/Downloads/test.ota   

out/apps/ota-requestor/chip-ota-requestor-app --discriminator 30 --secured-device-port 5560 --KVS /tmp/chip_kvs_requestor

out/apps/chip-tool/chip-tool otasoftwareupdaterequestor announce-ota-provider 0x00000000ABCD 0 0 0 0x0000001234567890 0

out/apps/chip-tool/chip-tool otasoftwareupdaterequestor subscribe-event download-error 5 10 1 0x1234567890 0
```

Control-C to kill OTA-P app.  Then verify OTA-R logs after ~5 minutes:

```
[1646422631635] [31885:4514894] CHIP: [DMG] <RE> OnReportConfirm: NumReports = 0
[1646422631635] [31885:4514894] CHIP: [DMG] IM RH moving to [GeneratingReports]
[1646422631635] [31885:4514894] CHIP: [EM] Sending Standalone Ack for MessageCounter:13363227 on exchange 5700i
[1646422631635] [31885:4514894] CHIP: [IN] Prepared secure message 0x700002771560 to 0x000000000001B669 (1) of type 0x10 and protocolId (0, 0) on exchange 5700i with MessageCounter:7287330.
[1646422631635] [31885:4514894] CHIP: [IN] Sending encrypted msg 0x700002771560 with MessageCounter:7287330 to 0x000000000001B669 (1) at monotonic time: 1254067287 msec
[1646422631635] [31885:4514894] CHIP: [EM] Flushed pending ack for MessageCounter:13363227 on exchange 5700i
[1646422636635] [31885:4514894] CHIP: [DMG] Unblock report hold after min 5 seconds
*[1646422639408] [31885:4514894] CHIP: [BDX] BDX transfer timeout*
[1646422639408] [31885:4514894] CHIP: [BDX] aborting due to timeout
[1646422639409] [31885:4514894] CHIP: [EVL] LogEvent event number: 0x0000000000190003 priority: 1, endpoint id: 0x0 cluster id: 0x0000_002A event id: 0x2 Sys timestamp: 0x000000004ABFAAB4
[1646422639409] [31885:4514894] CHIP: [DMG] Endpoint 0, Cluster 0x0000_002A update version to 7bca9141
[1646422639409] [31885:4514894] CHIP: [DMG] Endpoint 0, Cluster 0x0000_002A update version to 7bca9142
[1646422639409] [31885:4514894] CHIP: [EVL] LogEvent event number: 0x0000000000190004 priority: 1, endpoint id: 0x0 cluster id: 0x0000_002A event id: 0x0 Sys timestamp: 0x000000004ABFAAB4
[1646422639409] [31885:4514894] CHIP: [SWU] Starting the Default Provider timer, timeout: 86400 seconds
[1646422641635] [31885:4514893] CHIP: [DMG] Refresh subscribe timer sync after 5 seconds
[1646422641635] [31885:4514893] CHIP: [DMG] AccessControl: checking f=1 a=c s=0x000000000001B669 t= c=0x0000_002A e=0 p=v
[1646422641635] [31885:4514893] CHIP: [DMG] Fetched 1 events
[1646422641635] [31885:4514893] CHIP: [DMG] <RE> Sending report (payload has 67 bytes)...
[1646422641635] [31885:4514893] CHIP: [DMG] IM RH moving to [AwaitingReportResponse]
[1646422641635] [31885:4514893] CHIP: [IN] Prepared secure message 0x104dc6a08 to 0x000000000001B669 (1) of type 0x5 and protocolId (0, 1) on exchange 5701i with MessageCounter:7287331.
[1646422641635] [31885:4514893] CHIP: [IN] Sending encrypted msg 0x104dc6a08 with MessageCounter:7287331 to 0x000000000001B669 (1) at monotonic time: 1254077287 msec
[1646422641635] [31885:4514893] CHIP: [DMG] Refresh Subscribe Sync Timer with max 10 seconds
[1646422641635] [31885:4514893] CHIP: [DMG] <RE> ReportsInFlight = 1 with readHandler 0, RE has no more messages
[1646422641637] [31885:4514894] CHIP: [EM] Received message of type 0x1 with protocolId (0, 1) and MessageCounter:13363228 on exchange 5701i
```

Chip-tool logs:

```
[1646422641636] [31887:4519287] CHIP: [TOO] Endpoint: 0 Cluster: 0x0000_002A Event 0x0000_0002
[1646422641636] [31887:4519287] CHIP: [TOO] 	 Event number: 1638403
[1646422641636] [31887:4519287] CHIP: [TOO] 	 Priority: Info
[1646422641637] [31887:4519287] CHIP: [TOO] 	 Timestamp: 1254075060
[1646422641637] [31887:4519287] CHIP: [TOO]   DownloadError: {
[1646422641637] [31887:4519287] CHIP: [TOO]     SoftwareVersion: 1
[1646422641637] [31887:4519287] CHIP: [TOO]     BytesDownloaded: 4019
[1646422641637] [31887:4519287] CHIP: [TOO]     ProgressPercent: 83
[1646422641637] [31887:4519287] CHIP: [TOO]     PlatformCode: null
[1646422641637] [31887:4519287] CHIP: [TOO]    }
```
