### PR TITLE
Make sure to actually not advertise with CM=1 when we're not commissionable

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -158,7 +158,7 @@ void CommissioningWindowManager::OnSessionEstablished()
 
     DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEventWrapper, reinterpret_cast<intptr_t>(this));
 
-    StopAdvertisement(/* aShuttingDown = */ true);
+    StopAdvertisement(/* aShuttingDown = */ false);
     ChipLogProgress(AppServer, "Device completed Rendezvous process");
 }
 


### PR DESCRIPTION
The boolean passed to StopAdvertisement was wrong, which meant we didn't actually
stop/restart our DNS-SD advertising when we should have

#### Problem
Ending up advertising with CM=1 when we are not commissionable.

#### Change overview
Fix that.

#### Testing
Actually checked what advertisements we put on the network now.