### PR TITLE
[OTA] Kick off the initial periodic query timer

### DIFF
--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -87,9 +87,11 @@ static void InitOTARequestor(void)
     // Set the global instance of the OTA requestor core component
     SetRequestorInstance(&gRequestorCore);
 
+    // Periodic query timeout must be set prior to requestor being initialized
+    gRequestorUser.SetPeriodicQueryTimeout(gPeriodicQueryTimeoutSec);
+
     gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
-    gRequestorUser.SetPeriodicQueryTimeout(gPeriodicQueryTimeoutSec);
 
     // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at
     // the beginning of program execution. We're using hardcoded values here for now since this is a reference application.

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -116,6 +116,9 @@ public:
         percent.SetNull();
         OtaRequestorServerSetUpdateStateProgress(percent);
 
+        // This results in the initial periodic timer kicking off
+        RecordNewUpdateState(OTAUpdateStateEnum::kIdle, OTAChangeReasonEnum::kSuccess);
+
         return chip::DeviceLayer::PlatformMgrImpl().AddEventHandler(OnCommissioningCompleteRequestor,
                                                                     reinterpret_cast<intptr_t>(this));
     }
@@ -300,7 +303,7 @@ private:
     uint32_t mTargetVersion  = 0;
     char mFileDesignatorBuffer[bdx::kMaxFileDesignatorLen];
     CharSpan mFileDesignator;
-    OTAUpdateStateEnum mCurrentUpdateState = OTAUpdateStateEnum::kIdle;
+    OTAUpdateStateEnum mCurrentUpdateState = OTAUpdateStateEnum::kUnknown;
     Server * mServer                       = nullptr;
     chip::Optional<bool> mRequestorCanConsent;
     ProviderLocationList mDefaultOtaProviderList;


### PR DESCRIPTION
#### Problem
The first periodic query timer never gets kicked off. It would start once an OTA has completed, e.g. after an AnnounceOTAProvider command is received and processed, at the end of that download, the periodic timer would then start. The timer should start regardless of whether another method to start OTA has been done first.

#### Change overview
- Initialize the default state to kUnknown
- Upon OTARequestor initialization, update this state to kIdle -> this would kick off the first periodic timer
- Make sure the periodic timeout is set prior to OTARequestor init call

#### Testing
- Verified that the initial periodic timer occurs after bootup and a transfer occurs