### PR TITLE
BLEEndPoint ref count overflow check

### DIFF
--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -588,16 +588,13 @@ CHIP_ERROR BLEEndPoint::Init(BleLayer * bleLayer, BLE_CONNECTION_OBJECT connObj,
 
 void BLEEndPoint::AddRef()
 {
-    if (mRefCount == UINT32_MAX)
-    {
-        return;
-    }
-
+    VerifyOrDie(mRefCount < UINT32_MAX);
     mRefCount++;
 }
 
 void BLEEndPoint::Release()
 {
+    VerifyOrDie(mRefCount > 0u);
     // Decrement the ref count.  When it reaches zero, NULL out the pointer to the chip::System::Layer
     // object. This effectively declared the object free and ready for re-allocation.
     mRefCount--;

--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -586,6 +586,16 @@ CHIP_ERROR BLEEndPoint::Init(BleLayer * bleLayer, BLE_CONNECTION_OBJECT connObj,
     return CHIP_NO_ERROR;
 }
 
+void BLEEndPoint::AddRef()
+{
+    if (mRefCount == UINT32_MAX)
+    {
+        return;
+    }
+
+    mRefCount++;
+}
+
 void BLEEndPoint::Release()
 {
     // Decrement the ref count.  When it reaches zero, NULL out the pointer to the chip::System::Layer

--- a/src/ble/BLEEndPoint.h
+++ b/src/ble/BLEEndPoint.h
@@ -114,7 +114,7 @@ private:
 
     uint32_t mRefCount;
 
-    void AddRef() { mRefCount++; }
+    void AddRef();
     void Release();
 
     // Private data members:


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fixes #15579.

#### Change overview
Check for ref count over- and underflow.

#### Testing
How was this tested? (at least one bullet point required)
* WiFi-commissioned node via BLE.
