### PR TITLE
Update Darwin CHIPDevice data object format

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPAttributeCacheContainer.mm
+++ b/src/darwin/Framework/CHIP/CHIPAttributeCacheContainer.mm
@@ -21,6 +21,7 @@
 #import "CHIPDeviceControllerOverXPC+AttributeCache.h"
 #import "CHIPDevice_Internal.h"
 #import "CHIPError.h"
+#import "CHIPError_Internal.h"
 #import "CHIPLogging.h"
 
 #include <app/InteractionModelEngine.h>
@@ -152,30 +153,20 @@ static CHIP_ERROR AppendAttibuteValueToArray(
     if (err == CHIP_NO_ERROR) {
         id obj = NSObjectFromCHIPTLV(&reader);
         if (obj) {
-            [array addObject:@{
-                @"endpointId" : [NSNumber numberWithUnsignedShort:path.mEndpointId],
-                @"clusterId" : [NSNumber numberWithUnsignedLong:path.mClusterId],
-                @"attributeId" : [NSNumber numberWithUnsignedLong:path.mAttributeId],
-                @"status" : @0,
-                @"data" : obj
-            }];
+            [array addObject:@ { kCHIPAttributePathKey : [[CHIPAttributePath alloc] initWithPath:path], kCHIPDataKey : obj }];
             return CHIP_NO_ERROR;
         }
         CHIP_LOG_ERROR("Error: Cached value could not be converted to generic NSObject");
         [array addObject:@ {
-            @"endpointId" : [NSNumber numberWithUnsignedShort:path.mEndpointId],
-            @"clusterId" : [NSNumber numberWithUnsignedLong:path.mClusterId],
-            @"attributeId" : [NSNumber numberWithUnsignedLong:path.mAttributeId],
-            @"status" : [NSNumber numberWithInteger:CHIP_ERROR_DECODE_FAILED.AsInteger()]
+            kCHIPAttributePathKey : [[CHIPAttributePath alloc] initWithPath:path],
+            kCHIPErrorKey : [CHIPError errorForCHIPErrorCode:CHIP_ERROR_DECODE_FAILED]
         }];
         return CHIP_ERROR_DECODE_FAILED;
     }
     CHIP_LOG_ERROR("Error: Failed to read from attribute cache: %s", err.AsString());
     [array addObject:@ {
-        @"endpointId" : [NSNumber numberWithUnsignedShort:path.mEndpointId],
-        @"clusterId" : [NSNumber numberWithUnsignedLong:path.mClusterId],
-        @"attributeId" : [NSNumber numberWithUnsignedLong:path.mAttributeId],
-        @"status" : [NSNumber numberWithInteger:err.AsInteger()]
+        kCHIPAttributePathKey : [[CHIPAttributePath alloc] initWithPath:path],
+        kCHIPErrorKey : [CHIPError errorForCHIPErrorCode:err]
     }];
     return err;
 }

--- a/src/darwin/Framework/CHIP/CHIPDevice.h
+++ b/src/darwin/Framework/CHIP/CHIPDevice.h
@@ -22,28 +22,72 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * Handler for read attribute response, write attribute response, invoke command response and reports.
+ *
+ * Handler will receive either values or error. Either one of the parameters will be nil.
+ *
+ * @param values  Received values are an NSArray object with response-value element as described below.
+ *
+ *                A response-value is an NSDictionary object with the following key values:
+ *
+ *                kCHIPAttributePathKey : CHIPAttributePath object. Included for attribute value.
+ *                kCHIPCommandPathKey : CHIPCommandPath object. Included for command response.
+ *                kCHIPErrorKey : NSError object. Included to indicate an error.
+ *                kCHIPDataKey: Data-value NSDictionary object.
+ *                              Included when there is data and when there is no error.
+ *                              The data-value is described below.
+ *
+ *                A data-value is an NSDictionary object with the following key values:
+ *
+ *                kCHIPTypeKey : data type. kCHIPSignedIntegerValueType, kCHIPUnsignedIntegerValueType, kCHIPBooleanValueType,
+ *                               kCHIPUTF8StringValueType, kCHIPOctetStringValueType, kCHIPFloatValueType, kCHIPDoubleValueType,
+ *                               kCHIPNullValueType, kCHIPStructureValueType or kCHIPArrayValueType.
+ *
+ *                kCHIPValueKey : data value. Per each data type, data value shall be the following object:
+ *
+ *                          kCHIPSignedIntegerValueType: NSNumber object.
+ *                          kCHIPUnsignedIntegerValueType: NSNumber object.
+ *                          kCHIPBooleanValueType: NSNumber object.
+ *                          kCHIPUTF8StringValueType: NSString object.
+ *                          kCHIPOctetStringValueType: NSData object.
+ *                          kCHIPFloatValueType: NSNumber object.
+ *                          kCHIPDoubleValueType: NSNumber object.
+ *                          kCHIPNullValueType: "value" key will not be included.
+ *                          kCHIPStructureValueType: structure-value NSArray object.
+ *                                                   See below for the definition of structure-value.
+ *                          kCHIPArrayValueType: Array-value NSArray object. See below for the definition of array-value.
+ *
+ *                A structure-value is an NSArray object with NSDictionary objects as its elements. Each dictionary element will
+ *                contain the following key values.
+ *
+ *                kCHIPContextTagKey : NSNumber object as context tag.
+ *                kCHIPDataKey : Data-value NSDictionary object.
+ *
+ *                An array-value is an NSArray object with NSDictionary objects as its elements. Each dictionary element will
+ *                contain the following key values.
+ *
+ *                kCHIPDataKey : Data-value NSDictionary object.
+ */
 typedef void (^CHIPDeviceResponseHandler)(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error);
 
+extern NSString * const kCHIPAttributePathKey;
+extern NSString * const kCHIPCommandPathKey;
+extern NSString * const kCHIPDataKey;
+extern NSString * const kCHIPErrorKey;
 extern NSString * const kCHIPTypeKey;
 extern NSString * const kCHIPValueKey;
-extern NSString * const kCHIPTagKey;
-extern NSString * const kCHIPSignedIntegerValueTypeKey;
-extern NSString * const kCHIPUnsignedIntegerValueTypeKey;
-extern NSString * const kCHIPBooleanValueTypeKey;
-extern NSString * const kCHIPUTF8StringValueTypeKey;
-extern NSString * const kCHIPOctetStringValueTypeKey;
-extern NSString * const kCHIPFloatValueTypeKey;
-extern NSString * const kCHIPDoubleValueTypeKey;
-extern NSString * const kCHIPNullValueTypeKey;
-extern NSString * const kCHIPStructureValueTypeKey;
-extern NSString * const kCHIPArrayValueTypeKey;
-extern NSString * const kCHIPListValueTypeKey;
-extern NSString * const kCHIPEndpointIdKey;
-extern NSString * const kCHIPClusterIdKey;
-extern NSString * const kCHIPAttributeIdKey;
-extern NSString * const kCHIPCommandIdKey;
-extern NSString * const kCHIPDataKey;
-extern NSString * const kCHIPStatusKey;
+extern NSString * const kCHIPContextTagKey;
+extern NSString * const kCHIPSignedIntegerValueType;
+extern NSString * const kCHIPUnsignedIntegerValueType;
+extern NSString * const kCHIPBooleanValueType;
+extern NSString * const kCHIPUTF8StringValueType;
+extern NSString * const kCHIPOctetStringValueType;
+extern NSString * const kCHIPFloatValueType;
+extern NSString * const kCHIPDoubleValueType;
+extern NSString * const kCHIPNullValueType;
+extern NSString * const kCHIPStructureValueType;
+extern NSString * const kCHIPArrayValueType;
 
 @interface CHIPDevice : NSObject
 
@@ -77,17 +121,6 @@ extern NSString * const kCHIPStatusKey;
 
 /**
  * Read attribute in a designated attribute path
- *
- * @param completion  response handler will receive either value or error. value will be an NSArray object with NSDictionary
- * elements. Each NSDictionary will have "endpointId", "clusterId", "attributeId", "status" and "data" keys. "endpointId",
- * "clusterId", "attributeId" and "status" will be mapped to NSNumber objects. "status" with 0 value indicates success and non-zero
- * value indicates failure. "data" key is present only when "status" value is 0. "data" key will be mapped to an NSDictionary
- * object, representing attribute value of the path. NSDictionary representing attribute value will contain "type" and "value" keys.
- *                        "type" will be mapped to "SignedInteger", "UnsignedInteger", "UTF8String", "OctetString", "Float",
- * "Double", "Boolean", "Null", "Structure", "Array" or "List. "value" will be mapped to an NSNumber, NSString, nil or NSArray
- * instance. When "type" is "OctetStriing", "value" will be an NSData object. When "type" is "Structure", "Array" or "List", "value"
- * will be NSArray with NSDictionary elements. Each NSDictionary element will have "tag" and "value" keys. "tag" will be mapped to
- * an NSNumber value. "value" will be mapped to an NSDictionary instance representing any attribute value recursively.
  */
 - (void)readAttributeWithEndpointId:(NSUInteger)endpointId
                           clusterId:(NSUInteger)clusterId
@@ -98,10 +131,8 @@ extern NSString * const kCHIPStatusKey;
 /**
  * Write to attribute in a designated attribute path
  *
- * @param completion  response handler will receive either value or error. value will be an NSArray object with NSDictionary
- * elements. Each NSDictionary will have "endpointId", "clusterId", "attributeId" and "status" keys. "endpointId", "clusterId",
- * "attributeId" and "status" will be mapped to NSNumber objects. "status" with 0 value indicates success and non-zero value
- * indicates failure.
+ * @param value       A data-value NSDictionary object as described in
+ *                    CHIPDeviceResponseHandler.
  */
 - (void)writeAttributeWithEndpointId:(NSUInteger)endpointId
                            clusterId:(NSUInteger)clusterId
