### PR TITLE
Remove PrioritizeAddresses call since address resolve has now determi…

### DIFF
--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -157,7 +157,6 @@ static void HandleNodeIdResolve(void * context, DnssdService * result, const Spa
     }
 
     nodeData.LogNodeIdResolved();
-    nodeData.PrioritizeAddresses();
     proxy->OnOperationalNodeResolved(nodeData);
     proxy->Release();
 }

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -40,32 +40,6 @@ struct ResolvedNodeData
     // TODO: use pool to allow dynamic
     static constexpr unsigned kMaxIPAddresses = 5;
 
-    static bool IsIpLess(const Inet::IPAddress & a, const Inet::IPAddress & b)
-    {
-        // Link-local last
-        if (a.IsIPv6LinkLocal() && !b.IsIPv6LinkLocal())
-        {
-            return false;
-        }
-        if (!a.IsIPv6LinkLocal() && b.IsIPv6LinkLocal())
-        {
-            return true;
-        }
-
-        // IPv6 before IPv4
-        if (a.IsIPv6() && !b.IsIPv6())
-        {
-            return false;
-        }
-        if (!a.IsIPv6() && b.IsIPv6())
-        {
-            return true;
-        }
-
-        // no ordering, do not care
-        return false;
-    }
-
     void LogNodeIdResolved() const
     {
 #if CHIP_PROGRESS_LOGGING
@@ -80,25 +54,6 @@ struct ResolvedNodeData
             ChipLogProgress(Discovery, "    Addr %u: [%s]:%" PRIu16, i, addrBuffer, mPort);
         }
 #endif // CHIP_PROGRESS_LOGGING
-    }
-
-    /// Sorts IP addresses in a consistent order. Specifically places
-    /// Link-local IPv6 addresses at the end (e.g. mDNS reflector services in Unify will
-    /// return link-local addresses that will not work) and prioritizes global IPv6 addresses
-    /// before IPv4 ones.
-    void PrioritizeAddresses()
-    {
-        // Slow sort, however we have maximum kMaxIPAddreses, so this is good enough for now
-        for (unsigned i = 0; i + 1 < mNumIPs; i++)
-        {
-            for (unsigned j = i + 1; i < mNumIPs; i++)
-            {
-                if (IsIpLess(mAddress[j], mAddress[i]))
-                {
-                    std::swap(mAddress[i], mAddress[j]);
-                }
-            }
-        }
     }
 
     ReliableMessageProtocolConfig GetMRPConfig() const

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -338,7 +338,6 @@ void PacketDataReporter::OnComplete(ActiveResolveAttempts & activeAttempts)
     {
         activeAttempts.Complete(mNodeData.mPeerId);
         mNodeData.LogNodeIdResolved();
-        mNodeData.PrioritizeAddresses();
 
         //
         // This is a quick fix to address some failing tests. Issue #15489 tracks the correct fix here.


### PR DESCRIPTION
…nistic ordering

#### Problem
after #15934 address resolution is already ordered, no need to re-order it in packets.

#### Change overview
Remove address reordering methods and calls, should save a very slight bit of code and complexity.

#### Testing
N/A - simple remove, unit tests will validate that nothing breaks.