### PR TITLE
[ota] Remove two outdated/redundant methods

### DIFF
--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -122,12 +122,6 @@ static void InitOTARequestor(void)
     // Set server instance used for session establishment
     gRequestorCore.Init(chip::Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
 
-    // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at
-    // the beginning of program execution. We're using hardcoded values here for now since this is a reference application.
-    // TODO: instatiate and initialize these values when QueryImageResponse tells us an image is available
-    // TODO: add API for OTARequestor to pass QueryImageResponse info to the application to use for OTADownloader init
-    OTAImageProcessorParams ipParams;
-    gImageProcessor.SetOTAImageProcessorParams(ipParams);
     gImageProcessor.SetOTADownloader(&gDownloader);
 
     // Connect the Downloader and Image Processor objects

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -107,12 +107,6 @@ static void InitOTARequestor(void)
     // Set server instance used for session establishment
     gRequestorCore.Init(Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
 
-    // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at
-    // the beginning of program execution. We're using hardcoded values here for now since this is a reference application.
-    // TODO: instatiate and initialize these values when QueryImageResponse tells us an image is available
-    // TODO: add API for OTARequestor to pass QueryImageResponse info to the application to use for OTADownloader init
-    OTAImageProcessorParams ipParams;
-    gImageProcessor.SetOTAImageProcessorParams(ipParams);
     gImageProcessor.SetOTADownloader(&gDownloader);
 
     // Connect the Downloader and Image Processor objects

--- a/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -127,13 +127,7 @@ CHIP_ERROR AppTask::Init()
     gRequestorCore.Init(Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 
-    // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at
-    // the beginning of program execution. We're using hardcoded values here for now since this is a reference application.
-    // TODO: instatiate and initialize these values when QueryImageResponse tells us an image is available
-    // TODO: add API for OTARequestor to pass QueryImageResponse info to the application to use for OTADownloader init
-    OTAImageProcessorParams ipParams;
-    ipParams.imageFile = CharSpan("test.txt");
-    gImageProcessor.SetOTAImageProcessorParams(ipParams);
+    gImageProcessor.SetOTAImageFile(CharSpan("test.txt"));
     gImageProcessor.SetOTADownloader(&gDownloader);
 
     // Connect the gDownloader and Image Processor objects

--- a/examples/ota-requestor-app/ameba/main/chipinterface.cpp
+++ b/examples/ota-requestor-app/ameba/main/chipinterface.cpp
@@ -50,7 +50,6 @@ using chip::NodeId;
 using chip::OnDeviceConnected;
 using chip::OnDeviceConnectionFailure;
 using chip::OTADownloader;
-using chip::OTAImageProcessorParams;
 using chip::OTARequestor;
 using chip::PeerId;
 using chip::Server;
@@ -107,12 +106,6 @@ static void InitOTARequestor(void)
     // Set server instance used for session establishment
     gRequestorCore.Init(chip::Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
 
-    // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at
-    // the beginning of program execution. We're using hardcoded values here for now since this is a reference application.
-    // TODO: instatiate and initialize these values when QueryImageResponse tells us an image is available
-    // TODO: add API for OTARequestor to pass QueryImageResponse info to the application to use for OTADownloader init
-    OTAImageProcessorParams ipParams;
-    gImageProcessor.SetOTAImageProcessorParams(ipParams);
     gImageProcessor.SetOTADownloader(&gDownloader);
 
     // Connect the Downloader and Image Processor objects

--- a/examples/ota-requestor-app/efr32/src/AppTask.cpp
+++ b/examples/ota-requestor-app/efr32/src/AppTask.cpp
@@ -542,9 +542,7 @@ void AppTask::InitOTARequestor()
 
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 
-    OTAImageProcessorParams ipParams;
-    ipParams.imageFile = CharSpan("test.txt");
-    gImageProcessor.SetOTAImageProcessorParams(ipParams);
+    gImageProcessor.SetOTAImageFile(CharSpan("test.txt"));
     gImageProcessor.SetOTADownloader(&gDownloader);
 
     // Connect the Downloader and Image Processor objects

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -35,7 +35,6 @@ using chip::OnDeviceConnected;
 using chip::OnDeviceConnectionFailure;
 using chip::OTADownloader;
 using chip::OTAImageProcessorImpl;
-using chip::OTAImageProcessorParams;
 using chip::OTARequestor;
 using chip::PeerId;
 using chip::Server;
@@ -117,12 +116,7 @@ static void InitOTARequestor(void)
     gRequestorCore.Init(chip::Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 
-    // WARNING: this is probably not realistic to know such details of the image or to even have an
-    // OTADownloader instantiated at the beginning of program execution. We're using hardcoded
-    // values here for now since this is a reference application.
-    OTAImageProcessorParams ipParams;
-    ipParams.imageFile = CharSpan::fromCharString(gOtaDownloadPath);
-    gImageProcessor.SetOTAImageProcessorParams(ipParams);
+    gImageProcessor.SetOTAImageFile(CharSpan::fromCharString(gOtaDownloadPath));
     gImageProcessor.SetOTADownloader(&gDownloader);
 
     // Set the image processor instance used for handling image being downloaded

--- a/examples/ota-requestor-app/p6/src/AppTask.cpp
+++ b/examples/ota-requestor-app/p6/src/AppTask.cpp
@@ -65,7 +65,6 @@ using chip::GetRequestorInstance;
 using chip::NodeId;
 using chip::OTADownloader;
 using chip::OTAImageProcessorImpl;
-using chip::OTAImageProcessorParams;
 using chip::OTARequestor;
 using chip::System::Layer;
 

--- a/examples/platform/efr32/OTAConfig.cpp
+++ b/examples/platform/efr32/OTAConfig.cpp
@@ -77,9 +77,7 @@ void OTAConfig::Init()
 
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 
-    chip::OTAImageProcessorParams ipParams;
-    ipParams.imageFile = chip::CharSpan("test.txt");
-    gImageProcessor.SetOTAImageProcessorParams(ipParams);
+    gImageProcessor.SetOTAImageFile(chip::CharSpan("test.txt"));
     gImageProcessor.SetOTADownloader(&gDownloader);
 
     // Connect the Downloader and Image Processor objects

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -622,7 +622,7 @@ CHIP_ERROR OTARequestor::SendQueryImageRequest(OperationalDeviceProxy & devicePr
     ReturnErrorOnFailure(DeviceLayer::ConfigurationMgr().GetSoftwareVersion(args.softwareVersion));
 
     args.protocolsSupported = kProtocolsSupported;
-    args.requestorCanConsent.SetValue(mRequestorCanConsent.ValueOr(mOtaRequestorDriver->CanConsent()));
+    args.requestorCanConsent.SetValue(mOtaRequestorDriver->CanConsent());
 
     uint16_t hardwareVersion;
     if (DeviceLayer::ConfigurationMgr().GetHardwareVersion(hardwareVersion) == CHIP_NO_ERROR)

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -130,11 +130,6 @@ public:
                                                                     reinterpret_cast<intptr_t>(this));
     }
 
-    /**
-     * Called to set optional requestorCanConsent value provided by Requestor.
-     */
-    void SetRequestorCanConsent(bool requestorCanConsent) { mRequestorCanConsent.SetValue(requestorCanConsent); }
-
 private:
     using QueryImageResponseDecodableType  = app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType;
     using ApplyUpdateResponseDecodableType = app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType;
@@ -309,7 +304,6 @@ private:
     CharSpan mFileDesignator;
     OTAUpdateStateEnum mCurrentUpdateState = OTAUpdateStateEnum::kUnknown;
     Server * mServer                       = nullptr;
-    chip::Optional<bool> mRequestorCanConsent;
     ProviderLocationList mDefaultOtaProviderList;
     Optional<ProviderLocationType> mProviderLocation; // Provider location used for the current update in progress
 };

--- a/src/include/platform/OTAImageProcessor.h
+++ b/src/include/platform/OTAImageProcessor.h
@@ -26,9 +26,8 @@
 
 namespace chip {
 
-struct OTAImageProcessorParams
+struct OTAImageProgress
 {
-    CharSpan imageFile;
     uint64_t downloadedBytes = 0;
     uint64_t totalFileBytes  = 0;
 };
@@ -77,11 +76,6 @@ public:
     virtual CHIP_ERROR ProcessBlock(ByteSpan & block) = 0;
 
     /**
-     * Called to setup params for the OTA image download
-     */
-    virtual void SetOTAImageProcessorParams(OTAImageProcessorParams & params) { mParams = params; };
-
-    /**
      * Called to check the current download status of the OTA image download.
      */
     virtual app::DataModel::Nullable<uint8_t> GetPercentComplete()
@@ -97,7 +91,7 @@ public:
     virtual uint64_t GetBytesDownloaded() { return mParams.downloadedBytes; }
 
 protected:
-    OTAImageProcessorParams mParams;
+    OTAImageProgress mParams;
 };
 
 } // namespace chip

--- a/src/platform/EFR32/OTAImageProcessorImpl.cpp
+++ b/src/platform/EFR32/OTAImageProcessorImpl.cpp
@@ -34,7 +34,7 @@ uint32_t OTAImageProcessorImpl::mWriteOffset;
 
 CHIP_ERROR OTAImageProcessorImpl::PrepareDownload()
 {
-    if (mParams.imageFile.empty())
+    if (mImageFile.empty())
     {
         ChipLogError(SoftwareUpdate, "Invalid output image file supplied");
         return CHIP_ERROR_INTERNAL;
@@ -80,7 +80,7 @@ CHIP_ERROR OTAImageProcessorImpl::Apply()
 
 CHIP_ERROR OTAImageProcessorImpl::Abort()
 {
-    if (mParams.imageFile.empty())
+    if (mImageFile.empty())
     {
         ChipLogError(SoftwareUpdate, "Invalid output image file supplied");
         return CHIP_ERROR_INTERNAL;
@@ -143,7 +143,7 @@ void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
 
     imageProcessor->ReleaseBlock();
 
-    ChipLogProgress(SoftwareUpdate, "OTA image downloaded to %s", imageProcessor->mParams.imageFile.data());
+    ChipLogProgress(SoftwareUpdate, "OTA image downloaded to %s", imageProcessor->mImageFile.data());
 }
 
 void OTAImageProcessorImpl::HandleAbort(intptr_t context)

--- a/src/platform/EFR32/OTAImageProcessorImpl.h
+++ b/src/platform/EFR32/OTAImageProcessorImpl.h
@@ -37,6 +37,7 @@ public:
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
 
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
+    void SetOTAImageFile(CharSpan name) { mImageFile = name; }
 
 private:
     //////////// Actual handlers for the OTAImageProcessorInterface ///////////////
@@ -59,6 +60,7 @@ private:
     static uint8_t mSlotId;       // Bootloader storage slot
     MutableByteSpan mBlock;
     OTADownloader * mDownloader;
+    CharSpan mImageFile;
 };
 
 } // namespace chip

--- a/src/platform/Linux/OTAImageProcessorImpl.cpp
+++ b/src/platform/Linux/OTAImageProcessorImpl.cpp
@@ -25,7 +25,7 @@ namespace chip {
 
 CHIP_ERROR OTAImageProcessorImpl::PrepareDownload()
 {
-    if (mParams.imageFile.empty())
+    if (mImageFile.empty())
     {
         ChipLogError(SoftwareUpdate, "Invalid output image file supplied");
         return CHIP_ERROR_INTERNAL;
@@ -49,7 +49,7 @@ CHIP_ERROR OTAImageProcessorImpl::Apply()
 
 CHIP_ERROR OTAImageProcessorImpl::Abort()
 {
-    if (mParams.imageFile.empty())
+    if (mImageFile.empty())
     {
         ChipLogError(SoftwareUpdate, "Invalid output image file supplied");
         return CHIP_ERROR_INTERNAL;
@@ -97,8 +97,7 @@ void OTAImageProcessorImpl::HandlePrepareDownload(intptr_t context)
     }
 
     imageProcessor->mHeaderParser.Init();
-    imageProcessor->mOfs.open(imageProcessor->mParams.imageFile.data(),
-                              std::ofstream::out | std::ofstream::ate | std::ofstream::app);
+    imageProcessor->mOfs.open(imageProcessor->mImageFile.data(), std::ofstream::out | std::ofstream::ate | std::ofstream::app);
     if (!imageProcessor->mOfs.good())
     {
         imageProcessor->mDownloader->OnPreparedForDownload(CHIP_ERROR_OPEN_FAILED);
@@ -121,7 +120,7 @@ void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
     imageProcessor->mOfs.close();
     imageProcessor->ReleaseBlock();
 
-    ChipLogProgress(SoftwareUpdate, "OTA image downloaded to %s", imageProcessor->mParams.imageFile.data());
+    ChipLogProgress(SoftwareUpdate, "OTA image downloaded to %s", imageProcessor->mImageFile.data());
 }
 
 void OTAImageProcessorImpl::HandleApply(intptr_t context)
@@ -149,7 +148,7 @@ void OTAImageProcessorImpl::HandleAbort(intptr_t context)
     }
 
     imageProcessor->mOfs.close();
-    remove(imageProcessor->mParams.imageFile.data());
+    remove(imageProcessor->mImageFile.data());
     imageProcessor->ReleaseBlock();
 }
 

--- a/src/platform/Linux/OTAImageProcessorImpl.h
+++ b/src/platform/Linux/OTAImageProcessorImpl.h
@@ -38,6 +38,7 @@ public:
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
 
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
+    void SetOTAImageFile(CharSpan name) { mImageFile = name; }
 
 private:
     //////////// Actual handlers for the OTAImageProcessorInterface ///////////////
@@ -64,6 +65,7 @@ private:
     OTADownloader * mDownloader;
     OTAImageHeaderParser mHeaderParser;
     uint32_t mSoftwareVersion;
+    CharSpan mImageFile;
 };
 
 } // namespace chip

--- a/src/platform/nxp/k32w/k32w0/OTAImageProcessorImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/OTAImageProcessorImpl.cpp
@@ -28,7 +28,7 @@ namespace chip {
 
 CHIP_ERROR OTAImageProcessorImpl::PrepareDownload()
 {
-    if (mParams.imageFile.empty())
+    if (mImageFile.empty())
     {
         ChipLogError(SoftwareUpdate, "Invalid output image file supplied");
         return CHIP_ERROR_INTERNAL;
@@ -51,7 +51,7 @@ CHIP_ERROR OTAImageProcessorImpl::Apply()
 
 CHIP_ERROR OTAImageProcessorImpl::Abort()
 {
-    if (mParams.imageFile.empty())
+    if (mImageFile.empty())
     {
         ChipLogError(SoftwareUpdate, "Invalid output image file supplied");
         return CHIP_ERROR_INTERNAL;
@@ -95,7 +95,7 @@ void OTAImageProcessorImpl::HandlePrepareDownload(intptr_t context)
 
     if (gOtaSuccess_c == OTA_ClientInit())
     {
-        if (gOtaSuccess_c == OTA_StartImage(imageProcessor->mParams.imageFile.size()))
+        if (gOtaSuccess_c == OTA_StartImage(imageProcessor->mImageFile.size()))
         {
             imageProcessor->mDownloader->OnPreparedForDownload(CHIP_NO_ERROR);
         }
@@ -110,7 +110,7 @@ void OTAImageProcessorImpl::HandleAbort(intptr_t context)
         return;
     }
 
-    remove(imageProcessor->mParams.imageFile.data());
+    remove(imageProcessor->mImageFile.data());
     imageProcessor->ReleaseBlock();
 }
 

--- a/src/platform/nxp/k32w/k32w0/OTAImageProcessorImpl.h
+++ b/src/platform/nxp/k32w/k32w0/OTAImageProcessorImpl.h
@@ -35,6 +35,7 @@ public:
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
 
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
+    void SetOTAImageFile(CharSpan name) { mImageFile = name; }
 
 private:
     //////////// Actual handlers for the OTAImageProcessorInterface ///////////////
@@ -55,6 +56,7 @@ private:
 
     OTADownloader * mDownloader;
     MutableByteSpan mBlock;
+    CharSpan mImageFile;
 };
 
 } // namespace chip


### PR DESCRIPTION
#### Problem
* `OTARequestor::SetRequestorCanConsent` method is not needed since an application already has a different way to inject `RequestorCanConsent` attribute value. That is, `OTARequestorDriver::CanConsent` method. We don't need two alternative sources of this information.
* `OTAImageProcessorInterface::SetOTAImageProcessorParams` is used on some platforms, only, and against the original intent since the downloaded file name no longer needs to be set by the app (the downloaded file designator is obtained in `QueryImageResponse`).

#### Change overview
Remove the unnecessary methods and refactor the code accordingly.
Added dedicated `SetOTAImageFile` setters for platforms that allow to configure the output file name (where the downloaded image should be saved).

#### Testing
Ran OTA between Linux OTA requestor and provider.
