### PR TITLE
Remove unused declaration (_DeviceAddressUpdateDelegate_OnUpdateComplete)

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -51,8 +51,6 @@ __all__ = ["ChipDeviceController"]
 _DevicePairingDelegate_OnPairingCompleteFunct = CFUNCTYPE(None, c_uint32)
 _DevicePairingDelegate_OnCommissioningCompleteFunct = CFUNCTYPE(
     None, c_uint64, c_uint32)
-_DeviceAddressUpdateDelegate_OnUpdateComplete = CFUNCTYPE(
-    None, c_uint64, c_uint32)
 # void (*)(Device *, CHIP_ERROR).
 #
 # CHIP_ERROR is actually signed, so using c_uint32 is weird, but everything


### PR DESCRIPTION
#### Problem
Unused code, references DeviceAddressUpdateDelegate

#### Change overview
Remove unused code

#### Testing
Did a grep for usage, came up with no results after this one line removal:

```
rg _DeviceAddressUpdateDelegate_OnUpdateComplete --hidden
```