### PR TITLE
Allow runtime init of some `Server` members (2/2)

### DIFF
--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -184,7 +184,7 @@ CHIP_ERROR AccessControl::Finish()
     VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
     ChipLogProgress(DataManagement, "AccessControl: finishing");
     CHIP_ERROR retval = mDelegate->Finish();
-    mDelegate = nullptr;
+    mDelegate         = nullptr;
     return retval;
 }
 

--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -200,8 +200,8 @@ CHIP_ERROR AccessControl::Check(const SubjectDescriptor & subjectDescriptor, con
                         "AccessControl: checking f=%u a=%c s=0x" ChipLogFormatX64 " t=%s c=" ChipLogFormatMEI " e=%" PRIu16 " p=%c",
                         subjectDescriptor.fabricIndex, GetAuthModeStringForLogging(subjectDescriptor.authMode),
                         ChipLogValueX64(subjectDescriptor.subject),
-                        GetCatStringForLogging(catLogBuf, sizeof(catLogBuf), subjectDescriptor.cats), ChipLogValueMEI(requestPath.cluster),
-                        requestPath.endpoint, GetPrivilegeStringForLogging(requestPrivilege));
+                        GetCatStringForLogging(catLogBuf, sizeof(catLogBuf), subjectDescriptor.cats),
+                        ChipLogValueMEI(requestPath.cluster), requestPath.endpoint, GetPrivilegeStringForLogging(requestPrivilege));
     }
 #endif
 

