### PR TITLE
Fix urgent event support

### DIFF
--- a/src/app/ClusterInfo.h
+++ b/src/app/ClusterInfo.h
@@ -103,6 +103,7 @@ public:
     ListIndex mListIndex     = kInvalidListIndex;   // uint16
     EndpointId mEndpointId   = kInvalidEndpointId;  // uint16
     Optional<DataVersion> mDataVersion;             // uint32
+    bool mIsUrgentEvent = false;                    // uint8
 };
 } // namespace app
 } // namespace chip

--- a/src/app/EventLogging.h
+++ b/src/app/EventLogging.h
@@ -57,21 +57,18 @@ private:
  * LogEvent has 2 variant, one for fabric-scoped events and one for non-fabric-scoped events.
  * @param[in] aEventData  The event cluster object
  * @param[in] aEndpoint    The current cluster's Endpoint Id
- * @param[in] aUrgent    The EventOption Type, kUrgent or kNotUrgent
  * @param[out] aEventNumber The event Number if the event was written to the
  *                         log, 0 otherwise. The Event number is expected to monotonically increase.
  *
  * @return CHIP_ERROR  CHIP Error Code
  */
 template <typename T, std::enable_if_t<DataModel::IsFabricScoped<T>::value, bool> = true>
-CHIP_ERROR LogEvent(const T & aEventData, EndpointId aEndpoint, EventNumber & aEventNumber,
-                    EventOptions::Type aUrgent = EventOptions::Type::kNotUrgent)
+CHIP_ERROR LogEvent(const T & aEventData, EndpointId aEndpoint, EventNumber & aEventNumber)
 {
     EventLogger<T> eventData(aEventData);
     ConcreteEventPath path(aEndpoint, aEventData.GetClusterId(), aEventData.GetEventId());
     EventManagement & logMgmt = chip::app::EventManagement::GetInstance();
     EventOptions eventOptions;
-    eventOptions.mUrgent      = aUrgent;
     eventOptions.mPath        = path;
     eventOptions.mPriority    = aEventData.GetPriorityLevel();
     eventOptions.mFabricIndex = aEventData.GetFabricIndex();
@@ -88,14 +85,12 @@ CHIP_ERROR LogEvent(const T & aEventData, EndpointId aEndpoint, EventNumber & aE
 }
 
 template <typename T, std::enable_if_t<!DataModel::IsFabricScoped<T>::value, bool> = true>
-CHIP_ERROR LogEvent(const T & aEventData, EndpointId aEndpoint, EventNumber & aEventNumber,
-                    EventOptions::Type aUrgent = EventOptions::Type::kNotUrgent)
+CHIP_ERROR LogEvent(const T & aEventData, EndpointId aEndpoint, EventNumber & aEventNumber)
 {
     EventLogger<T> eventData(aEventData);
     ConcreteEventPath path(aEndpoint, aEventData.GetClusterId(), aEventData.GetEventId());
     EventManagement & logMgmt = chip::app::EventManagement::GetInstance();
     EventOptions eventOptions;
-    eventOptions.mUrgent   = aUrgent;
     eventOptions.mPath     = path;
     eventOptions.mPriority = aEventData.GetPriorityLevel();
     return logMgmt.LogEvent(&eventData, eventOptions, aEventNumber);

--- a/src/app/EventLoggingTypes.h
+++ b/src/app/EventLoggingTypes.h
@@ -127,21 +127,11 @@ struct Timestamp
 class EventOptions
 {
 public:
-    enum class Type
-    {
-        kUrgent = 0,
-        kNotUrgent,
-    };
-    EventOptions() : mPriority(PriorityLevel::Invalid), mUrgent(Type::kNotUrgent) {}
-    EventOptions(Timestamp aTimestamp) : mTimestamp(aTimestamp), mPriority(PriorityLevel::Invalid), mUrgent(Type::kNotUrgent) {}
-
-    EventOptions(Timestamp aTimestamp, Type aUrgent) : mTimestamp(aTimestamp), mPriority(PriorityLevel::Invalid), mUrgent(aUrgent)
-    {}
+    EventOptions() : mPriority(PriorityLevel::Invalid) {}
+    EventOptions(Timestamp aTimestamp) : mTimestamp(aTimestamp), mPriority(PriorityLevel::Invalid) {}
     ConcreteEventPath mPath;
     Timestamp mTimestamp;
     PriorityLevel mPriority = PriorityLevel::Invalid;
-    Type mUrgent            = Type::kNotUrgent; /**< A flag denoting if the event is time sensitive.  When kUrgent is set, it causes
-                                                       the event log to be flushed. */
     // kUndefinedFabricIndex 0 means not fabric associated at all
     FabricIndex mFabricIndex = kUndefinedFabricIndex;
 };

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -319,7 +319,6 @@ CHIP_ERROR EventManagement::ConstructEvent(EventLoadOutContext * apContext, Even
     eventPathBuilder.Endpoint(apOptions->mPath.mEndpointId)
         .Cluster(apOptions->mPath.mClusterId)
         .Event(apOptions->mPath.mEventId)
-        .IsUrgent(apOptions->mUrgent == EventOptions::Type::kUrgent)
         .EndOfEventPathIB();
     ReturnErrorOnFailure(eventPathBuilder.GetError());
     eventDataIBBuilder.EventNumber(apContext->mCurrentEventNumber).Priority(chip::to_underlying(apContext->mPriority));
@@ -476,7 +475,6 @@ CHIP_ERROR EventManagement::LogEventPrivate(EventLoggingDelegate * apDelegate, c
     // Create all event specific data
     // Timestamp; encoded as a delta time
 
-    opts.mUrgent      = aEventOptions.mUrgent;
     opts.mPath        = aEventOptions.mPath;
     opts.mFabricIndex = aEventOptions.mFabricIndex;
 
@@ -533,8 +531,7 @@ exit:
                       opts.mTimestamp.mType == Timestamp::Type::kSystem ? "Sys" : "Epoch", ChipLogValueX64(opts.mTimestamp.mValue));
 #endif // CHIP_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS
 
-        err = InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleEventDelivery(opts.mPath, opts.mUrgent,
-                                                                                                mBytesWritten);
+        err = InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleEventDelivery(opts.mPath, mBytesWritten);
     }
 
     return err;

--- a/src/app/EventPathParams.h
+++ b/src/app/EventPathParams.h
@@ -26,8 +26,8 @@ namespace chip {
 namespace app {
 struct EventPathParams
 {
-    EventPathParams(EndpointId aEndpointId, ClusterId aClusterId, EventId aEventId) :
-        mEndpointId(aEndpointId), mClusterId(aClusterId), mEventId(aEventId)
+    EventPathParams(EndpointId aEndpointId, ClusterId aClusterId, EventId aEventId, bool aUrgentEvent = false) :
+        mEndpointId(aEndpointId), mClusterId(aClusterId), mEventId(aEventId), mIsUrgentEvent(aUrgentEvent)
     {}
     EventPathParams() {}
     bool IsSamePath(const EventPathParams & other) const
@@ -47,6 +47,7 @@ struct EventPathParams
     EndpointId mEndpointId = kInvalidEndpointId;
     ClusterId mClusterId   = kInvalidClusterId;
     EventId mEventId       = kInvalidEventId;
+    bool mIsUrgentEvent    = false;
 };
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/EventPathIB.cpp
+++ b/src/app/MessageDef/EventPathIB.cpp
@@ -242,6 +242,10 @@ CHIP_ERROR EventPathIB::Builder::Encode(const EventPathParams & aEventPathParams
         Event(aEventPathParams.mEventId);
     }
 
+    if (aEventPathParams.mIsUrgentEvent)
+    {
+        IsUrgent(aEventPathParams.mIsUrgentEvent);
+    }
     EndOfEventPathIB();
     return GetError();
 }

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -515,6 +515,13 @@ CHIP_ERROR ReadHandler::ProcessEventPaths(EventPathIBs::Parser & aEventPathsPars
         }
         ReturnErrorOnFailure(err);
 
+        err = path.GetIsUrgent(&(clusterInfo.mIsUrgentEvent));
+        if (CHIP_END_OF_TLV == err)
+        {
+            err = CHIP_NO_ERROR;
+        }
+        ReturnErrorOnFailure(err);
+
         ReturnErrorOnFailure(InteractionModelEngine::GetInstance()->PushFront(mpEventClusterInfoList, clusterInfo));
     }
 

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -340,7 +340,7 @@ class PlatformMgrDelegate : public DeviceLayer::PlatformManagerDelegate
             Events::StartUp::Type event{ softwareVersion };
             EventNumber eventNumber;
 
-            CHIP_ERROR err = LogEvent(event, endpoint, eventNumber, EventOptions::Type::kUrgent);
+            CHIP_ERROR err = LogEvent(event, endpoint, eventNumber);
             if (CHIP_NO_ERROR != err)
             {
                 ChipLogError(Zcl, "PlatformMgrDelegate: Failed to record StartUp event: %" CHIP_ERROR_FORMAT, err.Format());
@@ -359,7 +359,7 @@ class PlatformMgrDelegate : public DeviceLayer::PlatformManagerDelegate
             Events::ShutDown::Type event;
             EventNumber eventNumber;
 
-            CHIP_ERROR err = LogEvent(event, endpoint, eventNumber, EventOptions::Type::kUrgent);
+            CHIP_ERROR err = LogEvent(event, endpoint, eventNumber);
             if (CHIP_NO_ERROR != err)
             {
                 ChipLogError(Zcl, "PlatformMgrDelegate: Failed to record ShutDown event: %" CHIP_ERROR_FORMAT, err.Format());

--- a/src/app/clusters/general-diagnostics-server/general-diagnostics-server.cpp
+++ b/src/app/clusters/general-diagnostics-server/general-diagnostics-server.cpp
@@ -206,7 +206,7 @@ class GeneralDiagnosticsDelegate : public DeviceLayer::ConnectivityManagerDelega
         Events::BootReason::Type event{ static_cast<EmberAfBootReasonType>(bootReason) };
         EventNumber eventNumber;
 
-        CHIP_ERROR err = LogEvent(event, 0, eventNumber, EventOptions::Type::kUrgent);
+        CHIP_ERROR err = LogEvent(event, 0, eventNumber);
         if (CHIP_NO_ERROR != err)
         {
             ChipLogError(Zcl, "GeneralDiagnosticsDelegate: Failed to record BootReason event: %" CHIP_ERROR_FORMAT, err.Format());
@@ -233,7 +233,7 @@ class GeneralDiagnosticsDelegate : public DeviceLayer::ConnectivityManagerDelega
                 reinterpret_cast<const HardwareFaultType *>(previous.data()), previous.size());
             Events::HardwareFaultChange::Type event{ currentList, previousList };
 
-            if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber, EventOptions::Type::kUrgent))
+            if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber))
             {
                 ChipLogError(Zcl, "GeneralDiagnosticsDelegate: Failed to record HardwareFault event");
             }
