### PR TITLE
Use unified APIs to initialize and shutdown app layer and platform la…

### DIFF
--- a/examples/all-clusters-app/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/all-clusters-app/ameba/main/CHIPDeviceManager.cpp
@@ -54,11 +54,8 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     CHIP_ERROR err;
     mCB = cb;
 
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
-
-    // Initialize the CHIP stack.
-    err = PlatformMgr().InitChipStack();
+    // Init Matter App Server and ZCL Data Model
+    err = MatterServerScheduleInit();
     SuccessOrExit(err);
 
     if (CONFIG_NETWORK_LAYER_BLE)

--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -134,9 +134,6 @@ static void InitOTARequestor(void)
 
 static void InitServer(intptr_t context)
 {
-    // Init ZCL Data Model and CHIP App Server
-    chip::Server::GetInstance().Init();
-
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
     NetWorkCommissioningInstInit();

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -84,25 +84,8 @@ BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
 #endif
 
-namespace {
 app::Clusters::NetworkCommissioning::Instance
     sWiFiNetworkCommissioningInstance(0 /* Endpoint Id */, &(NetworkCommissioning::ESPWiFiDriver::GetInstance()));
-} // namespace
-
-class AppCallbacks : public AppDelegate
-{
-public:
-    void OnRendezvousStarted() override { bluetoothLED.Set(true); }
-    void OnRendezvousStopped() override
-    {
-        bluetoothLED.Set(false);
-        pairingWindowLED.Set(false);
-    }
-    void OnPairingWindowOpened() override { pairingWindowLED.Set(true); }
-    void OnPairingWindowClosed() override { pairingWindowLED.Set(false); }
-};
-
-AppCallbacks sCallbacks;
 
 constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
 
@@ -110,9 +93,6 @@ constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
 
 static void InitServer(intptr_t context)
 {
-    // Init ZCL Data Model and CHIP App Server
-    chip::Server::GetInstance().Init(&sCallbacks);
-
     // We only have network commissioning on endpoint 0.
     emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);
 

--- a/examples/all-clusters-app/linux/fuzzing-main.cpp
+++ b/examples/all-clusters-app/linux/fuzzing-main.cpp
@@ -35,13 +35,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * aData, size_t aSize)
     static bool matterStackInitialized = false;
     if (!matterStackInitialized)
     {
-        // Might be simpler to do ChipLinuxAppInit() with argc == 0, argv set to
-        // just a fake executable name?
-        VerifyOrDie(Platform::MemoryInit() == CHIP_NO_ERROR);
-        VerifyOrDie(PlatformMgr().InitChipStack() == CHIP_NO_ERROR);
-
         // ChipLinuxAppMainLoop blocks, and we don't want that here.
-        VerifyOrDie(Server::GetInstance().Init() == CHIP_NO_ERROR);
+        VerifyOrDie(MatterServerInit() == CHIP_NO_ERROR);
 
         ApplicationInit();
 

--- a/examples/all-clusters-app/mbed/main/AppTask.cpp
+++ b/examples/all-clusters-app/mbed/main/AppTask.cpp
@@ -62,14 +62,6 @@ int AppTask::Init()
         },
         0);
 
-    // Init ZCL Data Model and start server
-    error = Server::GetInstance().Init();
-    if (error != CHIP_NO_ERROR)
-    {
-        ChipLogError(NotSpecified, "Server initialization failed: %s", error.AsString());
-        return EXIT_FAILURE;
-    }
-
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
     ConfigurationMgr().LogDeviceConfig();

--- a/examples/all-clusters-app/mbed/main/main.cpp
+++ b/examples/all-clusters-app/mbed/main/main.cpp
@@ -19,6 +19,7 @@
 #include "AppTask.h"
 
 #include "mbedtls/platform.h"
+#include <app/server/Server.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -45,18 +46,10 @@ int main(int argc, char * argv[])
         goto exit;
     }
 
-    err = chip::Platform::MemoryInit();
+    err = MatterServerScheduleInit();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(NotSpecified, "Memory initialization failed: %s", err.AsString());
-        ret = EXIT_FAILURE;
-        goto exit;
-    }
-
-    err = PlatformMgr().InitChipStack();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(NotSpecified, "Chip stack initialization failed: %s", err.AsString());
+        ChipLogError(NotSpecified, "Matter App Server and ZCL Data Model initialization failed: %s", err.AsString());
         ret = EXIT_FAILURE;
         goto exit;
     }

