### PR TITLE
[OTA] Set the current state on every attempt for CASE session establishment

### DIFF
--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -54,10 +54,10 @@ public:
     // Initiate download of the new image
     void DownloadUpdate() override;
 
-    // Send ApplyImage
+    // Initiate the session to send ApplyUpdateRequest command
     void ApplyUpdate() override;
 
-    // Send NotifyUpdateApplied, update Basic cluster SoftwareVersion attribute, log the VersionApplied event
+    // Initiate the session to send NotifyUpdateApplied command
     void NotifyUpdateApplied(uint32_t version) override;
 
     // Get image update progress in percents unit
@@ -230,7 +230,7 @@ private:
     enum OnConnectedAction
     {
         kQueryImage = 0,
-        kStartBDX,
+        kDownload,
         kApplyUpdate,
         kNotifyUpdateApplied,
     };

--- a/src/include/platform/OTARequestorInterface.h
+++ b/src/include/platform/OTARequestorInterface.h
@@ -182,10 +182,10 @@ public:
     // Download image
     virtual void DownloadUpdate() = 0;
 
-    // Send ApplyImage command
+    // Initiate the session to send ApplyUpdateRequest command
     virtual void ApplyUpdate() = 0;
 
-    // Send NotifyUpdateApplied command
+    // Initiate the session to send NotifyUpdateApplied command
     virtual void NotifyUpdateApplied(uint32_t version) = 0;
 
     // Get image update progress in percents unit


### PR DESCRIPTION
#### Problem
Currently, other than during querying, the current state is not being updated, e.g. when attempting to send a command for ApplyUpdateRequest and NotifyUpdateApplied. This is mostly ok because the current code would eventually set the current state on CASE session establishment. However, when an error is encountered, e.g. when a response for one of these commands is not received, we would be in the wrong state (still showing querying).

#### Change overview
- Update the current state before each call to `ConnectToProvider`
- Remove all the current state updates after CASE session established in `OnConnected`
- Renamed the enum `kStartBDX` to a more generic `kDownload`
- Update the API description for the apply/notify to more match what is does

#### Testing
- Verified that happy path of OTA download succeeds
- Verified that if a response is not received for a command, the state correctly reflects the last action attempted