@@ -259,7 +259,7 @@ class GeneralDiagnosticsDelegate : public DeviceLayer::ConnectivityManagerDelega
                 DataModel::List<const RadioFaultType>(reinterpret_cast<const RadioFaultType *>(previous.data()), previous.size());
             Events::RadioFaultChange::Type event{ currentList, previousList };
 
-            if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber, EventOptions::Type::kUrgent))
+            if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber))
             {
                 ChipLogError(Zcl, "GeneralDiagnosticsDelegate: Failed to record RadioFault event");
             }
@@ -285,7 +285,7 @@ class GeneralDiagnosticsDelegate : public DeviceLayer::ConnectivityManagerDelega
                 reinterpret_cast<const NetworkFaultType *>(previous.data()), previous.size());
             Events::NetworkFaultChange::Type event{ currentList, previousList };
 
-            if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber, EventOptions::Type::kUrgent))
+            if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber))
             {
                 ChipLogError(Zcl, "GeneralDiagnosticsDelegate: Failed to record NetworkFault event");
             }

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -735,18 +735,21 @@ CHIP_ERROR Engine::ScheduleBufferPressureEventDelivery(uint32_t aBytesWritten)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Engine::ScheduleUrgentEventDelivery(ConcreteEventPath & aPath)
+CHIP_ERROR Engine::ScheduleEventDelivery(ConcreteEventPath & aPath, uint32_t aBytesWritten)
 {
-    InteractionModelEngine::GetInstance()->mReadHandlers.ForEachActiveObject([&aPath](ReadHandler * handler) {
+    bool isUrgentEvent = false;
+    InteractionModelEngine::GetInstance()->mReadHandlers.ForEachActiveObject([&aPath, &isUrgentEvent](ReadHandler * handler) {
         if (handler->IsType(ReadHandler::InteractionType::Read))
         {
             return Loop::Continue;
         }
 
-        for (auto clusterInfo = handler->GetEventClusterInfolist(); clusterInfo != nullptr; clusterInfo = clusterInfo->mpNext)
+        for (auto * interestedPath = handler->GetEventClusterInfolist(); interestedPath != nullptr;
+             interestedPath        = interestedPath->mpNext)
         {
-            if (clusterInfo->IsEventPathSupersetOf(aPath))
+            if (interestedPath->IsEventPathSupersetOf(aPath) && interestedPath->mIsUrgentEvent)
             {
+                isUrgentEvent = true;
                 handler->UnblockUrgentEventDelivery();
                 break;
             }
@@ -755,18 +758,14 @@ CHIP_ERROR Engine::ScheduleUrgentEventDelivery(ConcreteEventPath & aPath)
         return Loop::Continue;
     });
 
-    return ScheduleRun();
-}
-
-CHIP_ERROR Engine::ScheduleEventDelivery(ConcreteEventPath & aPath, EventOptions::Type aUrgent, uint32_t aBytesWritten)
-{
-    if (aUrgent != EventOptions::Type::kUrgent)
+    if (isUrgentEvent)
     {
-        return ScheduleBufferPressureEventDelivery(aBytesWritten);
+        ChipLogDetail(DataManagement, "urgent event schedule run");
+        return ScheduleRun();
     }
     else
     {
-        return ScheduleUrgentEventDelivery(aPath);
+        return ScheduleBufferPressureEventDelivery(aBytesWritten);
     }
     return CHIP_NO_ERROR;
 }

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -94,7 +94,7 @@ public:
      *  Schedule the event delivery
      *
      */
-    CHIP_ERROR ScheduleEventDelivery(ConcreteEventPath & aPath, EventOptions::Type aUrgent, uint32_t aBytesWritten);
+    CHIP_ERROR ScheduleEventDelivery(ConcreteEventPath & aPath, uint32_t aBytesWritten);
 
     /*
      * Resets the tracker that tracks the currently serviced read handler.
@@ -164,7 +164,6 @@ private:
      */
     static void Run(System::Layer * aSystemLayer, void * apAppState);
 
-    CHIP_ERROR ScheduleUrgentEventDelivery(ConcreteEventPath & aPath);
     CHIP_ERROR ScheduleBufferPressureEventDelivery(uint32_t aBytesWritten);
     void GetMinEventLogPosition(uint32_t & aMinLogPosition);
 

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -306,10 +306,11 @@ public:
     }
 
     template <typename DecodableType>
-    CHIP_ERROR
-    SubscribeEvent(void * context, ReadResponseSuccessCallback<DecodableType> reportCb, ReadResponseFailureCallback failureCb,
-                   uint16_t minIntervalFloorSeconds, uint16_t maxIntervalCeilingSeconds,
-                   SubscriptionEstablishedCallback subscriptionEstablishedCb = nullptr, bool aKeepPreviousSubscriptions = false)
+    CHIP_ERROR SubscribeEvent(void * context, ReadResponseSuccessCallback<DecodableType> reportCb,
+                              ReadResponseFailureCallback failureCb, uint16_t minIntervalFloorSeconds,
+                              uint16_t maxIntervalCeilingSeconds,
+                              SubscriptionEstablishedCallback subscriptionEstablishedCb = nullptr,
+                              bool aKeepPreviousSubscriptions = false, bool aIsUrgentEvent = false)
     {
         VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
@@ -334,9 +335,10 @@ public:
             }
         };
 
-        return Controller::SubscribeEvent<DecodableType>(
-            mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint, onReportCb, onFailureCb,
-            minIntervalFloorSeconds, maxIntervalCeilingSeconds, onSubscriptionEstablishedCb, aKeepPreviousSubscriptions);
+        return Controller::SubscribeEvent<DecodableType>(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(),
+                                                         mEndpoint, onReportCb, onFailureCb, minIntervalFloorSeconds,
+                                                         maxIntervalCeilingSeconds, onSubscriptionEstablishedCb,
+                                                         aKeepPreviousSubscriptions, aIsUrgentEvent);
     }
 
 protected:

