### PR TITLE
Store fewer things as part of the fabric table.

### DIFF
--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -295,9 +295,7 @@ private:
 
     struct StorableFabricInfo
     {
-        uint16_t mFabric;   /* This field is serialized in LittleEndian byte order */
-        uint64_t mNodeId;   /* This field is serialized in LittleEndian byte order */
-        uint64_t mFabricId; /* This field is serialized in LittleEndian byte order */
+        uint8_t mFabricIndex;
         uint16_t mVendorId; /* This field is serialized in LittleEndian byte order */
 
         uint16_t mRootCertLen; /* This field is serialized in LittleEndian byte order */


### PR DESCRIPTION
The node id and fabric id are part of the NOC, so we don't need to
store them seaparately.

And the fabric index is 8-bit; there's no need to store a 16-bit
quantity for it.

#### Problem
See above.

#### Change overview
Store fewer things.

#### Testing
Should be no behavior changes, other than less data read/written.