### PR TITLE
Add missing space in DataVersion logging.

### DIFF
--- a/examples/chip-tool/templates/logging/DataModelLogger-src.zapt
+++ b/examples/chip-tool/templates/logging/DataModelLogger-src.zapt
@@ -62,7 +62,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent, const {{
 
 CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributePath & path, chip::TLV::TLVReader * data)
 {
-    ChipLogProgress(chipTool, "Endpoint: %" PRIu16 " Cluster: " ChipLogFormatMEI " Attribute " ChipLogFormatMEI "DataVersion: %" PRIu32, path.mEndpointId,
+    ChipLogProgress(chipTool, "Endpoint: %" PRIu16 " Cluster: " ChipLogFormatMEI " Attribute " ChipLogFormatMEI " DataVersion: %" PRIu32, path.mEndpointId,
                     ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId), path.mDataVersion.ValueOr(0));
 
     switch (path.mClusterId)

--- a/src/app/tests/suites/certification/Test_TC_BR_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BR_1.yaml
@@ -25,7 +25,7 @@ tests:
       verification:
           "./chip-tool descriptor read device-list 1 1
           C[1646119893.830333][3487:3492] CHIP:TOO: Endpoint: 1 Cluster:
-          0x0000_001D Attribute 0x0000_0000DataVersion: 4007324196
+          0x0000_001D Attribute 0x0000_0000 DataVersion: 4007324196
           [1646119893.830428][3487:3492] CHIP:TOO: device list: 1 entries
           [1646119893.830500][3487:3492] CHIP:TOO: [1]: {
           [1646119893.830531][3487:3492] CHIP:TOO: Type: 256

--- a/src/app/tests/suites/certification/Test_TC_GC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_GC_1_1.yaml
@@ -60,7 +60,7 @@ tests:
           SuppressResponse = true, [1646201945.126404][2860:2865] CHIP:DMG:
           InteractionModelRevision = 1 [1646201945.126437][2860:2865] CHIP:DMG:
           } [1646201945.126644][2860:2865] CHIP:TOO: Endpoint: 0 Cluster:
-          0x0000_0030 Attribute 0x0000_0002DataVersion: 1894223167
+          0x0000_0030 Attribute 0x0000_0002 DataVersion: 1894223167
           [1646201945.126728][2860:2865] CHIP:TOO: RegulatoryConfig: 0
           [1646201945.126810][2860:2865] CHIP:EM: Sending Standalone Ack for
           MessageCounter:2750188 on exchange 60766ii"
@@ -73,7 +73,7 @@ tests:
           SuppressResponse = true, [1646201921.080530][2848:2853] CHIP:DMG:
           InteractionModelRevision = 1 [1646201921.080561][2848:2853] CHIP:DMG:
           } [1646201921.080735][2848:2853] CHIP:TOO: Endpoint: 0 Cluster:
-          0x0000_0030 Attribute 0x0000_0003DataVersion: 1894223167
+          0x0000_0030 Attribute 0x0000_0003 DataVersion: 1894223167
           [1646201921.080821][2848:2853] CHIP:TOO: LocationCapability: 0
           [1646201921.080903][2848:2853] CHIP:EM: Sending Standalone Ack for
           MessageCounter:13587220 on exchange 43838ii"
@@ -83,7 +83,7 @@ tests:
       verification:
           "ubuntu@ubuntu:~/apps$ sudo ./chip-tool generalcommissioning read
           basic-commissioning-info 1 0 [1646201777.003556][2827:2832] CHIP:TOO:
-          Endpoint: 0 Cluster: 0x0000_0030 Attribute 0x0000_0001DataVersion:
+          Endpoint: 0 Cluster: 0x0000_0030 Attribute 0x0000_0001 DataVersion:
           1894223167 [1646201777.006423][2827:2832] CHIP:TOO:
           BasicCommissioningInfo: { [1646201777.006478][2827:2832] CHIP:TOO:
           FailSafeExpiryLengthSeconds: 60 [1646201777.006512][2827:2832]
@@ -127,7 +127,7 @@ tests:
           CHIP:DMG: SuppressResponse = true,[1646202241.425668][2879:2884]
           CHIP:DMG: InteractionModelRevision = 1 [1646202241.425702][2879:2884]
           CHIP:DMG: } [1646202241.426186][2879:2884] CHIP:TOO: Endpoint: 0
-          Cluster: 0x0000_0030 Attribute 0x0000_FFF8DataVersion: 1894223167
+          Cluster: 0x0000_0030 Attribute 0x0000_FFF8 DataVersion: 1894223167
           [1646202241.426293][2879:2884] CHIP:TOO: ServerGeneratedCommandList: 2
           entries [1646202241.426379][2879:2884] CHIP:TOO: [1]:
           1[1646202241.426420][2879:2884] CHIP:TOO: [2]: 5
@@ -142,7 +142,7 @@ tests:
           CHIP:DMG: SuppressResponse = true, [1646202324.586156][2908:2913]
           CHIP:DMG: InteractionModelRevision = 1 [1646202324.586198][2908:2913]
           CHIP:DMG: } [1646202324.587108][2908:2913] CHIP:TOO: Endpoint: 0