--- a/src/controller/ReadInteraction.h
+++ b/src/controller/ReadInteraction.h
@@ -196,14 +196,14 @@ struct ReportEventParams : public app::ReadPrepareParams
 
 template <typename DecodableEventType>
 CHIP_ERROR ReportEvent(Messaging::ExchangeManager * apExchangeMgr, EndpointId endpointId,
-                       ReportEventParams<DecodableEventType> && readParams)
+                       ReportEventParams<DecodableEventType> && readParams, bool aIsUrgentEvent)
 {
     ClusterId clusterId                  = DecodableEventType::GetClusterId();
     EventId eventId                      = DecodableEventType::GetEventId();
     app::InteractionModelEngine * engine = app::InteractionModelEngine::GetInstance();
     CHIP_ERROR err                       = CHIP_NO_ERROR;
 
-    auto readPaths = Platform::MakeUnique<app::EventPathParams>(endpointId, clusterId, eventId);
+    auto readPaths = Platform::MakeUnique<app::EventPathParams>(endpointId, clusterId, eventId, aIsUrgentEvent);
     VerifyOrReturnError(readPaths != nullptr, CHIP_ERROR_NO_MEMORY);
 
     readParams.mpEventPathParamsList = readPaths.get();
@@ -262,7 +262,7 @@ CHIP_ERROR ReadEvent(Messaging::ExchangeManager * exchangeMgr, const SessionHand
     detail::ReportEventParams<DecodableEventType> params(sessionHandle);
     params.mOnReportCb = onSuccessCb;
     params.mOnErrorCb  = onErrorCb;
-    return detail::ReportEvent(exchangeMgr, endpointId, std::move(params));
+    return detail::ReportEvent(exchangeMgr, endpointId, std::move(params), false /*aIsUrgentEvent*/);
 }
 
 /**
@@ -276,7 +276,7 @@ CHIP_ERROR SubscribeEvent(Messaging::ExchangeManager * exchangeMgr, const Sessio
                           uint16_t minIntervalFloorSeconds, uint16_t maxIntervalCeilingSeconds,
                           typename TypedReadEventCallback<DecodableEventType>::OnSubscriptionEstablishedCallbackType
                               onSubscriptionEstablishedCb = nullptr,
-                          bool keepPreviousSubscriptions  = false)
+                          bool keepPreviousSubscriptions = false, bool aIsUrgentEvent = false)
 {
     detail::ReportEventParams<DecodableEventType> params(sessionHandle);
     params.mOnReportCb                  = onReportCb;
@@ -286,7 +286,7 @@ CHIP_ERROR SubscribeEvent(Messaging::ExchangeManager * exchangeMgr, const Sessio
     params.mMaxIntervalCeilingSeconds   = maxIntervalCeilingSeconds;
     params.mKeepSubscriptions           = keepPreviousSubscriptions;
     params.mReportType                  = app::ReadClient::InteractionType::Subscribe;
-    return detail::ReportEvent(exchangeMgr, endpointId, std::move(params));
+    return detail::ReportEvent(exchangeMgr, endpointId, std::move(params), aIsUrgentEvent);
 }
 
 } // namespace Controller

--- a/src/controller/python/chip/clusters/attribute.cpp
+++ b/src/controller/python/chip/clusters/attribute.cpp
@@ -51,6 +51,7 @@ struct __attribute__((packed)) EventPath
     chip::EndpointId endpointId;
     chip::ClusterId clusterId;
     chip::EventId eventId;
+    uint8_t urgentEvent;
 };
 
 struct __attribute__((packed)) DataVersionFilter
@@ -472,7 +473,7 @@ chip::ChipError::StorageType pychip_ReadClient_ReadEvents(void * appContext, Rea
             python::EventPath pathObj;
             memcpy(&pathObj, path, sizeof(python::EventPath));
 
-            readPaths[i] = EventPathParams(pathObj.endpointId, pathObj.clusterId, pathObj.eventId);
+            readPaths[i] = EventPathParams(pathObj.endpointId, pathObj.clusterId, pathObj.eventId, pathObj.urgentEvent == 1);
         }
     }
 

--- a/src/controller/python/chip/interaction_model/delegate.py
+++ b/src/controller/python/chip/interaction_model/delegate.py
@@ -60,6 +60,7 @@ EventPathIBstruct = Struct(
     "EndpointId" / Int16ul,
     "ClusterId" / Int32ul,
     "EventId" / Int32ul,
+    "Urgent" / Int8ul,
 )
 
 DataVersionFilterIBstruct = Struct(
@@ -83,6 +84,7 @@ class EventPath:
     endpointId: int
     clusterId: int
     eventId: int
+    urgent: int
 
 
 @dataclass

--- a/src/controller/python/test/test_scripts/cluster_objects.py
+++ b/src/controller/python/test/test_scripts/cluster_objects.py
@@ -287,14 +287,14 @@ class ClusterObjectTests:
     async def TestReadEventRequests(cls, devCtrl, expectEventsNum):
         logger.info("1: Reading Ex Cx Ex")
         req = [
-            (1, Clusters.TestCluster.Events.TestEvent),
+            (1, Clusters.TestCluster.Events.TestEvent, 0),
         ]
 
         await cls.TriggerAndWaitForEvents(cls, devCtrl, req)
 
         logger.info("2: Reading Ex Cx E*")
         req = [
-            (1, Clusters.TestCluster),
+            (1, Clusters.TestCluster, 0),
         ]
 
         await cls.TriggerAndWaitForEvents(cls, devCtrl, req)
@@ -309,6 +309,13 @@ class ClusterObjectTests:
         logger.info("4: Reading E* C* E*")
         req = [
             '*'
+        ]
+
+        await cls.TriggerAndWaitForEvents(cls, devCtrl, req)
+
+        logger.info("5: Reading Ex Cx E* Urgency")
+        req = [
+            (1, Clusters.TestCluster, 1),
         ]
 
         await cls.TriggerAndWaitForEvents(cls, devCtrl, req)


### PR DESCRIPTION
#### Problem
#15838
Spec says that
"Events SHALL be queued by default and batch delivered as soon as possible, taking into account the minimum interval, unless the 'IsUrgent' flag has been specified for a particular event path in the EventPathIB. The queueing of any urgent event SHALL force an immediate generation of reports containing all events queued leading up to (and including) the urgent event in question. "

The spec means the urgency needs to be specified by subscribe request only, then when running LogEventPrivate, we need to compare logged EventPath against all interested event Paths from subscription, if there is matched path with urgency set, then EventManagement trigger engine run.
The spec also means the wildcard event can be set with urgent flag.

#### Change overview
--Update ReadClient to send event path with urgency boolean
--When running LogEventPrivate, we need to compare logged EventPath against all interested event Paths from subscription, if there is matched path with urgency set, then EventManagement trigger engine run.
--Remove urgent flag in returned event data.

#### Testing
Update unit test that read client sends event path with urgency boolean, server generates matched event, when found urgency flag, report engine trigger the urgent event delivery.
