### PR TITLE
[chiptest] Network-independent RPC server shutdown

### DIFF
--- a/scripts/tests/chiptest/accessories.py
+++ b/scripts/tests/chiptest/accessories.py
@@ -15,7 +15,6 @@
 
 import sys
 import threading
-from xmlrpc.client import ServerProxy
 from xmlrpc.server import SimpleXMLRPCServer
 
 IP = '127.0.0.1'
@@ -98,9 +97,6 @@ class AppsRegister:
             return accessory.waitForOperationalAdvertisement()
         return False
 
-    def ping(self):
-        return True
-
     def __startXMLRPCServer(self):
         self.server = SimpleXMLRPCServer((IP, PORT))
 
@@ -114,20 +110,9 @@ class AppsRegister:
         self.server.register_function(
             self.waitForOperationalAdvertisement,
             'waitForOperationalAdvertisement')
-        self.server.register_function(self.ping, 'ping')
 
-        self.server_thread = threading.Thread(target=self.__handle_request)
+        self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.start()
 
-    def __handle_request(self):
-        self.__should_handle_requests = True
-        while self.__should_handle_requests:
-            self.server.handle_request()
-
     def __stopXMLRPCServer(self):
-        self.__should_handle_requests = False
-        # handle_request will wait until it receives a message,
-        # so let's send a ping to the server
-        client = ServerProxy('http://' + IP + ':' +
-                             str(PORT) + '/', allow_none=True)
-        client.ping()
+        self.server.shutdown()


### PR DESCRIPTION
#### Problem
Terminating app-register RPC server with the usage RPC call itself might cause troubles in case when the network connection is not reliable (e.g. no route to the server). When this will happen, the test runner will not terminate properly (in my case it happens always):
```
$ ./scripts/tests/run_test_suite.py --target-glob "DL_LockUnlock" run 
2022-03-08 11:52:34.880 INFO    Ensuring /run is privately accessible
2022-03-08 11:52:35.043 INFO    Waiting for IPv6 DaD to complete (no tentative addresses)
2022-03-08 11:52:36.764 INFO    No more tentative addresses
2022-03-08 11:52:36.765 INFO    Each test will be executed 1 times
2022-03-08 11:52:36.765 INFO    Starting iteration 1
2022-03-08 11:52:39.482 INFO    DL_LockUnlock        - Completed in 2.72 seconds         <- here it stuck until RPC call timeout
^C
Aborted!
^CException ignored in: <module 'threading' from '/usr/lib/python3.8/threading.py'>
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 1388, in _shutdown
    lock.acquire()
KeyboardInterrupt: 
```

#### Change overview

- This commit simplifies the shutdown process by using dedicated shutdown method.

#### Testing

Now command `./scripts/tests/run_test_suite.py --target-glob "DL_LockUnlock" run` exits properly (no Ctrl-C required).