### PR TITLE
Add timeout argument to test command

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -47,14 +47,17 @@ public:
     {
         AddArgument("delayInMs", 0, UINT64_MAX, &mDelayInMs);
         AddArgument("PICS", &mPICSFilePath);
+        AddArgument("testTimeoutInS", 0, UINT16_MAX, &mTimeout);
     }
 
     ~TestCommand(){};
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(kTimeoutInSeconds); }
-
+    chip::System::Clock::Timeout GetWaitDuration() const override
+    {
+        return chip::System::Clock::Seconds16(mTimeout.ValueOr(kTimeoutInSeconds));
+    }
     virtual void NextTest() = 0;
 
 protected:


### PR DESCRIPTION
#### Problem
The test cluster command in particular is very long and the time
required to run it varies greatly depending on the network setup.
On the M5, we are timing out with the already increased default
value, whereas with a linux device this entire test completes in
less than 10s. Rather than forcing every platform to use the same
default, make the default settable on the command line.

#### Change overview
- add optional cmd argument to set the test timeout on the command line

#### Testing
Test: added a log to ensure that the returned GetWaitDuration returns
      the value from the command line. It does, log is removed.
