### PR TITLE
[chip-tool-darwin] Add a method to configure the path of the kvs to a…

### DIFF
--- a/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.mm
+++ b/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.mm
@@ -39,6 +39,7 @@ CHIP_ERROR CHIPCommandBridge::Run()
     }
 
     [mController setListenPort:kListenPort];
+    [mController setKeyValueStoreManagerPath:"/tmp/chip_kvs_darwin"];
 
     [nocSigner createOrLoadKeys:storage];
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -92,6 +92,8 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
  */
 - (void)setPairingDelegate:(id<CHIPDevicePairingDelegate>)delegate queue:(dispatch_queue_t)queue;
 
+- (void)setKeyValueStoreManagerPath:(const char *)keyValueStorePath;
+
 /**
  * Start the CHIP Stack. Repeated calls to startup without calls to shutdown in between are NO-OPs. Use the isRunning property to
  * check if the stack needs to be started up.

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -45,6 +45,7 @@
 static const char * const CHIP_COMMISSIONER_DEVICE_ID_KEY = "com.zigbee.chip.commissioner.device_id";
 
 static NSString * const kErrorMemoryInit = @"Init Memory failure";
+static NSString * const kErrorKVSInit = @"Init Key Value Store failure";
 static NSString * const kErrorCommissionerInit = @"Init failure while initializing a commissioner";
 static NSString * const kErrorOperationalCredentialsInit = @"Init failure while creating operational credentials delegate";
 static NSString * const kErrorPairingInit = @"Init failure while creating a pairing delegate";
@@ -69,6 +70,7 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
 @property (readonly) CHIPP256KeypairBridge keypairBridge;
 @property (readonly) chip::NodeId localDeviceId;
 @property (readonly) uint16_t listenPort;
+@property (readonly) const char * kvsPath;
 @end
 
 // TODO Replace Shared Controller with a Controller Factory Singleton
@@ -91,6 +93,7 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
         CHIP_ERROR errorCode = CHIP_NO_ERROR;
 
         _chipWorkQueue = chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue();
+        _kvsPath = nullptr;
 
         errorCode = chip::Platform::MemoryInit();
         if ([self checkForInitError:(CHIP_NO_ERROR == errorCode) logMsg:kErrorMemoryInit]) {
@@ -220,6 +223,13 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
         commissionerParams.controllerICAC = icac;
         commissionerParams.controllerNOC = noc;
         commissionerParams.controllerVendorId = vendorId;
+
+        if (_kvsPath != nullptr) {
+            errorCode = chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init(_kvsPath);
+            if ([self checkForInitError:(CHIP_NO_ERROR == errorCode) logMsg:kErrorKVSInit]) {
+                return;
+            }
+        }
 
         // TODO Replace Shared Controller with a Controller Factory Singleton
         auto & factory = chip::Controller::DeviceControllerFactory::GetInstance();
@@ -563,6 +573,11 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
     dispatch_async(_chipWorkQueue, ^{
         self->_pairingDelegateBridge->setDelegate(delegate, queue);
     });
+}
+
+- (void)setKeyValueStoreManagerPath:(const char *)kvsPath
+{
+    _kvsPath = kvsPath;
 }
 
 - (BOOL)checkForInitError:(BOOL)condition logMsg:(NSString *)logMsg


### PR DESCRIPTION
…void conflicts between chip-tool and chip-tool-darwin

#### Problem

`chip-tool` and `chip-tool-darwin` kvs store is saved at the same place. Add a method to `chip-tool-darwin` to configure where the kvs is stored to avoid conflicts.

#### Change overview
* Add a method to the objective-c controller to configure the path
