### PR TITLE
Add back "CI split between for ESP32", with devkitc smoke addded.

### DIFF
--- a/.github/workflows/full-esp32.yaml
+++ b/.github/workflows/full-esp32.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Project CHIP Authors
+ Copyright (c) 2020 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,11 +21,11 @@ on:
 concurrency:
     group: full-${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
-  
+
 jobs:
     esp32:
         name: Run
-        timeout-minutes: 200 
+        timeout-minutes: 200
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'

--- a/.github/workflows/full-esp32.yaml
+++ b/.github/workflows/full-esp32.yaml
@@ -12,21 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Build example - ESP32
+name: Full builds - ESP32
 
 on:
     push:
-    pull_request:
+    workflow_dispatch:
 
 concurrency:
-    group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
+    group: full-${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
   
 jobs:
-    # TODO ESP32 https://github.com/project-chip/connectedhomeip/issues/1510
     esp32:
-        name: ESP32
-        timeout-minutes: 80
+        name: Run
+        timeout-minutes: 200 
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -97,44 +96,6 @@ jobs:
               timeout-minutes: 10
               run: scripts/examples/esp_example.sh lock-app sdkconfig.defaults
 
-            - name: Uploading Size Reports
-              uses: actions/upload-artifact@v2
-              if: ${{ !env.ACT }}
-              with:
-                  name: Size,ESP32-Examples,${{ env.GH_EVENT_PR }},${{ env.GH_EVENT_HASH }},${{ env.GH_EVENT_PARENT }},${{ github.event_name }}
-                  path: /tmp/bloat_reports/
-
-    esp32_1:
-        name: ESP32_1
-        timeout-minutes: 70
-
-        runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
-
-        container:
-            image: connectedhomeip/chip-build-esp32:0.5.56
-            volumes:
-                - "/tmp/bloat_reports:/tmp/bloat_reports"
-
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
-              with:
-                  submodules: true
-
-            - name: Bootstrap
-              timeout-minutes: 10
-              run: scripts/build/gn_bootstrap.sh
-
-            - name: Uploading bootstrap logs
-              uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
-              with:
-                  name: bootstrap-logs
-                  path: |
-                   .environment/gn_out/.ninja_log
-                   .environment/pigweed-venv/*.log
-
             - name: Build example Bridge App
               timeout-minutes: 10
               run: scripts/examples/esp_example.sh bridge-app
@@ -162,3 +123,11 @@ jobs:
             - name: Build example OTA Provider App
               run: scripts/examples/esp_example.sh ota-provider-app sdkconfig.defaults
               timeout-minutes: 10
+
+            - name: Uploading Size Reports
+              uses: actions/upload-artifact@v2
+              if: ${{ !env.ACT }}
+              with:
+                  name: Size,ESP32-Examples,${{ env.GH_EVENT_PR }},${{ env.GH_EVENT_HASH }},${{ env.GH_EVENT_PARENT }},${{ github.event_name }}
+                  path: /tmp/bloat_reports/
+

--- a/.github/workflows/smoketest-esp32.yaml
+++ b/.github/workflows/smoketest-esp32.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
     esp32:
         name: Smoke Run - ESP32
-        timeout-minutes: 30
+        timeout-minutes: 45
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'

--- a/.github/workflows/smoketest-esp32.yaml
+++ b/.github/workflows/smoketest-esp32.yaml
@@ -1,0 +1,84 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Smoke test - ESP32
+
+on:
+    pull_request:
+    workflow_dispatch:
+
+concurrency:
+    group: smoke-${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
+    cancel-in-progress: true
+
+jobs:
+    esp32:
+        name: Smoke Run - ESP32
+        timeout-minutes: 30
+
+        runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io[bot]'
+
+        container:
+            image: connectedhomeip/chip-build-esp32:0.5.56
+            volumes:
+                - "/tmp/bloat_reports:/tmp/bloat_reports"
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  submodules: true
+
+            - name: Set up environment for size reports
+              if: ${{ !env.ACT }}
+              env:
+                  GH_CONTEXT: ${{ toJson(github) }}
+              run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
+
+            - name: Bootstrap
+              timeout-minutes: 10
+              run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }} && ${{ !env.ACT }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
+            - name: Build all-clusters on M5Stack
+              timeout-minutes: 30
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --enable-flashbundle \
+                        --target 'esp32-m5stack-all-clusters' \
+                        build \
+                        --copy-artifacts-to out/artifacts \
+                     "
+            - name: Prepare bloat report
+              run: |
+                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+                     esp32 m5stack all-clusters-app \
+                     out/esp32-m5stack-all-clusters/chip-all-clusters-app.elf \
+                     /tmp/bloat_reports/
+
+            - name: Uploading Size Reports
+              uses: actions/upload-artifact@v2
+              if: ${{ !env.ACT }}
+              with:
+                  name: Size,ESP32-Examples,${{ env.GH_EVENT_PR }},${{ env.GH_EVENT_HASH }},${{ env.GH_EVENT_PARENT }},${{ github.event_name }}
+                  path: /tmp/bloat_reports/
+

--- a/.github/workflows/smoketest-esp32.yaml
+++ b/.github/workflows/smoketest-esp32.yaml
@@ -68,6 +68,16 @@ jobs:
                         build \
                         --copy-artifacts-to out/artifacts \
                      "
+            - name: Build all-clusters on DevKitC
+              timeout-minutes: 30
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --enable-flashbundle \
+                        --target 'esp32-devkitc-all-clusters' \
+                        build \
+                        --copy-artifacts-to out/artifacts \
+                     "
             - name: Prepare bloat report
               run: |
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \


### PR DESCRIPTION
This reverts commit 66aef3e0b939b429aa097d25a605dcc6087b582c.

Adding back the split to remove queueing time. Please do not revert and
rather work to adding appropriate splits or logic as done in #15791
or add additional builds as needed.

For now, I added a devkitC build in the smoke test, since it seems DevKitC builds are different enough in types to trigger different compile errors (32/64 bit interger issues).

The split decreases PR queue time (not as affected) and has a global
timeout which seems easier to track than the timeout we are experiencing
in locations like:

https://github.com/project-chip/connectedhomeip/runs/5422883482?check_suite_focus=true

#### Problem
Previous revert was pushed as a hotfix. Need to have discussion of alternatives before.

#### Change overview
- Reverts the revert.
- Add devkitc builds in the smoke test, to cover some 32/64 bit compile errors that got past the original split.

#### Testing
CI can validate. Generally safe since it is only a revert on existing code.