### PR TITLE
[OTA] Remove extraneous using-declaration of ProviderLocationType

### DIFF
--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
@@ -71,8 +71,7 @@ public:
     void SendQueryImage() override;
 
     // Returns the next available Provider location
-    bool DetermineProviderLocation(
-        app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type & providerLocation) override;
+    bool DetermineProviderLocation(ProviderLocationType & providerLocation) override;
 
 protected:
     void StartDefaultProviderTimer();
@@ -86,7 +85,6 @@ protected:
     uint32_t mOtaStartDelaySec                   = 0;
     uint32_t mPeriodicQueryTimeInterval = (24 * 60 * 60); // Timeout for querying providers on the default OTA provider list
 
-    using ProviderLocationType = app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type;
     Optional<ProviderLocationType> mLastUsedProvider; // Provider location used for the last query or update
 };
 

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -80,7 +80,6 @@ public:
     // Clear all entries with the specified fabric index in the default OTA provider list
     CHIP_ERROR ClearDefaultOtaProviderList(FabricIndex fabricIndex) override;
 
-    using ProviderLocationType = app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type;
     void SetCurrentProviderLocation(ProviderLocationType providerLocation) override
     {
         mProviderLocation.SetValue(providerLocation);

--- a/src/app/clusters/ota-requestor/OTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/OTARequestorDriver.h
@@ -67,6 +67,8 @@ enum class UpdateNotFoundReason
 class OTARequestorDriver
 {
 public:
+    using ProviderLocationType = app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type;
+
     virtual ~OTARequestorDriver() = default;
 
     /// Return if the device provides UI for asking a user for consent before downloading a software image
@@ -105,7 +107,6 @@ public:
     /// Inform the driver that the device commissioning has completed
     virtual void OTACommissioningCallback() = 0;
 
-    using ProviderLocationType = app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type;
     virtual void
     /// Driver portion of the logic for processing the AnnounceOTAProviders command
     ProcessAnnounceOTAProviders(const ProviderLocationType & providerLocation,
@@ -120,8 +121,7 @@ public:
     // Driver picks the OTA Provider that should be used for the next query and update. The Provider is picked according to
     // the driver's internal logic such as, for example, traversing the default providers list.
     // Returns true if there is a Provider available for the next query, returns false otherwise.
-    virtual bool
-    DetermineProviderLocation(app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type & providerLocation) = 0;
+    virtual bool DetermineProviderLocation(ProviderLocationType & providerLocation) = 0;
 };
 
 } // namespace chip

--- a/src/app/clusters/ota-requestor/OTARequestorInterface.h
+++ b/src/app/clusters/ota-requestor/OTARequestorInterface.h
@@ -142,7 +142,8 @@ private:
 class OTARequestorInterface
 {
 public:
-    using OTAUpdateStateEnum = chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
+    using OTAUpdateStateEnum   = chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
+    using ProviderLocationType = app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type;
 
     // Return value for various trigger-type APIs
     enum OTATriggerResult
@@ -194,8 +195,6 @@ public:
 
     // Clear all entries with the specified fabric index in the default OTA provider list
     virtual CHIP_ERROR ClearDefaultOtaProviderList(FabricIndex fabricIndex) = 0;
-
-    using ProviderLocationType = app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type;
 
     // Set the provider location to be used in the next query and OTA update process
     virtual void SetCurrentProviderLocation(ProviderLocationType providerLocation) = 0;


### PR DESCRIPTION
#### Problem
`using ProviderLocationType = app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type;`is being used in multiple places within OTA components

#### Change overview
Minimize this declaration to only files that must declare it

#### Testing
Tree compiles
