### PR TITLE
Don't try to do something with message delivery failures on other fabrics.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -334,8 +334,8 @@ void DeviceController::OnFirstMessageDeliveryFailed(const SessionHandle & sessio
         return;
     }
 
-    FabricIndex ourIndex;
-    CHIP_ERROR err = GetFabricIndex(&ourIndex);
+    FabricIndex ourIndex = kUndefinedFabricIndex;
+    CHIP_ERROR err       = GetFabricIndex(&ourIndex);
     if (err != CHIP_NO_ERROR)
     {
         // We can't really do CASE, now can we?

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -321,10 +321,34 @@ CHIP_ERROR DeviceController::DisconnectDevice(NodeId nodeId)
 
 void DeviceController::OnFirstMessageDeliveryFailed(const SessionHandle & session)
 {
-    VerifyOrReturn(mState == State::Initialized,
-                   ChipLogError(Controller, "OnFirstMessageDeliveryFailed was called in incorrect state"));
-    VerifyOrReturn(session->GetSessionType() == Transport::Session::SessionType::kSecure);
-    CHIP_ERROR err = UpdateDevice(session->AsSecureSession()->GetPeerNodeId());
+    if (session->GetSessionType() != Session::SessionType::kSecure)
+    {
+        // Definitely not a CASE session.
+        return;
+    }
+
+    auto * secureSession = session->AsSecureSession();
+    if (secureSession->GetSecureSessionType() != SecureSession::Type::kCASE)
+    {
+        // Still not CASE.
+        return;
+    }
+
+    FabricIndex ourIndex;
+    CHIP_ERROR err = GetFabricIndex(&ourIndex);
+    if (err != CHIP_NO_ERROR)
+    {
+        // We can't really do CASE, now can we?
+        return;
+    }
+
+    if (ourIndex != session->GetFabricIndex())
+    {
+        // Not one of our sessions.
+        return;
+    }
+
+    err = UpdateDevice(secureSession->GetPeerNodeId());
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller,

--- a/src/transport/SessionDelegate.h
+++ b/src/transport/SessionDelegate.h
@@ -42,7 +42,8 @@ public:
      *   Called when the first message delivery in a session failed,
      *   so actions aiming to recover connection can be performed.
      *
-     * @param session   The handle to the secure session
+     * @param session   The handle to the session.  This may be any session type
+     *                  that supports MRP.
      */
     virtual void OnFirstMessageDeliveryFailed(const SessionHandle & session) = 0;
 };


### PR DESCRIPTION
If we have DeviceController instances for multiple fabrics around, all
will be notified via OnFirstMessageDeliveryFailed on message delivery
failure for any message.  Ignore the notifications unless they are for
a message over a CASE session for the fabric the controller is
associated with (in which case it might actually make sense for that
controller to act on the notification by redoing operational address
discovery and CASE).

#### Problem
See above.

#### Change overview
See above.

#### Testing
Made sure logs don't show multiple re-resolve attempts on different fabrics when a message is lost.