### PR TITLE
[chip-tool] Cancel the CHIPCallbacks when the chip-tool ends up to av…

### DIFF
--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -49,6 +49,12 @@ public:
         return CHIP_ERROR_BAD_REQUEST;
     };
 
+    void Shutdown() override
+    {
+        mOnDeviceConnectedCallback.Cancel();
+        mOnDeviceConnectionFailureCallback.Cancel();
+    }
+
 private:
     chip::NodeId mNodeId;
     std::vector<chip::EndpointId> mEndPointId;


### PR DESCRIPTION
…oid a use-after-free if there is a timeout trying to get the device

#### Problem

Running the command `./out/debug/standalone/chip-tool basic subscribe node-label 0 100 0 0x12344321 0` where `0x12344321` is not a known node id ends up into a `use-after-free`.

#### Change overview
* Manually cancels the callbacks
