### PR TITLE
Add non-generated IM dispatch to the Darwin framework.

### DIFF
--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -31,6 +31,7 @@
 #include <protocols/Protocols.h>
 #include <protocols/interaction_model/Constants.h>
 #include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
 
 namespace chip {
 namespace app {

--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -10,18 +10,6 @@
 		1E16A90226B98AB700683C53 /* CHIPTestClustersObjc.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1E16A8FA26B9835700683C53 /* CHIPTestClustersObjc.mm */; };
 		1E16A90326B98AF100683C53 /* CHIPTestClustersObjc.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E16A8F926B9835600683C53 /* CHIPTestClustersObjc.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1E85730C265519AE0050A4D9 /* callback-stub.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E857307265519AE0050A4D9 /* callback-stub.cpp */; };
-		1E857310265519AE0050A4D9 /* IMClusterCommandHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85730B265519AE0050A4D9 /* IMClusterCommandHandler.cpp */; };
-		1E85732226551A490050A4D9 /* binding-table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85731226551A490050A4D9 /* binding-table.cpp */; };
-		1E85732526551A490050A4D9 /* message.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85731526551A490050A4D9 /* message.cpp */; };
-		1E85732626551A490050A4D9 /* attribute-storage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85731626551A490050A4D9 /* attribute-storage.cpp */; };
-		1E85732726551A490050A4D9 /* client-api.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85731726551A490050A4D9 /* client-api.cpp */; };
-		1E85732826551A490050A4D9 /* attribute-table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85731826551A490050A4D9 /* attribute-table.cpp */; };
-		1E85732926551A490050A4D9 /* af-event.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85731926551A490050A4D9 /* af-event.cpp */; };
-		1E85732A26551A490050A4D9 /* ember-compatibility-functions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85731A26551A490050A4D9 /* ember-compatibility-functions.cpp */; };
-		1E85732C26551A490050A4D9 /* DataModelHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85731C26551A490050A4D9 /* DataModelHandler.cpp */; };
-		1E85732D26551A490050A4D9 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85731D26551A490050A4D9 /* util.cpp */; };
-		1E85732E26551A490050A4D9 /* ember-print.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85731E26551A490050A4D9 /* ember-print.cpp */; };
-		1E85732F26551A490050A4D9 /* attribute-size-util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85731F26551A490050A4D9 /* attribute-size-util.cpp */; };
 		1EB41B7B263C4CC60048E4C1 /* CHIPClustersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EB41B7A263C4CC60048E4C1 /* CHIPClustersTests.m */; };
 		1EC3238D271999E2002A8BF0 /* cluster-objects.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1EC3238C271999E2002A8BF0 /* cluster-objects.cpp */; };
 		1EC4CE5D25CC26E900D7304F /* CHIPClustersObjc.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1EC4CE5925CC26E900D7304F /* CHIPClustersObjc.mm */; };
@@ -47,6 +35,7 @@
 		5129BCFD26A9EE3300122DDF /* CHIPError.h in Headers */ = {isa = PBXBuildFile; fileRef = 5129BCFC26A9EE3300122DDF /* CHIPError.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		513DDB862761F69300DAA01A /* CHIPAttributeTLVValueDecoder_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 513DDB852761F69300DAA01A /* CHIPAttributeTLVValueDecoder_Internal.h */; };
 		513DDB8A2761F6F900DAA01A /* CHIPAttributeTLVValueDecoder.mm in Sources */ = {isa = PBXBuildFile; fileRef = 513DDB892761F6F900DAA01A /* CHIPAttributeTLVValueDecoder.mm */; };
