### PR TITLE
[chip-tool] Add an optional suppressResponse argument to chip-tool co…

### DIFF
--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -32,6 +32,7 @@ public:
         AddArgument("command-id", 0, UINT32_MAX, &mCommandId);
         AddArgument("payload", &mPayload);
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
+        AddArgument("suppressResponse", 0, 1, &mSuppressResponse);
         ModelCommand::AddArguments();
     }
 
@@ -41,6 +42,7 @@ public:
         AddArgument("command-id", 0, UINT32_MAX, &mCommandId);
         AddArgument("payload", &mPayload);
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
+        AddArgument("suppressResponse", 0, 1, &mSuppressResponse);
         ModelCommand::AddArguments();
     }
 
@@ -48,6 +50,7 @@ public:
         ModelCommand(commandName, credsIssuerConfig)
     {
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
+        AddArgument("suppressResponse", 0, 1, &mSuppressResponse);
     }
 
     ~ClusterCommand() {}
@@ -107,7 +110,8 @@ public:
         mCommandSender =
             std::make_unique<chip::app::CommandSender>(this, device->GetExchangeManager(), mTimedInteractionTimeoutMs.HasValue());
         VerifyOrReturnError(mCommandSender != nullptr, CHIP_ERROR_NO_MEMORY);
-        ReturnErrorOnFailure(mCommandSender->AddRequestDataNoTimedCheck(commandPath, value, mTimedInteractionTimeoutMs));
+        ReturnErrorOnFailure(mCommandSender->AddRequestDataNoTimedCheck(commandPath, value, mTimedInteractionTimeoutMs,
+                                                                        mSuppressResponse.ValueOr(false)));
         ReturnErrorOnFailure(mCommandSender->SendCommandRequest(device->GetSecureSession().Value()));
         return CHIP_NO_ERROR;
     }
@@ -137,6 +141,7 @@ private:
     chip::ClusterId mClusterId;
     chip::CommandId mCommandId;
     chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
+    chip::Optional<bool> mSuppressResponse;
 
     CHIP_ERROR mError = CHIP_NO_ERROR;
     CustomArgument mPayload;

--- a/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
+++ b/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
@@ -33,6 +33,7 @@ public:
         AddArgument("attribute-value", &mAttributeValue);
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
         AddArgument("data-version", 0, UINT32_MAX, &mDataVersion);
+        AddArgument("suppressResponse", 0, 1, &mSuppressResponse);
         ModelCommand::AddArguments();
     }
 
@@ -43,6 +44,7 @@ public:
         AddArgument("attribute-value", &mAttributeValue);
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
         AddArgument("data-version", 0, UINT32_MAX, &mDataVersion);
+        AddArgument("suppressResponse", 0, 1, &mSuppressResponse);
         ModelCommand::AddArguments();
     }
 
@@ -51,6 +53,7 @@ public:
     {
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
         AddArgument("data-version", 0, UINT32_MAX, &mDataVersion);
+        AddArgument("suppressResponse", 0, 1, &mSuppressResponse);
     }
 
     ~WriteAttribute() {}
@@ -103,7 +106,8 @@ public:
         attributePathParams.mClusterId   = clusterId;
         attributePathParams.mAttributeId = attributeId;
 
-        mWriteClient = std::make_unique<chip::app::WriteClient>(device->GetExchangeManager(), this, mTimedInteractionTimeoutMs);
+        mWriteClient = std::make_unique<chip::app::WriteClient>(device->GetExchangeManager(), this, mTimedInteractionTimeoutMs,
+                                                                mSuppressResponse.ValueOr(false));
 
         ReturnErrorOnFailure(mWriteClient->EncodeAttribute(attributePathParams, value, mDataVersion));
 
@@ -141,6 +145,7 @@ private:
     CHIP_ERROR mError = CHIP_NO_ERROR;
     chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
     chip::Optional<chip::DataVersion> mDataVersion = chip::NullOptional;
+    chip::Optional<bool> mSuppressResponse;
     CustomArgument mAttributeValue;
     std::unique_ptr<chip::app::WriteClient> mWriteClient;
 };

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -179,8 +179,9 @@ public:
      */
     template <typename CommandDataT>
     CHIP_ERROR AddRequestDataNoTimedCheck(const CommandPathParams & aCommandPath, const CommandDataT & aData,
-                                          const Optional<uint16_t> & aTimedInvokeTimeoutMs)
+                                          const Optional<uint16_t> & aTimedInvokeTimeoutMs, bool aSuppressResponse = false)
     {
+        mSuppressResponse = aSuppressResponse;
         return AddRequestDataInternal(aCommandPath, aData, aTimedInvokeTimeoutMs);
     }
 #endif // CONFIG_IM_BUILD_FOR_UNIT_TEST

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -240,6 +240,7 @@ CHIP_ERROR WriteClient::StartNewMessage()
     ReturnErrorOnFailure(mMessageWriter.ReserveBuffer(reservedSize));
 
     ReturnErrorOnFailure(mWriteRequestBuilder.Init(&mMessageWriter));
