### PR TITLE
GroupDataProvider: PersistentStorageDelegate Initialization

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -176,7 +176,7 @@ uint32_t InteractionModelEngine::GetNumActiveWriteHandlers() const
 }
 
 void InteractionModelEngine::CloseTransactionsFromFabricIndex(FabricIndex aFabricIndex)
-{ 
+{
     //
     // Walk through all existing subscriptions and shut down those whose subscriber matches
     // that which just came in.

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -105,9 +105,7 @@ Server::Server() :
         .dnsCache          = nullptr,
 #endif
         .devicePool        = &mDevicePool,
-        .dnsResolver       = nullptr,
-    }),
-    mGroupsProvider(mDeviceStorage)
+    })
 {}
 
 CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint16_t unsecureServicePort,
@@ -142,6 +140,7 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
     app::DnssdServer::Instance().SetCommissioningModeProvider(&mCommissioningWindowManager);
 
     // Group data provider must be initialized after mDeviceStorage
+    mGroupsProvider.SetStorageDelegate(&mDeviceStorage);
     err = mGroupsProvider.Init();
     SuccessOrExit(err);
     SetGroupDataProvider(&mGroupsProvider);
@@ -258,7 +257,7 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
                                                     &mSessions, &mFabrics);
     SuccessOrExit(err);
 
-    err = mCASESessionManager.Init();
+    err = mCASESessionManager.Init(&DeviceLayer::SystemLayer());
 
     // This code is necessary to restart listening to existing groups after a reboot
     // Each manufacturer needs to validate that they can rejoin groups by placing this code at the appropriate location for them

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -105,27 +105,32 @@ Server::Server() :
         .dnsCache          = nullptr,
 #endif
         .devicePool        = &mDevicePool,
+        .dnsResolver       = nullptr,
     }),
-    mCommissioningWindowManager(this), mGroupsProvider(), mAttributePersister(mDeviceStorage),
-    mAccessControl(Access::Examples::GetAccessControlDelegate(&mDeviceStorage))
+    mGroupsProvider(mDeviceStorage)
 {}
 
 CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint16_t unsecureServicePort,
                         Inet::InterfaceId interfaceId)
 {
+    Access::AccessControl::Delegate * accessDelegate = nullptr;
+
     mSecuredServicePort   = secureServicePort;
     mUnsecuredServicePort = unsecureServicePort;
     mInterfaceId          = interfaceId;
 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+    // TODO: Remove chip::Platform::MemoryInit() call from Server class, it belongs to outer code
     chip::Platform::MemoryInit();
 
+    SuccessOrExit(err = mCommissioningWindowManager.Init(this));
     mCommissioningWindowManager.SetAppDelegate(delegate);
     mCommissioningWindowManager.SetSessionIDAllocator(&mSessionIDAllocator);
 
     // Set up attribute persistence before we try to bring up the data model
     // handler.
+    SuccessOrExit(mAttributePersister.Init(&mDeviceStorage));
     SetAttributePersistenceProvider(&mAttributePersister);
 
     InitDataModelHandler(&mExchangeMgr);
@@ -137,13 +142,15 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
     app::DnssdServer::Instance().SetCommissioningModeProvider(&mCommissioningWindowManager);
 
     // Group data provider must be initialized after mDeviceStorage
-    mGroupsProvider.SetStorageDelegate(&mDeviceStorage);
     err = mGroupsProvider.Init();
     SuccessOrExit(err);
     SetGroupDataProvider(&mGroupsProvider);
 
     // Access control must be initialized after mDeviceStorage.
-    err = mAccessControl.Init();
+    accessDelegate = Access::Examples::GetAccessControlDelegate(&mDeviceStorage);
+    VerifyOrExit(accessDelegate != nullptr, ChipLogError(AppServer, "Invalid access delegate found."));
+
+    err = mAccessControl.Init(accessDelegate);
     SuccessOrExit(err);
     Access::SetAccessControl(mAccessControl);
 
@@ -251,7 +258,7 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
                                                     &mSessions, &mFabrics);
     SuccessOrExit(err);
 
-    err = mCASESessionManager.Init(&DeviceLayer::SystemLayer());
+    err = mCASESessionManager.Init();
 
     // This code is necessary to restart listening to existing groups after a reboot
     // Each manufacturer needs to validate that they can rejoin groups by placing this code at the appropriate location for them