@@ -113,16 +144,10 @@ extern NSString * const kCHIPStatusKey;
 /**
  * Invoke a command with a designated command path
  *
- * @param commandFields   command fields object. The object must be an NSDictionary object representing attribute value
- *                      as described in the readAttributeWithEndpointId:clusterId:attributeId:clientQueue:responseHandler: method.
- *                      The attribute must be a Structure, i.e., the NSDictionary "type" key must have the value "Structure".
- *
- * @param completion  response handler will receive either value or error. value will be an NSArray object with NSDictionary
- * elements. Each NSDictionary will have "endpointId", "clusterId", "commandId", "status" and "responseData" keys. "endpointId",
- * "clusterId", "attributeId" and "status" will be mapped to NSNumber objects. "status" with 0 value indicates success and non-zero
- * value indicates failure. "responseData" key will be included only when "status" key has 0 value and there is response data for
- * the command. "responseData" key value will be an NSDictionary object representing attribute value as described in the
- * readAttributeWithEndpointId:clusterId:attributeId:clientQueue:responseHandler: method.
+ * @param commandFields   command fields object. The object must be a data-value NSDictionary object
+ *                      as described in the CHIPDeviceResponseHandler.
+ *                      The attribute must be a Structure, i.e.,
+ *                      the NSDictionary kCHIPTypeKey key must have the value kCHIPStructureValueType.
  */
 - (void)invokeCommandWithEndpointId:(NSUInteger)endpointId
                           clusterId:(NSUInteger)clusterId
@@ -133,12 +158,6 @@ extern NSString * const kCHIPStatusKey;
 
 /**
  * Subscribe an attribute in a designated attribute path
- *
- * @param reportHandler   handler for the reports. Note that only the report handler by the last call to this method per the same
- * attribute path will receive reports. Report handler will receive either value or error. value will be an NSDictionary object. The
- * NSDictionary object will have "endpointId", "clusterId", "attributeId" and "value" keys. "endpointId", "clusterId" and
- * "attributeId" will be mapped to NSNumber objects. "value" key value will be an NSDictionary object representing attribute value
- *                      as described in the readAttributeWithEndpointId:clusterId:attributeId:clientQueue:responseHandler: method.
  */
 - (void)subscribeAttributeWithEndpointId:(NSUInteger)endpointId
                                clusterId:(NSUInteger)clusterId
@@ -146,8 +165,7 @@ extern NSString * const kCHIPStatusKey;
                              minInterval:(NSUInteger)minInterval
                              maxInterval:(NSUInteger)maxInterval
                              clientQueue:(dispatch_queue_t)clientQueue
-                           reportHandler:(void (^)(NSDictionary<NSString *, id> * _Nullable value,
-                                             NSError * _Nullable error))reportHandler
+                           reportHandler:(CHIPDeviceResponseHandler)reportHandler
                  subscriptionEstablished:(nullable void (^)(void))subscriptionEstablishedHandler;
 
 /**
@@ -165,6 +183,21 @@ extern NSString * const kCHIPStatusKey;
 @property (nonatomic, readonly, strong, nonnull) NSNumber * endpoint;
 @property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
 @property (nonatomic, readonly, strong, nonnull) NSNumber * attribute;
+
++ (instancetype)attributePathWithEndpointId:(NSNumber *)endpoint
+                                  clusterId:(NSNumber *)clusterId
+                                attributeId:(NSNumber *)attributeId;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+@end
+
+@interface CHIPCommandPath : NSObject
+@property (nonatomic, readonly, strong, nonnull) NSNumber * endpoint;
+@property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
+@property (nonatomic, readonly, strong, nonnull) NSNumber * command;
+
++ (instancetype)commandPathWithEndpointId:(NSNumber *)endpoint clusterId:(NSNumber *)clusterId commandId:(NSNumber *)commandId;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController+XPC.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController+XPC.h
@@ -35,8 +35,19 @@ NS_ASSUME_NONNULL_BEGIN
 + (CHIPDeviceController *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerId
                                  xpcConnectBlock:(NSXPCConnection * (^)(void) )connectBlock;
 
-@end
+/**
+ * Returns an encoded values object to send over XPC for read, write and command interactions
+ */
++ (NSArray<NSDictionary<NSString *, id> *> * _Nullable)encodeXPCResponseValues:
+    (NSArray<NSDictionary<NSString *, id> *> * _Nullable)values;
 
+/**
+ * Returns a decoded values object from a values object received from XPC for read, write and command interactions
+ */
++ (NSArray<NSDictionary<NSString *, id> *> * _Nullable)decodeXPCResponseValues:
+    (NSArray<NSDictionary<NSString *, id> *> * _Nullable)values;
+
+@end
 /**
  * Protocol that remote object must support over XPC
  */
@@ -126,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)handleReportWithController:(id _Nullable)controller
                             nodeId:(uint64_t)nodeId
-                             value:(id _Nullable)value
+                            values:(id _Nullable)values
                              error:(NSError * _Nullable)error;
 
 @end

--- a/src/darwin/Framework/CHIP/CHIPDeviceController+XPC.m
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController+XPC.m
@@ -17,9 +17,42 @@
 
 #import "CHIPDeviceController+XPC.h"
 
+#import "CHIPDevice.h"
 #import "CHIPDeviceControllerOverXPC.h"
 
 NS_ASSUME_NONNULL_BEGIN
+
+static NSArray * _Nullable serializeAttributePath(CHIPAttributePath * _Nullable path)
+{
+    if (!path) {
+        return nil;
+    }
+    return @[ path.endpoint, path.cluster, path.attribute ];
+}
+
+static NSArray * _Nullable serializeCommandPath(CHIPCommandPath * _Nullable path)
+{
+    if (!path) {
+        return nil;
+    }
+    return @[ path.endpoint, path.cluster, path.command ];
+}
+
+static CHIPAttributePath * _Nullable deserializeAttributePath(NSArray * _Nullable pathArray)
+{
+    if (pathArray == nil || [pathArray count] != 3) {
+        return nil;
+    }
+    return [CHIPAttributePath attributePathWithEndpointId:pathArray[0] clusterId:pathArray[1] attributeId:pathArray[2]];
+}
+
+static CHIPCommandPath * _Nullable deserializeCommandPath(NSArray * _Nullable pathArray)
+{
+    if (pathArray == nil || [pathArray count] != 3) {
+        return nil;
+    }
+    return [CHIPCommandPath commandPathWithEndpointId:pathArray[0] clusterId:pathArray[1] commandId:pathArray[2]];
+}
 
 @implementation CHIPDeviceController (XPC)
 
@@ -27,6 +60,55 @@ NS_ASSUME_NONNULL_BEGIN
                                  xpcConnectBlock:(NSXPCConnection * (^)(void) )connectBlock
 {
     return [CHIPDeviceControllerOverXPC sharedControllerWithId:controllerId xpcConnectBlock:connectBlock];
+}
+
++ (NSArray<NSDictionary<NSString *, id> *> * _Nullable)encodeXPCResponseValues:
+    (NSArray<NSDictionary<NSString *, id> *> * _Nullable)values
+{
+    if (!values) {
+        return values;
+    }
+    NSMutableArray * result = [NSMutableArray array];
+    for (NSDictionary<NSString *, id> * value in values) {
+        if (!value || (value[kCHIPAttributePathKey] == nil && value[kCHIPCommandPathKey] == nil)) {
+            [result addObject:value];
+            continue;
+        }
+        NSMutableDictionary<NSString *, id> * resultValue = [NSMutableDictionary dictionaryWithCapacity:[value count]];
+        [resultValue addEntriesFromDictionary:value];
+        if (value[kCHIPAttributePathKey]) {
+            resultValue[kCHIPAttributePathKey] = serializeAttributePath(value[kCHIPAttributePathKey]);
+        }
+        if (value[kCHIPCommandPathKey]) {
+            resultValue[kCHIPCommandPathKey] = serializeCommandPath(value[kCHIPCommandPathKey]);
+        }
+        [result addObject:resultValue];
+    }
+    return result;
+}
+
++ (NSArray<NSDictionary<NSString *, id> *> * _Nullable)decodeXPCResponseValues:
+    (NSArray<NSDictionary<NSString *, id> *> * _Nullable)values
+{
+    if (!values) {
+        return values;
+    }
+    NSMutableArray * result = [NSMutableArray array];
+    for (NSDictionary<NSString *, id> * value in values) {
+        if (!value || (value[kCHIPAttributePathKey] == nil && value[kCHIPCommandPathKey] == nil)) {
+            [result addObject:value];
+        }
+        NSMutableDictionary<NSString *, id> * resultValue = [NSMutableDictionary dictionaryWithCapacity:[value count]];
+        [resultValue addEntriesFromDictionary:value];
+        if (value[kCHIPAttributePathKey]) {
+            resultValue[kCHIPAttributePathKey] = deserializeAttributePath(value[kCHIPAttributePathKey]);
+        }
+        if (value[kCHIPCommandPathKey]) {
+            resultValue[kCHIPCommandPathKey] = deserializeCommandPath(value[kCHIPCommandPathKey]);
+        }
+        [result addObject:resultValue];
+    }
+    return result;
 }
 
 @end

--- a/src/darwin/Framework/CHIP/CHIPDeviceControllerOverXPC+AttributeCache.m
+++ b/src/darwin/Framework/CHIP/CHIPDeviceControllerOverXPC+AttributeCache.m
@@ -95,24 +95,24 @@ NS_ASSUME_NONNULL_BEGIN
             completion(nil, [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil]);
             return;
         }
