### PR TITLE
Fix sprintf type issue in TlvJson

### DIFF
--- a/src/lib/support/jsontlv/TlvJson.cpp
+++ b/src/lib/support/jsontlv/TlvJson.cpp
@@ -55,8 +55,8 @@ struct KeyContext
         key     = listIndex;
     }
 
-    KeyType keyType  = kRoot;
-    unsigned int key = 0;
+    KeyType keyType = kRoot;
+    uint32_t key    = 0;
 };
 } // namespace
 


### PR DESCRIPTION
#### Problem

Builds on MbedOS are failing due to mismatched type in a `sprintf` call inside `TlvJson.cpp`.