### PR TITLE
Generate .gbl bootloader file when efr apps are built

### DIFF
--- a/build/toolchain/flashable_executable.gni
+++ b/build/toolchain/flashable_executable.gni
@@ -64,7 +64,7 @@ template("gen_flashing_script") {
                            "gbl_file"
                          ])
 
-  action(target_name) {   
+  action(target_name) {
     outputs = [ flashing_script_name ]
 
     args = flashing_options

--- a/build/toolchain/flashable_executable.gni
+++ b/build/toolchain/flashable_executable.gni
@@ -73,35 +73,9 @@ template("gen_flashing_script") {
       rebase_path(flashing_script_name, root_build_dir),
     ]
     args += [ gbl_file ]
-
     script = flashing_script_generator
     inputs = flashing_script_inputs
   }
-}
-
-template("gen_gbl_script") {
-
-  if (defined(invoker.gbl_file_image_name)) {
-    gbl_file_image_name = "$root_out_dir/${invoker.gbl_file_image_name}"
-    gbl_script_generator = invoker.gbl_script_generator
-    gbl_script_name = "$root_out_dir/${invoker.gbl_script_name}"
-    flashing_script_inputs = invoker.flashing_script_inputs
-    gbl_options = invoker.gbl_options
-
-  }
-
-  executable_target = "$target_name.executable"
-  action(target_name) {
-    outputs = [ gbl_file_image_name ]
-    args = gbl_options
-    args += [
-      rebase_path(gbl_script_name, root_build_dir),
-    ]
-
-    script = gbl_script_generator
-    inputs = flashing_script_inputs
-  }
-
 }
 
 # Build target for an executable, optionally converted to the preferred form

--- a/build/toolchain/flashable_executable.gni
+++ b/build/toolchain/flashable_executable.gni
@@ -61,9 +61,10 @@ template("gen_flashing_script") {
                            "flashing_options",
                            "deps",
                            "data_deps",
+                           "gbl_file"
                          ])
 
-  action(target_name) {
+  action(target_name) {   
     outputs = [ flashing_script_name ]
 
     args = flashing_options
@@ -71,10 +72,36 @@ template("gen_flashing_script") {
       "--output",
       rebase_path(flashing_script_name, root_build_dir),
     ]
+    args += [ gbl_file ]
 
     script = flashing_script_generator
     inputs = flashing_script_inputs
   }
+}
+
+template("gen_gbl_script") {
+
+  if (defined(invoker.gbl_file_image_name)) {
+    gbl_file_image_name = "$root_out_dir/${invoker.gbl_file_image_name}"
+    gbl_script_generator = invoker.gbl_script_generator
+    gbl_script_name = "$root_out_dir/${invoker.gbl_script_name}"
+    flashing_script_inputs = invoker.flashing_script_inputs
+    gbl_options = invoker.gbl_options
+
+  }
+
+  executable_target = "$target_name.executable"
+  action(target_name) {
+    outputs = [ gbl_file_image_name ]
+    args = gbl_options
+    args += [
+      rebase_path(gbl_script_name, root_build_dir),
+    ]
+
+    script = gbl_script_generator
+    inputs = flashing_script_inputs
+  }
+
 }
 
 # Build target for an executable, optionally converted to the preferred form
