### PR TITLE
[ESP32] Fix commissioning of esp32

### DIFF
--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -314,7 +314,7 @@ CHIP_ERROR ESP32Utils::MapError(esp_err_t error)
     }
     if (error == ESP_ERR_NVS_NOT_FOUND)
     {
-        return CHIP_ERROR_KEY_NOT_FOUND;
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     }
     return CHIP_ERROR(ChipError::Range::kPlatform, error);
 }


### PR DESCRIPTION
#### Problem
* After merging #15841 commissiong over ble was failing for esp32.
* Was getting 
E (2699) chip[SVR]: ERROR setting up transport: Error CHIP:0x00000010


#### Change overview
Returned CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND for error CHIP_ERROR_KEY_NOT_FOUND

#### Testing
Manually tested esp32 all-clusters-app
