### PR TITLE
[OTA] Set OTA Requestor server attributes in CHIP context

### DIFF
--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -20,6 +20,7 @@
  * OTA Requestor logic is contained in this class.
  */
 
+#include <app/clusters/ota-requestor/ota-requestor-server.h>
 #include <lib/core/CHIPEncoding.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/OTAImageProcessor.h>
@@ -99,6 +100,17 @@ void SetRequestorInstance(OTARequestorInterface * instance)
 OTARequestorInterface * GetRequestorInstance()
 {
     return globalOTARequestorInstance;
+}
+
+void OTARequestor::InitState(intptr_t context)
+{
+    OTARequestor * requestorCore = reinterpret_cast<OTARequestor *>(context);
+    VerifyOrDie(requestorCore != nullptr);
+
+    // This results in the initial periodic timer kicking off
+    requestorCore->RecordNewUpdateState(OTAUpdateStateEnum::kIdle, OTAChangeReasonEnum::kSuccess);
+
+    OtaRequestorServerSetUpdateStateProgress(app::DataModel::NullNullable);
 }
 
 void OTARequestor::OnQueryImageResponse(void * context, const QueryImageResponse::DecodableType & response)

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #include <app/CASESessionManager.h>
-#include <app/clusters/ota-requestor/ota-requestor-server.h>
 #include <app/server/Server.h>
 #include <protocols/bdx/BdxMessages.h>
 
@@ -100,6 +99,8 @@ public:
                                 app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason) override;
     void OnUpdateProgressChanged(app::DataModel::Nullable<uint8_t> percent) override;
 
+    //////////// OTARequestor public APIs ///////////////
+
     /**
      * Called to perform some initialization including:
      *   - Set server instance used to get access to the system resources necessary to open CASE sessions and drive
@@ -120,11 +121,9 @@ public:
         mCurrentVersion = version;
 
         storage.LoadDefaultProviders(mDefaultOtaProviderList);
-        OtaRequestorServerSetUpdateState(mCurrentUpdateState);
-        OtaRequestorServerSetUpdateStateProgress(app::DataModel::NullNullable);
 
-        // This results in the initial periodic timer kicking off
-        RecordNewUpdateState(OTAUpdateStateEnum::kIdle, OTAChangeReasonEnum::kSuccess);
+        // Schedule the initializations that needs to be performed in the CHIP context
+        DeviceLayer::PlatformMgr().ScheduleWork(InitState, reinterpret_cast<intptr_t>(this));
 
         return chip::DeviceLayer::PlatformMgrImpl().AddEventHandler(OnCommissioningCompleteRequestor,
                                                                     reinterpret_cast<intptr_t>(this));
@@ -205,6 +204,11 @@ private:
         chip::Messaging::ExchangeContext * mExchangeCtx;
         chip::BDXDownloader * mDownloader;
     };
+
+    /**
+     * Callback to initialize states and server attributes in the CHIP context
+     */
+    static void InitState(intptr_t context);
 
     /**
      * Record the new update state by updating the corresponding server attribute and logging a StateTransition event


### PR DESCRIPTION
#### Problem
The OTARequestor was calling into core CHIP functionality (updating server attribute states) at start up on the main thread. This should be done in the CHIP context.

Fixes: https://github.com/project-chip/connectedhomeip/issues/15128

#### Change overview
- Create a callback function to be run in the CHIP context
- Schedule the work from `OTARequestor::Init`

#### Testing
- Verified that core CHIP functionality is not called on the main thread
- Verified that basic transfer between requestor/provider succeeds
