### PR TITLE
[OTA] Use OTAUpdateStateEnum when retrieving current update state

### DIFF
--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -302,47 +302,6 @@ void OTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
     }
 }
 
-OTARequestorInterface::UpdateState OTARequestor::GetCurrentUpdateState()
-{
-    UpdateState state = kStateUnknown;
-
-    switch (mCurrentUpdateState)
-    {
-    case OTAUpdateStateEnum::kUnknown:
-        state = kStateUnknown;
-        break;
-    case OTAUpdateStateEnum::kIdle:
-        state = kStateIdle;
-        break;
-    case OTAUpdateStateEnum::kQuerying:
-        state = kStateQuerying;
-        break;
-    case OTAUpdateStateEnum::kDelayedOnQuery:
-        state = kStateDelayedOnQuery;
-        break;
-    case OTAUpdateStateEnum::kDownloading:
-        state = kStateDownloading;
-        break;
-    case OTAUpdateStateEnum::kApplying:
-        state = kStateApplying;
-        break;
-    case OTAUpdateStateEnum::kDelayedOnApply:
-        state = kStateDelayedOnApply;
-        break;
-    case OTAUpdateStateEnum::kRollingBack:
-        state = kStateRollingBack;
-        break;
-    case OTAUpdateStateEnum::kDelayedOnUserConsent:
-        state = kStateDelayedOnUserConsent;
-        break;
-    default:
-        state = kStateUnknown;
-        break;
-    }
-
-    return state;
-}
-
 // Requestor is directed to cancel image update in progress. All the Requestor state is
 // cleared, UpdateState is reset to Idle
 void OTARequestor::CancelImageUpdate()

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -64,7 +64,10 @@ public:
     CHIP_ERROR GetUpdateProgress(EndpointId endpointId, app::DataModel::Nullable<uint8_t> & progress) override;
 
     // Get requestor state
-    CHIP_ERROR GetState(EndpointId endpointId, app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum & state) override;
+    CHIP_ERROR GetState(EndpointId endpointId, OTAUpdateStateEnum & state) override;
+
+    // Get the current state of the OTA update
+    OTAUpdateStateEnum GetCurrentUpdateState() override { return mCurrentUpdateState; }
 
     // Application directs the Requestor to cancel image update in progress. All the Requestor state is
     // cleared, UpdateState is reset to Idle
@@ -120,9 +123,6 @@ public:
                                                                     reinterpret_cast<intptr_t>(this));
     }
 
-    // Getter for the value of the UpdateState cached by the object
-    UpdateState GetCurrentUpdateState() override;
-
     /**
      * Called to set optional requestorCanConsent value provided by Requestor.
      */
@@ -132,7 +132,6 @@ private:
     using QueryImageResponseDecodableType  = app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType;
     using ApplyUpdateResponseDecodableType = app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType;
 
-    using OTAUpdateStateEnum  = app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
     using OTAChangeReasonEnum = app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum;
 
     static constexpr size_t kMaxUpdateTokenLen = 32;

--- a/src/include/platform/OTARequestorInterface.h
+++ b/src/include/platform/OTARequestorInterface.h
@@ -24,6 +24,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/CommandHandler.h>
 #include <app/util/af-enums.h>
+#include <lib/core/ClusterEnums.h>
 
 #pragma once
 
@@ -143,25 +144,14 @@ private:
 class OTARequestorInterface
 {
 public:
+    using OTAUpdateStateEnum = chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
+
     // Return value for various trigger-type APIs
     enum OTATriggerResult
     {
         kTriggerSuccessful = 0,
         kNoProviderKnown   = 1,
         kWrongState        = 2
-    };
-
-    enum UpdateState
-    {
-        kStateUnknown,
-        kStateIdle,
-        kStateQuerying,
-        kStateDelayedOnQuery,
-        kStateDownloading,
-        kStateApplying,
-        kStateDelayedOnApply,
-        kStateRollingBack,
-        kStateDelayedOnUserConsent,
     };
 
     // Handler for the AnnounceOTAProvider command
@@ -192,10 +182,10 @@ public:
     virtual CHIP_ERROR GetUpdateProgress(EndpointId endpointId, chip::app::DataModel::Nullable<uint8_t> & progress) = 0;
 
     // Get the value of the UpdateState attribute of the OTA Software Update Requestor Cluster on the given endpoint
-    virtual CHIP_ERROR GetState(EndpointId endpointId,
-                                chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum & state) = 0;
-    // Getter for the value of the UpdateState cached by the object
-    virtual UpdateState GetCurrentUpdateState() = 0;
+    virtual CHIP_ERROR GetState(EndpointId endpointId, OTAUpdateStateEnum & state) = 0;
+
+    // Get the current state of the OTA update
+    virtual OTAUpdateStateEnum GetCurrentUpdateState() = 0;
 
     // Application directs the Requestor to cancel image update in progress. All the Requestor state is
     // cleared, UpdateState is reset to Idle

--- a/src/platform/GenericOTARequestorDriver.cpp
+++ b/src/platform/GenericOTARequestorDriver.cpp
@@ -249,7 +249,7 @@ void GenericOTARequestorDriver::ProcessAnnounceOTAProviders(
     // This implementation of the OTARequestor driver ignores the announcement if an update is in progress,
     // otherwise it queries the provider passed in the announcement
 
-    if (mRequestor->GetCurrentUpdateState() != OTARequestorInterface::kStateIdle)
+    if (mRequestor->GetCurrentUpdateState() != OTAUpdateStateEnum::kIdle)
     {
         ChipLogProgress(SoftwareUpdate, "State is not kIdle, ignoring the AnnounceOTAProviders. State: %d",
                         (int) mRequestor->GetCurrentUpdateState());


### PR DESCRIPTION
#### Problem
OTA Requestor defined an `UpdateState` enum which is essentially the same as the one in ClusterEnums.h. This mapping is unnecessary.

Fixes: https://github.com/project-chip/connectedhomeip/issues/15696

#### Change overview
- Remove `UpdateState` enum
- Use `OTAUpdateStateEnum` from the cluster instead

#### Testing
- Verified basic OTA flow still works
- Verified that multiple AnnounceOTAProvider commands while an OTA is in progress is ignored (the usage of the enum is used in this case)
