### PR TITLE
[ota] Automatic NotifyUpdateApplied

### DIFF
--- a/examples/ota-requestor-app/p6/src/AppTask.cpp
+++ b/examples/ota-requestor-app/p6/src/AppTask.cpp
@@ -203,7 +203,7 @@ CHIP_ERROR AppTask::Init()
         chip::OTARequestorInterface * requestor = chip::GetRequestorInstance();
         if (requestor != nullptr)
         {
-            requestor->NotifyUpdateApplied(savedSoftwareVersion);
+            requestor->NotifyUpdateApplied();
         }
     }
 

--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
@@ -32,17 +32,16 @@ namespace DeviceLayer {
 class GenericOTARequestorDriver : public OTARequestorDriver
 {
 public:
-    //// Public API methods
     /**
-     * Called to perform some initialization including:
-     *   - Set the OTA requestor instance used to direct download progress
-     *   - Set the OTA image processor instance used to apply/abort the downloaded image
+     * Initialize OTA requestor driver.
+     *
+     * Set OTA requestor instance to be controlled by the driver, and OTA image processor, used to
+     * apply/abort the downloaded image.
+     *
+     * Additionally, if the current image is executed for the first time, approve the current image
+     * to make the update permanent, and send NotifyUpdateApplied command to the last OTA provider.
      */
-    void Init(OTARequestorInterface * requestor, OTAImageProcessorInterface * processor)
-    {
-        mRequestor      = requestor;
-        mImageProcessor = processor;
-    }
+    void Init(OTARequestorInterface * requestor, OTAImageProcessorInterface * processor);
 
     // Set the timeout (in seconds) for querying providers on the default OTA provider list; must be non-zero
     void SetPeriodicQueryTimeout(uint32_t timeout)

--- a/src/app/clusters/ota-requestor/OTARequestorInterface.h
+++ b/src/app/clusters/ota-requestor/OTARequestorInterface.h
@@ -178,7 +178,7 @@ public:
     virtual void ApplyUpdate() = 0;
 
     // Initiate the session to send NotifyUpdateApplied command
-    virtual void NotifyUpdateApplied(uint32_t version) = 0;
+    virtual void NotifyUpdateApplied() = 0;
 
     // Get image update progress in percents unit
     virtual CHIP_ERROR GetUpdateProgress(EndpointId endpointId, chip::app::DataModel::Nullable<uint8_t> & progress) = 0;

--- a/src/include/platform/OTAImageProcessor.h
+++ b/src/include/platform/OTAImageProcessor.h
@@ -90,6 +90,17 @@ public:
      */
     virtual uint64_t GetBytesDownloaded() { return mParams.downloadedBytes; }
 
+    /**
+     * Called to check if the current image is executed for the first time.
+     */
+    virtual bool IsFirstImageRun() = 0;
+
+    /**
+     * Called to confirm the current image in case it is running tentatively after applying
+     * a software update.
+     */
+    virtual CHIP_ERROR ConfirmCurrentImage() = 0;
+
 protected:
     OTAImageProgress mParams;
 };

--- a/src/lib/shell/commands/Ota.cpp
+++ b/src/lib/shell/commands/Ota.cpp
@@ -50,12 +50,9 @@ CHIP_ERROR ApplyImageHandler(int argc, char ** argv)
 CHIP_ERROR NotifyImageHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(GetRequestorInstance() != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(argc == 1, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(argc == 0, CHIP_ERROR_INVALID_ARGUMENT);
 
-    const intptr_t version = static_cast<intptr_t>(strtoul(argv[0], nullptr, 10));
-
-    PlatformMgr().ScheduleWork([](intptr_t arg) { GetRequestorInstance()->NotifyUpdateApplied(static_cast<uint32_t>(arg)); },
-                               version);
+    PlatformMgr().ScheduleWork([](intptr_t) { GetRequestorInstance()->NotifyUpdateApplied(); });
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/Ameba/AmebaOTAImageProcessor.cpp
+++ b/src/platform/Ameba/AmebaOTAImageProcessor.cpp
@@ -375,7 +375,7 @@ void AmebaOTAImageProcessor::HandleApply(intptr_t context)
     if (requestor != nullptr)
     {
         // TODO: Implement restarting into new image instead of changing the version
-        ConfigurationMgr().StoreSoftwareVersion(imageProcessor->mSoftwareVersion);
+        DeviceLayer::ConfigurationMgr().StoreSoftwareVersion(imageProcessor->mSoftwareVersion);
         requestor->NotifyUpdateApplied();
     }
 

--- a/src/platform/Ameba/AmebaOTAImageProcessor.cpp
+++ b/src/platform/Ameba/AmebaOTAImageProcessor.cpp
@@ -374,8 +374,9 @@ void AmebaOTAImageProcessor::HandleApply(intptr_t context)
     OTARequestorInterface * requestor = chip::GetRequestorInstance();
     if (requestor != nullptr)
     {
-        // TODO: Use software version from Configuration Manager
-        requestor->NotifyUpdateApplied(imageProcessor->mSoftwareVersion);
+        // TODO: Implement restarting into new image instead of changing the version
+        ConfigurationMgr().StoreSoftwareVersion(imageProcessor->mSoftwareVersion);
+        requestor->NotifyUpdateApplied();
     }
 
     // Reboot

--- a/src/platform/Ameba/AmebaOTAImageProcessor.h
+++ b/src/platform/Ameba/AmebaOTAImageProcessor.h
@@ -44,6 +44,8 @@ public:
     CHIP_ERROR Apply() override;
     CHIP_ERROR Abort() override;
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
+    bool IsFirstImageRun() override { return false; }
+    CHIP_ERROR ConfirmCurrentImage() override { return CHIP_NO_ERROR; }
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
 
 private:

--- a/src/platform/CYW30739/OTAImageProcessorImpl.h
+++ b/src/platform/CYW30739/OTAImageProcessorImpl.h
@@ -35,6 +35,8 @@ public:
     CHIP_ERROR Apply() override;
     CHIP_ERROR Abort() override;
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
+    bool IsFirstImageRun() override { return false; }
+    CHIP_ERROR ConfirmCurrentImage() override { return CHIP_NO_ERROR; }
 
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
 

--- a/src/platform/EFR32/OTAImageProcessorImpl.h
+++ b/src/platform/EFR32/OTAImageProcessorImpl.h
@@ -35,6 +35,8 @@ public:
     CHIP_ERROR Apply() override;
     CHIP_ERROR Abort() override;
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
+    bool IsFirstImageRun() override { return false; }
+    CHIP_ERROR ConfirmCurrentImage() override { return CHIP_NO_ERROR; }
 
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
     void SetOTAImageFile(CharSpan name) { mImageFile = name; }

--- a/src/platform/ESP32/OTAImageProcessorImpl.h
+++ b/src/platform/ESP32/OTAImageProcessorImpl.h
@@ -35,6 +35,8 @@ public:
     CHIP_ERROR Abort() override;
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; };
+    bool IsFirstImageRun() override { return false; }
+    CHIP_ERROR ConfirmCurrentImage() override { return CHIP_NO_ERROR; }
 
 private:
     static void HandlePrepareDownload(intptr_t context);

--- a/src/platform/Linux/OTAImageProcessorImpl.cpp
+++ b/src/platform/Linux/OTAImageProcessorImpl.cpp
@@ -134,8 +134,9 @@ void OTAImageProcessorImpl::HandleApply(intptr_t context)
     OTARequestorInterface * requestor = chip::GetRequestorInstance();
     if (requestor != nullptr)
     {
-        // TODO: Use software version from Configuration Manager
-        requestor->NotifyUpdateApplied(imageProcessor->mSoftwareVersion);
+        // TODO: Implement restarting into new image instead of changing the version
+        ConfigurationMgr().StoreSoftwareVersion(imageProcessor->mSoftwareVersion);
+        requestor->NotifyUpdateApplied();
     }
 }
 

--- a/src/platform/Linux/OTAImageProcessorImpl.cpp
+++ b/src/platform/Linux/OTAImageProcessorImpl.cpp
@@ -135,7 +135,7 @@ void OTAImageProcessorImpl::HandleApply(intptr_t context)
     if (requestor != nullptr)
     {
         // TODO: Implement restarting into new image instead of changing the version
-        ConfigurationMgr().StoreSoftwareVersion(imageProcessor->mSoftwareVersion);
+        DeviceLayer::ConfigurationMgr().StoreSoftwareVersion(imageProcessor->mSoftwareVersion);
         requestor->NotifyUpdateApplied();
     }
 }

