### PR TITLE
[OTA] Retry a CASE session establishment after session tear down

### DIFF
--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
@@ -83,11 +83,27 @@ bool GenericOTARequestorDriver::ProviderLocationsEqual(const ProviderLocationTyp
 
 void GenericOTARequestorDriver::HandleError(UpdateFailureState state, CHIP_ERROR error) {}
 
-void GenericOTARequestorDriver::HandleIdleState()
+void GenericOTARequestorDriver::HandleIdleState(IdleStateReason reason)
 {
-    // Default provider timer runs if and only if the OTARequestor's update state is kIdle.
-    // Must (re)start the timer every time we enter the kIdle state
-    StartDefaultProviderTimer();
+    switch (reason)
+    {
+    case IdleStateReason::kUnknown:
+        ChipLogProgress(SoftwareUpdate, "Unknown idle state reason so set the periodic timer for a next attempt");
+        StartDefaultProviderTimer();
+        break;
+    case IdleStateReason::kIdle:
+        // There is no current OTA update in progress so start the periodic query timer
+        StartDefaultProviderTimer();
+        break;
+    case IdleStateReason::kInvalidSession:
+        // An invalid session is detected which may be temporary so try to query again
+        ProviderLocationType providerLocation;
+        if (DetermineProviderLocation(providerLocation) == true)
+        {
+            DeviceLayer::SystemLayer().ScheduleLambda([this] { mRequestor->TriggerImmediateQueryInternal(); });
+        }
+        break;
+    }
 }
 
 void GenericOTARequestorDriver::UpdateAvailable(const UpdateDescription & update, System::Clock::Seconds32 delay)

--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
@@ -57,7 +57,7 @@ public:
     bool CanConsent() override;
     uint16_t GetMaxDownloadBlockSize() override;
     void HandleError(UpdateFailureState state, CHIP_ERROR error) override;
-    void HandleIdleState() override;
+    void HandleIdleState(IdleStateReason reason) override;
     void UpdateAvailable(const UpdateDescription & update, System::Clock::Seconds32 delay) override;
     void UpdateNotFound(UpdateNotFoundReason reason, System::Clock::Seconds32 delay) override;
     void UpdateDownloaded() override;

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -204,9 +204,14 @@ private:
     static void InitState(intptr_t context);
 
     /**
+     * Map a CHIP_ERROR to an IdleStateReason enum type
+     */
+    IdleStateReason MapErrorToIdleStateReason(CHIP_ERROR error);
+
+    /**
      * Record the new update state by updating the corresponding server attribute and logging a StateTransition event
      */
-    void RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeReasonEnum reason);
+    void RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error = CHIP_NO_ERROR);
 
     /**
      * Record the error update state by informing the driver of the error and calling `RecordNewUpdateState`

--- a/src/app/clusters/ota-requestor/OTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/OTARequestorDriver.h
@@ -62,6 +62,14 @@ enum class UpdateNotFoundReason
     ConnectionFailed,
 };
 
+// The reasons for why the OTA Requestor has entered idle state
+enum class IdleStateReason
+{
+    kUnknown,
+    kIdle,
+    kInvalidSession,
+};
+
 // Interface class to abstract the OTA-related business logic. Each application
 // must implement this interface. All calls must be non-blocking unless stated otherwise
 class OTARequestorDriver
@@ -80,8 +88,8 @@ public:
     /// Called when an error occurs at any OTA requestor operation
     virtual void HandleError(UpdateFailureState state, CHIP_ERROR error) = 0;
 
-    // Called when the OTA Requestor enters the kIdle update state
-    virtual void HandleIdleState() = 0;
+    // Called when the OTA Requestor has entered the Idle state for which the driver may need to take various actions
+    virtual void HandleIdleState(IdleStateReason reason) = 0;
 
     /// Called when the latest query found a software update
     virtual void UpdateAvailable(const UpdateDescription & update, System::Clock::Seconds32 delay) = 0;

--- a/src/app/clusters/ota-requestor/ota-requestor-server.cpp
+++ b/src/app/clusters/ota-requestor/ota-requestor-server.cpp
@@ -200,7 +200,7 @@ void OtaRequestorServerOnStateTransition(OTAUpdateStateEnum previousState, OTAUp
 {
     if (previousState == newState)
     {
-        ChipLogError(Zcl, "Previous state and new state are the same, no event to log");
+        ChipLogError(Zcl, "Previous state and new state are the same (%d), no event to log", to_underlying(newState));
         return;
     }
 


### PR DESCRIPTION
#### Problem
When a CASE session has become invalid (session was previously established but the provider has rebooted and has no knowledge of this session), requestor would tear down the CASE session. The tear down is discovered on a subsequent query attempt. However, after the tear down, there is no attempt at another query.

Fixes: https://github.com/project-chip/connectedhomeip/issues/16047

#### Change overview
- After the CASE session tear down occurs, allow OTA Requestor to continue another attempt

#### Testing
- Verified happy path transfer succeeds
- Verified that when provider is rebooted, subsequent transfer succeeds after CASE tear down
