### PR TITLE
Make TestTcp retry TCP initialization

### DIFF
--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -28,6 +28,7 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/UnitTestRegistration.h>
+#include <lib/support/UnitTestUtils.h>
 #include <system/SystemLayer.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/TCP.h>
@@ -107,6 +108,27 @@ public:
     void InitializeMessageTest(TCPImpl & tcp, const IPAddress & addr)
     {
         CHIP_ERROR err = tcp.Init(Transport::TcpListenParameters(mContext.GetTCPEndPointManager()).SetAddressType(addr.Type()));
+
+        // retry a few times in case the port is somehow in use.
+        // this is a WORKAROUND for flaky testing if we run tests very fast after each other.
+        // in that case, a port could be in a WAIT state.
+        // 
+        // What may be happening:
+        //   - We call InitializeMessageTest several times in this unit test
+        //   - closing sockets takes a while (FIN-wait or similar)
+        //   - trying InitializeMessageTest to take the same port right after may fail
+        //
+        // The tests may be run with a 0 port (to self select an active port) however I have not
+        // validated that this works and we need a followup for it
+        //
+        // TODO: stop using fixed ports.
+        for (int i = 0; (i < 50) && (err != CHIP_NO_ERROR); i++)
+        {
+            ChipLogProgress(NotSpecified, "RETRYING tcp initialization");
+            chip::test_utils::SleepMillis(100);
+            err = tcp.Init(Transport::TcpListenParameters(mContext.GetTCPEndPointManager()).SetAddressType(addr.Type()));
+        }
+
         NL_TEST_ASSERT(mSuite, err == CHIP_NO_ERROR);
 
         mTransportMgrBase.SetSessionManager(this);

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -112,7 +112,7 @@ public:
         // retry a few times in case the port is somehow in use.
         // this is a WORKAROUND for flaky testing if we run tests very fast after each other.
         // in that case, a port could be in a WAIT state.
-        // 
+        //
         // What may be happening:
         //   - We call InitializeMessageTest several times in this unit test
         //   - closing sockets takes a while (FIN-wait or similar)


### PR DESCRIPTION
#### Problem
TestTCP is flaky, seemingly because of a "Address already in use" error. See https://github.com/project-chip/connectedhomeip/runs/5407037210?check_suite_focus=true or 
https://github.com/project-chip/connectedhomeip/runs/5408995357?check_suite_focus=true

#### Change overview
Retry init a few times (5 seconds max) with a lengthy comment of what I think is happening and what a "followup fix" should contain.

#### Testing
Ran this 100s of times on a mac mini. Without the fix reproduced the crash, with the fix observed a 'retrying' message and test passed.