### PR TITLE
[EFR32] Adding  add binding commands to switch

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -1401,3 +1401,8 @@ kManage
 kOperate
 kView
 xFFFFFFFD
+NAMESERVER
+UTF
+localedef
+nameserver
+nmcli

--- a/examples/light-switch-app/efr32/README.md
+++ b/examples/light-switch-app/efr32/README.md
@@ -280,7 +280,7 @@ combination with JLinkRTTClient as follows:
     ```
     chip-tool pairing ble-thread 1 hex:<operationalDataset> 20202021 3840
 
-    chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 3, "authMode": 2, "subjects": [1], "targets": null }]' <lighting-node-id> 0
+    chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": [<chip-tool-node-id>], "targets": null }{"fabricIndex": 1, "privilege": 3, "authMode": 2, "subjects": [1], "targets": null }]' <lighting-node-id> 0
 
     chip-tool binding write binding '[{"fabricIndex": 1, "node": <lighting-node-id>, "endpoint": 1, "cluster":6}]' 1 1
     ```
@@ -302,6 +302,11 @@ combination with JLinkRTTClient as follows:
 
     ```
     chip-tool binding write binding '[{"fabricIndex": 1, "group": 257},{"fabricIndex": 1, "node": <lighting-node-id>, "endpoint": 1, "cluster":6} ]' 1 1
+    ```
+
+    To acquire the chip-tool node id, read the acl table right after commissioning
+    ```
+    ./connectedhomeip/out/chip-tool/chip-tool accesscontrol read acl <nodeid> 0
     ```
 
 ### Notes

--- a/examples/light-switch-app/efr32/README.md
+++ b/examples/light-switch-app/efr32/README.md
@@ -271,6 +271,11 @@ combination with JLinkRTTClient as follows:
         -  'switch groups onoff off'    : Sends On group command to bound group
         -  'switch groups onoff toggle' : Sends On group command to bound group
 
