### PR TITLE
Issue #15935 [ota-requestor] Cancel the TransferTimeout timer when QueryImage download succeeds or aborts

### DIFF
--- a/src/app/clusters/ota-requestor/BDXDownloader.cpp
+++ b/src/app/clusters/ota-requestor/BDXDownloader.cpp
@@ -61,7 +61,7 @@ System::Clock::Timeout BDXDownloader::GetTimeout()
 void BDXDownloader::Reset()
 {
     mPrevBlockCounter = 0;
-    DeviceLayer::SystemLayer().StartTimer(mTimeout, TransferTimeoutCheckHandler, this);
+    DeviceLayer::SystemLayer().CancelTimer(TransferTimeoutCheckHandler, this);
 }
 
 bool BDXDownloader::HasTransferTimedOut()


### PR DESCRIPTION
#### Problem
After a successful QueryImage download, the TransferTimeout timer isn't canceled.

Fixes: https://github.com/project-chip/connectedhomeip/issues/15935

#### Change overview
Upon QueryImage download success or abort due to failure, cancel the TransferTimeout timer.

#### Testing
After successful QueryImage download, let the Requestor app run for at least 10+ minutes to make sure the TransferTimeout timer doesn't run again and detect a false timeout.