@@ -337,8 +344,12 @@ void Server::Shutdown()
     }
     mSessions.Shutdown();
     mTransports.Close();
+
+    mAttributePersister.Shutdown();
     mCommissioningWindowManager.Shutdown();
     mCASESessionManager.Shutdown();
+
+    // TODO: Remove chip::Platform::MemoryInit() call from Server class, it belongs to outer code
     chip::Platform::MemoryShutdown();
 }
 

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -24,7 +24,6 @@
 #include <app/util/basic-types.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CHIPError.h>
-#include <lib/core/CHIPPersistentStorageDelegate.h>
 
 namespace chip {
 namespace Credentials {
@@ -222,15 +221,15 @@ public:
     uint16_t GetMaxGroupKeysPerFabric() { return mMaxGroupKeysPerFabric; }
 
     /**
-     *  Initialize the GroupDataProvider, including any persistent data store
-     *  initialization. Must be called once before any other API succeeds.
+     *  Initialize the GroupDataProvider, including possilby any persistent
+     *  data store initialization done by the implementation. Must be called once
+     *  before any other API succeeds.
      *
      *  @retval #CHIP_ERROR_INCORRECT_STATE if called when already initialized.
      *  @retval #CHIP_NO_ERROR on success
      */
     virtual CHIP_ERROR Init()                                            = 0;
     virtual void Finish()                                                = 0;
-    virtual void SetStorageDelegate(PersistentStorageDelegate * storage) = 0;
 
     //
     // Group Table

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -228,8 +228,8 @@ public:
      *  @retval #CHIP_ERROR_INCORRECT_STATE if called when already initialized.
      *  @retval #CHIP_NO_ERROR on success
      */
-    virtual CHIP_ERROR Init()                                            = 0;
-    virtual void Finish()                                                = 0;
+    virtual CHIP_ERROR Init() = 0;
+    virtual void Finish()     = 0;
 
     //
     // Group Table

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -228,8 +228,9 @@ public:
      *  @retval #CHIP_ERROR_INCORRECT_STATE if called when already initialized.
      *  @retval #CHIP_NO_ERROR on success
      */
-    virtual CHIP_ERROR Init(PersistentStorageDelegate * storage) = 0;
-    virtual void Finish()                                        = 0;
+    virtual CHIP_ERROR Init()                                            = 0;
+    virtual void Finish()                                                = 0;
+    virtual void SetStorageDelegate(PersistentStorageDelegate * storage) = 0;
 
     //
     // Group Table

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -24,6 +24,7 @@
 #include <app/util/basic-types.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CHIPError.h>
+#include <lib/core/CHIPPersistentStorageDelegate.h>
 
 namespace chip {
 namespace Credentials {
@@ -227,8 +228,8 @@ public:
      *  @retval #CHIP_ERROR_INCORRECT_STATE if called when already initialized.
      *  @retval #CHIP_NO_ERROR on success
      */
-    virtual CHIP_ERROR Init() = 0;
-    virtual void Finish()     = 0;
+    virtual CHIP_ERROR Init(PersistentStorageDelegate * storage) = 0;
+    virtual void Finish()                                        = 0;
 
     //
     // Group Table

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -221,7 +221,7 @@ public:
     uint16_t GetMaxGroupKeysPerFabric() { return mMaxGroupKeysPerFabric; }
 
     /**
-     *  Initialize the GroupDataProvider, including possilby any persistent
+     *  Initialize the GroupDataProvider, including possibly any persistent
      *  data store initialization done by the implementation. Must be called once
      *  before any other API succeeds.
      *

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -904,6 +904,7 @@ void GroupDataProviderImpl::Finish()
 
 void GroupDataProviderImpl::SetStorageDelegate(PersistentStorageDelegate * storage)
 {
+    VerifyOrDie(storage != nullptr);
     mStorage = storage;
 }
 

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <credentials/GroupDataProvider.h>
-#include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/support/Pool.h>
 
 namespace chip {
@@ -28,15 +27,13 @@ class GroupDataProviderImpl : public GroupDataProvider
 public:
     static constexpr size_t kIteratorsMax = CHIP_CONFIG_MAX_GROUP_CONCURRENT_ITERATORS;
 
-    GroupDataProviderImpl(chip::PersistentStorageDelegate & storage_delegate) : mStorage(storage_delegate) {}
-    GroupDataProviderImpl(chip::PersistentStorageDelegate & storage_delegate, uint16_t maxGroupsPerFabric,
-                          uint16_t maxGroupKeysPerFabric) :
-        GroupDataProvider(maxGroupsPerFabric, maxGroupKeysPerFabric),
-        mStorage(storage_delegate)
+    GroupDataProviderImpl() = default;
+    GroupDataProviderImpl(uint16_t maxGroupsPerFabric, uint16_t maxGroupKeysPerFabric) :
+        GroupDataProvider(maxGroupsPerFabric, maxGroupKeysPerFabric)
     {}
     virtual ~GroupDataProviderImpl() {}
 
-    CHIP_ERROR Init() override;
+    CHIP_ERROR Init(PersistentStorageDelegate * storage) override;
     void Finish() override;
 
     //
@@ -215,8 +212,8 @@ protected:
     };
     CHIP_ERROR RemoveEndpoints(FabricIndex fabric_index, GroupId group_id);
 
-    chip::PersistentStorageDelegate & mStorage;
-    bool mInitialized = false;
+    chip::PersistentStorageDelegate * mStorage = nullptr;
+    bool mInitialized                          = false;
     ObjectPool<GroupInfoIteratorImpl, kIteratorsMax> mGroupInfoIterators;
     ObjectPool<GroupKeyIteratorImpl, kIteratorsMax> mGroupKeyIterators;
     ObjectPool<EndpointIteratorImpl, kIteratorsMax> mEndpointIterators;

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -33,8 +33,9 @@ public:
     {}
     virtual ~GroupDataProviderImpl() {}
 
-    CHIP_ERROR Init(PersistentStorageDelegate * storage) override;
+    CHIP_ERROR Init() override;
     void Finish() override;
+    void SetStorageDelegate(PersistentStorageDelegate * storage) override;
 
     //
     // Group Info
@@ -210,10 +211,10 @@ protected:
         bool mFirstMap           = true;
         GroupKeyContext mKeyContext;
     };
+    bool IsInitialized() { return (mStorage == nullptr); }
     CHIP_ERROR RemoveEndpoints(FabricIndex fabric_index, GroupId group_id);
 
     chip::PersistentStorageDelegate * mStorage = nullptr;
-    bool mInitialized                          = false;
     ObjectPool<GroupInfoIteratorImpl, kIteratorsMax> mGroupInfoIterators;
     ObjectPool<GroupKeyIteratorImpl, kIteratorsMax> mGroupKeyIterators;
     ObjectPool<EndpointIteratorImpl, kIteratorsMax> mEndpointIterators;

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <credentials/GroupDataProvider.h>
+#include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/support/Pool.h>
 
 namespace chip {
@@ -33,9 +34,16 @@ public:
     {}
     virtual ~GroupDataProviderImpl() {}
 
+    /**
+     * @brief Set the storage implementation used for non-volatile storage of configuration data.
+     *        This method MUST be called before Init().
+     *
+     * @param storage Pointer to storage instance to set. Cannot be nullptr, will assert.
+     */
+    void SetStorageDelegate(PersistentStorageDelegate * storage);
+
     CHIP_ERROR Init() override;
     void Finish() override;
-    void SetStorageDelegate(PersistentStorageDelegate * storage) override;
 
     //
     // Group Info
@@ -211,7 +219,7 @@ protected:
         bool mFirstMap           = true;
         GroupKeyContext mKeyContext;
     };
-    bool IsInitialized() { return (mStorage == nullptr); }
+    bool IsInitialized() { return (mStorage != nullptr); }
     CHIP_ERROR RemoveEndpoints(FabricIndex fabric_index, GroupId group_id);
 
     chip::PersistentStorageDelegate * mStorage = nullptr;

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -1116,8 +1116,7 @@ void TestGroupDecryption(nlTestSuite * apSuite, void * apContext)
 namespace {
 
 static chip::TestPersistentStorageDelegate sDelegate;
-static GroupDataProviderImpl sProvider(sDelegate, chip::app::TestGroups::kMaxGroupsPerFabric,
-                                       chip::app::TestGroups::kMaxGroupKeysPerFabric);
+static GroupDataProviderImpl sProvider(chip::app::TestGroups::kMaxGroupsPerFabric, chip::app::TestGroups::kMaxGroupKeysPerFabric);
 
 static EpochKey kEpochKeys0[] = {
     { 0x0000000000000000, { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } },
@@ -1145,12 +1144,13 @@ static EpochKey kEpochKeys3[] = {
  */
 int Test_Setup(void * inContext)
 {
-    SetGroupDataProvider(&sProvider);
     VerifyOrReturnError(CHIP_NO_ERROR == chip::Platform::MemoryInit(), FAILURE);
-    VerifyOrReturnError(CHIP_NO_ERROR == sProvider.Init(), FAILURE);
 
+    // Initialize Group Data Provider
+    VerifyOrReturnError(CHIP_NO_ERROR == sProvider.Init(&sDelegate), FAILURE);
     // Event listener
     sProvider.SetListener(&chip::app::TestGroups::sListener);
+    SetGroupDataProvider(&sProvider);
 
     memcpy(chip::app::TestGroups::kKeySet0.epoch_keys, kEpochKeys0, sizeof(kEpochKeys0));
     memcpy(chip::app::TestGroups::kKeySet1.epoch_keys, kEpochKeys1, sizeof(kEpochKeys1));

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -1147,9 +1147,9 @@ int Test_Setup(void * inContext)
     VerifyOrReturnError(CHIP_NO_ERROR == chip::Platform::MemoryInit(), FAILURE);
 
     // Initialize Group Data Provider
-    VerifyOrReturnError(CHIP_NO_ERROR == sProvider.Init(&sDelegate), FAILURE);
-    // Event listener
+    sProvider.SetStorageDelegate(&sDelegate);
     sProvider.SetListener(&chip::app::TestGroups::sListener);
+    VerifyOrReturnError(CHIP_NO_ERROR == sProvider.Init(), FAILURE);
     SetGroupDataProvider(&sProvider);
 
     memcpy(chip::app::TestGroups::kKeySet0.epoch_keys, kEpochKeys0, sizeof(kEpochKeys0));

--- a/src/lib/support/TestGroupData.h
+++ b/src/lib/support/TestGroupData.h
@@ -27,7 +27,7 @@ constexpr uint16_t kMaxGroupsPerFabric    = 5;
 constexpr uint16_t kMaxGroupKeysPerFabric = 8;
 
 static chip::TestPersistentStorageDelegate sDeviceStorage;
-static chip::Credentials::GroupDataProviderImpl sGroupsProvider(sDeviceStorage, kMaxGroupsPerFabric, kMaxGroupKeysPerFabric);
+static chip::Credentials::GroupDataProviderImpl sGroupsProvider(kMaxGroupsPerFabric, kMaxGroupKeysPerFabric);
 
 static const chip::GroupId kGroup1   = 0x0101;
 static const chip::GroupId kGroup2   = 0x0102;
@@ -42,7 +42,7 @@ namespace GroupTesting {
 
 CHIP_ERROR InitProvider()
 {
-    ReturnErrorOnFailure(sGroupsProvider.Init());
+    ReturnErrorOnFailure(sGroupsProvider.Init(&sDeviceStorage));
     chip::Credentials::SetGroupDataProvider(&sGroupsProvider);
     return CHIP_NO_ERROR;
 }

--- a/src/lib/support/TestGroupData.h
+++ b/src/lib/support/TestGroupData.h
@@ -42,7 +42,8 @@ namespace GroupTesting {
 
 CHIP_ERROR InitProvider()
 {
-    ReturnErrorOnFailure(sGroupsProvider.Init(&sDeviceStorage));
+    sGroupsProvider.SetStorageDelegate(&sDeviceStorage);
+    ReturnErrorOnFailure(sGroupsProvider.Init());
     chip::Credentials::SetGroupDataProvider(&sGroupsProvider);
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Problem
The storage delegate should be injected using the Init() method, instead of the constructor
* Relates to [#16028](https://github.com/project-chip/connectedhomeip/issues/16028)

#### Change overview
* The storage delegate is now an argument of the GroupDataProvider::Init()
* Group data provider implementation updated accordingly
* Calls to the GroupDataProvider constructors, and Init() updated accordingly

#### Testing
Group, and Group Data Provider unit tests and YAML tests ran successfully.
