### PR TITLE
[EFR32] Add generation of EFR OTA image file to build process

### DIFF
--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -154,7 +154,7 @@ else
     arm-none-eabi-size -A "$BUILD_DIR"/*.out
 
     # Generate bootloader file
-    if [ ${BUILD_DIR:0:2} == "./"]; then
+    if [ "${BUILD_DIR:0:2}" == "./"]; then
         BUILD_DIR_TRIMMED="${BUILD_DIR:2}"
         S37_PATH=$(find "$BUILD_DIR_TRIMMED" -type f -name "*.s37")
         if [ -z "$S37_PATH" ]; then
@@ -168,6 +168,6 @@ else
         fi
 
     else
-        BUILD_DIR_TRIMMED="${BUILD_DIR}"
+        BUILD_DIR_TRIMMED="$BUILD_DIR"
     fi
 fi

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -156,10 +156,14 @@ else
     # Generate bootloader file
     BUILD_DIR_TRIMMED="${BUILD_DIR:2}" 
     S37_PATH=$(find "$BUILD_DIR_TRIMMED" -type f -name "*.s37")
-    TARGET_PATH=${S37_PATH%????}
-    OTA_PATH="${TARGET_PATH}".ota
-    commander gbl create $TARGET_PATH.gbl --app $S37_PATH
-
-    GBL_PATH="${TARGET_PATH}".ota
-    ./src/app/ota_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 1 -vs "1.0" -da sha256 $GBL_PATH $OTA_PATH
+    if [ -z "$S37_PATH" ]
+    then
+        echo "Bootloader could not be built"
+    else
+        TARGET_PATH=${S37_PATH%????}
+        OTA_PATH="${TARGET_PATH}".ota
+        commander gbl create $TARGET_PATH.gbl --app $S37_PATH
+        GBL_PATH="${TARGET_PATH}".ota
+        ./src/app/ota_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 1 -vs "1.0" -da sha256 $GBL_PATH $OTA_PATH
+    fi
 fi

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -154,7 +154,7 @@ else
     arm-none-eabi-size -A "$BUILD_DIR"/*.out
 
     # Generate bootloader file
-    BUILD_DIR_TRIMMED="${BUILD_DIR:2}"
+    BUILD_DIR_TRIMMED="${BUILD_DIR#*/}"
     S37_PATH=$(find "$BUILD_DIR_TRIMMED" -type f -name "*.s37")
     if [ -z "$S37_PATH" ]; then
         echo "Bootloader could not be built"

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -155,7 +155,7 @@ else
 
     # Generate bootloader file
     if [ ${BUILD_DIR:0:2} == "./"]; then
-        BUILD_DIR_TRIMMED="${BUILD_DIR:2}" 
+        BUILD_DIR_TRIMMED="${BUILD_DIR:2}"
         S37_PATH=$(find "$BUILD_DIR_TRIMMED" -type f -name "*.s37")
         if [ -z "$S37_PATH" ]; then
             echo "Bootloader could not be built"

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -153,4 +153,13 @@ else
     #print stats
     arm-none-eabi-size -A "$BUILD_DIR"/*.out
 
+    # Generate bootloader file
+    BUILD_DIR_TRIMMED="${BUILD_DIR:2}" 
+    S37_PATH=$(find "$BUILD_DIR_TRIMMED" -type f -name "*.s37")
+    TARGET_PATH=${S37_PATH%????}
+    OTA_PATH="${TARGET_PATH}".ota
+    commander gbl create $TARGET_PATH.gbl --app $S37_PATH
+
+    GBL_PATH=$(find "$BUILD_DIR_TRIMMED" -type f -name "*.gbl")
+    ./src/app/ota_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 1 -vs "1.0" -da sha256 $GBL_PATH $OTA_PATH
 fi

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -161,9 +161,9 @@ else
         echo "Bootloader could not be built"
     else
         TARGET_PATH=${S37_PATH%????}
-        OTA_PATH="${TARGET_PATH}".ota
-        commander gbl create $TARGET_PATH.gbl --app $S37_PATH
-        GBL_PATH="${TARGET_PATH}".ota
-        ./src/app/ota_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 1 -vs "1.0" -da sha256 $GBL_PATH $OTA_PATH
+        OTA_PATH="$TARGET_PATH".ota
+        commander gbl create "$TARGET_PATH".gbl --app "$S37_PATH"
+        GBL_PATH="$TARGET_PATH".ota
+        ./src/app/ota_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 1 -vs "1.0" -da sha256 "$GBL_PATH" "$OTA_PATH"
     fi
 fi

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -157,7 +157,7 @@ else
     if [ ${BUILD_DIR:0:2} == "./"]; then
         BUILD_DIR_TRIMMED="${BUILD_DIR:2}" 
     else
-        BUILD_DIR_TRIMMED="${BUILD_DIR#*/}"
+        BUILD_DIR_TRIMMED="${BUILD_DIR}"
     fi
     S37_PATH=$(find "$BUILD_DIR_TRIMMED" -type f -name "*.s37")
     if [ -z "$S37_PATH" ]; then

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -154,7 +154,7 @@ else
     arm-none-eabi-size -A "$BUILD_DIR"/*.out
 
     # Generate bootloader file
-    if [ {"$BUILD_DIR:2" == "./"}; then
+    if [ {"$BUILD_DIR:0:2" == "./"}; then
         BUILD_DIR_TRIMMED="${BUILD_DIR:2}" 
     else
         BUILD_DIR_TRIMMED="${BUILD_DIR#*/}"

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -156,8 +156,7 @@ else
     # Generate bootloader file
     BUILD_DIR_TRIMMED="${BUILD_DIR:2}"
     S37_PATH=$(find "$BUILD_DIR_TRIMMED" -type f -name "*.s37")
