### PR TITLE
Make CHIPTool use wildcard subscriptions for the temperature sensor

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
@@ -200,22 +200,26 @@
     if (CHIPGetConnectedDevice(^(CHIPDevice * _Nullable chipDevice, NSError * _Nullable error) {
             if (chipDevice) {
                 // Use a wildcard subscription
-                [chipDevice subscribeWithQueue:dispatch_get_main_queue() minInterval:minIntervalSeconds maxInterval:maxIntervalSeconds reportHandler:^(NSArray<CHIPAttributeReport *> * _Nullable reports, NSError * _Nullable error) {
-                    if (error) {
-                        NSLog(@"Status: update reportAttributeMeasuredValue completed with error %@", [error description]);
-                        return;
-                    }
-                    for (CHIPAttributeReport * report in reports)
-                    {
-                        // These should be exposed by the SDK
-                        if ([report.path.cluster isEqualToNumber:@(1026)] && [report.path.attribute isEqualToNumber:@(0)])
-                        {
-                            [self updateTempInUI:((NSNumber *)report.value).shortValue];
-                        }
-                    }
-                } subscriptionEstablished:^{
+                [chipDevice subscribeWithQueue:dispatch_get_main_queue()
+                                   minInterval:minIntervalSeconds
+                                   maxInterval:maxIntervalSeconds
+                                 reportHandler:^(NSArray<CHIPAttributeReport *> * _Nullable reports, NSError * _Nullable error) {
+                                     if (error) {
+                                         NSLog(@"Status: update reportAttributeMeasuredValue completed with error %@",
+                                             [error description]);
+                                         return;
+                                     }
+                                     for (CHIPAttributeReport * report in reports) {
+                                         // These should be exposed by the SDK
+                                         if ([report.path.cluster isEqualToNumber:@(1026)] &&
+                                             [report.path.attribute isEqualToNumber:@(0)]) {
+                                             [self updateTempInUI:((NSNumber *) report.value).shortValue];
+                                         }
+                                     }
+                                 }
+                       subscriptionEstablished:^ {
 
-                }];
+                       }];
             } else {
                 NSLog(@"Status: Failed to establish a connection with the device");
             }

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
@@ -199,23 +199,23 @@
 
     if (CHIPGetConnectedDevice(^(CHIPDevice * _Nullable chipDevice, NSError * _Nullable error) {
             if (chipDevice) {
-                CHIPTemperatureMeasurement * cluster =
-                    [[CHIPTemperatureMeasurement alloc] initWithDevice:chipDevice endpoint:1 queue:dispatch_get_main_queue()];
-                CHIPSubscribeParams * params = [[CHIPSubscribeParams alloc] init];
-                params.keepPreviousSubscriptions = @YES;
-                [cluster subscribeAttributeMeasuredValueWithMinInterval:@(minIntervalSeconds)
-                                                            maxInterval:@(maxIntervalSeconds)
-                                                                 params:params
-                                                subscriptionEstablished:nil
-                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
-                                                              if (error) {
-                                                                  NSLog(@"Status: update reportAttributeMeasuredValue completed "
-                                                                        @"with error %@",
-                                                                      [error description]);
-                                                                  return;
-                                                              }
-                                                              [self updateTempInUI:value.shortValue];
-                                                          }];
+                // Use a wildcard subscription
+                [chipDevice subscribeWithQueue:dispatch_get_main_queue() minInterval:minIntervalSeconds maxInterval:maxIntervalSeconds reportHandler:^(NSArray<CHIPAttributeReport *> * _Nullable reports, NSError * _Nullable error) {
+                    if (error) {
+                        NSLog(@"Status: update reportAttributeMeasuredValue completed with error %@", [error description]);
+                        return;
+                    }
+                    for (CHIPAttributeReport * report in reports)
+                    {
+                        // These should be exposed by the SDK
+                        if ([report.path.cluster isEqualToNumber:@(1026)] && [report.path.attribute isEqualToNumber:@(0)])
+                        {
+                            [self updateTempInUI:((NSNumber *)report.value).shortValue];
+                        }
+                    }
+                } subscriptionEstablished:^{
+
+                }];
             } else {
                 NSLog(@"Status: Failed to establish a connection with the device");
             }


### PR DESCRIPTION
#### Problem
Wildcard subscriptions are cool (and untested).

#### Change overview
Use wildcard subscriptions for the temperature sensor view controller.

#### Testing
How was this tested? (at least one bullet point required)
Manually tested that the subscription gets established but immediately crashes. 
