### PR TITLE
FabricInfo: Add API to create a fabric for test-cases

### DIFF
--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -179,8 +179,7 @@ public:
     }
 
     CHIP_ERROR VerifyCredentials(const ByteSpan & noc, const ByteSpan & icac, Credentials::ValidationContext & context,
-                                 FabricId & fabricId, NodeId & nodeId, CompressedFabricId & compressedFabricId,
-                                 Crypto::P256PublicKey & pubkey) const;
+                                 FabricId & fabricId, NodeId & nodeId, Crypto::P256PublicKey & pubkey) const;
 
     /**
      *  Reset the state to a completely uninitialized status.
@@ -202,11 +201,8 @@ public:
 
     CHIP_ERROR SetFabricInfo(FabricInfo & fabric);
 
-    /* Generate a compressed peer ID (containing compressed fabric ID) using provided fabric ID, node ID and
-       root public key of the fabric. The generated compressed ID is returned via compressedPeerId
-       output parameter */
-    static CHIP_ERROR ComputeCompressedFabricId(FabricId fabricId, NodeId nodeId,
-                                                const Credentials::P256PublicKeySpan & rootPubkeySpan, CompressedFabricId & result);
+    /* Compute and cache compressedFabricId, using mFabricId and root pubkey. Store it in mCompressedFabricId */
+    CHIP_ERROR ComputeCompressedFabricId();
 
     /* A test-only function, to build a fabric used in tests. Returns a fabric which can be added into a fabric table. */
     static CHIP_ERROR BuildNewFabric(FabricId fabricId, NodeId nodeId, const chip::ByteSpan & cert, FabricInfo & result);

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -53,24 +53,21 @@ void TestGetCompressedFabricID(nlTestSuite * inSuite, void * inContext)
 {
     FabricInfo fabricInfo;
 
-    NL_TEST_ASSERT(inSuite, fabricInfo.SetRootCert(ByteSpan(sTestRootCert)) == CHIP_NO_ERROR);
-
-    PeerId compressedId;
-    NL_TEST_ASSERT(inSuite, fabricInfo.GeneratePeerId(1234, 4321, &compressedId) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, FabricInfo::BuildNewFabric(1234, 4321, ByteSpan(sTestRootCert), fabricInfo) == CHIP_NO_ERROR);
 
     // We are compairing with hard coded values here (which are generated manually when the test was written)
     // This is to ensure that the same value is generated on big endian and little endian platforms.
-    // If in this test any input to GeneratePeerId() is changed, this value must be recomputed.
-    NL_TEST_ASSERT(inSuite, compressedId.GetCompressedFabricId() == 0x090F17C67be7b663);
-    NL_TEST_ASSERT(inSuite, compressedId.GetNodeId() == 4321);
+    // If in this test any input to ComputeCompressedFabricId() is changed, this value must be recomputed.
+    NL_TEST_ASSERT(inSuite, fabricInfo.GetCompressedId() == 0x090F17C67be7b663);
+    NL_TEST_ASSERT(inSuite, fabricInfo.GetNodeId() == 4321);
 
-    NL_TEST_ASSERT(inSuite, fabricInfo.GeneratePeerId(0xabcd, 0xdeed, &compressedId) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, FabricInfo::BuildNewFabric(0xabcd, 0xdeed, ByteSpan(sTestRootCert), fabricInfo) == CHIP_NO_ERROR);
 
     // We are compairing with hard coded values here (which are generated manually when the test was written)
     // This is to ensure that the same value is generated on big endian and little endian platforms
-    // If in this test any input to GeneratePeerId() is changed, this value must be recomputed.
-    NL_TEST_ASSERT(inSuite, compressedId.GetCompressedFabricId() == 0xf3fecbcec485d5d7);
-    NL_TEST_ASSERT(inSuite, compressedId.GetNodeId() == 0xdeed);
+    // If in this test any input to ComputeCompressedFabricId() is changed, this value must be recomputed.
+    NL_TEST_ASSERT(inSuite, fabricInfo.GetCompressedId() == 0xf3fecbcec485d5d7);
+    NL_TEST_ASSERT(inSuite, fabricInfo.GetNodeId() == 0xdeed);
 }
 
 // Test Suite

--- a/src/lib/core/PeerId.h
+++ b/src/lib/core/PeerId.h
@@ -38,6 +38,9 @@ class PeerId
 {
 public:
     PeerId() {}
+    constexpr PeerId(NodeId nodeId, CompressedFabricId compressedFabricId) :
+        mNodeId(nodeId), mCompressedFabricId(compressedFabricId)
+    {}
 
     NodeId GetNodeId() const { return mNodeId; }
     PeerId & SetNodeId(NodeId id)

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1273,13 +1273,12 @@ CHIP_ERROR CASESession::ValidatePeerIdentity(const ByteSpan & peerNOC, const Byt
 
     ReturnErrorOnFailure(SetEffectiveTime());
 
-    PeerId peerId;
     FabricId peerNOCFabricId;
-    ReturnErrorOnFailure(mFabricInfo->VerifyCredentials(peerNOC, peerICAC, mValidContext, peerId, peerNOCFabricId, peerPublicKey));
+    CompressedFabricId compressedFabricId;
+    ReturnErrorOnFailure(mFabricInfo->VerifyCredentials(peerNOC, peerICAC, mValidContext, peerNOCFabricId, peerNodeId,
+                                                        compressedFabricId, peerPublicKey));
 
     VerifyOrReturnError(mFabricInfo->GetFabricId() == peerNOCFabricId, CHIP_ERROR_INVALID_CASE_PARAMETER);
-
-    peerNodeId = peerId.GetNodeId();
 
     return CHIP_NO_ERROR;
 }

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1274,9 +1274,7 @@ CHIP_ERROR CASESession::ValidatePeerIdentity(const ByteSpan & peerNOC, const Byt
     ReturnErrorOnFailure(SetEffectiveTime());
 
     FabricId peerNOCFabricId;
-    CompressedFabricId compressedFabricId;
-    ReturnErrorOnFailure(mFabricInfo->VerifyCredentials(peerNOC, peerICAC, mValidContext, peerNOCFabricId, peerNodeId,
-                                                        compressedFabricId, peerPublicKey));
+    ReturnErrorOnFailure(mFabricInfo->VerifyCredentials(peerNOC, peerICAC, mValidContext, peerNOCFabricId, peerNodeId, peerPublicKey));
 
     VerifyOrReturnError(mFabricInfo->GetFabricId() == peerNOCFabricId, CHIP_ERROR_INVALID_CASE_PARAMETER);
 


### PR DESCRIPTION
#### Problem
The peer Alice and Bob in our messaging context doesn't have proper fabric. This PR adds a API to create a fabric, so we can add fabric for them in following PRs.

#### Change overview
* Add `FabricInfo::BuildNewFabric` to create a new fabric, which can be added to a fabric table.
* Split `FabircInfo::mOperationalId` into 2 fields `mNodeId` and `mCompressedFabricid`, which yields smaller and more readable code, because they are rarely used together.
* Change `GeneratePeerId` to `static ComputeCompressedFabricId`, make it cleaner.

#### Testing
Passed unit-tests.