### PR TITLE
[nrfconnect] Bump SDK version in Docker

### DIFF
--- a/integrations/docker/images/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/chip-build-nrf-platform/Dockerfile
@@ -2,7 +2,7 @@ ARG VERSION=latest
 FROM connectedhomeip/chip-build:${VERSION} as build
 
 # Compatible Nordic Connect SDK revision.
-ARG NCS_REVISION=v1.9.0
+ARG NCS_REVISION=v1.9.1
 
 RUN set -x \
     && apt-get update \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.57 Version bump reason: Update Infineon P6 Docker
+0.5.58 Version bump reason: Update nRF Connect SDK


### PR DESCRIPTION
#### Problem
An OpenThread bug was discovered in 1.9.0 version, so we need to bump the supported nRF Connect SDK to 1.9.1 version that includes the fix.

#### Change overview
Bump nRF Connect SDK version in the Docker image.

#### Testing
Docker build tested by CI.
