### PR TITLE
[ESP32] map CHIP_ERROR_KEY_NOT_FOUND to ESP_ERR_NVS_NOT_FOUND

### DIFF
--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -33,6 +33,7 @@
 #include "esp_netif.h"
 #include "esp_netif_net_stack.h"
 #include "esp_wifi.h"
+#include "nvs.h"
 
 using namespace ::chip::DeviceLayer::Internal;
 using chip::DeviceLayer::Internal::DeviceNetworkInfo;
@@ -310,6 +311,10 @@ CHIP_ERROR ESP32Utils::MapError(esp_err_t error)
     if (error == ESP_OK)
     {
         return CHIP_NO_ERROR;
+    }
+    if (error == ESP_ERR_NVS_NOT_FOUND)
+    {
+        return CHIP_ERROR_KEY_NOT_FOUND;
     }
     return CHIP_ERROR(ChipError::Range::kPlatform, error);
 }


### PR DESCRIPTION
#### Problem
The ESP examples commissioning fails on latest master.

In this PR: [Group] Add chip-tool group command support #15644 
add return value check `ReturnErrorOnFailure(mGroupClientCounter.Init(storageDelegate))` in `SessionManager::Init()` cause chip init failed like below.
`E (2815) chip[SVR]: ERROR setting up transport: Error ESP32:0x05001102`

The reason is during the init process, `mGroupClientCounter.Init(storageDelegate)` use  `mStorage->SyncGetKeyValue` to get value from storage.
```
err = mStorage->SyncGetKeyValue(key.GroupControlCounter(), &temp, size);
if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND || err == CHIP_ERROR_KEY_NOT_FOUND)
{
   mGroupControlCounter = 0; // TODO should be random
}
else if (err != CHIP_NO_ERROR)
{
    return err;
}
```
We expect it to return `CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND` or `CHIP_ERROR_KEY_NOT_FOUND` if the value or key not found.However this function returns `CHIP_ERROR(ChipError::Range::kPlatform, ESP_ERR_NVS_NOT_FOUND)` which return an error in `mGroupClientCounter.Init(storageDelegate)` and cause `SessionManager::Init()` failed.

#### Change overview
Return `CHIP_ERROR_KEY_NOT_FOUND` instead of `CHIP_ERROR(ChipError::Range::kPlatform, ESP_ERR_NVS_NOT_FOUND)`  when not found a key.

#### Testing
Manually tested in M5stack and Esp32-DevKitC