### PR TITLE
[OTA] Tear down CASE session during a timeout error

### DIFF
--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -184,7 +184,14 @@ void OTARequestor::OnQueryImageFailure(void * context, CHIP_ERROR error)
     OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
-    ChipLogDetail(SoftwareUpdate, "QueryImage failure response %" CHIP_ERROR_FORMAT, error.Format());
+    ChipLogError(SoftwareUpdate, "Received QueryImage failure response: %" CHIP_ERROR_FORMAT, error.Format());
+
+    if (error == CHIP_ERROR_TIMEOUT)
+    {
+        ChipLogError(SoftwareUpdate, "CASE session may be invalid, tear down session");
+        requestorCore->DisconnectFromProvider();
+    }
+
     requestorCore->RecordErrorUpdateState(UpdateFailureState::kQuerying, error);
 }
 
@@ -303,6 +310,33 @@ void OTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
         RecordErrorUpdateState(UpdateFailureState::kUnknown, CHIP_ERROR_INCORRECT_STATE);
         return;
     }
+}
+
+void OTARequestor::DisconnectFromProvider()
+{
+    if (mServer == nullptr)
+    {
+        ChipLogError(SoftwareUpdate, "Server not set");
+        RecordErrorUpdateState(UpdateFailureState::kUnknown, CHIP_ERROR_INCORRECT_STATE);
+        return;
+    }
+
+    if (!mProviderLocation.HasValue())
+    {
+        ChipLogError(SoftwareUpdate, "Provider location not set");
+        RecordErrorUpdateState(UpdateFailureState::kUnknown, CHIP_ERROR_INCORRECT_STATE);
+        return;
+    }
+
+    FabricInfo * fabricInfo = mServer->GetFabricTable().FindFabricWithIndex(mProviderLocation.Value().fabricIndex);
+    if (fabricInfo == nullptr)
+    {
+        ChipLogError(SoftwareUpdate, "Cannot find fabric");
+        RecordErrorUpdateState(UpdateFailureState::kUnknown, CHIP_ERROR_INCORRECT_STATE);
+        return;
+    }
+
+    mCASESessionManager->ReleaseSession(fabricInfo->GetPeerIdForNode(mProviderLocation.Value().providerNodeID));
 }
 
 // Requestor is directed to cancel image update in progress. All the Requestor state is

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -241,11 +241,16 @@ private:
     };
 
     /**
-     * Called to establish a session to mProviderLocation.
+     * Called to establish a session to provider indicated by mProviderLocation
      *
      * @param onConnectedAction  The action to take once session to provider has been established
      */
     void ConnectToProvider(OnConnectedAction onConnectedAction);
+
+    /**
+     * Called to tear down a session to provider indicated by mProviderLocation
+     */
+    void DisconnectFromProvider();
 
     /**
      * Start download of the software image returned in QueryImageResponse


### PR DESCRIPTION
#### Problem
Once the Requestor establishes a CASE session with the Provider, it just assumes that session is good forever. Upon receiving a timeout error from the provider, nothing is being done to rectify this scenario.

Fixes: https://github.com/project-chip/connectedhomeip/issues/15599

#### Change overview
- When a timeout error is received from CASE session establishment attempt, tear down the session
- Make sure the OperationalDeviceProxy also marks the session as expired

#### Testing
- Verify that a successful OTA transfer occurs using Linux requestor/provider apps
- Terminate the ota-provider-app and relaunch
- Make another attempt at QueryImage (either via announce-ota-provider command or the periodic query timer expiring)
- Verify that error received and tear down occurs
- Make another attempt at QueryImage (either via announce-ota-provider command or the periodic query timer expiring)
- Verify that this time, CASE session is established and OTA transfer occurs successfully