### PR TITLE
Fix XPC connection failure handling

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceControllerXPCConnection.m
+++ b/src/darwin/Framework/CHIP/CHIPDeviceControllerXPCConnection.m
@@ -93,6 +93,7 @@
             if (!xpcConnection) {
                 CHIP_LOG_ERROR("Cannot connect to XPC server for remote controller");
                 completion(self.workQueue, nil);
+                return;
             }
             xpcConnection.remoteObjectInterface = self.remoteDeviceServerProtocol;
             xpcConnection.exportedInterface = self.remoteDeviceClientProtocol;


### PR DESCRIPTION
#### Problem
* Fix redundant completion block call when XPC connection fails in Darwin CHIPDeviceController.

#### Change overview
* Inserted breaking return in failure path

#### Testing
* A new unit test was added and observed redundant call is not made: note that the redundant call itself is harmless except for a confusing log message.