-        [self.xpcConnection
-            getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull queue, CHIPDeviceControllerXPCProxyHandle * _Nullable handle) {
-                if (handle) {
-                    [handle.proxy readAttributeCacheWithController:self.controllerId
-                                                            nodeId:nodeId
-                                                        endpointId:endpointId
-                                                         clusterId:clusterId
-                                                       attributeId:attributeId
-                                                        completion:^(id _Nullable values, NSError * _Nullable error) {
-                                                            completion(values, error);
-                                                            __auto_type handleRetainer = handle;
-                                                            (void) handleRetainer;
-                                                        }];
-                } else {
-                    CHIP_LOG_ERROR("Attribute cache read failed due to XPC connection failure");
-                    completion(nil, [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil]);
-                }
-            }];
+        [self.xpcConnection getProxyHandleWithCompletion:^(
+            dispatch_queue_t _Nonnull queue, CHIPDeviceControllerXPCProxyHandle * _Nullable handle) {
+            if (handle) {
+                [handle.proxy readAttributeCacheWithController:self.controllerId
+                                                        nodeId:nodeId
+                                                    endpointId:endpointId
+                                                     clusterId:clusterId
+                                                   attributeId:attributeId
+                                                    completion:^(id _Nullable values, NSError * _Nullable error) {
+                                                        completion([CHIPDeviceController decodeXPCResponseValues:values], error);
+                                                        __auto_type handleRetainer = handle;
+                                                        (void) handleRetainer;
+                                                    }];
+            } else {
+                CHIP_LOG_ERROR("Attribute cache read failed due to XPC connection failure");
+                completion(nil, [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil]);
+            }
+        }];
     });
 }
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceControllerXPCConnection.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceControllerXPCConnection.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
                                          CHIPDeviceControllerXPCProxyHandle * _Nullable container))completion;
 - (void)registerReportHandlerWithController:(id<NSCopying>)controller
                                      nodeId:(NSUInteger)nodeId
-                                    handler:(void (^)(id _Nullable value, NSError * _Nullable error))handler;
+                                    handler:(void (^)(id _Nullable values, NSError * _Nullable error))handler;
 - (void)deregisterReportHandlersWithController:(id<NSCopying>)controller
                                         nodeId:(NSUInteger)nodeId
                                     completion:(void (^)(void))completion;

--- a/src/darwin/Framework/CHIP/CHIPDeviceControllerXPCConnection.m
+++ b/src/darwin/Framework/CHIP/CHIPDeviceControllerXPCConnection.m
@@ -121,7 +121,7 @@
 
 - (void)registerReportHandlerWithController:(id<NSCopying>)controller
                                      nodeId:(NSUInteger)nodeId
-                                    handler:(void (^)(id _Nullable value, NSError * _Nullable error))handler
+                                    handler:(void (^)(id _Nullable values, NSError * _Nullable error))handler
 {
     dispatch_async(_workQueue, ^{
         BOOL shouldRetainProxyForReport = ([self.reportRegistry count] == 0);
@@ -170,7 +170,7 @@
 
 - (void)handleReportWithController:(id)controller
                             nodeId:(NSUInteger)nodeId
-                             value:(id _Nullable)value
+                            values:(id _Nullable)values
                              error:(NSError * _Nullable)error
 {
     dispatch_async(_workQueue, ^{
@@ -183,8 +183,8 @@
         if (!nodeArray) {
             return;
         }
-        for (void (^handler)(id _Nullable value, NSError * _Nullable error) in nodeArray) {
-            handler(value, error);
+        for (void (^handler)(id _Nullable values, NSError * _Nullable error) in nodeArray) {
+            handler(values, error);
         }
     });
 }

--- a/src/darwin/Framework/CHIP/CHIPDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/CHIPDevice_Internal.h
@@ -21,6 +21,8 @@
 #import "CHIPDevice.h"
 #import <Foundation/Foundation.h>
 
+#include <app/ConcreteAttributePath.h>
+#include <app/ConcreteCommandPath.h>
 #include <app/DeviceProxy.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -30,6 +32,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDevice:(chip::DeviceProxy *)device;
 - (chip::DeviceProxy *)internalDevice;
 
+@end
+
+@interface CHIPAttributePath ()
+- (instancetype)initWithPath:(const chip::app::ConcreteDataAttributePath &)path;
+@end
+
+@interface CHIPCommandPath ()
+- (instancetype)initWithPath:(const chip::app::ConcreteCommandPath &)path;
 @end
 
 // Exported utility function

--- a/src/darwin/Framework/CHIPTests/CHIPXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPXPCListenerSampleTests.m
@@ -162,20 +162,24 @@ static NSString * const kCHIPDeviceControllerId = @"CHIPController";
     (void) controller;
     __auto_type sharedController = [CHIPDeviceController sharedController];
     if (sharedController) {
-        [sharedController getConnectedDevice:nodeId
-                                       queue:dispatch_get_main_queue()
-                           completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
-                               if (error) {
-                                   NSLog(@"Failed to get connected device");
-                                   completion(nil, error);
-                               } else {
-                                   [device readAttributeWithEndpointId:endpointId
-                                                             clusterId:clusterId
-                                                           attributeId:attributeId
-                                                           clientQueue:dispatch_get_main_queue()
-                                                            completion:completion];
-                               }
-                           }];
+        [sharedController
+            getConnectedDevice:nodeId
+                         queue:dispatch_get_main_queue()
+             completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                 if (error) {
+                     NSLog(@"Failed to get connected device");
+                     completion(nil, error);
+                 } else {
+                     [device readAttributeWithEndpointId:endpointId
+                                               clusterId:clusterId
+                                             attributeId:attributeId
+                                             clientQueue:dispatch_get_main_queue()
+                                              completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values,
+                                                  NSError * _Nullable error) {
+                                                  completion([CHIPDeviceController encodeXPCResponseValues:values], error);
+                                              }];
+                 }
+             }];
     } else {
         NSLog(@"Failed to get shared controller");
         completion(nil, [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil]);
@@ -193,21 +197,25 @@ static NSString * const kCHIPDeviceControllerId = @"CHIPController";
     (void) controller;
     __auto_type sharedController = [CHIPDeviceController sharedController];
     if (sharedController) {
-        [sharedController getConnectedDevice:nodeId
-                                       queue:dispatch_get_main_queue()
-                           completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
-                               if (error) {
-                                   NSLog(@"Failed to get connected device");
-                                   completion(nil, error);
-                               } else {
-                                   [device writeAttributeWithEndpointId:endpointId
-                                                              clusterId:clusterId
-                                                            attributeId:attributeId
-                                                                  value:value
-                                                            clientQueue:dispatch_get_main_queue()
-                                                             completion:completion];
-                               }
-                           }];
+        [sharedController
+            getConnectedDevice:nodeId
+                         queue:dispatch_get_main_queue()
+             completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                 if (error) {
+                     NSLog(@"Failed to get connected device");
+                     completion(nil, error);
+                 } else {
+                     [device writeAttributeWithEndpointId:endpointId
+                                                clusterId:clusterId
+                                              attributeId:attributeId
+                                                    value:value
+                                              clientQueue:dispatch_get_main_queue()
+                                               completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values,
+                                                   NSError * _Nullable error) {
+                                                   completion([CHIPDeviceController encodeXPCResponseValues:values], error);
+                                               }];
+                 }
+             }];
     } else {
         NSLog(@"Failed to get shared controller");
         completion(nil, [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil]);
@@ -225,21 +233,25 @@ static NSString * const kCHIPDeviceControllerId = @"CHIPController";
     (void) controller;
     __auto_type sharedController = [CHIPDeviceController sharedController];
     if (sharedController) {
-        [sharedController getConnectedDevice:nodeId
-                                       queue:dispatch_get_main_queue()
-                           completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
-                               if (error) {
-                                   NSLog(@"Failed to get connected device");
-                                   completion(nil, error);
-                               } else {
-                                   [device invokeCommandWithEndpointId:endpointId
-                                                             clusterId:clusterId
-                                                             commandId:commandId
-                                                         commandFields:fields
-                                                           clientQueue:dispatch_get_main_queue()
-                                                            completion:completion];
-                               }
-                           }];
+        [sharedController
+            getConnectedDevice:nodeId
+                         queue:dispatch_get_main_queue()
+             completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                 if (error) {
+                     NSLog(@"Failed to get connected device");
+                     completion(nil, error);
+                 } else {
+                     [device invokeCommandWithEndpointId:endpointId
+                                               clusterId:clusterId
+                                               commandId:commandId
+                                           commandFields:fields
+                                             clientQueue:dispatch_get_main_queue()
+                                              completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values,
+                                                  NSError * _Nullable error) {
+                                                  completion([CHIPDeviceController encodeXPCResponseValues:values], error);
+                                              }];
+                 }
+             }];
     } else {
         NSLog(@"Failed to get shared controller");
         completion(nil, [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil]);
@@ -257,43 +269,45 @@ static NSString * const kCHIPDeviceControllerId = @"CHIPController";
 {
     __auto_type sharedController = [CHIPDeviceController sharedController];
     if (sharedController) {
-        [sharedController getConnectedDevice:nodeId
-                                       queue:dispatch_get_main_queue()
-                           completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
-                               if (error) {
-                                   NSLog(@"Failed to get connected device");
-                                   establishedHandler();
-                                   // Send an error report so that the client knows of the failure
-                                   [self.clientProxy handleReportWithController:controller
-                                                                         nodeId:nodeId
-                                                                          value:nil
-                                                                          error:[NSError errorWithDomain:CHIPErrorDomain
-                                                                                                    code:CHIPErrorCodeGeneralError
-                                                                                                userInfo:nil]];
-                               } else {
-                                   [device subscribeAttributeWithEndpointId:endpointId
-                                                                  clusterId:clusterId
-                                                                attributeId:attributeId
-                                                                minInterval:minInterval
-                                                                maxInterval:maxInterval
-                                                                clientQueue:dispatch_get_main_queue()
-                                                              reportHandler:^(NSDictionary<NSString *, id> * _Nullable value,
-                                                                  NSError * _Nullable error) {
-                                                                  [self.clientProxy handleReportWithController:controller
-                                                                                                        nodeId:nodeId
-                                                                                                         value:value
-                                                                                                         error:error];
-                                                              }
-                                                    subscriptionEstablished:establishedHandler];
-                               }
-                           }];
+        [sharedController
+            getConnectedDevice:nodeId
+                         queue:dispatch_get_main_queue()
+             completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                 if (error) {
+                     NSLog(@"Failed to get connected device");
+                     establishedHandler();
+                     // Send an error report so that the client knows of the failure
+                     [self.clientProxy handleReportWithController:controller
+                                                           nodeId:nodeId
+                                                           values:nil
+                                                            error:[NSError errorWithDomain:CHIPErrorDomain
+                                                                                      code:CHIPErrorCodeGeneralError
+                                                                                  userInfo:nil]];
+                 } else {
+                     [device subscribeAttributeWithEndpointId:endpointId
+                                                    clusterId:clusterId
+                                                  attributeId:attributeId
+                                                  minInterval:minInterval
+                                                  maxInterval:maxInterval
+                                                  clientQueue:dispatch_get_main_queue()
+                                                reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values,
+                                                    NSError * _Nullable error) {
+                                                    [self.clientProxy handleReportWithController:controller
+                                                                                          nodeId:nodeId
+                                                                                          values:[CHIPDeviceController
+                                                                                                     encodeXPCResponseValues:values]
+                                                                                           error:error];
+                                                }
+                                      subscriptionEstablished:establishedHandler];
+                 }
+             }];
     } else {
         NSLog(@"Failed to get shared controller");
         establishedHandler();
         // Send an error report so that the client knows of the failure
         [self.clientProxy handleReportWithController:controller
                                               nodeId:nodeId
-                                               value:nil
+                                              values:nil
                                                error:[NSError errorWithDomain:CHIPErrorDomain
                                                                          code:CHIPErrorCodeGeneralError
                                                                      userInfo:nil]];
@@ -337,11 +351,14 @@ static NSString * const kCHIPDeviceControllerId = @"CHIPController";
 {
     CHIPAttributeCacheContainer * attributeCacheContainer = _attributeCacheDictionary[[NSNumber numberWithUnsignedLongLong:nodeId]];
     if (attributeCacheContainer) {
-        [attributeCacheContainer readAttributeWithEndpointId:endpointId
-                                                   clusterId:clusterId
-                                                 attributeId:attributeId
-                                                 clientQueue:dispatch_get_main_queue()
-                                                  completion:completion];
+        [attributeCacheContainer
+            readAttributeWithEndpointId:endpointId
+                              clusterId:clusterId
+                            attributeId:attributeId
+                            clientQueue:dispatch_get_main_queue()
+                             completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                                 completion([CHIPDeviceController encodeXPCResponseValues:values], error);
+                             }];
     } else {
         NSLog(@"Attribute cache for node ID %llu was not setup", nodeId);
         completion(nil, [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil]);
@@ -547,9 +564,9 @@ static CHIPDeviceController * GetDeviceController(void)
                                      XCTAssertTrue([values isKindOfClass:[NSArray class]]);
                                      NSArray * resultArray = values;
                                      for (NSDictionary * result in resultArray) {
-                                         XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 29);
-                                         XCTAssertEqual([result[@"attributeId"] unsignedIntegerValue], 0);
-                                         XCTAssertTrue([result[@"endpointId"] isKindOfClass:[NSNumber class]]);
+                                         CHIPAttributePath * path = result[@"attributePath"];
+                                         XCTAssertEqual([path.cluster unsignedIntegerValue], 29);
+                                         XCTAssertEqual([path.attribute unsignedIntegerValue], 0);
                                          XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
                                          XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Array"]);
                                      }
@@ -589,10 +606,11 @@ static CHIPDeviceController * GetDeviceController(void)
                                       XCTAssertTrue([values isKindOfClass:[NSArray class]]);
                                       NSArray * resultArray = values;
                                       for (NSDictionary * result in resultArray) {
-                                          XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
-                                          XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 8);
-                                          XCTAssertEqual([result[@"attributeId"] unsignedIntegerValue], 17);
-                                          XCTAssertEqual([result[@"status"] unsignedIntegerValue], 0);
+                                          CHIPAttributePath * path = result[@"attributePath"];
+                                          XCTAssertEqual([path.endpoint unsignedIntegerValue], 1);
+                                          XCTAssertEqual([path.cluster unsignedIntegerValue], 8);
+                                          XCTAssertEqual([path.attribute unsignedIntegerValue], 17);
+                                          XCTAssertNil(result[@"error"]);
                                       }
                                       XCTAssertEqual([resultArray count], 1);
                                   }
