### PR TITLE
ESP32: Getting autonomous connection status for network commissioning driver

### DIFF
--- a/src/platform/ESP32/BUILD.gn
+++ b/src/platform/ESP32/BUILD.gn
@@ -40,7 +40,6 @@ static_library("ESP32") {
     "KeyValueStoreManagerImpl.h",
     "Logging.cpp",
     "LwIPCoreLock.cpp",
-    "NetworkCommissioningDriver.h",
     "PlatformManagerImpl.cpp",
     "PlatformManagerImpl.h",
     "SystemTimeSupport.cpp",
@@ -68,13 +67,16 @@ static_library("ESP32") {
   if (chip_enable_wifi) {
     sources += [
       "ConnectivityManagerImpl_WiFi.cpp",
-      "NetworkCommissioningWiFiDriver.cpp",
+      "NetworkCommissioningDriver.cpp",
+      "NetworkCommissioningDriver.h",
     ]
   }
 
   if (chip_enable_openthread) {
     sources += [
       "../OpenThread/DnssdImpl.cpp",
+      "../OpenThread/GenericNetworkCommissioningThreadDriver.cpp",
+      "../OpenThread/GenericNetworkCommissioningThreadDriver.h",
       "../OpenThread/OpenThreadUtils.cpp",
       "ThreadStackManagerImpl.cpp",
       "ThreadStackManagerImpl.h",

--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -463,6 +463,7 @@ void ConnectivityManagerImpl::OnWiFiPlatformEvent(const ChipDeviceEvent * event)
                 break;
             case WIFI_EVENT_STA_DISCONNECTED:
                 ChipLogProgress(DeviceLayer, "WIFI_EVENT_STA_DISCONNECTED");
+                NetworkCommissioning::ESPWiFiDriver::GetInstance().SetLastDisconnectReason(event);
                 if (mWiFiStationState == kWiFiStationState_Connecting)
                 {
                     ChangeWiFiStationState(kWiFiStationState_Connecting_Failed);
@@ -684,6 +685,7 @@ void ConnectivityManagerImpl::ChangeWiFiStationState(WiFiStationState newState)
         ChipLogProgress(DeviceLayer, "WiFi station state change: %s -> %s", WiFiStationStateToStr(mWiFiStationState),
                         WiFiStationStateToStr(newState));
         mWiFiStationState = newState;
+        SystemLayer().ScheduleLambda([]() { NetworkCommissioning::ESPWiFiDriver::GetInstance().OnNetworkStatusChange(); });
     }
 }
 

--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -54,6 +54,21 @@ CHIP_ERROR ESP32Utils::IsAPEnabled(bool & apEnabled)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ESP32Utils::IsStationEnabled(bool & staEnabled)
+{
+    wifi_mode_t curWiFiMode;
+    esp_err_t err = esp_wifi_get_mode(&curWiFiMode);
+    if (err != ESP_OK)
+    {
+        ChipLogError(DeviceLayer, "esp_wifi_get_mode() failed: %s", esp_err_to_name(err));
+        return ESP32Utils::MapError(err);
+    }
+
+    staEnabled = (curWiFiMode == WIFI_MODE_STA || curWiFiMode == WIFI_MODE_APSTA);
+
+    return CHIP_NO_ERROR;
+}
+
 bool ESP32Utils::IsStationProvisioned(void)
 {
     wifi_config_t stationConfig;

--- a/src/platform/ESP32/ESP32Utils.h
+++ b/src/platform/ESP32/ESP32Utils.h
@@ -30,6 +30,7 @@ class ESP32Utils
 {
 public:
     static CHIP_ERROR IsAPEnabled(bool & apEnabled);
+    static CHIP_ERROR IsStationEnabled(bool & staEnabled);
     static bool IsStationProvisioned(void);
     static CHIP_ERROR IsStationConnected(bool & connected);
     static CHIP_ERROR StartWiFiLayer(void);

--- a/src/platform/ESP32/NetworkCommissioningDriver.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver.cpp
@@ -27,7 +27,7 @@
 #include <string>
 
 using namespace ::chip;
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+using namespace ::chip::DeviceLayer::Internal;
 namespace chip {
 namespace DeviceLayer {
 namespace NetworkCommissioning {
@@ -59,14 +59,16 @@ CHIP_ERROR ESPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
     mSavedNetwork.credentialsLen = credentialsLen;
     mSavedNetwork.ssidLen        = ssidLen;
 
-    mStagingNetwork   = mSavedNetwork;
-    mpScanCallback    = nullptr;
-    mpConnectCallback = nullptr;
+    mStagingNetwork        = mSavedNetwork;
+    mpScanCallback         = nullptr;
+    mpConnectCallback      = nullptr;
+    mpStatusChangeCallback = networkStatusChangeCallback;
     return err;
 }
 
 CHIP_ERROR ESPWiFiDriver::Shutdown()
 {
+    mpStatusChangeCallback = nullptr;
     return CHIP_NO_ERROR;
 }
 
@@ -276,20 +278,7 @@ void ESPWiFiDriver::OnScanWiFiNetworkDone()
     }
 }
 
-void ESPWiFiDriver::ScanNetworks(ByteSpan ssid, WiFiDriver::ScanCallback * callback)
-{
-    if (callback != nullptr)
-    {
-        mpScanCallback = callback;
-        if (StartScanWiFiNetworks(ssid) != CHIP_NO_ERROR)
-        {
-            mpScanCallback = nullptr;
-            callback->OnFinished(Status::kUnknownError, CharSpan(), nullptr);
-        }
-    }
-}
-
-CHIP_ERROR GetConnectedNetwork(Network & network)
+CHIP_ERROR GetConfiguredNetwork(Network & network)
 {
     wifi_ap_record_t ap_info;
     esp_err_t err;
@@ -308,6 +297,57 @@ CHIP_ERROR GetConnectedNetwork(Network & network)
     return CHIP_NO_ERROR;
 }
 
+void ESPWiFiDriver::OnNetworkStatusChange()
+{
+    Network configuredNetwork;
+    bool staEnabled = false, staConnected = false;
+    VerifyOrReturn(ESP32Utils::IsStationEnabled(staEnabled) == CHIP_NO_ERROR);
+    VerifyOrReturn(staEnabled && mpStatusChangeCallback != nullptr);
+    CHIP_ERROR err = GetConfiguredNetwork(configuredNetwork);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to get configured network when updating network status: %s", err.AsString());
+        return;
+    }
+    VerifyOrReturn(ESP32Utils::IsStationConnected(staConnected) == CHIP_NO_ERROR);
+    if (staConnected)
+    {
+        mpStatusChangeCallback->OnNetworkingStatusChange(
+            Status::kSuccess, MakeOptional(ByteSpan(configuredNetwork.networkID, configuredNetwork.networkIDLen)), NullOptional);
+        return;
+    }
+    mpStatusChangeCallback->OnNetworkingStatusChange(
+        Status::kUnknownError, MakeOptional(ByteSpan(configuredNetwork.networkID, configuredNetwork.networkIDLen)),
+        MakeOptional(GetLastDisconnectReason()));
+}
+
+void ESPWiFiDriver::ScanNetworks(ByteSpan ssid, WiFiDriver::ScanCallback * callback)
+{
+    if (callback != nullptr)
+    {
+        mpScanCallback = callback;
+        if (StartScanWiFiNetworks(ssid) != CHIP_NO_ERROR)
+        {
+            mpScanCallback = nullptr;
+            callback->OnFinished(Status::kUnknownError, CharSpan(), nullptr);
+        }
+    }
+}
+
+CHIP_ERROR ESPWiFiDriver::SetLastDisconnectReason(const ChipDeviceEvent * event)
+{
+    VerifyOrReturnError(event->Type == DeviceEventType::kESPSystemEvent && event->Platform.ESPSystemEvent.Base == WIFI_EVENT &&
+                            event->Platform.ESPSystemEvent.Id == WIFI_EVENT_STA_DISCONNECTED,
+                        CHIP_ERROR_INVALID_ARGUMENT);
+    mLastDisconnectedReason = event->Platform.ESPSystemEvent.Data.WiFiStaDisconnected.reason;
+    return CHIP_NO_ERROR;
+}
+
+int32_t ESPWiFiDriver::GetLastDisconnectReason()
+{
+    return mLastDisconnectedReason;
+}
+
 size_t ESPWiFiDriver::WiFiNetworkIterator::Count()
 {
     return mDriver->mStagingNetwork.ssidLen == 0 ? 0 : 1;
@@ -324,12 +364,14 @@ bool ESPWiFiDriver::WiFiNetworkIterator::Next(Network & item)
     item.connected    = false;
     mExhausted        = true;
 
-    Network connectedNetwork;
-    CHIP_ERROR err = GetConnectedNetwork(connectedNetwork);
+    Network configuredNetwork;
+    CHIP_ERROR err = GetConfiguredNetwork(configuredNetwork);
     if (err == CHIP_NO_ERROR)
     {
-        if (connectedNetwork.networkIDLen == item.networkIDLen &&
-            memcmp(connectedNetwork.networkID, item.networkID, item.networkIDLen) == 0)
+        bool isConnected = false;
+        err              = ESP32Utils::IsStationConnected(isConnected);
+        if (err == CHIP_NO_ERROR && isConnected && configuredNetwork.networkIDLen == item.networkIDLen &&
+            memcmp(configuredNetwork.networkID, item.networkID, item.networkIDLen) == 0)
         {
             item.connected = true;
         }
@@ -340,4 +382,3 @@ bool ESPWiFiDriver::WiFiNetworkIterator::Next(Network & item)
 } // namespace NetworkCommissioning
 } // namespace DeviceLayer
 } // namespace chip
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI

--- a/src/platform/ESP32/NetworkCommissioningDriver.h
+++ b/src/platform/ESP32/NetworkCommissioningDriver.h
@@ -22,7 +22,6 @@
 namespace chip {
 namespace DeviceLayer {
 namespace NetworkCommissioning {
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 namespace {
 constexpr uint8_t kMaxWiFiNetworks                  = 1;
 constexpr uint8_t kWiFiScanNetworksTimeOutSeconds   = 10;
@@ -110,6 +109,11 @@ public:
     CHIP_ERROR ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, const char * key, uint8_t keyLen);
     void OnConnectWiFiNetwork();
     void OnScanWiFiNetworkDone();
+    void OnNetworkStatusChange();
+
+    CHIP_ERROR SetLastDisconnectReason(const ChipDeviceEvent * event);
+    int32_t GetLastDisconnectReason();
+
     static ESPWiFiDriver & GetInstance()
     {
         static ESPWiFiDriver instance;
@@ -125,12 +129,10 @@ private:
     WiFiNetwork mStagingNetwork;
     ScanCallback * mpScanCallback;
     ConnectCallback * mpConnectCallback;
+    NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
+    int32_t mLastDisconnectedReason;
 };
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-// TODO: Add Thread Driver for ESP32H2 platform
-#endif
 } // namespace NetworkCommissioning
 } // namespace DeviceLayer
 } // namespace chip


### PR DESCRIPTION
#### Problem
#15700 Need to add the ability of getting autonomous connection status for ESP32 network commissioning driver.

#### Change overview
* Update ESP32 NetworkCommissioning Driver

#### Testing
Tested on ESP32C3
