### PR TITLE
[Python] Print data version when dumping cluster attributes

### DIFF
--- a/src/controller/python/chip/clusters/ClusterObjects.py
+++ b/src/controller/python/chip/clusters/ClusterObjects.py
@@ -220,15 +220,29 @@ class ClusterCommand(ClusterObject):
 
 class Cluster(ClusterObject):
     '''
-    When send read requests with returnClusterObject=True, we will set the dataVersion property of the object.
+    When send read requests with returnClusterObject=True, we will set the data_version property of the object.
     Otherwise the [endpoint][cluster][Clusters.DataVersion] will be set to the DataVersion of the cluster.
+
+    For data_version, we do not make it a real property so we can distinguish it with real attributes internally,
+    especially the TLV decoding logic. Also ThreadNetworkDiagnostics has an attribute with the same name so we
+    picked data_version as its name.
     '''
-    @ChipUtility.classproperty
-    def dataVersion(self) -> int:
-        return self._dataVersion
+    @property
+    def data_version(self) -> int:
+        return self._data_version
+
+    def __rich_repr__(self):
+        '''
+        Override the default behavior of rich.pretty.pprint for adding the cluster data version.
+        '''
+        if self._data_version is not None:
+            yield "(data version)", self.data_version
+        for k in self.__dataclass_fields__.keys():
+            if k in self.__dict__:
+                yield k, self.__dict__[k]
 
     def SetDataVersion(self, version: int) -> None:
-        self._dataVersion = version
+        self._data_version = version
 
 
 class ClusterAttributeDescriptor:


### PR DESCRIPTION
#### Problem
When printing the values from ReadAttributes() in repl, data version is not included. 

#### Change overview
Implement __rich_repr__  for adding an extra data version output

#### Testing

```
In [1]: res = await devCtrl.ReadAttribute(
   ...:     nodeid=233, attributes=[(Clusters.Descriptor)], returnClusterObject=True
   ...: )

In [2]: res
Out[2]: 
{
│   0: {
│   │   <class 'chip.clusters.Objects.Descriptor'>: Descriptor(
│   │   │   (data version)=923884270,
...
```
