### PR TITLE
[chiptest] Fix UTF-8 decoding error in stdout/err

### DIFF
--- a/scripts/tests/chiptest/runner.py
+++ b/scripts/tests/chiptest/runner.py
@@ -69,7 +69,7 @@ class LogPipe(threading.Thread):
         while True:
             try:
                 line = self.reader.readline()
-                # It seems that Darwin platfrom returns empty string in case
+                # It seems that Darwin platform returns empty string in case
                 # when writing side of PTY is closed (Linux raises OSError).
                 if line == '':
                     break

--- a/scripts/tests/chiptest/runner.py
+++ b/scripts/tests/chiptest/runner.py
@@ -18,11 +18,18 @@ import pty
 import queue
 import re
 import subprocess
-import sys
 import threading
 
 
 class LogPipe(threading.Thread):
+    """Create PTY-based PIPE for IPC.
+
+    Python provides a built-in mechanism for creating comunication PIPEs for
+    subprocesses spawned with Popen(). However, created PIPEs will most likely
+    enable IO buffering in the spawned process. In order to trick such process
+    to flush its streams immediately, we are going to create a PIPE based on
+    pseudoterminal (PTY).
+    """
 
     def __init__(self, level, capture_delegate=None, name=None):
         """
@@ -32,12 +39,8 @@ class LogPipe(threading.Thread):
 
         self.daemon = False
         self.level = level
-        if sys.platform == 'darwin':
-            self.fd_read, self.fd_write = pty.openpty()
-        else:
-            self.fd_read, self.fd_write = os.pipe()
-
-        self.pipeReader = os.fdopen(self.fd_read)
+        self.fd_read, self.fd_write = pty.openpty()
+        self.reader = open(self.fd_read, encoding='utf-8', errors='ignore')
         self.captured_logs = []
         self.capture_delegate = capture_delegate
         self.name = name
@@ -63,13 +66,20 @@ class LogPipe(threading.Thread):
 
     def run(self):
         """Run the thread, logging everything."""
-        for line in iter(self.pipeReader.readline, ''):
+        while True:
+            try:
+                line = self.reader.readline()
+                # It seems that Darwin platfrom returns empty string in case
+                # when writing side of PTY is closed (Linux raises OSError).
+                if line == '':
+                    break
+            except OSError:
+                break
             logging.log(self.level, line.strip('\n'))
             self.captured_logs.append(line)
             if self.capture_delegate:
                 self.capture_delegate.Log(self.name, line)
-
-        self.pipeReader.close()
+        self.reader.close()
 
     def close(self):
         """Close the write end of the pipe."""


### PR DESCRIPTION
#### Problem

Without such a change the bug #15796 was impossible to detect:
```
2022-03-11 09:36:07.432 INFO    Starting iteration 1                                                                                                                                                                 
2022-03-11 09:36:10.104 INFO    DL_LockUnlock        - Completed in 2.67 seconds                                                                                                                                     
2022-03-11 09:36:12.999 INFO    DL_Schedules         - Completed in 2.89 seconds                                                                                                                                     
Exception in thread APP  OUT:                                                                                                                                                                                        
Traceback (most recent call last):                                                                                                                                                                                   
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner                                                                                                                                              
    self.run()                                                                                                                                                                                                       
  File "/home/a.bokowy/connectedhomeip/scripts/tests/chiptest/runner.py", line 65, in run                                                                                                                            
    for line in iter(self.pipeReader.readline, ''):                                                                                                                                                                  
  File "/usr/lib/python3.8/codecs.py", line 322, in decode                                                                                                                                                           
    (result, consumed) = self._buffer_decode(data, self.errors, final)                                                                                                                                               
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 145: invalid start byte
```

#### Change overview

- fix UTF-8 decoding
- unifies PIPE type for Linux and Darwin platforms. From now, all platforms will use PTY-based PIPE for reading subprocess output in real time (without 4k block buffering).

#### Testing

Checked that running `/scripts/tests/run_test_suite.py --target-glob "DL_*" run` with reversed commit 0b58f58dca908339ee6ba7f2493bacf8166c5445 properly shows ASAN output.