### PR TITLE
Updated Fabric ID Validation in Fabric Table

### DIFF
--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -1013,7 +1013,7 @@ CHIP_ERROR ExtractNodeIdFabricIdFromOpCert(const ChipCertificateData & opcert, N
     }
     if (!foundNodeId || !foundFabricId)
     {
-        return CHIP_ERROR_INVALID_ARGUMENT;
+        return CHIP_ERROR_NOT_FOUND;
     }
 
     *outNodeId   = nodeId;
@@ -1054,7 +1054,7 @@ CHIP_ERROR ExtractFabricIdFromCert(const ChipCertificateData & cert, FabricId * 
         }
     }
 
-    return CHIP_ERROR_INVALID_ARGUMENT;
+    return CHIP_ERROR_NOT_FOUND;
 }
 
 CHIP_ERROR ExtractCATsFromOpCert(const ByteSpan & opcert, CATValues & cats)

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -781,7 +781,7 @@ CHIP_ERROR ConvertECDSASignatureDERToRaw(ASN1::ASN1Reader & reader, chip::TLV::T
  * These certificates may not contain a NodeID, so ExtractNodeIdFabricIdFromOpCert()
  * cannot be used for such certificates.
  *
- * @return CHIP_ERROR_INVALID_ARGUMENT if the passed-in cert does not have RDN
+ * @return CHIP_ERROR_NOT_FOUND if the passed-in cert does not have RDN
  * corresponding to FabricID.
  */
 CHIP_ERROR ExtractFabricIdFromCert(const ChipCertificateData & cert, FabricId * fabricId);
@@ -790,7 +790,7 @@ CHIP_ERROR ExtractFabricIdFromCert(const ChipCertificateData & cert, FabricId * 
  * Extract Node ID and Fabric ID from an operational certificate that has already been
  * parsed.
  *
- * @return CHIP_ERROR_INVALID_ARGUMENT if the passed-in cert does not have at
+ * @return CHIP_ERROR_NOT_FOUND if the passed-in cert does not have at
  * least one NodeId RDN and one FabricId RDN in the Subject DN.  No other
  * validation (e.g. checkign that there is exactly one RDN of each type) is
  * performed.

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -1196,7 +1196,7 @@ static void TestChipCert_ExtractNodeIdFabricId(nlTestSuite * inSuite, void * inC
 
         FabricId fabricId;
         err = ExtractFabricIdFromCert(cert, &fabricId);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NOT_FOUND);
     }
 
     // Test extraction from the parsed form of ICA Cert that doesn't have FabricId.
@@ -1209,7 +1209,7 @@ static void TestChipCert_ExtractNodeIdFabricId(nlTestSuite * inSuite, void * inC
 
         FabricId fabricId;
         err = ExtractFabricIdFromCert(certSet.GetCertSet()[0], &fabricId);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NOT_FOUND);
         certSet.Release();
     }
 }


### PR DESCRIPTION
#### Problem
#15892

This PR follows updates in #15829.

#### Change overview
  -- Updated logic that checks optional fabric id attribute in ICAC and RCAC to match
     fabric id attribute in NOC.
  -- According to spec there is no need to require fabric id in ICAC if it is present in RCAC.
  -- NOTE: validity check for NodeId, FabricId and other DN attributes is performed when
     loading certificates for validation (LoadCert()). So there is no need to check validity
     again in FabricInfo::VerifyCredentials().

  -- Changed return value of ExtractNodeIdFabricIdFromOpCert() and ExtractFabricIdFromCert()
     to CHIP_ERROR_NOT_FOUND when requested element is not found in the certificate.

#### Testing
Existing tests 