### PR TITLE
Remove deviceAddressUpdateDelegate member of init params in CHIPDevic…

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -327,7 +327,6 @@ CHIP_ERROR InitCommissioner()
     factoryParams.fabricIndependentStorage = &gServerStorage;
 
     params.storageDelegate                = &gServerStorage;
-    params.deviceAddressUpdateDelegate    = nullptr;
     params.operationalCredentialsDelegate = &gOpCredsIssuer;
 
     ReturnErrorOnFailure(gOpCredsIssuer.Initialize(gServerStorage));

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -129,7 +129,6 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
     ReturnErrorOnFailure(mDNSResolver.Init(params.systemState->UDPEndPointManager()));
     mDNSResolver.SetOperationalDelegate(this);
     mDNSResolver.SetCommissioningDelegate(this);
-    RegisterDeviceAddressUpdateDelegate(params.deviceAddressUpdateDelegate);
     RegisterDeviceDiscoveryDelegate(params.deviceDiscoveryDelegate);
 
     VerifyOrReturnError(params.operationalCredentialsDelegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -91,7 +91,6 @@ struct ControllerInitParams
 {
     PersistentStorageDelegate * storageDelegate                     = nullptr;
     DeviceControllerSystemState * systemState                       = nullptr;
-    DeviceAddressUpdateDelegate * deviceAddressUpdateDelegate       = nullptr;
     DeviceDiscoveryDelegate * deviceDiscoveryDelegate               = nullptr;
     OperationalCredentialsDelegate * operationalCredentialsDelegate = nullptr;
 

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -203,7 +203,6 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
 
 void DeviceControllerFactory::PopulateInitParams(ControllerInitParams & controllerParams, const SetupParams & params)
 {
-    controllerParams.deviceAddressUpdateDelegate    = params.deviceAddressUpdateDelegate;
     controllerParams.operationalCredentialsDelegate = params.operationalCredentialsDelegate;
     controllerParams.operationalKeypair             = params.operationalKeypair;
     controllerParams.controllerNOC                  = params.controllerNOC;

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -39,7 +39,6 @@ namespace Controller {
 
 struct SetupParams
 {
-    DeviceAddressUpdateDelegate * deviceAddressUpdateDelegate       = nullptr;
     OperationalCredentialsDelegate * operationalCredentialsDelegate = nullptr;
 
     PersistentStorageDelegate * storageDelegate = nullptr;

--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -164,7 +164,6 @@ ChipError::StorageType pychip_OpCreds_AllocateController(OpCredsContext * contex
 
     Controller::SetupParams initParams;
     initParams.storageDelegate                = sStorageAdapter;
-    initParams.deviceAddressUpdateDelegate    = nullptr;
     initParams.pairingDelegate                = &sPairingDelegate;
     initParams.operationalCredentialsDelegate = context->mAdapter.get();
     initParams.operationalKeypair             = &ephemeralKey;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -198,7 +198,6 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
         params.fabricStorage = _fabricStorage;
         params.fabricIndependentStorage = _persistentStorageDelegateBridge;
         commissionerParams.storageDelegate = _persistentStorageDelegateBridge;
-        commissionerParams.deviceAddressUpdateDelegate = nullptr;
         commissionerParams.pairingDelegate = _pairingDelegateBridge;
 
         commissionerParams.operationalCredentialsDelegate = _operationalCredentialsDelegate;


### PR DESCRIPTION
…eController

#### Problem
deviceAddressUpdateDelegate is not used (always nullptr). It used to be used for logging only, however that got removed so we can simplify the code and have less coupling.

#### Change overview
Deletes deviceAddressUpdateDelegate and its use.

#### Testing
CI will validate that code still compiles. Code shows that that all setters of this value were always nullptr.