@@ -614,18 +632,13 @@ static CHIPDeviceController * GetDeviceController(void)
     CHIPDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    NSDictionary * fields = [NSDictionary
-        dictionaryWithObjectsAndKeys:@"Structure", @"type",
-        [NSArray arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:0], @"tag",
-                                                [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type",
-                                                              [NSNumber numberWithUnsignedInteger:0], @"value", nil],
-                                                @"value", nil],
-                 [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:1], @"tag",
-                               [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type",
-                                             [NSNumber numberWithUnsignedInteger:10], @"value", nil],
-                               @"value", nil],
-                 nil],
-        @"value", nil];
+    NSDictionary * fields = @{
+        @"type" : @"Structure",
+        @"value" : @[
+            @{ @"contextTag" : @0, @"data" : @ { @"type" : @"UnsignedInteger", @"value" : @0 } },
+            @{ @"contextTag" : @1, @"data" : @ { @"type" : @"UnsignedInteger", @"value" : @10 } }
+        ]
+    };
     [device invokeCommandWithEndpointId:1
                               clusterId:8
                               commandId:4
@@ -640,10 +653,11 @@ static CHIPDeviceController * GetDeviceController(void)
                                      XCTAssertTrue([values isKindOfClass:[NSArray class]]);
                                      NSArray * resultArray = values;
                                      for (NSDictionary * result in resultArray) {
-                                         XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
-                                         XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 8);
-                                         XCTAssertEqual([result[@"commandId"] unsignedIntegerValue], 4);
-                                         XCTAssertEqual([result[@"status"] unsignedIntegerValue], 0);
+                                         CHIPCommandPath * path = result[@"commandPath"];
+                                         XCTAssertEqual([path.endpoint unsignedIntegerValue], 1);
+                                         XCTAssertEqual([path.cluster unsignedIntegerValue], 8);
+                                         XCTAssertEqual([path.command unsignedIntegerValue], 4);
+                                         XCTAssertNil(result[@"error"]);
                                      }
                                      XCTAssertEqual([resultArray count], 1);
                                  }
@@ -692,18 +706,18 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Set up expectation for report
     expectation = [self expectationWithDescription:@"receive OnOff attribute report"];
-    globalReportHandler = ^(id _Nullable value, NSError * _Nullable error) {
+    globalReportHandler = ^(id _Nullable values, NSError * _Nullable error) {
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
+        XCTAssertTrue([values isKindOfClass:[NSArray class]]);
 
-        {
-            XCTAssertTrue([value isKindOfClass:[NSDictionary class]]);
-            NSDictionary * result = value;
-            XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
-            XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 6);
-            XCTAssertEqual([result[@"attributeId"] unsignedIntegerValue], 0);
-            XCTAssertTrue([result[@"value"] isKindOfClass:[NSDictionary class]]);
-            XCTAssertTrue([result[@"value"][@"type"] isEqualToString:@"Boolean"]);
-            XCTAssertEqual([result[@"value"][@"value"] boolValue], YES);
+        for (NSDictionary * result in values) {
+            CHIPAttributePath * path = result[@"attributePath"];
+            XCTAssertEqual([path.endpoint unsignedIntegerValue], 1);
+            XCTAssertEqual([path.cluster unsignedIntegerValue], 6);
+            XCTAssertEqual([path.attribute unsignedIntegerValue], 0);
+            XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
+            XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Boolean"]);
+            XCTAssertEqual([result[@"data"][@"value"] boolValue], YES);
         }
         [expectation fulfill];
     };
@@ -724,10 +738,11 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
                                      XCTAssertTrue([values isKindOfClass:[NSArray class]]);
                                      NSArray * resultArray = values;
                                      for (NSDictionary * result in resultArray) {
-                                         XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
-                                         XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 6);
-                                         XCTAssertEqual([result[@"commandId"] unsignedIntegerValue], 1);
-                                         XCTAssertEqual([result[@"status"] unsignedIntegerValue], 0);
+                                         CHIPCommandPath * path = result[@"commandPath"];
+                                         XCTAssertEqual([path.endpoint unsignedIntegerValue], 1);
+                                         XCTAssertEqual([path.cluster unsignedIntegerValue], 6);
+                                         XCTAssertEqual([path.command unsignedIntegerValue], 1);
+                                         XCTAssertNil(result[@"error"]);
                                      }
                                      XCTAssertEqual([resultArray count], 1);
                                  }
@@ -851,8 +866,8 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Set up expectation for report
     XCTestExpectation * errorReportExpectation = [self expectationWithDescription:@"receive OnOff attribute report"];
-    globalReportHandler = ^(id _Nullable value, NSError * _Nullable error) {
-        XCTAssertNil(value);
+    globalReportHandler = ^(id _Nullable values, NSError * _Nullable error) {
+        XCTAssertNil(values);
         // Error is copied over XPC and hence cannot use CHIPErrorTestUtils utility which checks against a local domain string
         // object.
         XCTAssertTrue([error.domain isEqualToString:MatterInteractionErrorDomain]);
@@ -934,10 +949,11 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
                                      XCTAssertTrue([values isKindOfClass:[NSArray class]]);
                                      NSArray * resultArray = values;
                                      for (NSDictionary * result in resultArray) {
-                                         XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
-                                         XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 6);
-                                         XCTAssertEqual([result[@"commandId"] unsignedIntegerValue], 1);
-                                         XCTAssertEqual([result[@"status"] unsignedIntegerValue], 0);
+                                         CHIPCommandPath * path = result[@"commandPath"];
+                                         XCTAssertEqual([path.endpoint unsignedIntegerValue], 1);
+                                         XCTAssertEqual([path.cluster unsignedIntegerValue], 6);
+                                         XCTAssertEqual([path.command unsignedIntegerValue], 1);
+                                         XCTAssertNil(result[@"error"]);
                                      }
                                      XCTAssertEqual([resultArray count], 1);
                                  }
