### PR TITLE
Lock standard output when composing log message

### DIFF
--- a/src/platform/Linux/Logging.cpp
+++ b/src/platform/Linux/Logging.cpp
@@ -37,11 +37,17 @@ void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char
     // indicate the error occurred during getting time.
     gettimeofday(&tv, nullptr);
 
+    // Lock standard output, so a single log line will not be corrupted in case
+    // where multiple threads are using logging subsystem at the same time.
+    flockfile(stdout);
+
     printf("[%" PRIu64 ".%06" PRIu64 "][%lld:%lld] CHIP:%s: ", static_cast<uint64_t>(tv.tv_sec), static_cast<uint64_t>(tv.tv_usec),
            static_cast<long long>(syscall(SYS_getpid)), static_cast<long long>(syscall(SYS_gettid)), module);
     vprintf(msg, v);
     printf("\n");
     fflush(stdout);
+
+    funlockfile(stdout);
 
     // Let the application know that a log message has been emitted.
     DeviceLayer::OnLogOutput();


### PR DESCRIPTION
#### Problem

Single log message is created by calling printf function multiple number of times. In case of using log subsystem from more than one thread, the log message might be corrupted. In order to prevent that, it is advised to use flockfile()/funlockfile() for given stream.

#### Change overview

* wrapped `printf()` calls in the log function with `flockfile()`/`funlockfile()` pair

#### Testing

```
./scripts/tests/run_test_suite.py \
   --chip-tool out/examples/chip-tool/chip-tool \
  run \
    --all-clusters-app out/examples/all-clusters-app/chip-all-clusters-app \
    --tv-app out/examples/tv-app/chip-tv-app \
```