### PR TITLE
Read the min network connection time from the device

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -262,7 +262,7 @@ Optional<System::Clock::Timeout> AutoCommissioner::GetCommandTimeout(Commissioni
 {
     // Per spec, all commands that are sent with the arm failsafe held need at least a 30s timeout.
     // Network clusters can indicate the time required to connect, so if we are connecting, use that time as long as it is > 30s.
-    uint8_t seconds = 30;
+    app::Clusters::NetworkCommissioning::Attributes::ConnectMaxTimeSeconds::TypeInfo::DecodableType seconds = 30;
     switch (stage)
     {
     case CommissioningStage::kWiFiNetworkEnable:

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1583,8 +1583,7 @@ void DeviceCommissioner::OnDone()
 
     err = mAttributeCache->ForEachAttribute(app::Clusters::Basic::Id, [this, &info](const app::ConcreteAttributePath & path) {
         if (path.mAttributeId != app::Clusters::Basic::Attributes::VendorID::Id &&
-            path.mAttributeId != app::Clusters::Basic::Attributes::ProductID::Id &&
-            path.mAttributeId != app::Clusters::Basic::Attributes::SoftwareVersion::Id)
+            path.mAttributeId != app::Clusters::Basic::Attributes::ProductID::Id)
         {
             // Continue on
             return CHIP_NO_ERROR;
@@ -1596,9 +1595,6 @@ void DeviceCommissioner::OnDone()
             return this->mAttributeCache->Get<app::Clusters::Basic::Attributes::VendorID::TypeInfo>(path, info.basic.vendorId);
         case app::Clusters::Basic::Attributes::ProductID::Id:
             return this->mAttributeCache->Get<app::Clusters::Basic::Attributes::ProductID::TypeInfo>(path, info.basic.productId);
-        case app::Clusters::Basic::Attributes::SoftwareVersion::Id:
-            return this->mAttributeCache->Get<app::Clusters::Basic::Attributes::SoftwareVersion::TypeInfo>(
-                path, info.basic.softwareVersion);
         default:
             return CHIP_NO_ERROR;
         }
@@ -1606,6 +1602,7 @@ void DeviceCommissioner::OnDone()
     // Try to parse as much as we can here before returning, even if this is an error.
     return_err = err == CHIP_NO_ERROR ? return_err : err;
 
+    // Set the network cluster endpoints first so we can match up the connection times.
     err = mAttributeCache->ForEachAttribute(
         app::Clusters::NetworkCommissioning::Id, [this, &info](const app::ConcreteAttributePath & path) {
             if (path.mAttributeId != app::Clusters::NetworkCommissioning::Attributes::FeatureMap::Id)
@@ -1620,31 +1617,57 @@ void DeviceCommissioner::OnDone()
                 {
                     if (features.Has(app::Clusters::NetworkCommissioning::NetworkCommissioningFeature::kWiFiNetworkInterface))
                     {
-                        info.network.wifi = path.mEndpointId;
+                        info.network.wifi.endpoint = path.mEndpointId;
                     }
                     else if (features.Has(
                                  app::Clusters::NetworkCommissioning::NetworkCommissioningFeature::kThreadNetworkInterface))
                     {
-                        info.network.thread = path.mEndpointId;
+                        info.network.thread.endpoint = path.mEndpointId;
                     }
                     else if (features.Has(
                                  app::Clusters::NetworkCommissioning::NetworkCommissioningFeature::kEthernetNetworkInterface))
                     {
-                        info.network.eth = path.mEndpointId;
+                        info.network.eth.endpoint = path.mEndpointId;
                     }
                     else
                     {
                         // TODO: Gross workaround for the empty feature map on all clusters. Remove.
-                        if (info.network.thread == kInvalidEndpointId)
+                        if (info.network.thread.endpoint == kInvalidEndpointId)
                         {
-                            info.network.thread = path.mEndpointId;
+                            info.network.thread.endpoint = path.mEndpointId;
                         }
-                        if (info.network.wifi == kInvalidEndpointId)
+                        if (info.network.wifi.endpoint == kInvalidEndpointId)
                         {
-                            info.network.wifi = path.mEndpointId;
+                            info.network.wifi.endpoint = path.mEndpointId;
                         }
                     }
                 }
+            }
+            return CHIP_NO_ERROR;
+        });
+    return_err = err == CHIP_NO_ERROR ? return_err : err;
+
+    err = mAttributeCache->ForEachAttribute(
+        app::Clusters::NetworkCommissioning::Id, [this, &info](const app::ConcreteAttributePath & path) {
+            if (path.mAttributeId != app::Clusters::NetworkCommissioning::Attributes::ConnectMaxTimeSeconds::Id)
+            {
+                return CHIP_NO_ERROR;
+            }
+            app::Clusters::NetworkCommissioning::Attributes::ConnectMaxTimeSeconds::TypeInfo::DecodableArgType time;
+            ReturnErrorOnFailure(
+                this->mAttributeCache->Get<app::Clusters::NetworkCommissioning::Attributes::ConnectMaxTimeSeconds::TypeInfo>(path,
+                                                                                                                             time));
+            if (path.mEndpointId == info.network.wifi.endpoint)
+            {
+                info.network.wifi.minConnectionTime = time;
+            }
+            else if (path.mEndpointId == info.network.thread.endpoint)
+            {
+                info.network.thread.minConnectionTime = time;
+            }
+            else if (path.mEndpointId == info.network.eth.endpoint)
+            {
+                info.network.eth.minConnectionTime = time;
             }
             return CHIP_NO_ERROR;
         });
@@ -1755,8 +1778,9 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         readPaths[5] = app::AttributePathParams(endpoint, app::Clusters::Basic::Id, app::Clusters::Basic::Attributes::VendorID::Id);
         readPaths[6] =
             app::AttributePathParams(endpoint, app::Clusters::Basic::Id, app::Clusters::Basic::Attributes::ProductID::Id);
-        readPaths[7] =
-            app::AttributePathParams(endpoint, app::Clusters::Basic::Id, app::Clusters::Basic::Attributes::SoftwareVersion::Id);
+        // Read the requested minimum connection times from all network commissioning clusters
+        readPaths[7] = app::AttributePathParams(app::Clusters::NetworkCommissioning::Id,
+                                                app::Clusters::NetworkCommissioning::Attributes::ConnectMaxTimeSeconds::Id);
 
         readParams.mpAttributePathParamsList    = readPaths;
         readParams.mAttributePathParamsListSize = 8;

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -284,17 +284,21 @@ struct OperationalNodeFoundData
     OperationalDeviceProxy * operationalProxy;
 };
 
+struct NetworkClusterInfo
+{
+    EndpointId endpoint = kInvalidEndpointId;
+    app::Clusters::NetworkCommissioning::Attributes::ConnectMaxTimeSeconds::TypeInfo::DecodableType minConnectionTime;
+};
 struct NetworkClusters
 {
-    EndpointId wifi   = kInvalidEndpointId;
-    EndpointId thread = kInvalidEndpointId;
-    EndpointId eth    = kInvalidEndpointId;
+    NetworkClusterInfo wifi;
+    NetworkClusterInfo thread;
+    NetworkClusterInfo eth;
 };
 struct BasicClusterInfo
 {
-    VendorId vendorId        = VendorId::Common;
-    uint16_t productId       = 0;
-    uint32_t softwareVersion = 0;
+    VendorId vendorId  = VendorId::Common;
+    uint16_t productId = 0;
 };
 struct GeneralCommissioningInfo
 {


### PR DESCRIPTION
#### Problem
The device exposes an attribute indicating how long we should wait for a connection command to complete, but we weren't using it.
Fixes: #15611

#### Change overview
- remove the read of the software version
- add read of the software connection time and pass it to the commissioning delegate
- update auto commissioner to set the network connection time based on that value (min of that value or 30s as specified in spec)

#### Testing
Tested by commissioning on M5. Confirmed good read of the cluster (vs. chip-tool cluster read), confirmed timeout set correctly by logging.
