### PR TITLE
[YAML] Remove GetUniqueDiscriminator since cross-talks seems to be gone now

### DIFF
--- a/src/app/tests/suites/TestDiscovery.yaml
+++ b/src/app/tests/suites/TestDiscovery.yaml
@@ -19,7 +19,7 @@ config:
     endpoint: 0
     discriminator:
         type: INT16U
-        defaultValue: GetUniqueDiscriminator()
+        defaultValue: 3840
     vendorId:
         type: INT16U
         defaultValue: 65521

--- a/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
+++ b/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
@@ -20,7 +20,6 @@
 
 #include <lib/support/SafeInt.h>
 #include <platform/CHIPDeviceLayer.h>
-#include <random>
 
 CHIP_ERROR DiscoveryCommands::FindCommissionable()
 {
@@ -114,36 +113,12 @@ CHIP_ERROR DiscoveryCommands::TearDownDiscoveryCommands()
     return CHIP_NO_ERROR;
 }
 
-uint16_t DiscoveryCommands::GetUniqueDiscriminator()
-{
-    if (mDiscriminatorUseForFiltering == 0)
-    {
-        std::random_device dev;
-        std::mt19937 rng(dev());
-        std::uniform_int_distribution<std::mt19937::result_type> distribution(1, 4096);
-        mDiscriminatorUseForFiltering = static_cast<uint16_t>(distribution(rng));
-    }
-    return mDiscriminatorUseForFiltering;
-}
-
 void DiscoveryCommands::OnNodeDiscovered(const chip::Dnssd::DiscoveredNodeData & nodeData)
 {
     // TODO: If multiple results are found for the same filter, then the test result depends
     //       on which result comes first. At the moment, the code assume that there is only
     //       a single match on the network, but if that's not enough, there may be a need
     //       to implement some sort of list that is built for a given duration before returning
-    //
-    //       But also, running on CI seems to show cross-talks between CI instances, so multiple
-    //       results will comes up. Unexpected advertisements are filtered by validating the
-    //       discriminator from the advertisement matches the one coming from the config section
-    //       of the test.
-    if (nodeData.longDiscriminator != GetUniqueDiscriminator())
-    {
-        ChipLogError(chipTool, "Non fatal error: Unexpected node advertisment. It will be ignored");
-        nodeData.LogDetail();
-        return;
-    }
-
     ReturnOnFailure(TearDownDiscoveryCommands());
 
     nodeData.LogDetail();

--- a/src/app/tests/suites/commands/discovery/DiscoveryCommands.h
+++ b/src/app/tests/suites/commands/discovery/DiscoveryCommands.h
@@ -69,12 +69,7 @@ public:
     /////////// CommissioningDelegate Interface /////////
     void OnNodeDiscovered(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
 
-protected:
-    // This function initialize a random discriminator once and returns it all the time afterwards
-    uint16_t GetUniqueDiscriminator();
-
 private:
     bool mReady = false;
     chip::Dnssd::ResolverProxy mDNSResolver;
-    uint16_t mDiscriminatorUseForFiltering = 0;
 };

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -76782,7 +76782,7 @@ private:
             isExpectedDnssdResult = true;
 
             VerifyOrReturn(CheckValue("longDiscriminator", value.longDiscriminator,
-                                      mDiscriminator.HasValue() ? mDiscriminator.Value() : GetUniqueDiscriminator()));
+                                      mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U));
             VerifyOrReturn(CheckConstraintMinValue<uint16_t>("value.longDiscriminator", value.longDiscriminator, 0U));
             VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("value.longDiscriminator", value.longDiscriminator, 4096U));
         }
@@ -76870,7 +76870,7 @@ private:
     CHIP_ERROR TestRebootTargetDevice_0()
     {
         SetIdentity(kIdentityAlpha);
-        return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : GetUniqueDiscriminator());
+        return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
     }
 
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_1()
@@ -76917,14 +76917,13 @@ private:
     CHIP_ERROR TestCheckLongDiscriminatorL_4()
     {
         SetIdentity(kIdentityAlpha);
-        return FindCommissionableByLongDiscriminator(mDiscriminator.HasValue() ? mDiscriminator.Value() : GetUniqueDiscriminator());
+        return FindCommissionableByLongDiscriminator(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
     }
 
     CHIP_ERROR TestCheckShortDiscriminatorS_5()
     {
         SetIdentity(kIdentityAlpha);
-        return FindCommissionableByShortDiscriminator(mDiscriminator.HasValue() ? mDiscriminator.Value()
-                                                                                : GetUniqueDiscriminator());
+        return FindCommissionableByShortDiscriminator(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
     }
 
     CHIP_ERROR TestCheckCommissioningModeCm_6()
@@ -77008,7 +77007,7 @@ private:
     CHIP_ERROR TestRebootTargetDevice_19()
     {
         SetIdentity(kIdentityAlpha);
-        return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : GetUniqueDiscriminator());
+        return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
     }
 
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_20()


### PR DESCRIPTION
#### Problem

The `GetUniqueDiscriminator` method in YAML was used as a way to workaround the collisions between instances mdns advertisement on CI. Mdns advertisement are now broadcasting only onto the local interface so this method can be removed.

#### Change overview
* Remove `GetUniqueDiscriminator`