@@ -960,9 +976,10 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
                              for (NSDictionary<NSString *, id> * value in values) {
                                  XCTAssertTrue([value isKindOfClass:[NSDictionary class]]);
                                  NSDictionary * result = value;
-                                 XCTAssertEqual([result[@"endpointId"] unsignedIntegerValue], 1);
-                                 XCTAssertEqual([result[@"clusterId"] unsignedIntegerValue], 6);
-                                 XCTAssertEqual([result[@"attributeId"] unsignedIntegerValue], 0);
+                                 CHIPAttributePath * path = result[@"attributePath"];
+                                 XCTAssertEqual([path.endpoint unsignedIntegerValue], 1);
+                                 XCTAssertEqual([path.cluster unsignedIntegerValue], 6);
+                                 XCTAssertEqual([path.attribute unsignedIntegerValue], 0);
                                  XCTAssertTrue([result[@"data"] isKindOfClass:[NSDictionary class]]);
                                  XCTAssertTrue([result[@"data"][@"type"] isEqualToString:@"Boolean"]);
                                  XCTAssertEqual([result[@"data"][@"value"] boolValue], YES);

--- a/src/darwin/Framework/CHIPTests/CHIPXPCProtocolTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPXPCProtocolTests.m
@@ -34,6 +34,48 @@ static const uint16_t kTimeoutInSeconds = 3;
 // Inverted expectation timeout
 static const uint16_t kNegativeTimeoutInSeconds = 1;
 
+@interface CHIPAttributePath (Test)
+- (BOOL)isEqual:(id)object;
+@end
+
+@implementation CHIPAttributePath (Test)
+- (BOOL)isEqual:(id)object
+{
+    if ([object isKindOfClass:[CHIPAttributePath class]]) {
+        CHIPAttributePath * other = object;
+        return [self.endpoint isEqualToNumber:other.endpoint] && [self.cluster isEqualToNumber:other.cluster] &&
+            [self.attribute isEqualToNumber:other.attribute];
+    }
+    return NO;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"CHIPAttributePath(%@,%@,%@)", self.endpoint, self.cluster, self.attribute];
+}
+@end
+
+@interface CHIPCommandPath (Test)
+- (BOOL)isEqual:(id)object;
+@end
+
+@implementation CHIPCommandPath (Test)
+- (BOOL)isEqual:(id)object
+{
+    if ([object isKindOfClass:[CHIPCommandPath class]]) {
+        CHIPCommandPath * other = object;
+        return [self.endpoint isEqualToNumber:other.endpoint] && [self.cluster isEqualToNumber:other.cluster] &&
+            [self.command isEqualToNumber:other.command];
+    }
+    return NO;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"CHIPCommandPath(%@,%@,%@)", self.endpoint, self.cluster, self.command];
+}
+@end
+
 @interface CHIPXPCProtocolTests<NSXPCListenerDelegate, CHIPRemoteDeviceProtocol> : XCTestCase
 
 @property (nonatomic, readwrite, strong) NSXPCListener * xpcListener;
@@ -185,6 +227,8 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
 - (void)setUp
 {
+    [self setContinueAfterFailure:NO];
+
     _xpcListener = [NSXPCListener anonymousListener];
     [_xpcListener setDelegate:(id<NSXPCListenerDelegate>) self];
     _serviceInterface = [NSXPCInterface interfaceWithProtocol:@protocol(CHIPDeviceControllerServerProtocol)];
@@ -212,13 +256,13 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSUInteger myEndpointId = 100;
     NSUInteger myClusterId = 200;
     NSUInteger myAttributeId = 300;
-    NSArray * myValues =
-        [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId],
-                                               @"endpointId", [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId",
-                                               [NSNumber numberWithUnsignedInteger:myAttributeId], @"attributeId",
-                                               [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
-                                                             [NSNumber numberWithInteger:123456], @"value", nil],
-                                               @"data", nil]];
+    NSArray * myValues = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
+    } ];
+
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
 
@@ -231,7 +275,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
         XCTAssertEqual(clusterId, myClusterId);
         XCTAssertEqual(attributeId, myAttributeId);
         [callExpectation fulfill];
-        completion(myValues, nil);
+        completion([CHIPDeviceController encodeXPCResponseValues:myValues], nil);
     };
 
     [_remoteDeviceController getConnectedDevice:myNodeId
@@ -319,11 +363,12 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSUInteger myAttributeId = 300;
     NSDictionary * myValue =
         [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithInteger:654321], @"value", nil];
-    NSArray * myResults =
-        [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId],
-                                               @"endpointId", [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId",
-                                               [NSNumber numberWithUnsignedInteger:myAttributeId], @"attributeId",
-                                               [NSNumber numberWithInteger:0], @"status", nil]];
+    NSArray * myResults = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]]
+    } ];
+
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
 
@@ -337,7 +382,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
         XCTAssertEqual(attributeId, myAttributeId);
         XCTAssertTrue([value isEqualTo:myValue]);
         [callExpectation fulfill];
-        completion(myResults, nil);
+        completion([CHIPDeviceController encodeXPCResponseValues:myResults], nil);
     };
 
     [_remoteDeviceController getConnectedDevice:myNodeId
@@ -432,11 +477,11 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                             [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:@"Float", @"Type",
                                                                                    [NSNumber numberWithFloat:1.0], @"value", nil]],
                                             @"value", nil];
-    NSArray * myResults =
-        [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId],
-                                               @"endpointId", [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId",
-                                               [NSNumber numberWithUnsignedInteger:myCommandId], @"commandId",
-                                               [NSNumber numberWithInteger:0], @"status", nil]];
+    NSArray * myResults = @[ @{
+        @"commandPath" : [CHIPCommandPath commandPathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                          clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                          commandId:[NSNumber numberWithUnsignedInteger:myCommandId]]
+    } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
 
@@ -450,7 +495,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
         XCTAssertEqual(commandId, myCommandId);
         XCTAssertTrue([commandFields isEqualTo:myFields]);
         [callExpectation fulfill];
-        completion(myResults, nil);
+        completion([CHIPDeviceController encodeXPCResponseValues:myResults], nil);
     };
 
     [_remoteDeviceController getConnectedDevice:myNodeId
@@ -545,12 +590,12 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSUInteger myAttributeId = 300;
     NSUInteger myMinInterval = 5;
     NSUInteger myMaxInterval = 60;
-    __block NSDictionary * myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:123456], @"value", nil],
-        @"data", nil];
+    __block NSArray * myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
+    } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
     __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Report sent"];
@@ -571,48 +616,55 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
 
-    [_remoteDeviceController getConnectedDevice:myNodeId
-                                          queue:dispatch_get_main_queue()
-                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
-                                  XCTAssertNotNil(device);
-                                  XCTAssertNil(error);
-                                  NSLog(@"Device acquired. Subscribing...");
-                                  [device subscribeAttributeWithEndpointId:myEndpointId
-                                      clusterId:myClusterId
-                                      attributeId:myAttributeId
-                                      minInterval:myMinInterval
-                                      maxInterval:myMaxInterval
-                                      clientQueue:dispatch_get_main_queue()
-                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
-                                          NSLog(@"Report value: %@", value);
-                                          XCTAssertNotNil(value);
-                                          XCTAssertNil(error);
-                                          XCTAssertTrue([myReport isEqualTo:value]);
-                                          [reportExpectation fulfill];
-                                      }
-                                      subscriptionEstablished:^{
-                                          [establishExpectation fulfill];
-                                      }];
-                              }];
+    [_remoteDeviceController
+        getConnectedDevice:myNodeId
+                     queue:dispatch_get_main_queue()
+         completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+             XCTAssertNotNil(device);
+             XCTAssertNil(error);
+             NSLog(@"Device acquired. Subscribing...");
+             [device subscribeAttributeWithEndpointId:myEndpointId
+                 clusterId:myClusterId
+                 attributeId:myAttributeId
+                 minInterval:myMinInterval
+                 maxInterval:myMaxInterval
+                 clientQueue:dispatch_get_main_queue()
+                 reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                     NSLog(@"Report value: %@", values);
+                     XCTAssertNotNil(values);
+                     XCTAssertNil(error);
+                     XCTAssertTrue([myReport isEqualTo:values]);
+                     [reportExpectation fulfill];
+                 }
+                 subscriptionEstablished:^{
+                     [establishExpectation fulfill];
+                 }];
+         }];
 
     [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
 
     // Inject report
     id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
 
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
-    myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
-        @"data", nil];
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
+    } ];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
@@ -641,14 +693,14 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSUInteger myAttributeId = 300;
     NSUInteger myMinInterval = 5;
     NSUInteger myMaxInterval = 60;
-    // Incorrect report value. Report must be a single NSDictionary
-    __block id myReport =
-        [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId],
-                                               @"endpointId", [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId",
-                                               [NSNumber numberWithUnsignedInteger:myAttributeId], @"attributeId",
-                                               [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
-                                                             [NSNumber numberWithInteger:123456], @"value", nil],
-                                               @"data", nil]];
+    // Incorrect serialized report value. Report should have ben a single NSDictionary
+    __block id myReport = @{
+        @"attributePath" : @[
+            [NSNumber numberWithUnsignedInteger:myEndpointId], [NSNumber numberWithUnsignedInteger:myClusterId],
+            [NSNumber numberWithUnsignedInteger:myAttributeId]
+        ],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
+    };
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
     __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Unexpected report sent"];
@@ -670,48 +722,52 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
 
