### PR TITLE
[IM] Abort read/subscribe transactions when deleting related fabric

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -177,7 +177,7 @@ uint32_t InteractionModelEngine::GetNumActiveWriteHandlers() const
 
 void InteractionModelEngine::CloseTransactionsFromFabricIndex(FabricIndex aFabricIndex)
 { 
-//
+    //
     // Walk through all existing subscriptions and shut down those whose subscriber matches
     // that which just came in.
     //

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -176,7 +176,8 @@ uint32_t InteractionModelEngine::GetNumActiveWriteHandlers() const
 }
 
 void InteractionModelEngine::CloseTransactionsFromFabricIndex(FabricIndex aFabricIndex)
-{ //
+{ 
+//
     // Walk through all existing subscriptions and shut down those whose subscriber matches
     // that which just came in.
     //

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -175,6 +175,23 @@ uint32_t InteractionModelEngine::GetNumActiveWriteHandlers() const
     return numActive;
 }
 
+void InteractionModelEngine::CloseTransactionsFromFabricIndex(FabricIndex aFabricIndex)
+{ //
+    // Walk through all existing subscriptions and shut down those whose subscriber matches
+    // that which just came in.
+    //
+    mReadHandlers.ForEachActiveObject([this, aFabricIndex](ReadHandler * handler) {
+        if (handler->GetAccessingFabricIndex() == aFabricIndex)
+        {
+            ChipLogProgress(InteractionModel, "Deleting expired ReadHandler for NodeId: " ChipLogFormatX64 ", FabricIndex: %u",
+                            ChipLogValueX64(handler->GetInitiatorNodeId()), aFabricIndex);
+            mReadHandlers.ReleaseObject(handler);
+        }
+
+        return Loop::Continue;
+    });
+}
+
 CHIP_ERROR InteractionModelEngine::ShutdownSubscription(uint64_t aSubscriptionId)
 {
     for (auto * readClient = mpActiveReadClientList; readClient != nullptr; readClient = readClient->GetNextClient())

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -110,6 +110,12 @@ public:
      */
     CHIP_ERROR ShutdownSubscriptions(FabricIndex aFabricIndex, NodeId aPeerNodeId);
 
+    /**
+     * Expire active transactions and release related objects for the given fabric index.
+     * This is used for releasing transactions that won't be closed when a fabric is removed.
+     */
+    void CloseTransactionsFromFabricIndex(FabricIndex aFabricIndex);
+
     uint32_t GetNumActiveReadHandlers() const;
     uint32_t GetNumActiveReadHandlers(ReadHandler::InteractionType type) const;
 

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -356,6 +356,7 @@ public:
     void OnExchangeClosing(chip::Messaging::ExchangeContext * ec) override
     {
         FabricIndex currentFabricIndex = ec->GetSessionHandle()->GetFabricIndex();
+        InteractionModelEngine::GetInstance()->CloseTransactionsFromFabricIndex(currentFabricIndex);
         ec->GetExchangeMgr()->GetSessionManager()->ExpireAllPairingsForFabric(currentFabricIndex);
     }
 };
@@ -412,6 +413,7 @@ exit:
         }
         else
         {
+            InteractionModelEngine::GetInstance()->CloseTransactionsFromFabricIndex(fabricBeingRemoved);
             ec->GetExchangeMgr()->GetSessionManager()->ExpireAllPairingsForFabric(fabricBeingRemoved);
         }
     }


### PR DESCRIPTION
#### Problem
Fixes #15182 

#### Change overview
Adds `CloseTransactionsFromFabricIndex` for shutting down a ReadHandler when deleting related fabric

#### Testing

Send the following command via REPL:
```
In [1]: devCtrl.CommissionIP(b"172.16.243.197", 20202021, 233)

In [2]: res = await devCtrl.ReadAttribute(
   ...:     nodeid=233, attributes=[("*")], reportInterval=(10, 20), returnClusterObject=True
   ...: )

In [5]: cmd = await devCtrl.SendCommand(
   ...:     nodeid=233,
   ...:     endpoint=0,
   ...:     payload=Clusters.OperationalCredentials.Commands.RemoveFabric(1),
   ...: )
```

Found this log on the server side
```
[1646631925.449431][2068159:2068159] CHIP:IM: Deleting expired ReadHandler for NodeId: 0000000000000001, FabricIndex: 1
```

And no more error logs in #15182 