### PR TITLE
Allow runtime init of some `Server` members (1/2)

### DIFF
--- a/src/app/DefaultAttributePersistenceProvider.cpp
+++ b/src/app/DefaultAttributePersistenceProvider.cpp
@@ -25,6 +25,8 @@ namespace app {
 CHIP_ERROR DefaultAttributePersistenceProvider::WriteValue(const ConcreteAttributePath & aPath,
                                                            const EmberAfAttributeMetadata * aMetadata, const ByteSpan & aValue)
 {
+    VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
     // TODO: we may want to have a small cache for values that change a lot, so
     // we only write them once a bunch of changes happen or on timer or
     // shutdown.
@@ -33,15 +35,17 @@ CHIP_ERROR DefaultAttributePersistenceProvider::WriteValue(const ConcreteAttribu
     {
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
-    return mStorage.SyncSetKeyValue(key.AttributeValue(aPath), aValue.data(), static_cast<uint16_t>(aValue.size()));
+    return mStorage->SyncSetKeyValue(key.AttributeValue(aPath), aValue.data(), static_cast<uint16_t>(aValue.size()));
 }
 
 CHIP_ERROR DefaultAttributePersistenceProvider::ReadValue(const ConcreteAttributePath & aPath,
                                                           const EmberAfAttributeMetadata * aMetadata, MutableByteSpan & aValue)
 {
+    VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
     DefaultStorageKeyAllocator key;
     uint16_t size = static_cast<uint16_t>(min(aValue.size(), static_cast<size_t>(UINT16_MAX)));
-    ReturnErrorOnFailure(mStorage.SyncGetKeyValue(key.AttributeValue(aPath), aValue.data(), size));
+    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(key.AttributeValue(aPath), aValue.data(), size));
     EmberAfAttributeType type = aMetadata->attributeType;
     if (emberAfIsStringAttributeType(type))
     {

--- a/src/app/DefaultAttributePersistenceProvider.h
+++ b/src/app/DefaultAttributePersistenceProvider.h
@@ -33,9 +33,9 @@ namespace app {
 class DefaultAttributePersistenceProvider : public AttributePersistenceProvider
 {
 public:
-    // aStorage must outlive this object.
     DefaultAttributePersistenceProvider() {}
 
+    // Passed-in storage must outlive this object.
     CHIP_ERROR Init(PersistentStorageDelegate * storage)
     {
         if (storage == nullptr)

--- a/src/app/DefaultAttributePersistenceProvider.h
+++ b/src/app/DefaultAttributePersistenceProvider.h
@@ -34,7 +34,19 @@ class DefaultAttributePersistenceProvider : public AttributePersistenceProvider
 {
 public:
     // aStorage must outlive this object.
-    DefaultAttributePersistenceProvider(PersistentStorageDelegate & aStorage) : mStorage(aStorage) {}
+    DefaultAttributePersistenceProvider() {}
+
+    CHIP_ERROR Init(PersistentStorageDelegate * storage)
+    {
+        if (storage == nullptr)
+        {
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        mStorage = storage;
+        return CHIP_NO_ERROR;
+    }
+
+    void Shutdown() {}
 
     // AttributePersistenceProvider implementation.
     CHIP_ERROR WriteValue(const ConcreteAttributePath & aPath, const EmberAfAttributeMetadata * aMetadata,
@@ -42,8 +54,8 @@ public:
     CHIP_ERROR ReadValue(const ConcreteAttributePath & aPath, const EmberAfAttributeMetadata * aMetadata,
                          MutableByteSpan & aValue) override;
 
-private:
-    PersistentStorageDelegate & mStorage;
+protected:
+    PersistentStorageDelegate * mStorage;
 };
 
 } // namespace app

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -39,7 +39,17 @@ class Server;
 class CommissioningWindowManager : public SessionEstablishmentDelegate, public app::CommissioningModeProvider
 {
 public:
-    CommissioningWindowManager(Server * server) : mAppDelegate(nullptr), mServer(server) {}
+    CommissioningWindowManager() {}
+
+    CHIP_ERROR Init(Server * server)
+    {
+        if (server == nullptr)
+        {
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        mServer = server;
+        return CHIP_NO_ERROR;
+    }
 
     void SetAppDelegate(AppDelegate * delegate) { mAppDelegate = delegate; }
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -106,7 +106,8 @@ Server::Server() :
 #endif
         .devicePool        = &mDevicePool,
         .dnsResolver       = nullptr,
-    }), mGroupsProvider(mDeviceStorage), mAccessControl(Access::Examples::GetAccessControlDelegate(&mDeviceStorage))
+    }),
+    mGroupsProvider(mDeviceStorage), mAccessControl(Access::Examples::GetAccessControlDelegate(&mDeviceStorage))
 {}
 
 CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint16_t unsecureServicePort,
@@ -342,7 +343,6 @@ void Server::Shutdown()
     mAttributePersister.Shutdown();
     mCommissioningWindowManager.Shutdown();
     mCASESessionManager.Shutdown();
-
 
     // TODO: Remove chip::Platform::MemoryInit() call from Server class, it belongs to outer code
     chip::Platform::MemoryShutdown();


### PR DESCRIPTION
#### Problem
This PR is on the path towards having Server::Server no longer
statically initialize its members with storage, and instead
relying on Server::Init(). This will simplify organization
of unit tests and also the convergence of Controller/Server
storage to address issue #16028

Issue #16028

#### Change overview
- Change several places where constructors receive a PersistentStorageDelegate to using an Init() argument instead
- This is a minor structural change with no functional changes

#### Testing
- Ran cert tests, still pass
- Ran unit tests, still pass