+		51431AF927D2973E008A7943 /* CHIPIMDispatch.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51431AF827D2973E008A7943 /* CHIPIMDispatch.mm */; };
 		51431AFB27D29CA4008A7943 /* ota-provider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 51431AFA27D29CA4008A7943 /* ota-provider.cpp */; };
 		51B22C1E2740CB0A008D5055 /* CHIPStructsObjc.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B22C1D2740CB0A008D5055 /* CHIPStructsObjc.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		51B22C222740CB1D008D5055 /* CHIPCommandPayloadsObjc.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B22C212740CB1D008D5055 /* CHIPCommandPayloadsObjc.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -113,18 +102,6 @@
 		1E16A8F926B9835600683C53 /* CHIPTestClustersObjc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CHIPTestClustersObjc.h; path = "zap-generated/CHIPTestClustersObjc.h"; sourceTree = "<group>"; };
 		1E16A8FA26B9835700683C53 /* CHIPTestClustersObjc.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = CHIPTestClustersObjc.mm; path = "zap-generated/CHIPTestClustersObjc.mm"; sourceTree = "<group>"; };
 		1E857307265519AE0050A4D9 /* callback-stub.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "callback-stub.cpp"; path = "../../../../zzz_generated/controller-clusters/zap-generated/callback-stub.cpp"; sourceTree = "<group>"; };
-		1E85730B265519AE0050A4D9 /* IMClusterCommandHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IMClusterCommandHandler.cpp; path = "../../../../zzz_generated/controller-clusters/zap-generated/IMClusterCommandHandler.cpp"; sourceTree = "<group>"; };
-		1E85731226551A490050A4D9 /* binding-table.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "binding-table.cpp"; path = "../../../app/util/binding-table.cpp"; sourceTree = "<group>"; };
-		1E85731526551A490050A4D9 /* message.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = message.cpp; path = ../../../app/util/message.cpp; sourceTree = "<group>"; };
-		1E85731626551A490050A4D9 /* attribute-storage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "attribute-storage.cpp"; path = "../../../app/util/attribute-storage.cpp"; sourceTree = "<group>"; };
-		1E85731726551A490050A4D9 /* client-api.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "client-api.cpp"; path = "../../../app/util/client-api.cpp"; sourceTree = "<group>"; };
-		1E85731826551A490050A4D9 /* attribute-table.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "attribute-table.cpp"; path = "../../../app/util/attribute-table.cpp"; sourceTree = "<group>"; };
-		1E85731926551A490050A4D9 /* af-event.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "af-event.cpp"; path = "../../../app/util/af-event.cpp"; sourceTree = "<group>"; };
-		1E85731A26551A490050A4D9 /* ember-compatibility-functions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "ember-compatibility-functions.cpp"; path = "../../../app/util/ember-compatibility-functions.cpp"; sourceTree = "<group>"; };
-		1E85731C26551A490050A4D9 /* DataModelHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DataModelHandler.cpp; path = ../../../app/util/DataModelHandler.cpp; sourceTree = "<group>"; };
-		1E85731D26551A490050A4D9 /* util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = util.cpp; path = ../../../app/util/util.cpp; sourceTree = "<group>"; };
-		1E85731E26551A490050A4D9 /* ember-print.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "ember-print.cpp"; path = "../../../app/util/ember-print.cpp"; sourceTree = "<group>"; };
-		1E85731F26551A490050A4D9 /* attribute-size-util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "attribute-size-util.cpp"; path = "../../../app/util/attribute-size-util.cpp"; sourceTree = "<group>"; };
 		1EB41B7A263C4CC60048E4C1 /* CHIPClustersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CHIPClustersTests.m; sourceTree = "<group>"; };
 		1EC3238C271999E2002A8BF0 /* cluster-objects.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "cluster-objects.cpp"; path = "../../../../zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp"; sourceTree = "<group>"; };
 		1EC4CE5925CC26E900D7304F /* CHIPClustersObjc.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = CHIPClustersObjc.mm; path = "zap-generated/CHIPClustersObjc.mm"; sourceTree = "<group>"; };
@@ -150,6 +127,7 @@
 		5129BCFC26A9EE3300122DDF /* CHIPError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CHIPError.h; path = CHIP/CHIPError.h; sourceTree = "<group>"; };
 		513DDB852761F69300DAA01A /* CHIPAttributeTLVValueDecoder_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPAttributeTLVValueDecoder_Internal.h; sourceTree = "<group>"; };
 		513DDB892761F6F900DAA01A /* CHIPAttributeTLVValueDecoder.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = CHIPAttributeTLVValueDecoder.mm; path = "zap-generated/CHIPAttributeTLVValueDecoder.mm"; sourceTree = "<group>"; };
+		51431AF827D2973E008A7943 /* CHIPIMDispatch.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPIMDispatch.mm; sourceTree = "<group>"; };
 		51431AFA27D29CA4008A7943 /* ota-provider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "ota-provider.cpp"; path = "../../../app/clusters/ota-provider/ota-provider.cpp"; sourceTree = "<group>"; };
 		51B22C1D2740CB0A008D5055 /* CHIPStructsObjc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CHIPStructsObjc.h; path = "zap-generated/CHIPStructsObjc.h"; sourceTree = "<group>"; };
 		51B22C212740CB1D008D5055 /* CHIPCommandPayloadsObjc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CHIPCommandPayloadsObjc.h; path = "zap-generated/CHIPCommandPayloadsObjc.h"; sourceTree = "<group>"; };
@@ -232,17 +210,6 @@
 			children = (
 				2FD775542695557E00FF4B12 /* error-mapping.cpp */,
 				51431AFA27D29CA4008A7943 /* ota-provider.cpp */,