-    [_remoteDeviceController getConnectedDevice:myNodeId
-                                          queue:dispatch_get_main_queue()
-                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
-                                  XCTAssertNotNil(device);
-                                  XCTAssertNil(error);
-                                  NSLog(@"Device acquired. Subscribing...");
-                                  [device subscribeAttributeWithEndpointId:myEndpointId
-                                      clusterId:myClusterId
-                                      attributeId:myAttributeId
-                                      minInterval:myMinInterval
-                                      maxInterval:myMaxInterval
-                                      clientQueue:dispatch_get_main_queue()
-                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
-                                          NSLog(@"Report value: %@", value);
-                                          XCTAssertNotNil(value);
-                                          XCTAssertNil(error);
-                                          XCTAssertTrue([myReport isEqualTo:value]);
-                                          [reportExpectation fulfill];
-                                      }
-                                      subscriptionEstablished:^{
-                                          [establishExpectation fulfill];
-                                      }];
-                              }];
+    [_remoteDeviceController
+        getConnectedDevice:myNodeId
+                     queue:dispatch_get_main_queue()
+         completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+             XCTAssertNotNil(device);
+             XCTAssertNil(error);
+             NSLog(@"Device acquired. Subscribing...");
+             [device subscribeAttributeWithEndpointId:myEndpointId
+                 clusterId:myClusterId
+                 attributeId:myAttributeId
+                 minInterval:myMinInterval
+                 maxInterval:myMaxInterval
+                 clientQueue:dispatch_get_main_queue()
+                 reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                     NSLog(@"Report value: %@", values);
+                     XCTAssertNotNil(values);
+                     XCTAssertNil(error);
+                     XCTAssertTrue([myReport isEqualTo:values]);
+                     [reportExpectation fulfill];
+                 }
+                 subscriptionEstablished:^{
+                     [establishExpectation fulfill];
+                 }];
+         }];
 
     [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
 
     // Inject badly formatted report
     id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    [clientObject handleReportWithController:uuid nodeId:myNodeId values:myReport error:nil];
 
     // Wait for report, which isn't expected.
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kNegativeTimeoutInSeconds];
 
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"Report sent"];
-    myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
-        @"data", nil];
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
+    } ];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
@@ -741,12 +797,12 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSUInteger myAttributeId = 300;
     NSUInteger myMinInterval = 5;
     NSUInteger myMaxInterval = 60;
-    __block NSDictionary * myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId + 1], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:123456], @"value", nil],
-        @"data", nil];
+    __block NSArray * myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId + 1]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
+    } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
     __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Unexpected report sent"];
@@ -768,48 +824,55 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
 
-    [_remoteDeviceController getConnectedDevice:myNodeId
-                                          queue:dispatch_get_main_queue()
-                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
-                                  XCTAssertNotNil(device);
-                                  XCTAssertNil(error);
-                                  NSLog(@"Device acquired. Subscribing...");
-                                  [device subscribeAttributeWithEndpointId:myEndpointId
-                                      clusterId:myClusterId
-                                      attributeId:myAttributeId
-                                      minInterval:myMinInterval
-                                      maxInterval:myMaxInterval
-                                      clientQueue:dispatch_get_main_queue()
-                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
-                                          NSLog(@"Report value: %@", value);
-                                          XCTAssertNotNil(value);
-                                          XCTAssertNil(error);
-                                          XCTAssertTrue([myReport isEqualTo:value]);
-                                          [reportExpectation fulfill];
-                                      }
-                                      subscriptionEstablished:^{
-                                          [establishExpectation fulfill];
-                                      }];
-                              }];
+    [_remoteDeviceController
+        getConnectedDevice:myNodeId
+                     queue:dispatch_get_main_queue()
+         completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+             XCTAssertNotNil(device);
+             XCTAssertNil(error);
+             NSLog(@"Device acquired. Subscribing...");
+             [device subscribeAttributeWithEndpointId:myEndpointId
+                 clusterId:myClusterId
+                 attributeId:myAttributeId
+                 minInterval:myMinInterval
+                 maxInterval:myMaxInterval
+                 clientQueue:dispatch_get_main_queue()
+                 reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                     NSLog(@"Report value: %@", values);
+                     XCTAssertNotNil(values);
+                     XCTAssertNil(error);
+                     XCTAssertTrue([myReport isEqualTo:values]);
+                     [reportExpectation fulfill];
+                 }
+                 subscriptionEstablished:^{
+                     [establishExpectation fulfill];
+                 }];
+         }];
 
     [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
 
     // Inject report
     id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report which isn't expected
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kNegativeTimeoutInSeconds];
 
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
-    myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
-        @"data", nil];
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
+    } ];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
@@ -838,12 +901,12 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSUInteger myAttributeId = 300;
     NSUInteger myMinInterval = 5;
     NSUInteger myMaxInterval = 60;
-    __block NSDictionary * myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId + 1], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:123456], @"value", nil],
-        @"data", nil];
+    __block NSArray * myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId + 1]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
+    } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
     __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Unexpected report sent"];
@@ -865,48 +928,55 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
 
-    [_remoteDeviceController getConnectedDevice:myNodeId
-                                          queue:dispatch_get_main_queue()
-                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
-                                  XCTAssertNotNil(device);
-                                  XCTAssertNil(error);
-                                  NSLog(@"Device acquired. Subscribing...");
-                                  [device subscribeAttributeWithEndpointId:myEndpointId
-                                      clusterId:myClusterId
-                                      attributeId:myAttributeId
-                                      minInterval:myMinInterval
-                                      maxInterval:myMaxInterval
-                                      clientQueue:dispatch_get_main_queue()
-                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
-                                          NSLog(@"Report value: %@", value);
-                                          XCTAssertNotNil(value);
-                                          XCTAssertNil(error);
-                                          XCTAssertTrue([myReport isEqualTo:value]);
-                                          [reportExpectation fulfill];
-                                      }
-                                      subscriptionEstablished:^{
-                                          [establishExpectation fulfill];
-                                      }];
-                              }];
+    [_remoteDeviceController
+        getConnectedDevice:myNodeId
+                     queue:dispatch_get_main_queue()
+         completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+             XCTAssertNotNil(device);
+             XCTAssertNil(error);
+             NSLog(@"Device acquired. Subscribing...");
+             [device subscribeAttributeWithEndpointId:myEndpointId
+                 clusterId:myClusterId
+                 attributeId:myAttributeId
+                 minInterval:myMinInterval
+                 maxInterval:myMaxInterval
+                 clientQueue:dispatch_get_main_queue()
+                 reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                     NSLog(@"Report value: %@", values);
+                     XCTAssertNotNil(values);
+                     XCTAssertNil(error);
+                     XCTAssertTrue([myReport isEqualTo:values]);
+                     [reportExpectation fulfill];
+                 }
+                 subscriptionEstablished:^{
+                     [establishExpectation fulfill];
+                 }];
+         }];
 
     [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
 
     // Inject report
     id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report not to come
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kNegativeTimeoutInSeconds];
 
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
-    myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
-        @"data", nil];
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
+    } ];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
@@ -935,12 +1005,12 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSUInteger myAttributeId = 300;
     NSUInteger myMinInterval = 5;
     NSUInteger myMaxInterval = 60;
-    __block NSDictionary * myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId + 1],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:123456], @"value", nil],
-        @"data", nil];
+    __block NSArray * myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId + 1]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
+    } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
     __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Unexpected report sent"];
@@ -962,48 +1032,55 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
 
-    [_remoteDeviceController getConnectedDevice:myNodeId
-                                          queue:dispatch_get_main_queue()
-                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
-                                  XCTAssertNotNil(device);
-                                  XCTAssertNil(error);
-                                  NSLog(@"Device acquired. Subscribing...");
-                                  [device subscribeAttributeWithEndpointId:myEndpointId
-                                      clusterId:myClusterId
-                                      attributeId:myAttributeId
-                                      minInterval:myMinInterval
-                                      maxInterval:myMaxInterval
-                                      clientQueue:dispatch_get_main_queue()
-                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
-                                          NSLog(@"Report value: %@", value);
-                                          XCTAssertNotNil(value);
-                                          XCTAssertNil(error);
-                                          XCTAssertTrue([myReport isEqualTo:value]);
-                                          [reportExpectation fulfill];
-                                      }
-                                      subscriptionEstablished:^{
-                                          [establishExpectation fulfill];
-                                      }];
-                              }];
+    [_remoteDeviceController
+        getConnectedDevice:myNodeId
+                     queue:dispatch_get_main_queue()
+         completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+             XCTAssertNotNil(device);
+             XCTAssertNil(error);
+             NSLog(@"Device acquired. Subscribing...");
+             [device subscribeAttributeWithEndpointId:myEndpointId
+                 clusterId:myClusterId
+                 attributeId:myAttributeId
+                 minInterval:myMinInterval
+                 maxInterval:myMaxInterval
+                 clientQueue:dispatch_get_main_queue()
+                 reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                     NSLog(@"Report value: %@", values);
+                     XCTAssertNotNil(values);
+                     XCTAssertNil(error);
+                     XCTAssertTrue([myReport isEqualTo:values]);
+                     [reportExpectation fulfill];
+                 }
+                 subscriptionEstablished:^{
+                     [establishExpectation fulfill];
+                 }];
+         }];
 
     [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
 
     // Inject report
     id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report not to come
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kNegativeTimeoutInSeconds];
 
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
-    myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
-        @"data", nil];
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
+    } ];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
@@ -1032,12 +1109,12 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSUInteger myAttributeId = 300;
     NSUInteger myMinInterval = 5;
     NSUInteger myMaxInterval = 60;
-    __block NSDictionary * myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:123456], @"value", nil],
-        @"data", nil];
+    __block NSArray * myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
+    } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
     __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Unexpected report sent"];
@@ -1059,48 +1136,55 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
 