-          Cluster: 0x0000_0030 Attribute 0x0000_FFF9DataVersion: 1894223167
+          Cluster: 0x0000_0030 Attribute 0x0000_FFF9 DataVersion: 1894223167
           [1646202324.587242][2908:2913] CHIP:TOO: ClientGeneratedCommandList: 4
           entries [1646202324.587385][2908:2913] CHIP:TOO: [1]: 0
           [1646202324.587438][2908:2913] CHIP:TOO: [2]: 2

--- a/src/app/tests/suites/certification/Test_TC_IDM_1_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_IDM_1_2.yaml
@@ -240,7 +240,7 @@ tests:
           [5094:213098] CHIP: [DMG] SuppressResponse = true, [1646261193889]
           [5094:213098] CHIP: [DMG] InteractionModelRevision = 1 [1646261193889]
           [5094:213098] CHIP: [DMG] } [1646261193889] [5094:213098] CHIP: [TOO]
-          Endpoint: 0 Cluster: 0x0000_0028 Attribute 0x0000_FFF9DataVersion:
+          Endpoint: 0 Cluster: 0x0000_0028 Attribute 0x0000_FFF9 DataVersion:
           759594214 [1646261193889] [5094:213098] CHIP: [TOO]
           ClientGeneratedCommandList: 0 entries"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_MC_10_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_10_1.yaml
@@ -84,7 +84,7 @@ tests:
           true, [1646143737358] [87142:3768651] CHIP: [DMG]
           InteractionModelRevision = 1 [1646143737358] [87142:3768651] CHIP:
           [DMG] } [1646143737359] [87142:3768651] CHIP: [TOO] Endpoint: 1
-          Cluster: 0x0000_050A Attribute 0x0000_0000DataVersion: 1291728690
+          Cluster: 0x0000_050A Attribute 0x0000_0000 DataVersion: 1291728690
           [1646143737360] [87142:3768651] CHIP: [TOO] AcceptHeader: 2 entries
           [1646143737360] [87142:3768651] CHIP: [TOO] [1]: example
           [1646143737360] [87142:3768651] CHIP: [TOO] [2]: example
@@ -131,7 +131,7 @@ tests:
           true, [1646143780979] [87181:3769324] CHIP: [DMG]
           InteractionModelRevision = 1 [1646143780979] [87181:3769324] CHIP:
           [DMG] } [1646143780979] [87181:3769324] CHIP: [TOO] Endpoint: 1
-          Cluster: 0x0000_050A Attribute 0x0000_0001DataVersion: 1291728690
+          Cluster: 0x0000_050A Attribute 0x0000_0001 DataVersion: 1291728690
           [1646143780980] [87181:3769324] CHIP: [TOO]
           SupportedStreamingProtocols: 0 [1646143780980] [87181:3769324] CHIP:
           [EM] Sending Standalone Ack for MessageCounter:6010019 on exchange