-				1E85731926551A490050A4D9 /* af-event.cpp */,
-				1E85731F26551A490050A4D9 /* attribute-size-util.cpp */,
-				1E85731626551A490050A4D9 /* attribute-storage.cpp */,
-				1E85731826551A490050A4D9 /* attribute-table.cpp */,
-				1E85731226551A490050A4D9 /* binding-table.cpp */,
-				1E85731726551A490050A4D9 /* client-api.cpp */,
-				1E85731C26551A490050A4D9 /* DataModelHandler.cpp */,
-				1E85731A26551A490050A4D9 /* ember-compatibility-functions.cpp */,
-				1E85731E26551A490050A4D9 /* ember-print.cpp */,
-				1E85731526551A490050A4D9 /* message.cpp */,
-				1E85731D26551A490050A4D9 /* util.cpp */,
 			);
 			name = CHIPApp;
 			sourceTree = "<group>";
@@ -260,7 +227,6 @@
 				1E16A8FA26B9835700683C53 /* CHIPTestClustersObjc.mm */,
 				1ED276DF26C57CF000547A89 /* CHIPCallbackBridge.mm */,
 				1E857307265519AE0050A4D9 /* callback-stub.cpp */,
-				1E85730B265519AE0050A4D9 /* IMClusterCommandHandler.cpp */,
 				1EC4CE6325CC276600D7304F /* CHIPClustersObjc.h */,
 				1EC4CE5925CC26E900D7304F /* CHIPClustersObjc.mm */,
 			);
@@ -295,6 +261,7 @@
 				1ED276E326C5832500547A89 /* CHIPCluster.h */,
 				1ED276E126C5812A00547A89 /* CHIPCluster.mm */,
 				2C5EEEF4268A85C400CAE3D3 /* CHIPDeviceConnectionBridge.h */,
+				51431AF827D2973E008A7943 /* CHIPIMDispatch.mm */,
 				2C5EEEF5268A85C400CAE3D3 /* CHIPDeviceConnectionBridge.mm */,
 				1E857311265519DE0050A4D9 /* CHIPApp */,
 				2C1B02792641DB4E00780EF1 /* CHIPOperationalCredentialsDelegate.h */,
@@ -548,7 +515,6 @@
 				998F287126D56940001846C6 /* CHIPP256KeypairBridge.mm in Sources */,
 				1E16A90226B98AB700683C53 /* CHIPTestClustersObjc.mm in Sources */,
 				51B22C2A2740CB47008D5055 /* CHIPCommandPayloadsObjc.mm in Sources */,
-				1E85732E26551A490050A4D9 /* ember-print.cpp in Sources */,
 				2C5EEEF7268A85C400CAE3D3 /* CHIPDeviceConnectionBridge.mm in Sources */,
 				51B22C262740CB32008D5055 /* CHIPStructsObjc.mm in Sources */,
 				2C222AD1255C620600E446B9 /* CHIPDevice.mm in Sources */,
@@ -556,34 +522,24 @@
 				991DC0892475F47D00C13860 /* CHIPDeviceController.mm in Sources */,
 				B2E0D7B7245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.mm in Sources */,
 				1EC4CE5D25CC26E900D7304F /* CHIPClustersObjc.mm in Sources */,
-				1E85732226551A490050A4D9 /* binding-table.cpp in Sources */,
 				1ED276E226C5812A00547A89 /* CHIPCluster.mm in Sources */,
