### PR TITLE
[Android] Fix CHIPTool cluster cmds fail or app crashes (Issue #15637).

### DIFF
--- a/src/platform/android/DnssdImpl.cpp
+++ b/src/platform/android/DnssdImpl.cpp
@@ -44,7 +44,7 @@ jmethodID sPublishMethod        = nullptr;
 jmethodID sRemoveServicesMethod = nullptr;
 } // namespace
 
-// Implemention of functions declared in lib/dnssd/platform/Dnssd.h
+// Implementation of functions declared in lib/dnssd/platform/Dnssd.h
 
 CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context)
 {

--- a/src/platform/android/DnssdImpl.cpp
+++ b/src/platform/android/DnssdImpl.cpp
@@ -223,7 +223,11 @@ void HandleResolve(jstring instanceName, jstring serviceType, jstring address, j
         callback(reinterpret_cast<void *>(contextHandle), service, Span<Inet::IPAddress>(), error);
     };
 
+<<<<<<< HEAD
     VerifyOrReturn(address != nullptr && port != 0, dispatch(CHIP_ERROR_UNKNOWN_RESOURCE_ID));
+=======
+    VerifyOrReturn(!(address == nullptr || port == 0), dispatch(CHIP_ERROR_UNKNOWN_RESOURCE_ID));
+>>>>>>> 668bb4657 ([Android] Fix expression in verification instead of commenting out the verification.)
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     JniUtfString jniInstanceName(env, instanceName);

--- a/src/platform/android/DnssdImpl.cpp
+++ b/src/platform/android/DnssdImpl.cpp
@@ -223,11 +223,7 @@ void HandleResolve(jstring instanceName, jstring serviceType, jstring address, j
         callback(reinterpret_cast<void *>(contextHandle), service, Span<Inet::IPAddress>(), error);
     };
 
-<<<<<<< HEAD
     VerifyOrReturn(address != nullptr && port != 0, dispatch(CHIP_ERROR_UNKNOWN_RESOURCE_ID));
-=======
-    VerifyOrReturn(!(address == nullptr || port == 0), dispatch(CHIP_ERROR_UNKNOWN_RESOURCE_ID));
->>>>>>> 668bb4657 ([Android] Fix expression in verification instead of commenting out the verification.)
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     JniUtfString jniInstanceName(env, instanceName);

--- a/src/platform/android/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/android/KeyValueStoreManagerImpl.cpp
@@ -120,7 +120,8 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
         ChipLogError(DeviceLayer, "KeyValueStoreManager base64 decoding failed");
         return CHIP_ERROR_INTEGRITY_CHECK_FAILED;
     }
-    ReturnErrorCodeIf(offset_bytes >= decodedLength, CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnErrorCodeIf(offset_bytes != 0 && offset_bytes >= decodedLength,
+                      CHIP_ERROR_INVALID_ARGUMENT);
     size_t read_size = std::min<size_t>(value_size, decodedLength - offset_bytes);
     if (value_size + offset_bytes < decodedLength)
     {

--- a/src/platform/android/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/android/KeyValueStoreManagerImpl.cpp
@@ -120,8 +120,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
         ChipLogError(DeviceLayer, "KeyValueStoreManager base64 decoding failed");
         return CHIP_ERROR_INTEGRITY_CHECK_FAILED;
     }
-    ReturnErrorCodeIf(offset_bytes != 0 && offset_bytes >= decodedLength,
-                      CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnErrorCodeIf(offset_bytes != 0 && offset_bytes >= decodedLength, CHIP_ERROR_INVALID_ARGUMENT);
     size_t read_size = std::min<size_t>(value_size, decodedLength - offset_bytes);
     if (value_size + offset_bytes < decodedLength)
     {


### PR DESCRIPTION
#### Problem
* Fixes #15637 Android CHIPTool app fails or crashes when calling cluster cmds.

#### Change overview
* Ignore `offset_bytes >= decodedLength` check if `offset_bytes` is zero.
* Skip verification of `address != nullptr` and `port != 0` when "PROVISIONING CHIP DEVICE WITH WI-FI" as the verification gets called multiple times during provisioning. 

#### Testing
How was this tested? (at least one bullet point required)
* Tested on Pixel phone provisioning an ESP32 device.
* Tested to reproduce the crashes / fail provisioning first.
* Then applied changes and tested that:
* provisioning succeeded, 
* device as commissioned with WiFi details 
* "LIGHT ON/OFF & LEVEL CLUSTER" part of the Android app was able to turn the ESP32 light ON, OFF, TOGGLE and READ
* "SENSOR CLUSTERS" part of the Android app was able to read the temperature from the ESP32
