### PR TITLE
Make the IM command timeouts in chip-tool configurable.

### DIFF
--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -36,11 +36,12 @@ public:
     {
         AddArgument("node-id/group-id", 0, UINT64_MAX, &mNodeId);
         AddArgument("endpoint-id-ignored-for-group-commands", 0, UINT16_MAX, &mEndPointId);
+        AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(10); }
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(mTimeout.ValueOr(10)); }
 
     virtual CHIP_ERROR SendCommand(ChipDevice * device, std::vector<chip::EndpointId> endPointIds) = 0;
 
@@ -54,6 +55,9 @@ public:
         mOnDeviceConnectedCallback.Cancel();
         mOnDeviceConnectionFailureCallback.Cancel();
     }
+
+protected:
+    chip::Optional<uint16_t> mTimeout;
 
 private:
     chip::NodeId mNodeId;

--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -303,6 +303,13 @@ protected:
         return mReadClient->SendRequest(params);
     }
 
+    // Use a 3x-longer-than-default timeout because wildcard reads can take a
+    // while.
+    chip::System::Clock::Timeout GetWaitDuration() const override
+    {
+        return mTimeout.HasValue() ? chip::System::Clock::Seconds16(mTimeout.Value()) : (ModelCommand::GetWaitDuration() * 3);
+    }
+
     std::unique_ptr<chip::app::ReadClient> mReadClient;
     chip::app::BufferedReadCallback mBufferedReadAdapter;
 
@@ -411,7 +418,7 @@ public:
 
     chip::System::Clock::Timeout GetWaitDuration() const override
     {
-        return chip::System::Clock::Seconds16(mWait ? UINT16_MAX : 10);
+        return mWait ? chip::System::Clock::Seconds16(UINT16_MAX) : ReportCommand::GetWaitDuration();
     }
 
     void OnAttributeSubscription() override
@@ -525,7 +532,7 @@ public:
 
     chip::System::Clock::Timeout GetWaitDuration() const override
     {
-        return chip::System::Clock::Seconds16(mWait ? UINT16_MAX : 10);
+        return mWait ? chip::System::Clock::Seconds16(UINT16_MAX) : ReportCommand::GetWaitDuration();
     }
 
     void OnEventSubscription() override


### PR DESCRIPTION
Adds a --timeout optional command-line argument (to match the one that
test commands have).

Also changes the default timeout for read/subscribe from 10s to 30s,
because wildcard read/subscribe can take a while.

https://github.com/project-chip/connectedhomeip/issues/16118

#### Problem
See #16118.

#### Change overview
See above.

#### Testing
Verified that the `--timeout` optional arg appears in the commands and that doing:
```
chip-tool any read-by-id 6 0 17 1 --timeout 1
```
when there is no node 17 around in fact times out after 1 second, while doing:
```
chip-tool any read-by-id 6 0 17 1 --timeout 5
```
takes 5 seconds to time out.