### PR TITLE
Remove FabricStorage

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -45,10 +45,8 @@ CHIP_ERROR CHIPCommand::Run()
 #endif
 
     ReturnLogErrorOnFailure(mDefaultStorage.Init());
-    ReturnLogErrorOnFailure(mFabricStorage.Initialize(&mDefaultStorage));
 
     chip::Controller::FactoryInitParams factoryInitParams;
-    factoryInitParams.fabricStorage            = &mFabricStorage;
     factoryInitParams.fabricIndependentStorage = &mDefaultStorage;
     factoryInitParams.listenPort               = static_cast<uint16_t>(mDefaultStorage.GetListenPort() + CurrentCommissionerId());
     ReturnLogErrorOnFailure(DeviceControllerFactory::GetInstance().Init(factoryInitParams));

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -91,7 +91,6 @@ protected:
 
     PersistentStorage mDefaultStorage;
     PersistentStorage mCommissionerStorage;
-    chip::SimpleFabricStorage mFabricStorage;
     CredentialIssuerCommands * mCredIssuerCmds;
 
     std::string GetIdentity();

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -310,7 +310,6 @@ DeviceCommissioner gCommissioner;
 CommissionerDiscoveryController gCommissionerDiscoveryController;
 MyCommissionerCallback gCommissionerCallback;
 MyServerStorageDelegate gServerStorage;
-SimpleFabricStorage gFabricStorage;
 ExampleOperationalCredentialsIssuer gOpCredsIssuer;
 NodeId gLocalId = kMaxOperationalNodeId;
 
@@ -319,9 +318,6 @@ CHIP_ERROR InitCommissioner()
     Controller::FactoryInitParams factoryParams;
     Controller::SetupParams params;
 
-    ReturnErrorOnFailure(gFabricStorage.Initialize(&gServerStorage));
-
-    factoryParams.fabricStorage = &gFabricStorage;
     // use a different listen port for the commissioner than the default used by chip-tool.
     factoryParams.listenPort               = LinuxDeviceOptions::GetInstance().securedCommissionerPort + 10;
     factoryParams.fabricIndependentStorage = &gServerStorage;

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -113,7 +113,7 @@ private:
 
     static Server sServer;
 
-    class DeviceStorageDelegate : public PersistentStorageDelegate, public FabricStorage
+    class DeviceStorageDelegate : public PersistentStorageDelegate
     {
         CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
         {
@@ -137,18 +137,6 @@ private:
         {
             return DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key);
         }
-
-        CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override
-        {
-            return SyncSetKeyValue(key, buffer, size);
-        };
-
-        CHIP_ERROR SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) override
-        {
-            return SyncGetKeyValue(key, buffer, size);
-        };
-
-        CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override { return SyncDeleteKeyValue(key); };
     };
 
     class GroupDataProviderListener final : public Credentials::GroupDataProvider::GroupListener

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -54,7 +54,6 @@ CHIP_ERROR DeviceControllerFactory::Init(FactoryInitParams params)
     }
 
     mListenPort               = params.listenPort;
-    mFabricStorage            = params.fabricStorage;
     mFabricIndependentStorage = params.fabricIndependentStorage;
 
     CHIP_ERROR err = InitSystemState(params);
@@ -145,7 +144,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     stateParams.exchangeMgr           = chip::Platform::New<Messaging::ExchangeManager>();
     stateParams.messageCounterManager = chip::Platform::New<secure_channel::MessageCounterManager>();
 