@@ -142,6 +169,7 @@ template("flashable_executable") {
       flashing_script_generator = invoker.flashing_script_generator
       flashing_script_inputs = invoker.flashing_script_inputs
       flashing_script_name = "$root_out_dir/${invoker.flashing_script_name}"
+      gbl_file = invoker.gbl_file_image_name
       if (defined(invoker.flashing_options)) {
         flashing_options = invoker.flashing_options
       } else {

--- a/scripts/flashing/efr32_firmware_utils.py
+++ b/scripts/flashing/efr32_firmware_utils.py
@@ -138,6 +138,15 @@ class Flasher(firmware_utils.Flasher):
             ['flash', self.DEVICE_ARGUMENTS, image],
             name='Flash')
 
+    def gbl_create(self, argv):
+        """Create gbl file"""
+        self.parser.description = 'Generate a flashing script.'
+
+        return self.run_tool(
+            'commander',
+            ['gbl', 'create', self.DEVICE_ARGUMENTS, argv[5], '--app', argv[2]],
+            name='GblCreate')
+
     def reset(self):
         """Reset the device."""
         return self.run_tool(

--- a/scripts/flashing/efr32_firmware_utils.py
+++ b/scripts/flashing/efr32_firmware_utils.py
@@ -53,6 +53,8 @@ import sys
 
 import firmware_utils
 
+import glob
+
 # Additional options that can be use to configure an `Flasher`
 # object (as dictionary keys) and/or passed as command line options.
 EFR32_OPTIONS = {
@@ -110,6 +112,11 @@ class Flasher(firmware_utils.Flasher):
     def __init__(self, **options):
         super().__init__(platform='EFR32', module=__name__, **options)
         self.define_options(EFR32_OPTIONS)
+        self.run_tool(
+            'commander',
+            ['gbl', 'create', self.DEVICE_ARGUMENTS, 'chip-efr32-lighting-example.gbl', '--app',  glob.glob("*.s37")],
+            name='GblCreate')
+        
 
     # Common command line arguments for commander device subcommands.
     DEVICE_ARGUMENTS = [{'optional': 'serialno'}, {
@@ -137,15 +144,6 @@ class Flasher(firmware_utils.Flasher):
             'commander',
             ['flash', self.DEVICE_ARGUMENTS, image],
             name='Flash')
-
-    def gbl_create(self, argv):
-        """Create gbl file"""
-        self.parser.description = 'Generate a flashing script.'
-
-        return self.run_tool(
-            'commander',
-            ['gbl', 'create', self.DEVICE_ARGUMENTS, argv[5], '--app', argv[2]],
-            name='GblCreate')
 
     def reset(self):
         """Reset the device."""
@@ -175,9 +173,6 @@ class Flasher(firmware_utils.Flasher):
         if self.option.reset:
             if self.reset().err:
                 return self
-
-        return self
-
 
 if __name__ == '__main__':
     sys.exit(Flasher().flash_command(sys.argv))

--- a/scripts/flashing/efr32_firmware_utils.py
+++ b/scripts/flashing/efr32_firmware_utils.py
@@ -174,5 +174,8 @@ class Flasher(firmware_utils.Flasher):
             if self.reset().err:
                 return self
 
+        return self
+
+
 if __name__ == '__main__':
     sys.exit(Flasher().flash_command(sys.argv))

--- a/scripts/flashing/firmware_utils.py
+++ b/scripts/flashing/firmware_utils.py
@@ -405,7 +405,7 @@ class Flasher:
             required=True,
             help='flashing script name')
         self.argv0 = argv[0]
-        args = self.parser.parse_args(argv[1:])
+        args = self.parser.parse_args(argv[1:5])
 
         # Give platform-specific code a chance to manipulate the arguments
         # for the wrapper script.

--- a/scripts/flashing/gen_flashing_script.py
+++ b/scripts/flashing/gen_flashing_script.py
@@ -21,5 +21,4 @@ platform = importlib.import_module(sys.argv[1] + '_firmware_utils')
 del sys.argv[1]
 
 if __name__ == '__main__':
-    platform.Flasher().gbl_create(sys.argv)
     sys.exit(platform.Flasher().make_wrapper(sys.argv))

--- a/scripts/flashing/gen_flashing_script.py
+++ b/scripts/flashing/gen_flashing_script.py
@@ -12,13 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Generate script to flash or erase a device."""
+"""Generate script to flash or erase a device. Also creates a bootloader for the device"""
 
-import importlib
+import importlib 
 import sys
 
 platform = importlib.import_module(sys.argv[1] + '_firmware_utils')
 del sys.argv[1]
 
 if __name__ == '__main__':
+    platform.Flasher().gbl_create(sys.argv)
     sys.exit(platform.Flasher().make_wrapper(sys.argv))

--- a/scripts/flashing/gen_flashing_script.py
+++ b/scripts/flashing/gen_flashing_script.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Generate script to flash or erase a device. Also creates a bootloader for the device"""
+"""Generate script to flash or erase a device.""
 
 import importlib
 import sys

--- a/scripts/flashing/gen_flashing_script.py
+++ b/scripts/flashing/gen_flashing_script.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Generate script to flash or erase a device. Also creates a bootloader for the device"""
 
-import importlib 
+import importlib
 import sys
 
 platform = importlib.import_module(sys.argv[1] + '_firmware_utils')

--- a/third_party/efr32_sdk/efr32_executable.gni
+++ b/third_party/efr32_sdk/efr32_executable.gni
@@ -46,7 +46,6 @@ template("efr32_executable") {
 
   flash_target_name = target_name + ".flash_executable"
   flashbundle_name = "${target_name}.flashbundle.txt"
-  gbl_file_image_name = output_base_name + ".gbl"
   flashable_executable(flash_target_name) {
     forward_variables_from(invoker, "*")
     data_deps = [ ":${flashing_runtime_target}" ]

--- a/third_party/efr32_sdk/efr32_executable.gni
+++ b/third_party/efr32_sdk/efr32_executable.gni
@@ -46,6 +46,7 @@ template("efr32_executable") {
 
   flash_target_name = target_name + ".flash_executable"
   flashbundle_name = "${target_name}.flashbundle.txt"
+  gbl_file_image_name = output_base_name + ".gbl"
   flashable_executable(flash_target_name) {
     forward_variables_from(invoker, "*")
     data_deps = [ ":${flashing_runtime_target}" ]


### PR DESCRIPTION
#### Problem
.gbl bootloader files have to be manually built

#### Change overview
When the efr32 lighting app is built, a .gbl file is built along with it

#### Testing
When building an efr32 app, it was verified that the .gbl file was created.
