### PR TITLE
Add Darwin error mapping for CHIP_ERROR_TIMEOUT.

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPError.h
+++ b/src/darwin/Framework/CHIP/CHIPError.h
@@ -49,6 +49,7 @@ typedef NS_ERROR_ENUM(CHIPErrorDomain, CHIPErrorCode){
     CHIPErrorCodeInvalidState         = 6,
     CHIPErrorCodeWrongAddressType     = 7,
     CHIPErrorCodeIntegrityCheckFailed = 8,
+    CHIPErrorCodeTimeout              = 9,
 };
 // clang-format on
 

--- a/src/darwin/Framework/CHIP/CHIPError.mm
+++ b/src/darwin/Framework/CHIP/CHIPError.mm
@@ -77,6 +77,12 @@ NSString * const MatterInteractionErrorDomain = @"MatterInteractionErrorDomain";
                                userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Integrity check failed.", nil) }];
     }
 
+    if (errorCode == CHIP_ERROR_TIMEOUT) {
+        return [NSError errorWithDomain:CHIPErrorDomain
+                                   code:CHIPErrorCodeTimeout
+                               userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Transaction timed out.", nil) }];
+    }
+
     return [NSError errorWithDomain:CHIPErrorDomain
                                code:CHIPErrorCodeGeneralError
                            userInfo:@{
@@ -237,6 +243,8 @@ NSString * const MatterInteractionErrorDomain = @"MatterInteractionErrorDomain";
         return CHIP_ERROR_INCORRECT_STATE;
     case CHIPErrorCodeIntegrityCheckFailed:
         return CHIP_ERROR_INTEGRITY_CHECK_FAILED;
+    case CHIPErrorCodeTimeout:
+        return CHIP_ERROR_TIMEOUT;
     default:
         return CHIP_ERROR_INTERNAL;
     }


### PR DESCRIPTION
#### Problem
"Undefined error:50" is not very clear.

#### Change overview
Add a nicer error message.

#### Testing
Code inspection.