-    ReturnErrorOnFailure(stateParams.fabricTable->Init(mFabricStorage));
+    ReturnErrorOnFailure(stateParams.fabricTable->Init(params.fabricIndependentStorage));
 
     ReturnErrorOnFailure(stateParams.sessionMgr->Init(stateParams.systemLayer, stateParams.transportMgr,
                                                       stateParams.messageCounterManager, params.fabricIndependentStorage,
@@ -269,7 +268,6 @@ void DeviceControllerFactory::Shutdown()
         chip::Platform::Delete(mSystemState);
         mSystemState = nullptr;
     }
-    mFabricStorage            = nullptr;
     mFabricIndependentStorage = nullptr;
 }
 

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -74,7 +74,6 @@ struct SetupParams
 // We're blocked because of the need to support !CHIP_DEVICE_LAYER
 struct FactoryInitParams
 {
-    FabricStorage * fabricStorage                                 = nullptr;
     System::Layer * systemLayer                                   = nullptr;
     PersistentStorageDelegate * fabricIndependentStorage          = nullptr;
     Inet::EndPointManager<Inet::TCPEndPoint> * tcpEndPointManager = nullptr;
@@ -145,7 +144,6 @@ private:
     CHIP_ERROR InitSystemState();
 
     uint16_t mListenPort;
-    FabricStorage * mFabricStorage                        = nullptr;
     DeviceControllerSystemState * mSystemState            = nullptr;
     PersistentStorageDelegate * mFabricIndependentStorage = nullptr;
 };

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -118,7 +118,6 @@ AndroidDeviceControllerWrapper::AllocateNew(JavaVM * vm, jobject deviceControlle
     initParams.systemLayer        = systemLayer;
     initParams.tcpEndPointManager = tcpEndPointManager;
     initParams.udpEndPointManager = udpEndPointManager;
-    initParams.fabricStorage      = wrapper.get();
 
     // move bleLayer into platform/android to share with app server
 #if CONFIG_NETWORK_LAYER_BLE
@@ -329,19 +328,3 @@ CHIP_ERROR AndroidDeviceControllerWrapper::SyncDeleteKeyValue(const char * key)
     ChipLogProgress(chipTool, "KVS: Deleting key %s", key);
     return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key);
 }
-
-CHIP_ERROR AndroidDeviceControllerWrapper::SyncStore(chip::FabricIndex fabricIndex, const char * key, const void * buffer,
-                                                     uint16_t size)
-{
-    return SyncSetKeyValue(key, buffer, size);
-};
-
-CHIP_ERROR AndroidDeviceControllerWrapper::SyncLoad(chip::FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size)
-{
-    return SyncGetKeyValue(key, buffer, size);
-};
-
-CHIP_ERROR AndroidDeviceControllerWrapper::SyncDelete(chip::FabricIndex fabricIndex, const char * key)
-{
-    return SyncDeleteKeyValue(key);
-};

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -35,9 +35,7 @@
  *
  * Generally it contains the DeviceController class itself, plus any related delegates/callbacks.
  */
