### PR TITLE
[placeholder] Allow placeholder examples to emit dnssd requests

### DIFF
--- a/examples/placeholder/linux/include/TestCommand.h
+++ b/examples/placeholder/linux/include/TestCommand.h
@@ -26,7 +26,9 @@
 #include <app/tests/suites/commands/delay/DelayCommands.h>
 #include <app/tests/suites/commands/discovery/DiscoveryCommands.h>
 #include <app/tests/suites/commands/log/LogCommands.h>
+#include <app/tests/suites/include/ConstraintsChecker.h>
 #include <app/tests/suites/include/PICSChecker.h>
+#include <app/tests/suites/include/ValueChecker.h>
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
@@ -36,7 +38,12 @@ constexpr const char kIdentityAlpha[] = "";
 constexpr const char kIdentityBeta[]  = "";
 constexpr const char kIdentityGamma[] = "";
 
-class TestCommand : public PICSChecker, public LogCommands, public DiscoveryCommands, public DelayCommands
+class TestCommand : public PICSChecker,
+                    public LogCommands,
+                    public DiscoveryCommands,
+                    public DelayCommands,
+                    public ValueChecker,
+                    public ConstraintsChecker
 {
 public:
     TestCommand(const char * commandName) : mCommandPath(0, 0, 0), mAttributePath(0, 0, 0) {}
@@ -75,7 +82,7 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    void Exit(std::string message)
+    void Exit(std::string message) override
     {
         ChipLogError(chipTool, " ***** Test Failure: %s\n", message.c_str());
         SetCommandExitStatus(CHIP_ERROR_INTERNAL);

--- a/examples/placeholder/templates/templates.json
+++ b/examples/placeholder/templates/templates.json
@@ -8,6 +8,7 @@
         "../../../src/app/zap-templates/templates/chip/helper.js",
         "../../../src/app/zap-templates/common/ClusterTestGeneration.js",
         "../../../examples/chip-tool/templates/helper.js",
+        "../../../examples/chip-tool/templates/tests/helper.js",
         "helper.js"
     ],
     "override": "../../../src/app/zap-templates/common/override.js",
@@ -19,6 +20,18 @@
         {
             "name": "test_cluster",
             "path": "../../../examples/chip-tool/templates/tests/partials/test_cluster.zapt"
+        },
+        {
+            "name": "maybeCheckExpectedValue",
+            "path": "../../../examples/chip-tool/templates/tests/partials/checks/maybeCheckExpectedValue.zapt"
+        },
+        {
+            "name": "maybeCheckExpectedConstraints",
+            "path": "../../../examples/chip-tool/templates/tests/partials/checks/maybeCheckExpectedConstraints.zapt"
+        },
+        {
+            "name": "maybeSaveAs",
+            "path": "../../../examples/chip-tool/templates/tests/partials/saveAs/maybeSaveAs.zapt"
         },
         {
             "name": "setupSaveAs",

--- a/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
+++ b/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
@@ -103,12 +103,14 @@ CHIP_ERROR DiscoveryCommands::SetupDiscoveryCommands()
         ReturnErrorOnFailure(mDNSResolver.Init(chip::DeviceLayer::UDPEndPointManager()));
         mReady = true;
     }
+    mDNSResolver.SetOperationalDelegate(this);
     mDNSResolver.SetCommissioningDelegate(this);
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DiscoveryCommands::TearDownDiscoveryCommands()
 {
+    mDNSResolver.SetOperationalDelegate(nullptr);
     mDNSResolver.SetCommissioningDelegate(nullptr);
     return CHIP_NO_ERROR;
 }

--- a/src/app/tests/suites/commands/discovery/DiscoveryCommands.h
+++ b/src/app/tests/suites/commands/discovery/DiscoveryCommands.h
@@ -43,7 +43,7 @@ struct DiscoveryCommandResult
     chip::Optional<uint32_t> mrpRetryIntervalActive;
 };
 
-class DiscoveryCommands : public chip::Dnssd::CommissioningResolveDelegate
+class DiscoveryCommands : public chip::Dnssd::CommissioningResolveDelegate, public chip::Dnssd::OperationalResolveDelegate
 {
 public:
     DiscoveryCommands(){};
@@ -68,6 +68,10 @@ public:
 
     /////////// CommissioningDelegate Interface /////////
     void OnNodeDiscovered(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
+
+    /////////// OperationalDelegate Interface /////////
+    void OnOperationalNodeResolved(const chip::Dnssd::ResolvedNodeData & nodeData) override{};
+    void OnOperationalNodeResolutionFailed(const chip::PeerId & peerId, CHIP_ERROR error) override{};
 
 private:
     bool mReady = false;


### PR DESCRIPTION
#### Problem

The generated placeholder tests can not emit mdns requests. 

#### Change overview
 * Add the missing glue

#### Testing
 I have locally updated the `app1` to validate that it works