### PR TITLE
Added Node and fabric data to BDXOtaSender to keep track of connections

### DIFF
--- a/examples/ota-provider-app/esp32/main/include/ota-provider-common/BdxOtaSender.h
+++ b/examples/ota-provider-app/esp32/main/include/ota-provider-common/BdxOtaSender.h
@@ -71,6 +71,9 @@ struct BdxOtaSenderCallbacks
 class BdxOtaSender : public chip::bdx::Responder
 {
 public:
+    // Initializes BDX transfer-related metadata. Should always be called first.
+    CHIP_ERROR InitializeTransfer(chip::FabricIndex fabricIndex, chip::NodeId nodeId);
+
     void SetCallbacks(BdxOtaSenderCallbacks callbacks);
 
     /**
@@ -96,6 +99,12 @@ private:
     void Reset();
 
     uint32_t mNumBytesSent = 0;
+
+    bool mInitialized = false;
+
+    chip::Optional<chip::FabricIndex> mFabricIndex;
+
+    chip::Optional<chip::NodeId> mNodeId;
 
     chip::Callback::Callback<OnBdxBlockQuery> * mOnBlockQueryCallback             = nullptr;
     chip::Callback::Callback<OnBdxTransferComplete> * mOnTransferCompleteCallback = nullptr;

--- a/examples/ota-provider-app/ota-provider-common/BdxOtaSender.h
+++ b/examples/ota-provider-app/ota-provider-common/BdxOtaSender.h
@@ -25,6 +25,9 @@ class BdxOtaSender : public chip::bdx::Responder
 public:
     BdxOtaSender();
 
+    // Initializes BDX transfer-related metadata. Should always be called first.
+    CHIP_ERROR InitializeTransfer(chip::FabricIndex fabricIndex, chip::NodeId nodeId);
+
 private:
     // Inherited from bdx::TransferFacilitator
     void HandleTransferSessionOutput(chip::bdx::TransferSession::OutputEvent & event) override;
@@ -35,4 +38,10 @@ private:
     char mFileDesignator[chip::bdx::kMaxFileDesignatorLen];
 
     uint32_t mNumBytesSent = 0;
+
+    bool mInitialized = false;
+
+    chip::Optional<chip::FabricIndex> mFabricIndex;
+
+    chip::Optional<chip::NodeId> mNodeId;
 };

--- a/src/lib/core/CHIPError.cpp
+++ b/src/lib/core/CHIPError.cpp
@@ -695,6 +695,9 @@ bool FormatCHIPError(char * buf, uint16_t bufSize, CHIP_ERROR err)
     case CHIP_ERROR_IM_MALFORMED_TIMED_REQUEST_MESSAGE.AsInteger():
         desc = "Malformed Interaction Model Timed Request Message";
         break;
+    case CHIP_ERROR_BUSY.AsInteger():
+        desc = "The Resource is busy and cannot process the request";
+        break;
     }
 #endif // !CHIP_CONFIG_SHORT_ERROR_STR
 

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -2401,6 +2401,15 @@ using CHIP_ERROR = ::chip::ChipError;
 #define CHIP_ERROR_INVALID_FILE_IDENTIFIER                     CHIP_CORE_ERROR(0xda)
 
 /**
+ * @def CHIP_ERROR_BUSY
+ *
+ * @brief
+ *   The Resource is busy and cannot process the request. Trying again might work.
+ */
+#define CHIP_ERROR_BUSY                     CHIP_CORE_ERROR(0xdb)
+
+
+/**
  *  @}
  */
 


### PR DESCRIPTION
#### Problem
What is being fixed?  #16044 

#### Change overview
The BDXOtaSender keeps track of the fabricIdx and nodeId of the "active" requestor. If the requestor hangs/dies and re-attempts a connection, the previous BDX session will be cleaned up, to allow the connection. If a new node tries to connect in the interim a BUSY message will be sent to it, requesting it to retry later. Note that the BDX connection will eventually timeout on no-activity and should reset automatically as well.

#### Testing
- Tested the following scenarios:
- If a requestor fails to continue an OTA after getting a QueryImage response (i.e. crashes), a new Query-image can be sent immediately, upon re-connecting.
- A requestor does not continue an OTA after getting a QueryImage response (i.e. crashes). If a new node sends a queryImage to the provider, it will get a BUSY response.
