### PR TITLE
[ota] Fix BDX downloader timeout

### DIFF
--- a/src/app/clusters/ota-requestor/BDXDownloader.cpp
+++ b/src/app/clusters/ota-requestor/BDXDownloader.cpp
@@ -66,7 +66,7 @@ void BDXDownloader::Reset()
 
 bool BDXDownloader::HasTransferTimedOut()
 {
-    uint32_t curBlockCounter = mBdxTransfer.GetNextBlockNum();
+    uint32_t curBlockCounter = mBdxTransfer.GetNextQueryNum();
 
     if (curBlockCounter > mPrevBlockCounter)
     {

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -297,7 +297,8 @@ public:
     uint64_t GetStartOffset() const { return mStartOffset; }
     uint64_t GetTransferLength() const { return mTransferLength; }
     uint16_t GetTransferBlockSize() const { return mTransferMaxBlockSize; }
-    uint32_t GetNextBlockNum() { return mNextBlockNum; }
+    uint32_t GetNextBlockNum() const { return mNextBlockNum; }
+    uint32_t GetNextQueryNum() const { return mNextQueryNum; }
     size_t GetNumBytesProcessed() const { return mNumBytesProcessed; }
     const uint8_t * GetFileDesignator(uint16_t & fileDesignatorLen) const
     {


### PR DESCRIPTION
#### Problem
The code for checking the progress used a wrong counter. That is, the counter of sent rather than queried blocks.
Consequently, the transfer would be interrupted after 5 minutes (the current timeout).

#### Change overview
Use the correct block counter.

#### Testing
Temporarily reduced the timeout to 10 seconds and tested that the image download is not interrupted.