### PR TITLE
Avahi - Don't error when receiving an ipv4 address

### DIFF
--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -727,8 +727,7 @@ void MdnsAvahi::HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex inte
         context->mCallback(context->mContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_INTERNAL);
         break;
     case AVAHI_RESOLVER_FOUND:
-        DnssdService result   = {};
-        CHIP_ERROR result_err = CHIP_NO_ERROR;
+        DnssdService result = {};
 
         result.mAddress.SetValue(chip::Inet::IPAddress());
         ChipLogError(DeviceLayer, "Avahi resolve found");
@@ -753,6 +752,7 @@ void MdnsAvahi::HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex inte
             *dot = '\0';
         }
 
+        CHIP_ERROR result_err = CHIP_ERROR_INVALID_ADDRESS;
         if (address)
         {
             switch (address->proto)
@@ -763,8 +763,8 @@ void MdnsAvahi::HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex inte
 
                 memcpy(&addr4, &(address->data.ipv4), sizeof(addr4));
                 result.mAddress.SetValue(chip::Inet::IPAddress(addr4));
+                result_err = CHIP_NO_ERROR;
 #else
-                result_err = CHIP_ERROR_INVALID_ADDRESS;
                 ChipLogError(Discovery, "Ignoring IPv4 mDNS address.");
 #endif
                 break;
@@ -773,6 +773,7 @@ void MdnsAvahi::HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex inte
 
                 memcpy(&addr6, &(address->data.ipv6), sizeof(addr6));
                 result.mAddress.SetValue(chip::Inet::IPAddress(addr6));
+                result_err = CHIP_NO_ERROR;
                 break;
             default:
                 break;


### PR DESCRIPTION
#### Problem
Avahi will throw an error if it gets an A record and doesn't support IPV4.
Receiving an ipv4 address isn't an error, we should just ignore it
if we don't support it.

#### Change overview
Changes address error to check for any useable address.

#### Testing
Tested with 1p device that returns both ipv4 and ipv6. Saw ignore message, but got responses.
