### PR TITLE
Add BLE and thread pairing capabilities to chip-tool-darwin.

### DIFF
--- a/examples/chip-tool-darwin/commands/pairing/Commands.h
+++ b/examples/chip-tool-darwin/commands/pairing/Commands.h
@@ -23,19 +23,31 @@
 class PairQRCode : public PairingCommandBridge
 {
 public:
-    PairQRCode() : PairingCommandBridge("qrcode", PairingMode::QRCode) {}
+    PairQRCode() : PairingCommandBridge("qrcode", PairingMode::QRCode, PairingNetworkType::None) {}
 };
 
 class PairManualCode : public PairingCommandBridge
 {
 public:
-    PairManualCode() : PairingCommandBridge("manualcode", PairingMode::ManualCode) {}
+    PairManualCode() : PairingCommandBridge("manualcode", PairingMode::ManualCode, PairingNetworkType::None) {}
 };
 
 class PairWithIPAddress : public PairingCommandBridge
 {
 public:
-    PairWithIPAddress() : PairingCommandBridge("ethernet", PairingMode::Ethernet) {}
+    PairWithIPAddress() : PairingCommandBridge("ethernet", PairingMode::Ethernet, PairingNetworkType::Ethernet) {}
+};
+
+class PairBleWiFi : public PairingCommandBridge
+{
+public:
+    PairBleWiFi() : PairingCommandBridge("ble-wifi", PairingMode::Ble, PairingNetworkType::WiFi) {}
+};
+
+class PairBleThread : public PairingCommandBridge
+{
+public:
+    PairBleThread() : PairingCommandBridge("ble-thread", PairingMode::Ble, PairingNetworkType::Thread) {}
 };
 
 void registerCommandsPairing(Commands & commands)
@@ -43,9 +55,8 @@ void registerCommandsPairing(Commands & commands)
     const char * clusterName = "Pairing";
 
     commands_list clusterCommands = {
-        make_unique<PairQRCode>(),
-        make_unique<PairManualCode>(),
-        make_unique<PairWithIPAddress>(),
+        make_unique<PairQRCode>(),  make_unique<PairManualCode>(), make_unique<PairWithIPAddress>(),
+        make_unique<PairBleWiFi>(), make_unique<PairBleThread>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool-darwin/commands/pairing/PairingDelegateBridge.h
+++ b/examples/chip-tool-darwin/commands/pairing/PairingDelegateBridge.h
@@ -21,6 +21,9 @@
 @interface CHIPToolPairingDelegate : NSObject <CHIPDevicePairingDelegate>
 @property PairingCommandBridge * commandBridge;
 @property chip::NodeId deviceID;
+@property CHIPDeviceController * commissioner;
+@property CHIPCommissioningParameters * params;
+
 - (void)onPairingComplete:(NSError *)error;
 - (void)onPairingDeleted:(NSError *)error;
 - (void)onCommissioningComplete:(NSError *)error;

--- a/examples/chip-tool-darwin/commands/pairing/PairingDelegateBridge.mm
+++ b/examples/chip-tool-darwin/commands/pairing/PairingDelegateBridge.mm
@@ -17,6 +17,7 @@
  */
 
 #include "PairingDelegateBridge.h"
+#import <CHIP/CHIPCommissioningParameters.h>
 #import <CHIP/CHIPError_Internal.h>
 
 @interface CHIPToolPairingDelegate ()
@@ -41,10 +42,19 @@
 
 - (void)onPairingComplete:(NSError *)error
 {
+    NSError * __block commissionError;
     CHIP_ERROR err = [CHIPError errorToCHIPErrorCode:error];
+    if (err != CHIP_NO_ERROR) {
+        _commandBridge->SetCommandExitStatus(err);
+        return;
+    }
     ChipLogProgress(chipTool, "Pairing Complete: %s", chip::ErrorStr(err));
-
-    _commandBridge->SetCommandExitStatus(err);
+    [_commissioner commissionDevice:_deviceID commissioningParams:_params error:&commissionError];
+    err = [CHIPError errorToCHIPErrorCode:commissionError];
+    if (err != CHIP_NO_ERROR) {
+        _commandBridge->SetCommandExitStatus(err);
+        return;
+    }
 }
 
 - (void)onPairingDeleted:(NSError *)error

--- a/src/darwin/Framework/CHIP/BUILD.gn
+++ b/src/darwin/Framework/CHIP/BUILD.gn
@@ -30,6 +30,7 @@ static_library("framework") {
   sources = [
     "CHIP.h",
     "CHIPCluster.mm",
+    "CHIPCommissioningParameters.m",
     "CHIPControllerAccessControl.h",
     "CHIPControllerAccessControl.mm",
     "CHIPDevice.h",


### PR DESCRIPTION
#### Problem
BLE and Thread commissioning is missing in chip-tool-darwin.

#### Change overview
- Add Thread and BLE pair commissioning to chip-tool-darwin.

#### Testing
- Validated pairing and commissioning through BLE