--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -71,17 +71,10 @@ CHIP_ERROR AppTask::Init()
     // Initialize CHIP stack
     LOG_INF("Init CHIP stack");
 
-    CHIP_ERROR err = chip::Platform::MemoryInit();
+    err = MatterServerScheduleInit();
     if (err != CHIP_NO_ERROR)
     {
-        LOG_ERR("Platform::MemoryInit() failed");
-        return err;
-    }
-
-    err = PlatformMgr().InitChipStack();
-    if (err != CHIP_NO_ERROR)
-    {
-        LOG_ERR("PlatformMgr().InitChipStack() failed");
+        LOG_ERR("Init Matter App Server and ZCL Data Model failed");
         return err;
     }
 
@@ -125,7 +118,6 @@ CHIP_ERROR AppTask::Init()
 
     // Initialize CHIP server
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-    ReturnErrorOnFailure(chip::Server::GetInstance().Init());
     ConfigurationMgr().LogDeviceConfig();
     PrintOnboardingCodes(chip::RendezvousInformationFlag(chip::RendezvousInformationFlag::kBLE));
     InitOTARequestor();

--- a/examples/all-clusters-app/p6/src/AppTask.cpp
+++ b/examples/all-clusters-app/p6/src/AppTask.cpp
@@ -112,8 +112,6 @@ CHIP_ERROR AppTask::Init()
             }
         },
         0);
-    // Init ZCL Data Model
-    chip::Server::GetInstance().Init();
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());

--- a/examples/all-clusters-app/p6/src/main.cpp
+++ b/examples/all-clusters-app/p6/src/main.cpp
@@ -77,9 +77,6 @@ extern "C" void vApplicationIdleHook(void)
 
 extern "C" void vApplicationDaemonTaskStartupHook()
 {
-    // Init Chip memory management before the stack
-    chip::Platform::MemoryInit();
-
     /* Create the Main task. */
     xTaskCreate(main_task, "Main task", MAIN_TASK_STACK_SIZE, NULL, MAIN_TASK_PRIORITY, NULL);
 }
@@ -93,10 +90,10 @@ static void main_task(void * pvParameters)
         appError(ret);
     }
 
-    ret = PlatformMgr().InitChipStack();
+    ret = MatterServerScheduleInit();
     if (ret != CHIP_NO_ERROR)
     {
-        P6_LOG("PlatformMgr().InitChipStack() failed");
+        P6_LOG("Init Matter App Server and ZCL Data Model failed");
         appError(ret);
     }
 

--- a/examples/lighting-app/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/lighting-app/ameba/main/CHIPDeviceManager.cpp
@@ -37,6 +37,7 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <app-common/zap-generated/command-id.h>
+#include <app/server/Server.h>
 #include <app/util/af-types.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/util.h>
@@ -63,10 +64,8 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     CHIP_ERROR err;
     mCB = cb;
 
-    err = Platform::MemoryInit();
-    SuccessOrExit(err);
-
-    err = PlatformMgr().InitChipStack();
+    // Init Matter App Server and ZCL Data Model
+    err = MatterServerScheduleInit();
     SuccessOrExit(err);
 
     if (CONFIG_NETWORK_LAYER_BLE)
@@ -74,7 +73,8 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
         ConnectivityMgr().SetBLEAdvertisingEnabled(true);
     }
 
