### PR TITLE
When establishing a CASE session fails, the failure callback in not c…

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -127,7 +127,15 @@ void CASESessionManager::OnOperationalNodeResolved(const Dnssd::ResolvedNodeData
 
 void CASESessionManager::OnOperationalNodeResolutionFailed(const PeerId & peer, CHIP_ERROR error)
 {
+    OperationalDeviceProxy * session = FindExistingSession(peer);
+    VerifyOrReturn(
+        session != nullptr,
+        ChipLogDetail(Controller,
+                      "OnOperationalNodeResolutionFailed was called for a device with no active sessions, ignoring it."));
+
     ChipLogError(Controller, "Error resolving node id: %s", ErrorStr(error));
+    session->OnSessionEstablishmentError(error);
+    ReleaseSession(peer);
 }
 
 CHIP_ERROR CASESessionManager::GetPeerAddress(PeerId peerId, Transport::PeerAddress & addr)

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -292,6 +292,15 @@ void OperationalDeviceProxy::CloseCASESession()
     }
 }
 
+void OperationalDeviceProxy::OnSessionEstablishmentError(CHIP_ERROR error)
+{
+    mState = State::Initialized;
+
+    DequeueConnectionSuccessCallbacks(/* executeCallback */ false);
+    DequeueConnectionFailureCallbacks(error, /* executeCallback */ true);
+    CloseCASESession();
+}
+
 void OperationalDeviceProxy::OnSessionReleased()
 {
     mState = State::Initialized;

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -124,6 +124,8 @@ public:
      */
     void OnSessionReleased() override;
 
+    void OnSessionEstablishmentError(CHIP_ERROR error) override;
+
     void OnNodeIdResolved(const Dnssd::ResolvedNodeData & nodeResolutionData)
     {
         mDeviceAddress = ToPeerAddress(nodeResolutionData);

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -95,14 +95,6 @@ static void HandleNodeResolve(void * context, DnssdService * result, const Span<
 static void HandleNodeIdResolve(void * context, DnssdService * result, const Span<Inet::IPAddress> & extraIPs, CHIP_ERROR error)
 {
     ResolverDelegateProxy * proxy = static_cast<ResolverDelegateProxy *>(context);
-    if (CHIP_NO_ERROR != error)
-    {
-        proxy->OnOperationalNodeResolutionFailed(PeerId(), error);
-        proxy->Release();
-        return;
-    }
-
-    VerifyOrDie(proxy != nullptr);
 
     if (result == nullptr)
     {
@@ -114,10 +106,19 @@ static void HandleNodeIdResolve(void * context, DnssdService * result, const Spa
     VerifyOrDie(proxy != nullptr);
 
     PeerId peerId;
-    error = ExtractIdFromInstanceName(result->mName, &peerId);
+    CHIP_ERROR err = ExtractIdFromInstanceName(result->mName, &peerId);
+    if (CHIP_NO_ERROR != err)
+    {
+        proxy->OnOperationalNodeResolutionFailed(PeerId(), err);
+        proxy->Release();
+        return;
+    }
+
+    VerifyOrDie(proxy != nullptr);
+
     if (CHIP_NO_ERROR != error)
     {
-        proxy->OnOperationalNodeResolutionFailed(PeerId(), error);
+        proxy->OnOperationalNodeResolutionFailed(peerId, error);
         proxy->Release();
         return;
     }

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -124,6 +124,7 @@ public:
     CHIP_ERROR Remove(GenericContext * context);
     CHIP_ERROR Removes(ContextType type);
     CHIP_ERROR Get(ContextType type, GenericContext ** context);
+    bool Has(GenericContext * context);
     CHIP_ERROR GetRegisterType(const char * type, GenericContext ** context);
 
     void SetHostname(const char * name) { mHostname = name; }


### PR DESCRIPTION
…alled

#### Problem

The mdns platform implementation can not map a failure to resolve a node id to the original session.

#### Change overview
 * Add a timeout to the darwin mdns resolve implementation
 * Update the mdns platform resolver implementation so if there is a name into the result it can be converted to a `peerId` before beeing used to retrieved the corresponding `OperationalDeviceProxy` 
 * Get `CASESessionManager` to actually use the failure callback if the mdns resolving fails.

