### PR TITLE
[ota] Store Default OTA Providers in flash

### DIFF
--- a/config/mbed/CMakeLists.txt
+++ b/config/mbed/CMakeLists.txt
@@ -466,6 +466,7 @@ if (CONFIG_CHIP_OTA_REQUESTOR)
     target_sources(${APP_TARGET} PRIVATE
         ${CHIP_ROOT}/examples/platform/mbed/ota/OTARequestorDriverImpl.cpp
         ${CHIP_ROOT}/src/app/clusters/ota-requestor/OTARequestor.cpp
+        ${CHIP_ROOT}/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
         ${CHIP_ROOT}/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
         ${CHIP_ROOT}/src/app/clusters/ota-requestor/BDXDownloader.cpp
         ${CHIP_ROOT}/src/platform/mbed/OTAImageProcessorImpl.cpp

--- a/examples/all-clusters-app/ameba/chip_main.cmake
+++ b/examples/all-clusters-app/ameba/chip_main.cmake
@@ -118,6 +118,7 @@ list(
     #OTARequestor
     ${chip_dir}/src/app/clusters/ota-requestor/BDXDownloader.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/OTARequestor.cpp
+    ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/ota-requestor-server.cpp
 )

--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -39,8 +39,8 @@
 #include <support/CHIPMem.h>
 
 #if CONFIG_ENABLE_OTA_REQUESTOR
-#include <app/clusters/ota-requestor/BDXDownloader.h>
 #include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
+#include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/Ameba/AmebaOTAImageProcessor.h>

--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -40,6 +40,7 @@
 
 #if CONFIG_ENABLE_OTA_REQUESTOR
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/Ameba/AmebaOTAImageProcessor.h>
@@ -91,6 +92,7 @@ static DeviceCallbacks EchoCallbacks;
 
 #if CONFIG_ENABLE_OTA_REQUESTOR
 OTARequestor gRequestorCore;
+DefaultOTARequestorStorage gRequestorStorage;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 AmebaOTAImageProcessor gImageProcessor;
@@ -115,8 +117,10 @@ static void InitOTARequestor(void)
     // Initialize and interconnect the Requestor and Image Processor objects -- START
     SetRequestorInstance(&gRequestorCore);
 
+    gRequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
+
     // Set server instance used for session establishment
-    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorCore.Init(chip::Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
 
     // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at
     // the beginning of program execution. We're using hardcoded values here for now since this is a reference application.

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -38,6 +38,7 @@
 
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <app/server/OnboardingCodesUtil.h>
@@ -77,6 +78,7 @@ namespace {
 
 #if CONFIG_ENABLE_OTA_REQUESTOR
 OTARequestor gRequestorCore;
+DefaultOTARequestorStorage gRequestorStorage;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
@@ -127,7 +129,8 @@ static void InitOTARequestor(void)
 {
 #if CONFIG_ENABLE_OTA_REQUESTOR
     SetRequestorInstance(&gRequestorCore);
-    gRequestorCore.Init(&Server::GetInstance(), &gRequestorUser, &gDownloader);
+    gRequestorStorage.Init(Server::GetInstance().GetPersistentStorage());
+    gRequestorCore.Init(Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
     gImageProcessor.SetOTADownloader(&gDownloader);
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);

--- a/examples/all-clusters-app/nrfconnect/CMakeLists.txt
+++ b/examples/all-clusters-app/nrfconnect/CMakeLists.txt
@@ -71,10 +71,7 @@ target_sources(app PRIVATE
                ${ALL_CLUSTERS_COMMON_DIR}/src/bridged-actions-stub.cpp
                ${GEN_DIR}/all-clusters-app/zap-generated/callback-stub.cpp
                ${GEN_DIR}/all-clusters-app/zap-generated/IMClusterCommandHandler.cpp
-               ${NRFCONNECT_COMMON}/util/LEDWidget.cpp
-               ${CHIP_ROOT}/src/app/clusters/ota-requestor/OTARequestor.cpp
-               ${CHIP_ROOT}/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
-               ${CHIP_ROOT}/src/app/clusters/ota-requestor/BDXDownloader.cpp)
+               ${NRFCONNECT_COMMON}/util/LEDWidget.cpp)
 
 
 chip_configure_data_model(app

--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -149,7 +149,8 @@ void AppTask::InitOTARequestor()
     mOTAImageProcessor.SetOTADownloader(&mBDXDownloader);
     mBDXDownloader.SetImageProcessorDelegate(&mOTAImageProcessor);
     mOTARequestorDriver.Init(&mOTARequestor, &mOTAImageProcessor);
-    mOTARequestor.Init(&chip::Server::GetInstance(), &mOTARequestorDriver, &mBDXDownloader);
+    mOTARequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
+    mOTARequestor.Init(chip::Server::GetInstance(), mOTARequestorStorage, mOTARequestorDriver, mBDXDownloader);
     chip::SetRequestorInstance(&mOTARequestor);
 #endif
 }

--- a/examples/all-clusters-app/nrfconnect/main/include/AppTask.h
+++ b/examples/all-clusters-app/nrfconnect/main/include/AppTask.h
@@ -21,6 +21,7 @@
 
 #if CONFIG_CHIP_OTA_REQUESTOR
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/nrfconnect/OTAImageProcessorImpl.h>
@@ -73,6 +74,7 @@ private:
     bool mHaveBLEConnections{ false };
 
 #if CONFIG_CHIP_OTA_REQUESTOR
+    chip::DefaultOTARequestorStorage mOTARequestorStorage;
     chip::DeviceLayer::GenericOTARequestorDriver mOTARequestorDriver;
     chip::DeviceLayer::OTAImageProcessorImpl mOTAImageProcessor;
     chip::BDXDownloader mBDXDownloader;

--- a/examples/lighting-app/ameba/chip_main.cmake
+++ b/examples/lighting-app/ameba/chip_main.cmake
@@ -16,6 +16,7 @@ list(
     #OTARequestor
     ${chip_dir}/src/app/clusters/ota-requestor/BDXDownloader.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/OTARequestor.cpp
+    ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/ota-requestor-server.cpp
 )

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -42,8 +42,8 @@
 #include <lwip_netconf.h>
 
 #if CONFIG_ENABLE_OTA_REQUESTOR
-#include <app/clusters/ota-requestor/BDXDownloader.h>
 #include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
+#include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/Ameba/AmebaOTAImageProcessor.h>

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -43,6 +43,7 @@
 
 #if CONFIG_ENABLE_OTA_REQUESTOR
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/Ameba/AmebaOTAImageProcessor.h>
@@ -76,6 +77,7 @@ static DeviceCallbacks EchoCallbacks;
 
 #if CONFIG_ENABLE_OTA_REQUESTOR
 OTARequestor gRequestorCore;
+DefaultOTARequestorStorage gRequestorStorage;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 AmebaOTAImageProcessor gImageProcessor;
@@ -100,8 +102,10 @@ static void InitOTARequestor(void)
     // Initialize and interconnect the Requestor and Image Processor objects -- START
     SetRequestorInstance(&gRequestorCore);
 
+    gRequestorStorage.Init(Server::GetInstance().GetPersistentStorage());
+
     // Set server instance used for session establishment
-    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorCore.Init(Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
 
     // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at
     // the beginning of program execution. We're using hardcoded values here for now since this is a reference application.

--- a/examples/lighting-app/esp32/main/main.cpp
+++ b/examples/lighting-app/esp32/main/main.cpp
@@ -28,6 +28,7 @@
 #include "shell_extension/launch.h"
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <app/server/OnboardingCodesUtil.h>
@@ -44,6 +45,7 @@ using namespace ::chip::DeviceLayer;
 
 #if CONFIG_ENABLE_OTA_REQUESTOR
 OTARequestor gRequestorCore;
+DefaultOTARequestorStorage gRequestorStorage;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
@@ -64,7 +66,8 @@ static void InitOTARequestor(void)
 {
 #if CONFIG_ENABLE_OTA_REQUESTOR
     SetRequestorInstance(&gRequestorCore);
-    gRequestorCore.Init(&Server::GetInstance(), &gRequestorUser, &gDownloader);
+    gRequestorStorage.Init(Server::GetInstance().GetPersistentStorage());
+    gRequestorCore.Init(Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
     gImageProcessor.SetOTADownloader(&gDownloader);
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);

--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -92,10 +92,7 @@ target_sources(app PRIVATE
                ${GEN_DIR}/lighting-app/zap-generated/callback-stub.cpp
                ${GEN_DIR}/lighting-app/zap-generated/IMClusterCommandHandler.cpp
                ${NRFCONNECT_COMMON}/util/LEDWidget.cpp
-               ${NRFCONNECT_COMMON}/util/ThreadUtil.cpp
-               ${CHIP_ROOT}/src/app/clusters/ota-requestor/OTARequestor.cpp
-               ${CHIP_ROOT}/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
-               ${CHIP_ROOT}/src/app/clusters/ota-requestor/BDXDownloader.cpp)
+               ${NRFCONNECT_COMMON}/util/ThreadUtil.cpp)
 
 chip_configure_data_model(app
     INCLUDE_SERVER

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -41,6 +41,7 @@
 
 #if CONFIG_CHIP_OTA_REQUESTOR
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/nrfconnect/OTAImageProcessorImpl.h>
@@ -85,6 +86,7 @@ bool sIsThreadEnabled     = false;
 bool sHaveBLEConnections  = false;
 
 #if CONFIG_CHIP_OTA_REQUESTOR
+DefaultOTARequestorStorage sRequestorStorage;
 GenericOTARequestorDriver sOTARequestorDriver;
 OTAImageProcessorImpl sOTAImageProcessor;
 chip::BDXDownloader sBDXDownloader;
@@ -203,7 +205,8 @@ void AppTask::InitOTARequestor()
     sOTAImageProcessor.SetOTADownloader(&sBDXDownloader);
     sBDXDownloader.SetImageProcessorDelegate(&sOTAImageProcessor);
     sOTARequestorDriver.Init(&sOTARequestor, &sOTAImageProcessor);
-    sOTARequestor.Init(&chip::Server::GetInstance(), &sOTARequestorDriver, &sBDXDownloader);
+    sRequestorStorage.Init(Server::GetInstance().GetPersistentStorage());
+    sOTARequestor.Init(Server::GetInstance(), sRequestorStorage, sOTARequestorDriver, sBDXDownloader);
     chip::SetRequestorInstance(&sOTARequestor);
 #endif
 }

--- a/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -85,7 +85,8 @@ AppTask AppTask::sAppTask;
 
 /* OTA related variables */
 static OTARequestor gRequestorCore;
-DeviceLayer::GenericOTARequestorDriver gRequestorUser;
+static DefaultOTARequestorStorage gRequestorStorage;
+static DeviceLayer::GenericOTARequestorDriver gRequestorUser;
 static BDXDownloader gDownloader;
 static OTAImageProcessorImpl gImageProcessor;
 
@@ -121,7 +122,8 @@ CHIP_ERROR AppTask::Init()
     // Initialize and interconnect the Requestor and Image Processor objects -- START
     SetRequestorInstance(&gRequestorCore);
 
-    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorStorage.Init(Server::GetInstance().GetPersistentStorage());
+    gRequestorCore.Init(Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 
     // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at

--- a/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -37,6 +37,7 @@
 #include "OTAImageProcessorImpl.h"
 #include "OtaSupport.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 

--- a/examples/lock-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/lock-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -30,6 +30,7 @@
 #include <platform/CHIPDeviceLayer.h>
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <lib/support/CHIPMem.h>
@@ -63,6 +64,7 @@ static Button_Handle sAppRightHandle;
 AppTask AppTask::sAppTask;
 
 static OTARequestor sRequestorCore;
+static DefaultOTARequestorStorage sRequestorStorage;
 static GenericOTARequestorDriver sRequestorUser;
 static BDXDownloader sDownloader;
 static OTAImageProcessorImpl sImageProcessor;
@@ -72,7 +74,8 @@ void InitializeOTARequestor(void)
     // Initialize and interconnect the Requestor and Image Processor objects
     SetRequestorInstance(&sRequestorCore);
 
-    sRequestorCore.Init(&Server::GetInstance(), &sRequestorUser, &sDownloader);
+    sRequestorStorage.Init(Server::GetInstance().GetPersistentStorage());
+    sRequestorCore.Init(Server::GetInstance(), sRequestorStorage, sRequestorUser, sDownloader);
     sImageProcessor.SetOTADownloader(&sDownloader);
     sDownloader.SetImageProcessorDelegate(&sImageProcessor);
     sRequestorUser.Init(&sRequestorCore, &sImageProcessor);

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -37,6 +37,7 @@
 
 #if CONFIG_CHIP_OTA_REQUESTOR
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/nrfconnect/OTAImageProcessorImpl.h>
@@ -74,6 +75,7 @@ bool sIsThreadEnabled     = false;
 bool sHaveBLEConnections  = false;
 
 #if CONFIG_CHIP_OTA_REQUESTOR
+DefaultOTARequestorStorage sRequestorStorage;
 GenericOTARequestorDriver sOTARequestorDriver;
 OTAImageProcessorImpl sOTAImageProcessor;
 chip::BDXDownloader sBDXDownloader;
@@ -184,7 +186,8 @@ void AppTask::InitOTARequestor()
     sOTAImageProcessor.SetOTADownloader(&sBDXDownloader);
     sBDXDownloader.SetImageProcessorDelegate(&sOTAImageProcessor);
     sOTARequestorDriver.Init(&sOTARequestor, &sOTAImageProcessor);
-    sOTARequestor.Init(&chip::Server::GetInstance(), &sOTARequestorDriver, &sBDXDownloader);
+    sRequestorStorage.Init(Server::GetInstance().GetPersistentStorage());
+    sOTARequestor.Init(Server::GetInstance(), sRequestorStorage, sOTARequestorDriver, sBDXDownloader);
     chip::SetRequestorInstance(&sOTARequestor);
 #endif
 }

--- a/examples/ota-requestor-app/ameba/chip_main.cmake
+++ b/examples/ota-requestor-app/ameba/chip_main.cmake
@@ -24,6 +24,7 @@ list(
 
     ${chip_dir}/src/app/clusters/ota-requestor/BDXDownloader.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/OTARequestor.cpp
+    ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/ota-requestor-server.cpp
 )

--- a/examples/ota-requestor-app/ameba/main/chipinterface.cpp
+++ b/examples/ota-requestor-app/ameba/main/chipinterface.cpp
@@ -32,8 +32,8 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <support/CHIPMem.h>
 
-#include <app/clusters/ota-requestor/BDXDownloader.h>
 #include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
+#include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/Ameba/AmebaOTAImageProcessor.h>

--- a/examples/ota-requestor-app/ameba/main/chipinterface.cpp
+++ b/examples/ota-requestor-app/ameba/main/chipinterface.cpp
@@ -33,6 +33,7 @@
 #include <support/CHIPMem.h>
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/Ameba/AmebaOTAImageProcessor.h>
@@ -78,6 +79,7 @@ void NetWorkCommissioningInstInit()
 static DeviceCallbacks EchoCallbacks;
 
 OTARequestor gRequestorCore;
+DefaultOTARequestorStorage gRequestorStorage;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 AmebaOTAImageProcessor gImageProcessor;
@@ -100,8 +102,10 @@ static void InitOTARequestor(void)
     // Initialize and interconnect the Requestor and Image Processor objects -- START
     SetRequestorInstance(&gRequestorCore);
 
+    gRequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
+
     // Set server instance used for session establishment
-    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorCore.Init(chip::Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
 
     // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at
     // the beginning of program execution. We're using hardcoded values here for now since this is a reference application.

--- a/examples/ota-requestor-app/ameba/main/chipinterface.cpp
+++ b/examples/ota-requestor-app/ameba/main/chipinterface.cpp
@@ -32,8 +32,8 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <support/CHIPMem.h>
 
-#include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/Ameba/AmebaOTAImageProcessor.h>

--- a/examples/ota-requestor-app/cyw30739/args.gni
+++ b/examples/ota-requestor-app/cyw30739/args.gni
@@ -19,6 +19,9 @@ cyw30739_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_openthread_ftd = true
 
+# Disable progress logging to fit in flash
+chip_progress_logging = false
+
 declare_args() {
   chip_enable_ota_requestor = true
 }

--- a/examples/ota-requestor-app/cyw30739/src/main.cpp
+++ b/examples/ota-requestor-app/cyw30739/src/main.cpp
@@ -18,6 +18,7 @@
  */
 #include <ChipShellCollection.h>
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <app/server/Server.h>
@@ -42,6 +43,7 @@ using namespace chip::Shell;
 static void InitApp(intptr_t args);
 
 OTARequestor gRequestorCore;
+DefaultOTARequestorStorage gRequestorStorage;
 DeviceLayer::GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
@@ -129,7 +131,8 @@ void InitApp(intptr_t args)
     // Initialize and interconnect the Requestor and Image Processor objects -- START
     SetRequestorInstance(&gRequestorCore);
 
-    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
+    gRequestorCore.Init(chip::Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 
     gImageProcessor.SetOTADownloader(&gDownloader);

--- a/examples/ota-requestor-app/efr32/src/AppTask.cpp
+++ b/examples/ota-requestor-app/efr32/src/AppTask.cpp
@@ -32,8 +32,8 @@
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
 
-#include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/EFR32/OTAImageProcessorImpl.h>

--- a/examples/ota-requestor-app/efr32/src/AppTask.cpp
+++ b/examples/ota-requestor-app/efr32/src/AppTask.cpp
@@ -33,6 +33,7 @@
 #include <app/util/attribute-storage.h>
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/EFR32/OTAImageProcessorImpl.h>
@@ -98,6 +99,7 @@ using namespace ::chip::DeviceLayer;
 
 // Global OTA objects
 OTARequestor gRequestorCore;
+DefaultOTARequestorStorage gRequestorStorage;
 DeviceLayer::GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
@@ -535,7 +537,8 @@ void AppTask::InitOTARequestor()
     // Initialize and interconnect the Requestor and Image Processor objects -- START
     SetRequestorInstance(&gRequestorCore);
 
-    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
+    gRequestorCore.Init(chip::Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
 
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 

--- a/examples/ota-requestor-app/efr32/src/AppTask.cpp
+++ b/examples/ota-requestor-app/efr32/src/AppTask.cpp
@@ -32,8 +32,8 @@
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
 
-#include <app/clusters/ota-requestor/BDXDownloader.h>
 #include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
+#include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/EFR32/OTAImageProcessorImpl.h>

--- a/examples/ota-requestor-app/esp32/main/main.cpp
+++ b/examples/ota-requestor-app/esp32/main/main.cpp
@@ -30,6 +30,7 @@
 #include "nvs_flash.h"
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <app/server/Server.h>
@@ -53,6 +54,7 @@ const char * TAG = "ota-requester-app";
 static DeviceCallbacks EchoCallbacks;
 
 OTARequestor gRequestorCore;
+DefaultOTARequestorStorage gRequestorStorage;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
@@ -70,7 +72,8 @@ static void InitServer(intptr_t context)
     sWiFiNetworkCommissioningInstance.Init();
 
     SetRequestorInstance(&gRequestorCore);
-    gRequestorCore.Init(&(Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorStorage.Init(Server::GetInstance().GetPersistentStorage());
+    gRequestorCore.Init(Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
     gImageProcessor.SetOTADownloader(&gDownloader);
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -48,6 +48,7 @@ using namespace chip::Messaging;
 using namespace chip::app::Clusters::OtaSoftwareUpdateProvider::Commands;
 
 OTARequestor gRequestorCore;
+DefaultOTARequestorStorage gRequestorStorage;
 DeviceLayer::ExtendedOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
@@ -99,7 +100,8 @@ static void InitOTARequestor(void)
     // Periodic query timeout must be set prior to requestor being initialized
     gRequestorUser.SetPeriodicQueryTimeout(gPeriodicQueryTimeoutSec);
 
-    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
+    gRequestorCore.Init(chip::Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 
     // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -18,6 +18,7 @@
 
 #include "AppMain.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorUserConsentProvider.h>
 #include <app/clusters/ota-requestor/ExtendedOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>

--- a/examples/ota-requestor-app/p6/src/AppTask.cpp
+++ b/examples/ota-requestor-app/p6/src/AppTask.cpp
@@ -29,6 +29,7 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <app/server/Dnssd.h>
@@ -94,6 +95,7 @@ StackType_t appStack[APP_TASK_STACK_SIZE / sizeof(StackType_t)];
 StaticTask_t appTaskStruct;
 
 OTARequestor gRequestorCore;
+DefaultOTARequestorStorage gRequestorStorage;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
@@ -180,7 +182,8 @@ CHIP_ERROR AppTask::Init()
     ConfigurationMgr().LogDeviceConfig();
 
     SetRequestorInstance(&gRequestorCore);
-    gRequestorCore.Init(&(Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
+    gRequestorCore.Init(chip::Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
     gImageProcessor.SetOTADownloader(&gDownloader);
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);

--- a/examples/platform/efr32/OTAConfig.cpp
+++ b/examples/platform/efr32/OTAConfig.cpp
@@ -62,6 +62,7 @@ __attribute__((used)) ApplicationProperties_t sl_app_properties = {
 
 // Global OTA objects
 chip::OTARequestor gRequestorCore;
+chip::DefaultOTARequestorStorage gRequestorStorage;
 chip::DeviceLayer::GenericOTARequestorDriver gRequestorUser;
 chip::BDXDownloader gDownloader;
 chip::OTAImageProcessorImpl gImageProcessor;
@@ -71,7 +72,8 @@ void OTAConfig::Init()
     // Initialize and interconnect the Requestor and Image Processor objects -- START
     SetRequestorInstance(&gRequestorCore);
 
-    gRequestorCore.Init(&(chip::Server::GetInstance()), &gRequestorUser, &gDownloader);
+    gRequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
+    gRequestorCore.Init(chip::Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
 
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 

--- a/examples/platform/efr32/OTAConfig.h
+++ b/examples/platform/efr32/OTAConfig.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
-#include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/EFR32/OTAImageProcessorImpl.h>

--- a/examples/platform/efr32/OTAConfig.h
+++ b/examples/platform/efr32/OTAConfig.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
-#include <app/clusters/ota-requestor/BDXDownloader.h>
 #include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
+#include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/EFR32/OTAImageProcessorImpl.h>

--- a/examples/platform/efr32/OTAConfig.h
+++ b/examples/platform/efr32/OTAConfig.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/EFR32/OTAImageProcessorImpl.h>

--- a/examples/platform/mbed/util/DFUManager.cpp
+++ b/examples/platform/mbed/util/DFUManager.cpp
@@ -56,7 +56,8 @@ CHIP_ERROR DFUManager::Init(chip::Callback::Callback<OnUpdateAvailable> * onUpda
 
 #ifdef CHIP_OTA_REQUESTOR
     SetRequestorInstance(&mRequestorCore);
-    mRequestorCore.Init(&(chip::Server::GetInstance()), &mRequestorDriver, &mDownloader);
+    mRequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
+    mRequestorCore.Init(chip::Server::GetInstance(), mRequestorStorage, mRequestorDriver, mDownloader);
     mImageProcessor.SetOTADownloader(&mDownloader);
     mDownloader.SetImageProcessorDelegate(&mImageProcessor);
     mRequestorDriver.Init(&mRequestorCore, &mImageProcessor, &mOnOtaUpdateAvailableCallback, &mOnOtaUpdateApplyCallback);

--- a/examples/platform/mbed/util/include/DFUManager.h
+++ b/examples/platform/mbed/util/include/DFUManager.h
@@ -54,6 +54,7 @@ private:
 
 #ifdef CHIP_OTA_REQUESTOR
     chip::OTARequestor mRequestorCore;
+    chip::DefaultOTARequestorStorage mRequestorStorage;
     chip::DeviceLayer::OTARequestorDriverImpl mRequestorDriver;
     chip::BDXDownloader mDownloader;
     chip::OTAImageProcessorImpl mImageProcessor;

--- a/examples/platform/qpg/ota/ota.cpp
+++ b/examples/platform/qpg/ota/ota.cpp
@@ -28,6 +28,7 @@
 #include <platform/CHIPDeviceLayer.h>
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/qpg/OTAImageProcessorImpl.h>
@@ -40,6 +41,7 @@ using namespace chip::DeviceLayer;
  *****************************************************************************/
 
 OTARequestor gRequestorCore;
+DefaultOTARequestorStorage gRequestorStorage;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
@@ -53,7 +55,8 @@ void InitializeOTARequestor(void)
     // Initialize and interconnect the Requestor and Image Processor objects
     SetRequestorInstance(&gRequestorCore);
 
-    gRequestorCore.Init(&Server::GetInstance(), &gRequestorUser, &gDownloader);
+    gRequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
+    gRequestorCore.Init(chip::Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
     gImageProcessor.SetOTADownloader(&gDownloader);
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);

--- a/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -33,6 +33,7 @@
 
 #if defined(CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR)
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/cc13x2_26x2/OTAImageProcessorImpl.h>
@@ -76,6 +77,7 @@ AppTask AppTask::sAppTask;
 
 #if defined(CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR)
 static OTARequestor sRequestorCore;
+static DefaultOTARequestorStorage sRequestorStorage;
 static GenericOTARequestorDriver sRequestorUser;
 static BDXDownloader sDownloader;
 static OTAImageProcessorImpl sImageProcessor;
@@ -85,7 +87,8 @@ void InitializeOTARequestor(void)
     // Initialize and interconnect the Requestor and Image Processor objects
     SetRequestorInstance(&sRequestorCore);
 
-    sRequestorCore.Init(&Server::GetInstance(), &sRequestorUser, &sDownloader);
+    sRequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
+    sRequestorCore.Init(chip::Server::GetInstance(), sRequestorStorage, sRequestorUser, sDownloader);
     sImageProcessor.SetOTADownloader(&sDownloader);
     sDownloader.SetImageProcessorDelegate(&sImageProcessor);
     sRequestorUser.Init(&sRequestorCore, &sImageProcessor);

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -38,6 +38,7 @@
 
 #if CONFIG_CHIP_OTA_REQUESTOR
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/nrfconnect/OTAImageProcessorImpl.h>
@@ -77,6 +78,7 @@ bool sIsThreadEnabled     = false;
 bool sHaveBLEConnections  = false;
 
 #if CONFIG_CHIP_OTA_REQUESTOR
+DefaultOTARequestorStorage sRequestorStorage;
 GenericOTARequestorDriver sOTARequestorDriver;
 OTAImageProcessorImpl sOTAImageProcessor;
 chip::BDXDownloader sBDXDownloader;
@@ -181,7 +183,8 @@ void AppTask::InitOTARequestor()
     sOTAImageProcessor.SetOTADownloader(&sBDXDownloader);
     sBDXDownloader.SetImageProcessorDelegate(&sOTAImageProcessor);
     sOTARequestorDriver.Init(&sOTARequestor, &sOTAImageProcessor);
-    sOTARequestor.Init(&chip::Server::GetInstance(), &sOTARequestorDriver, &sBDXDownloader);
+    sRequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
+    sOTARequestor.Init(chip::Server::GetInstance(), sRequestorStorage, sOTARequestorDriver, sBDXDownloader);
     chip::SetRequestorInstance(&sOTARequestor);
 #endif
 }

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -38,6 +38,7 @@
 
 #if CONFIG_CHIP_OTA_REQUESTOR
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/nrfconnect/OTAImageProcessorImpl.h>
@@ -74,6 +75,7 @@ bool sIsThreadEnabled     = false;
 bool sHaveBLEConnections  = false;
 
 #if CONFIG_CHIP_OTA_REQUESTOR
+DefaultOTARequestorStorage sRequestorStorage;
 GenericOTARequestorDriver sOTARequestorDriver;
 OTAImageProcessorImpl sOTAImageProcessor;
 chip::BDXDownloader sBDXDownloader;
@@ -178,7 +180,8 @@ void AppTask::InitOTARequestor()
     sOTAImageProcessor.SetOTADownloader(&sBDXDownloader);
     sBDXDownloader.SetImageProcessorDelegate(&sOTAImageProcessor);
     sOTARequestorDriver.Init(&sOTARequestor, &sOTAImageProcessor);
-    sOTARequestor.Init(&chip::Server::GetInstance(), &sOTARequestorDriver, &sBDXDownloader);
+    sRequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
+    sOTARequestor.Init(chip::Server::GetInstance(), sRequestorStorage, sOTARequestorDriver, sBDXDownloader);
     chip::SetRequestorInstance(&sOTARequestor);
 #endif
 }

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -131,10 +131,13 @@ template("chip_data_model") {
           "${_app_root}/clusters/${cluster}/${cluster}-server.cpp",
           "${_app_root}/clusters/${cluster}/BDXDownloader.cpp",
           "${_app_root}/clusters/${cluster}/BDXDownloader.h",
+          "${_app_root}/clusters/${cluster}/DefaultOTARequestorStorage.cpp",
+          "${_app_root}/clusters/${cluster}/DefaultOTARequestorStorage.h",
           "${_app_root}/clusters/${cluster}/DefaultOTARequestorUserConsentProvider.h",
           "${_app_root}/clusters/${cluster}/ExtendedOTARequestorDriver.cpp",
           "${_app_root}/clusters/${cluster}/GenericOTARequestorDriver.cpp",
           "${_app_root}/clusters/${cluster}/OTARequestor.cpp",
+          "${_app_root}/clusters/${cluster}/OTARequestorStorage.h",
         ]
       } else if (cluster == "bindings") {
         sources += [

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.h
@@ -41,6 +41,7 @@ public:
     CHIP_ERROR LoadUpdateToken(MutableByteSpan & updateToken) override;
 
 private:
+    CHIP_ERROR Load(const char * key, MutableByteSpan & buffer);
     PersistentStorageDelegate * mPersistentStorage = nullptr;
 };
 

--- a/src/app/clusters/ota-requestor/OTARequestorInterface.h
+++ b/src/app/clusters/ota-requestor/OTARequestorInterface.h
@@ -116,20 +116,15 @@ public:
     /**
      * Delete a provider location from the list if found
      */
-    CHIP_ERROR Delete(const app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type & providerLocation)
+    CHIP_ERROR Delete(FabricIndex fabricIndex)
     {
         for (size_t i = 0; i < mMaxSize; i++)
         {
-            if (mList[i].HasValue())
+            if (mList[i].HasValue() && mList[i].Value().GetFabricIndex() == fabricIndex)
             {
-                const app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type & pl = mList[i].Value();
-                if ((pl.GetFabricIndex() == providerLocation.GetFabricIndex()) &&
-                    (pl.providerNodeID == providerLocation.providerNodeID) && (pl.endpoint == providerLocation.endpoint))
-                {
-                    mList[i].ClearValue();
-                    mListSize--;
-                    return CHIP_NO_ERROR;
-                }
+                mList[i].ClearValue();
+                mListSize--;
+                return CHIP_NO_ERROR;
             }
         }
 

--- a/src/app/clusters/ota-requestor/OTARequestorInterface.h
+++ b/src/app/clusters/ota-requestor/OTARequestorInterface.h
@@ -114,7 +114,7 @@ public:
     }
 
     /**
-     * Delete a provider location from the list if found
+     * Delete a provider location for the given fabric index.
      */
     CHIP_ERROR Delete(FabricIndex fabricIndex)
     {

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -72,9 +72,9 @@ public:
     const char * BindingTable() { return Format("bt"); }
     const char * BindingTableEntry(uint8_t index) { return Format("bt/%x", index); }
 
-    const char * OTADefaultProviders() { return "o/dp"; }
-    const char * OTACurrentProvider() { return "o/pl"; }
-    const char * OTAUpdateToken() { return "o/ut"; }
+    static const char * OTADefaultProviders() { return "o/dp"; }
+    static const char * OTACurrentProvider() { return "o/cp"; }
+    static const char * OTAUpdateToken() { return "o/ut"; }
 
 private:
     static const size_t kKeyLengthMax = 32;


### PR DESCRIPTION
#### Problem
OTA Requestor's `DefaultOTAProviders` attribute is not persisted.

#### Change overview
Add `OTARequestorStorage` to all examples using `OTARequestor`.
Use `OTARequestorStorage` interface to load `DefaultOTAProviders` on application startup and store it on each modification.
The current approach may cause some unnecessary writes since each attribute write is actually "Remove all" + "Append item" operations, but the existing attribute accessor interface doesn't notify an implementation that a given list operation is the last one in the action.
Fixes #14338.

#### Testing
`DefaultOTARequestorStorage` is covered by unit tests.
Additionally, tested on nRF connect platform that the attribute survives a device reboot.
