### PR TITLE
Fix chip-shell base64 decode failure handling

### DIFF
--- a/src/lib/shell/commands/Base64.cpp
+++ b/src/lib/shell/commands/Base64.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <cstdint>
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -48,6 +49,7 @@ static CHIP_ERROR Base64DecodeHandler(int argc, char ** argv)
 
     VerifyOrReturnError(argc > 0, CHIP_ERROR_INVALID_ARGUMENT);
     binarySize = Base64Decode(argv[0], strlen(argv[0]), binary);
+    VerifyOrReturnError(binarySize != UINT16_MAX, CHIP_ERROR_INVALID_ARGUMENT);
     streamer_print_hex(sout, binary, binarySize);
     streamer_printf(sout, "\r\n");
     return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fixes #15574 chip-shell decode handler was not checking for a failed decode, resulting in over-read.

#### Change overview
Properly handle failed decode.

#### Testing
How was this tested? (at least one bullet point required)
* Checked in chip-shell that `base64 decode E!Q=` correctly errors instead of dumping memory data.
