### PR TITLE
The Linux platform KVS init should ignore multiple init calls

### DIFF
--- a/src/platform/Linux/CHIPLinuxStorage.cpp
+++ b/src/platform/Linux/CHIPLinuxStorage.cpp
@@ -53,6 +53,13 @@ CHIP_ERROR ChipLinuxStorage::Init(const char * configFile)
 {
     CHIP_ERROR retval = CHIP_NO_ERROR;
 
+    ChipLogDetail(DeviceLayer, "ChipLinuxStorage::Init: Using KVS config file: %s", configFile);
+    if (mInitialized)
+    {
+        ChipLogError(DeviceLayer, "ChipLinuxStorage::Init: Attempt to re-initialize with KVS config file: %s", configFile);
+        return CHIP_NO_ERROR;
+    }
+
     mConfigPath.assign(configFile);
     retval = ChipLinuxStorageIni::Init();
 
@@ -75,6 +82,8 @@ CHIP_ERROR ChipLinuxStorage::Init(const char * configFile)
     {
         retval = ChipLinuxStorageIni::AddConfig(mConfigPath);
     }
+
+    mInitialized = true;
 
     return retval;
 }

--- a/src/platform/Linux/CHIPLinuxStorage.h
+++ b/src/platform/Linux/CHIPLinuxStorage.h
@@ -88,6 +88,7 @@ private:
     std::mutex mLock;
     bool mDirty;
     std::string mConfigPath;
+    bool mInitialized = false;
 };
 
 } // namespace Internal


### PR DESCRIPTION
#### Problem
The Linux KVS should ignore multiple calls to Init().

As an example, all Linux applications initialize the KVS (based on a custom provided path) in ChipLinuxAppInit(). Immediately following this, the KVS gets "re-initialized" in InitChipStack(), due to the change in #15741.
Ideally we will need to trace all Init() calls and ensure an application has just one such call, but that's probably a different story.

#### Change overview
Return from Init() safely if called again

#### Testing
- Ensured that the custom KVS path was actually utilized and data written to/read from.
- OTA application was broken on Linux and it works now.