-    PlatformMgr().AddEventHandler(CHIPDeviceManager::CommonDeviceEventHandler, reinterpret_cast<intptr_t>(cb));
+    err = PlatformMgr().AddEventHandler(CHIPDeviceManager::CommonDeviceEventHandler, reinterpret_cast<intptr_t>(cb));
+    SuccessOrExit(err);
 
     // // Start a task to run the CHIP Device event loop.
     err = PlatformMgr().StartEventLoopTask();

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -155,9 +155,6 @@ static Identify gIdentify1 = {
 
 static void InitServer(intptr_t context)
 {
-    // Init ZCL Data Model and CHIP App Server
-    chip::Server::GetInstance().Init();
-
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
     NetWorkCommissioningInstInit();

--- a/examples/lighting-app/cyw30739/src/main.cpp
+++ b/examples/lighting-app/cyw30739/src/main.cpp
@@ -56,12 +56,6 @@ APPLICATION_START()
 
     mbedtls_platform_set_calloc_free(CHIPPlatformMemoryCalloc, CHIPPlatformMemoryFree);
 
-    err = chip::Platform::MemoryInit();
-    if (err != CHIP_NO_ERROR)
-    {
-        printf("ERROR MemoryInit %ld\n", err.AsInteger());
-    }
-
     result = app_button_init();
     if (result != WICED_SUCCESS)
     {
@@ -73,11 +67,11 @@ APPLICATION_START()
     if (result != WICED_SUCCESS)
         printf("wiced_led_manager_init fail (%d)\n", result);
 
-    printf("Initializing CHIP\n");
-    err = PlatformMgr().InitChipStack();
+    printf("Initializing Matter App Server and ZCL Data Model\n");
+    err = MatterServerScheduleInit();
     if (err != CHIP_NO_ERROR)
     {
-        printf("ERROR InitChipStack %ld\n", err.AsInteger());
+        printf("ERROR Init Matter App Server and ZCL Data Model %ld\n", err.AsInteger());
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
@@ -134,9 +128,6 @@ void InitApp(intptr_t args)
     ConfigurationMgr().LogDeviceConfig();
 
     PlatformMgrImpl().AddEventHandler(EventHandler, 0);
-
-    /* Start CHIP datamodel server */
-    chip::Server::GetInstance().Init();
 
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 

--- a/examples/lighting-app/efr32/src/main.cpp
+++ b/examples/lighting-app/efr32/src/main.cpp
@@ -134,16 +134,16 @@ int main(void)
     EFR32_LOG("==================================================");
 
     EFR32_LOG("Init CHIP Stack");
-    // Init Chip memory management before the stack
-    chip::Platform::MemoryInit();
-    chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init();
 
-    CHIP_ERROR ret = PlatformMgr().InitChipStack();
+    // Init Matter App Server and ZCL Data Model
+    CHIP_ERROR ret = MatterServerScheduleInit();
     if (ret != CHIP_NO_ERROR)
     {
-        EFR32_LOG("PlatformMgr().InitChipStack() failed");
+        EFR32_LOG("Init Matter App Server and ZCL Data Model failed");
         appError(ret);
     }
+
+    chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init();
     chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(BLE_DEV_NAME);
 #if CHIP_ENABLE_OPENTHREAD
     EFR32_LOG("Initializing OpenThread stack");
@@ -168,11 +168,6 @@ int main(void)
         appError(ret);
     }
 #endif // CHIP_ENABLE_OPENTHREAD
-
-    chip::DeviceLayer::PlatformMgr().LockChipStack();
-    // Init ZCL Data Model
-    chip::Server::GetInstance().Init();
-    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
     EFR32_LOG("Starting Platform Manager Event Loop");
     ret = PlatformMgr().StartEventLoopTask();

--- a/examples/lighting-app/esp32/main/main.cpp
+++ b/examples/lighting-app/esp32/main/main.cpp
@@ -32,7 +32,6 @@
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
 #include <app/server/OnboardingCodesUtil.h>
-#include <app/server/Server.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <platform/ESP32/NetworkCommissioningDriver.h>
@@ -74,12 +73,10 @@ static void InitOTARequestor(void)
 #endif
 }
 
-static void InitServer(intptr_t context)
+static void InitNetworkCommissioning(intptr_t context)
 {
     // Print QR Code URL
     PrintOnboardingCodes(chip::RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE));
-
-    chip::Server::GetInstance().Init();
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
@@ -118,5 +115,5 @@ extern "C" void app_main()
 
     InitOTARequestor();
 
-    chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(InitNetworkCommissioning, reinterpret_cast<intptr_t>(nullptr));
 }

--- a/examples/lighting-app/mbed/main/AppTask.cpp
+++ b/examples/lighting-app/mbed/main/AppTask.cpp
@@ -114,14 +114,6 @@ int AppTask::Init()
     LightingMgr().Init(MBED_CONF_APP_LIGHTING_STATE_LED);
     LightingMgr().SetCallbacks(ActionInitiated, ActionCompleted);
 
-    // Init ZCL Data Model and start server
-    error = Server::GetInstance().Init();
-    if (error != CHIP_NO_ERROR)
-    {
-        ChipLogError(NotSpecified, "Server initialization failed: %s", error.AsString());
-        return EXIT_FAILURE;
-    }
-
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
     ConfigurationMgr().LogDeviceConfig();

--- a/examples/lighting-app/mbed/main/main.cpp
+++ b/examples/lighting-app/mbed/main/main.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include "mbedtls/platform.h"
+#include <app/server/Server.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -68,18 +69,10 @@ int main()
         goto exit;
     }
 
