### PR TITLE
[asan] heap-buffer-overflow if the txt record does not contains an = …

### DIFF
--- a/src/lib/dnssd/minimal_mdns/RecordData.cpp
+++ b/src/lib/dnssd/minimal_mdns/RecordData.cpp
@@ -18,6 +18,7 @@
 #include "RecordData.h"
 
 #include <inet/arpa-inet-compatibility.h>
+#include <stdio.h>
 
 namespace mdns {
 namespace Minimal {
@@ -36,25 +37,30 @@ bool ParseTxtRecord(const BytesRange & data, TxtRecordDelegate * callback)
         {
             return false;
         }
-        pos++;
 
         // name=value string of size length
-        const uint8_t * equalPos = pos;
-        while ((*equalPos != '=') && ((equalPos - pos) < length))
+        const uint8_t * equalPos = pos + 1;
+        while (((equalPos - pos) < length) && (*equalPos != '='))
         {
             equalPos++;
         }
 
-        if (pos + length == equalPos)
+        if (pos + length == equalPos && *equalPos == '=')
         {
-            callback->OnRecord(BytesRange(pos, equalPos), BytesRange());
+            // If there is an '=' sign with an empty value, just ignore it and position the end cursor directly onto
+            // the position of the '='
+            callback->OnRecord(BytesRange(pos + 1, equalPos), BytesRange());
+        }
+        else if (pos + length == equalPos && *equalPos != '=')
+        {
+            callback->OnRecord(BytesRange(pos + 1, equalPos + 1), BytesRange());
         }
         else
         {
-            callback->OnRecord(BytesRange(pos, equalPos), BytesRange(equalPos + 1, pos + length));
+            callback->OnRecord(BytesRange(pos + 1, equalPos), BytesRange(equalPos + 1, pos + 1 + length));
         }
 
-        pos += length;
+        pos += 1 + length;
     }
 
     return pos == data.End();


### PR DESCRIPTION
#### Problem

```
AddressSanitizer: heap-buffer-overflow on address 0x616000055a86 at pc 0x00010b77948e bp 0x7000025dc050 sp 0x7000025dc048

#0 0x10b77948d in mdns::Minimal::ParseTxtRecord(mdns::Minimal::BytesRange const&, mdns::Minimal::TxtRecordDelegate*) RecordData.cpp:45
#1 0x10b76e301 in chip::Dnssd::(anonymous namespace)::PacketDataReporter::OnResource(mdns::Minimal::ResourceType, mdns::Minimal::ResourceData const&) Resolver_ImplMinimalMdns.cpp:269
#2 0x10b7780f1 in mdns::Minimal::ParsePacket(mdns::Minimal::BytesRange const&, mdns::Minimal::ParserDelegate*) Parser.cpp:200
#3 0x10b7643fe in chip::Dnssd::(anonymous namespace)::MinMdnsResolver::OnMdnsPacketData(mdns::Minimal::BytesRange const&, chip::Inet::IPPacketInfo const*) Resolver_ImplMinimalMdns.cpp:417
#4 0x10b75f67c in chip::Dnssd::GlobalMinimalMdnsServer::OnResponse(mdns::Minimal::BytesRange const&, chip::Inet::IPPacketInfo const*) MinimalMdnsServer.h:113
#5 0x10b784c17 in mdns::Minimal::ServerBase::OnUdpPacketReceived(chip::Inet::UDPEndPoint*, chip::System::PacketBufferHandle&&, chip::Inet::IPPacketInfo const*) Server.cpp:428
#6 0x10b42fdd9 in chip::Inet::UDPEndPointImplSockets::HandlePendingIO(chip::BitFlags<chip::System::SocketEventFlags, unsigned char>) UDPEndPointImplSockets.cpp:688
#7 0x10b42dec2 in invocation function for block in chip::Inet::UDPEndPointImplSockets::BindImpl(chip::Inet::IPAddressType, chip::Inet::IPAddress const&, unsigned short, chip::Inet::InterfaceId) UDPEndPointImplSockets.cpp:218
#8 0x10f78ec4a in __wrap_dispatch_source_set_event_handler_block_invoke+0xca (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x47c4a)
#9 0x7fff20262805 in _dispatch_client_callout+0x7 (libdispatch.dylib:x86_64+0x3805)
#10 0x7fff202651af in _dispatch_continuation_pop+0x1a6 (libdispatch.dylib:x86_64+0x61af)
#11 0x7fff20275563 in _dispatch_source_invoke+0x80c (libdispatch.dylib:x86_64+0x16563)
#12 0x7fff20268492 in _dispatch_lane_serial_drain+0x106 (libdispatch.dylib:x86_64+0x9492)
#13 0x7fff202690ac in _dispatch_lane_invoke+0x16d (libdispatch.dylib:x86_64+0xa0ac)
#14 0x7fff20272c0c in _dispatch_workloop_worker_thread+0x32a (libdispatch.dylib:x86_64+0x13c0c)
#15 0x7fff2040945c in _pthread_wqthread+0x139 (libsystem_pthread.dylib:x86_64+0x345c)
#16 0x7fff2040842e in start_wqthread+0xe (libsystem_pthread.dylib:x86_64+0x242e)
```

#### Change overview

Make sure to not read past the buffer

#### Testing
It does happens randomly for me, but I got got reproducibility using: ```./scripts/tests/run_test_suite.py --chip-tool out/debug/standalone/chip-tool --target TestMultiAdmin --log-level debug run --iterations 10```