### PR TITLE
Force clear previous dnssd services before advertising operational services

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -252,9 +252,14 @@ CHIP_ERROR DnssdServer::GetCommissionableInstanceName(char * buffer, size_t buff
 /// Set MDNS operational advertisement
 CHIP_ERROR DnssdServer::AdvertiseOperational()
 {
-    VerifyOrDie(mFabricTable != nullptr);
+    auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
 
-    for (const FabricInfo & fabricInfo : *mFabricTable)
+    // clear existing advertisements before advertising operational.
+    ChipLogDetail(Discovery, "Removing previous advertisements before opertional advertisement.");
+    mdnsAdvertiser.RemoveServices();
+
+    VerifyOrDie(mFabricTable != nullptr);
+    for (const FabricInfo & fabricInfo : Server::GetInstance().GetFabricTable())
     {
         if (fabricInfo.IsInitialized())
         {
@@ -274,8 +279,6 @@ CHIP_ERROR DnssdServer::AdvertiseOperational()
                                                  .SetMRPConfig(GetLocalMRPConfig())
                                                  .SetTcpSupported(Optional<bool>(INET_CONFIG_ENABLE_TCP_ENDPOINT))
                                                  .EnableIpV4(true);
-
-            auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
 
             ChipLogProgress(Discovery, "Advertise operational node " ChipLogFormatX64 "-" ChipLogFormatX64,
                             ChipLogValueX64(advertiseParameters.GetPeerId().GetCompressedFabricId()),

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -259,7 +259,7 @@ CHIP_ERROR DnssdServer::AdvertiseOperational()
     mdnsAdvertiser.RemoveServices();
 
     VerifyOrDie(mFabricTable != nullptr);
-    for (const FabricInfo & fabricInfo : Server::GetInstance().GetFabricTable())
+    for (const FabricInfo & fabricInfo : *mFabricTable)
     {
         if (fabricInfo.IsInitialized())
         {


### PR DESCRIPTION
#### Problem
Our dnssd implementation always starts the commissionable advertisement on init. 

This is not a problem until the operational network is provisioned at which point, the operational advertisement is requested. 

This causes both the commissionable advertisement and the operational ones to go live briefly.

#### Change overview
Clear any existing services before starting the operational advertisement. 

#### Testing
* If manually tested, what platforms controller and device platforms were manually tested, and how?
Manually tested that the esp32 is not advertising a matterc._udp service after its operational advertisement goes live,