### PR TITLE
Fix removal of all fabrics in CHIPTool

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Fabric/FabricUIViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Fabric/FabricUIViewController.m
@@ -326,16 +326,15 @@
                                          isError:YES];
                             }
 
-                        CHIPOperationalCredentials * opCredsCluster =
-                            [[CHIPOperationalCredentials alloc] initWithDevice:chipDevice
-                                                                      endpoint:0
-                                                                         queue:dispatch_get_main_queue()];
+                            CHIPOperationalCredentials * opCredsCluster =
+                                [[CHIPOperationalCredentials alloc] initWithDevice:chipDevice
+                                                                          endpoint:0
+                                                                             queue:dispatch_get_main_queue()];
 
-                        dispatch_group_t removeGroup = dispatch_group_create();
+                            dispatch_group_t removeGroup = dispatch_group_create();
                             // Loop over the list of all fabrics and for each, call remove
                             for (CHIPOperationalCredentialsClusterFabricDescriptor * fabricDescriptor in self.fabricsList) {
-                                if ([fabricDescriptor.fabricIndex isEqualToNumber:self.currentFabricIndex])
-                                {
+                                if ([fabricDescriptor.fabricIndex isEqualToNumber:self.currentFabricIndex]) {
                                     // We'll remove our own fabric later
                                     continue;
                                 }
@@ -351,28 +350,28 @@
                                              [self updateResult:[NSString stringWithFormat:@"Removed Fabric Index %@ with Error %@",
                                                                           params.fabricIndex, error]
                                                         isError:error];
-                                        dispatch_group_leave(removeGroup);
+                                             dispatch_group_leave(removeGroup);
                                          }];
                             }
-                        dispatch_group_notify(removeGroup, dispatch_get_main_queue(), ^{
-                            // now we can remove ourselves
-                            CHIPOperationalCredentialsClusterRemoveFabricParams * params =
-                                [[CHIPOperationalCredentialsClusterRemoveFabricParams alloc] init];
-                            params.fabricIndex = self.currentFabricIndex;
-                            [opCredsCluster
-                                removeFabricWithParams:params
-                                     completionHandler:^(CHIPOperationalCredentialsClusterNOCResponseParams * _Nullable data,
-                                         NSError * _Nullable error) {
-                                         if (!error) {
-                                             CHIPSetDevicePaired(CHIPGetLastPairedDeviceId(), NO);
-                                         }
-                                         [self updateResult:[NSString stringWithFormat:@"Removed own Fabric Index %@ with Error %@",
-                                                                      params.fabricIndex, error]
-                                                    isError:error];
-                                    dispatch_group_leave(removeGroup);
-                                     }];
-                        });
-
+                            dispatch_group_notify(removeGroup, dispatch_get_main_queue(), ^{
+                                // now we can remove ourselves
+                                CHIPOperationalCredentialsClusterRemoveFabricParams * params =
+                                    [[CHIPOperationalCredentialsClusterRemoveFabricParams alloc] init];
+                                params.fabricIndex = self.currentFabricIndex;
+                                [opCredsCluster
+                                    removeFabricWithParams:params
+                                         completionHandler:^(CHIPOperationalCredentialsClusterNOCResponseParams * _Nullable data,
+                                             NSError * _Nullable error) {
+                                             if (!error) {
+                                                 CHIPSetDevicePaired(CHIPGetLastPairedDeviceId(), NO);
+                                             }
+                                             [self updateResult:[NSString
+                                                                    stringWithFormat:@"Removed own Fabric Index %@ with Error %@",
+                                                                    params.fabricIndex, error]
+                                                        isError:error];
+                                             dispatch_group_leave(removeGroup);
+                                         }];
+                            });
                         })) {
                         [self updateResult:[NSString stringWithFormat:@"Waiting for connection with the device"] isError:NO];
                     } else {

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Fabric/FabricUIViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Fabric/FabricUIViewController.m
@@ -325,27 +325,54 @@
                                                      stringWithFormat:@"Failed to establish a connection with the device %@", error]
                                          isError:YES];
                             }
