### PR TITLE
[OTA] Fix OTARequestorDriverImpl inclusion

### DIFF
--- a/config/mbed/CMakeLists.txt
+++ b/config/mbed/CMakeLists.txt
@@ -456,6 +456,7 @@ endif(CONFIG_CHIP_PW_RPC)
 
 if (CONFIG_CHIP_OTA_REQUESTOR)
     target_include_directories(${APP_TARGET} PRIVATE
+        ${CHIP_ROOT}/examples/platform/mbed/ota/
         ${CHIP_ROOT}/src/app/clusters/ota-requestor
         ${CHIP_ROOT}/src/platform
         ${CHIP_ROOT}/src/platform/mbed


### PR DESCRIPTION
#### Problem
https://github.com/project-chip/connectedhomeip/pull/15949 moves the OTARequestorDriver to the clusters directory. In that PR, it also moves any non-default impl from src/platform into examples/platform directory. The include directory is not updated for mbed to the examples/platform directory.

#### Change overview
Add examples/platform/mbed/ota directory to be part of include directories

#### Testing
Tree compiles
