### PR TITLE
Fix CoreData violations in the Darwin KVS implementation

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/xcshareddata/xcschemes/CHIP Tool App.xcscheme
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/xcshareddata/xcschemes/CHIP Tool App.xcscheme
@@ -64,6 +64,12 @@
             ReferencedContainer = "container:CHIPTool.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/src/platform/Darwin/KeyValueStoreManagerImpl.mm
+++ b/src/platform/Darwin/KeyValueStoreManagerImpl.mm
@@ -288,8 +288,7 @@ namespace DeviceLayer {
             KeyValueItem * item = FindItemForKey(itemKey, nil);
             if (!item) {
                 [gContext performBlockAndWait:^{
-                    KeyValueItem * item = [[KeyValueItem alloc] initWithContext:gContext key:itemKey value:data];
-                    [gContext insertObject:item];
+                    [gContext insertObject:[[KeyValueItem alloc] initWithContext:gContext key:itemKey value:data]];
                 }];
             } else {
                 [gContext performBlockAndWait:^{

--- a/src/platform/Darwin/KeyValueStoreManagerImpl.mm
+++ b/src/platform/Darwin/KeyValueStoreManagerImpl.mm
@@ -222,22 +222,28 @@ namespace DeviceLayer {
                 return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
             }
 
+            __block NSData * itemValue = nil;
+            // can only access this object on the managed queue
+            [gContext performBlockAndWait:^{
+                itemValue = item.value;
+            }];
+
             if (read_bytes_size != nullptr) {
-                *read_bytes_size = item.value.length;
+                *read_bytes_size = itemValue.length;
             }
 
             if (value != nullptr) {
-                memcpy(value, item.value.bytes, std::min<size_t>((item.value.length), value_size));
+                memcpy(value, itemValue.bytes, std::min<size_t>((itemValue.length), value_size));
 #if CHIP_CONFIG_DARWIN_STORAGE_VERBOSE_LOGGING
                 fprintf(stderr, "GETTING VALUE FOR: '%s': ", key);
-                for (size_t i = 0; i < std::min<size_t>((item.value.length), value_size); ++i) {
+                for (size_t i = 0; i < std::min<size_t>((itemValue.length), value_size); ++i) {
                     fprintf(stderr, "%02x ", static_cast<uint8_t *>(value)[i]);
                 }
                 fprintf(stderr, "\n");
 #endif
             }
 
-            if (item.value.length > value_size) {
+            if (itemValue.length > value_size) {
                 return CHIP_ERROR_BUFFER_TOO_SMALL;
             }
 
@@ -281,12 +287,14 @@ namespace DeviceLayer {
 
             KeyValueItem * item = FindItemForKey(itemKey, nil);
             if (!item) {
-                item = [[KeyValueItem alloc] initWithContext:gContext key:itemKey value:data];
                 [gContext performBlockAndWait:^{
+                    KeyValueItem * item = [[KeyValueItem alloc] initWithContext:gContext key:itemKey value:data];
                     [gContext insertObject:item];
                 }];
             } else {
-                item.value = data;
+                [gContext performBlockAndWait:^{
+                    item.value = data;
+                }];
             }
 
             __block BOOL success = NO;


### PR DESCRIPTION
#### Problem
We access CoreData Managed KeyValueItems on the chip workqueue after creating them on the NSManagedContext's private queue. 

This is a multithreading violation in CoreData. 

#### Change overview
Ensure Managed objects are only accessed on the same queue they were created on. 

Add the CoreData concurrency enforcement to CHIPTool.

**Need to figure out how to enable this for all darwin tests**.

#### Testing
Tested that CHIPTool doesn't just crash immediately when launched with concurrency enforcement. 