--- a/src/app/tests/suites/certification/Test_TC_MC_3_13.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_13.yaml
@@ -26,7 +26,7 @@ tests:
       verification:
           "./chip-tool mediainput read input-list 1 1 [1646140193572]
           [83167:3718213] CHIP: [TOO] Endpoint: 1 Cluster: 0x0000_0507 Attribute
-          0x0000_0000DataVersion: 645543558 [1646140193572] [83167:3718213]
+          0x0000_0000 DataVersion: 645543558 [1646140193572] [83167:3718213]
           CHIP: [TOO] InputList: 2 entries [1646140193572] [83167:3718213] CHIP:
           [TOO] [1]: { [1646140193572] [83167:3718213] CHIP: [TOO] Index: 1
           [1646140193573] [83167:3718213] CHIP: [TOO] InputType: 4
@@ -88,7 +88,7 @@ tests:
       verification:
           "./chip-tool mediainput read input-list 1 1 [1646140289219]
           [83463:3720087] CHIP: [TOO] Endpoint: 1 Cluster: 0x0000_0507 Attribute
-          0x0000_0000DataVersion: 645543558 [1646140289219] [83463:3720087]
+          0x0000_0000 DataVersion: 645543558 [1646140289219] [83463:3720087]
           CHIP: [TOO] InputList: 2 entries [1646140289219] [83463:3720087] CHIP:
           [TOO] [1]: { [1646140289219] [83463:3720087] CHIP: [TOO] Index: 1
           [1646140289219] [83463:3720087] CHIP: [TOO] InputType: 4

--- a/src/app/tests/suites/certification/Test_TC_MC_4_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_4_1.yaml
@@ -24,7 +24,7 @@ tests:
       verification:
           "./chip-tool wakeonlan read macaddress 1 1 [1646140497523]
           [83791:3722553] CHIP: [TOO] Endpoint: 1 Cluster: 0x0000_0503 Attribute
-          0x0000_0000DataVersion: 937942620 [1646140497523] [83791:3722553]
+          0x0000_0000 DataVersion: 937942620 [1646140497523] [83791:3722553]
           CHIP: [TOO] MACAddress: 00:00:00:00:00"
       disabled: true
 

--- a/src/app/tests/suites/certification/Test_TC_MOD_1_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MOD_1_2.yaml
@@ -71,7 +71,7 @@ tests:
           [1645776767.610958][4667:4672] CHIP:DMG: InteractionModelRevision = 1
           [1645776767.610983][4667:4672] CHIP:DMG: }
           [1645776767.611140][4667:4672] CHIP:TOO: Endpoint: 1 Cluster:
-          0x0000_0050 Attribute 0x0000_0000DataVersion: 3781469718
+          0x0000_0050 Attribute 0x0000_0000 DataVersion: 3781469718
           [1645776767.611214][4667:4672] CHIP:TOO: CurrentMode: 0"
       disabled: true
 
@@ -105,7 +105,7 @@ tests:
           [1645776797.704080][4674:4679] CHIP:DMG: InteractionModelRevision = 1
           [1645776797.704108][4674:4679] CHIP:DMG: }
           [1645776797.704270][4674:4679] CHIP:TOO: Endpoint: 1 Cluster:
-          0x0000_0050 Attribute 0x0000_0002DataVersion: 3781469718
+          0x0000_0050 Attribute 0x0000_0002 DataVersion: 3781469718
           [1645776797.704349][4674:4679] CHIP:TOO: OnMode: 0"
       disabled: true
 
@@ -139,7 +139,7 @@ tests:
           [1645776818.700095][4682:4687] CHIP:DMG: InteractionModelRevision = 1
           [1645776818.700127][4682:4687] CHIP:DMG: }
           [1645776818.700294][4682:4687] CHIP:TOO: Endpoint: 1 Cluster:
-          0x0000_0050 Attribute 0x0000_0003DataVersion: 3781469718
+          0x0000_0050 Attribute 0x0000_0003 DataVersion: 3781469718
           [1645776818.700374][4682:4687] CHIP:TOO: StartUpMode: 0"
       disabled: true
 
@@ -173,7 +173,7 @@ tests:
           [1645776853.155563][4691:4696] CHIP:DMG: InteractionModelRevision = 1
           [1645776853.155591][4691:4696] CHIP:DMG: }
           [1645776853.155757][4691:4696] CHIP:TOO: Endpoint: 1 Cluster:
-          0x0000_0050 Attribute 0x0000_0004DataVersion: 3781469718
+          0x0000_0050 Attribute 0x0000_0004 DataVersion: 3781469718
           [1645776853.155812][4691:4696] CHIP:TOO: Description: Coffee"
       disabled: true
 

--- a/src/app/tests/suites/certification/Test_TC_MOD_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MOD_2_1.yaml
@@ -105,7 +105,7 @@ tests:
           [1645777197.118618][4759:4764] CHIP:DMG: InteractionModelRevision = 1
           [1645777197.118647][4759:4764] CHIP:DMG: }
           [1645777197.118795][4759:4764] CHIP:TOO: Endpoint: 1 Cluster:
-          0x0000_0050 Attribute 0x0000_0000DataVersion: 3781469720
+          0x0000_0050 Attribute 0x0000_0000 DataVersion: 3781469720
           [1645777197.118866][4759:4764] CHIP:TOO: CurrentMode: 4"
       disabled: true
 

--- a/src/app/tests/suites/certification/Test_TC_MOD_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MOD_3_1.yaml
@@ -50,7 +50,7 @@ tests:
           [1645777342.721698][4783:4788] CHIP:DMG: InteractionModelRevision = 1
           [1645777342.721723][4783:4788] CHIP:DMG: }
           [1645777342.721860][4783:4788] CHIP:TOO: Endpoint: 1 Cluster:
-          0x0000_0050 Attribute 0x0000_0002DataVersion: 3781469720
+          0x0000_0050 Attribute 0x0000_0002 DataVersion: 3781469720
           [1645777342.721929][4783:4788] CHIP:TOO: OnMode: 0"
       disabled: true
 
@@ -84,7 +84,7 @@ tests:
           [1645777371.982914][4789:4794] CHIP:DMG: InteractionModelRevision = 1
           [1645777371.982945][4789:4794] CHIP:DMG: }
           [1645777371.983122][4789:4794] CHIP:TOO: Endpoint: 1 Cluster:
-          0x0000_0050 Attribute 0x0000_0000DataVersion: 3781469720
+          0x0000_0050 Attribute 0x0000_0000 DataVersion: 3781469720
           [1645777371.983204][4789:4794] CHIP:TOO: CurrentMode: 4"
       disabled: true
 
@@ -257,6 +257,6 @@ tests:
           [1645777734.855968][4848:4853] CHIP:DMG: InteractionModelRevision = 1
           [1645777734.855993][4848:4853] CHIP:DMG: }
           [1645777734.856233][4848:4853] CHIP:TOO: Endpoint: 1 Cluster:
-          0x0000_0050 Attribute 0x0000_0000DataVersion: 3781469721
+          0x0000_0050 Attribute 0x0000_0000 DataVersion: 3781469721
           [1645777734.856345][4848:4853] CHIP:TOO: CurrentMode: 0"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_MOD_3_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MOD_3_2.yaml
@@ -50,7 +50,7 @@ tests:
           [1645777708.406700][4841:4846] CHIP:DMG: InteractionModelRevision = 1
           [1645777708.406725][4841:4846] CHIP:DMG: }
           [1645777708.406864][4841:4846] CHIP:TOO: Endpoint: 1 Cluster:
-          0x0000_0050 Attribute 0x0000_0003DataVersion: 3781469721
+          0x0000_0050 Attribute 0x0000_0003 DataVersion: 3781469721
           [1645777708.406933][4841:4846] CHIP:TOO: StartUpMode: 0"
       disabled: true
 
