### PR TITLE
[mbed] Disable unit test build

### DIFF
--- a/.github/workflows/full-mbed.yaml
+++ b/.github/workflows/full-mbed.yaml
@@ -124,6 +124,8 @@ jobs:
                     /tmp/bloat_reports/
 
             - name: Build unit tests
+              # Temporarily disable build due to running out of flash space
+              if: false
               timeout-minutes: 20
               run: scripts/tests/mbed/mbed_unit_tests.sh -b=$APP_TARGET -p=$APP_PROFILE
 


### PR DESCRIPTION
#### Problem
The build fails on master as the unit test firmware no longer fits in flash.

#### Change overview
Disable unit test build for mbed-os

#### Testing
CI only.
