### PR TITLE
Change fabric table persistence to not use a single blob per fabric.

### DIFF
--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -214,6 +214,11 @@ private:
         return TLV::EstimateStructOverhead(sizeof(VendorId), kFabricLabelMaxLengthInBytes);
     }
 
+    static constexpr size_t OpKeyTLVMaxSize()
+    {
+        return TLV::EstimateStructOverhead(sizeof(uint16_t), Crypto::P256SerializedKeypair::Capacity());
+    }
+
     PeerId mOperationalId;
 
     FabricIndex mFabric                                 = kUndefinedFabricIndex;

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -32,6 +32,7 @@
 #endif
 #include <lib/core/CHIPEncoding.h>
 #include <lib/core/CHIPSafeCasts.h>
+#include <lib/core/CHIPTLV.h>
 #include <lib/core/Optional.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/DLLUtil.h>
@@ -48,11 +49,6 @@ static constexpr FabricIndex kMaxValidFabricIndex     = std::min<FabricIndex>(UI
 static constexpr uint8_t kFabricLabelMaxLengthInBytes = 32;
 
 static_assert(kUndefinedFabricIndex < chip::kMinValidFabricIndex, "Undefined fabric index should not be valid");
-
-// KVS store is sensitive to length of key strings, based on the underlying
-// platform. Keeping them short.
-constexpr char kFabricTableKeyPrefix[] = "Fabric";
-constexpr char kFabricTableCountKey[]  = "NumFabrics";
 
 /**
  * Defines state of a pairing established by a fabric.
@@ -213,6 +209,11 @@ public:
     friend class FabricTable;
 
 private:
+    static constexpr size_t MetadataTLVMaxSize()
+    {
+        return TLV::EstimateStructOverhead(sizeof(VendorId), kFabricLabelMaxLengthInBytes);
+    }
+
     PeerId mOperationalId;
 
     FabricIndex mFabric                                 = kUndefinedFabricIndex;
@@ -230,10 +231,6 @@ private:
     MutableByteSpan mNOCCert;
 
     FabricId mFabricId = 0;
-
-    static constexpr size_t kKeySize = sizeof(kFabricTableKeyPrefix) + 2 * sizeof(FabricIndex);
-
-    static CHIP_ERROR GenerateKey(FabricIndex id, char * key, size_t len);
 
     CHIP_ERROR CommitToStorage(PersistentStorageDelegate * storage);
     CHIP_ERROR LoadFromStorage(PersistentStorageDelegate * storage);

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -34,8 +34,11 @@ public:
     const char * KeyName() { return mKeyName; }
 
     // Fabric Table
-
-    const char * FabricTable(chip::FabricIndex fabric) { return Format("f/%x/t", fabric); }
+    const char * FabricNOC(FabricIndex fabric) { return Format("f/%x/n", fabric); }
+    const char * FabricICAC(FabricIndex fabric) { return Format("f/%x/i", fabric); }
+    const char * FabricRCAC(FabricIndex fabric) { return Format("f/%x/r", fabric); }
+    const char * FabricMetadata(FabricIndex fabric) { return Format("f/%x/m", fabric); }
+    const char * FabricOpKey(FabricIndex fabric) { return Format("f/%x/o", fabric); }
 
     // Access Control List
 


### PR DESCRIPTION
This will let us do a better job of loading things on demand as
needed, in followups, so we don't have to keep the certs in RAM all
the time.

#### Problem
A fabric table entry is being stored as a single blob, so we have to read it all-or-nothing.

Issue: #7695

#### Change overview
Store the separate bits separately, so we can read just the part we want.

#### Testing
In addition to our CI, did ran chip-all-clusters-app and then ran the following commands:
```
./out/debug/standalone/chip-tool pairing onnetwork 17 20202021

./out/debug/standalone/chip-tool operationalcredentials update-fabric-label "party" 17 0

./out/debug/standalone/chip-tool operationalcredentials read fabrics 17 0 --fabric-filtered 0

./out/debug/standalone/chip-tool administratorcommissioning open-basic-commissioning-window 600 17 0 --timedInteractionTimeoutMs 10000

./out/debug/standalone/chip-tool pairing onnetwork 18 20202021 --commissioner-name beta

./out/debug/standalone/chip-tool operationalcredentials update-fabric-label "basement" 18 0 --commissioner-name beta

./out/debug/standalone/chip-tool operationalcredentials read fabrics 17 0 --fabric-filtered 0

./out/debug/standalone/chip-tool operationalcredentials read fabrics 18 0 --fabric-filtered 0 --commissioner-name beta
```

where for each read I ran it, then restarted all-clusters-app, then ran the read again and verified that the information did not change.