### PR TITLE
[chiptest] Wait for subprocess instead of polling

### DIFF
--- a/scripts/tests/chiptest/accessories.py
+++ b/scripts/tests/chiptest/accessories.py
@@ -35,6 +35,11 @@ class AppsRegister:
     def uninit(self):
         self.__stopXMLRPCServer()
 
+    @property
+    def accessories(self):
+        """List of registered accessory applications."""
+        return self.__accessories.values()
+
     def add(self, name, accessory):
         self.__accessories[name] = accessory
 
@@ -43,13 +48,6 @@ class AppsRegister:
 
     def removeAll(self):
         self.__accessories = {}
-
-    def poll(self):
-        for accessory in self.__accessories.values():
-            status = accessory.poll()
-            if status is not None:
-                return status
-        return None
 
     def kill(self, name):
         accessory = self.__accessories[name]

--- a/scripts/tests/chiptest/runner.py
+++ b/scripts/tests/chiptest/runner.py
@@ -15,6 +15,7 @@
 import logging
 import os
 import pty
+import queue
 import re
 import subprocess
 import sys
@@ -75,7 +76,26 @@ class LogPipe(threading.Thread):
         os.close(self.fd_write)
 
 
+class RunnerWaitQueue:
+
+    def __init__(self):
+        self.queue = queue.Queue()
+
+    def __wait(self, process, userdata):
+        process.wait()
+        self.queue.put((process, userdata))
+
+    def add_process(self, process, userdata=None):
+        t = threading.Thread(target=self.__wait, args=(process, userdata))
+        t.daemon = True
+        t.start()
+
+    def get(self):
+        return self.queue.get()
+
+
 class Runner:
+
     def __init__(self, capture_delegate=None):
         self.capture_delegate = capture_delegate
 
@@ -97,16 +117,22 @@ class Runner:
         if not wait:
             return s, outpipe, errpipe
 
-        while s.poll() is None:
-            # dependencies MUST NOT be done
-            for dependency in dependencies:
-                if dependency.poll() is not None:
-                    s.kill()
-                    raise Exception("Unexpected return %d for %r" %
-                                    (dependency.poll(), dependency))
+        wait = RunnerWaitQueue()
+        wait.add_process(s)
 
-        code = s.wait()
-        if code != 0:
-            raise Exception('Command %r failed: %d' % (cmd, code))
-        else:
-            logging.debug('Command %r completed with error code 0', cmd)
+        for dependency in dependencies:
+            for accessory in dependency.accessories:
+                wait.add_process(accessory, dependency)
+
+        for process, userdata in iter(wait.queue.get, None):
+            if process == s:
+                break
+            # dependencies MUST NOT be done
+            s.kill()
+            raise Exception("Unexpected return %d for %r" %
+                            (process.returncode, userdata))
+
+        if s.returncode != 0:
+            raise Exception('Command %r failed: %d' % (cmd, s.returncode))
+
+        logging.debug('Command %r completed with error code 0', cmd)


### PR DESCRIPTION
#### Problem

Polling for subprocess return-code hogs CPU (chiptest Python process uses 100% CPU). Instead of polling it's better to use `wait()` call, which effectively puts Python process into sleep until subprocess terminates.

#### Change overview

- refactor active polling code and replace it with proper `wait()` calls.

#### Testing

Witch this changes, running `./scripts/tests/run_test_suite.py run` does not show 100% CPU usage for run_test_suite.py process.