### PR TITLE
[mrp] Fix #15799 - add exponential backoff.

### DIFF
--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -189,11 +189,11 @@ CHIP_ERROR ReliableMessageMgr::AddToRetransTable(ReliableMessageContext * rc, Re
 
 System::Clock::Timestamp ReliableMessageMgr::GetBackoff(System::Clock::Timestamp backoffBase, uint8_t sendCount)
 {
-    static constexpr uint32_t MRP_BACKOFF_JITTER_BASE = 1000;
-    static constexpr uint32_t MRP_BACKOFF_JITTER_MAX = 250;
-    static constexpr uint32_t MRP_BACKOFF_BASE_NUMERATOR = 16;
+    static constexpr uint32_t MRP_BACKOFF_JITTER_BASE      = 1000;
+    static constexpr uint32_t MRP_BACKOFF_JITTER_MAX       = 250;
+    static constexpr uint32_t MRP_BACKOFF_BASE_NUMERATOR   = 16;
     static constexpr uint32_t MRP_BACKOFF_BASE_DENOMENATOR = 10;
-    static constexpr uint32_t MRP_BACKOFF_THRESHOLD = 1;
+    static constexpr uint32_t MRP_BACKOFF_THRESHOLD        = 1;
 
     System::Clock::Timestamp backoff = backoffBase;
 

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -146,9 +146,8 @@ void ReliableMessageMgr::ExecuteActions()
                       messageCounter, ChipLogValueExchange(&entry->ec.Get()), entry->sendCount);
         // TODO(#15800): Choose active/idle timeout corresponding to the activity of exchanges of the session.
         System::Clock::Timestamp backoff =
-            ReliableMessageMgr::GetBackoff(entry->ec->GetSessionHandle()->GetMRPConfig().mIdleRetransTimeout, entry->sendCount);
-        entry->nextRetransTime =
-            System::SystemClock().GetMonotonicTimestamp() + backoff;
+            ReliableMessageMgr::GetBackoff(entry->ec->GetSessionHandle()->GetMRPConfig().mActiveRetransTimeout, entry->sendCount);
+        entry->nextRetransTime = System::SystemClock().GetMonotonicTimestamp() + backoff;
         SendFromRetransTable(entry);
         // For test not using async IO loop, the entry may have been removed after send, do not use entry below
 

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -189,11 +189,11 @@ CHIP_ERROR ReliableMessageMgr::AddToRetransTable(ReliableMessageContext * rc, Re
 
 System::Clock::Timestamp ReliableMessageMgr::GetBackoff(System::Clock::Timestamp backoffBase, uint8_t sendCount)
 {
-    static constexpr unsigned MRP_BACKOFF_JITTER_BASE = 1000;
-    static constexpr unsigned MRP_BACKOFF_JITTER_MAX = 250;
-    static constexpr unsigned MRP_BACKOFF_BASE_NUMERATOR = 16;
-    static constexpr unsigned MRP_BACKOFF_BASE_DENOMENATOR = 10;
-    static constexpr unsigned MRP_BACKOFF_THRESHOLD = 1;
+    static constexpr uint32_t MRP_BACKOFF_JITTER_BASE = 1000;
+    static constexpr uint32_t MRP_BACKOFF_JITTER_MAX = 250;
+    static constexpr uint32_t MRP_BACKOFF_BASE_NUMERATOR = 16;
+    static constexpr uint32_t MRP_BACKOFF_BASE_DENOMENATOR = 10;
+    static constexpr uint32_t MRP_BACKOFF_THRESHOLD = 1;
 
     System::Clock::Timestamp backoff = backoffBase;
 

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -197,14 +197,16 @@ System::Clock::Timestamp ReliableMessageMgr::GetBackoff(System::Clock::Timestamp
 
     System::Clock::Timestamp backoff = backoffBase;
 
-    // Generate fixed point equivalent of 1.6^retryCount
+    // Implement `t = i⋅MRP_BACKOFF_BASE^max(0,n−MRP_BACKOFF_THRESHOLD)` from Section 4.11.2.1. Retransmissions
+
+    // Generate fixed point equivalent of `retryCount = max(0,n−MRP_BACKOFF_THRESHOLD)`
     int retryCount = sendCount - MRP_BACKOFF_THRESHOLD;
     if (retryCount < 0)
         retryCount = 0; // Enforce floor
     if (retryCount > 4)
         retryCount = 4; // Enforce reasonable maximum after 5 tries
 
-    // Implement `t = i⋅MRP_BACKOFF_BASE^max(0,n−MRP_BACKOFF_THRESHOLD)` from Section 4.15.2.1. Retransmissions
+    // Generate fixed point equivalent of `backoff = i⋅1.6^retryCount`
     unsigned backoffNum   = 1;
     unsigned backoffDenom = 1;
     for (int i = 0; i < retryCount; i++)

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -207,8 +207,8 @@ System::Clock::Timestamp ReliableMessageMgr::GetBackoff(System::Clock::Timestamp
         retryCount = 4; // Enforce reasonable maximum after 5 tries
 
     // Generate fixed point equivalent of `backoff = i⋅1.6^retryCount`
-    unsigned backoffNum   = 1;
-    unsigned backoffDenom = 1;
+    uint32_t backoffNum   = 1;
+    uint32_t backoffDenom = 1;
     for (int i = 0; i < retryCount; i++)
     {
         backoffNum *= MRP_BACKOFF_BASE_NUMERATOR;
@@ -218,7 +218,7 @@ System::Clock::Timestamp ReliableMessageMgr::GetBackoff(System::Clock::Timestamp
 
     // Implement jitter scaler: `t *= (1.0+random(0,1)⋅MRP_BACKOFF_JITTER)`
     // where jitter is random multiplier from 1.000 to 1.250:
-    unsigned jitter = MRP_BACKOFF_JITTER_BASE + Crypto::GetRandU16() % MRP_BACKOFF_JITTER_MAX;
+    uint32_t jitter = MRP_BACKOFF_JITTER_BASE + Crypto::GetRandU16() % MRP_BACKOFF_JITTER_MAX;
     backoff         = backoff * jitter / MRP_BACKOFF_JITTER_BASE;
 
     return backoff;

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -189,8 +189,7 @@ CHIP_ERROR ReliableMessageMgr::AddToRetransTable(ReliableMessageContext * rc, Re
 
 System::Clock::Timestamp ReliableMessageMgr::GetBackoff(System::Clock::Timestamp backoffBase, uint8_t sendCount)
 {
-    static constexpr uint32_t MRP_BACKOFF_JITTER_BASE      = 1000;
-    static constexpr uint32_t MRP_BACKOFF_JITTER_MAX       = 250;
+    static constexpr uint32_t MRP_BACKOFF_JITTER_BASE      = 1024;
     static constexpr uint32_t MRP_BACKOFF_BASE_NUMERATOR   = 16;
     static constexpr uint32_t MRP_BACKOFF_BASE_DENOMENATOR = 10;
     static constexpr uint32_t MRP_BACKOFF_THRESHOLD        = 1;
@@ -218,7 +217,7 @@ System::Clock::Timestamp ReliableMessageMgr::GetBackoff(System::Clock::Timestamp
 
     // Implement jitter scaler: `t *= (1.0+random(0,1)⋅MRP_BACKOFF_JITTER)`
     // where jitter is random multiplier from 1.000 to 1.250:
-    uint32_t jitter = MRP_BACKOFF_JITTER_BASE + Crypto::GetRandU16() % MRP_BACKOFF_JITTER_MAX;
+    uint32_t jitter = MRP_BACKOFF_JITTER_BASE + Crypto::GetRandU8();
     backoff         = backoff * jitter / MRP_BACKOFF_JITTER_BASE;
 
     return backoff;
@@ -228,7 +227,7 @@ void ReliableMessageMgr::StartRetransmision(RetransTableEntry * entry)
 {
     // TODO(#15800): Choose active/idle timeout corresponding to the ActiveState of peer in session.
     System::Clock::Timestamp backoff =
-        ReliableMessageMgr::GetBackoff(entry->ec->GetSessionHandle()->GetMRPConfig().mActiveRetransTimeout, entry->sendCount);
+        ReliableMessageMgr::GetBackoff(entry->ec->GetSessionHandle()->GetMRPConfig().mIdleRetransTimeout, entry->sendCount);
     entry->nextRetransTime = System::SystemClock().GetMonotonicTimestamp() + backoff;
     StartTimer();
 }

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -190,6 +190,7 @@ CHIP_ERROR ReliableMessageMgr::AddToRetransTable(ReliableMessageContext * rc, Re
 System::Clock::Timestamp ReliableMessageMgr::GetBackoff(System::Clock::Timestamp baseInterval, uint8_t sendCount)
 {
 #define MRP_BACKOFF_JITTER_BASE 1000
+#define MRP_BACKOFF_JITTER_MAX 250
 #define MRP_BACKOFF_BASE_NUMERATOR 16
 #define MRP_BACKOFF_BASE_DENOMENATOR 10
 
@@ -213,7 +214,7 @@ System::Clock::Timestamp ReliableMessageMgr::GetBackoff(System::Clock::Timestamp
     backoff = backoff * backoffNum / backoffDenom;
 
     // Generate jitter as random multiplier from 1.000 to 1.250:
-    unsigned jitter = MRP_BACKOFF_JITTER_BASE + Crypto::GetRandU8() % 250;
+    unsigned jitter = MRP_BACKOFF_JITTER_BASE + Crypto::GetRandU16() % MRP_BACKOFF_JITTER_MAX;
     backoff         = backoff * jitter / MRP_BACKOFF_JITTER_BASE;
 
     return backoff;
@@ -223,7 +224,7 @@ void ReliableMessageMgr::StartRetransmision(RetransTableEntry * entry)
 {
     // TODO(#15800): Choose active/idle timeout corresponding to the ActiveState of peer in session.
     System::Clock::Timestamp backoff =
-        GetBackoff(entry->ec->GetSessionHandle()->GetMRPConfig().mIdleRetransTimeout, entry->sendCount);
+        GetBackoff(entry->ec->GetSessionHandle()->GetMRPConfig().mActiveRetransTimeout, entry->sendCount);
     entry->nextRetransTime = System::SystemClock().GetMonotonicTimestamp() + backoff;
     StartTimer();
 }

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -144,9 +144,11 @@ void ReliableMessageMgr::ExecuteActions()
                       "Retransmitting MessageCounter:" ChipLogFormatMessageCounter " on exchange " ChipLogFormatExchange
                       " Send Cnt %d",
                       messageCounter, ChipLogValueExchange(&entry->ec.Get()), entry->sendCount);
-        // TODO: Choose active/idle timeout corresponding to the activity of exchanges of the session.
+        // TODO(#15800): Choose active/idle timeout corresponding to the activity of exchanges of the session.
+        System::Clock::Timestamp backoff =
+            ReliableMessageMgr::GetBackoff(entry->ec->GetSessionHandle()->GetMRPConfig().mIdleRetransTimeout, entry->sendCount);
         entry->nextRetransTime =
-            System::SystemClock().GetMonotonicTimestamp() + entry->ec->GetSessionHandle()->GetMRPConfig().mActiveRetransTimeout;
+            System::SystemClock().GetMonotonicTimestamp() + backoff;
         SendFromRetransTable(entry);
         // For test not using async IO loop, the entry may have been removed after send, do not use entry below
 

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -189,11 +189,11 @@ CHIP_ERROR ReliableMessageMgr::AddToRetransTable(ReliableMessageContext * rc, Re
 
 System::Clock::Timestamp ReliableMessageMgr::GetBackoff(System::Clock::Timestamp backoffBase, uint8_t sendCount)
 {
-#define MRP_BACKOFF_JITTER_BASE 1000
-#define MRP_BACKOFF_JITTER_MAX 250
-#define MRP_BACKOFF_BASE_NUMERATOR 16
-#define MRP_BACKOFF_BASE_DENOMENATOR 10
-#define MRP_BACKOFF_THRESHOLD 1
+    static constexpr unsigned MRP_BACKOFF_JITTER_BASE = 1000;
+    static constexpr unsigned MRP_BACKOFF_JITTER_MAX = 250;
+    static constexpr unsigned MRP_BACKOFF_BASE_NUMERATOR = 16;
+    static constexpr unsigned MRP_BACKOFF_BASE_DENOMENATOR = 10;
+    static constexpr unsigned MRP_BACKOFF_THRESHOLD = 1;
 
     System::Clock::Timestamp backoff = backoffBase;
 
@@ -226,7 +226,7 @@ void ReliableMessageMgr::StartRetransmision(RetransTableEntry * entry)
 {
     // TODO(#15800): Choose active/idle timeout corresponding to the ActiveState of peer in session.
     System::Clock::Timestamp backoff =
-        GetBackoff(entry->ec->GetSessionHandle()->GetMRPConfig().mActiveRetransTimeout, entry->sendCount);
+        ReliableMessageMgr::GetBackoff(entry->ec->GetSessionHandle()->GetMRPConfig().mActiveRetransTimeout, entry->sendCount);
     entry->nextRetransTime = System::SystemClock().GetMonotonicTimestamp() + backoff;
     StartTimer();
 }

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -110,7 +110,7 @@ public:
      *
      *  @retval  The backoff time value, including jitter.
      */
-    System::Clock::Timestamp GetBackoff(System::Clock::Timestamp backoffBase, uint8_t sendCount);
+    static System::Clock::Timestamp GetBackoff(System::Clock::Timestamp backoffBase, uint8_t sendCount);
 
     /**
      *  Start retranmisttion of cached encryped packet for current entry.

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -106,7 +106,8 @@ public:
      *  Calculate the backoff timer for the retransmission.
      *
      *  @param[in]   backoffBase    The base interval to use for the backoff calculation, either the active or idle interval.
-     *  @param[in]   sendCount      Count of how many times this message has been sent, including the current attempt.
+     *  @param[in]   sendCount      Count of how many times this message has been sent, including the current retransmission attempt
+     * starting from `0`.
      *
      *  @retval  The backoff time value, including jitter.
      */

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -106,8 +106,10 @@ public:
      *  Calculate the backoff timer for the retransmission.
      *
      *  @param[in]   backoffBase    The base interval to use for the backoff calculation, either the active or idle interval.
-     *  @param[in]   sendCount      Count of how many times this message has been sent, including the current retransmission attempt
-     * starting from `0`.
+     *  @param[in]   sendCount      Count of how many times this message
+     *                              has been retransmitted so far (0 if it has
+     *                              been sent only once with no retransmits,
+     *                              1 if it has been sent twice, etc).
      *
      *  @retval  The backoff time value, including jitter.
      */

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -103,6 +103,16 @@ public:
     CHIP_ERROR AddToRetransTable(ReliableMessageContext * rc, RetransTableEntry ** rEntry);
 
     /**
+     *  Calculate the backoff timer for the retransmission.
+     *
+     *  @param[in]   baseInterval   The base interval to use for the backoff calculation, either the active or idle interval.
+     *  @param[in]   sendCount      Count of how many times this message has been sent, including the current attempt.
+     *
+     *  @retval  The backoff time value, including jitter.
+     */
+    System::Clock::Timestamp GetBackoff(System::Clock::Timestamp baseInterval, uint8_t sendCount);
+
+    /**
      *  Start retranmisttion of cached encryped packet for current entry.
      *
      *  @param[in]   entry    A pointer to a retransmission table entry added into the table.

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -105,12 +105,12 @@ public:
     /**
      *  Calculate the backoff timer for the retransmission.
      *
-     *  @param[in]   baseInterval   The base interval to use for the backoff calculation, either the active or idle interval.
+     *  @param[in]   backoffBase    The base interval to use for the backoff calculation, either the active or idle interval.
      *  @param[in]   sendCount      Count of how many times this message has been sent, including the current attempt.
      *
      *  @retval  The backoff time value, including jitter.
      */
-    System::Clock::Timestamp GetBackoff(System::Clock::Timestamp baseInterval, uint8_t sendCount);
+    System::Clock::Timestamp GetBackoff(System::Clock::Timestamp backoffBase, uint8_t sendCount);
 
     /**
      *  Start retranmisttion of cached encryped packet for current entry.

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -1443,6 +1443,66 @@ void CheckLostStandaloneAck(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
 }
 
+struct BackoffComplianceTestVector
+{
+    uint8_t sendCount;
+    System::Clock::Timestamp backoffBase;
+    System::Clock::Timestamp backoffMin;
+    System::Clock::Timestamp backoffMax;
+};
+
+struct BackoffComplianceTestVector theBackoffComplianceTestVector[] = {
+    {
+        .sendCount   = 0,
+        .backoffBase = System::Clock::Timestamp(300),
+        .backoffMin  = System::Clock::Timestamp(300),
+        .backoffMax  = System::Clock::Timestamp(375),
+    },
+    {
+        .sendCount   = 1,
+        .backoffBase = System::Clock::Timestamp(300),
+        .backoffMin  = System::Clock::Timestamp(300),
+        .backoffMax  = System::Clock::Timestamp(375),
+    },
+    {
+        .sendCount   = 2,
+        .backoffBase = System::Clock::Timestamp(300),
+        .backoffMin  = System::Clock::Timestamp(480),
+        .backoffMax  = System::Clock::Timestamp(600),
+    },
+    {
+        .sendCount   = 3,
+        .backoffBase = System::Clock::Timestamp(300),
+        .backoffMin  = System::Clock::Timestamp(768),
+        .backoffMax  = System::Clock::Timestamp(960),
+    },
+    {
+        .sendCount   = 4,
+        .backoffBase = System::Clock::Timestamp(300),
+        .backoffMin  = System::Clock::Timestamp(1229),
+        .backoffMax  = System::Clock::Timestamp(1536),
+    },
+};
+
+const unsigned theBackoffComplianceTestVectorLength =
+    sizeof(theBackoffComplianceTestVector) / sizeof(struct BackoffComplianceTestVector);
+
+void CheckGetBackoff(nlTestSuite * inSuite, void * inContext)
+{
+    TestContext & ctx       = *reinterpret_cast<TestContext *>(inContext);
+    ReliableMessageMgr * rm = ctx.GetExchangeManager().GetReliableMessageMgr();
+
+    for (unsigned i = 0; i < theBackoffComplianceTestVectorLength; i++)
+    {
+        struct BackoffComplianceTestVector * test = &theBackoffComplianceTestVector[i];
+        System::Clock::Timestamp backoff          = rm->GetBackoff(test->backoffBase, test->sendCount);
+        ChipLogProgress(Test, "Backoff # %d: %d", test->sendCount, (uint32_t) backoff.count());
+
+        NL_TEST_ASSERT(inSuite, backoff >= test->backoffMin);
+        NL_TEST_ASSERT(inSuite, backoff <= test->backoffMax);
+    }
+}
+
 int InitializeTestCase(void * inContext)
 {
     TestContext & ctx = *static_cast<TestContext *>(inContext);
@@ -1491,6 +1551,7 @@ const nlTest sTests[] =
     NL_TEST_DEF("Test that unencrypted message is dropped if exchange requires encryption", CheckUnencryptedMessageReceiveFailure),
     NL_TEST_DEF("Test that dropping an application-level message with a piggyback ack works ok once both sides retransmit", CheckLostResponseWithPiggyback),
     NL_TEST_DEF("Test that an application-level response-to-response after a lost standalone ack to the initial message works", CheckLostStandaloneAck),
+    NL_TEST_DEF("Test MRP backoff algorithm", CheckGetBackoff),
 
     NL_TEST_SENTINEL()
 };

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -1501,14 +1501,16 @@ const unsigned theBackoffComplianceTestVectorLength =
 
 void CheckGetBackoff(nlTestSuite * inSuite, void * inContext)
 {
-    for (unsigned i = 0; i < theBackoffComplianceTestVectorLength; i++)
-    {
-        struct BackoffComplianceTestVector * test = &theBackoffComplianceTestVector[i];
-        System::Clock::Timestamp backoff          = ReliableMessageMgr::GetBackoff(test->backoffBase, test->sendCount);
-        ChipLogProgress(Test, "Backoff # %d: %d", test->sendCount, (uint32_t) backoff.count());
+    for (uint32_t j = 0; j < 3; j++) {
+        for (uint32_t i = 0; i < theBackoffComplianceTestVectorLength; i++)
+        {
+            struct BackoffComplianceTestVector * test = &theBackoffComplianceTestVector[i];
+            System::Clock::Timestamp backoff          = ReliableMessageMgr::GetBackoff(test->backoffBase, test->sendCount);
+            ChipLogProgress(Test, "Backoff # %d: %d", test->sendCount, (uint32_t) backoff.count());
 
-        NL_TEST_ASSERT(inSuite, backoff >= test->backoffMin);
-        NL_TEST_ASSERT(inSuite, backoff <= test->backoffMax);
+            NL_TEST_ASSERT(inSuite, backoff >= test->backoffMin);
+            NL_TEST_ASSERT(inSuite, backoff <= test->backoffMax);
+        }
     }
 }
 

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -1501,7 +1501,9 @@ const unsigned theBackoffComplianceTestVectorLength =
 
 void CheckGetBackoff(nlTestSuite * inSuite, void * inContext)
 {
-    for (uint32_t j = 0; j < 3; j++) {
+    // Run 3x iterations to thoroughly test random jitter always results in backoff within bounds.
+    for (uint32_t j = 0; j < 3; j++)
+    {
         for (uint32_t i = 0; i < theBackoffComplianceTestVectorLength; i++)
         {
             struct BackoffComplianceTestVector * test = &theBackoffComplianceTestVector[i];

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -1501,13 +1501,10 @@ const unsigned theBackoffComplianceTestVectorLength =
 
 void CheckGetBackoff(nlTestSuite * inSuite, void * inContext)
 {
-    TestContext & ctx       = *reinterpret_cast<TestContext *>(inContext);
-    ReliableMessageMgr * rm = ctx.GetExchangeManager().GetReliableMessageMgr();
-
     for (unsigned i = 0; i < theBackoffComplianceTestVectorLength; i++)
     {
         struct BackoffComplianceTestVector * test = &theBackoffComplianceTestVector[i];
-        System::Clock::Timestamp backoff          = rm->GetBackoff(test->backoffBase, test->sendCount);
+        System::Clock::Timestamp backoff          = ReliableMessageMgr::GetBackoff(test->backoffBase, test->sendCount);
         ChipLogProgress(Test, "Backoff # %d: %d", test->sendCount, (uint32_t) backoff.count());
 
         NL_TEST_ASSERT(inSuite, backoff >= test->backoffMin);

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -1482,6 +1482,18 @@ struct BackoffComplianceTestVector theBackoffComplianceTestVector[] = {
         .backoffMin  = System::Clock::Timestamp(1229),
         .backoffMax  = System::Clock::Timestamp(1536),
     },
+    {
+        .sendCount   = 5,
+        .backoffBase = System::Clock::Timestamp(300),
+        .backoffMin  = System::Clock::Timestamp(1966),
+        .backoffMax  = System::Clock::Timestamp(2458),
+    },
+    {
+        .sendCount   = 6,
+        .backoffBase = System::Clock::Timestamp(300),
+        .backoffMin  = System::Clock::Timestamp(1966),
+        .backoffMax  = System::Clock::Timestamp(2458),
+    },
 };
 
 const unsigned theBackoffComplianceTestVectorLength =

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -237,7 +237,7 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, P
 
     while (gLoopback.mMessageDropped)
     {
-        chip::test_utils::SleepMillis(65);
+        chip::test_utils::SleepMillis(85);
         gLoopback.mMessageDropped = false;
         ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), ctx.GetExchangeManager().GetReliableMessageMgr());
         ctx.DrainAndServiceIO();


### PR DESCRIPTION
#### Problem
Fix #15799 - implement exponential backoff in MRP..

#15800 is related, but would come as a separate PR.

#### Change overview
Implements the backoff algorithm as specified but in fixed point:

```
t = i⋅MRP_BACKOFF_BASE^max(0,n−MRP_BACKOFF_THRESHOLD) ⋅ (1.0+random(0,1)⋅MRP_BACKOFF_JITTER)

Where:

  t = the resultant retransmission timeout for this transmission
  n = the transmission count of the message, starting with 0 
  i = the base retry interval for the Exchange (either IDLE or ACTIVE)

MRP_BACKOFF_BASE      | 1.6  | The base number for the exponential backoff equation.
MRP_BACKOFF_JITTER    | 0.25 | The scaler for random jitter in the backoff equation.
MRP_BACKOFF_THRESHOLD | 1    | # of retransmissions before transition from linear to exponential backoff.
```

#### Testing
How was this tested? (at least one bullet point required)
* CI
* Includes Unit test
* Working on unit tests in draft phase