@@ -84,7 +84,7 @@ tests:
           [1645778146.171262][4876:4881] CHIP:DMG: InteractionModelRevision = 1
           [1645778146.171290][4876:4881] CHIP:DMG: }
           [1645778146.171510][4876:4881] CHIP:TOO: Endpoint: 1 Cluster:
-          0x0000_0050 Attribute 0x0000_0000DataVersion: 3781469721
+          0x0000_0050 Attribute 0x0000_0000 DataVersion: 3781469721
           [1645778146.171602][4876:4881] CHIP:TOO: CurrentMode: 7"
       disabled: true
 
@@ -189,6 +189,6 @@ tests:
           [1645778146.171262][4876:4881] CHIP:DMG: InteractionModelRevision = 1
           [1645778146.171290][4876:4881] CHIP:DMG: }
           [1645778146.171510][4876:4881] CHIP:TOO: Endpoint: 1 Cluster:
-          0x0000_0050 Attribute 0x0000_0000DataVersion: 3781469721
+          0x0000_0050 Attribute 0x0000_0000 DataVersion: 3781469721
           [1645778146.171602][4876:4881] CHIP:TOO: CurrentMode: 0"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_MOD_3_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MOD_3_3.yaml
@@ -50,7 +50,7 @@ tests:
           [1645778279.692921][4898:4903] CHIP:DMG: InteractionModelRevision = 1
           [1645778279.692944][4898:4903] CHIP:DMG: }
           [1645778279.693082][4898:4903] CHIP:TOO: Endpoint: 1 Cluster:
-          0x0000_0050 Attribute 0x0000_0003DataVersion: 3781469722
+          0x0000_0050 Attribute 0x0000_0003 DataVersion: 3781469722
           [1645778279.693151][4898:4903] CHIP:TOO: StartUpMode: 0"
       disabled: true
 
@@ -83,7 +83,7 @@ tests:
           [1645778146.171262][4876:4881] CHIP:DMG: InteractionModelRevision = 1
           [1645778146.171290][4876:4881] CHIP:DMG: }
           [1645778146.171510][4876:4881] CHIP:TOO: Endpoint: 1 Cluster:
-          0x0000_0050 Attribute 0x0000_0000DataVersion: 3781469721
+          0x0000_0050 Attribute 0x0000_0000 DataVersion: 3781469721
           [1645778146.171602][4876:4881] CHIP:TOO: CurrentMode: 7"
       disabled: true
 
@@ -190,6 +190,6 @@ tests:
           [1645778146.171262][4876:4881] CHIP:DMG: InteractionModelRevision = 1
           [1645778146.171290][4876:4881] CHIP:DMG: }
           [1645778146.171510][4876:4881] CHIP:TOO: Endpoint: 1 Cluster:
-          0x0000_0050 Attribute 0x0000_0000DataVersion: 3781469721
+          0x0000_0050 Attribute 0x0000_0000 DataVersion: 3781469721
           [1645778146.171602][4876:4881] CHIP:TOO: CurrentMode: 4"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_OCC_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OCC_2_3.yaml
@@ -29,14 +29,14 @@ tests:
     - label: "TH reads OccupancySensorType attribute from DUT"
       verification:
           "./chip-tool occupancysensing read occupancy-sensor-type 1 1 Endpoint:
-          1 Cluster: 0x0000_0406 Attribute 0x0000_0001DataVersion: 289401399
+          1 Cluster: 0x0000_0406 Attribute 0x0000_0001 DataVersion: 289401399
           [1646129490.492433][2997:3002] CHIP:TOO: occupancy sensor type: 0"
       disabled: true
 
     - label: "TH reads OccupancySensorTypeBitmap attribute from DUT"
       verification:
           "./chip-tool occupancysensing read occupancy-sensor-type-bitmap 1 1