-    if [ -z "$S37_PATH" ]
-    then
+    if [ -z "$S37_PATH" ]; then
         echo "Bootloader could not be built"
     else
         TARGET_PATH=${S37_PATH%????}

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -166,4 +166,5 @@ else
             GBL_PATH="$TARGET_PATH".gbl
             ./src/app/ota_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 1 -vs "1.0" -da sha256 "$GBL_PATH" "$OTA_PATH"
         fi
+    fi
 fi

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -154,7 +154,7 @@ else
     arm-none-eabi-size -A "$BUILD_DIR"/*.out
 
     # Generate bootloader file
-    if [ ${"BUILD_DIR:0:2"} == "./"]; then
+    if [ ${BUILD_DIR:0:2} == "./"]; then
         BUILD_DIR_TRIMMED="${BUILD_DIR:2}" 
     else
         BUILD_DIR_TRIMMED="${BUILD_DIR#*/}"

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -160,6 +160,6 @@ else
     OTA_PATH="${TARGET_PATH}".ota
     commander gbl create $TARGET_PATH.gbl --app $S37_PATH
 
-    GBL_PATH=$(find "$BUILD_DIR_TRIMMED" -type f -name "*.gbl")
+    GBL_PATH="${TARGET_PATH}".ota
     ./src/app/ota_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 1 -vs "1.0" -da sha256 $GBL_PATH $OTA_PATH
 fi

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -166,8 +166,4 @@ else
             GBL_PATH="$TARGET_PATH".gbl
             ./src/app/ota_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 1 -vs "1.0" -da sha256 "$GBL_PATH" "$OTA_PATH"
         fi
-
-    else
-        BUILD_DIR_TRIMMED="$BUILD_DIR"
-    fi
 fi

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -156,17 +156,18 @@ else
     # Generate bootloader file
     if [ ${BUILD_DIR:0:2} == "./"]; then
         BUILD_DIR_TRIMMED="${BUILD_DIR:2}" 
+        S37_PATH=$(find "$BUILD_DIR_TRIMMED" -type f -name "*.s37")
+        if [ -z "$S37_PATH" ]; then
+            echo "Bootloader could not be built"
+        else
+            TARGET_PATH=${S37_PATH%????}
+            OTA_PATH="$TARGET_PATH".ota
+            commander gbl create "$TARGET_PATH".gbl --app "$S37_PATH"
+            GBL_PATH="$TARGET_PATH".gbl
+            ./src/app/ota_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 1 -vs "1.0" -da sha256 "$GBL_PATH" "$OTA_PATH"
+        fi
+
     else
         BUILD_DIR_TRIMMED="${BUILD_DIR}"
-    fi
-    S37_PATH=$(find "$BUILD_DIR_TRIMMED" -type f -name "*.s37")
-    if [ -z "$S37_PATH" ]; then
-        echo "Bootloader could not be built"
-    else
-        TARGET_PATH=${S37_PATH%????}
-        OTA_PATH="$TARGET_PATH".ota
-        commander gbl create "$TARGET_PATH".gbl --app "$S37_PATH"
-        GBL_PATH="$TARGET_PATH".gbl
-        ./src/app/ota_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 1 -vs "1.0" -da sha256 "$GBL_PATH" "$OTA_PATH"
     fi
 fi

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -154,7 +154,11 @@ else
     arm-none-eabi-size -A "$BUILD_DIR"/*.out
 
     # Generate bootloader file
-    BUILD_DIR_TRIMMED="${BUILD_DIR#*/}"
+    if [ {"$BUILD_DIR:2" == "./"}; then
+        BUILD_DIR_TRIMMED="${BUILD_DIR:2}" 
+    else
+        BUILD_DIR_TRIMMED="${BUILD_DIR#*/}"
+    fi
     S37_PATH=$(find "$BUILD_DIR_TRIMMED" -type f -name "*.s37")
     if [ -z "$S37_PATH" ]; then
         echo "Bootloader could not be built"

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -154,7 +154,7 @@ else
     arm-none-eabi-size -A "$BUILD_DIR"/*.out
 
     # Generate bootloader file
-    if [ {"$BUILD_DIR:0:2" == "./"}; then
+    if [ ${"BUILD_DIR:0:2"} == "./"]; then
         BUILD_DIR_TRIMMED="${BUILD_DIR:2}" 
     else
         BUILD_DIR_TRIMMED="${BUILD_DIR#*/}"

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -162,7 +162,7 @@ else
         TARGET_PATH=${S37_PATH%????}
         OTA_PATH="$TARGET_PATH".ota
         commander gbl create "$TARGET_PATH".gbl --app "$S37_PATH"
-        GBL_PATH="$TARGET_PATH".ota
+        GBL_PATH="$TARGET_PATH".gbl
         ./src/app/ota_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 1 -vs "1.0" -da sha256 "$GBL_PATH" "$OTA_PATH"
     fi
 fi

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -154,7 +154,7 @@ else
     arm-none-eabi-size -A "$BUILD_DIR"/*.out
 
     # Generate bootloader file
-    BUILD_DIR_TRIMMED="${BUILD_DIR:2}" 
+    BUILD_DIR_TRIMMED="${BUILD_DIR:2}"
     S37_PATH=$(find "$BUILD_DIR_TRIMMED" -type f -name "*.s37")
     if [ -z "$S37_PATH" ]
     then


### PR DESCRIPTION
#### Problem
Gecko bootloader file currently has to be generated manually.
.ota file has to be generated manually

#### Change overview
This adds functionality to automatically generate a .gbl and .ota file when an application is built.

#### Testing
.gbl and .ota are built and placed in out/{application-name}/{board-name}
