### PR TITLE
Make sure we use the right storage when restarting the stack in iOS CHIPTool.

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
@@ -26,6 +26,7 @@ extern NSString * const kNetworkPasswordDefaultsKey;
 extern NSString * const kFabricIdKey;
 
 CHIPDeviceController * InitializeCHIP(void);
+void CHIPRestartController(CHIPDeviceController * controller);
 id CHIPGetDomainValueForKey(NSString * domain, NSString * key);
 void CHIPSetDomainValueForKey(NSString * domain, NSString * key, id value);
 void CHIPRemoveDomainValueForKey(NSString * domain, NSString * key);

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -64,9 +64,10 @@ void CHIPSetNextAvailableDeviceID(uint64_t id)
     CHIPSetDomainValueForKey(kCHIPToolDefaultsDomain, kCHIPNextAvailableDeviceIDKey, [NSNumber numberWithUnsignedLongLong:id]);
 }
 
+static CHIPToolPersistentStorageDelegate * storage = nil;
+
 CHIPDeviceController * InitializeCHIP(void)
 {
-    static CHIPToolPersistentStorageDelegate * storage = nil;
     static dispatch_once_t onceToken;
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
     dispatch_once(&onceToken, ^{
@@ -75,6 +76,14 @@ CHIPDeviceController * InitializeCHIP(void)
     });
 
     return controller;
+}
+
+void CHIPRestartController(CHIPDeviceController * controller)
+{
+    NSLog(@"Shutting down the stack");
+    [controller shutdown];
+    NSLog(@"Starting up the stack");
+    [controller startup:storage vendorId:0 nocSigner:nil];
 }
 
 uint64_t CHIPGetLastPairedDeviceId(void)

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -790,10 +790,7 @@
 
 - (void)_restartMatterStack
 {
-    NSLog(@"Shutting down the stack");
-    [self.chipController shutdown];
-    NSLog(@"Starting up the stack");
-    [self.chipController startup:nil vendorId:0 nocSigner:nil];
+    CHIPRestartController(self.chipController);
 }
 
 - (void)handleRendezVousDefault:(NSString *)payload


### PR DESCRIPTION
We were using the wrong storage, and getting the wrong node id as a result.

Fixes https://github.com/project-chip/connectedhomeip/issues/15761

#### Problem
See above.

#### Change overview
Use the same storage when restarting.

#### Testing
Made sure the node ids logged are the same whether we are using the camera to scan a QR code or not.