### PR TITLE
[OTA] Consolidate provider location between requestor core and driver

### DIFF
--- a/src/app/clusters/ota-requestor/ExtendedOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/ExtendedOTARequestorDriver.cpp
@@ -68,15 +68,16 @@ void ExtendedOTARequestorDriver::PollUserConsentState()
 CHIP_ERROR ExtendedOTARequestorDriver::GetUserConsentSubject(chip::ota::UserConsentSubject & subject,
                                                              const UpdateDescription & update)
 {
-    if (mLastUsedProvider.HasValue())
+    Optional<ProviderLocationType> lastUsedProvider;
+    mRequestor->GetProviderLocation(lastUsedProvider);
+    if (lastUsedProvider.HasValue())
     {
-        // mLastUsedProvider has the provider fabric index and endpoint id
-        subject.fabricIndex        = mLastUsedProvider.Value().fabricIndex;
-        subject.providerEndpointId = mLastUsedProvider.Value().endpoint;
+        subject.fabricIndex        = lastUsedProvider.Value().fabricIndex;
+        subject.providerEndpointId = lastUsedProvider.Value().endpoint;
     }
     else
     {
-        ChipLogError(SoftwareUpdate, "mLastProvider is empty");
+        ChipLogError(SoftwareUpdate, "Last used provider is empty");
         return CHIP_ERROR_INTERNAL;
     }
 

--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
@@ -79,13 +79,12 @@ protected:
     void DefaultProviderTimerHandler(System::Layer * systemLayer, void * appState);
     void ScheduleDelayedAction(System::Clock::Seconds32 delay, System::TimerCompleteCallback action, void * aAppState);
     void CancelDelayedAction(System::TimerCompleteCallback action, void * aAppState);
+    bool ProviderLocationsEqual(const ProviderLocationType & a, const ProviderLocationType & b);
 
     OTARequestorInterface * mRequestor           = nullptr;
     OTAImageProcessorInterface * mImageProcessor = nullptr;
     uint32_t mOtaStartDelaySec                   = 0;
     uint32_t mPeriodicQueryTimeInterval = (24 * 60 * 60); // Timeout for querying providers on the default OTA provider list
-
-    Optional<ProviderLocationType> mLastUsedProvider; // Provider location used for the last query or update
 };
 
 } // namespace DeviceLayer

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -264,9 +264,9 @@ EmberAfStatus OTARequestor::HandleAnnounceOTAProvider(app::CommandHandler * comm
         return EMBER_ZCL_STATUS_FAILURE;
     }
 
-    ProviderLocation::Type providerLocation = { .providerNodeID = commandData.providerNodeId,
-                                                .endpoint       = commandData.endpoint,
-                                                .fabricIndex    = commandObj->GetAccessingFabricIndex() };
+    ProviderLocationType providerLocation = { .providerNodeID = commandData.providerNodeId,
+                                              .endpoint       = commandData.endpoint,
+                                              .fabricIndex    = commandObj->GetAccessingFabricIndex() };
 
     ChipLogDetail(SoftwareUpdate, "  FabricIndex: %u", providerLocation.fabricIndex);
     ChipLogDetail(SoftwareUpdate, "  ProviderNodeID: 0x" ChipLogFormatX64, ChipLogValueX64(providerLocation.providerNodeID));
