### PR TITLE
Cleanup OperationalCredentials if the fail-safe timer expires

### DIFF
--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -444,6 +444,8 @@ struct ChipDeviceEvent final
             CHIP_ERROR Status;
             uint64_t PeerNodeId;
             FabricIndex PeerFabricIndex;
+            bool AddNocCommandHasBeenInvoked;
+            bool UpdateNocCommandHasBeenInvoked;
         } CommissioningComplete;
 
         struct

--- a/src/include/platform/FailSafeContext.h
+++ b/src/include/platform/FailSafeContext.h
@@ -55,12 +55,20 @@ public:
         return (accessingFabricIndex == mFabricIndex);
     }
 
-    inline bool NocCommandHasBeenInvoked() const { return mNocCommandHasBeenInvoked; }
+    inline bool NocCommandHasBeenInvoked() const { return mAddNocCommandHasBeenInvoked || mUpdateNocCommandHasBeenInvoked; }
+    inline bool AddNocCommandHasBeenInvoked() { return mAddNocCommandHasBeenInvoked; }
+    inline bool UpdateNocCommandHasBeenInvoked() { return mUpdateNocCommandHasBeenInvoked; }
 
-    inline void SetNocCommandInvoked(FabricIndex nocFabricIndex)
+    inline void SetAddNocCommandInvoked(FabricIndex nocFabricIndex)
     {
-        mNocCommandHasBeenInvoked = true;
-        mFabricIndex              = nocFabricIndex;
+        mAddNocCommandHasBeenInvoked = true;
+        mFabricIndex                 = nocFabricIndex;
+    }
+
+    inline void SetUpdateNocCommandInvoked(FabricIndex nocFabricIndex)
+    {
+        mUpdateNocCommandHasBeenInvoked = true;
+        mFabricIndex                    = nocFabricIndex;
     }
 
     inline FabricIndex GetFabricIndex() const
@@ -72,9 +80,10 @@ public:
 private:
     // ===== Private members reserved for use by this class only.
 
-    bool mFailSafeArmed            = false;
-    bool mNocCommandHasBeenInvoked = false;
-    FabricIndex mFabricIndex       = kUndefinedFabricIndex;
+    bool mFailSafeArmed                  = false;
+    bool mAddNocCommandHasBeenInvoked    = false;
+    bool mUpdateNocCommandHasBeenInvoked = false;
+    FabricIndex mFabricIndex             = kUndefinedFabricIndex;
 
     // TODO:: Track the state of what was mutated during fail-safe.
 

--- a/src/platform/DeviceControlServer.cpp
+++ b/src/platform/DeviceControlServer.cpp
@@ -37,11 +37,16 @@ DeviceControlServer & DeviceControlServer::DeviceControlSvr()
 CHIP_ERROR DeviceControlServer::CommissioningComplete(NodeId peerNodeId, FabricIndex accessingFabricIndex)
 {
     VerifyOrReturnError(CHIP_NO_ERROR == mFailSafeContext.DisarmFailSafe(), CHIP_ERROR_INTERNAL);
+
     ChipDeviceEvent event;
-    event.Type                                  = DeviceEventType::kCommissioningComplete;
-    event.CommissioningComplete.PeerNodeId      = peerNodeId;
-    event.CommissioningComplete.PeerFabricIndex = accessingFabricIndex;
-    event.CommissioningComplete.Status          = CHIP_NO_ERROR;
+
+    event.Type                                                 = DeviceEventType::kCommissioningComplete;
+    event.CommissioningComplete.PeerNodeId                     = peerNodeId;
+    event.CommissioningComplete.PeerFabricIndex                = accessingFabricIndex;
+    event.CommissioningComplete.AddNocCommandHasBeenInvoked    = mFailSafeContext.AddNocCommandHasBeenInvoked();
+    event.CommissioningComplete.UpdateNocCommandHasBeenInvoked = mFailSafeContext.UpdateNocCommandHasBeenInvoked();
+    event.CommissioningComplete.Status                         = CHIP_NO_ERROR;
+
     return PlatformMgr().PostEvent(&event);
 }
 

