### PR TITLE
Remove unused SetupEmberAfCommandSender function.

### DIFF
--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -146,33 +146,6 @@ EmberAfAttributeType BaseType(EmberAfAttributeType type)
 
 } // namespace
 
-void SetupEmberAfCommandSender(CommandSender * command, const ConcreteCommandPath & commandPath)
-{
-    Messaging::ExchangeContext * commandExchangeCtx = command->GetExchangeContext();
-
-    imCompatibilityEmberApsFrame.clusterId           = commandPath.mClusterId;
-    imCompatibilityEmberApsFrame.destinationEndpoint = commandPath.mEndpointId;
-    imCompatibilityEmberApsFrame.sourceEndpoint      = 1; // source endpoint is fixed to 1 for now.
-    imCompatibilityEmberApsFrame.sequence =
-        (commandExchangeCtx != nullptr ? static_cast<uint8_t>(commandExchangeCtx->GetExchangeId() & 0xFF) : 0);
-
-    if (commandExchangeCtx->IsGroupExchangeContext())
-    {
-        imCompatibilityEmberAfCluster.type = EMBER_INCOMING_MULTICAST;
-    }
-    else
-    {
-        imCompatibilityEmberAfCluster.type = EMBER_INCOMING_UNICAST;
-    }
-
-    imCompatibilityEmberAfCluster.commandId      = commandPath.mCommandId;
-    imCompatibilityEmberAfCluster.apsFrame       = &imCompatibilityEmberApsFrame;
-    imCompatibilityEmberAfCluster.interPanHeader = &imCompatibilityInterpanHeader;
-    imCompatibilityEmberAfCluster.source         = commandExchangeCtx;
-
-    emAfCurrentCommand = &imCompatibilityEmberAfCluster;
-}
-
 void SetupEmberAfCommandHandler(CommandHandler * command, const ConcreteCommandPath & commandPath)
 {
     Messaging::ExchangeContext * commandExchangeCtx = command->GetExchangeContext();

--- a/src/app/util/ember-compatibility-functions.h
+++ b/src/app/util/ember-compatibility-functions.h
@@ -32,7 +32,6 @@ namespace chip {
 namespace app {
 namespace Compatibility {
 
-void SetupEmberAfCommandSender(CommandSender * command, const ConcreteCommandPath & commandPath);
 void SetupEmberAfCommandHandler(CommandHandler * command, const ConcreteCommandPath & commandPath);
 bool IMEmberAfSendDefaultResponseWithCallback(EmberAfStatus status);
 void ResetEmberAfObjects();


### PR DESCRIPTION
We have not been using this since we stopped going through generic dispatch for CommandSender.

#### Problem
Unused code.

#### Change overview
Remove it.

#### Testing
It's not used.