### PR TITLE
[events] Refactor startup and shutdown event management

### DIFF
--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -22,6 +22,7 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/DataModelRevision.h>
 #include <app/EventLogging.h>
+#include <app/InteractionModelEngine.h>
 #include <app/util/attribute-storage.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/ConfigurationManager.h>
@@ -329,10 +330,10 @@ CHIP_ERROR BasicAttrAccess::WriteLocation(AttributeValueDecoder & aDecoder)
 
 class PlatformMgrDelegate : public DeviceLayer::PlatformManagerDelegate
 {
-    // Gets called by the current Node after completing a boot or reboot process
     void OnStartUp(uint32_t softwareVersion) override
     {
-        ChipLogProgress(Zcl, "PlatformMgrDelegate: OnStartUp");
+        // The StartUp event SHALL be emitted by a Node after completing a boot or reboot process
+        ChipLogDetail(Zcl, "Emitting StartUp event");
 
         for (auto endpoint : EnabledEndpointsWithServerCluster(Basic::Id))
         {
@@ -343,15 +344,15 @@ class PlatformMgrDelegate : public DeviceLayer::PlatformManagerDelegate
             CHIP_ERROR err = LogEvent(event, endpoint, eventNumber, EventOptions::Type::kUrgent);
             if (CHIP_NO_ERROR != err)
             {
-                ChipLogError(Zcl, "PlatformMgrDelegate: Failed to record StartUp event: %" CHIP_ERROR_FORMAT, err.Format());
+                ChipLogError(Zcl, "Failed to emit StartUp event: %" CHIP_ERROR_FORMAT, err.Format());
             }
         }
     }
 
-    // Gets called by the current Node prior to any orderly shutdown sequence on a best-effort basis.
     void OnShutDown() override
     {
-        ChipLogProgress(Zcl, "PlatformMgrDelegate: OnShutDown");
+        // The ShutDown event SHOULD be emitted on a best-effort basis by a Node prior to any orderly shutdown sequence.
+        ChipLogDetail(Zcl, "Emitting ShutDown event");
 
         for (auto endpoint : EnabledEndpointsWithServerCluster(Basic::Id))
         {
@@ -362,9 +363,12 @@ class PlatformMgrDelegate : public DeviceLayer::PlatformManagerDelegate
             CHIP_ERROR err = LogEvent(event, endpoint, eventNumber, EventOptions::Type::kUrgent);
             if (CHIP_NO_ERROR != err)
             {
-                ChipLogError(Zcl, "PlatformMgrDelegate: Failed to record ShutDown event: %" CHIP_ERROR_FORMAT, err.Format());
+                ChipLogError(Zcl, "Failed to emit ShutDown event: %" CHIP_ERROR_FORMAT, err.Format());
             }
         }
+
+        // Flush the events to increase chances that they get sent before the shutdown
+        InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleUrgentEventDeliverySync();
     }
 };
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -104,8 +104,6 @@ public:
 
     void ScheduleFactoryReset();
 