--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -164,32 +164,34 @@ AccessControl::EntryIterator::Delegate AccessControl::EntryIterator::mDefaultDel
 
 CHIP_ERROR AccessControl::Init(AccessControl::Delegate * delegate)
 {
-    VerifyOrReturnError(!mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(!IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     ChipLogProgress(DataManagement, "AccessControl: initializing");
 
     // delegate can never be null. This was already checked
-    mDelegate         = delegate;
-    CHIP_ERROR retval = mDelegate->Init();
-    mIsInitialized    = (CHIP_NO_ERROR == retval);
+    CHIP_ERROR retval = delegate->Init();
+    if (retval == CHIP_NO_ERROR)
+    {
+        mDelegate = delegate;
+    }
+
     return retval;
 }
 
 CHIP_ERROR AccessControl::Finish()
 {
-    VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
     ChipLogProgress(DataManagement, "AccessControl: finishing");
     CHIP_ERROR retval = mDelegate->Finish();
-
-    mIsInitialized = false;
+    mDelegate = nullptr;
     return retval;
 }
 
 CHIP_ERROR AccessControl::Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath,
                                 Privilege requestPrivilege)
 {
-    VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 
 #if CHIP_PROGRESS_LOGGING
     {

--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -170,9 +170,9 @@ CHIP_ERROR AccessControl::Init(AccessControl::Delegate * delegate)
     ChipLogProgress(DataManagement, "AccessControl: initializing");
 
     // delegate can never be null. This was already checked
-    mDelegate = delegate;
+    mDelegate         = delegate;
     CHIP_ERROR retval = mDelegate->Init();
-    mIsInitialized = (CHIP_NO_ERROR == retval);
+    mIsInitialized    = (CHIP_NO_ERROR == retval);
     return retval;
 }
 

--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -161,19 +161,18 @@ namespace Access {
 
 AccessControl::Entry::Delegate AccessControl::Entry::mDefaultDelegate;
 AccessControl::EntryIterator::Delegate AccessControl::EntryIterator::mDefaultDelegate;
-AccessControl::Delegate AccessControl::mDefaultDelegate;
 
-CHIP_ERROR AccessControl::Init()
+CHIP_ERROR AccessControl::Init(AccessControl::Delegate * delegate)
 {
     VerifyOrReturnError(!mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     ChipLogProgress(DataManagement, "AccessControl: initializing");
-    CHIP_ERROR retval = mDelegate->Init();
 
-    if (retval == CHIP_NO_ERROR)
-    {
-        mIsInitialized = true;
-    }
+    // delegate can never be null. This was already checked
+    mDelegate = delegate;
+    CHIP_ERROR retval = mDelegate->Init();
+    mIsInitialized = (CHIP_NO_ERROR == retval);
     return retval;
 }
 

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -22,8 +22,8 @@
 #include "RequestPath.h"
 #include "SubjectDescriptor.h"
 
-#include <lib/core/CHIPCore.h>
 #include "lib/support/CodeUtils.h"
+#include <lib/core/CHIPCore.h>
 
 namespace chip {
 namespace Access {

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -360,7 +360,7 @@ public:
     ~AccessControl()
     {
         // Never-initialized AccessControl instances will not have the delegate set.
-        if (mIsInitialized && mDelegate != nullptr)
+        if (IsInitialized())
         {
             mDelegate->Release();
         }
@@ -384,14 +384,14 @@ public:
     // Capabilities
     CHIP_ERROR GetMaxEntryCount(size_t & value) const
     {
-        VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
         return mDelegate->GetMaxEntryCount(value);
     }
 
     // Actualities
     CHIP_ERROR GetEntryCount(size_t & value) const
     {
-        VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
         return mDelegate->GetEntryCount(value);
     }
 
@@ -404,7 +404,7 @@ public:
      */
     CHIP_ERROR PrepareEntry(Entry & entry)
     {
-        VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
         return mDelegate->PrepareEntry(entry);
     }
 
@@ -418,7 +418,7 @@ public:
     CHIP_ERROR CreateEntry(size_t * index, const Entry & entry, FabricIndex * fabricIndex = nullptr)
     {
         ReturnErrorCodeIf(!IsValid(entry), CHIP_ERROR_INVALID_ARGUMENT);
-        VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
         return mDelegate->CreateEntry(index, entry, fabricIndex);
     }
 
@@ -431,7 +431,7 @@ public:
      */
     CHIP_ERROR ReadEntry(size_t index, Entry & entry, const FabricIndex * fabricIndex = nullptr) const
     {
-        VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
         return mDelegate->ReadEntry(index, entry, fabricIndex);
     }
 
@@ -445,7 +445,7 @@ public:
     CHIP_ERROR UpdateEntry(size_t index, const Entry & entry, const FabricIndex * fabricIndex = nullptr)
     {
         ReturnErrorCodeIf(!IsValid(entry), CHIP_ERROR_INVALID_ARGUMENT);
-        VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
         return mDelegate->UpdateEntry(index, entry, fabricIndex);
     }
 
@@ -457,7 +457,7 @@ public:
      */
     CHIP_ERROR DeleteEntry(size_t index, const FabricIndex * fabricIndex = nullptr)
     {
-        VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
         return mDelegate->DeleteEntry(index, fabricIndex);
     }
 
@@ -469,7 +469,7 @@ public:
      */
     CHIP_ERROR Entries(EntryIterator & iterator, const FabricIndex * fabricIndex = nullptr) const
     {
-        VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
         return mDelegate->Entries(iterator, fabricIndex);
     }
 
@@ -484,11 +484,11 @@ public:
     CHIP_ERROR Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath, Privilege requestPrivilege);
 
 private:
+    bool IsInitialized() const { return (mDelegate != nullptr); }
+
     bool IsValid(const Entry & entry);
 
     Delegate * mDelegate = nullptr;
-
-    bool mIsInitialized = false;
 };
 
 /**

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -23,6 +23,7 @@
 #include "SubjectDescriptor.h"
 
 #include <lib/core/CHIPCore.h>
+#include "lib/support/CodeUtils.h"
 
 namespace chip {
 namespace Access {
@@ -353,12 +354,35 @@ public:
 
     AccessControl() = default;
 
-    AccessControl(Delegate & delegate) : mDelegate(delegate) {}
-
     AccessControl(const AccessControl &) = delete;
     AccessControl & operator=(const AccessControl &) = delete;
 
-    ~AccessControl() { mDelegate.Release(); }
+    ~AccessControl() { mDelegate->Release(); }
+
+    /**
+     * @brief Set the delegate that will handle access control entries. Must be called before Init().
+     *
+     * @param delegate - The delegate to use
+     * @return CHIP_NO_ERROR on success, CHIP_ERROR_INCORRECT_STATE if set after Init(), and
+     *         CHIP_ERROR_INVALID_ARGUMENT if delegate is null.
+     */
+    CHIP_ERROR SetDelegate(Delegate * delegate)
+    {
+        if (mIsInitialized)
+        {
+            return CHIP_ERROR_INCORRECT_STATE;
+        }
+        else if (delegate == nullptr)
+        {
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+
+        // De-initialize the default-set delegate.
+        mDelegate->Release();
+
+        mDelegate = delegate;
+        return CHIP_NO_ERROR;
+    }
 
     /**
      * Initialize the access control module. Must be called before first use.
@@ -373,10 +397,18 @@ public:
     CHIP_ERROR Finish();
 
     // Capabilities
-    CHIP_ERROR GetMaxEntryCount(size_t & value) const { return mDelegate.GetMaxEntryCount(value); }
+    CHIP_ERROR GetMaxEntryCount(size_t & value) const
+    {
+        VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+        return mDelegate->GetMaxEntryCount(value);
+    }
 
     // Actualities
-    CHIP_ERROR GetEntryCount(size_t & value) const { return mDelegate.GetEntryCount(value); }
+    CHIP_ERROR GetEntryCount(size_t & value) const
+    {
+        VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+        return mDelegate->GetEntryCount(value);
+    }
 
     /**
      * Prepares an entry.
@@ -385,7 +417,11 @@ public:
      *
      * @param [in] entry        Entry to prepare.
      */
-    CHIP_ERROR PrepareEntry(Entry & entry) { return mDelegate.PrepareEntry(entry); }
+    CHIP_ERROR PrepareEntry(Entry & entry)
+    {
+        VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+        return mDelegate->PrepareEntry(entry);
+    }
 
     /**
      * Creates an entry in the access control list.
@@ -397,7 +433,8 @@ public:
     CHIP_ERROR CreateEntry(size_t * index, const Entry & entry, FabricIndex * fabricIndex = nullptr)
     {
         ReturnErrorCodeIf(!IsValid(entry), CHIP_ERROR_INVALID_ARGUMENT);
-        return mDelegate.CreateEntry(index, entry, fabricIndex);
+        VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+        return mDelegate->CreateEntry(index, entry, fabricIndex);
     }
 
     /**
@@ -409,7 +446,8 @@ public:
      */
     CHIP_ERROR ReadEntry(size_t index, Entry & entry, const FabricIndex * fabricIndex = nullptr) const
     {
-        return mDelegate.ReadEntry(index, entry, fabricIndex);
+        VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+        return mDelegate->ReadEntry(index, entry, fabricIndex);
     }
 
     /**
@@ -422,7 +460,8 @@ public:
     CHIP_ERROR UpdateEntry(size_t index, const Entry & entry, const FabricIndex * fabricIndex = nullptr)
     {
         ReturnErrorCodeIf(!IsValid(entry), CHIP_ERROR_INVALID_ARGUMENT);
-        return mDelegate.UpdateEntry(index, entry, fabricIndex);
+        VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+        return mDelegate->UpdateEntry(index, entry, fabricIndex);
     }
 
     /**
@@ -433,7 +472,8 @@ public:
      */
     CHIP_ERROR DeleteEntry(size_t index, const FabricIndex * fabricIndex = nullptr)
     {
-        return mDelegate.DeleteEntry(index, fabricIndex);
+        VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+        return mDelegate->DeleteEntry(index, fabricIndex);
     }
 
     /**
@@ -444,7 +484,8 @@ public:
      */
     CHIP_ERROR Entries(EntryIterator & iterator, const FabricIndex * fabricIndex = nullptr) const
     {
-        return mDelegate.Entries(iterator, fabricIndex);
+        VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
+        return mDelegate->Entries(iterator, fabricIndex);
     }
 
     /**
@@ -461,7 +502,9 @@ private:
     bool IsValid(const Entry & entry);
 
     static Delegate mDefaultDelegate;
-    Delegate & mDelegate = mDefaultDelegate;
+    Delegate * mDelegate = &mDefaultDelegate;
+
+    bool mIsInitialized = false;
 };
 
 /**

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -357,7 +357,8 @@ public:
     AccessControl(const AccessControl &) = delete;
     AccessControl & operator=(const AccessControl &) = delete;
 
-    ~AccessControl() {
+    ~AccessControl()
+    {
         // Never-initialized AccessControl instances will not have the delegate set.
         if (mIsInitialized && mDelegate != nullptr)
         {

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -357,39 +357,23 @@ public:
     AccessControl(const AccessControl &) = delete;
     AccessControl & operator=(const AccessControl &) = delete;
 
-    ~AccessControl() { mDelegate->Release(); }
-
-    /**
-     * @brief Set the delegate that will handle access control entries. Must be called before Init().
-     *
-     * @param delegate - The delegate to use
-     * @return CHIP_NO_ERROR on success, CHIP_ERROR_INCORRECT_STATE if set after Init(), and
-     *         CHIP_ERROR_INVALID_ARGUMENT if delegate is null.
-     */
-    CHIP_ERROR SetDelegate(Delegate * delegate)
-    {
-        if (mIsInitialized)
+    ~AccessControl() {
+        // Never-initialized AccessControl instances will not have the delegate set.
+        if (mIsInitialized && mDelegate != nullptr)
         {
-            return CHIP_ERROR_INCORRECT_STATE;
+            mDelegate->Release();
         }
-        else if (delegate == nullptr)
-        {
-            return CHIP_ERROR_INVALID_ARGUMENT;
-        }
-
-        // De-initialize the default-set delegate.
-        mDelegate->Release();
-
-        mDelegate = delegate;
-        return CHIP_NO_ERROR;
     }
 
     /**
      * Initialize the access control module. Must be called before first use.
      *
-     * @retval various errors, probably fatal.
+     * @param delegate - The delegate to use for acces control
+     *
+     * @return CHIP_NO_ERROR on success, CHIP_ERROR_INCORRECT_STATE if called more than once,
+     *         CHIP_ERROR_INVALID_ARGUMENT if delegate is null, or other fatal error.
      */
-    CHIP_ERROR Init();
+    CHIP_ERROR Init(AccessControl::Delegate * delegate);
 
     /**
      * Deinitialize the access control module. Must be called when finished.
@@ -501,8 +485,7 @@ public:
 private:
     bool IsValid(const Entry & entry);
 
-    static Delegate mDefaultDelegate;
-    Delegate * mDelegate = &mDefaultDelegate;
+    Delegate * mDelegate = nullptr;
 
     bool mIsInitialized = false;
 };

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -1310,11 +1310,11 @@ namespace chip {
 namespace Access {
 namespace Examples {
 
-AccessControl::Delegate & GetAccessControlDelegate(PersistentStorageDelegate * storageDelegate)
+AccessControl::Delegate * GetAccessControlDelegate(PersistentStorageDelegate * storageDelegate)
 {
     static AccessControlDelegate accessControlDelegate;
     accessControlDelegate.SetStorageDelegate(storageDelegate);
-    return accessControlDelegate;
+    return &accessControlDelegate;
 }
 
 } // namespace Examples

--- a/src/access/examples/ExampleAccessControlDelegate.h
+++ b/src/access/examples/ExampleAccessControlDelegate.h
@@ -30,9 +30,9 @@ namespace Examples {
  *       not manage lifecycle considerations.
  *
  * @param storageDelegate Storage instance to access persisted ACL data.
- * @return a reference to the AccessControl::Delegate singleton.
+ * @return a pointer to the AccessControl::Delegate singleton.
  */
-AccessControl::Delegate & GetAccessControlDelegate(PersistentStorageDelegate * storageDelegate);
+AccessControl::Delegate * GetAccessControlDelegate(PersistentStorageDelegate * storageDelegate);
 
 } // namespace Examples
 } // namespace Access

--- a/src/access/examples/PermissiveAccessControlDelegate.cpp
+++ b/src/access/examples/PermissiveAccessControlDelegate.cpp
@@ -69,10 +69,10 @@ namespace chip {
 namespace Access {
 namespace Examples {
 
-AccessControl::Delegate & GetPermissiveAccessControlDelegate()
+AccessControl::Delegate * GetPermissiveAccessControlDelegate()
 {
     static AccessControlDelegate accessControlDelegate;
-    return accessControlDelegate;
+    return &accessControlDelegate;
 }
 
 } // namespace Examples

--- a/src/access/examples/PermissiveAccessControlDelegate.h
+++ b/src/access/examples/PermissiveAccessControlDelegate.h
@@ -22,7 +22,7 @@ namespace chip {
 namespace Access {
 namespace Examples {
 
-AccessControl::Delegate & GetPermissiveAccessControlDelegate();
+AccessControl::Delegate * GetPermissiveAccessControlDelegate();
 
 } // namespace Examples
 } // namespace Access

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -33,7 +33,7 @@ using Entry         = AccessControl::Entry;
 using EntryIterator = AccessControl::EntryIterator;
 using Target        = Entry::Target;
 
-AccessControl accessControl(Examples::GetAccessControlDelegate(nullptr));
+AccessControl accessControl;
 
 constexpr ClusterId kOnOffCluster         = 0x0000'0006;
 constexpr ClusterId kLevelControlCluster  = 0x0000'0008;
@@ -2133,6 +2133,8 @@ void TestUpdateEntry(nlTestSuite * inSuite, void * inContext)
 
 int Setup(void * inContext)
 {
+    AccessControl::Delegate *delegate = Examples::GetAccessControlDelegate(nullptr);
+    accessControl.SetDelegate(delegate);
     SetAccessControl(accessControl);
     GetAccessControl().Init();
     return SUCCESS;

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -2134,9 +2134,8 @@ void TestUpdateEntry(nlTestSuite * inSuite, void * inContext)
 int Setup(void * inContext)
 {
     AccessControl::Delegate * delegate = Examples::GetAccessControlDelegate(nullptr);
-    accessControl.SetDelegate(delegate);
     SetAccessControl(accessControl);
-    GetAccessControl().Init();
+    VerifyOrDie(GetAccessControl().Init(delegate) == CHIP_NO_ERROR);
     return SUCCESS;
 }
 

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -2133,7 +2133,7 @@ void TestUpdateEntry(nlTestSuite * inSuite, void * inContext)
 
 int Setup(void * inContext)
 {
-    AccessControl::Delegate *delegate = Examples::GetAccessControlDelegate(nullptr);
+    AccessControl::Delegate * delegate = Examples::GetAccessControlDelegate(nullptr);
     accessControl.SetDelegate(delegate);
     SetAccessControl(accessControl);
     GetAccessControl().Init();

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -107,13 +107,13 @@ Server::Server() :
         .devicePool        = &mDevicePool,
         .dnsResolver       = nullptr,
     }),
-    mCommissioningWindowManager(this), mGroupsProvider(mDeviceStorage), mAttributePersister(mDeviceStorage),
-    mAccessControl(Access::Examples::GetAccessControlDelegate(&mDeviceStorage))
-{}
+    mCommissioningWindowManager(this), mGroupsProvider(mDeviceStorage), mAttributePersister(mDeviceStorage) {}
 
 CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint16_t unsecureServicePort,
                         Inet::InterfaceId interfaceId)
 {
+    Access::AccessControl::Delegate * accessDelegate = nullptr;
+
     mSecuredServicePort   = secureServicePort;
     mUnsecuredServicePort = unsecureServicePort;
     mInterfaceId          = interfaceId;
@@ -143,6 +143,10 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
     SetGroupDataProvider(&mGroupsProvider);
 
     // Access control must be initialized after mDeviceStorage.
+    accessDelegate = Access::Examples::GetAccessControlDelegate(&mDeviceStorage);
+    VerifyOrExit(accessDelegate != nullptr, ChipLogError(AppServer, "Invalid access delegate found."));
+    mAccessControl.SetDelegate(accessDelegate);
+
     err = mAccessControl.Init();
     SuccessOrExit(err);
     Access::SetAccessControl(mAccessControl);

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -107,7 +107,8 @@ Server::Server() :
         .devicePool        = &mDevicePool,
         .dnsResolver       = nullptr,
     }),
-    mCommissioningWindowManager(this), mGroupsProvider(mDeviceStorage), mAttributePersister(mDeviceStorage) {}
+    mCommissioningWindowManager(this), mGroupsProvider(mDeviceStorage), mAttributePersister(mDeviceStorage)
+{}
 
 CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint16_t unsecureServicePort,
                         Inet::InterfaceId interfaceId)

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -146,9 +146,8 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
     // Access control must be initialized after mDeviceStorage.
     accessDelegate = Access::Examples::GetAccessControlDelegate(&mDeviceStorage);
     VerifyOrExit(accessDelegate != nullptr, ChipLogError(AppServer, "Invalid access delegate found."));
-    mAccessControl.SetDelegate(accessDelegate);
 
-    err = mAccessControl.Init();
+    err = mAccessControl.Init(accessDelegate);
     SuccessOrExit(err);
     Access::SetAccessControl(mAccessControl);
 

--- a/src/app/tests/AppTestContext.cpp
+++ b/src/app/tests/AppTestContext.cpp
@@ -24,7 +24,7 @@
 
 namespace {
 
-chip::Access::AccessControl permissiveAccessControl(chip::Access::Examples::GetPermissiveAccessControlDelegate());
+chip::Access::AccessControl gPermissiveAccessControl;
 
 } // namespace
 
@@ -36,7 +36,8 @@ CHIP_ERROR AppContext::Init()
     ReturnErrorOnFailure(Super::Init());
     ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->Init(&GetExchangeManager()));
 
-    Access::SetAccessControl(permissiveAccessControl);
+    gPermissiveAccessControl.SetDelegate(chip::Access::Examples::GetPermissiveAccessControlDelegate());
+    Access::SetAccessControl(gPermissiveAccessControl);
     ReturnErrorOnFailure(Access::GetAccessControl().Init());
 
     return CHIP_NO_ERROR;

--- a/src/app/tests/AppTestContext.cpp
+++ b/src/app/tests/AppTestContext.cpp
@@ -36,9 +36,8 @@ CHIP_ERROR AppContext::Init()
     ReturnErrorOnFailure(Super::Init());
     ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->Init(&GetExchangeManager()));
 
-    gPermissiveAccessControl.SetDelegate(chip::Access::Examples::GetPermissiveAccessControlDelegate());
     Access::SetAccessControl(gPermissiveAccessControl);
-    ReturnErrorOnFailure(Access::GetAccessControl().Init());
+    ReturnErrorOnFailure(Access::GetAccessControl().Init(chip::Access::Examples::GetPermissiveAccessControlDelegate()));
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Problem
- This PR is on the path towards having Server::Server no longer
  statically initialize its members with storage, and instead
  relying on Server::Init(). This will simplify organization
  of unit tests and also the convergence of Controller/Server
  storage to address issue #16028

Issue #16028

#### Change overview

- This PR separates init of AccessControl so that the delegate need not be
  passed to the Constructor, which allows simpler splitting of storage
  init and decoupling from Server::Server() static inializer list.
- This is a structural, non-functional change, touching only AccessControl.

#### Testing
- Ran cert tests, still pass
- Ran unit tests after structural adaptation, still pass