+
+                        CHIPOperationalCredentials * opCredsCluster =
+                            [[CHIPOperationalCredentials alloc] initWithDevice:chipDevice
+                                                                      endpoint:0
+                                                                         queue:dispatch_get_main_queue()];
+
+                        dispatch_group_t removeGroup = dispatch_group_create();
                             // Loop over the list of all fabrics and for each, call remove
                             for (CHIPOperationalCredentialsClusterFabricDescriptor * fabricDescriptor in self.fabricsList) {
-                                CHIPOperationalCredentials * opCredsCluster =
-                                    [[CHIPOperationalCredentials alloc] initWithDevice:chipDevice
-                                                                              endpoint:0
-                                                                                 queue:dispatch_get_main_queue()];
+                                if ([fabricDescriptor.fabricIndex isEqualToNumber:self.currentFabricIndex])
+                                {
+                                    // We'll remove our own fabric later
+                                    continue;
+                                }
+
                                 CHIPOperationalCredentialsClusterRemoveFabricParams * params =
                                     [[CHIPOperationalCredentialsClusterRemoveFabricParams alloc] init];
                                 params.fabricIndex = fabricDescriptor.fabricIndex;
+                                dispatch_group_enter(removeGroup);
                                 [opCredsCluster
                                     removeFabricWithParams:params
                                          completionHandler:^(CHIPOperationalCredentialsClusterNOCResponseParams * _Nullable data,
                                              NSError * _Nullable error) {
-                                             if (!error) {
-                                                 CHIPSetDevicePaired(CHIPGetLastPairedDeviceId(), NO);
-                                             }
                                              [self updateResult:[NSString stringWithFormat:@"Removed Fabric Index %@ with Error %@",
                                                                           params.fabricIndex, error]
                                                         isError:error];
+                                        dispatch_group_leave(removeGroup);
                                          }];
                             }
+                        dispatch_group_notify(removeGroup, dispatch_get_main_queue(), ^{
+                            // now we can remove ourselves
+                            CHIPOperationalCredentialsClusterRemoveFabricParams * params =
+                                [[CHIPOperationalCredentialsClusterRemoveFabricParams alloc] init];
+                            params.fabricIndex = self.currentFabricIndex;
+                            [opCredsCluster
+                                removeFabricWithParams:params
+                                     completionHandler:^(CHIPOperationalCredentialsClusterNOCResponseParams * _Nullable data,
+                                         NSError * _Nullable error) {
+                                         if (!error) {
+                                             CHIPSetDevicePaired(CHIPGetLastPairedDeviceId(), NO);
+                                         }
+                                         [self updateResult:[NSString stringWithFormat:@"Removed own Fabric Index %@ with Error %@",
+                                                                      params.fabricIndex, error]
+                                                    isError:error];
+                                    dispatch_group_leave(removeGroup);
+                                     }];
+                        });
+
                         })) {
                         [self updateResult:[NSString stringWithFormat:@"Waiting for connection with the device"] isError:NO];
                     } else {

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Fabric/FabricUIViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Fabric/FabricUIViewController.m
@@ -369,7 +369,6 @@
                                                                     stringWithFormat:@"Removed own Fabric Index %@ with Error %@",
                                                                     params.fabricIndex, error]
                                                         isError:error];
-                                             dispatch_group_leave(removeGroup);
                                          }];
                             });
                         })) {


### PR DESCRIPTION
#### Problem
Fixes: https://github.com/project-chip/connectedhomeip/issues/15942

#### Change overview
Remove our own fabric at the very end of the removal loop.

#### Testing

* If manually tested, what platforms controller and device platforms were manually tested, and how?
Tested with CHIPTool iOS, it's a little random. I didn't see the issue.