-class AndroidDeviceControllerWrapper : public chip::Controller::DevicePairingDelegate,
-                                       public chip::PersistentStorageDelegate,
-                                       public chip::FabricStorage
+class AndroidDeviceControllerWrapper : public chip::Controller::DevicePairingDelegate, public chip::PersistentStorageDelegate
 {
 public:
     ~AndroidDeviceControllerWrapper();
@@ -65,11 +63,6 @@ public:
     CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override;
     CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override;
     CHIP_ERROR SyncDeleteKeyValue(const char * key) override;
-
-    // FabricStorage implementation
-    CHIP_ERROR SyncStore(chip::FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override;
-    CHIP_ERROR SyncLoad(chip::FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) override;
-    CHIP_ERROR SyncDelete(chip::FabricIndex fabricIndex, const char * key) override;
 
     static AndroidDeviceControllerWrapper * FromJNIHandle(jlong handle)
     {

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -83,7 +83,6 @@ typedef void (*ChipThreadTaskRunnerFunct)(intptr_t context);
 }
 
 namespace {
-chip::SimpleFabricStorage sFabricStorage;
 chip::Platform::ScopedMemoryBuffer<uint8_t> sSsidBuf;
 chip::Platform::ScopedMemoryBuffer<uint8_t> sCredsBuf;
 chip::Platform::ScopedMemoryBuffer<uint8_t> sThreadBuf;
@@ -215,11 +214,9 @@ ChipError::StorageType pychip_DeviceController_StackInit()
 
     VerifyOrDie(sStorageAdapter != nullptr);
 
-    err = sFabricStorage.Initialize(sStorageAdapter);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err.AsInteger());
 
     FactoryInitParams factoryParams;
-    factoryParams.fabricStorage            = &sFabricStorage;
     factoryParams.fabricIndependentStorage = sStorageAdapter;
     factoryParams.enableServerInteractions = true;
 

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -210,11 +210,7 @@ chip::Controller::Python::StorageAdapter * pychip_Storage_GetStorageAdapter()
 
 ChipError::StorageType pychip_DeviceController_StackInit()
 {
-    CHIP_ERROR err;
-
     VerifyOrDie(sStorageAdapter != nullptr);
-
-    VerifyOrReturnError(err == CHIP_NO_ERROR, err.AsInteger());
 
     FactoryInitParams factoryParams;
     factoryParams.fabricIndependentStorage = sStorageAdapter;

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -82,7 +82,6 @@ private:
 };
 
 ServerStorageDelegate gServerStorage;
-chip::SimpleFabricStorage gFabricStorage;
 ScriptDevicePairingDelegate gPairingDelegate;
 chip::Controller::ExampleOperationalCredentialsIssuer gOperationalCredentialsIssuer;
 
@@ -116,10 +115,6 @@ extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_N
         const chip::Credentials::AttestationTrustStore * testingRootStore = chip::Credentials::GetTestAttestationTrustStore();
         chip::Credentials::SetDeviceAttestationVerifier(chip::Credentials::GetDefaultDACVerifier(testingRootStore));
 
-        err = gFabricStorage.Initialize(&gServerStorage);
-        SuccessOrExit(err);
-
-        factoryParams.fabricStorage            = &gFabricStorage;
         factoryParams.fabricIndependentStorage = &gServerStorage;
 
         commissionerParams.pairingDelegate = &gPairingDelegate;

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -41,7 +41,7 @@ CHIP_ERROR FabricInfo::SetFabricLabel(const CharSpan & fabricLabel)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR FabricInfo::CommitToStorage(FabricStorage * storage)
+CHIP_ERROR FabricInfo::CommitToStorage(PersistentStorageDelegate * storage)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -102,7 +102,7 @@ CHIP_ERROR FabricInfo::CommitToStorage(FabricStorage * storage)
         memcpy(info->mNOCCert, mNOCCert.data(), mNOCCert.size());
     }
 
-    err = storage->SyncStore(mFabric, key, info, sizeof(StorableFabricInfo));
+    err = storage->SyncSetKeyValue(key, info, sizeof(StorableFabricInfo));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Discovery, "Error occurred calling SyncSetKeyValue: %s", chip::ErrorStr(err));
@@ -116,7 +116,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR FabricInfo::LoadFromStorage(FabricStorage * storage)
+CHIP_ERROR FabricInfo::LoadFromStorage(PersistentStorageDelegate * storage)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     char key[kKeySize];
@@ -132,7 +132,7 @@ CHIP_ERROR FabricInfo::LoadFromStorage(FabricStorage * storage)
     size_t stringLength;
     NodeId nodeId;
 
-    SuccessOrExit(err = storage->SyncLoad(mFabric, key, info, infoSize));
+    SuccessOrExit(err = storage->SyncGetKeyValue(key, info, infoSize));
 
     id          = info->mFabricIndex;
     mVendorId   = Encoding::LittleEndian::HostSwap16(info->mVendorId);
@@ -210,14 +210,14 @@ CHIP_ERROR FabricInfo::GetCompressedId(FabricId fabricId, NodeId nodeId, PeerId 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR FabricInfo::DeleteFromStorage(FabricStorage * storage, FabricIndex fabricIndex)
+CHIP_ERROR FabricInfo::DeleteFromStorage(PersistentStorageDelegate * storage, FabricIndex fabricIndex)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     char key[kKeySize];
     ReturnErrorOnFailure(GenerateKey(fabricIndex, key, sizeof(key)));
 
-    err = storage->SyncDelete(fabricIndex, key);
+    err = storage->SyncDeleteKeyValue(key);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogDetail(Discovery, "Fabric %d is not yet configured", fabricIndex);
@@ -648,7 +648,7 @@ void FabricTable::DeleteAllFabrics()
     }
 }
 
