### PR TITLE
Do not checkout submodules when spell checking

### DIFF
--- a/.github/workflows/spell.yml
+++ b/.github/workflows/spell.yml
@@ -47,7 +47,6 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000

--- a/src/lib/address_resolve/README.md
+++ b/src/lib/address_resolve/README.md
@@ -10,5 +10,5 @@ addresses due to:
 
 The purpose of address resolution is to find a _single_ ip address to use for
 the given lookup. It employs a set of heuristics to determine what the best IP
-(the more likely to route correctly) is and allows custom implementations from
+(the most likely to route correctly) is and allows custom implementations from
 applications by not including the default implementation.


### PR DESCRIPTION
#### Problem
Spell check checkout is slow because it pulls submodules. There is not need to spellcheck submodules.

#### Change overview
Do not checkout submodules when running spellchecker

#### Testing
CI will validate (it will run spellcheck).