-    static void FactoryReset(intptr_t arg);
-
     static Server & GetInstance() { return sServer; }
 
 private:

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -118,6 +118,18 @@ public:
     PlatformManagerDelegate * GetDelegate() const { return mDelegate; }
 
     /**
+     * Should be called after initializing all layers of the Matter stack to
+     * run all needed post-startup actions.
+     */
+    void HandleServerStarted();
+
+    /**
+     * Should be called before shutting down the Matter stack or restarting the
+     * application to run all needed pre-shutdown actions.
+     */
+    void HandleServerShuttingDown();
+
+    /**
      * ScheduleWork can be called after InitChipStack has been called.  Calls
      * that happen before either StartEventLoopTask or RunEventLoop will queue
      * the work up but that work will NOT run until one of those functions is
@@ -340,6 +352,16 @@ inline CHIP_ERROR PlatformManager::AddEventHandler(EventHandlerFunct handler, in
 inline void PlatformManager::RemoveEventHandler(EventHandlerFunct handler, intptr_t arg)
 {
     static_cast<ImplClass *>(this)->_RemoveEventHandler(handler, arg);
+}
+
+inline void PlatformManager::HandleServerStarted()
+{
+    static_cast<ImplClass *>(this)->_HandleServerStarted();
+}
+
+inline void PlatformManager::HandleServerShuttingDown()
+{
+    static_cast<ImplClass *>(this)->_HandleServerShuttingDown();
 }
 
 inline void PlatformManager::ScheduleWork(AsyncWorkFunct workFunct, intptr_t arg)

--- a/src/include/platform/internal/GenericPlatformManagerImpl.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.h
@@ -55,6 +55,8 @@ protected:
     CHIP_ERROR _Shutdown();
     CHIP_ERROR _AddEventHandler(PlatformManager::EventHandlerFunct handler, intptr_t arg);
     void _RemoveEventHandler(PlatformManager::EventHandlerFunct handler, intptr_t arg);
+    void _HandleServerStarted();
+    void _HandleServerShuttingDown();
     void _ScheduleWork(AsyncWorkFunct workFunct, intptr_t arg);
     void _DispatchEvent(const ChipDeviceEvent * event);
 
@@ -78,7 +80,6 @@ protected:
 private:
     bool mMsgLayerWasActive;
 
-    static void HandleDeviceRebooted(intptr_t arg);
     ImplClass * Impl() { return static_cast<ImplClass *>(this); }
 };
 

--- a/src/platform/fake/PlatformManagerImpl.h
+++ b/src/platform/fake/PlatformManagerImpl.h
@@ -49,6 +49,8 @@ private:
 
     CHIP_ERROR _AddEventHandler(EventHandlerFunct handler, intptr_t arg = 0) { return CHIP_ERROR_NOT_IMPLEMENTED; }
     void _RemoveEventHandler(EventHandlerFunct handler, intptr_t arg = 0) {}
+    void _HandleServerStarted() {}
+    void _HandleServerShuttingDown() {}
     void _ScheduleWork(AsyncWorkFunct workFunct, intptr_t arg = 0) {}
 
     void _RunEventLoop()

--- a/src/platform/nrfconnect/CHIPDevicePlatformConfig.h
+++ b/src/platform/nrfconnect/CHIPDevicePlatformConfig.h
@@ -67,6 +67,12 @@
 #define CHIP_DEVICE_CONFIG_OTA_REQUESTOR_REBOOT_DELAY_MS 1000
 #endif // CHIP_DEVICE_CONFIG_OTA_REQUESTOR_REBOOT_DELAY_MS
 
+#ifndef CHIP_DEVICE_CONFIG_SERVER_SHUTDOWN_ACTIONS_SLEEP_MS
+/// Time to sleep after running server shutdown actions to let lower layers complete the actions.
+/// This may include transmitting packets created by the actions.
+#define CHIP_DEVICE_CONFIG_SERVER_SHUTDOWN_ACTIONS_SLEEP_MS 10
+#endif // CHIP_DEVICE_CONFIG_SERVER_SHUTDOWN_ACTIONS_SLEEP_MS
+
 // ========== Platform-specific Configuration Overrides =========
 
 #ifndef CHIP_DEVICE_CONFIG_CHIP_TASK_PRIORITY


### PR DESCRIPTION
#### Problem
Basic cluster's StartUp event may no be generated if an application doesn't follow a specific initialization order (see #15295)
Basic cluster's ShutDown event is not generated when restarting the device after applying a firmware upgrade.

#### Change overview
* Add `PlatformMgr().HandleServerStarted()` to handle post-init actions, such as emitting StartUp and BootReason events and
call it explicitly inside Server::Init not to rely on any specific Matter stack initialization mechanism.
* Add PlatformMgr().HandleServerShuttingDown() to handle pre-shutdown actions, such as emitting Shutdown event. Use
the method in the existing factory reset sequence, and in nRF Connect OTA image processor (other platforms should
probably be updated, too).

#### Testing
Tested that both StartUp and ShutDown events are generated properly on nRF connect examples.

Fixes #15295