### PR TITLE
Ensure that we shut down open exchanges when controller shuts down.

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -78,9 +78,14 @@ void CASESessionManager::ReleaseSession(PeerId peerId)
     ReleaseSession(FindExistingSession(peerId));
 }
 
-void CASESessionManager::ReleaseSessionForFabric(CompressedFabricId compressedFabricId)
+void CASESessionManager::ReleaseSessionsForFabric(CompressedFabricId compressedFabricId)
 {
-    mConfig.devicePool->ReleaseDeviceForFabric(compressedFabricId);
+    mConfig.devicePool->ReleaseDevicesForFabric(compressedFabricId);
+}
+
+void CASESessionManager::ReleaseAllSessions()
+{
+    mConfig.devicePool->ReleaseAllDevices();
 }
 
 CHIP_ERROR CASESessionManager::ResolveDeviceAddress(FabricInfo * fabric, NodeId nodeId)

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -78,7 +78,9 @@ public:
 
     void ReleaseSession(PeerId peerId);
 
-    void ReleaseSessionForFabric(CompressedFabricId compressedFabricId);
+    void ReleaseSessionsForFabric(CompressedFabricId compressedFabricId);
+
+    void ReleaseAllSessions();
 
     /**
      * This API triggers the DNS-SD resolution for the given node ID. The node ID will be looked up

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -302,6 +302,13 @@ CHIP_ERROR OperationalDeviceProxy::ShutdownSubscriptions()
     return app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(mFabricInfo->GetFabricIndex(), GetDeviceId());
 }
 
-OperationalDeviceProxy::~OperationalDeviceProxy() {}
+OperationalDeviceProxy::~OperationalDeviceProxy()
+{
+    if (mCASEClient)
+    {
+        // Make sure we don't leak it.
+        mInitParams.clientPool->Release(mCASEClient);
+    }
+}
 
 } // namespace chip

--- a/src/app/OperationalDeviceProxyPool.h
+++ b/src/app/OperationalDeviceProxyPool.h
@@ -37,7 +37,9 @@ public:
 
     virtual OperationalDeviceProxy * FindDevice(PeerId peerId) = 0;
 
-    virtual void ReleaseDeviceForFabric(CompressedFabricId compressedFabricId) = 0;
+    virtual void ReleaseDevicesForFabric(CompressedFabricId compressedFabricId) = 0;
+
+    virtual void ReleaseAllDevices() = 0;
 
     virtual ~OperationalDeviceProxyPoolDelegate() {}
 };
@@ -91,13 +93,21 @@ public:
         return foundDevice;
     }
 
-    void ReleaseDeviceForFabric(CompressedFabricId compressedFabricId) override
+    void ReleaseDevicesForFabric(CompressedFabricId compressedFabricId) override
     {
         mDevicePool.ForEachActiveObject([&](auto * activeDevice) {
             if (activeDevice->GetPeerId().GetCompressedFabricId() == compressedFabricId)
             {
                 Release(activeDevice);
             }
+            return Loop::Continue;
+        });
+    }
+
+    void ReleaseAllDevices() override
+    {
+        mDevicePool.ForEachActiveObject([&](auto * activeDevice) {
+            Release(activeDevice);
             return Loop::Continue;
         });
     }

--- a/src/app/clusters/bindings/BindingManager.cpp
+++ b/src/app/clusters/bindings/BindingManager.cpp
@@ -158,7 +158,7 @@ void BindingManager::HandleDeviceConnectionFailure(PeerId peerId, CHIP_ERROR err
 void BindingManager::FabricRemoved(CompressedFabricId compressedFabricId, FabricIndex fabricIndex)
 {
     mPendingNotificationMap.RemoveAllEntriesForFabric(fabricIndex);
-    mAppServer->GetCASESessionManager()->ReleaseSessionForFabric(compressedFabricId);
+    mAppServer->GetCASESessionManager()->ReleaseSessionsForFabric(compressedFabricId);
 }
 
 CHIP_ERROR BindingManager::NotifyBindingAdded(const EmberBindingTableEntry & binding)

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -110,14 +110,18 @@ void CASESession::Clear()
 
     mState = kInitialized;
 
-    CloseExchange();
+    AbortExchange();
 }
 
-void CASESession::CloseExchange()
+void CASESession::AbortExchange()
 {
     if (mExchangeCtxt != nullptr)
     {
-        mExchangeCtxt->Close();
+        // The only time we reach this is if we are getting destroyed in the
+        // middle of our handshake.  In that case, there is no point trying to
+        // do MRP resends of the last message we sent, so abort the exchange
+        // instead of just closing it.
+        mExchangeCtxt->Abort();
         mExchangeCtxt = nullptr;
     }
 }

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -216,7 +216,7 @@ private:
     void OnSuccessStatusReport() override;
     CHIP_ERROR OnFailureStatusReport(Protocols::SecureChannel::GeneralStatusCode generalCode, uint16_t protocolCode) override;
 
-    void CloseExchange();
+    void AbortExchange();
 
     /**
      * Clear our reference to our exchange context pointer so that it can close


### PR DESCRIPTION
We already handled shutdown of any ongoing PASE bits.

This PR adds two more things:

1) Shutting down any ongoing CASE session establishment exchanges for
   which we are the initiator.  This is done by shutting down all the
   operational device proxies on our mCASESessionManager (since we own
   all of those anyway) and fixing operational device proxy
   shutdown/destruction to actually clean up the CASEClient if we're
   still in the middle of CASE establishment.

2) Expiring the SecureSessions for our fabric, so that any still-open
   operational exchanges for those sessions get closed correctly (with
   a timeout).  This is needed because our client cluster APIs don't
   give us any way to cancel the operation (invoke, read, write, etc)
   and we need to make sure those get cleaned up when we shut down.

In addition to that:
    
* Reject wrong-fabric results in DeviceCommissioner::OnOperationalNodeResolved (due to buggy minimal mdns), so if we start sharing a CASESessionManager across controllers we will not be in a position where we are ending up with CASE sessions we create but can't tear down.
* Fix CASE shutdown to not leave a dangling MRP entry after it shuts down the exchange.

Fixes https://github.com/project-chip/connectedhomeip/issues/15760

#### Problem
Leaking exchanges on the controller in various cases.

#### Change overview
Fix the leaks.

#### Testing
Tried shutting down the controller while in the middle of a chunked read.  Without this fix, fails a VerifyOrDie; with this fix is ok.