+    **_Binding Cluster_**
+
+        - 'switch binding unicast  <fabric index> <node id> <endpoint>' : Creates a unicast binding
+        - 'switch binding group <fabric index> <group id>'              : Creates a group binding
+
 *   You can provision and control the Chip device using the python controller,
     [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
     standalone, Android or iOS app

--- a/examples/light-switch-app/efr32/README.md
+++ b/examples/light-switch-app/efr32/README.md
@@ -304,7 +304,9 @@ combination with JLinkRTTClient as follows:
     chip-tool binding write binding '[{"fabricIndex": 1, "group": 257},{"fabricIndex": 1, "node": <lighting-node-id>, "endpoint": 1, "cluster":6} ]' 1 1
     ```
 
-    To acquire the chip-tool node id, read the acl table right after commissioning
+    To acquire the chip-tool node id, read the acl table right after
+    commissioning
+
     ```
     ./connectedhomeip/out/chip-tool/chip-tool accesscontrol read acl <nodeid> 0
     ```

--- a/examples/light-switch-app/efr32/include/binding-handler.h
+++ b/examples/light-switch-app/efr32/include/binding-handler.h
@@ -22,6 +22,7 @@
 
 CHIP_ERROR InitBindingHandler();
 void SwitchWorkerFunction(intptr_t context);
+void BindingWorkerFunction(intptr_t context);
 
 struct BindingCommandData
 {

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -233,7 +233,8 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
     entry->type                    = EMBER_MULTICAST_BINDING;
     entry->fabricIndex             = atoi(argv[0]);
     entry->groupId                 = atoi(argv[1]);
-    entry->clusterId.SetValue(6); // Hardcoded to OnOff cluster for now
+    entry->local                   = 1; // Hardcoded to endpoint 1 for now
+    entry->clusterId.SetValue(6);       // Hardcoded to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -23,6 +23,7 @@
 #include "app/server/Server.h"
 #include "controller/InvokeInteraction.h"
 #include "platform/CHIPDeviceLayer.h"
+#include <app/clusters/bindings/bindings.h>
 #include <lib/support/CodeUtils.h>
 
 #if defined(ENABLE_CHIP_SHELL)
@@ -406,22 +407,7 @@ void BindingWorkerFunction(intptr_t context)
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "BindingWorkerFunction - Invalid work data"));
 
     EmberBindingTableEntry * entry = reinterpret_cast<EmberBindingTableEntry *>(context);
-
-    if (entry->type == EMBER_UNICAST_BINDING)
-    {
-        CHIP_ERROR err = BindingManager::GetInstance().UnicastBindingCreated(entry->fabricIndex, entry->nodeId);
-        if (err != CHIP_NO_ERROR)
-        {
-            // Unicast connection failure can happen if peer is offline. We'll retry connection on-demand.
-            ChipLogProgress(NotSpecified,
-                            "Binding: Failed to create session for unicast binding to device " ChipLogFormatX64
-                            ": %" CHIP_ERROR_FORMAT,
-                            ChipLogValueX64(entry->nodeId), err.Format());
-        }
-    }
-
-    BindingTable::GetInstance().Add(*entry);
-    BindingManager::GetInstance().NotifyBindingAdded(*entry);
+    SaveBindingEntry(*entry);
 
     Platform::Delete(entry);
 }

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -132,7 +132,6 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DevicePro
     }
 }
 
-#define ENABLE_CHIP_SHELL 1
 #ifdef ENABLE_CHIP_SHELL
 
 /********************************************************

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -233,6 +233,7 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
     entry->type                    = EMBER_MULTICAST_BINDING;
     entry->fabricIndex             = atoi(argv[0]);
     entry->groupId                 = atoi(argv[1]);
+    entry->clusterId.SetValue(6); // Hardcoded to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
@@ -240,7 +241,7 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
 
 CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
 {
-    VerifyOrReturnError(argc == 4, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(argc == 3, CHIP_ERROR_INVALID_ARGUMENT);
 
     EmberBindingTableEntry * entry = Platform::New<EmberBindingTableEntry>();
     entry->type                    = EMBER_UNICAST_BINDING;
@@ -248,7 +249,7 @@ CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
     entry->nodeId                  = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
     entry->remote                  = atoi(argv[2]);
-    entry->clusterId.SetValue(atoi(argv[3]));
+    entry->clusterId.SetValue(6)); // Hardcode to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
@@ -361,8 +362,7 @@ static void RegisterSwitchCommands()
     static const shell_command_t sSwitchBindingSubCommands[] = {
         { &BindingHelpHandler, "help", "Usage: switch binding <subcommand>" },
         { &BindingGroupBindCommandHandler, "group", "Usage: switch binding group <fabric index> <group id>" },
-        { &BindingUnicastBindCommandHandler, "unicast",
-          "Usage: switch binding group <fabric index> <node id> <endpoint> <cluster>" }
+        { &BindingUnicastBindCommandHandler, "unicast", "Usage: switch binding group <fabric index> <node id> <endpoint>" }
     };
 
     static const shell_command_t sSwitchCommand = { &SwitchCommandHandler, "switch",
@@ -407,7 +407,7 @@ void BindingWorkerFunction(intptr_t context)
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "BindingWorkerFunction - Invalid work data"));
 
     EmberBindingTableEntry * entry = reinterpret_cast<EmberBindingTableEntry *>(context);
-    SaveBindingEntry(*entry);
+    AddBindingEntry(*entry);
 
     Platform::Delete(entry);
 }

--- a/src/app/clusters/bindings/bindings.cpp
+++ b/src/app/clusters/bindings/bindings.cpp
@@ -84,7 +84,7 @@ CHIP_ERROR CheckValidBindingList(const DecodableBindingListType & bindingList, F
     return CHIP_NO_ERROR;
 }
 
-void AddBindingEntry(const TargetStructType & entry, EndpointId localEndpoint)
+void CreateBindingEntry(const TargetStructType & entry, EndpointId localEndpoint)
 {
     EmberBindingTableEntry bindingEntry;
 
@@ -98,7 +98,7 @@ void AddBindingEntry(const TargetStructType & entry, EndpointId localEndpoint)
                                                        entry.cluster);
     }
 
-    SaveBindingEntry(bindingEntry);
+    AddBindingEntry(bindingEntry);
 }
 
 CHIP_ERROR BindingTableAccess::Read(const ConcreteReadAttributePath & path, AttributeValueEncoder & encoder)
@@ -189,7 +189,7 @@ CHIP_ERROR BindingTableAccess::WriteBindingTable(const ConcreteDataAttributePath
         auto iter = newBindingList.begin();
         while (iter.Next())
         {
-            AddBindingEntry(iter.GetValue(), path.mEndpointId);
+            CreateBindingEntry(iter.GetValue(), path.mEndpointId);
         }
         return CHIP_NO_ERROR;
     }
@@ -201,7 +201,7 @@ CHIP_ERROR BindingTableAccess::WriteBindingTable(const ConcreteDataAttributePath
         {
             return CHIP_IM_GLOBAL_STATUS(ConstraintError);
         }
-        AddBindingEntry(target, path.mEndpointId);
+        CreateBindingEntry(target, path.mEndpointId);
         return CHIP_NO_ERROR;
     }
     return CHIP_IM_GLOBAL_STATUS(UnsupportedWrite);
@@ -213,7 +213,7 @@ void MatterBindingPluginServerInitCallback()
     registerAttributeAccessOverride(&gAttrAccess);
 }
 
-void SaveBindingEntry(EmberBindingTableEntry & entry)
+void AddBindingEntry(const EmberBindingTableEntry & entry)
 {
     if (entry.type == EMBER_UNICAST_BINDING)
     {

--- a/src/app/clusters/bindings/bindings.h
+++ b/src/app/clusters/bindings/bindings.h
@@ -21,7 +21,7 @@
 
 /**
  * @brief appends a binding to the list of bindings
- *        This function is to be used when a device wants to add a binding to it's own table
+ *        This function is to be used when a device wants to add a binding to its own table
  *        If entry is a unicast binding, BindingManager will be notified and will establish a case session with the peer device
  *        Entry will be added to the binding table and persisted into storage
  *        BindingManager will be notified and the binding added callback will be called if it has been set

--- a/src/app/clusters/bindings/bindings.h
+++ b/src/app/clusters/bindings/bindings.h
@@ -1,0 +1,27 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/util/binding-table.h>
+#include <app/clusters/bindings/BindingManager.h>
+
+/**
+ * @brief Saves binding in storage and notifies a new binding has been added
+ * 
+ * @param entry binding to save
+ */
+void SaveBindingEntry(EmberBindingTableEntry & entry);

--- a/src/app/clusters/bindings/bindings.h
+++ b/src/app/clusters/bindings/bindings.h
@@ -20,8 +20,12 @@
 #include <app/util/binding-table.h>
 
 /**
- * @brief Saves binding in storage and notifies a new binding has been added
+ * @brief appends a binding to the list of bindings
+ *        This function is to be used when a device wants to add a binding to it's own table
+ *        If entry is a unicast binding, BindingManager will be notified and will establish a case session with the peer device
+ *        Entry will be added to the binding table and persisted into storage
+ *        BindingManager will be notified and the binding added callback will be called if it has been set
  *
- * @param entry binding to save
+ * @param entry binding to add
  */
-void SaveBindingEntry(EmberBindingTableEntry & entry);
+void AddBindingEntry(const EmberBindingTableEntry & entry);

--- a/src/app/clusters/bindings/bindings.h
+++ b/src/app/clusters/bindings/bindings.h
@@ -16,8 +16,8 @@
  */
 #pragma once
 
-#include <app/util/binding-table.h>
 #include <app/clusters/bindings/BindingManager.h>
+#include <app/util/binding-table.h>
 
 /**
  * @brief Saves binding in storage and notifies a new binding has been added

--- a/src/app/clusters/bindings/bindings.h
+++ b/src/app/clusters/bindings/bindings.h
@@ -21,7 +21,7 @@
 
 /**
  * @brief Saves binding in storage and notifies a new binding has been added
- * 
+ *
  * @param entry binding to save
  */
 void SaveBindingEntry(EmberBindingTableEntry & entry);


### PR DESCRIPTION
#### Problem
* With the light-switch, it was not possible to bind a lighting-app to the light-switch without using the chip-tool

#### Change overview
* With the matter shell, added the feature to append a binding
* This is a first iteration with basic functionalities 

#### Testing
* Manual test with two EFR32 devices when adding a unicast and group binding