-    [_remoteDeviceController getConnectedDevice:myNodeId
-                                          queue:dispatch_get_main_queue()
-                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
-                                  XCTAssertNotNil(device);
-                                  XCTAssertNil(error);
-                                  NSLog(@"Device acquired. Subscribing...");
-                                  [device subscribeAttributeWithEndpointId:myEndpointId
-                                      clusterId:myClusterId
-                                      attributeId:myAttributeId
-                                      minInterval:myMinInterval
-                                      maxInterval:myMaxInterval
-                                      clientQueue:dispatch_get_main_queue()
-                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
-                                          NSLog(@"Report value: %@", value);
-                                          XCTAssertNotNil(value);
-                                          XCTAssertNil(error);
-                                          XCTAssertTrue([myReport isEqualTo:value]);
-                                          [reportExpectation fulfill];
-                                      }
-                                      subscriptionEstablished:^{
-                                          [establishExpectation fulfill];
-                                      }];
-                              }];
+    [_remoteDeviceController
+        getConnectedDevice:myNodeId
+                     queue:dispatch_get_main_queue()
+         completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+             XCTAssertNotNil(device);
+             XCTAssertNil(error);
+             NSLog(@"Device acquired. Subscribing...");
+             [device subscribeAttributeWithEndpointId:myEndpointId
+                 clusterId:myClusterId
+                 attributeId:myAttributeId
+                 minInterval:myMinInterval
+                 maxInterval:myMaxInterval
+                 clientQueue:dispatch_get_main_queue()
+                 reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                     NSLog(@"Report value: %@", values);
+                     XCTAssertNotNil(values);
+                     XCTAssertNil(error);
+                     XCTAssertTrue([myReport isEqualTo:values]);
+                     [reportExpectation fulfill];
+                 }
+                 subscriptionEstablished:^{
+                     [establishExpectation fulfill];
+                 }];
+         }];
 
     [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
 
     // Inject report
     id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
-    [clientObject handleReportWithController:uuid nodeId:myNodeId + 1 value:myReport error:nil];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId + 1
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report not to come
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kNegativeTimeoutInSeconds];
 
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
-    myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
-        @"data", nil];
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
+    } ];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
@@ -1129,12 +1213,12 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSUInteger myAttributeId = 300;
     NSUInteger myMinInterval = 5;
     NSUInteger myMaxInterval = 60;
-    __block NSDictionary * myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:123456], @"value", nil],
-        @"data", nil];
+    __block NSArray * myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
+    } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
     __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Report sent"];
@@ -1155,48 +1239,55 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
 
-    [_remoteDeviceController getConnectedDevice:myNodeId
-                                          queue:dispatch_get_main_queue()
-                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
-                                  XCTAssertNotNil(device);
-                                  XCTAssertNil(error);
-                                  NSLog(@"Device acquired. Subscribing...");
-                                  [device subscribeAttributeWithEndpointId:0xffff
-                                      clusterId:myClusterId
-                                      attributeId:myAttributeId
-                                      minInterval:myMinInterval
-                                      maxInterval:myMaxInterval
-                                      clientQueue:dispatch_get_main_queue()
-                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
-                                          NSLog(@"Report value: %@", value);
-                                          XCTAssertNotNil(value);
-                                          XCTAssertNil(error);
-                                          XCTAssertTrue([myReport isEqualTo:value]);
-                                          [reportExpectation fulfill];
-                                      }
-                                      subscriptionEstablished:^{
-                                          [establishExpectation fulfill];
-                                      }];
-                              }];
+    [_remoteDeviceController
+        getConnectedDevice:myNodeId
+                     queue:dispatch_get_main_queue()
+         completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+             XCTAssertNotNil(device);
+             XCTAssertNil(error);
+             NSLog(@"Device acquired. Subscribing...");
+             [device subscribeAttributeWithEndpointId:0xffff
+                 clusterId:myClusterId
+                 attributeId:myAttributeId
+                 minInterval:myMinInterval
+                 maxInterval:myMaxInterval
+                 clientQueue:dispatch_get_main_queue()
+                 reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                     NSLog(@"Report value: %@", values);
+                     XCTAssertNotNil(values);
+                     XCTAssertNil(error);
+                     XCTAssertTrue([myReport isEqualTo:values]);
+                     [reportExpectation fulfill];
+                 }
+                 subscriptionEstablished:^{
+                     [establishExpectation fulfill];
+                 }];
+         }];
 
     [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
 
     // Inject report
     id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kNegativeTimeoutInSeconds];
 
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
-    myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
-        @"data", nil];
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
+    } ];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
@@ -1225,12 +1316,12 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSUInteger myAttributeId = 300;
     NSUInteger myMinInterval = 5;
     NSUInteger myMaxInterval = 60;
-    __block NSDictionary * myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:123456], @"value", nil],
-        @"data", nil];
+    __block NSArray * myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
+    } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
     __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Report sent"];
@@ -1251,48 +1342,55 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
 
-    [_remoteDeviceController getConnectedDevice:myNodeId
-                                          queue:dispatch_get_main_queue()
-                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
-                                  XCTAssertNotNil(device);
-                                  XCTAssertNil(error);
-                                  NSLog(@"Device acquired. Subscribing...");
-                                  [device subscribeAttributeWithEndpointId:myEndpointId
-                                      clusterId:0xffffffff
-                                      attributeId:myAttributeId
-                                      minInterval:myMinInterval
-                                      maxInterval:myMaxInterval
-                                      clientQueue:dispatch_get_main_queue()
-                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
-                                          NSLog(@"Report value: %@", value);
-                                          XCTAssertNotNil(value);
-                                          XCTAssertNil(error);
-                                          XCTAssertTrue([myReport isEqualTo:value]);
-                                          [reportExpectation fulfill];
-                                      }
-                                      subscriptionEstablished:^{
-                                          [establishExpectation fulfill];
-                                      }];
-                              }];
+    [_remoteDeviceController
+        getConnectedDevice:myNodeId
+                     queue:dispatch_get_main_queue()
+         completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+             XCTAssertNotNil(device);
+             XCTAssertNil(error);
+             NSLog(@"Device acquired. Subscribing...");
+             [device subscribeAttributeWithEndpointId:myEndpointId
+                 clusterId:0xffffffff
+                 attributeId:myAttributeId
+                 minInterval:myMinInterval
+                 maxInterval:myMaxInterval
+                 clientQueue:dispatch_get_main_queue()
+                 reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                     NSLog(@"Report value: %@", values);
+                     XCTAssertNotNil(values);
+                     XCTAssertNil(error);
+                     XCTAssertTrue([myReport isEqualTo:values]);
+                     [reportExpectation fulfill];
+                 }
+                 subscriptionEstablished:^{
+                     [establishExpectation fulfill];
+                 }];
+         }];
 
     [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
 
     // Inject report
     id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kNegativeTimeoutInSeconds];
 
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
-    myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
-        @"data", nil];
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
+    } ];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
@@ -1321,12 +1419,12 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSUInteger myAttributeId = 300;
     NSUInteger myMinInterval = 5;
     NSUInteger myMaxInterval = 60;
-    __block NSDictionary * myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:123456], @"value", nil],
-        @"data", nil];
+    __block NSArray * myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
+    } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
     __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Report sent"];
@@ -1347,48 +1445,55 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
 
-    [_remoteDeviceController getConnectedDevice:myNodeId
-                                          queue:dispatch_get_main_queue()
-                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
-                                  XCTAssertNotNil(device);
-                                  XCTAssertNil(error);
-                                  NSLog(@"Device acquired. Subscribing...");
-                                  [device subscribeAttributeWithEndpointId:myEndpointId
-                                      clusterId:myClusterId
-                                      attributeId:0xffffffff
-                                      minInterval:myMinInterval
-                                      maxInterval:myMaxInterval
-                                      clientQueue:dispatch_get_main_queue()
-                                      reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
-                                          NSLog(@"Report value: %@", value);
-                                          XCTAssertNotNil(value);
-                                          XCTAssertNil(error);
-                                          XCTAssertTrue([myReport isEqualTo:value]);
-                                          [reportExpectation fulfill];
-                                      }
-                                      subscriptionEstablished:^{
-                                          [establishExpectation fulfill];
-                                      }];
-                              }];
+    [_remoteDeviceController
+        getConnectedDevice:myNodeId
+                     queue:dispatch_get_main_queue()
+         completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+             XCTAssertNotNil(device);
+             XCTAssertNil(error);
+             NSLog(@"Device acquired. Subscribing...");
+             [device subscribeAttributeWithEndpointId:myEndpointId
+                 clusterId:myClusterId
+                 attributeId:0xffffffff
+                 minInterval:myMinInterval
+                 maxInterval:myMaxInterval
+                 clientQueue:dispatch_get_main_queue()
+                 reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                     NSLog(@"Report value: %@", values);
+                     XCTAssertNotNil(values);
+                     XCTAssertNil(error);
+                     XCTAssertTrue([myReport isEqualTo:values]);
+                     [reportExpectation fulfill];
+                 }
+                 subscriptionEstablished:^{
+                     [establishExpectation fulfill];
+                 }];
+         }];
 
     [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
 
     // Inject report
     id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
 
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
-    myReport = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId], @"endpointId",
-        [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId", [NSNumber numberWithUnsignedInteger:myAttributeId],
-        @"attributeId",
-        [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type", [NSNumber numberWithInteger:771234], @"value", nil],
-        @"data", nil];
-    [clientObject handleReportWithController:uuid nodeId:myNodeId value:myReport error:nil];
+    myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
+    } ];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
@@ -1423,7 +1528,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     __block NSUInteger myAttributeId = attributeIds[0];
     __block NSUInteger myMinInterval = minIntervals[0];
     __block NSUInteger myMaxInterval = maxIntervals[0];
-    __block NSArray<NSDictionary *> * myReports;
+    __block NSArray<NSArray *> * myReports;
     __block XCTestExpectation * callExpectation;
     __block XCTestExpectation * establishExpectation;
     __block NSArray<XCTestExpectation *> * reportExpectations;
