### PR TITLE
Remove extra namespace scope identifier

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -84,10 +84,8 @@ BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
 #endif
 
-namespace {
 app::Clusters::NetworkCommissioning::Instance
     sWiFiNetworkCommissioningInstance(0 /* Endpoint Id */, &(NetworkCommissioning::ESPWiFiDriver::GetInstance()));
-} // namespace
 
 class AppCallbacks : public AppDelegate
 {


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Already in namespace {}, extra namespace with same scope identifier

#### Change overview
Remove extra namespace scope identifier

#### Testing
How was this tested? (at least one bullet point required)
* Cleanup only, no logic change
