### PR TITLE
Fix BLE commissioning with iOS CHIPTool.

### DIFF
--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -226,6 +226,8 @@ public:
         return LoadSecureSessionParametersIfNeeded(loadedSecureSession);
     };
 
+    Transport::Type GetDeviceTransportType() const { return mDeviceAddress.GetTransportType(); }
+
 private:
     enum class ConnectionState
     {

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -479,10 +479,20 @@
     if (error != nil) {
         NSLog(@"Got pairing error back %@", error);
     } else {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self->_deviceList refreshDeviceList];
-            [self retrieveAndSendWiFiCredentials];
-        });
+        CHIPDeviceController * controller = [CHIPDeviceController sharedController];
+        uint64_t deviceId = CHIPGetLastPairedDeviceId();
+        if ([controller deviceBeingCommissionedOverBLE:deviceId]) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self->_deviceList refreshDeviceList];
+                [self retrieveAndSendWiFiCredentials];
+            });
+        } else {
+            CHIPCommissioningParameters * params = [[CHIPCommissioningParameters alloc] init];
+            NSError * error;
+            if (![controller commissionDevice:deviceId commissioningParams:params error:&error]) {
+                NSLog(@"Failed to commission Device %llu, with error %@", deviceId, error);
+            }
+        }
     }
 }
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -70,6 +70,12 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
                                        setupPIN:(NSUInteger)setupPIN
                                           error:(NSError * __autoreleasing *)error;
 
+/**
+ * Temporary until PairingDelegate is fixed to clearly communicate this
+ * information to consumers.
+ */
+- (BOOL)deviceBeingCommissionedOverBLE:(uint64_t)deviceId;
+
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceControllerOverXPC.m
+++ b/src/darwin/Framework/CHIP/CHIPDeviceControllerOverXPC.m
@@ -103,6 +103,12 @@ static void SetupXPCQueue(void)
     return nil;
 }
 
+- (BOOL)deviceBeingCommissionedOverBLE:(uint64_t)deviceId
+{
+    CHIP_LOG_ERROR("CHIPDevice doesn't support deviceBeingCommissionedOverBLE over XPC");
+    return NO;
+}
+
 - (BOOL)getConnectedDevice:(uint64_t)deviceID
                      queue:(dispatch_queue_t)queue
          completionHandler:(CHIPDeviceConnectionCallback)completionHandler


### PR DESCRIPTION
Two changes:

1. Fix BLE commissioning by explicitly using EstablishPASESession so
   we get a chance to provide network credentials after that's done.

2. Fix the CHIPTool UI for the on-network case to not prompt for
   network credentials after the PASE session is established by exposing
   whether the device being commissioned is connected over BLE or not.

We need a better plan for how to handle that last bit, but that will
probably be part of the general PairingDelegate redesign.

Fixes https://github.com/project-chip/connectedhomeip/issues/16053

#### Problem
iOS CHIPTool can't commission over BLE.

#### Change overview
See above.

#### Testing
Verified that I can commission both an m5stack over BLE and chip-clusters-app on my laptop on-network.