### PR TITLE
[OTA] Set only one timer when querying a non-existent provider

### DIFF
--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
@@ -68,9 +68,7 @@ public:
     void ProcessAnnounceOTAProviders(const ProviderLocationType & providerLocation,
                                      app::Clusters::OtaSoftwareUpdateRequestor::OTAAnnouncementReason announcementReason) override;
     void SendQueryImage() override;
-
-    // Returns the next available Provider location
-    bool DetermineProviderLocation(ProviderLocationType & providerLocation) override;
+    bool GetNextProviderLocation(ProviderLocationType & providerLocation) override;
 
 protected:
     void StartDefaultProviderTimer();

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -170,7 +170,7 @@ void OTARequestor::OnQueryImageResponse(void * context, const QueryImageResponse
                           update.softwareVersion, requestorCore->mCurrentVersion);
 
             requestorCore->RecordNewUpdateState(OTAUpdateStateEnum::kIdle, OTAChangeReasonEnum::kSuccess);
-            requestorCore->mOtaRequestorDriver->UpdateNotFound(UpdateNotFoundReason::UpToDate,
+            requestorCore->mOtaRequestorDriver->UpdateNotFound(UpdateNotFoundReason::kUpToDate,
                                                                System::Clock::Seconds32(response.delayedActionTime.ValueOr(0)));
         }
 
@@ -178,12 +178,12 @@ void OTARequestor::OnQueryImageResponse(void * context, const QueryImageResponse
     }
     case OTAQueryStatus::kBusy:
         requestorCore->RecordNewUpdateState(OTAUpdateStateEnum::kDelayedOnQuery, OTAChangeReasonEnum::kDelayByProvider);
-        requestorCore->mOtaRequestorDriver->UpdateNotFound(UpdateNotFoundReason::Busy,
+        requestorCore->mOtaRequestorDriver->UpdateNotFound(UpdateNotFoundReason::kBusy,
                                                            System::Clock::Seconds32(response.delayedActionTime.ValueOr(0)));
         break;
     case OTAQueryStatus::kNotAvailable:
         requestorCore->RecordNewUpdateState(OTAUpdateStateEnum::kIdle, OTAChangeReasonEnum::kSuccess);
-        requestorCore->mOtaRequestorDriver->UpdateNotFound(UpdateNotFoundReason::NotAvailable,
+        requestorCore->mOtaRequestorDriver->UpdateNotFound(UpdateNotFoundReason::kNotAvailable,
                                                            System::Clock::Seconds32(response.delayedActionTime.ValueOr(0)));
         break;
     default:
@@ -459,9 +459,6 @@ void OTARequestor::OnConnectionFailure(void * context, PeerId peerId, CHIP_ERROR
     default:
         break;
     }
-
-    // Give driver a chance to schedule another query
-    requestorCore->mOtaRequestorDriver->UpdateNotFound(UpdateNotFoundReason::ConnectionFailed, chip::System::Clock::Seconds32(0));
 }
 
 // Sends the QueryImage command to the Provider currently set in the OTARequestor
@@ -478,7 +475,7 @@ void OTARequestor::TriggerImmediateQueryInternal()
 OTARequestorInterface::OTATriggerResult OTARequestor::TriggerImmediateQuery()
 {
     ProviderLocationType providerLocation;
-    if (mOtaRequestorDriver->DetermineProviderLocation(providerLocation) != true)
+    if (mOtaRequestorDriver->GetNextProviderLocation(providerLocation) != true)
     {
         ChipLogError(SoftwareUpdate, "No OTA Providers available");
         return kNoProviderKnown;

--- a/src/app/clusters/ota-requestor/OTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/OTARequestorDriver.h
@@ -56,10 +56,9 @@ enum class UpdateFailureState
 
 enum class UpdateNotFoundReason
 {
-    Busy,
-    NotAvailable,
-    UpToDate,
-    ConnectionFailed,
+    kBusy,
+    kNotAvailable,
+    kUpToDate,
 };
 
 // The reasons for why the OTA Requestor has entered idle state
@@ -129,7 +128,7 @@ public:
     // Driver picks the OTA Provider that should be used for the next query and update. The Provider is picked according to
     // the driver's internal logic such as, for example, traversing the default providers list.
     // Returns true if there is a Provider available for the next query, returns false otherwise.
-    virtual bool DetermineProviderLocation(ProviderLocationType & providerLocation) = 0;
+    virtual bool GetNextProviderLocation(ProviderLocationType & providerLocation) = 0;
 };
 
 } // namespace chip


### PR DESCRIPTION
#### Problem
There are a few issues addressed with this PR
* When querying a non-existent provider on the fabric, OTARequestor would set two timers- one from the call to `UpdateNotFound` and another due to transition to idle state
* When using a CASE session that was previously valid but is no longer valid, the driver will attempt to query again but to a different provider

#### Change overview
* In the non-existent provider scenario, use the transition to idle state to schedule a query at the next periodic interval- this prevents repeatedly querying a possibly bad provider over and over again (done by the `UpdateNotFound` path), draining power
* In the invalid CASE session scenario, make sure to query the same provider again in case it was just temporarily unavailable- if the provider is truly out of commission, the path for the non-existent provider be applied

#### Testing
- Verified that querying a non-existent provider would result in the next provider in the default list is queried on the next periodic interval
- Verified that when a previous valid CASE session for a provider is temporarily invalid, it is queried again. If it still is not available, a periodic query is scheduled to try a different provider
