### PR TITLE
Release commissionee device pool on exit

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -668,7 +668,7 @@ CHIP_ERROR DeviceCommissioner::Shutdown()
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
-    // Release everything from the commissionee device pool here. DeviceController::Shutdown releasese operational.
+    // Release everything from the commissionee device pool here. DeviceController::Shutdown releases operational.
     mCommissioneeDevicePool.ReleaseAll();
 
     DeviceController::Shutdown();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -668,6 +668,9 @@ CHIP_ERROR DeviceCommissioner::Shutdown()
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
+    // Release everything from the commissionee device pool here. DeviceController::Shutdown releasese operational.
+    mCommissioneeDevicePool.ReleaseAll();
+
     DeviceController::Shutdown();
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Problem
We release the operational pool on shutdown, but not the commissionee pool

#### Change overview
release commissionee pool on shutdown

#### Testing
covered by cirque tests.