### PR TITLE
fixed type in test yaml. `labe` -> `label`

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_MC_6_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_6_1.yaml
@@ -29,7 +29,7 @@ tests:
                 value: nodeId
 
     #issue #12884 Media cluster commands and precondition not supported
-    - labe: "Precondition: Connect media content available for playback"
+    - label: "Precondition: Connect media content available for playback"
       disabled: true
 
     - label:

--- a/src/app/tests/suites/certification/Test_TC_MC_6_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_6_2.yaml
@@ -29,7 +29,7 @@ tests:
                 value: nodeId
 
     #issue #12884 Media cluster commands and precondition not supported
-    - labe: "Precondition: Connect media content available for playback"
+    - label: "Precondition: Connect media content available for playback"
       disabled: true
 
     - label:

--- a/src/app/tests/suites/certification/Test_TC_MC_6_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_6_3.yaml
@@ -29,7 +29,7 @@ tests:
                 value: nodeId
 
     #issue #12884 Media cluster commands and precondition not supported
-    - labe: "Precondition: Connect media content available for playback"
+    - label: "Precondition: Connect media content available for playback"
       disabled: true
 
     - label:

--- a/src/app/tests/suites/certification/Test_TC_MC_6_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_6_4.yaml
@@ -29,7 +29,7 @@ tests:
                 value: nodeId
 
     #issue #12884 Media cluster commands and precondition not supported
-    - labe: "Precondition: Connect media content available for playback"
+    - label: "Precondition: Connect media content available for playback"
       disabled: true
 
     - label:


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* The following 4 YAML files for certifications had invalid yaml key for `label`:
  * Test_TC_MC_6_1.yaml
  * Test_TC_MC_6_2.yaml
  * Test_TC_MC_6_3.yaml
  * Test_TC_MC_6_4.yaml
  

#### Change overview
Simple typo fix

#### Testing
No testing now as the tests are currently disabled in YAML.
