### PR TITLE
Enable operational advertising (and CASE server) in Darwin framework.

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -183,6 +183,7 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
         if (_listenPort) {
             params.listenPort = _listenPort;
         }
+        params.enableServerInteractions = true;
 
         // Initialize device attestation verifier
         // TODO: Replace testingRootStore with a AttestationTrustStore that has the necessary official PAA roots available


### PR DESCRIPTION
Operational advertising and a CASE server is needed for at least two things:

1. Subscriptions, so the other side can establish a CASE session if
   there isn't one already.

2. OTA provider server implementation.

Chances are, things using the framework will want at leasts one of
these things, so we just enable unconditionally when bringing up the
Matter stack.

#### Problem
Applications using the Darwin framework don't do operational advertising.

#### Change overview
Tell the controller factory to set that up.

#### Testing
Checked that the dns-sd records are published.  Can't test actual CASE connection yet, because have not figured out what I need to do to an iOS app to allow that.