-    err = chip::Platform::MemoryInit();
+    err = MatterServerScheduleInit();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(NotSpecified, "Memory initialization failed: %s", err.AsString());
-        ret = EXIT_FAILURE;
-        goto exit;
-    }
-
-    err = PlatformMgr().InitChipStack();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(NotSpecified, "Chip stack initialization failed: %s", err.AsString());
+        ChipLogError(NotSpecified, "Init Matter App Server and ZCL Data Model failed: %s", err.AsString());
         ret = EXIT_FAILURE;
         goto exit;
     }

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -102,17 +102,10 @@ CHIP_ERROR AppTask::Init()
     // Initialize CHIP stack
     LOG_INF("Init CHIP stack");
 
-    CHIP_ERROR err = chip::Platform::MemoryInit();
+    err = MatterServerScheduleInit();
     if (err != CHIP_NO_ERROR)
     {
-        LOG_ERR("Platform::MemoryInit() failed");
-        return err;
-    }
-
-    err = PlatformMgr().InitChipStack();
-    if (err != CHIP_NO_ERROR)
-    {
-        LOG_ERR("PlatformMgr().InitChipStack() failed");
+        LOG_ERR("Init Matter App Server and ZCL Data Model failed");
         return err;
     }
 
@@ -181,7 +174,6 @@ CHIP_ERROR AppTask::Init()
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
     InitOTARequestor();
     chip::app::DnssdServer::Instance().SetExtendedDiscoveryTimeoutSecs(kExtDiscoveryTimeoutSecs);
-    ReturnErrorOnFailure(chip::Server::GetInstance().Init());
     ConfigurationMgr().LogDeviceConfig();
     PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
 

--- a/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -110,9 +110,6 @@ CHIP_ERROR AppTask::Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    // Init ZCL Data Model and start server
-    chip::Server::GetInstance().Init();
-
     // Initialize device attestation config
 #ifdef ENABLE_HSM_DEVICE_ATTESTATION
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleSe05xDACProvider());

--- a/examples/lighting-app/nxp/k32w/k32w0/main/main.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/main.cpp
@@ -27,6 +27,7 @@
 #include <openthread/error.h>
 #include <openthread/heap.h>
 
+#include <app/server/Server.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPPlatformMemory.h>
@@ -75,13 +76,11 @@ extern "C" void main_task(void const * argument)
      * Thread and Weave tasks are using it */
     freertos_mbedtls_mutex_init();
 
-    // Init Chip memory management before the stack
-    chip::Platform::MemoryInit();
-
-    CHIP_ERROR ret = PlatformMgr().InitChipStack();
+    // Init Matter App Server and ZCL Data Model
+    CHIP_ERROR ret = MatterServerScheduleInit();
     if (ret != CHIP_NO_ERROR)
     {
-        K32W_LOG("Error during PlatformMgr().InitWeaveStack()");
+        K32W_LOG("Error during Matter App Server and ZCL Data Model initialization");
         goto exit;
     }
 

--- a/examples/lighting-app/p6/src/AppTask.cpp
+++ b/examples/lighting-app/p6/src/AppTask.cpp
@@ -117,8 +117,6 @@ CHIP_ERROR AppTask::Init()
             }
         },
         0);
-    // Init ZCL Data Model
-    chip::Server::GetInstance().Init();
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());

--- a/examples/lighting-app/p6/src/main.cpp
+++ b/examples/lighting-app/p6/src/main.cpp
@@ -76,9 +76,6 @@ extern "C" void vApplicationIdleHook(void)
 
 extern "C" void vApplicationDaemonTaskStartupHook()
 {
-    // Init Chip memory management before the stack
-    chip::Platform::MemoryInit();
-
     /* Create the Main task. */
     xTaskCreate(main_task, "Main task", MAIN_TASK_STACK_SIZE, NULL, MAIN_TASK_PRIORITY, NULL);
 }
@@ -92,12 +89,13 @@ static void main_task(void * pvParameters)
         appError(ret);
     }
 
-    ret = PlatformMgr().InitChipStack();
+    ret = MatterServerScheduleInit();
     if (ret != CHIP_NO_ERROR)
     {
-        P6_LOG("PlatformMgr().InitChipStack() failed");
+        P6_LOG("Init Matter App Server and ZCL Data Model failed");
         appError(ret);
     }
+
     chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName("P6_LIGHT");
     P6_LOG("Starting Platform Manager Event Loop");
     ret = PlatformMgr().StartEventLoopTask();

