### PR TITLE
[IM] Cache FabricId + NodeId instead of SessionHandle in ReadClient

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -853,6 +853,9 @@ CHIP_ERROR ReadClient::SendSubscribeRequest(ReadPrepareParams & aReadPreparePara
     mPeerNodeId  = aReadPrepareParams.mSessionHolder->AsSecureSession()->GetPeerNodeId();
     mFabricIndex = aReadPrepareParams.mSessionHolder->GetFabricIndex();
 
+    // We will try to get an up-to-date session when resubscribe.
+    aReadPrepareParams.mSessionHolder->Release();
+
     MoveToState(ClientState::AwaitingInitialReport);
 
     return CHIP_NO_ERROR;
@@ -862,8 +865,19 @@ void ReadClient::OnResubscribeTimerCallback(System::Layer * apSystemLayer, void 
 {
     ReadClient * const _this = reinterpret_cast<ReadClient *>(apAppState);
     assert(_this != nullptr);
-    _this->SendSubscribeRequest(_this->mReadPrepareParams);
+
     _this->mNumRetries++;
+
+    // Get an up-to-date session from session manager.
+    auto session = _this->mpExchangeMgr->GetSessionManager()->FindSecureSessionForPeer(_this->mFabricIndex, _this->mPeerNodeId);
+    if (!session.HasValue())
+    {
+        return;
+    }
+
+    _this->mReadPrepareParams.mSessionHolder.Grab(session.Value());
+
+    _this->SendSubscribeRequest(_this->mReadPrepareParams);
 }
 
 bool ReadClient::ResubscribeIfNeeded()

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -774,6 +774,28 @@ SessionHandle SessionManager::FindSecureSessionForNode(NodeId peerNodeId)
     return SessionHandle(*found);
 }
 
+Optional<SessionHandle> SessionManager::FindSecureSessionForPeer(FabricIndex fabricIndex, NodeId peerNodeId)
+{
+    SecureSession * found = nullptr;
+    mSecureSessions.ForEachSession([&](auto session) {
+        if (session->GetPeerNodeId() == peerNodeId && session->GetFabricIndex() == fabricIndex)
+        {
+            found = session;
+            return Loop::Break;
+        }
+        return Loop::Continue;
+    });
+
+    if (found)
+    {
+        return MakeOptional(SessionHandle(*found));
+    }
+    else
+    {
+        return NullOptional;
+    }
+}
+
 /**
  * Provides a means to get diagnostic information such as number of sessions.
  */

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -225,6 +225,8 @@ public:
         return mUnauthenticatedSessions.AllocInitiator(ephemeralInitiatorNodeID, peerAddress, config);
     }
 
+    Optional<SessionHandle> FindSecureSessionForPeer(chip::FabricIndex fabricIndex, NodeId nodeId);
+
     // TODO: this is a temporary solution for legacy tests which use nodeId to send packets
     // and tv-casting-app that uses the TV's node ID to find the associated secure session
     SessionHandle FindSecureSessionForNode(NodeId peerNodeId);


### PR DESCRIPTION
#### Problem
Re-subscription is not working if the secure session is expired.

Fixes #15766 

#### Change overview
What's in this PR

#### Testing
Use REPL + all-clusters-app to verify:

```
In [1]: res = await devCtrl.ReadAttribute(
   ...:     nodeid=233, attributes=[(Clusters.Descriptor)], returnClusterObject=True, reportInterval=(1, 10))

# Kill and restart the all-cluster-app, should see many errors related due to outdated session
# Expect the app use some external heart beat to create a new session with the client, do this manaully here.

In [2]: devCtrl.CloseSession(233)
Out[2]: 0

In [3]: devCtrl.ResolveNode(233)

# Wait for a while (re-subscription timeout fired)
# The subscription should recovered from the log.
```