### PR TITLE
[chip-tool] Allow passing multiple data versions for attributes reads

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -223,13 +223,28 @@ bool Command::InitArgument(size_t argIndex, char * argValue)
                 vectorArgument->push_back(static_cast<uint16_t>(v));
             }
         }
-        else
+        else if (arg.type == ArgumentType::Vector32 && arg.flags != Argument::kOptional)
         {
             auto vectorArgument = static_cast<std::vector<uint32_t> *>(arg.value);
             for (uint64_t v : values)
             {
                 vectorArgument->push_back(static_cast<uint32_t>(v));
             }
+        }
+        else if (arg.type == ArgumentType::Vector32 && arg.flags == Argument::kOptional)
+        {
+            std::vector<uint32_t> vectorArgument;
+            for (uint64_t v : values)
+            {
+                vectorArgument.push_back(static_cast<uint32_t>(v));
+            }
+
+            auto optionalArgument = static_cast<chip::Optional<std::vector<uint32_t>> *>(arg.value);
+            optionalArgument->SetValue(vectorArgument);
+        }
+        else
+        {
+            return false;
         }
 
         return true;
@@ -553,6 +568,19 @@ size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, std::v
     arg.min   = min;
     arg.max   = max;
     arg.flags = 0;
+
+    return AddArgumentToList(std::move(arg));
+}
+
+size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<std::vector<uint32_t>> * value)
+{
+    Argument arg;
+    arg.type  = ArgumentType::Vector32;
+    arg.name  = name;
+    arg.value = static_cast<void *>(value);
+    arg.min   = min;
+    arg.max   = max;
+    arg.flags = Argument::kOptional;
 
     return AddArgumentToList(std::move(arg));
 }

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -174,6 +174,7 @@ public:
 
     size_t AddArgument(const char * name, int64_t min, uint64_t max, std::vector<uint16_t> * value);
     size_t AddArgument(const char * name, int64_t min, uint64_t max, std::vector<uint32_t> * value);
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<std::vector<uint32_t>> * value);
 
     template <typename T, typename = std::enable_if_t<std::is_enum<T>::value>>
     size_t AddArgument(const char * name, int64_t min, uint64_t max, T * out, uint8_t flags = 0)


### PR DESCRIPTION
#### Problem

`chip-tool` does not supports building requests with multiple data versions for attributes reads.

#### Change overview
 * Change the single `chip::DataVersion` optional argument to be a vector

#### Testing
Tried with:
```
$ ./out/debug/standalone/chip-tool onoff read-by-id 0,0,0 0x12344321 1 --data-version 0
$ ./out/debug/standalone/chip-tool onoff read-by-id 0 0x12344321 1 --data-version 0,1
``
