### PR TITLE
Implement a simple DetermineProviderLocation

### DIFF
--- a/scripts/tests/ota_test.sh
+++ b/scripts/tests/ota_test.sh
@@ -9,12 +9,18 @@ FIRMWARE_BIN="my-firmware.bin"
 FIRMWARE_OTA="my-firmware.ota"
 
 OTA_PROVIDER_APP="chip-ota-provider-app"
+OTA_PROVIDER_FOLDER="out/ota_provider_debug"
 OTA_REQUESTOR_APP="chip-ota-requestor-app"
+OTA_REQUESTOR_FOLDER="out/ota_requestor_debug"
+CHIP_TOOL_APP="chip-tool"
+CHIP_TOOL_FOLDER="out"
 
 killall -e "$OTA_PROVIDER_APP" "$OTA_REQUESTOR_APP"
 rm -f "$FIRMWARE_OTA" "$FIRMWARE_BIN" "$OTA_DOWNLOAD_PATH"
 
-scripts/examples/gn_build_example.sh examples/chip-tool out/
+scripts/examples/gn_build_example.sh examples/chip-tool "$CHIP_TOOL_FOLDER"
+scripts/examples/gn_build_example.sh examples/ota-requestor-app/linux "$OTA_REQUESTOR_FOLDER" chip_config_network_layer_ble=false
+scripts/examples/gn_build_example.sh examples/ota-provider-app/linux "$OTA_PROVIDER_FOLDER" chip_config_network_layer_ble=false
 
 echo "Test" >"$FIRMWARE_BIN"
 
@@ -26,24 +32,24 @@ if [ ! -f "$FIRMWARE_OTA" ]; then
     exit 1
 fi
 
-./out/ota_provider_debug/"$OTA_PROVIDER_APP" -f "$FIRMWARE_OTA" | tee /tmp/ota/provider-log.txt &
+./"$OTA_PROVIDER_FOLDER"/"$OTA_PROVIDER_APP" -f "$FIRMWARE_OTA" | tee /tmp/ota/provider-log.txt &
 
 echo "Commissioning Provider"
 
-./out/chip-tool pairing onnetwork 1 "$PASSCODE" | tee /tmp/ota/chip-tool-commission-provider.txt
+./"$CHIP_TOOL_FOLDER"/"$CHIP_TOOL_APP" pairing onnetwork 1 "$PASSCODE" | tee /tmp/ota/chip-tool-commission-provider.txt
 if grep "Device commissioning completed with success" /tmp/ota/chip-tool-commission-provider.txt; then
     echo Provider Commissioned
 else
     echo Provider not commissioned properly
 fi
 
-./out/chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": [112233], "targets": null}, {"fabricIndex": 1, "privilege": 3, "authMode": 2, "subjects": null, "targets": null}]' 1 0
+./"$CHIP_TOOL_FOLDER"/"$CHIP_TOOL_APP" accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": [112233], "targets": null}, {"fabricIndex": 1, "privilege": 3, "authMode": 2, "subjects": null, "targets": null}]' 1 0
 
-stdbuf -o0 ./out/ota_requestor_debug/"$OTA_REQUESTOR_APP" --discriminator "$DISCRIMINATOR" --secured-device-port "$UDP_PORT" --KVS /tmp/chip_kvs_requestor --otaDownloadPath "$OTA_DOWNLOAD_PATH" | tee /tmp/ota/requestor-log.txt &
+stdbuf -o0 ./"$OTA_REQUESTOR_FOLDER"/"$OTA_REQUESTOR_APP" --discriminator "$DISCRIMINATOR" --secured-device-port "$UDP_PORT" --KVS /tmp/chip_kvs_requestor --otaDownloadPath "$OTA_DOWNLOAD_PATH" | tee /tmp/ota/requestor-log.txt &
 
 echo "Commissioning Requestor"
 
-./out/chip-tool pairing onnetwork-long 2 "$PASSCODE" "$DISCRIMINATOR" | tee /tmp/ota/chip-tool-commission-requestor.txt
+./"$CHIP_TOOL_FOLDER"/"$CHIP_TOOL_APP" pairing onnetwork-long 2 "$PASSCODE" "$DISCRIMINATOR" | tee /tmp/ota/chip-tool-commission-requestor.txt
 
 if grep "Device commissioning completed with success" /tmp/ota/chip-tool-commission-requestor.txt; then
     echo Requestor Commissioned
@@ -53,7 +59,7 @@ fi
 
 echo "Sending announce-ota-provider"
 
-./out/chip-tool otasoftwareupdaterequestor announce-ota-provider 1 0 0 0 2 0 | tee /tmp/ota/chip-tool-announce-ota.txt
+./"$CHIP_TOOL_FOLDER"/"$CHIP_TOOL_APP" otasoftwareupdaterequestor announce-ota-provider 1 0 0 0 2 0 | tee /tmp/ota/chip-tool-announce-ota.txt
 
 timeout 30 grep -q "OTA image downloaded to" <(tail -n0 -f /tmp/ota/requestor-log.txt)
 

--- a/src/app/clusters/ota-requestor/ExtendedOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/ExtendedOTARequestorDriver.cpp
@@ -68,9 +68,17 @@ void ExtendedOTARequestorDriver::PollUserConsentState()
 CHIP_ERROR ExtendedOTARequestorDriver::GetUserConsentSubject(chip::ota::UserConsentSubject & subject,
                                                              const UpdateDescription & update)
 {
-    // mLastUsedProvider has the provider fabric index and endpoint id
-    subject.fabricIndex        = mLastUsedProvider.fabricIndex;
-    subject.providerEndpointId = mLastUsedProvider.endpoint;
+    if (mLastUsedProvider.HasValue())
+    {
+        // mLastUsedProvider has the provider fabric index and endpoint id
+        subject.fabricIndex        = mLastUsedProvider.Value().fabricIndex;
+        subject.providerEndpointId = mLastUsedProvider.Value().endpoint;
+    }
+    else
+    {
+        ChipLogError(SoftwareUpdate, "mLastProvider is empty");
+        return CHIP_ERROR_INTERNAL;
+    }
 
     // TODO: As we cannot use the src/app/Server.h in here so, figure out a way to get the node id.
 

--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
@@ -87,7 +87,7 @@ protected:
     uint32_t mPeriodicQueryTimeInterval = (24 * 60 * 60); // Timeout for querying providers on the default OTA provider list
 
     using ProviderLocationType = app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type;
-    ProviderLocationType mLastUsedProvider; // Provider location used for the last query or update
+    Optional<ProviderLocationType> mLastUsedProvider; // Provider location used for the last query or update
 };
 
 } // namespace DeviceLayer


### PR DESCRIPTION
#### Problem
Provide a generic implementation for DetermineProviderLocation()

#### Change overview
It has been decided that a simple "iterate-through-the-list" approach would be the best path forward.
DetermineProviderLocation() iterates through the list of DefaultOTAProviders, finds the last-used-provider and returns the entry after it (cycles back to the start of the list). If no suitable candidate has been found, an error is returned.

#### Testing
- Tested by verifying the OTARequestor runs through the entire list in order (by reducing the periodicity of the QueryImage timer)
- Ensured OTA download works on Linux (With #15963 changes)
