### PR TITLE
Switch return type for OpCert signing request

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -339,8 +339,8 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
             break;
         case CommissioningStage::kSendOpCertSigningRequest: {
             NOCChainGenerationParameters nocParams;
-            nocParams.nocsrElements = report.Get<OpCertResponse>().attestationElements;
-            nocParams.signature     = report.Get<OpCertResponse>().signature;
+            nocParams.nocsrElements = report.Get<CSRResponse>().nocsrElements;
+            nocParams.signature     = report.Get<CSRResponse>().signature;
             mParams.SetNOCChainGenerationParameters(nocParams);
         }
         break;

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -339,8 +339,8 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
             break;
         case CommissioningStage::kSendOpCertSigningRequest: {
             NOCChainGenerationParameters nocParams;
-            nocParams.nocsrElements = report.Get<AttestationResponse>().attestationElements;
-            nocParams.signature     = report.Get<AttestationResponse>().signature;
+            nocParams.nocsrElements = report.Get<OpCertResponse>().attestationElements;
+            nocParams.signature     = report.Get<OpCertResponse>().signature;
             mParams.SetNOCChainGenerationParameters(nocParams);
         }
         break;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1135,7 +1135,7 @@ void DeviceCommissioner::OnOperationalCertificateSigningRequest(
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
 
     CommissioningDelegate::CommissioningReport report;
-    report.Set<AttestationResponse>(AttestationResponse(data.NOCSRElements, data.attestationSignature));
+    report.Set<OpCertResponse>(OpCertResponse(data.NOCSRElements, data.attestationSignature));
     commissioner->CommissioningStageComplete(CHIP_NO_ERROR, report);
 }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1135,7 +1135,7 @@ void DeviceCommissioner::OnOperationalCertificateSigningRequest(
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
 
     CommissioningDelegate::CommissioningReport report;
-    report.Set<OpCertResponse>(OpCertResponse(data.NOCSRElements, data.attestationSignature));
+    report.Set<CSRResponse>(CSRResponse(data.NOCSRElements, data.attestationSignature));
     commissioner->CommissioningStageComplete(CHIP_NO_ERROR, report);
 }
 

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -266,6 +266,15 @@ struct AttestationResponse
     ByteSpan signature;
 };
 
+struct OpCertResponse
+{
+    OpCertResponse(ByteSpan newAttestationElements, ByteSpan newSignature) :
+        attestationElements(newAttestationElements), signature(newSignature)
+    {}
+    ByteSpan attestationElements;
+    ByteSpan signature;
+};
+
 struct NocChain
 {
     NocChain(ByteSpan newNoc, ByteSpan newIcac, ByteSpan newRcac, AesCcm128KeySpan newIpk, NodeId newAdminSubject) :
@@ -324,8 +333,8 @@ class CommissioningDelegate
 {
 public:
     virtual ~CommissioningDelegate(){};
-    struct CommissioningReport : Variant<RequestedCertificate, AttestationResponse, NocChain, OperationalNodeFoundData,
-                                         ReadCommissioningInfo, AdditionalErrorInfo>
+    struct CommissioningReport : Variant<RequestedCertificate, AttestationResponse, OpCertResponse, NocChain,
+                                         OperationalNodeFoundData, ReadCommissioningInfo, AdditionalErrorInfo>
     {
         CommissioningReport() : stageCompleted(CommissioningStage::kError) {}
         CommissioningStage stageCompleted;

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -266,12 +266,10 @@ struct AttestationResponse
     ByteSpan signature;
 };
 
-struct OpCertResponse
+struct CSRResponse
 {
-    OpCertResponse(ByteSpan newAttestationElements, ByteSpan newSignature) :
-        attestationElements(newAttestationElements), signature(newSignature)
-    {}
-    ByteSpan attestationElements;
+    CSRResponse(ByteSpan elements, ByteSpan newSignature) : nocsrElements(elements), signature(newSignature) {}
+    ByteSpan nocsrElements;
     ByteSpan signature;
 };
 
@@ -333,8 +331,8 @@ class CommissioningDelegate
 {
 public:
     virtual ~CommissioningDelegate(){};
-    struct CommissioningReport : Variant<RequestedCertificate, AttestationResponse, OpCertResponse, NocChain,
-                                         OperationalNodeFoundData, ReadCommissioningInfo, AdditionalErrorInfo>
+    struct CommissioningReport : Variant<RequestedCertificate, AttestationResponse, CSRResponse, NocChain, OperationalNodeFoundData,
+                                         ReadCommissioningInfo, AdditionalErrorInfo>
     {
         CommissioningReport() : stageCompleted(CommissioningStage::kError) {}
         CommissioningStage stageCompleted;


### PR DESCRIPTION
#### Problem
I originally re-used the AttestationResponse type for the op cert
signing requests because they return data in the same format. This
was confusing, so adding another struct define with the same name.
Fixes: #15614

#### Change overview
Add a new type for op cert signing response and use that in the report.

#### Testing
Commissioned all clusters app on linux. Also tested by cirque