@@ -474,7 +474,7 @@ void OTARequestor::TriggerImmediateQueryInternal()
 // Sends the QueryImage command to the next available Provider
 OTARequestorInterface::OTATriggerResult OTARequestor::TriggerImmediateQuery()
 {
-    ProviderLocation::Type providerLocation;
+    ProviderLocationType providerLocation;
     if (mOtaRequestorDriver->DetermineProviderLocation(providerLocation) != true)
     {
         ChipLogError(SoftwareUpdate, "No OTA Providers available");
@@ -539,13 +539,13 @@ CHIP_ERROR OTARequestor::ClearDefaultOtaProviderList(FabricIndex fabricIndex)
     return mStorage->StoreDefaultProviders(mDefaultOtaProviderList);
 }
 
-CHIP_ERROR OTARequestor::AddDefaultOtaProvider(const ProviderLocation::Type & providerLocation)
+CHIP_ERROR OTARequestor::AddDefaultOtaProvider(const ProviderLocationType & providerLocation)
 {
     // Look for an entry with the same fabric index indicated
     auto iterator = mDefaultOtaProviderList.Begin();
     while (iterator.Next())
     {
-        ProviderLocation::Type pl = iterator.GetValue();
+        ProviderLocationType pl = iterator.GetValue();
         if (pl.GetFabricIndex() == providerLocation.GetFabricIndex())
         {
             ChipLogError(SoftwareUpdate, "Default OTA provider entry with fabric %d already exists", pl.GetFabricIndex());

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -84,11 +84,10 @@ public:
         mProviderLocation.SetValue(providerLocation);
     }
 
-    void ClearCurrentProviderLocation() override { mProviderLocation.ClearValue(); }
+    void GetProviderLocation(Optional<ProviderLocationType> & providerLocation) override { providerLocation = mProviderLocation; }
 
     // Add a default OTA provider to the cached list
-    CHIP_ERROR AddDefaultOtaProvider(
-        const app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type & providerLocation) override;
+    CHIP_ERROR AddDefaultOtaProvider(const ProviderLocationType & providerLocation) override;
 
     // Retrieve an iterator to the cached default OTA provider list
     ProviderLocationList::Iterator GetDefaultOTAProviderListIterator(void) override { return mDefaultOtaProviderList.Begin(); }
@@ -313,7 +312,7 @@ private:
     OTAUpdateStateEnum mCurrentUpdateState = OTAUpdateStateEnum::kUnknown;
     Server * mServer                       = nullptr;
     ProviderLocationList mDefaultOtaProviderList;
-    Optional<ProviderLocationType> mProviderLocation; // Provider location used for the current update in progress
+    Optional<ProviderLocationType> mProviderLocation; // Provider location used for the current/last update in progress
 };
 
 } // namespace chip

--- a/src/app/clusters/ota-requestor/OTARequestorInterface.h
+++ b/src/app/clusters/ota-requestor/OTARequestorInterface.h
@@ -199,12 +199,12 @@ public:
     // Set the provider location to be used in the next query and OTA update process
     virtual void SetCurrentProviderLocation(ProviderLocationType providerLocation) = 0;
 
-    // Clear the provider location to indicate that no OTA update may be in progress
-    virtual void ClearCurrentProviderLocation() = 0;
+    // If there is an OTA update in progress, returns the provider location for the current OTA update, otherwise, returns the
+    // provider location that was last used
+    virtual void GetProviderLocation(Optional<ProviderLocationType> & providerLocation) = 0;
 
     // Add a default OTA provider to the cached list
-    virtual CHIP_ERROR
-    AddDefaultOtaProvider(const app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type & providerLocation) = 0;
+    virtual CHIP_ERROR AddDefaultOtaProvider(const ProviderLocationType & providerLocation) = 0;
 
     // Retrieve an iterator to the cached default OTA provider list
     virtual ProviderLocationList::Iterator GetDefaultOTAProviderListIterator(void) = 0;


### PR DESCRIPTION
#### Problem
Both `OTARequestor::mProviderLocation` and `GenericOTARequestorDriver::mLastUsedProvider` exist. These two essentially contain the same provider information. When one is set, the other should too. They should just be consolidated.

Fixes: https://github.com/project-chip/connectedhomeip/issues/15974

#### Change overview
- Remove GenericOTARequestorDriver::mLastUsedProvider - this is only used to determine the next provider location so just use OTARequestor::mProviderLocation to do that
- Create a getter for OTARequestor::mProviderLocation - call this getter in the driver wherever it references `mLastUsedProvider`
- OTARequestor::mProviderLocation is no longer cleared once set - it was meant to be cleared whenever no OTA in progress but OTARequestor::mCurrentUpdateState can be used to determine that

#### Testing
- Verified that basic transfer succeeds
- Verified that `DetermineProviderLocation` is still selecting correctly when multiple default OTA providers are in the list