--- a/src/platform/Linux/OTAImageProcessorImpl.h
+++ b/src/platform/Linux/OTAImageProcessorImpl.h
@@ -36,6 +36,8 @@ public:
     CHIP_ERROR Apply() override;
     CHIP_ERROR Abort() override;
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
+    bool IsFirstImageRun() override { return false; }
+    CHIP_ERROR ConfirmCurrentImage() override { return CHIP_NO_ERROR; }
 
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
     void SetOTAImageFile(CharSpan name) { mImageFile = name; }

--- a/src/platform/P6/OTAImageProcessorImpl.h
+++ b/src/platform/P6/OTAImageProcessorImpl.h
@@ -43,6 +43,8 @@ public:
     CHIP_ERROR Apply() override;
     CHIP_ERROR Abort() override;
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
+    bool IsFirstImageRun() override { return false; }
+    CHIP_ERROR ConfirmCurrentImage() override { return CHIP_NO_ERROR; }
 
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
 

--- a/src/platform/cc13x2_26x2/OTAImageProcessorImpl.h
+++ b/src/platform/cc13x2_26x2/OTAImageProcessorImpl.h
@@ -35,6 +35,8 @@ public:
     CHIP_ERROR Apply() override;
     CHIP_ERROR Abort() override;
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
+    bool IsFirstImageRun() override { return false; }
+    CHIP_ERROR ConfirmCurrentImage() override { return CHIP_NO_ERROR; }
 
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
 