+    mWriteRequestBuilder.SuppressResponse(mSuppressResponse);
     mWriteRequestBuilder.TimedRequest(mTimedWriteTimeoutMs.HasValue());
     ReturnErrorOnFailure(mWriteRequestBuilder.GetError());
     mWriteRequestBuilder.CreateWriteRequests();

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -120,11 +120,12 @@ public:
      *  @param[in]    apExchangeMgr    A pointer to the ExchangeManager object.
      *  @param[in]    apCallback       Callback set by application.
      *  @param[in]    aTimedWriteTimeoutMs If provided, do a timed write using this timeout.
+     *  @param[in]    aSuppressResponse If provided, set SuppressResponse field to the provided value
      */
-    WriteClient(Messaging::ExchangeManager * apExchangeMgr, Callback * apCallback,
-                const Optional<uint16_t> & aTimedWriteTimeoutMs) :
+    WriteClient(Messaging::ExchangeManager * apExchangeMgr, Callback * apCallback, const Optional<uint16_t> & aTimedWriteTimeoutMs,
+                bool aSuppressResponse = false) :
         mpExchangeMgr(apExchangeMgr),
-        mpCallback(apCallback), mTimedWriteTimeoutMs(aTimedWriteTimeoutMs)
+        mpCallback(apCallback), mTimedWriteTimeoutMs(aTimedWriteTimeoutMs), mSuppressResponse(aSuppressResponse)
     {}
 
 #if CONFIG_IM_BUILD_FOR_UNIT_TEST
@@ -391,6 +392,7 @@ private:
     // If mTimedWriteTimeoutMs has a value, we are expected to do a timed
     // write.
     Optional<uint16_t> mTimedWriteTimeoutMs;
+    bool mSuppressResponse = false;
 
     // A list of buffers, one buffer for each chunk.
     System::PacketBufferHandle mChunks;

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -46,6 +46,7 @@ CHIP_ERROR WriteHandler::Init()
 
 void WriteHandler::Close()
 {
+    mSuppressResponse = false;
     VerifyOrReturn(mState != State::Uninitialized);
 
     if (mpExchangeCtx != nullptr)
@@ -394,7 +395,6 @@ Status WriteHandler::ProcessWriteRequest(System::PacketBufferHandle && aPayload,
     WriteRequestMessage::Parser writeRequestParser;
     AttributeDataIBs::Parser AttributeDataIBsParser;
     TLV::TLVReader AttributeDataIBsReader;
-    bool needSuppressResponse = false;
     // Default to InvalidAction for our status; that's what we want if any of
     // the parsing of our overall structure or paths fails.  Once we have a
     // successfully parsed path, the only way we will get a failure return is if
@@ -413,7 +413,7 @@ Status WriteHandler::ProcessWriteRequest(System::PacketBufferHandle && aPayload,
     err = writeRequestParser.CheckSchemaValidity();
     SuccessOrExit(err);
 #endif
-    err = writeRequestParser.GetSuppressResponse(&needSuppressResponse);
+    err = writeRequestParser.GetSuppressResponse(&mSuppressResponse);
     if (err == CHIP_END_OF_TLV)
     {
         err = CHIP_NO_ERROR;

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -148,9 +148,10 @@ private: // ExchangeDelegate
 private:
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
     WriteResponseMessage::Builder mWriteResponseBuilder;
-    State mState         = State::Uninitialized;
-    bool mIsTimedRequest = false;
-    bool mHasMoreChunks  = false;
+    State mState           = State::Uninitialized;
+    bool mIsTimedRequest   = false;
+    bool mSuppressResponse = false;
+    bool mHasMoreChunks    = false;
     Optional<ConcreteAttributePath> mProcessingAttributePath;
     Optional<AttributeAccessToken> mACLCheckCache = NullOptional;
 };


### PR DESCRIPTION
…mmand line for cluster commands and write commands

#### Problem

`chip-tool` can not set the `SuppressResponse` flag.

#### Change overview
 * Update `chip-tool` commands to allow for an optional argument to set `SuppressResponse`
 * Update `src/app` interfaces to let `chip-tool` set the flag

#### Testing
I have observed the logged commands/responses to check that the flag is well set. That does not means that the feature works, since this is mostly unimplemented.

 close #15720