-				1E85732526551A490050A4D9 /* message.cpp in Sources */,
 				B2E0D7B3245B0B5C003C5B48 /* CHIPError.mm in Sources */,
-				1E85732726551A490050A4D9 /* client-api.cpp in Sources */,
 				1E85730C265519AE0050A4D9 /* callback-stub.cpp in Sources */,
-				1E857310265519AE0050A4D9 /* IMClusterCommandHandler.cpp in Sources */,
 				1ED276E026C57CF000547A89 /* CHIPCallbackBridge.mm in Sources */,
 				5A6FEC9627B5983000F25F42 /* CHIPDeviceControllerXPCConnection.m in Sources */,
-				1E85732D26551A490050A4D9 /* util.cpp in Sources */,
 				5ACDDD7D27CD16D200EFD68A /* CHIPAttributeCacheContainer.mm in Sources */,
 				513DDB8A2761F6F900DAA01A /* CHIPAttributeTLVValueDecoder.mm in Sources */,
 				2FD775552695557E00FF4B12 /* error-mapping.cpp in Sources */,
 				5A7947E427C0129600434CF2 /* CHIPDeviceController+XPC.m in Sources */,
 				5A6FEC9027B563D900F25F42 /* CHIPDeviceControllerOverXPC.m in Sources */,
-				1E85732A26551A490050A4D9 /* ember-compatibility-functions.cpp in Sources */,
 				B289D4222639C0D300D4E314 /* CHIPOnboardingPayloadParser.m in Sources */,
-				1E85732F26551A490050A4D9 /* attribute-size-util.cpp in Sources */,
 				2C1B027A2641DB4E00780EF1 /* CHIPOperationalCredentialsDelegate.mm in Sources */,
-				1E85732926551A490050A4D9 /* af-event.cpp in Sources */,
 				B2E0D7B9245B0B5C003C5B48 /* CHIPSetupPayload.mm in Sources */,
 				B2E0D7B6245B0B5C003C5B48 /* CHIPManualSetupPayloadParser.mm in Sources */,
 				5A6FEC9827B5C6AF00F25F42 /* CHIPDeviceOverXPC.m in Sources */,
-				1E85732826551A490050A4D9 /* attribute-table.cpp in Sources */,
+				51431AF927D2973E008A7943 /* CHIPIMDispatch.mm in Sources */,
 				5A830D6E27CFCFF90053B85D /* CHIPDeviceControllerOverXPC+AttributeCache.m in Sources */,
 				51431AFB27D29CA4008A7943 /* ota-provider.cpp in Sources */,