--- a/src/platform/mbed/OTAImageProcessorImpl.h
+++ b/src/platform/mbed/OTAImageProcessorImpl.h
@@ -65,6 +65,10 @@ public:
      */
     CHIP_ERROR ProcessBlock(ByteSpan & block);
 
+    bool IsFirstImageRun() override { return false; }
+
+    CHIP_ERROR ConfirmCurrentImage() override { return CHIP_NO_ERROR; }
+
     /**
      * Check if memory for update image is works correctly.
      */

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
@@ -24,6 +24,7 @@
 
 #include <dfu/dfu_target.h>
 #include <dfu/dfu_target_mcuboot.h>
+#include <dfu/mcuboot.h>
 #include <sys/reboot.h>
 
 namespace chip {
@@ -98,6 +99,16 @@ CHIP_ERROR OTAImageProcessorImpl::ProcessBlock(ByteSpan & block)
             mDownloader->EndDownload(error);
         }
     });
+}
+
+bool OTAImageProcessorImpl::IsFirstImageRun()
+{
+    return mcuboot_swap_type() == BOOT_SWAP_TYPE_REVERT;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::ConfirmCurrentImage()
+{
+    return System::MapErrorZephyr(boot_write_img_confirmed());
 }
 
 CHIP_ERROR OTAImageProcessorImpl::ProcessHeader(ByteSpan & block)

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.h
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.h
@@ -40,6 +40,8 @@ public:
     CHIP_ERROR Abort() override;
     CHIP_ERROR Apply() override;
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
+    bool IsFirstImageRun() override;
+    CHIP_ERROR ConfirmCurrentImage() override;
 
 private:
     CHIP_ERROR PrepareDownloadImpl();

--- a/src/platform/nxp/k32w/k32w0/OTAImageProcessorImpl.h
+++ b/src/platform/nxp/k32w/k32w0/OTAImageProcessorImpl.h
@@ -33,6 +33,8 @@ public:
     CHIP_ERROR Apply() override;
     CHIP_ERROR Abort() override;
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
+    bool IsFirstImageRun() override { return false; }
+    CHIP_ERROR ConfirmCurrentImage() override { return CHIP_NO_ERROR; }
 
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
     void SetOTAImageFile(CharSpan name) { mImageFile = name; }

--- a/src/platform/qpg/OTAImageProcessorImpl.h
+++ b/src/platform/qpg/OTAImageProcessorImpl.h
@@ -33,6 +33,8 @@ public:
     CHIP_ERROR Apply() override;
     CHIP_ERROR Abort() override;
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
+    bool IsFirstImageRun() override { return false; }
+    CHIP_ERROR ConfirmCurrentImage() override { return CHIP_NO_ERROR; }
 
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
 


### PR DESCRIPTION
#### Problem
`NotifyUpdateApplied` command is not sent automatically.

#### Change overview
Add two methods to `OTAImageProcessor`:
- `IsFirstImageRun()` to determine if the currently running image is executed for the first time
- `ConfirmCurrentImage()` to confirm that the current image is stable and the update can be left permanently.

Add storing and loading the current provider and the update token in `OTARequestor`.
Then extend GenericOTARequestorDriver to automatically confirm the current image and send `NotifyUpdateApplied`
command to the last provider.
Fixes #15404

#### Testing
Tested on nRF Connect platform that the full OTA succeeds and NotifyUpdateApplied is sent after applying an update.
