### PR TITLE
[nrfconnect] Optimized external flash power usage.

### DIFF
--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -146,9 +146,9 @@ CHIP_ERROR AppTask::Init()
 void AppTask::InitOTARequestor()
 {
 #if CONFIG_CHIP_OTA_REQUESTOR
-    mOTAImageProcessor.SetOTADownloader(&mBDXDownloader);
-    mBDXDownloader.SetImageProcessorDelegate(&mOTAImageProcessor);
-    mOTARequestorDriver.Init(&mOTARequestor, &mOTAImageProcessor);
+    OTAImageProcessorNrf::Get().SetOTADownloader(&mBDXDownloader);
+    mBDXDownloader.SetImageProcessorDelegate(&OTAImageProcessorNrf::Get());
+    mOTARequestorDriver.Init(&mOTARequestor, &OTAImageProcessorNrf::Get());
     mOTARequestor.Init(&chip::Server::GetInstance(), &mOTARequestorDriver, &mBDXDownloader);
     chip::SetRequestorInstance(&mOTARequestor);
 #endif

--- a/examples/all-clusters-app/nrfconnect/main/include/AppTask.h
+++ b/examples/all-clusters-app/nrfconnect/main/include/AppTask.h
@@ -74,7 +74,6 @@ private:
 
 #if CONFIG_CHIP_OTA_REQUESTOR
     chip::DeviceLayer::GenericOTARequestorDriver mOTARequestorDriver;
-    chip::DeviceLayer::OTAImageProcessorImpl mOTAImageProcessor;
     chip::BDXDownloader mBDXDownloader;
     chip::OTARequestor mOTARequestor;
 #endif

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -86,7 +86,6 @@ bool sHaveBLEConnections  = false;
 
 #if CONFIG_CHIP_OTA_REQUESTOR
 GenericOTARequestorDriver sOTARequestorDriver;
-OTAImageProcessorImpl sOTAImageProcessor;
 chip::BDXDownloader sBDXDownloader;
 chip::OTARequestor sOTARequestor;
 #endif
@@ -200,9 +199,9 @@ CHIP_ERROR AppTask::Init()
 void AppTask::InitOTARequestor()
 {
 #if CONFIG_CHIP_OTA_REQUESTOR
-    sOTAImageProcessor.SetOTADownloader(&sBDXDownloader);
-    sBDXDownloader.SetImageProcessorDelegate(&sOTAImageProcessor);
-    sOTARequestorDriver.Init(&sOTARequestor, &sOTAImageProcessor);
+    OTAImageProcessorNrf::Get().SetOTADownloader(&sBDXDownloader);
+    sBDXDownloader.SetImageProcessorDelegate(&OTAImageProcessorNrf::Get());
+    sOTARequestorDriver.Init(&sOTARequestor, &OTAImageProcessorNrf::Get());
     sOTARequestor.Init(&chip::Server::GetInstance(), &sOTARequestorDriver, &sBDXDownloader);
     chip::SetRequestorInstance(&sOTARequestor);
 #endif

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -75,7 +75,6 @@ bool sHaveBLEConnections  = false;
 
 #if CONFIG_CHIP_OTA_REQUESTOR
 GenericOTARequestorDriver sOTARequestorDriver;
-OTAImageProcessorImpl sOTAImageProcessor;
 chip::BDXDownloader sBDXDownloader;
 chip::OTARequestor sOTARequestor;
 #endif
@@ -181,9 +180,9 @@ CHIP_ERROR AppTask::Init()
 void AppTask::InitOTARequestor()
 {
 #if CONFIG_CHIP_OTA_REQUESTOR
-    sOTAImageProcessor.SetOTADownloader(&sBDXDownloader);
-    sBDXDownloader.SetImageProcessorDelegate(&sOTAImageProcessor);
-    sOTARequestorDriver.Init(&sOTARequestor, &sOTAImageProcessor);
+    OTAImageProcessorNrf::Get().SetOTADownloader(&sBDXDownloader);
+    sBDXDownloader.SetImageProcessorDelegate(&OTAImageProcessorNrf::Get());
+    sOTARequestorDriver.Init(&sOTARequestor, &OTAImageProcessorNrf::Get());
     sOTARequestor.Init(&chip::Server::GetInstance(), &sOTARequestorDriver, &sBDXDownloader);
     chip::SetRequestorInstance(&sOTARequestor);
 #endif

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -78,7 +78,6 @@ bool sHaveBLEConnections  = false;
 
 #if CONFIG_CHIP_OTA_REQUESTOR
 GenericOTARequestorDriver sOTARequestorDriver;
-OTAImageProcessorImpl sOTAImageProcessor;
 chip::BDXDownloader sBDXDownloader;
 chip::OTARequestor sOTARequestor;
 #endif
@@ -178,9 +177,9 @@ CHIP_ERROR AppTask::Init()
 void AppTask::InitOTARequestor()
 {
 #if CONFIG_CHIP_OTA_REQUESTOR
-    sOTAImageProcessor.SetOTADownloader(&sBDXDownloader);
-    sBDXDownloader.SetImageProcessorDelegate(&sOTAImageProcessor);
-    sOTARequestorDriver.Init(&sOTARequestor, &sOTAImageProcessor);
+    OTAImageProcessorNrf::Get().SetOTADownloader(&sBDXDownloader);
+    sBDXDownloader.SetImageProcessorDelegate(&OTAImageProcessorNrf::Get());
+    sOTARequestorDriver.Init(&sOTARequestor, &OTAImageProcessorNrf::Get());
     sOTARequestor.Init(&chip::Server::GetInstance(), &sOTARequestorDriver, &sBDXDownloader);
     chip::SetRequestorInstance(&sOTARequestor);
 #endif

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -75,7 +75,6 @@ bool sHaveBLEConnections  = false;
 
 #if CONFIG_CHIP_OTA_REQUESTOR
 GenericOTARequestorDriver sOTARequestorDriver;
-OTAImageProcessorImpl sOTAImageProcessor;
 chip::BDXDownloader sBDXDownloader;
 chip::OTARequestor sOTARequestor;
 #endif
@@ -175,9 +174,9 @@ CHIP_ERROR AppTask::Init()
 void AppTask::InitOTARequestor()
 {
 #if CONFIG_CHIP_OTA_REQUESTOR
-    sOTAImageProcessor.SetOTADownloader(&sBDXDownloader);
-    sBDXDownloader.SetImageProcessorDelegate(&sOTAImageProcessor);
-    sOTARequestorDriver.Init(&sOTARequestor, &sOTAImageProcessor);
+    OTAImageProcessorNrf::Get().SetOTADownloader(&sBDXDownloader);
+    sBDXDownloader.SetImageProcessorDelegate(&OTAImageProcessorNrf::Get());
+    sOTARequestorDriver.Init(&sOTARequestor, &OTAImageProcessorNrf::Get());
     sOTARequestor.Init(&chip::Server::GetInstance(), &sOTARequestorDriver, &sBDXDownloader);
     chip::SetRequestorInstance(&sOTARequestor);
 #endif

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
@@ -24,6 +24,7 @@
 
 #include <dfu/dfu_target.h>
 #include <dfu/dfu_target_mcuboot.h>
+#include <pm/device.h>
 #include <sys/reboot.h>
 
 namespace chip {
@@ -123,6 +124,44 @@ CHIP_ERROR OTAImageProcessorImpl::ProcessHeader(ByteSpan & block)
     }
 
     return CHIP_NO_ERROR;
+}
+
+// external flash optimization
+void ExtFlashHandler::DoAction(Action action)
+{
+    // introduce the QSPI driver into idle power mode
+    static constexpr auto sFlashDevice{ DT_LABEL(DT_INST(0, nordic_qspi_nor)) };
+    const auto * qspi_dev = device_get_binding(sFlashDevice);
+    if (qspi_dev)
+    {
+        const auto requestedAction = Action::WAKE_UP == action ? PM_DEVICE_ACTION_RESUME : PM_DEVICE_ACTION_SUSPEND;
+        (void) pm_device_action_run(qspi_dev, requestedAction); // not much can be done in case of a failure
+    }
+}
+
+OTAImageProcessorImplPMDevice::OTAImageProcessorImplPMDevice(ExtFlashHandler & aHandler) : mHandler(aHandler)
+{
+    mHandler.DoAction(ExtFlashHandler::Action::SLEEP);
+}
+
+CHIP_ERROR OTAImageProcessorImplPMDevice::PrepareDownload()
+{
+    mHandler.DoAction(ExtFlashHandler::Action::WAKE_UP);
+    return OTAImageProcessorImpl::PrepareDownload();
+}
+
+CHIP_ERROR OTAImageProcessorImplPMDevice::Abort()
+{
+    auto status = OTAImageProcessorImpl::Abort();
+    mHandler.DoAction(ExtFlashHandler::Action::SLEEP);
+    return status;
+}
+
+CHIP_ERROR OTAImageProcessorImplPMDevice::Apply()
+{
+    auto status = OTAImageProcessorImpl::Apply();
+    mHandler.DoAction(ExtFlashHandler::Action::SLEEP);
+    return status;
 }
 
 } // namespace DeviceLayer


### PR DESCRIPTION
#### Problem
* QSPI consumes ~1.8 mA in active mode
* this is default mode for nRF53, even if the external flash is not used (no DFU ongoing)
* such high power consumption is a no-go for SED

#### Change overview
Force the QSPI into sleep mode and wake it up only on demand, i.e. right before the DFU

#### Testing
* tested on nrf53 and lock-app example, i.e. measured the power consumption before/during/after DFU in SED configuration
