### PR TITLE
Add vscode configuration entries for debugging OTA applications

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,12 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Attach to running process",
+            "type": "lldb",
+            "request": "attach",
+            "pid": "${command:pickProcess}"
+        },
+        {
             "name": "QRCode Tests",
             "type": "cppdbg",
             "request": "launch",
@@ -349,6 +355,38 @@
             ],
             "runToMain": true, // if true, program will halt at main. Not used for a restart
             "showDevDebugOutput": false // When set to true, displays output of GDB.
+        },
+
+        {
+            "name": "OTA Requestor App (Linux)",
+            "type": "lldb",
+            "request": "launch",
+            "program": "${workspaceFolder}/out/ota-requestor/chip-ota-requestor-app",
+            "args": [
+                "--discriminator",
+                "18",
+                "--secured-device-port",
+                "5560",
+                "--KVS",
+                "/tmp/chip_kvs_requestor"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+
+        {
+            "name": "OTA Provider App (Linux)",
+            "type": "lldb",
+            "request": "launch",
+            "program": "${workspaceFolder}/out/ota-provider/chip-ota-provider-app",
+            "args": [
+                "--discriminator",
+                "22",
+                "--KVS",
+                "/tmp/chip_kvs_provider",
+                "--filepath",
+                "/tmp/ota-image.bin"
+            ],
+            "cwd": "${workspaceFolder}"
         }
     ],
     "inputs": [


### PR DESCRIPTION
#### Problem
There is no configuration for debugging OTA applications in vscode

#### Change overview
- Add configuration entries for OTA applications
- Also add a generic entry for attaching to any running process

#### Testing
OTA applications can be debugged in vscode