--- a/src/platform/FailSafeContext.cpp
+++ b/src/platform/FailSafeContext.cpp
@@ -35,14 +35,13 @@ void FailSafeContext::HandleArmFailSafe(System::Layer * layer, void * aAppState)
 
 void FailSafeContext::CommissioningFailedTimerComplete()
 {
-    // TODO: If the fail-safe timer expires before the CommissioningComplete command is
-    // successfully invoked, conduct clean-up steps.
-
     ChipDeviceEvent event;
-    event.Type                                  = DeviceEventType::kCommissioningComplete;
-    event.CommissioningComplete.PeerFabricIndex = mFabricIndex;
-    event.CommissioningComplete.Status          = CHIP_ERROR_TIMEOUT;
-    CHIP_ERROR status                           = PlatformMgr().PostEvent(&event);
+    event.Type                                                 = DeviceEventType::kCommissioningComplete;
+    event.CommissioningComplete.PeerFabricIndex                = mFabricIndex;
+    event.CommissioningComplete.AddNocCommandHasBeenInvoked    = mAddNocCommandHasBeenInvoked;
+    event.CommissioningComplete.UpdateNocCommandHasBeenInvoked = mUpdateNocCommandHasBeenInvoked;
+    event.CommissioningComplete.Status                         = CHIP_ERROR_TIMEOUT;
+    CHIP_ERROR status                                          = PlatformMgr().PostEvent(&event);
 
     mFailSafeArmed                  = false;
     mAddNocCommandHasBeenInvoked    = false;

--- a/src/platform/FailSafeContext.cpp
+++ b/src/platform/FailSafeContext.cpp
@@ -39,9 +39,10 @@ void FailSafeContext::CommissioningFailedTimerComplete()
     // successfully invoked, conduct clean-up steps.
 
     ChipDeviceEvent event;
-    event.Type                         = DeviceEventType::kCommissioningComplete;
-    event.CommissioningComplete.Status = CHIP_ERROR_TIMEOUT;
-    CHIP_ERROR status                  = PlatformMgr().PostEvent(&event);
+    event.Type                                  = DeviceEventType::kCommissioningComplete;
+    event.CommissioningComplete.PeerFabricIndex = mFabricIndex;
+    event.CommissioningComplete.Status          = CHIP_ERROR_TIMEOUT;
+    CHIP_ERROR status                           = PlatformMgr().PostEvent(&event);
 
     mFailSafeArmed                  = false;
     mAddNocCommandHasBeenInvoked    = false;

--- a/src/platform/FailSafeContext.cpp
+++ b/src/platform/FailSafeContext.cpp
@@ -43,8 +43,9 @@ void FailSafeContext::CommissioningFailedTimerComplete()
     event.CommissioningComplete.Status = CHIP_ERROR_TIMEOUT;
     CHIP_ERROR status                  = PlatformMgr().PostEvent(&event);
 
-    mFailSafeArmed            = false;
-    mNocCommandHasBeenInvoked = false;
+    mFailSafeArmed                  = false;
+    mAddNocCommandHasBeenInvoked    = false;
+    mUpdateNocCommandHasBeenInvoked = false;
 
     if (status != CHIP_NO_ERROR)
     {
@@ -62,8 +63,9 @@ CHIP_ERROR FailSafeContext::ArmFailSafe(FabricIndex accessingFabricIndex, System
 
 CHIP_ERROR FailSafeContext::DisarmFailSafe()
 {
-    mFailSafeArmed            = false;
-    mNocCommandHasBeenInvoked = false;
+    mFailSafeArmed                  = false;
+    mAddNocCommandHasBeenInvoked    = false;
+    mUpdateNocCommandHasBeenInvoked = false;
     DeviceLayer::SystemLayer().CancelTimer(HandleArmFailSafe, this);
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* According to the latest spec update, we need to do the following cleanups in OperationalCredentials cluster if the fail-safe timer expires:
* If an AddNOC or UpdateNOC command has been successfully invoked, terminate all CASE sessions associated with the Fabric whose Fabric Index is recorded in the Fail-Safe context

* If an UpdateNOC command had been successfully invoked, revert the state of operational key pair, NOC and ICAC for that Fabric to the state prior to the Fail-Safe timer being armed, for the Fabric Index that was the subject of the UpdateNOC command.

* If an AddNOC command had been successfully invoked, achieve the equivalent effect of invoking the RemoveFabric command against the Fabric Index stored in the Fail-Safe Context for the Fabric Index that was the subject of the AddNOC command. This SHALL remove all associations to that Fabric including all fabric-scoped data, and MAY possibly factory-reset the device depending on current device state. This SHALL only apply to Fabrics added during the fail-safe period as the result of the AddNOC command.

* Remove any RCACs added by the AddTrustedRootCertificate command that are not currently referenced by any entry in the Fabrics attribute.

#### Change overview
Cleanup OperationalCredentials if the fail-safe timer expires

#### Testing
How was this tested? (at least one bullet point required)
* Inject kCommissioningComplete event with failure and confirm related cleanups have been done from log
