### PR TITLE
Fix Darwin crash with wildcard subscription.

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDevice.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevice.mm
@@ -1298,7 +1298,12 @@ void SubscriptionCallback::ReportError(NSError * _Nullable err)
     dispatch_async(mQueue, ^{
         callback(nil, err);
 
-        delete myself;
+        // Deletion of our ReadClient (and hence of ourselves, since the
+        // ReadClient has a pointer to us) needs to happen on the Matter work
+        // queue.
+        dispatch_async(DeviceLayer::PlatformMgrImpl().GetWorkQueue(), ^{
+            delete myself;
+        });
     });
 
     mHaveQueuedDeletion = true;


### PR DESCRIPTION
We were deleting things on the wrong work queue, so ended up deleting
an object while we were in the middle of executing one of its methods.

The fix is to make sure to delete Matter objects on the Matter work queue.

#### Problem
Crash.

#### Change overview
See above.

#### Testing
Followed steps described in #15928 but did not crash.