-				1E85732626551A490050A4D9 /* attribute-storage.cpp in Sources */,
-				1E85732C26551A490050A4D9 /* DataModelHandler.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/darwin/Framework/CHIP/CHIPIMDispatch.mm
+++ b/src/darwin/Framework/CHIP/CHIPIMDispatch.mm
@@ -1,0 +1,284 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#import <Foundation/Foundation.h>
+
+#include <access/SubjectDescriptor.h>
+#include <app-common/zap-generated/att-storage.h>
+#include <app-common/zap-generated/callback.h>
+#include <app-common/zap-generated/cluster-objects.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app-common/zap-generated/ids/Commands.h>
+#include <app/AttributeAccessInterface.h>
+#include <app/CommandHandler.h>
+#include <app/ConcreteAttributePath.h>
+#include <app/ConcreteCommandPath.h>
+#include <app/MessageDef/AttributeReportIBs.h>
+#include <app/MessageDef/StatusIB.h>
+#include <app/WriteHandler.h>
+#include <app/data-model/Decode.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/CHIPTLV.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/core/Optional.h>
+#include <protocols/interaction_model/Constants.h>
+
+/**
+ * This file defines the APIs needed to handle interaction model dispatch.
+ * These are the APIs normally defined in
+ * src/app/util/ember-compatibility-functions.cpp and the generated
+ * IMClusterCommandHandler.cpp but we want a different implementation of these
+ * to enable more dynamic behavior, since not all framework consumers will be
+ * implementing the same server clusters.
+ */
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+
+namespace {
+
+// TODO: Maybe consider making this configurable?
+constexpr EndpointId kSupportedEndpoint = 0;
+
+} // anonymous namespace
+
+namespace chip {
+namespace app {
+
+    using Protocols::InteractionModel::Status;
+    using Access::SubjectDescriptor;
+
+    namespace {
+
+        Status DetermineAttributeStatus(const ConcreteAttributePath & aPath, bool aIsWrite)
+        {
+            // We don't have any non-global attributes.
+            using namespace Globals::Attributes;
+
+            // TODO: Consider making this configurable for applications that are not
+            // trying to be an OTA provider, though in practice it just affects which
+            // error is returned.
+            if (aPath.mEndpointId != kSupportedEndpoint) {
+                return Status::UnsupportedEndpoint;
+            }
+
+            // TODO: Consider making this configurable for applications that are not
+            // trying to be an OTA provider, though in practice it just affects which
+            // error is returned.
+            if (aPath.mClusterId != OtaSoftwareUpdateProvider::Id) {
+                return Status::UnsupportedCluster;
+            }
+
+            switch (aPath.mAttributeId) {
+            case AttributeList::Id:
+                FALLTHROUGH;
+            case ClientGeneratedCommandList::Id:
+                FALLTHROUGH;
+            case ServerGeneratedCommandList::Id:
+                FALLTHROUGH;
+                // When EventList is supported, include it here.
+#if 0
+    case EventList::Id:
+        FALLTHROUGH;
+#endif
+            case FeatureMap::Id:
+                FALLTHROUGH;
+            case ClusterRevision::Id:
+                // No permissions for this for read, and none of these are writable for
+                // write.  The writable-or-not check happens before the ACL check.
+                return aIsWrite ? Status::UnsupportedWrite : Status::UnsupportedAccess;
+            default:
+                // No other attributes.
+                break;
+            }
+
+            return Status::UnsupportedAttribute;
+        }
+
+    } // anonymous namespace
+
+    CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, bool aIsFabricFiltered,
+        const ConcreteReadAttributePath & aPath, AttributeReportIBs::Builder & aAttributeReports,
+        AttributeValueEncoder::AttributeEncodeState * aEncoderState)
+    {
+        Status status = DetermineAttributeStatus(aPath, /* aIsWrite = */ false);
+        return aAttributeReports.EncodeAttributeStatus(aPath, StatusIB(status));
+    }
+
+    Status ServerClusterCommandExists(const ConcreteCommandPath & aPath)
+    {
+        // TODO: Consider making this configurable for applications that are not
+        // trying to be an OTA provider.
+        using namespace OtaSoftwareUpdateProvider::Commands;
+
+        if (aPath.mEndpointId != kSupportedEndpoint) {
+            return Status::UnsupportedEndpoint;
+        }
+
+        if (aPath.mClusterId != OtaSoftwareUpdateProvider::Id) {
+            return Status::UnsupportedCluster;
+        }
+
+        switch (aPath.mCommandId) {
+        case QueryImage::Id:
+            FALLTHROUGH;
+        case ApplyUpdateRequest::Id:
+            FALLTHROUGH;
+        case NotifyUpdateApplied::Id:
+            return Status::Success;
+        }
+
+        return Status::UnsupportedCommand;
+    }
+
+    bool IsClusterDataVersionEqual(const ConcreteClusterPath & aConcreteClusterPath, DataVersion aRequiredVersion)
+    {
+        // Will never be called anyway; we have no attributes.
+        return false;
+    }
+
+    CHIP_ERROR WriteSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, const ConcreteDataAttributePath & aPath,
+        TLV::TLVReader & aReader, WriteHandler * aWriteHandler)
+    {
+        Status status = DetermineAttributeStatus(aPath, /* aIsWrite = */ true);
+        return aWriteHandler->AddStatus(aPath, status);
+    }
+
+    void DispatchSingleClusterCommand(const ConcreteCommandPath & aPath, TLV::TLVReader & aReader, CommandHandler * aCommandObj)
+    {
+        // This command passed ServerClusterCommandExists so we know it's one of our
+        // supported commands.
+        using namespace OtaSoftwareUpdateProvider::Commands;
+
+        bool wasHandled = false;
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        switch (aPath.mCommandId) {
+        case QueryImage::Id: {
+            QueryImage::DecodableType commandData;
+            err = DataModel::Decode(aReader, commandData);
+            if (err == CHIP_NO_ERROR) {
+                wasHandled = emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(aCommandObj, aPath, commandData);
+            }
+            break;
+        }
+        case ApplyUpdateRequest::Id: {
+            ApplyUpdateRequest::DecodableType commandData;
+            err = DataModel::Decode(aReader, commandData);
+            if (err == CHIP_NO_ERROR) {
+                wasHandled = emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestCallback(aCommandObj, aPath, commandData);
+            }
+            break;
+        }
+        case NotifyUpdateApplied::Id: {
+            NotifyUpdateApplied::DecodableType commandData;
+            err = DataModel::Decode(aReader, commandData);
+            if (err == CHIP_NO_ERROR) {
+                wasHandled = emberAfOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedCallback(aCommandObj, aPath, commandData);
+            }
+            break;
+        }
+        default:
+            break;
+        }
+
+        if (CHIP_NO_ERROR != err || !wasHandled) {
+            aCommandObj->AddStatus(aPath, Status::InvalidCommand);
+        }
+    }
+
+} // namespace app
+} // namespace chip
+
+/**
+ * Called by the OTA provider cluster server to determine an index
+ * into its array.
+ */
+uint16_t emberAfFindClusterServerEndpointIndex(EndpointId endpoint, ClusterId clusterId)
+{
+    if (endpoint == kSupportedEndpoint && clusterId == OtaSoftwareUpdateProvider::Id) {
+        return 0;
+    }
+
+    return UINT16_MAX;
+}
+
+/**
+ * Methods used by AttributePathExpandIterator, which need to exist
+ * because it is part of libCHIP.  For AttributePathExpandIterator
+ * purposes, for now, we just pretend like we have just our one
+ * endpoint, the OTA Provider cluster, and no attributes (because we
+ * would be erroring out from them anyway).
+ */
+uint16_t emberAfGetServerAttributeCount(EndpointId endpoint, ClusterId cluster) { return 0; }
+
+uint16_t emberAfEndpointCount(void) { return 1; }
+
+uint16_t emberAfIndexFromEndpoint(EndpointId endpoint)
+{
+    if (endpoint == kSupportedEndpoint) {
+        return 0;
+    }
+
+    return UINT16_MAX;
+}
+
+EndpointId emberAfEndpointFromIndex(uint16_t index)
+{
+    // Index must be valid here, so 0.
+    return kSupportedEndpoint;
+}
+
+Optional<ClusterId> emberAfGetNthClusterId(EndpointId endpoint, uint8_t n, bool server)
+{
+    if (endpoint == kSupportedEndpoint && n == 0 && server) {
+        return MakeOptional(OtaSoftwareUpdateProvider::Id);
+    }
+
+    return NullOptional;
+}
+
+uint16_t emberAfGetServerAttributeIndexByAttributeId(EndpointId endpoint, ClusterId cluster, AttributeId attributeId)
+{
+    return UINT16_MAX;
+}
+
+uint8_t emberAfClusterCount(EndpointId endpoint, bool server)
+{
+    if (endpoint == kSupportedEndpoint && server) {
+        return 1;
+    }
+
+    return 0;
+}
+
+Optional<AttributeId> emberAfGetServerAttributeIdByIndex(EndpointId endpoint, ClusterId cluster, uint16_t attributeIndex)
+{
+    return NullOptional;
+}
+
+uint8_t emberAfClusterIndex(EndpointId endpoint, ClusterId clusterId, EmberAfClusterMask mask)
+{
+    if (endpoint == kSupportedEndpoint && clusterId == OtaSoftwareUpdateProvider::Id && (mask & CLUSTER_MASK_SERVER)) {
+        return 0;
+    }
+
+    return UINT8_MAX;
+}
+
+bool emberAfEndpointIndexIsEnabled(uint16_t index) { return index == 0; }


### PR DESCRIPTION
#### Problem
We will want different framework consumers to have different server clusters "exposed", so want to do dynamic dispatch, not codegen-based static dispatch.

#### Change overview
Switch the way incoming IM messages are dispatched when using the Darwin framework.

#### Testing
Not tested yet.  Still sorting out how to get a framework-based application to respond to CASE Sigma1 messages.