-          Endpoint: 1 Cluster: 0x0000_0406 Attribute 0x0000_0002DataVersion:
+          Endpoint: 1 Cluster: 0x0000_0406 Attribute 0x0000_0002 DataVersion:
           289401399 [1646129577.158531][3007:3013] CHIP:TOO: occupancy sensor
           type bitmap: 1"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_OCC_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OCC_3_1.yaml
@@ -27,7 +27,7 @@ tests:
     - label: "TH reads Occupancy attribute from DUT"
       verification:
           "./chip-tool occupancysensing read occupancy 1 1 Endpoint: 1 Cluster:
-          0x0000_0406 Attribute 0x0000_0000DataVersion: 289401399
+          0x0000_0406 Attribute 0x0000_0000 DataVersion: 289401399
           [1646130536.783615][3045:3050] CHIP:TOO: occupancy: 0"
       disabled: true
 
@@ -38,6 +38,6 @@ tests:
     - label: "after a few seconds, TH reads Occupancy attribute from DUT"
       verification:
           "./chip-tool occupancysensing read occupancy 1 1 Endpoint: 1 Cluster:
-          0x0000_0406 Attribute 0x0000_0000DataVersion: 289401399
+          0x0000_0406 Attribute 0x0000_0000 DataVersion: 289401399
           [1646130536.783615][3045:3050] CHIP:TOO: occupancy: 1"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_PRS_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PRS_2_3.yaml
@@ -35,7 +35,7 @@ tests:
           [1646049376.458003][12096:12101] CHIP:DMG: InteractionModelRevision =
           1 [1646049376.458033][12096:12101] CHIP:DMG: }
           [1646049376.458206][12096:12101] CHIP:TOO: Endpoint: 1 Cluster:
-          0x0000_0403 Attribute 0x0000_0000 DataVersion: 781236764
+          0x0000_0403 Attribute 0x0000_0000  DataVersion: 781236764
           [1646049376.458395][12096:12101] CHIP:TOO: MeasuredValue: 0"
       disabled: true
 

--- a/src/app/tests/suites/certification/Test_TC_PSCFG_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PSCFG_1_1.yaml
@@ -70,7 +70,7 @@ tests:
           "./chip-tool powersourceconfiguration read
           client-generated-command-list 1234 0 [...]
           [1646048092.858800][36301:36306] CHIP:TOO: Endpoint: 0 Cluster:
-          0x0000_002E Attribute 0x0000_FFF9DataVersion: 502821112
+          0x0000_002E Attribute 0x0000_FFF9 DataVersion: 502821112
           [1646048092.858890][36301:36306] CHIP:TOO: ClientGeneratedCommandList:
           0 entries"
       disabled: true
@@ -80,7 +80,7 @@ tests:
           "./chip-tool powersourceconfiguration read
           server-generated-command-list 1234 0 [...]
           [1646048186.753316][36310:36315] CHIP:TOO: Endpoint: 0 Cluster:
-          0x0000_002E Attribute 0x0000_FFF8DataVersion: 502821112
+          0x0000_002E Attribute 0x0000_FFF8 DataVersion: 502821112
           [1646048186.753391][36310:36315] CHIP:TOO: ServerGeneratedCommandList:
           0 entries"
       disabled: true

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
@@ -4243,7 +4243,7 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributePath & path, chip::TLV::TLVReader * data)
 {
     ChipLogProgress(
-        chipTool, "Endpoint: %" PRIu16 " Cluster: " ChipLogFormatMEI " Attribute " ChipLogFormatMEI "DataVersion: %" PRIu32,
+        chipTool, "Endpoint: %" PRIu16 " Cluster: " ChipLogFormatMEI " Attribute " ChipLogFormatMEI " DataVersion: %" PRIu32,
         path.mEndpointId, ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId), path.mDataVersion.ValueOr(0));
 
     switch (path.mClusterId)


### PR DESCRIPTION
The attribute id was getting glued to "DataVersion".

#### Problem
Logging is running values into labels.

#### Change overview
Add a space.

#### Testing
Checked that the logs have a space.