### PR TITLE
fix disable ipv4 build error on android

### DIFF
--- a/src/platform/android/InetPlatformConfig.h
+++ b/src/platform/android/InetPlatformConfig.h
@@ -25,8 +25,9 @@
 #pragma once
 
 // ==================== Platform Adaptations ====================
-
+#ifndef INET_CONFIG_ENABLE_IPV4
 #define INET_CONFIG_ENABLE_IPV4 1
+#endif // INET_CONFIG_ENABLE_IPV4
 
 // ========== Platform-specific Configuration Overrides =========
 


### PR DESCRIPTION
#### Problem
* build failed on android if we disable ipv4

#### Change overview
* remove redefine of INET_CONFIG_ENABLE_IPV4

#### Testing
* chip-tool basic
