### PR TITLE
Fix documentation to align with code.

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -77,19 +77,10 @@ jobs:
               # enable it for various reasons.  Keep whatever Xcode settings
               # for OTHER_CFLAGS exist by using ${inherited}.
               #
-              # Disable -Wdocumentation because so much of our doxygen is so
-              # broken.  See https://github.com/project-chip/connectedhomeip/issues/6734
-              #
-              # Disable -Wconditional-uninitialized because the generated IM TLV
-              # code hits this all over the place.
-              #
               # Disable -Wmacro-redefined because CHIP_DEVICE_CONFIG_ENABLE_MDNS
               # seems to be unconditionally defined in CHIPDeviceBuildConfig.h,
               # which is apparently being included after CHIPDeviceConfig.h.
-              #
-              # Disable -Wdeprecated-declarations because we use deprecated
-              # things like PairTestDeviceWithoutSecurity.
-              run: xcodebuild -target "CHIP" -sdk macosx OTHER_CFLAGS='${inherited} -Werror -Wno-documentation -Wno-conditional-uninitialized -Wno-macro-redefined -Wno-deprecated-declarations'
+              run: xcodebuild -target "CHIP" -sdk macosx OTHER_CFLAGS='${inherited} -Werror -Wno-macro-redefined'
               working-directory: src/darwin/Framework
             - name: Clean Build
               run: xcodebuild clean
@@ -118,7 +109,7 @@ jobs:
               run: |
                 mkdir -p /tmp/darwin/framework-tests
                 ../../../out/debug/chip-all-clusters-app > >(tee /tmp/darwin/framework-tests/all-cluster-app.log) 2> >(tee /tmp/darwin/framework-tests/all-cluster-app-err.log >&2) &
-                xcodebuild test -target "CHIP" -scheme "CHIP Framework Tests" -sdk macosx OTHER_CFLAGS='${inherited} -Werror -Wno-documentation -Wno-conditional-uninitialized -Wno-incomplete-umbrella' > >(tee /tmp/darwin/framework-tests/darwin-tests.log) 2> >(tee /tmp/darwin/framework-tests/darwin-tests-err.log >&2)
+                xcodebuild test -target "CHIP" -scheme "CHIP Framework Tests" -sdk macosx OTHER_CFLAGS='${inherited} -Werror -Wno-incomplete-umbrella' > >(tee /tmp/darwin/framework-tests/darwin-tests.log) 2> >(tee /tmp/darwin/framework-tests/darwin-tests-err.log >&2)
               working-directory: src/darwin/Framework
             - name: Uploading log files
               uses: actions/upload-artifact@v2

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -326,7 +326,7 @@ public:
      *                         completion, the event number of the next one we plan to fetch.
      *
      * @param[out] aEventCount The number of fetched event
-     * @param[in] aFabricIndex fabric index for current read handler
+     * @param[in] aSubjectDescriptor Subject descriptor for current read handler
      * @retval #CHIP_END_OF_TLV             The function has reached the end of the
      *                                       available log entries at the specified
      *                                       priority level

--- a/src/app/MessageDef/EventPathIB.h
+++ b/src/app/MessageDef/EventPathIB.h
@@ -119,7 +119,7 @@ public:
     /**
      *  @brief Fill the fields in apPath from the parser, the path in the parser should be a concrete path.
      *
-     *  @param [in] apEvent    A pointer to apEvent
+     *  @param [in] apPath    A pointer to the path to fill in.
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_ERROR_IM_MALFORMED_EVENT_PATH if the path from the reader is not a valid concrere event path.

--- a/src/credentials/attestation_verifier/DeviceAttestationVerifier.h
+++ b/src/credentials/attestation_verifier/DeviceAttestationVerifier.h
@@ -222,7 +222,7 @@ public:
     /**
      * @brief Verify an attestation information payload against a DAC/PAI chain.
      *
-     * @param[in] attestationInfo All of the information required to verify the attestation.
+     * @param[in] info All of the information required to verify the attestation.
      * @param[in] onCompletion Callback handler to provide Attestation Information Verification result to the caller of
      *                         VerifyAttestationInformation()
      */


### PR DESCRIPTION
#### Problem
Javadoc comments that don't match the code, triggering build warnings.

#### Change overview
* Fix the comments.
* Enable checking for this in CI, since it looks like we now have all such broken comments fixed.
* Enable checking for a few other warnings in CI now that we are not triggering them.

#### Testing
Should have no behavior changes.