-CHIP_ERROR FabricTable::Init(FabricStorage * storage)
+CHIP_ERROR FabricTable::Init(PersistentStorageDelegate * storage)
 {
     VerifyOrReturnError(storage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     mStorage = storage;
@@ -698,29 +698,5 @@ CHIP_ERROR formatKey(FabricIndex fabricIndex, MutableCharSpan formattedKey, cons
     }
     return err;
 }
-
-CHIP_ERROR SimpleFabricStorage::SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size)
-{
-    VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    char formattedKey[MAX_KEY_SIZE] = "";
-    ReturnErrorOnFailure(formatKey(fabricIndex, MutableCharSpan(formattedKey, MAX_KEY_SIZE), key));
-    return mStorage->SyncSetKeyValue(formattedKey, buffer, size);
-};
-
-CHIP_ERROR SimpleFabricStorage::SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size)
-{
-    VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    char formattedKey[MAX_KEY_SIZE] = "";
-    ReturnErrorOnFailure(formatKey(fabricIndex, MutableCharSpan(formattedKey, MAX_KEY_SIZE), key));
-    return mStorage->SyncGetKeyValue(formattedKey, buffer, size);
-};
-
-CHIP_ERROR SimpleFabricStorage::SyncDelete(FabricIndex fabricIndex, const char * key)
-{
-    VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    char formattedKey[MAX_KEY_SIZE] = "";
-    ReturnErrorOnFailure(formatKey(fabricIndex, MutableCharSpan(formattedKey, MAX_KEY_SIZE), key));
-    return mStorage->SyncDeleteKeyValue(formattedKey);
-};
 
 } // namespace chip

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -53,61 +53,6 @@ static_assert(kUndefinedFabricIndex < chip::kMinValidFabricIndex, "Undefined fab
 constexpr char kFabricTableKeyPrefix[] = "Fabric";
 constexpr char kFabricTableCountKey[]  = "NumFabrics";
 
-class DLL_EXPORT FabricStorage
-{
-public:
-    virtual ~FabricStorage() {}
-
-    /**
-     * Gets called when fabric data needs to be stored.
-     **/
-    virtual CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) = 0;
-
-    /**
-     * Gets called when fabric data needs to be loaded.
-     **/
-    virtual CHIP_ERROR SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) = 0;
-
-    /**
-     * Gets called when fabric data needs to be removed.
-     **/
-    virtual CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) = 0;
-};
-
-/**
- * @brief A default implementation of Fabric storage that preserves legacy behavior of using
- *        the Persistent storage delegate directly.
- *
- *        This class automatically prefixes the Fabric Storage Keys with the FabricIndex.
- *        The keys are formatted like so: "F%02X/" + key.
- *
- */
-class DLL_EXPORT SimpleFabricStorage : public FabricStorage
-{
-public:
-    SimpleFabricStorage(){};
-    SimpleFabricStorage(PersistentStorageDelegate * storage) : mStorage(storage){};
-    ~SimpleFabricStorage() override { mStorage = nullptr; };
-
-    CHIP_ERROR Initialize(PersistentStorageDelegate * storage)
-    {
-        VerifyOrReturnError(mStorage == nullptr || storage == mStorage, CHIP_ERROR_INCORRECT_STATE);
-        mStorage = storage;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override;
-
-    CHIP_ERROR SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) override;
-
-    CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override;
-
-private:
-    const static int MAX_KEY_SIZE = 32;
-
-    PersistentStorageDelegate * mStorage = nullptr;
-};
-
 /**
  * Defines state of a pairing established by a fabric.
  * Node ID is only settable using the device operational credentials.
@@ -279,9 +224,9 @@ private:
 
     static CHIP_ERROR GenerateKey(FabricIndex id, char * key, size_t len);
 
-    CHIP_ERROR CommitToStorage(FabricStorage * storage);
-    CHIP_ERROR LoadFromStorage(FabricStorage * storage);
-    static CHIP_ERROR DeleteFromStorage(FabricStorage * storage, FabricIndex fabricIndex);
+    CHIP_ERROR CommitToStorage(PersistentStorageDelegate * storage);
+    CHIP_ERROR LoadFromStorage(PersistentStorageDelegate * storage);
+    static CHIP_ERROR DeleteFromStorage(PersistentStorageDelegate * storage, FabricIndex fabricIndex);
 
     void ReleaseCert(MutableByteSpan & cert);
     void ReleaseOperationalCerts()
@@ -438,7 +383,7 @@ public:
 
     void Reset();
 
-    CHIP_ERROR Init(FabricStorage * storage);
+    CHIP_ERROR Init(PersistentStorageDelegate * storage);
     CHIP_ERROR AddFabricDelegate(FabricTableDelegate * delegate);
 
     uint8_t FabricCount() const { return mFabricCount; }
@@ -450,7 +395,7 @@ public:
 
 private:
     FabricInfo mStates[CHIP_CONFIG_MAX_FABRICS];
-    FabricStorage * mStorage = nullptr;
+    PersistentStorageDelegate * mStorage = nullptr;
 
     FabricTableDelegate * mDelegate = nullptr;
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -65,7 +65,6 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
 @property (readonly) chip::Controller::DeviceCommissioner * cppCommissioner;
 @property (readonly) CHIPDevicePairingDelegateBridge * pairingDelegateBridge;
 @property (readonly) CHIPPersistentStorageDelegateBridge * persistentStorageDelegateBridge;
-@property (readonly) chip::FabricStorage * fabricStorage;
 @property (readonly) CHIPOperationalCredentialsDelegate * operationalCredentialsDelegate;
 @property (readonly) CHIPP256KeypairBridge keypairBridge;
 @property (readonly) chip::NodeId localDeviceId;
@@ -159,11 +158,6 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
         CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
 
         _persistentStorageDelegateBridge->setFrameworkDelegate(storageDelegate);
-        // TODO Expose FabricStorage to CHIPFramework consumers.
-        _fabricStorage = new chip::SimpleFabricStorage(_persistentStorageDelegateBridge);
-        if ([self checkForStartError:(_fabricStorage != nullptr) logMsg:kErrorMemoryInit]) {
-            return;
-        }
         // create a CHIPP256KeypairBridge here and pass it to the operationalCredentialsDelegate
         std::unique_ptr<chip::Crypto::CHIPP256KeypairNativeBridge> nativeBridge;
         if (nocSigner != nil) {
@@ -195,7 +189,6 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
         const chip::Credentials::AttestationTrustStore * testingRootStore = chip::Credentials::GetTestAttestationTrustStore();
         chip::Credentials::SetDeviceAttestationVerifier(chip::Credentials::GetDefaultDACVerifier(testingRootStore));
 
-        params.fabricStorage = _fabricStorage;
         params.fabricIndependentStorage = _persistentStorageDelegateBridge;
         commissionerParams.storageDelegate = _persistentStorageDelegateBridge;
         commissionerParams.pairingDelegate = _pairingDelegateBridge;
@@ -611,11 +604,6 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
         _cppCommissioner = NULL;
     }
 
-    if (_fabricStorage) {
-        delete _fabricStorage;
-        _fabricStorage = nullptr;
-    }
-
     return YES;
 }
 
@@ -635,10 +623,6 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
 
 - (void)dealloc
 {
-    if (_fabricStorage) {
-        delete _fabricStorage;
-        _fabricStorage = nullptr;
-    }
 }
 
 @end

--- a/src/lib/support/TestPersistentStorageDelegate.h
+++ b/src/lib/support/TestPersistentStorageDelegate.h
@@ -29,8 +29,8 @@
 #include <vector>
 
 namespace chip {
-// TODO : Remove FabricStorage dependency
-class TestPersistentStorageDelegate : public PersistentStorageDelegate, public FabricStorage
+
+class TestPersistentStorageDelegate : public PersistentStorageDelegate
 {
 public:
     TestPersistentStorageDelegate() {}
@@ -75,18 +75,6 @@ public:
         mStorage.erase(key);
         return CHIP_NO_ERROR;
     }
-
-    CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override
-    {
-        return SyncSetKeyValue(key, buffer, size);
-    };
-
-    CHIP_ERROR SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) override
-    {
-        return SyncGetKeyValue(key, buffer, size);
-    };
-
-    CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override { return SyncDeleteKeyValue(key); };
 
     void AddErrorKey(const std::string & key) { mErrorKeys.insert(key); }
 

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -260,7 +260,7 @@ void CASE_SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
     CASE_SecurePairingHandshakeTestCommon(inSuite, inContext, pairingCommissioner, delegateCommissioner);
 }
 
-class TestCASESessionPersistentStorageDelegate : public PersistentStorageDelegate, public FabricStorage
+class TestCASESessionPersistentStorageDelegate : public PersistentStorageDelegate
 {
 public:
     TestCASESessionPersistentStorageDelegate()
@@ -350,18 +350,6 @@ public:
         }
         return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     }
-
-    CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override
-    {
-        return SyncSetKeyValue(key, buffer, size);
-    };
-
-    CHIP_ERROR SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) override
-    {
-        return SyncGetKeyValue(key, buffer, size);
-    };
-
-    CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override { return SyncDeleteKeyValue(key); };
 
 private:
     char * keys[16]; // Not null-terminated

--- a/src/transport/tests/TestSessionManager.cpp
+++ b/src/transport/tests/TestSessionManager.cpp
@@ -100,14 +100,13 @@ void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext)
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
     TransportMgr<LoopbackTransport> transportMgr;
-    SimpleFabricStorage fabricStorage;
     FabricTable fabricTable;
     SessionManager sessionManager;
     secure_channel::MessageCounterManager gMessageCounterManager;
     chip::TestPersistentStorageDelegate deviceStorage;
 
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == transportMgr.Init("LOOPBACK"));
-    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.Init(&fabricStorage));
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.Init(&deviceStorage));
     NL_TEST_ASSERT(
         inSuite,
         CHIP_NO_ERROR ==
@@ -131,14 +130,13 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     TransportMgr<LoopbackTransport> transportMgr;
-    SimpleFabricStorage fabricStorage;
     FabricTable fabricTable;
     SessionManager sessionManager;
     secure_channel::MessageCounterManager gMessageCounterManager;
     chip::TestPersistentStorageDelegate deviceStorage;
 
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == transportMgr.Init("LOOPBACK"));
-    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.Init(&fabricStorage));
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.Init(&deviceStorage));
     NL_TEST_ASSERT(
         inSuite,
         CHIP_NO_ERROR ==
@@ -227,14 +225,13 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     TransportMgr<LoopbackTransport> transportMgr;
-    SimpleFabricStorage fabricStorage;
     FabricTable fabricTable;
     SessionManager sessionManager;
     secure_channel::MessageCounterManager gMessageCounterManager;
     chip::TestPersistentStorageDelegate deviceStorage;
 
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == transportMgr.Init("LOOPBACK"));
-    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.Init(&fabricStorage));
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.Init(&deviceStorage));
     NL_TEST_ASSERT(
         inSuite,
         CHIP_NO_ERROR ==
@@ -309,14 +306,13 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     TransportMgr<LoopbackTransport> transportMgr;
-    SimpleFabricStorage fabricStorage;
     FabricTable fabricTable;
     SessionManager sessionManager;
     secure_channel::MessageCounterManager gMessageCounterManager;
     chip::TestPersistentStorageDelegate deviceStorage;
 
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == transportMgr.Init("LOOPBACK"));
-    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.Init(&fabricStorage));
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.Init(&deviceStorage));
     NL_TEST_ASSERT(
         inSuite,
         CHIP_NO_ERROR ==
@@ -419,14 +415,13 @@ void StaleConnectionDropTest(nlTestSuite * inSuite, void * inContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     TransportMgr<LoopbackTransport> transportMgr;
-    SimpleFabricStorage fabricStorage;
     FabricTable fabricTable;
     SessionManager sessionManager;
     secure_channel::MessageCounterManager gMessageCounterManager;
     chip::TestPersistentStorageDelegate deviceStorage;
 
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == transportMgr.Init("LOOPBACK"));
-    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.Init(&fabricStorage));
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.Init(&deviceStorage));
     NL_TEST_ASSERT(
         inSuite,
         CHIP_NO_ERROR ==
@@ -495,14 +490,13 @@ void SendPacketWithOldCounterTest(nlTestSuite * inSuite, void * inContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     TransportMgr<LoopbackTransport> transportMgr;
-    SimpleFabricStorage fabricStorage;
     FabricTable fabricTable;
     SessionManager sessionManager;
     secure_channel::MessageCounterManager gMessageCounterManager;
     chip::TestPersistentStorageDelegate deviceStorage;
 
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == transportMgr.Init("LOOPBACK"));
-    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.Init(&fabricStorage));
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.Init(&deviceStorage));
     NL_TEST_ASSERT(
         inSuite,
         CHIP_NO_ERROR ==
@@ -590,14 +584,13 @@ void SendPacketWithTooOldCounterTest(nlTestSuite * inSuite, void * inContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     TransportMgr<LoopbackTransport> transportMgr;
-    SimpleFabricStorage fabricStorage;
     FabricTable fabricTable;
     SessionManager sessionManager;
     secure_channel::MessageCounterManager gMessageCounterManager;
     chip::TestPersistentStorageDelegate deviceStorage;
 
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == transportMgr.Init("LOOPBACK"));
-    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.Init(&fabricStorage));
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.Init(&deviceStorage));
     NL_TEST_ASSERT(
         inSuite,
         CHIP_NO_ERROR ==


### PR DESCRIPTION
#### Problem
`FabricStorage` is basically same as `PersistentStorageDelegate`

#### Change overview
Remove `FabricStorage` and all its related classes and funtions.

The `FabricStorage` usage inside `FabricTable` is replaced by a `PersistentStorageDelegate`

#### Testing
Passed unit-tests