### PR TITLE
chip-shell: properly null-terminate maxed line

### DIFF
--- a/src/lib/shell/MainLoopDefault.cpp
+++ b/src/lib/shell/MainLoopDefault.cpp
@@ -32,7 +32,7 @@ using chip::Shell::streamer_get;
 namespace {
 
 // max > 1
-ssize_t ReadLine(char * buffer, size_t max)
+size_t ReadLine(char * buffer, size_t max)
 {
     size_t line_sz = 0;
 
@@ -191,7 +191,7 @@ void Engine::RunMainLoop()
     while (true)
     {
         char * line = static_cast<char *>(Platform::MemoryAlloc(CHIP_SHELL_MAX_LINE_SIZE));
-        if (ReadLine(line, CHIP_SHELL_MAX_LINE_SIZE) == 0)
+        if (ReadLine(line, CHIP_SHELL_MAX_LINE_SIZE) == 0u)
         {
             // Stop loop in case of empty read (Ctrl-D).
             break;

--- a/src/lib/shell/MainLoopDefault.cpp
+++ b/src/lib/shell/MainLoopDefault.cpp
@@ -46,41 +46,44 @@ ssize_t ReadLine(char * buffer, size_t max)
             break;
         }
 
-        if (streamer_read(streamer_get(), buffer + line_sz, 1) == 1)
+        if (streamer_read(streamer_get(), buffer + line_sz, 1) != 1)
         {
-            switch (buffer[line_sz])
+            continue;
+        }
+
+        // Process character we just read.
+        switch (buffer[line_sz])
+        {
+        case '\r':
+        case '\n':
+            streamer_printf(streamer_get(), "\r\n");
+            buffer[line_sz] = '\0';
+            line_sz++;
+            done = true;
+            break;
+        case 0x04:
+            // Do not accept EOT character (i.e. don't increment line_sz).
+            // Stop the read loop if the input is still empty.
+            if (line_sz == 0u)
             {
-            case '\r':
-            case '\n':
-                streamer_printf(streamer_get(), "\r\n");
-                buffer[line_sz] = '\0';
-                line_sz++;
                 done = true;
-                break;
-            case 0x04:
-                // Do not accept EOT character (i.e. don't increment line_sz).
-                // Stop the read loop if the input is still empty.
-                if (line_sz == 0u)
-                {
-                    done = true;
-                }
-                break;
-            case 0x7F:
-                // Do not accept backspace character (i.e. don't increment line_sz) and remove 1 additional character if it exists.
-                if (line_sz >= 1u)
-                {
-                    streamer_printf(streamer_get(), "\b \b");
-                    line_sz--;
-                }
-                break;
-            default:
-                if (isprint(static_cast<int>(buffer[line_sz])) || buffer[line_sz] == '\t')
-                {
-                    streamer_printf(streamer_get(), "%c", buffer[line_sz]);
-                    line_sz++;
-                }
-                break;
             }
+            break;
+        case 0x7F:
+            // Do not accept backspace character (i.e. don't increment line_sz) and remove 1 additional character if it exists.
+            if (line_sz >= 1u)
+            {
+                streamer_printf(streamer_get(), "\b \b");
+                line_sz--;
+            }
+            break;
+        default:
+            if (isprint(static_cast<int>(buffer[line_sz])) || buffer[line_sz] == '\t')
+            {
+                streamer_printf(streamer_get(), "%c", buffer[line_sz]);
+                line_sz++;
+            }
+            break;
         }
     }
 

--- a/src/lib/shell/MainLoopEFR32.cpp
+++ b/src/lib/shell/MainLoopEFR32.cpp
@@ -34,58 +34,50 @@ namespace {
 
 constexpr const char kShellPrompt[] = "matterCli > ";
 
+// max > 1
 void ReadLine(char * buffer, size_t max)
 {
-    ssize_t read = 0;
-    bool done    = false;
-    char * inptr = buffer;
+    size_t line_sz = 0;
 
-    // Read in characters until we get a new line or we hit our max size.
-    while (((inptr - buffer) < static_cast<int>(max)) && !done)
+    // Read in characters until we get a line ending or EOT.
+    for (bool done = false; !done;)
     {
-        chip::WaitForShellActivity();
-        if (read == 0)
+        // Stop reading if we've run out of space in the buffer (still need to null-terminate).
+        if (line_sz >= max - 1u)
         {
-            read = streamer_read(streamer_get(), inptr, 1);
+            buffer[max - 1] = '\0';
+            break;
         }
 
-        // Process any characters we just read in.
-        while (read > 0)
+        chip::WaitForShellActivity();
+
+        if (streamer_read(streamer_get(), buffer + line_sz, 1) == 1)
         {
-            switch (*inptr)
+            switch (buffer[line_sz])
             {
             case '\r':
             case '\n':
                 streamer_printf(streamer_get(), "\r\n");
-                *inptr = 0; // null terminate
-                done   = true;
+                buffer[line_sz] = '\0';
+                line_sz++;
+                done = true;
                 break;
             case 0x7F:
-                // delete backspace character + 1 more
-                inptr -= 2;
-                if (inptr >= buffer - 1)
+                // Do not accept backspace character (i.e. don't increment line_sz) and remove 1 additional character if it exists.
+                if (line_sz >= 1u)
                 {
                     streamer_printf(streamer_get(), "\b \b");
-                }
-                else
-                {
-                    inptr = buffer - 1;
+                    line_sz--;
                 }
                 break;
             default:
-                if (isprint(static_cast<int>(*inptr)) || *inptr == '\t')
+                if (isprint(static_cast<int>(buffer[line_sz])) || buffer[line_sz] == '\t')
                 {
-                    streamer_printf(streamer_get(), "%c", *inptr);
-                }
-                else
-                {
-                    inptr--;
+                    streamer_printf(streamer_get(), "%c", buffer[line_sz]);
+                    line_sz++;
                 }
                 break;
             }
-
-            inptr++;
-            read--;
         }
     }
 }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fixes #15577.

#### Change overview
Properly null-terminate a command line that reaches maximum length.
Refactor ReadlLine to eliminate pointer differences, as requested in review.

#### Testing
How was this tested? (at least one bullet point required)
* Linux chip-shell:
- Checked that only 255 characters were read.
- Checked that a regular command runs properly.
- Checked that Ctrl-D works when there is no other input (but not when there is).
- Checked that backspace works correctly both when there is other input and when not.
- Checked that horizontal tabs can be used instead of spaces.
