### PR TITLE
Add user input to UserPrompt function.

### DIFF
--- a/src/app/tests/suites/TestLogCommands.yaml
+++ b/src/app/tests/suites/TestLogCommands.yaml
@@ -36,6 +36,28 @@ tests:
               - name: "message"
                 value: "This is a simple message"
 
+    - label: "Do a simple user prompt message. Expect 'y' to pass."
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      disabled: true
+      arguments:
+          values:
+              - name: "message"
+                value: "Please enter 'y' for success"
+              - name: "expectedValue"
+                value: "y"
+
+    - label: "Do a simple user prompt message. Use enter to coninue."
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      disabled: true
+      arguments:
+          values:
+              - name: "message"
+                value: "Please enter enter to continue"
+              - name: "expectedValue"
+                value: ""
+
     - label: "Do a simple user prompt message"
       cluster: "LogCommands"
       command: "UserPrompt"

--- a/src/app/tests/suites/commands/log/LogCommands.cpp
+++ b/src/app/tests/suites/commands/log/LogCommands.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "LogCommands.h"
+#include <iostream>
 
 CHIP_ERROR LogCommands::Log(const char * message)
 {
@@ -24,8 +25,20 @@ CHIP_ERROR LogCommands::Log(const char * message)
     return ContinueOnChipMainThread(CHIP_NO_ERROR);
 }
 
-CHIP_ERROR LogCommands::UserPrompt(const char * message)
+CHIP_ERROR LogCommands::UserPrompt(const char * message, const char * expectedValue)
 {
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    std::string line;
     ChipLogDetail(chipTool, "USER_PROMPT: %s", message);
-    return ContinueOnChipMainThread(CHIP_NO_ERROR);
+    if (expectedValue == nullptr)
+    {
+        return ContinueOnChipMainThread(err);
+    }
+
+    std::getline(std::cin, line);
+    if (line != expectedValue)
+    {
+        err = CHIP_ERROR_INVALID_ARGUMENT;
+    }
+    return ContinueOnChipMainThread(err);
 }

--- a/src/app/tests/suites/commands/log/LogCommands.h
+++ b/src/app/tests/suites/commands/log/LogCommands.h
@@ -29,5 +29,5 @@ public:
     virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) = 0;
 
     CHIP_ERROR Log(const char * message);
-    CHIP_ERROR UserPrompt(const char * message);
+    CHIP_ERROR UserPrompt(const char * message, const char * expectedValue = nullptr);
 };

--- a/src/app/zap-templates/common/simulated-clusters/clusters/LogCommands.js
+++ b/src/app/zap-templates/common/simulated-clusters/clusters/LogCommands.js
@@ -32,7 +32,7 @@ const Log = {
 
 const UserPrompt = {
   name : 'UserPrompt',
-  arguments : [ { type : 'CHAR_STRING', name : 'message' } ],
+  arguments : [ { type : 'CHAR_STRING', name : 'message' }, { type : 'CHAR_STRING', name : 'expectedValue', isOptional : true } ],
   response : { arguments : [] }
 };
 


### PR DESCRIPTION
#### Problem
Currently there is no input from UserPrompt function when adding it to YAML. We need a way to determine if the user completed the task requested in test. 

#### Change overview
- Add ability to accept user input. 
- Add ability to specify accepted value.
- If value is set to empty quotes, enter will allow to proceed.
- If no value is set in YAML, continues without user prompt. 

#### Testing
Tested all scenarios. CI can only run when no value is set to user prompt and test will continue. 