--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -113,9 +113,6 @@ CHIP_ERROR AppTask::Init()
     chip::app::DnssdServer::Instance().SetExtendedDiscoveryTimeoutSecs(extDiscTimeoutSecs);
 #endif
 
-    // Init ZCL Data Model
-    chip::Server::GetInstance().Init();
-
     // Init OTA engine
     InitializeOTARequestor();
 

--- a/examples/lighting-app/telink/src/AppTask.cpp
+++ b/examples/lighting-app/telink/src/AppTask.cpp
@@ -96,9 +96,6 @@ CHIP_ERROR AppTask::Init()
 
     LightingMgr().SetCallbacks(ActionInitiated, ActionCompleted);
 
-    // Init ZCL Data Model and start server
-    chip::Server::GetInstance().Init();
-
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 

--- a/examples/lighting-app/telink/src/main.cpp
+++ b/examples/lighting-app/telink/src/main.cpp
@@ -18,6 +18,7 @@
 
 #include "AppTask.h"
 
+#include <app/server/Server.h>
 #include <lib/support/CHIPMem.h>
 #include <platform/CHIPDeviceLayer.h>
 
@@ -33,18 +34,11 @@ int main(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    err = chip::Platform::MemoryInit();
-    if (err != CHIP_NO_ERROR)
-    {
-        LOG_ERR("Platform::MemoryInit() failed");
-        goto exit;
-    }
-
     LOG_INF("Init CHIP stack");
-    err = PlatformMgr().InitChipStack();
+    err = MatterServerScheduleInit();
     if (err != CHIP_NO_ERROR)
     {
-        LOG_ERR("PlatformMgr().InitChipStack() failed");
+        LOG_ERR("Init Matter App Server and ZCL Data Model failed");
         goto exit;
     }
 

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -176,7 +176,7 @@ uint32_t InteractionModelEngine::GetNumActiveWriteHandlers() const
 }
 
 void InteractionModelEngine::CloseTransactionsFromFabricIndex(FabricIndex aFabricIndex)
-{ 
+{
     //
     // Walk through all existing subscriptions and shut down those whose subscriber matches
     // that which just came in.

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -60,8 +60,8 @@ using ServerTransportMgr = chip::TransportMgr<chip::Transport::UDP
 class Server
 {
 public:
-    CHIP_ERROR Init(AppDelegate * delegate = nullptr, uint16_t secureServicePort = CHIP_PORT,
-                    uint16_t unsecureServicePort = CHIP_UDC_PORT, Inet::InterfaceId interfaceId = Inet::InterfaceId::Null());
+    CHIP_ERROR Init(AppDelegate * delegate, uint16_t secureServicePort, uint16_t unsecureServicePort,
+                    Inet::InterfaceId interfaceId);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     CHIP_ERROR SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress commissioner);
@@ -239,5 +239,18 @@ private:
     uint16_t mUnsecuredServicePort;
     Inet::InterfaceId mInterfaceId;
 };
+
+/**
+ * Initialize the Matter App server and ZCL Data Module.
+ */
+CHIP_ERROR MatterServerInit(AppDelegate * delegate = nullptr, uint16_t secureServicePort = CHIP_PORT,
+                            uint16_t unsecureServicePort  = CHIP_UDC_PORT,
+                            Inet::InterfaceId interfaceId = Inet::InterfaceId::Null());
+
+/**
+ * Schedules a work to initialize the Matter App server and ZCL Data Module in the CHIP context.
+ * This function is normally used in embedded systems which have small stack configuration in main app thread.
+ */
+CHIP_ERROR MatterServerScheduleInit(AppDelegate * delegate = nullptr);
 
 } // namespace chip


### PR DESCRIPTION
…yer together

#### Problem
What is being fixed?  Examples:
* The problem is the Matter*PluginServerInitCallback functions are currently implemented as if they are called once per process lifetime, which register delegates to platform, but CHIP stack init(chip::DeviceLayer::PlatformMgr().InitChipStack()) is handled in the application logic. For all server examples, if the CHIP stack is shut down and restarted (e.g. via PlatformManager::Shutdown and then a new InitChipStack, etc), those registered delegates might not valid

* Fixes #11568

#### Change overview
Use unified APIs to initialize and shutdown app layer and platform layer together

#### Testing
How was this tested? (at least one bullet point required)
* Test pairing with lighting-app and all-clusters-app on Linux and ESP32 platforms and confirm no regression. 
