### PR TITLE
Fix segfault caused by accessing released device object

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1219,8 +1219,8 @@ CHIP_ERROR DeviceCommissioner::SendOperationalCertificate(DeviceProxy * device, 
     request.caseAdminNode = adminSubject;
     request.adminVendorId = mVendorId;
 
-    ReturnErrorOnFailure(SendCommand<OperationalCredentialsCluster>(mDeviceBeingCommissioned, request,
-                                                                    OnOperationalCertificateAddResponse, OnAddNOCFailureResponse));
+    ReturnErrorOnFailure(
+        SendCommand<OperationalCredentialsCluster>(device, request, OnOperationalCertificateAddResponse, OnAddNOCFailureResponse));
 
     ChipLogProgress(Controller, "Sent operational certificate to the device");
 


### PR DESCRIPTION
#### Problem

The local pointer to commissioned device was not cleared when the device object was released. This has caused SIGSEGV when the `DeviceCommissioner::Shutdown()` was called after `OnSessionEstablishmentTimeout()`.

#### Change overview

- clear `mDeviceBeingCommissioned` local pointer after every `ReleaseCommissioneeDevice()` call

#### Testing

1. Change [kSessionEstablishmentTimeout](https://github.com/project-chip/connectedhomeip/blob/master/src/controller/CHIPDeviceController.cpp#L105) to 1ms
2. Run tests, e.g. `./scripts/tests/run_test_suite.py --target-glob "DL_LockUnlock" run`
3. There shall be no "AddressSanitizer: heap-use-after-free on address ..." error