### PR TITLE
[groups] Fix storing group data counter

### DIFF
--- a/src/transport/GroupPeerMessageCounter.cpp
+++ b/src/transport/GroupPeerMessageCounter.cpp
@@ -275,6 +275,7 @@ CHIP_ERROR GroupOutgoingCounters::Init(chip::PersistentStorageDelegate * storage
     }
 
     temp = mGroupControlCounter + GROUP_MSG_COUNTER_MIN_INCREMENT;
+    size = static_cast<uint16_t>(sizeof(temp));
     ReturnErrorOnFailure(mStorage->SyncSetKeyValue(key.GroupControlCounter(), &temp, size));
 
     temp = mGroupDataCounter + GROUP_MSG_COUNTER_MIN_INCREMENT;


### PR DESCRIPTION
#### Problem
`Server::Init` returns: `E: 31694 [SVR]ERROR setting up transport: Error CHIP:0x0000002F` on some platforms.
Depending on the KVS implementation, the size variable passed to the SyncSetKeyValue() might have been modified by previous SyncGetKeyValue() calls.

#### Change overview
Set the correct variable size before storing it into KVS.

#### Testing
Tested on Nordic hardware.
