### PR TITLE
Fix numRetries for subscription

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -769,6 +769,11 @@ CHIP_ERROR ReadClient::ProcessSubscribeResponse(System::PacketBufferHandle && aP
 
     MoveToState(ClientState::SubscriptionActive);
 
+    if (mReadPrepareParams.mResubscribePolicy != nullptr)
+    {
+        mNumRetries = 0;
+    }
+
     RefreshLivenessCheckTimer();
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem
See issue #16186 

#### Change overview
-- clear the counter back to 0 on successful establishment of a subscription.

#### Testing
Manual testing, create subscription, restart responder, initiator retry with success and observe the log
