### PR TITLE
Update Docker for infineon P6 platform

### DIFF
--- a/integrations/docker/images/chip-build-infineon/Dockerfile
+++ b/integrations/docker/images/chip-build-infineon/Dockerfile
@@ -9,18 +9,18 @@ RUN apt update -y \
 
 # ------------------------------------------------------------------------------
 # Download and extract ModusToolbox 2.3
-RUN curl --fail --location --silent --show-error http://dlm.cypress.com.edgesuite.net/akdlm/downloadmanager/software/ModusToolbox/ModusToolbox_2.3/ModusToolbox_2.3.0.4276-linux-install.tar.gz -o /tmp/ModusToolbox_2.3.0.4276-linux-install.tar.gz \
- && tar -C /opt -zxf /tmp/ModusToolbox_2.3.0.4276-linux-install.tar.gz \
- && rm /tmp/ModusToolbox_2.3.0.4276-linux-install.tar.gz
+RUN curl --fail --location --silent --show-error https://download.cypress.com/downloadmanager/software/ModusToolbox/ModusToolbox_2.4/ModusToolbox_2.4.0.5972-linux-install.tar.gz -o /tmp/ModusToolbox_2.4.0.5972-linux-install.tar.gz \
+ && tar -C /opt -zxf /tmp/ModusToolbox_2.4.0.5972-linux-install.tar.gz \
+ && rm /tmp/ModusToolbox_2.4.0.5972-linux-install.tar.gz
 
 # ------------------------------------------------------------------------------
 # Execute post-build scripts
-RUN /opt/ModusToolbox/tools_2.3/modus-shell/postinstall
+RUN /opt/ModusToolbox/tools_2.4/modus-shell/postinstall
 
 # NOTE: udev rules are NOT installed:
-#   /opt/ModusToolbox/tools_2.3/fw-loader/udev_rules/install_rules.sh
+#   /opt/ModusToolbox/tools_2.4/fw-loader/udev_rules/install_rules.sh
 # because docker containers do not support udev
 
 # ------------------------------------------------------------------------------
 # Set environment variable required by ModusToolbox application makefiles
-ENV CY_TOOLS_PATHS="/opt/ModusToolbox/tools_2.3"
+ENV CY_TOOLS_PATHS="/opt/ModusToolbox/tools_2.4"

--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -66,7 +66,7 @@ ENV OPENOCD_PATH=/opt/openocd/
 ENV PW_ENVIRONMENT_ROOT=/home/vscode/pigweed/env
 ENV TELINK_ZEPHYR_BASE=/opt/telink/zephyrproject/zephyr
 ENV TELINK_ZEPHYR_SDK_DIR=/opt/telink/zephyr-sdk-0.13.0
-ENV CY_TOOLS_PATHS="/opt/ModusToolbox/tools_2.3"
+ENV CY_TOOLS_PATHS="/opt/ModusToolbox/tools_2.4"
 ENV TIZEN_HOME /opt/tizen_sdk
 ENV SYSROOT_AARCH64=/opt/ubuntu-21.04-aarch64-sysroot
 ENV AMEBA_PATH=/opt/ameba/ambd_sdk_with_chip_non_NDA

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.56 Version bump reason: Update nRF Connect SDK
+0.5.57 Version bump reason: Update Infineon P6 Docker

--- a/scripts/examples/gn_p6_example.sh
+++ b/scripts/examples/gn_p6_example.sh
@@ -22,18 +22,18 @@ source "$(dirname "$0")/../../scripts/activate.sh"
 
 # Install required software
 if [ -d "/opt/ModusToolbox" ]; then
-    export CY_TOOLS_PATHS="/opt/ModusToolbox/tools_2.3"
+    export CY_TOOLS_PATHS="/opt/ModusToolbox/tools_2.4"
 elif [ -d "$HOME/ModusToolbox" ]; then
     # Set CY TOOLS PATH
-    export CY_TOOLS_PATHS="$HOME/ModusToolbox/tools_2.3"
+    export CY_TOOLS_PATHS="$HOME/ModusToolbox/tools_2.4"
 else
     # Install Modustoolbox
-    curl --fail --location --silent --show-error http://dlm.cypress.com.edgesuite.net/akdlm/downloadmanager/software/ModusToolbox/ModusToolbox_2.3/ModusToolbox_2.3.0.4276-linux-install.tar.gz -o /tmp/ModusToolbox_2.3.0.4276-linux-install.tar.gz &&
-        tar -C "$HOME" -zxf /tmp/ModusToolbox_2.3.0.4276-linux-install.tar.gz &&
-        rm /tmp/ModusToolbox_2.3.0.4276-linux-install.tar.gz
+    curl --fail --location --silent --show-error https://download.cypress.com/downloadmanager/software/ModusToolbox/ModusToolbox_2.4/ModusToolbox_2.4.0.5972-linux-install.tar.gz -o /tmp/ModusToolbox_2.4.0.5972-linux-install.tar.gz -o /tmp/ModusToolbox_2.4.0.5972-linux-install.tar.gz &&
+        tar -C "$HOME" -zxf /tmp/ModusToolbox_2.4.0.5972-linux-install.tar.gz &&
+        rm /tmp/ModusToolbox_2.4.0.5972-linux-install.tar.gz
 
     # Set CY TOOLS PATH
-    export CY_TOOLS_PATHS="$HOME/ModusToolbox/tools_2.3"
+    export CY_TOOLS_PATHS="$HOME/ModusToolbox/tools_2.4"
 fi
 
 set -x


### PR DESCRIPTION
#### Problem
Old URL for Modistoolbox Software is removed and Docker build fails for Infineon P6

#### Change overview
Modustoolbox URL link and version update to 2.4 

#### Testing
Verified Docker Build in CI