### PR TITLE
Remove no-longer-needed checks for CHIP_ERROR_KEY_NOT_FOUND.

### DIFF
--- a/src/transport/GroupPeerMessageCounter.cpp
+++ b/src/transport/GroupPeerMessageCounter.cpp
@@ -243,7 +243,7 @@ CHIP_ERROR GroupOutgoingCounters::Init(chip::PersistentStorageDelegate * storage
     uint32_t temp;
     CHIP_ERROR err;
     err = mStorage->SyncGetKeyValue(key.GroupControlCounter(), &temp, size);
-    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND || err == CHIP_ERROR_KEY_NOT_FOUND)
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         // might be the first time we retrieve the value
         // TODO handle this case
@@ -259,7 +259,7 @@ CHIP_ERROR GroupOutgoingCounters::Init(chip::PersistentStorageDelegate * storage
     }
 
     err = mStorage->SyncGetKeyValue(key.GroupDataCounter(), &temp, size);
-    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND || err == CHIP_ERROR_KEY_NOT_FOUND)
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         // might be the first time we retrieve the value
         // TODO handle this case


### PR DESCRIPTION
Our storage now guarantees it will return
CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND when there is nothing stored under the key.

#### Problem
Code more complicated than it has to be.

#### Change overview
Simplify.

#### Testing
No behavior changes.  The KEY_NOT_FOUND case could never be hit anymore.