### PR TITLE
ESP32: Remove example connection from menuconfig

### DIFF
--- a/examples/all-clusters-app/esp32/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/CMakeLists.txt
@@ -23,7 +23,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
     "${CMAKE_CURRENT_LIST_DIR}/../../common/QRCode"
-    "${IDF_PATH}/examples/common_components"
+    "${IDF_PATH}/examples/common_components/led_strip"
 )
 if(${IDF_TARGET} STREQUAL "esp32")
     list(APPEND EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/m5stack-tft/repo/components/tft"

--- a/examples/lighting-app/esp32/CMakeLists.txt
+++ b/examples/lighting-app/esp32/CMakeLists.txt
@@ -23,7 +23,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
     "${CMAKE_CURRENT_LIST_DIR}/../../common/QRCode"
-    "${IDF_PATH}/examples/common_components"
+    "${IDF_PATH}/examples/common_components/led_strip"
 )
 
 project(chip-lighting-app)


### PR DESCRIPTION
#### Problem
#15952 We have provided a way to connect an AP so the example connection is not required.

#### Change overview
Remove it from the extra components.

#### Testing
Components path change, CI is enough.
