### PR TITLE
Remove stale todo

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -222,7 +222,6 @@ EndpointId AutoCommissioner::GetEndpoint(const CommissioningStage & stage)
 
 CHIP_ERROR AutoCommissioner::StartCommissioning(DeviceCommissioner * commissioner, CommissioneeDeviceProxy * proxy)
 {
-    // TODO: check that there is no commissioning in progress currently.
     if (commissioner == nullptr)
     {
         ChipLogError(Controller, "Invalid DeviceCommissioner");


### PR DESCRIPTION
#### Problem
Commissioning state is already checked by the caller. We don't need to double track it in the auto commissioner. We should just take the DeviceCommissioner's word that we need to start commissioning. Other implementations may track if they wish, but this example impl doesn't need it and tracking the state in more than once place can lead to bugs.
Fixes: #14081

#### Change overview
Remove todo. We don't want to do it.

#### Testing
Comment removal only.
