### PR TITLE
[op-creds] Fix RemoveFabric on Sleepy End Devices

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -290,7 +290,6 @@ class OpCredsFabricTableDelegate : public FabricTableDelegate
     // Gets called when a fabric is deleted from KVS store
     void OnFabricDeletedFromStorage(CompressedFabricId compressedFabricId, FabricIndex fabricId) override
     {
-        printf("OpCredsFabricTableDelegate::OnFabricDeletedFromStorage\n");
         emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Fabric 0x%u was deleted from fabric storage.", fabricId);
         fabricListChanged();
 

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -87,6 +87,14 @@ void ExchangeContext::SetResponseTimeout(Timeout timeout)
 #if CONFIG_DEVICE_LAYER && CHIP_DEVICE_CONFIG_ENABLE_SED
 void ExchangeContext::UpdateSEDPollingMode()
 {
+    if (!HasSessionHandle())
+    {
+        // After the session has been deleted, no further communication can occur on the exchange,
+        // so withdraw a SED fast-polling mode request.
+        UpdateSEDPollingMode(false);
+        return;
+    }
+
     Transport::PeerAddress address;
 
     switch (GetSessionHandle()->GetSessionType())


### PR DESCRIPTION
#### Problem
RemoveFabric command sent for the current fabric crashes on Sleepy End Devices because UpdateSEDPollingMode() method,
used to switch between fast and slow polling mode, references a session object that is released by the command.

#### Change overview
Add a check for the session state.
By the way, remove a debug `printf()`.
Fixes #15910

#### Testing
Sent `RemoveFabric` command with the current fabric as an argument and tested that the application doesn't crash.