### PR TITLE
Remove mIsIpRendezvous variable

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -798,8 +798,6 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
 
     mDeviceBeingCommissioned = device;
 
-    mIsIPRendezvous = (params.GetPeerAddress().GetTransportType() != Transport::Type::kBle);
-
     {
         FabricIndex fabricIndex = mFabricInfo != nullptr ? mFabricInfo->GetFabricIndex() : kUndefinedFabricIndex;
         device->Init(GetControllerDeviceInitParams(), remoteDeviceId, peerAddress, fabricIndex);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -694,12 +694,6 @@ private:
 
     CommissioneeDeviceProxy * mDeviceBeingCommissioned = nullptr;
 
-    /* TODO: BLE rendezvous and IP rendezvous should share the same procedure, so this is just a
-       workaround-like flag and should be removed in the future.
-       When using IP rendezvous, we need to disable network provisioning. In the future, network
-       provisioning will no longer be a part of rendezvous procedure. */
-    bool mIsIPRendezvous;
-
     /* This field is true when device pairing information changes, e.g. a new device is paired, or
        the pairing for a device is removed. The DeviceCommissioner uses this to decide when to
        persist the device list */


### PR DESCRIPTION
#### Problem
mIsIpRendezvous variable is set once, and never used again.

#### Change overview
remove the variable

#### Testing
covered by cirque tests.