@@ -1467,11 +1572,11 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                      minInterval:myMinInterval
                      maxInterval:myMaxInterval
                      clientQueue:dispatch_get_main_queue()
-                     reportHandler:^(NSDictionary<NSString *, id> * _Nullable value, NSError * _Nullable error) {
-                         NSLog(@"Subscriber [%d] report value: %@", i, value);
-                         XCTAssertNotNil(value);
+                     reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                         NSLog(@"Subscriber [%d] report value: %@", i, values);
+                         XCTAssertNotNil(values);
                          XCTAssertNil(error);
-                         XCTAssertTrue([myReports[i] isEqualTo:value]);
+                         XCTAssertTrue([myReports[i] isEqualTo:values]);
                          [reportExpectations[i] fulfill];
                      }
                      subscriptionEstablished:^{
@@ -1490,24 +1595,29 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             arrayWithObjects:[self expectationWithDescription:[NSString
                                                                   stringWithFormat:@"Report(%d) for first subscriber sent", count]],
             [self expectationWithDescription:[NSString stringWithFormat:@"Report(%d) for second subscriber sent", count]], nil];
-        myReports = [NSArray
-            arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:endpointIds[0]],
-                                           @"endpointId", [NSNumber numberWithUnsignedInteger:clusterIds[0]], @"clusterId",
-                                           [NSNumber numberWithUnsignedInteger:attributeIds[0]], @"attributeId",
-                                           [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
-                                                         [NSNumber numberWithInteger:123456 + count * 100], @"value", nil],
-                                           @"data", nil],
-            [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:endpointIds[1]], @"endpointId",
-                          [NSNumber numberWithUnsignedInteger:clusterIds[1]], @"clusterId",
-                          [NSNumber numberWithUnsignedInteger:attributeIds[1]], @"attributeId",
-                          [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
-                                        [NSNumber numberWithInteger:123457 + count * 100], @"value", nil],
-                          @"data", nil],
-            nil];
+        myReports = @[
+            @[ @{
+                @"attributePath" :
+                    [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:endpointIds[0]]
+                                                         clusterId:[NSNumber numberWithUnsignedInteger:clusterIds[0]]
+                                                       attributeId:[NSNumber numberWithUnsignedInteger:attributeIds[0]]],
+                @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:123456 + count * 100] }
+            } ],
+            @[ @{
+                @"attributePath" :
+                    [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:endpointIds[1]]
+                                                         clusterId:[NSNumber numberWithUnsignedInteger:clusterIds[1]]
+                                                       attributeId:[NSNumber numberWithUnsignedInteger:attributeIds[1]]],
+                @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:123457 + count * 100] }
+            } ]
+        ];
         for (int i = 0; i < 2; i++) {
             NSUInteger nodeId = nodeIds[i];
             dispatch_async(dispatch_get_main_queue(), ^{
-                [clientObject handleReportWithController:uuid nodeId:nodeId value:myReports[i] error:nil];
+                [clientObject handleReportWithController:uuid
+                                                  nodeId:nodeId
+                                                  values:[CHIPDeviceController encodeXPCResponseValues:myReports[i]]
+                                                   error:nil];
             });
         }
         [self waitForExpectations:reportExpectations timeout:kTimeoutInSeconds];
@@ -1535,24 +1645,29 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                                                   stringWithFormat:@"Report(%d) for first subscriber sent", count]],
             [self expectationWithDescription:[NSString stringWithFormat:@"Report(%d) for second subscriber sent", count]], nil];
         reportExpectations[0].inverted = YES;
-        myReports = [NSArray
-            arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:endpointIds[0]],
-                                           @"endpointId", [NSNumber numberWithUnsignedInteger:clusterIds[0]], @"clusterId",
-                                           [NSNumber numberWithUnsignedInteger:attributeIds[0]], @"attributeId",
-                                           [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
-                                                         [NSNumber numberWithInteger:223456 + count * 100], @"value", nil],
-                                           @"data", nil],
-            [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:endpointIds[1]], @"endpointId",
-                          [NSNumber numberWithUnsignedInteger:clusterIds[1]], @"clusterId",
-                          [NSNumber numberWithUnsignedInteger:attributeIds[1]], @"attributeId",
-                          [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
-                                        [NSNumber numberWithInteger:223457 + count * 100], @"value", nil],
-                          @"data", nil],
-            nil];
+        myReports = @[
+            @[ @{
+                @"attributePath" :
+                    [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:endpointIds[0]]
+                                                         clusterId:[NSNumber numberWithUnsignedInteger:clusterIds[0]]
+                                                       attributeId:[NSNumber numberWithUnsignedInteger:attributeIds[0]]],
+                @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:223456 + count * 100] }
+            } ],
+            @[ @{
+                @"attributePath" :
+                    [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:endpointIds[1]]
+                                                         clusterId:[NSNumber numberWithUnsignedInteger:clusterIds[1]]
+                                                       attributeId:[NSNumber numberWithUnsignedInteger:attributeIds[1]]],
+                @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:223457 + count * 100] }
+            } ]
+        ];
         for (int i = 0; i < 2; i++) {
             NSUInteger nodeId = nodeIds[i];
             dispatch_async(dispatch_get_main_queue(), ^{
-                [clientObject handleReportWithController:uuid nodeId:nodeId value:myReports[i] error:nil];
+                [clientObject handleReportWithController:uuid
+                                                  nodeId:nodeId
+                                                  values:[CHIPDeviceController encodeXPCResponseValues:myReports[i]]
+                                                   error:nil];
             });
         }
         [self waitForExpectations:reportExpectations timeout:kTimeoutInSeconds];
@@ -1584,24 +1699,29 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             [self expectationWithDescription:[NSString stringWithFormat:@"Report(%d) for second subscriber sent", count]], nil];
         reportExpectations[0].inverted = YES;
         reportExpectations[1].inverted = YES;
-        myReports = [NSArray
-            arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:endpointIds[0]],
-                                           @"endpointId", [NSNumber numberWithUnsignedInteger:clusterIds[0]], @"clusterId",
-                                           [NSNumber numberWithUnsignedInteger:attributeIds[0]], @"attributeId",
-                                           [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
-                                                         [NSNumber numberWithInteger:223456 + count * 100], @"value", nil],
-                                           @"data", nil],
-            [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:endpointIds[1]], @"endpointId",
-                          [NSNumber numberWithUnsignedInteger:clusterIds[1]], @"clusterId",
-                          [NSNumber numberWithUnsignedInteger:attributeIds[1]], @"attributeId",
-                          [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
-                                        [NSNumber numberWithInteger:223457 + count * 100], @"value", nil],
-                          @"data", nil],
-            nil];
+        myReports = @[
+            @[ @{
+                @"attributePath" :
+                    [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:endpointIds[0]]
+                                                         clusterId:[NSNumber numberWithUnsignedInteger:clusterIds[0]]
+                                                       attributeId:[NSNumber numberWithUnsignedInteger:attributeIds[0]]],
+                @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:223456 + count * 100] }
+            } ],
+            @[ @{
+                @"attributePath" :
+                    [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:endpointIds[1]]
+                                                         clusterId:[NSNumber numberWithUnsignedInteger:clusterIds[1]]
+                                                       attributeId:[NSNumber numberWithUnsignedInteger:attributeIds[1]]],
+                @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:223457 + count * 100] }
+            } ]
+        ];
         for (int i = 0; i < 2; i++) {
             NSUInteger nodeId = nodeIds[i];
             dispatch_async(dispatch_get_main_queue(), ^{
-                [clientObject handleReportWithController:uuid nodeId:nodeId value:myReports[i] error:nil];
+                [clientObject handleReportWithController:uuid
+                                                  nodeId:nodeId
+                                                  values:[CHIPDeviceController encodeXPCResponseValues:myReports[i]]
+                                                   error:nil];
             });
         }
         [self waitForExpectations:reportExpectations timeout:kNegativeTimeoutInSeconds];
@@ -1706,13 +1826,13 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSUInteger myEndpointId = 100;
     NSUInteger myClusterId = 200;
     NSUInteger myAttributeId = 300;
-    NSArray * myValues =
-        [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:myEndpointId],
-                                               @"endpointId", [NSNumber numberWithUnsignedInteger:myClusterId], @"clusterId",
-                                               [NSNumber numberWithUnsignedInteger:myAttributeId], @"attributeId",
-                                               [NSDictionary dictionaryWithObjectsAndKeys:@"SignedInteger", @"type",
-                                                             [NSNumber numberWithInteger:123456], @"value", nil],
-                                               @"data", nil]];
+    NSArray * myValues = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
+                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
+                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
+    } ];
+
     XCTestExpectation * subscribeExpectation = [self expectationWithDescription:@"Cache subscription complete"];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
@@ -1735,7 +1855,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
         XCTAssertEqual(clusterId, myClusterId);
         XCTAssertEqual(attributeId, myAttributeId);
         [callExpectation fulfill];
-        completion(myValues, nil);
+        completion([CHIPDeviceController encodeXPCResponseValues:myValues], nil);
     };
 
     [attributeCacheContainer subscribeWithDeviceController:_remoteDeviceController


### PR DESCRIPTION
#### Problem
* Addresses subset of #15930

#### Change overview
* CHIPAttributePath object and CHIPCommandPath object are used for paths
  instead of individual dictionary keys for path elements.
* NSError object replaces implementation specific status value.
* List TLV conversion code was removed.
* Implementation specific tag is replaced with context tag number just
  for Structure TLV.
* 64 bit int conversion was fixed.
* new operator was replaced with Platform::New.
* Float and double TLV decoding was fixed to distinguish them.
* Potential buffer overrun during UTF8String TLV conversion was fixed.
* String constant names were corrected.
* Method header comments were corrected.

#### Testing
* Previous unit tests and integration tests were updated to verify the object and decoding changes.