### PR TITLE
Rename IV to nonce

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -552,15 +552,15 @@ CHIP_ERROR ConvertIntegerRawToDerWithoutTag(const ByteSpan & raw_integer, Mutabl
  * @param aad_length Length of additional authentication data
  * @param key Encryption key
  * @param key_length Length of encryption key (in bytes)
- * @param iv Initial vector
- * @param iv_length Length of initial vector
+ * @param nonce Encryption nonce
+ * @param nonce_length Length of encryption nonce
  * @param ciphertext Buffer to write ciphertext into. Caller must ensure this is large enough to hold the ciphertext
  * @param tag Buffer to write tag into. Caller must ensure this is large enough to hold the tag
  * @param tag_length Expected length of tag
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  * */
 CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, const uint8_t * aad, size_t aad_length,
-                           const uint8_t * key, size_t key_length, const uint8_t * iv, size_t iv_length, uint8_t * ciphertext,
+                           const uint8_t * key, size_t key_length, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
                            uint8_t * tag, size_t tag_length);
 
 /**
@@ -579,15 +579,15 @@ CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, c
  * @param tag_length Length of tag
  * @param key Decryption key
  * @param key_length Length of Decryption key (in bytes)
- * @param iv Initial vector
- * @param iv_length Length of initial vector
+ * @param nonce Encryption nonce
+ * @param nonce_length Length of encryption nonce
  * @param plaintext Buffer to write plaintext into
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
 
 CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_length, const uint8_t * aad, size_t aad_length,
-                           const uint8_t * tag, size_t tag_length, const uint8_t * key, size_t key_length, const uint8_t * iv,
-                           size_t iv_length, uint8_t * plaintext);
+                           const uint8_t * tag, size_t tag_length, const uint8_t * key, size_t key_length, const uint8_t * nonce,
+                           size_t nonce_length, uint8_t * plaintext);
 
 /**
  * @brief Verify the Certificate Signing Request (CSR). If successfully verified, it outputs the public key from the CSR.

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -111,7 +111,7 @@ static bool _isValidKeyLength(size_t length)
 }
 
 CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, const uint8_t * aad, size_t aad_length,
-                           const uint8_t * key, size_t key_length, const uint8_t * iv, size_t iv_length, uint8_t * ciphertext,
+                           const uint8_t * key, size_t key_length, const uint8_t * nonce, size_t nonce_length, uint8_t * ciphertext,
                            uint8_t * tag, size_t tag_length)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
@@ -124,8 +124,8 @@ CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, c
     VerifyOrExit(ciphertext != nullptr || plaintext_length == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(key != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(_isValidKeyLength(key_length), error = CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE);
-    VerifyOrExit(iv != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(iv_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(nonce != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(nonce_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(tag != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(_isValidTagLength(tag_length), error = CHIP_ERROR_INVALID_ARGUMENT);
     if (aad_length > 0)
@@ -140,7 +140,7 @@ CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, c
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     // Encrypt
-    result = mbedtls_ccm_encrypt_and_tag(&context, plaintext_length, Uint8::to_const_uchar(iv), iv_length,
+    result = mbedtls_ccm_encrypt_and_tag(&context, plaintext_length, Uint8::to_const_uchar(nonce), nonce_length,
                                          Uint8::to_const_uchar(aad), aad_length, Uint8::to_const_uchar(plaintext),
                                          Uint8::to_uchar(ciphertext), Uint8::to_uchar(tag), tag_length);
     _log_mbedTLS_error(result);
@@ -152,8 +152,8 @@ exit:
 }
 
 CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_len, const uint8_t * aad, size_t aad_len,
-                           const uint8_t * tag, size_t tag_length, const uint8_t * key, size_t key_length, const uint8_t * iv,
-                           size_t iv_length, uint8_t * plaintext)
+                           const uint8_t * tag, size_t tag_length, const uint8_t * key, size_t key_length, const uint8_t * nonce,
+                           size_t nonce_length, uint8_t * plaintext)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 1;
@@ -167,8 +167,8 @@ CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_len, co
     VerifyOrExit(_isValidTagLength(tag_length), error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(key != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(_isValidKeyLength(key_length), error = CHIP_ERROR_UNSUPPORTED_ENCRYPTION_TYPE);
-    VerifyOrExit(iv != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(iv_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(nonce != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(nonce_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     if (aad_len > 0)
     {
         VerifyOrExit(aad != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
@@ -181,9 +181,9 @@ CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_len, co
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     // Decrypt
-    result = mbedtls_ccm_auth_decrypt(&context, ciphertext_len, Uint8::to_const_uchar(iv), iv_length, Uint8::to_const_uchar(aad),
-                                      aad_len, Uint8::to_const_uchar(ciphertext), Uint8::to_uchar(plaintext),
-                                      Uint8::to_const_uchar(tag), tag_length);
+    result = mbedtls_ccm_auth_decrypt(&context, ciphertext_len, Uint8::to_const_uchar(nonce), nonce_length,
+                                      Uint8::to_const_uchar(aad), aad_len, Uint8::to_const_uchar(ciphertext),
+                                      Uint8::to_uchar(plaintext), Uint8::to_const_uchar(tag), tag_length);
     _log_mbedTLS_error(result);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 

--- a/src/crypto/tests/AES_CCM_128_test_vectors.h
+++ b/src/crypto/tests/AES_CCM_128_test_vectors.h
@@ -33,8 +33,8 @@ struct ccm_128_test_vector
     size_t aad_len;
     const uint8_t * key;
     size_t key_len;
-    const uint8_t * iv;
-    size_t iv_len;
+    const uint8_t * nonce;
+    size_t nonce_len;
     const uint8_t * ct;
     size_t ct_len;
     const uint8_t * tag;
@@ -47,910 +47,910 @@ static const uint8_t chiptest_dac9e1195a0d_pt_1[]                           = { 
 static const uint8_t chiptest_dac9e1195a0d_aad_2[]                          = {};
 static const uint8_t chiptest_dac9e1195a0d_key_3[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                        0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_4[]                           = { 0x75, 0xc7, 0xc1, 0x23, 0xb3, 0x9b, 0x8a, 0x7e };
+static const uint8_t chiptest_dac9e1195a0d_nonce_4[]                        = { 0x75, 0xc7, 0xc1, 0x23, 0xb3, 0x9b, 0x8a, 0x7e };
 static const uint8_t chiptest_dac9e1195a0d_ct_5[]                           = { 0x74 };
 static const uint8_t chiptest_dac9e1195a0d_tag_6[]                          = { 0x32, 0xf0, 0xc8, 0xf7, 0xdc, 0x07, 0x7c, 0xb8 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_7 = { .pt      = chiptest_dac9e1195a0d_pt_1,
-                                                                                .pt_len  = 1,
-                                                                                .aad     = chiptest_dac9e1195a0d_aad_2,
-                                                                                .aad_len = 0,
-                                                                                .key     = chiptest_dac9e1195a0d_key_3,
-                                                                                .key_len = 16,
-                                                                                .iv      = chiptest_dac9e1195a0d_iv_4,
-                                                                                .iv_len  = 8,
-                                                                                .ct      = chiptest_dac9e1195a0d_ct_5,
-                                                                                .ct_len  = 1,
-                                                                                .tag     = chiptest_dac9e1195a0d_tag_6,
-                                                                                .tag_len = 8,
-                                                                                .tcId    = 1,
-                                                                                .result  = CHIP_NO_ERROR };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_7 = { .pt        = chiptest_dac9e1195a0d_pt_1,
+                                                                                .pt_len    = 1,
+                                                                                .aad       = chiptest_dac9e1195a0d_aad_2,
+                                                                                .aad_len   = 0,
+                                                                                .key       = chiptest_dac9e1195a0d_key_3,
+                                                                                .key_len   = 16,
+                                                                                .nonce     = chiptest_dac9e1195a0d_nonce_4,
+                                                                                .nonce_len = 8,
+                                                                                .ct        = chiptest_dac9e1195a0d_ct_5,
+                                                                                .ct_len    = 1,
+                                                                                .tag       = chiptest_dac9e1195a0d_tag_6,
+                                                                                .tag_len   = 8,
+                                                                                .tcId      = 1,
+                                                                                .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_8[]                           = { 0xee };
 static const uint8_t chiptest_dac9e1195a0d_aad_9[]                          = {};
 static const uint8_t chiptest_dac9e1195a0d_key_10[]                         = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                         0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_11[]                          = { 0x75, 0xc7, 0xc1, 0x23, 0xb3, 0x9b, 0x8a, 0x7e };
+static const uint8_t chiptest_dac9e1195a0d_nonce_11[]                       = { 0x75, 0xc7, 0xc1, 0x23, 0xb3, 0x9b, 0x8a, 0x7e };
 static const uint8_t chiptest_dac9e1195a0d_ct_12[]                          = { 0x74 };
 static const uint8_t chiptest_dac9e1195a0d_tag_13[] = { 0xc0, 0x1c, 0x51, 0x81, 0x8d, 0x2a, 0x93, 0x57, 0xb4, 0x69, 0x2b, 0x24 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_14 = { .pt      = chiptest_dac9e1195a0d_pt_8,
-                                                                                 .pt_len  = 1,
-                                                                                 .aad     = chiptest_dac9e1195a0d_aad_9,
-                                                                                 .aad_len = 0,
-                                                                                 .key     = chiptest_dac9e1195a0d_key_10,
-                                                                                 .key_len = 16,
-                                                                                 .iv      = chiptest_dac9e1195a0d_iv_11,
-                                                                                 .iv_len  = 8,
-                                                                                 .ct      = chiptest_dac9e1195a0d_ct_12,
-                                                                                 .ct_len  = 1,
-                                                                                 .tag     = chiptest_dac9e1195a0d_tag_13,
-                                                                                 .tag_len = 12,
-                                                                                 .tcId    = 2,
-                                                                                 .result  = CHIP_NO_ERROR };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_14 = { .pt        = chiptest_dac9e1195a0d_pt_8,
+                                                                                 .pt_len    = 1,
+                                                                                 .aad       = chiptest_dac9e1195a0d_aad_9,
+                                                                                 .aad_len   = 0,
+                                                                                 .key       = chiptest_dac9e1195a0d_key_10,
+                                                                                 .key_len   = 16,
+                                                                                 .nonce     = chiptest_dac9e1195a0d_nonce_11,
+                                                                                 .nonce_len = 8,
+                                                                                 .ct        = chiptest_dac9e1195a0d_ct_12,
+                                                                                 .ct_len    = 1,
+                                                                                 .tag       = chiptest_dac9e1195a0d_tag_13,
+                                                                                 .tag_len   = 12,
+                                                                                 .tcId      = 2,
+                                                                                 .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_15[]                           = { 0xee };
 static const uint8_t chiptest_dac9e1195a0d_aad_16[]                          = {};
 static const uint8_t chiptest_dac9e1195a0d_key_17[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                         0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_18[]                           = { 0x75, 0xc7, 0xc1, 0x23, 0xb3, 0x9b, 0x8a, 0x7e };
+static const uint8_t chiptest_dac9e1195a0d_nonce_18[]                        = { 0x75, 0xc7, 0xc1, 0x23, 0xb3, 0x9b, 0x8a, 0x7e };
 static const uint8_t chiptest_dac9e1195a0d_ct_19[]                           = { 0x74 };
 static const uint8_t chiptest_dac9e1195a0d_tag_20[]                          = { 0x35, 0x5e, 0x27, 0x43, 0xb6, 0x79, 0x36, 0x94,
                                                         0xca, 0x78, 0xd6, 0xd9, 0xc8, 0xdc, 0x14, 0x6c };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_21 = { .pt      = chiptest_dac9e1195a0d_pt_15,
-                                                                                 .pt_len  = 1,
-                                                                                 .aad     = chiptest_dac9e1195a0d_aad_16,
-                                                                                 .aad_len = 0,
-                                                                                 .key     = chiptest_dac9e1195a0d_key_17,
-                                                                                 .key_len = 16,
-                                                                                 .iv      = chiptest_dac9e1195a0d_iv_18,
-                                                                                 .iv_len  = 8,
-                                                                                 .ct      = chiptest_dac9e1195a0d_ct_19,
-                                                                                 .ct_len  = 1,
-                                                                                 .tag     = chiptest_dac9e1195a0d_tag_20,
-                                                                                 .tag_len = 16,
-                                                                                 .tcId    = 3,
-                                                                                 .result  = CHIP_NO_ERROR };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_21 = { .pt        = chiptest_dac9e1195a0d_pt_15,
+                                                                                 .pt_len    = 1,
+                                                                                 .aad       = chiptest_dac9e1195a0d_aad_16,
+                                                                                 .aad_len   = 0,
+                                                                                 .key       = chiptest_dac9e1195a0d_key_17,
+                                                                                 .key_len   = 16,
+                                                                                 .nonce     = chiptest_dac9e1195a0d_nonce_18,
+                                                                                 .nonce_len = 8,
+                                                                                 .ct        = chiptest_dac9e1195a0d_ct_19,
+                                                                                 .ct_len    = 1,
+                                                                                 .tag       = chiptest_dac9e1195a0d_tag_20,
+                                                                                 .tag_len   = 16,
+                                                                                 .tcId      = 3,
+                                                                                 .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_22[]                           = { 0xcd };
 static const uint8_t chiptest_dac9e1195a0d_aad_23[]                          = {};
 static const uint8_t chiptest_dac9e1195a0d_key_24[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                         0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_25[]  = { 0x56, 0x59, 0x39, 0x7e, 0x06, 0x02, 0x8b, 0x14, 0x9d, 0x0b, 0x2b, 0x2b };
-static const uint8_t chiptest_dac9e1195a0d_ct_26[]  = { 0xf5 };
-static const uint8_t chiptest_dac9e1195a0d_tag_27[] = { 0x24, 0x70, 0x9e, 0xaf, 0x87, 0x95, 0x80, 0xe8 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_28 = { .pt      = chiptest_dac9e1195a0d_pt_22,
-                                                                                 .pt_len  = 1,
-                                                                                 .aad     = chiptest_dac9e1195a0d_aad_23,
-                                                                                 .aad_len = 0,
-                                                                                 .key     = chiptest_dac9e1195a0d_key_24,
-                                                                                 .key_len = 16,
-                                                                                 .iv      = chiptest_dac9e1195a0d_iv_25,
-                                                                                 .iv_len  = 12,
-                                                                                 .ct      = chiptest_dac9e1195a0d_ct_26,
-                                                                                 .ct_len  = 1,
-                                                                                 .tag     = chiptest_dac9e1195a0d_tag_27,
-                                                                                 .tag_len = 8,
-                                                                                 .tcId    = 4,
-                                                                                 .result  = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_nonce_25[] = { 0x56, 0x59, 0x39, 0x7e, 0x06, 0x02, 0x8b, 0x14, 0x9d, 0x0b, 0x2b, 0x2b };
+static const uint8_t chiptest_dac9e1195a0d_ct_26[]    = { 0xf5 };
+static const uint8_t chiptest_dac9e1195a0d_tag_27[]   = { 0x24, 0x70, 0x9e, 0xaf, 0x87, 0x95, 0x80, 0xe8 };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_28 = { .pt        = chiptest_dac9e1195a0d_pt_22,
+                                                                                 .pt_len    = 1,
+                                                                                 .aad       = chiptest_dac9e1195a0d_aad_23,
+                                                                                 .aad_len   = 0,
+                                                                                 .key       = chiptest_dac9e1195a0d_key_24,
+                                                                                 .key_len   = 16,
+                                                                                 .nonce     = chiptest_dac9e1195a0d_nonce_25,
+                                                                                 .nonce_len = 12,
+                                                                                 .ct        = chiptest_dac9e1195a0d_ct_26,
+                                                                                 .ct_len    = 1,
+                                                                                 .tag       = chiptest_dac9e1195a0d_tag_27,
+                                                                                 .tag_len   = 8,
+                                                                                 .tcId      = 4,
+                                                                                 .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_29[]                           = { 0xcd };
 static const uint8_t chiptest_dac9e1195a0d_aad_30[]                          = {};
 static const uint8_t chiptest_dac9e1195a0d_key_31[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                         0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_32[]  = { 0x56, 0x59, 0x39, 0x7e, 0x06, 0x02, 0x8b, 0x14, 0x9d, 0x0b, 0x2b, 0x2b };
-static const uint8_t chiptest_dac9e1195a0d_ct_33[]  = { 0xf5 };
-static const uint8_t chiptest_dac9e1195a0d_tag_34[] = { 0x9a, 0x23, 0xec, 0x3e, 0xac, 0xef, 0x72, 0xc2, 0x2c, 0x6a, 0x37, 0x08 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_35 = { .pt      = chiptest_dac9e1195a0d_pt_29,
-                                                                                 .pt_len  = 1,
-                                                                                 .aad     = chiptest_dac9e1195a0d_aad_30,
-                                                                                 .aad_len = 0,
-                                                                                 .key     = chiptest_dac9e1195a0d_key_31,
-                                                                                 .key_len = 16,
-                                                                                 .iv      = chiptest_dac9e1195a0d_iv_32,
-                                                                                 .iv_len  = 12,
-                                                                                 .ct      = chiptest_dac9e1195a0d_ct_33,
-                                                                                 .ct_len  = 1,
-                                                                                 .tag     = chiptest_dac9e1195a0d_tag_34,
-                                                                                 .tag_len = 12,
-                                                                                 .tcId    = 5,
-                                                                                 .result  = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_nonce_32[] = { 0x56, 0x59, 0x39, 0x7e, 0x06, 0x02, 0x8b, 0x14, 0x9d, 0x0b, 0x2b, 0x2b };
+static const uint8_t chiptest_dac9e1195a0d_ct_33[]    = { 0xf5 };
+static const uint8_t chiptest_dac9e1195a0d_tag_34[]   = { 0x9a, 0x23, 0xec, 0x3e, 0xac, 0xef, 0x72, 0xc2, 0x2c, 0x6a, 0x37, 0x08 };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_35 = { .pt        = chiptest_dac9e1195a0d_pt_29,
+                                                                                 .pt_len    = 1,
+                                                                                 .aad       = chiptest_dac9e1195a0d_aad_30,
+                                                                                 .aad_len   = 0,
+                                                                                 .key       = chiptest_dac9e1195a0d_key_31,
+                                                                                 .key_len   = 16,
+                                                                                 .nonce     = chiptest_dac9e1195a0d_nonce_32,
+                                                                                 .nonce_len = 12,
+                                                                                 .ct        = chiptest_dac9e1195a0d_ct_33,
+                                                                                 .ct_len    = 1,
+                                                                                 .tag       = chiptest_dac9e1195a0d_tag_34,
+                                                                                 .tag_len   = 12,
+                                                                                 .tcId      = 5,
+                                                                                 .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_36[]                           = { 0xcd };
 static const uint8_t chiptest_dac9e1195a0d_aad_37[]                          = {};
 static const uint8_t chiptest_dac9e1195a0d_key_38[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                         0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_39[]  = { 0x56, 0x59, 0x39, 0x7e, 0x06, 0x02, 0x8b, 0x14, 0x9d, 0x0b, 0x2b, 0x2b };
-static const uint8_t chiptest_dac9e1195a0d_ct_40[]  = { 0xf5 };
-static const uint8_t chiptest_dac9e1195a0d_tag_41[] = { 0x9f, 0x5c, 0xd7, 0x4a, 0x83, 0x60, 0xc7, 0x76,
+static const uint8_t chiptest_dac9e1195a0d_nonce_39[] = { 0x56, 0x59, 0x39, 0x7e, 0x06, 0x02, 0x8b, 0x14, 0x9d, 0x0b, 0x2b, 0x2b };
+static const uint8_t chiptest_dac9e1195a0d_ct_40[]    = { 0xf5 };
+static const uint8_t chiptest_dac9e1195a0d_tag_41[]   = { 0x9f, 0x5c, 0xd7, 0x4a, 0x83, 0x60, 0xc7, 0x76,
                                                         0xe7, 0x16, 0x7d, 0xe2, 0xdb, 0xef, 0xac, 0x98 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_42 = { .pt      = chiptest_dac9e1195a0d_pt_36,
-                                                                                 .pt_len  = 1,
-                                                                                 .aad     = chiptest_dac9e1195a0d_aad_37,
-                                                                                 .aad_len = 0,
-                                                                                 .key     = chiptest_dac9e1195a0d_key_38,
-                                                                                 .key_len = 16,
-                                                                                 .iv      = chiptest_dac9e1195a0d_iv_39,
-                                                                                 .iv_len  = 12,
-                                                                                 .ct      = chiptest_dac9e1195a0d_ct_40,
-                                                                                 .ct_len  = 1,
-                                                                                 .tag     = chiptest_dac9e1195a0d_tag_41,
-                                                                                 .tag_len = 16,
-                                                                                 .tcId    = 6,
-                                                                                 .result  = CHIP_NO_ERROR };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_42 = { .pt        = chiptest_dac9e1195a0d_pt_36,
+                                                                                 .pt_len    = 1,
+                                                                                 .aad       = chiptest_dac9e1195a0d_aad_37,
+                                                                                 .aad_len   = 0,
+                                                                                 .key       = chiptest_dac9e1195a0d_key_38,
+                                                                                 .key_len   = 16,
+                                                                                 .nonce     = chiptest_dac9e1195a0d_nonce_39,
+                                                                                 .nonce_len = 12,
+                                                                                 .ct        = chiptest_dac9e1195a0d_ct_40,
+                                                                                 .ct_len    = 1,
+                                                                                 .tag       = chiptest_dac9e1195a0d_tag_41,
+                                                                                 .tag_len   = 16,
+                                                                                 .tcId      = 6,
+                                                                                 .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_43[]                           = { 0xf4 };
 static const uint8_t chiptest_dac9e1195a0d_aad_44[]                          = { 0xb3, 0x3f, 0xa8, 0xae, 0x4b, 0xc6, 0xea, 0xe4,
                                                         0x5f, 0x28, 0x61, 0x9a, 0xc8, 0xd3, 0xae, 0x79 };
 static const uint8_t chiptest_dac9e1195a0d_key_45[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                         0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_46[]                           = { 0x6d, 0x4c, 0x91, 0x17, 0x0d, 0xc6, 0x21, 0x7e };
+static const uint8_t chiptest_dac9e1195a0d_nonce_46[]                        = { 0x6d, 0x4c, 0x91, 0x17, 0x0d, 0xc6, 0x21, 0x7e };
 static const uint8_t chiptest_dac9e1195a0d_ct_47[]                           = { 0x7f };
 static const uint8_t chiptest_dac9e1195a0d_tag_48[]                          = { 0xc6, 0x3e, 0x43, 0xfc, 0x80, 0x03, 0x60, 0xf5 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_49 = { .pt      = chiptest_dac9e1195a0d_pt_43,
-                                                                                 .pt_len  = 1,
-                                                                                 .aad     = chiptest_dac9e1195a0d_aad_44,
-                                                                                 .aad_len = 16,
-                                                                                 .key     = chiptest_dac9e1195a0d_key_45,
-                                                                                 .key_len = 16,
-                                                                                 .iv      = chiptest_dac9e1195a0d_iv_46,
-                                                                                 .iv_len  = 8,
-                                                                                 .ct      = chiptest_dac9e1195a0d_ct_47,
-                                                                                 .ct_len  = 1,
-                                                                                 .tag     = chiptest_dac9e1195a0d_tag_48,
-                                                                                 .tag_len = 8,
-                                                                                 .tcId    = 7,
-                                                                                 .result  = CHIP_NO_ERROR };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_49 = { .pt        = chiptest_dac9e1195a0d_pt_43,
+                                                                                 .pt_len    = 1,
+                                                                                 .aad       = chiptest_dac9e1195a0d_aad_44,
+                                                                                 .aad_len   = 16,
+                                                                                 .key       = chiptest_dac9e1195a0d_key_45,
+                                                                                 .key_len   = 16,
+                                                                                 .nonce     = chiptest_dac9e1195a0d_nonce_46,
+                                                                                 .nonce_len = 8,
+                                                                                 .ct        = chiptest_dac9e1195a0d_ct_47,
+                                                                                 .ct_len    = 1,
+                                                                                 .tag       = chiptest_dac9e1195a0d_tag_48,
+                                                                                 .tag_len   = 8,
+                                                                                 .tcId      = 7,
+                                                                                 .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_50[]                           = { 0xf4 };
 static const uint8_t chiptest_dac9e1195a0d_aad_51[]                          = { 0xb3, 0x3f, 0xa8, 0xae, 0x4b, 0xc6, 0xea, 0xe4,
                                                         0x5f, 0x28, 0x61, 0x9a, 0xc8, 0xd3, 0xae, 0x79 };
 static const uint8_t chiptest_dac9e1195a0d_key_52[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                         0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_53[]                           = { 0x6d, 0x4c, 0x91, 0x17, 0x0d, 0xc6, 0x21, 0x7e };
+static const uint8_t chiptest_dac9e1195a0d_nonce_53[]                        = { 0x6d, 0x4c, 0x91, 0x17, 0x0d, 0xc6, 0x21, 0x7e };
 static const uint8_t chiptest_dac9e1195a0d_ct_54[]                           = { 0x7f };
 static const uint8_t chiptest_dac9e1195a0d_tag_55[] = { 0xcf, 0x3d, 0x2c, 0xe6, 0x3c, 0xf3, 0x38, 0x07, 0x67, 0x36, 0xd1, 0x1c };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_56 = { .pt      = chiptest_dac9e1195a0d_pt_50,
-                                                                                 .pt_len  = 1,
-                                                                                 .aad     = chiptest_dac9e1195a0d_aad_51,
-                                                                                 .aad_len = 16,
-                                                                                 .key     = chiptest_dac9e1195a0d_key_52,
-                                                                                 .key_len = 16,
-                                                                                 .iv      = chiptest_dac9e1195a0d_iv_53,
-                                                                                 .iv_len  = 8,
-                                                                                 .ct      = chiptest_dac9e1195a0d_ct_54,
-                                                                                 .ct_len  = 1,
-                                                                                 .tag     = chiptest_dac9e1195a0d_tag_55,
-                                                                                 .tag_len = 12,
-                                                                                 .tcId    = 8,
-                                                                                 .result  = CHIP_NO_ERROR };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_56 = { .pt        = chiptest_dac9e1195a0d_pt_50,
+                                                                                 .pt_len    = 1,
+                                                                                 .aad       = chiptest_dac9e1195a0d_aad_51,
+                                                                                 .aad_len   = 16,
+                                                                                 .key       = chiptest_dac9e1195a0d_key_52,
+                                                                                 .key_len   = 16,
+                                                                                 .nonce     = chiptest_dac9e1195a0d_nonce_53,
+                                                                                 .nonce_len = 8,
+                                                                                 .ct        = chiptest_dac9e1195a0d_ct_54,
+                                                                                 .ct_len    = 1,
+                                                                                 .tag       = chiptest_dac9e1195a0d_tag_55,
+                                                                                 .tag_len   = 12,
+                                                                                 .tcId      = 8,
+                                                                                 .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_57[]                           = { 0xf4 };
 static const uint8_t chiptest_dac9e1195a0d_aad_58[]                          = { 0xb3, 0x3f, 0xa8, 0xae, 0x4b, 0xc6, 0xea, 0xe4,
                                                         0x5f, 0x28, 0x61, 0x9a, 0xc8, 0xd3, 0xae, 0x79 };
 static const uint8_t chiptest_dac9e1195a0d_key_59[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                         0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_60[]                           = { 0x6d, 0x4c, 0x91, 0x17, 0x0d, 0xc6, 0x21, 0x7e };
+static const uint8_t chiptest_dac9e1195a0d_nonce_60[]                        = { 0x6d, 0x4c, 0x91, 0x17, 0x0d, 0xc6, 0x21, 0x7e };
 static const uint8_t chiptest_dac9e1195a0d_ct_61[]                           = { 0x7f };
 static const uint8_t chiptest_dac9e1195a0d_tag_62[]                          = { 0x08, 0x85, 0x6b, 0x4a, 0x5d, 0x73, 0x56, 0xc4,
                                                         0xf0, 0x46, 0x3e, 0xa9, 0x0e, 0x3c, 0x36, 0x77 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_63 = { .pt      = chiptest_dac9e1195a0d_pt_57,
-                                                                                 .pt_len  = 1,
-                                                                                 .aad     = chiptest_dac9e1195a0d_aad_58,
-                                                                                 .aad_len = 16,
-                                                                                 .key     = chiptest_dac9e1195a0d_key_59,
-                                                                                 .key_len = 16,
-                                                                                 .iv      = chiptest_dac9e1195a0d_iv_60,
-                                                                                 .iv_len  = 8,
-                                                                                 .ct      = chiptest_dac9e1195a0d_ct_61,
-                                                                                 .ct_len  = 1,
-                                                                                 .tag     = chiptest_dac9e1195a0d_tag_62,
-                                                                                 .tag_len = 16,
-                                                                                 .tcId    = 9,
-                                                                                 .result  = CHIP_NO_ERROR };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_63 = { .pt        = chiptest_dac9e1195a0d_pt_57,
+                                                                                 .pt_len    = 1,
+                                                                                 .aad       = chiptest_dac9e1195a0d_aad_58,
+                                                                                 .aad_len   = 16,
+                                                                                 .key       = chiptest_dac9e1195a0d_key_59,
+                                                                                 .key_len   = 16,
+                                                                                 .nonce     = chiptest_dac9e1195a0d_nonce_60,
+                                                                                 .nonce_len = 8,
+                                                                                 .ct        = chiptest_dac9e1195a0d_ct_61,
+                                                                                 .ct_len    = 1,
+                                                                                 .tag       = chiptest_dac9e1195a0d_tag_62,
+                                                                                 .tag_len   = 16,
+                                                                                 .tcId      = 9,
+                                                                                 .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_64[]                           = { 0x38 };
 static const uint8_t chiptest_dac9e1195a0d_aad_65[]                          = { 0xf4, 0xc7, 0xa8, 0x88, 0x22, 0x1e, 0xef, 0xf4,
                                                         0xc8, 0x15, 0x51, 0xdc, 0x15, 0xd4, 0x10, 0xfb };
 static const uint8_t chiptest_dac9e1195a0d_key_66[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                         0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_67[]  = { 0x7f, 0xf3, 0x44, 0xc6, 0xb3, 0x64, 0xc4, 0x4e, 0x4f, 0xe0, 0xaa, 0xa7 };
-static const uint8_t chiptest_dac9e1195a0d_ct_68[]  = { 0x55 };
-static const uint8_t chiptest_dac9e1195a0d_tag_69[] = { 0x4b, 0xae, 0xdd, 0xe7, 0xe8, 0xc1, 0x48, 0xed };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_70 = { .pt      = chiptest_dac9e1195a0d_pt_64,
-                                                                                 .pt_len  = 1,
-                                                                                 .aad     = chiptest_dac9e1195a0d_aad_65,
-                                                                                 .aad_len = 16,
-                                                                                 .key     = chiptest_dac9e1195a0d_key_66,
-                                                                                 .key_len = 16,
-                                                                                 .iv      = chiptest_dac9e1195a0d_iv_67,
-                                                                                 .iv_len  = 12,
-                                                                                 .ct      = chiptest_dac9e1195a0d_ct_68,
-                                                                                 .ct_len  = 1,
-                                                                                 .tag     = chiptest_dac9e1195a0d_tag_69,
-                                                                                 .tag_len = 8,
-                                                                                 .tcId    = 10,
-                                                                                 .result  = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_nonce_67[] = { 0x7f, 0xf3, 0x44, 0xc6, 0xb3, 0x64, 0xc4, 0x4e, 0x4f, 0xe0, 0xaa, 0xa7 };
+static const uint8_t chiptest_dac9e1195a0d_ct_68[]    = { 0x55 };
+static const uint8_t chiptest_dac9e1195a0d_tag_69[]   = { 0x4b, 0xae, 0xdd, 0xe7, 0xe8, 0xc1, 0x48, 0xed };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_70 = { .pt        = chiptest_dac9e1195a0d_pt_64,
+                                                                                 .pt_len    = 1,
+                                                                                 .aad       = chiptest_dac9e1195a0d_aad_65,
+                                                                                 .aad_len   = 16,
+                                                                                 .key       = chiptest_dac9e1195a0d_key_66,
+                                                                                 .key_len   = 16,
+                                                                                 .nonce     = chiptest_dac9e1195a0d_nonce_67,
+                                                                                 .nonce_len = 12,
+                                                                                 .ct        = chiptest_dac9e1195a0d_ct_68,
+                                                                                 .ct_len    = 1,
+                                                                                 .tag       = chiptest_dac9e1195a0d_tag_69,
+                                                                                 .tag_len   = 8,
+                                                                                 .tcId      = 10,
+                                                                                 .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_71[]                           = { 0x38 };
 static const uint8_t chiptest_dac9e1195a0d_aad_72[]                          = { 0xf4, 0xc7, 0xa8, 0x88, 0x22, 0x1e, 0xef, 0xf4,
                                                         0xc8, 0x15, 0x51, 0xdc, 0x15, 0xd4, 0x10, 0xfb };
 static const uint8_t chiptest_dac9e1195a0d_key_73[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                         0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_74[]  = { 0x7f, 0xf3, 0x44, 0xc6, 0xb3, 0x64, 0xc4, 0x4e, 0x4f, 0xe0, 0xaa, 0xa7 };
-static const uint8_t chiptest_dac9e1195a0d_ct_75[]  = { 0x55 };
-static const uint8_t chiptest_dac9e1195a0d_tag_76[] = { 0xdd, 0x3a, 0x04, 0xbc, 0xe4, 0x50, 0xa7, 0xe9, 0x84, 0x26, 0xd2, 0x5c };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_77 = { .pt      = chiptest_dac9e1195a0d_pt_71,
-                                                                                 .pt_len  = 1,
-                                                                                 .aad     = chiptest_dac9e1195a0d_aad_72,
-                                                                                 .aad_len = 16,
-                                                                                 .key     = chiptest_dac9e1195a0d_key_73,
-                                                                                 .key_len = 16,
-                                                                                 .iv      = chiptest_dac9e1195a0d_iv_74,
-                                                                                 .iv_len  = 12,
-                                                                                 .ct      = chiptest_dac9e1195a0d_ct_75,
-                                                                                 .ct_len  = 1,
-                                                                                 .tag     = chiptest_dac9e1195a0d_tag_76,
-                                                                                 .tag_len = 12,
-                                                                                 .tcId    = 11,
-                                                                                 .result  = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_nonce_74[] = { 0x7f, 0xf3, 0x44, 0xc6, 0xb3, 0x64, 0xc4, 0x4e, 0x4f, 0xe0, 0xaa, 0xa7 };
+static const uint8_t chiptest_dac9e1195a0d_ct_75[]    = { 0x55 };
+static const uint8_t chiptest_dac9e1195a0d_tag_76[]   = { 0xdd, 0x3a, 0x04, 0xbc, 0xe4, 0x50, 0xa7, 0xe9, 0x84, 0x26, 0xd2, 0x5c };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_77 = { .pt        = chiptest_dac9e1195a0d_pt_71,
+                                                                                 .pt_len    = 1,
+                                                                                 .aad       = chiptest_dac9e1195a0d_aad_72,
+                                                                                 .aad_len   = 16,
+                                                                                 .key       = chiptest_dac9e1195a0d_key_73,
+                                                                                 .key_len   = 16,
+                                                                                 .nonce     = chiptest_dac9e1195a0d_nonce_74,
+                                                                                 .nonce_len = 12,
+                                                                                 .ct        = chiptest_dac9e1195a0d_ct_75,
+                                                                                 .ct_len    = 1,
+                                                                                 .tag       = chiptest_dac9e1195a0d_tag_76,
+                                                                                 .tag_len   = 12,
+                                                                                 .tcId      = 11,
+                                                                                 .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_78[]                           = { 0x38 };
 static const uint8_t chiptest_dac9e1195a0d_aad_79[]                          = { 0xf4, 0xc7, 0xa8, 0x88, 0x22, 0x1e, 0xef, 0xf4,
                                                         0xc8, 0x15, 0x51, 0xdc, 0x15, 0xd4, 0x10, 0xfb };
 static const uint8_t chiptest_dac9e1195a0d_key_80[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                         0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_81[]  = { 0x7f, 0xf3, 0x44, 0xc6, 0xb3, 0x64, 0xc4, 0x4e, 0x4f, 0xe0, 0xaa, 0xa7 };
-static const uint8_t chiptest_dac9e1195a0d_ct_82[]  = { 0x55 };
-static const uint8_t chiptest_dac9e1195a0d_tag_83[] = { 0x20, 0xc7, 0xb9, 0x71, 0xfb, 0xf3, 0x6f, 0x9c,
+static const uint8_t chiptest_dac9e1195a0d_nonce_81[] = { 0x7f, 0xf3, 0x44, 0xc6, 0xb3, 0x64, 0xc4, 0x4e, 0x4f, 0xe0, 0xaa, 0xa7 };
+static const uint8_t chiptest_dac9e1195a0d_ct_82[]    = { 0x55 };
+static const uint8_t chiptest_dac9e1195a0d_tag_83[]   = { 0x20, 0xc7, 0xb9, 0x71, 0xfb, 0xf3, 0x6f, 0x9c,
                                                         0x44, 0x24, 0x78, 0x12, 0xd3, 0x99, 0xb1, 0x45 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_84 = { .pt      = chiptest_dac9e1195a0d_pt_78,
-                                                                                 .pt_len  = 1,
-                                                                                 .aad     = chiptest_dac9e1195a0d_aad_79,
-                                                                                 .aad_len = 16,
-                                                                                 .key     = chiptest_dac9e1195a0d_key_80,
-                                                                                 .key_len = 16,
-                                                                                 .iv      = chiptest_dac9e1195a0d_iv_81,
-                                                                                 .iv_len  = 12,
-                                                                                 .ct      = chiptest_dac9e1195a0d_ct_82,
-                                                                                 .ct_len  = 1,
-                                                                                 .tag     = chiptest_dac9e1195a0d_tag_83,
-                                                                                 .tag_len = 16,
-                                                                                 .tcId    = 12,
-                                                                                 .result  = CHIP_NO_ERROR };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_84 = { .pt        = chiptest_dac9e1195a0d_pt_78,
+                                                                                 .pt_len    = 1,
+                                                                                 .aad       = chiptest_dac9e1195a0d_aad_79,
+                                                                                 .aad_len   = 16,
+                                                                                 .key       = chiptest_dac9e1195a0d_key_80,
+                                                                                 .key_len   = 16,
+                                                                                 .nonce     = chiptest_dac9e1195a0d_nonce_81,
+                                                                                 .nonce_len = 12,
+                                                                                 .ct        = chiptest_dac9e1195a0d_ct_82,
+                                                                                 .ct_len    = 1,
+                                                                                 .tag       = chiptest_dac9e1195a0d_tag_83,
+                                                                                 .tag_len   = 16,
+                                                                                 .tcId      = 12,
+                                                                                 .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_85[]                           = { 0x86, 0x74, 0x64, 0xe5, 0x0b, 0xd4, 0x0d, 0x90,
                                                        0xe1, 0x17, 0xa3, 0x2d, 0x4b, 0xd4, 0xe1, 0xe6 };
 static const uint8_t chiptest_dac9e1195a0d_aad_86[]                          = {};
 static const uint8_t chiptest_dac9e1195a0d_key_87[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                         0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_88[]                           = { 0xf2, 0xf0, 0x11, 0x4f, 0xe7, 0x9a, 0x24, 0xfb };
+static const uint8_t chiptest_dac9e1195a0d_nonce_88[]                        = { 0xf2, 0xf0, 0x11, 0x4f, 0xe7, 0x9a, 0x24, 0xfb };
 static const uint8_t chiptest_dac9e1195a0d_ct_89[]                           = { 0x17, 0x8d, 0xfc, 0xe4, 0xe8, 0x7b, 0xeb, 0x87,
                                                        0x63, 0xe3, 0xdd, 0xc8, 0x68, 0xfa, 0x73, 0x88 };
 static const uint8_t chiptest_dac9e1195a0d_tag_90[]                          = { 0x7f, 0x10, 0xcf, 0x6c, 0x9b, 0x22, 0xb3, 0x96 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_91 = { .pt      = chiptest_dac9e1195a0d_pt_85,
-                                                                                 .pt_len  = 16,
-                                                                                 .aad     = chiptest_dac9e1195a0d_aad_86,
-                                                                                 .aad_len = 0,
-                                                                                 .key     = chiptest_dac9e1195a0d_key_87,
-                                                                                 .key_len = 16,
-                                                                                 .iv      = chiptest_dac9e1195a0d_iv_88,
-                                                                                 .iv_len  = 8,
-                                                                                 .ct      = chiptest_dac9e1195a0d_ct_89,
-                                                                                 .ct_len  = 16,
-                                                                                 .tag     = chiptest_dac9e1195a0d_tag_90,
-                                                                                 .tag_len = 8,
-                                                                                 .tcId    = 13,
-                                                                                 .result  = CHIP_NO_ERROR };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_91 = { .pt        = chiptest_dac9e1195a0d_pt_85,
+                                                                                 .pt_len    = 16,
+                                                                                 .aad       = chiptest_dac9e1195a0d_aad_86,
+                                                                                 .aad_len   = 0,
+                                                                                 .key       = chiptest_dac9e1195a0d_key_87,
+                                                                                 .key_len   = 16,
+                                                                                 .nonce     = chiptest_dac9e1195a0d_nonce_88,
+                                                                                 .nonce_len = 8,
+                                                                                 .ct        = chiptest_dac9e1195a0d_ct_89,
+                                                                                 .ct_len    = 16,
+                                                                                 .tag       = chiptest_dac9e1195a0d_tag_90,
+                                                                                 .tag_len   = 8,
+                                                                                 .tcId      = 13,
+                                                                                 .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_92[]                           = { 0x86, 0x74, 0x64, 0xe5, 0x0b, 0xd4, 0x0d, 0x90,
                                                        0xe1, 0x17, 0xa3, 0x2d, 0x4b, 0xd4, 0xe1, 0xe6 };
 static const uint8_t chiptest_dac9e1195a0d_aad_93[]                          = {};
 static const uint8_t chiptest_dac9e1195a0d_key_94[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                         0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_95[]                           = { 0xf2, 0xf0, 0x11, 0x4f, 0xe7, 0x9a, 0x24, 0xfb };
+static const uint8_t chiptest_dac9e1195a0d_nonce_95[]                        = { 0xf2, 0xf0, 0x11, 0x4f, 0xe7, 0x9a, 0x24, 0xfb };
 static const uint8_t chiptest_dac9e1195a0d_ct_96[]                           = { 0x17, 0x8d, 0xfc, 0xe4, 0xe8, 0x7b, 0xeb, 0x87,
                                                        0x63, 0xe3, 0xdd, 0xc8, 0x68, 0xfa, 0x73, 0x88 };
 static const uint8_t chiptest_dac9e1195a0d_tag_97[] = { 0x6f, 0x4c, 0x9a, 0x68, 0x32, 0x37, 0x33, 0x1d, 0x6a, 0x98, 0x74, 0xbc };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_98  = { .pt      = chiptest_dac9e1195a0d_pt_92,
-                                                                                 .pt_len  = 16,
-                                                                                 .aad     = chiptest_dac9e1195a0d_aad_93,
-                                                                                 .aad_len = 0,
-                                                                                 .key     = chiptest_dac9e1195a0d_key_94,
-                                                                                 .key_len = 16,
-                                                                                 .iv      = chiptest_dac9e1195a0d_iv_95,
-                                                                                 .iv_len  = 8,
-                                                                                 .ct      = chiptest_dac9e1195a0d_ct_96,
-                                                                                 .ct_len  = 16,
-                                                                                 .tag     = chiptest_dac9e1195a0d_tag_97,
-                                                                                 .tag_len = 12,
-                                                                                 .tcId    = 14,
-                                                                                 .result  = CHIP_NO_ERROR };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_98  = { .pt        = chiptest_dac9e1195a0d_pt_92,
+                                                                                 .pt_len    = 16,
+                                                                                 .aad       = chiptest_dac9e1195a0d_aad_93,
+                                                                                 .aad_len   = 0,
+                                                                                 .key       = chiptest_dac9e1195a0d_key_94,
+                                                                                 .key_len   = 16,
+                                                                                 .nonce     = chiptest_dac9e1195a0d_nonce_95,
+                                                                                 .nonce_len = 8,
+                                                                                 .ct        = chiptest_dac9e1195a0d_ct_96,
+                                                                                 .ct_len    = 16,
+                                                                                 .tag       = chiptest_dac9e1195a0d_tag_97,
+                                                                                 .tag_len   = 12,
+                                                                                 .tcId      = 14,
+                                                                                 .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_99[]                            = { 0x86, 0x74, 0x64, 0xe5, 0x0b, 0xd4, 0x0d, 0x90,
                                                        0xe1, 0x17, 0xa3, 0x2d, 0x4b, 0xd4, 0xe1, 0xe6 };
 static const uint8_t chiptest_dac9e1195a0d_aad_100[]                          = {};
 static const uint8_t chiptest_dac9e1195a0d_key_101[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_102[]                           = { 0xf2, 0xf0, 0x11, 0x4f, 0xe7, 0x9a, 0x24, 0xfb };
+static const uint8_t chiptest_dac9e1195a0d_nonce_102[]                        = { 0xf2, 0xf0, 0x11, 0x4f, 0xe7, 0x9a, 0x24, 0xfb };
 static const uint8_t chiptest_dac9e1195a0d_ct_103[]                           = { 0x17, 0x8d, 0xfc, 0xe4, 0xe8, 0x7b, 0xeb, 0x87,
                                                         0x63, 0xe3, 0xdd, 0xc8, 0x68, 0xfa, 0x73, 0x88 };
 static const uint8_t chiptest_dac9e1195a0d_tag_104[]                          = { 0x7e, 0x04, 0x2a, 0x69, 0xd0, 0x1b, 0x87, 0x26,
                                                          0xac, 0xe1, 0x31, 0xde, 0x34, 0x22, 0xc6, 0xae };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_105 = { .pt      = chiptest_dac9e1195a0d_pt_99,
-                                                                                  .pt_len  = 16,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_100,
-                                                                                  .aad_len = 0,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_101,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_102,
-                                                                                  .iv_len  = 8,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_103,
-                                                                                  .ct_len  = 16,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_104,
-                                                                                  .tag_len = 16,
-                                                                                  .tcId    = 14,
-                                                                                  .result  = CHIP_NO_ERROR };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_105 = { .pt        = chiptest_dac9e1195a0d_pt_99,
+                                                                                  .pt_len    = 16,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_100,
+                                                                                  .aad_len   = 0,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_101,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_102,
+                                                                                  .nonce_len = 8,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_103,
+                                                                                  .ct_len    = 16,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_104,
+                                                                                  .tag_len   = 16,
+                                                                                  .tcId      = 14,
+                                                                                  .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_106[]                           = { 0xab, 0xf9, 0x8a, 0x73, 0x5c, 0xd5, 0x47, 0x8b,
                                                         0x9d, 0x6d, 0x3d, 0xdf, 0x02, 0x56, 0x5a, 0xe0 };
 static const uint8_t chiptest_dac9e1195a0d_aad_107[]                          = {};
 static const uint8_t chiptest_dac9e1195a0d_key_108[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_109[]  = { 0xc7, 0xcf, 0x09, 0xa8, 0xe2, 0x3b, 0xaa, 0xc1, 0xb6, 0x95, 0xc0, 0x42 };
-static const uint8_t chiptest_dac9e1195a0d_ct_110[]  = { 0xf8, 0x86, 0xc0, 0x74, 0xae, 0x03, 0xe9, 0x02,
+static const uint8_t chiptest_dac9e1195a0d_nonce_109[] = { 0xc7, 0xcf, 0x09, 0xa8, 0xe2, 0x3b, 0xaa, 0xc1, 0xb6, 0x95, 0xc0, 0x42 };
+static const uint8_t chiptest_dac9e1195a0d_ct_110[]    = { 0xf8, 0x86, 0xc0, 0x74, 0xae, 0x03, 0xe9, 0x02,
                                                         0xf3, 0x3d, 0x0c, 0x91, 0x9e, 0xd7, 0xb5, 0xee };
-static const uint8_t chiptest_dac9e1195a0d_tag_111[] = { 0x44, 0x45, 0x35, 0xc9, 0x73, 0xc9, 0x2b, 0xbb };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_112 = { .pt      = chiptest_dac9e1195a0d_pt_106,
-                                                                                  .pt_len  = 16,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_107,
-                                                                                  .aad_len = 0,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_108,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_109,
-                                                                                  .iv_len  = 12,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_110,
-                                                                                  .ct_len  = 16,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_111,
-                                                                                  .tag_len = 8,
-                                                                                  .tcId    = 15,
-                                                                                  .result  = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_tag_111[]   = { 0x44, 0x45, 0x35, 0xc9, 0x73, 0xc9, 0x2b, 0xbb };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_112 = { .pt        = chiptest_dac9e1195a0d_pt_106,
+                                                                                  .pt_len    = 16,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_107,
+                                                                                  .aad_len   = 0,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_108,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_109,
+                                                                                  .nonce_len = 12,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_110,
+                                                                                  .ct_len    = 16,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_111,
+                                                                                  .tag_len   = 8,
+                                                                                  .tcId      = 15,
+                                                                                  .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_113[]                           = { 0xab, 0xf9, 0x8a, 0x73, 0x5c, 0xd5, 0x47, 0x8b,
                                                         0x9d, 0x6d, 0x3d, 0xdf, 0x02, 0x56, 0x5a, 0xe0 };
 static const uint8_t chiptest_dac9e1195a0d_aad_114[]                          = {};
 static const uint8_t chiptest_dac9e1195a0d_key_115[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_116[]  = { 0xc7, 0xcf, 0x09, 0xa8, 0xe2, 0x3b, 0xaa, 0xc1, 0xb6, 0x95, 0xc0, 0x42 };
-static const uint8_t chiptest_dac9e1195a0d_ct_117[]  = { 0xf8, 0x86, 0xc0, 0x74, 0xae, 0x03, 0xe9, 0x02,
+static const uint8_t chiptest_dac9e1195a0d_nonce_116[] = { 0xc7, 0xcf, 0x09, 0xa8, 0xe2, 0x3b, 0xaa, 0xc1, 0xb6, 0x95, 0xc0, 0x42 };
+static const uint8_t chiptest_dac9e1195a0d_ct_117[]    = { 0xf8, 0x86, 0xc0, 0x74, 0xae, 0x03, 0xe9, 0x02,
                                                         0xf3, 0x3d, 0x0c, 0x91, 0x9e, 0xd7, 0xb5, 0xee };
-static const uint8_t chiptest_dac9e1195a0d_tag_118[] = { 0xc9, 0xa7, 0x79, 0xa1, 0xaa, 0x43, 0x0c, 0x7a, 0x4a, 0x43, 0x2f, 0x49 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_119 = { .pt      = chiptest_dac9e1195a0d_pt_113,
-                                                                                  .pt_len  = 16,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_114,
-                                                                                  .aad_len = 0,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_115,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_116,
-                                                                                  .iv_len  = 12,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_117,
-                                                                                  .ct_len  = 16,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_118,
-                                                                                  .tag_len = 12,
-                                                                                  .tcId    = 16,
-                                                                                  .result  = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_tag_118[]   = { 0xc9, 0xa7, 0x79, 0xa1, 0xaa, 0x43, 0x0c, 0x7a, 0x4a, 0x43, 0x2f, 0x49 };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_119 = { .pt        = chiptest_dac9e1195a0d_pt_113,
+                                                                                  .pt_len    = 16,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_114,
+                                                                                  .aad_len   = 0,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_115,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_116,
+                                                                                  .nonce_len = 12,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_117,
+                                                                                  .ct_len    = 16,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_118,
+                                                                                  .tag_len   = 12,
+                                                                                  .tcId      = 16,
+                                                                                  .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_120[]                           = { 0xab, 0xf9, 0x8a, 0x73, 0x5c, 0xd5, 0x47, 0x8b,
                                                         0x9d, 0x6d, 0x3d, 0xdf, 0x02, 0x56, 0x5a, 0xe0 };
 static const uint8_t chiptest_dac9e1195a0d_aad_121[]                          = {};
 static const uint8_t chiptest_dac9e1195a0d_key_122[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_123[]  = { 0xc7, 0xcf, 0x09, 0xa8, 0xe2, 0x3b, 0xaa, 0xc1, 0xb6, 0x95, 0xc0, 0x42 };
-static const uint8_t chiptest_dac9e1195a0d_ct_124[]  = { 0xf8, 0x86, 0xc0, 0x74, 0xae, 0x03, 0xe9, 0x02,
+static const uint8_t chiptest_dac9e1195a0d_nonce_123[] = { 0xc7, 0xcf, 0x09, 0xa8, 0xe2, 0x3b, 0xaa, 0xc1, 0xb6, 0x95, 0xc0, 0x42 };
+static const uint8_t chiptest_dac9e1195a0d_ct_124[]    = { 0xf8, 0x86, 0xc0, 0x74, 0xae, 0x03, 0xe9, 0x02,
                                                         0xf3, 0x3d, 0x0c, 0x91, 0x9e, 0xd7, 0xb5, 0xee };
-static const uint8_t chiptest_dac9e1195a0d_tag_125[] = { 0x1f, 0x5d, 0xdb, 0xdd, 0x5b, 0xcf, 0xc5, 0x4f,
+static const uint8_t chiptest_dac9e1195a0d_tag_125[]   = { 0x1f, 0x5d, 0xdb, 0xdd, 0x5b, 0xcf, 0xc5, 0x4f,
                                                          0x0c, 0xbc, 0xf4, 0x7f, 0x46, 0x34, 0x63, 0x67 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_126 = { .pt      = chiptest_dac9e1195a0d_pt_120,
-                                                                                  .pt_len  = 16,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_121,
-                                                                                  .aad_len = 0,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_122,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_123,
-                                                                                  .iv_len  = 12,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_124,
-                                                                                  .ct_len  = 16,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_125,
-                                                                                  .tag_len = 16,
-                                                                                  .tcId    = 17,
-                                                                                  .result  = CHIP_NO_ERROR };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_126 = { .pt        = chiptest_dac9e1195a0d_pt_120,
+                                                                                  .pt_len    = 16,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_121,
+                                                                                  .aad_len   = 0,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_122,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_123,
+                                                                                  .nonce_len = 12,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_124,
+                                                                                  .ct_len    = 16,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_125,
+                                                                                  .tag_len   = 16,
+                                                                                  .tcId      = 17,
+                                                                                  .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_127[]                           = { 0x0a, 0x61, 0xf2, 0xb4, 0xd6, 0x13, 0x5e, 0x2f,
                                                         0x63, 0xd3, 0xae, 0x42, 0xc3, 0x08, 0x08, 0x3e };
 static const uint8_t chiptest_dac9e1195a0d_aad_128[]                          = { 0x2c, 0xa7, 0x1b, 0x23, 0x18, 0xdd, 0x96, 0xb2,
                                                          0x43, 0xc8, 0x70, 0xa3, 0xdd, 0xa9, 0xfa, 0x0d };
 static const uint8_t chiptest_dac9e1195a0d_key_129[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_130[]                           = { 0x60, 0x66, 0x73, 0x03, 0x90, 0xc3, 0xae, 0x06 };
+static const uint8_t chiptest_dac9e1195a0d_nonce_130[]                        = { 0x60, 0x66, 0x73, 0x03, 0x90, 0xc3, 0xae, 0x06 };
 static const uint8_t chiptest_dac9e1195a0d_ct_131[]                           = { 0xc2, 0xaf, 0x35, 0x3b, 0x99, 0x82, 0xc3, 0x9f,
                                                         0x6d, 0x91, 0x4a, 0xef, 0x8c, 0xf4, 0x97, 0x19 };
 static const uint8_t chiptest_dac9e1195a0d_tag_132[]                          = { 0xce, 0xb1, 0x1e, 0x3a, 0x99, 0xeb, 0x3b, 0xcd };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_133 = { .pt      = chiptest_dac9e1195a0d_pt_127,
-                                                                                  .pt_len  = 16,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_128,
-                                                                                  .aad_len = 16,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_129,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_130,
-                                                                                  .iv_len  = 8,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_131,
-                                                                                  .ct_len  = 16,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_132,
-                                                                                  .tag_len = 8,
-                                                                                  .tcId    = 18,
-                                                                                  .result  = CHIP_NO_ERROR };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_133 = { .pt        = chiptest_dac9e1195a0d_pt_127,
+                                                                                  .pt_len    = 16,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_128,
+                                                                                  .aad_len   = 16,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_129,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_130,
+                                                                                  .nonce_len = 8,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_131,
+                                                                                  .ct_len    = 16,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_132,
+                                                                                  .tag_len   = 8,
+                                                                                  .tcId      = 18,
+                                                                                  .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_134[]                           = { 0x0a, 0x61, 0xf2, 0xb4, 0xd6, 0x13, 0x5e, 0x2f,
                                                         0x63, 0xd3, 0xae, 0x42, 0xc3, 0x08, 0x08, 0x3e };
 static const uint8_t chiptest_dac9e1195a0d_aad_135[]                          = { 0x2c, 0xa7, 0x1b, 0x23, 0x18, 0xdd, 0x96, 0xb2,
                                                          0x43, 0xc8, 0x70, 0xa3, 0xdd, 0xa9, 0xfa, 0x0d };
 static const uint8_t chiptest_dac9e1195a0d_key_136[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_137[]                           = { 0x60, 0x66, 0x73, 0x03, 0x90, 0xc3, 0xae, 0x06 };
+static const uint8_t chiptest_dac9e1195a0d_nonce_137[]                        = { 0x60, 0x66, 0x73, 0x03, 0x90, 0xc3, 0xae, 0x06 };
 static const uint8_t chiptest_dac9e1195a0d_ct_138[]                           = { 0xc2, 0xaf, 0x35, 0x3b, 0x99, 0x82, 0xc3, 0x9f,
                                                         0x6d, 0x91, 0x4a, 0xef, 0x8c, 0xf4, 0x97, 0x19 };
 static const uint8_t chiptest_dac9e1195a0d_tag_139[] = { 0x54, 0x26, 0x39, 0x94, 0xd2, 0x41, 0xe4, 0xff, 0x06, 0x0c, 0xcb, 0x0f };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_140 = { .pt      = chiptest_dac9e1195a0d_pt_134,
-                                                                                  .pt_len  = 16,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_135,
-                                                                                  .aad_len = 16,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_136,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_137,
-                                                                                  .iv_len  = 8,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_138,
-                                                                                  .ct_len  = 16,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_139,
-                                                                                  .tag_len = 12,
-                                                                                  .tcId    = 19,
-                                                                                  .result  = CHIP_NO_ERROR };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_140 = { .pt        = chiptest_dac9e1195a0d_pt_134,
+                                                                                  .pt_len    = 16,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_135,
+                                                                                  .aad_len   = 16,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_136,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_137,
+                                                                                  .nonce_len = 8,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_138,
+                                                                                  .ct_len    = 16,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_139,
+                                                                                  .tag_len   = 12,
+                                                                                  .tcId      = 19,
+                                                                                  .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_141[]                           = { 0x0a, 0x61, 0xf2, 0xb4, 0xd6, 0x13, 0x5e, 0x2f,
                                                         0x63, 0xd3, 0xae, 0x42, 0xc3, 0x08, 0x08, 0x3e };
 static const uint8_t chiptest_dac9e1195a0d_aad_142[]                          = { 0x2c, 0xa7, 0x1b, 0x23, 0x18, 0xdd, 0x96, 0xb2,
                                                          0x43, 0xc8, 0x70, 0xa3, 0xdd, 0xa9, 0xfa, 0x0d };
 static const uint8_t chiptest_dac9e1195a0d_key_143[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_144[]                           = { 0x60, 0x66, 0x73, 0x03, 0x90, 0xc3, 0xae, 0x06 };
+static const uint8_t chiptest_dac9e1195a0d_nonce_144[]                        = { 0x60, 0x66, 0x73, 0x03, 0x90, 0xc3, 0xae, 0x06 };
 static const uint8_t chiptest_dac9e1195a0d_ct_145[]                           = { 0xc2, 0xaf, 0x35, 0x3b, 0x99, 0x82, 0xc3, 0x9f,
                                                         0x6d, 0x91, 0x4a, 0xef, 0x8c, 0xf4, 0x97, 0x19 };
 static const uint8_t chiptest_dac9e1195a0d_tag_146[]                          = { 0x08, 0x68, 0x46, 0xcc, 0x2f, 0x72, 0xa4, 0x90,
                                                          0x23, 0xc3, 0x0f, 0xc6, 0x9a, 0xac, 0x4b, 0x7f };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_147 = { .pt      = chiptest_dac9e1195a0d_pt_141,
-                                                                                  .pt_len  = 16,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_142,
-                                                                                  .aad_len = 16,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_143,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_144,
-                                                                                  .iv_len  = 8,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_145,
-                                                                                  .ct_len  = 16,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_146,
-                                                                                  .tag_len = 16,
-                                                                                  .tcId    = 20,
-                                                                                  .result  = CHIP_NO_ERROR };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_147 = { .pt        = chiptest_dac9e1195a0d_pt_141,
+                                                                                  .pt_len    = 16,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_142,
+                                                                                  .aad_len   = 16,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_143,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_144,
+                                                                                  .nonce_len = 8,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_145,
+                                                                                  .ct_len    = 16,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_146,
+                                                                                  .tag_len   = 16,
+                                                                                  .tcId      = 20,
+                                                                                  .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_148[]                           = { 0x33, 0x23, 0x11, 0xb6, 0xae, 0xb2, 0x15, 0x2e,
                                                         0xb8, 0x44, 0x59, 0x4f, 0x41, 0xf8, 0xec, 0x69 };
 static const uint8_t chiptest_dac9e1195a0d_aad_149[]                          = { 0xa4, 0x08, 0xf7, 0x5d, 0xdc, 0x1a, 0x13, 0x31,
                                                          0x3d, 0xfb, 0x35, 0x5f, 0x79, 0xcc, 0x36, 0x55 };
 static const uint8_t chiptest_dac9e1195a0d_key_150[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_151[]  = { 0x63, 0x90, 0x36, 0xf0, 0xad, 0x89, 0x82, 0x51, 0x58, 0xb0, 0x49, 0xca };
-static const uint8_t chiptest_dac9e1195a0d_ct_152[]  = { 0x4f, 0x19, 0xc6, 0xa3, 0xbc, 0x09, 0x99, 0x34,
+static const uint8_t chiptest_dac9e1195a0d_nonce_151[] = { 0x63, 0x90, 0x36, 0xf0, 0xad, 0x89, 0x82, 0x51, 0x58, 0xb0, 0x49, 0xca };
+static const uint8_t chiptest_dac9e1195a0d_ct_152[]    = { 0x4f, 0x19, 0xc6, 0xa3, 0xbc, 0x09, 0x99, 0x34,
                                                         0xe3, 0x5b, 0x32, 0x9b, 0x89, 0xa8, 0x5e, 0x18 };
-static const uint8_t chiptest_dac9e1195a0d_tag_153[] = { 0x92, 0x62, 0xb1, 0x84, 0xe2, 0xec, 0xe1, 0xd4 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_154 = { .pt      = chiptest_dac9e1195a0d_pt_148,
-                                                                                  .pt_len  = 16,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_149,
-                                                                                  .aad_len = 16,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_150,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_151,
-                                                                                  .iv_len  = 12,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_152,
-                                                                                  .ct_len  = 16,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_153,
-                                                                                  .tag_len = 8,
-                                                                                  .tcId    = 21,
-                                                                                  .result  = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_tag_153[]   = { 0x92, 0x62, 0xb1, 0x84, 0xe2, 0xec, 0xe1, 0xd4 };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_154 = { .pt        = chiptest_dac9e1195a0d_pt_148,
+                                                                                  .pt_len    = 16,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_149,
+                                                                                  .aad_len   = 16,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_150,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_151,
+                                                                                  .nonce_len = 12,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_152,
+                                                                                  .ct_len    = 16,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_153,
+                                                                                  .tag_len   = 8,
+                                                                                  .tcId      = 21,
+                                                                                  .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_155[]                           = { 0x33, 0x23, 0x11, 0xb6, 0xae, 0xb2, 0x15, 0x2e,
                                                         0xb8, 0x44, 0x59, 0x4f, 0x41, 0xf8, 0xec, 0x69 };
 static const uint8_t chiptest_dac9e1195a0d_aad_156[]                          = { 0xa4, 0x08, 0xf7, 0x5d, 0xdc, 0x1a, 0x13, 0x31,
                                                          0x3d, 0xfb, 0x35, 0x5f, 0x79, 0xcc, 0x36, 0x55 };
 static const uint8_t chiptest_dac9e1195a0d_key_157[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_158[]  = { 0x63, 0x90, 0x36, 0xf0, 0xad, 0x89, 0x82, 0x51, 0x58, 0xb0, 0x49, 0xca };
-static const uint8_t chiptest_dac9e1195a0d_ct_159[]  = { 0x4f, 0x19, 0xc6, 0xa3, 0xbc, 0x09, 0x99, 0x34,
+static const uint8_t chiptest_dac9e1195a0d_nonce_158[] = { 0x63, 0x90, 0x36, 0xf0, 0xad, 0x89, 0x82, 0x51, 0x58, 0xb0, 0x49, 0xca };
+static const uint8_t chiptest_dac9e1195a0d_ct_159[]    = { 0x4f, 0x19, 0xc6, 0xa3, 0xbc, 0x09, 0x99, 0x34,
                                                         0xe3, 0x5b, 0x32, 0x9b, 0x89, 0xa8, 0x5e, 0x18 };
-static const uint8_t chiptest_dac9e1195a0d_tag_160[] = { 0x0c, 0xc2, 0xc1, 0x5e, 0x0e, 0x93, 0x5a, 0x64, 0x9a, 0xfe, 0x4c, 0xce };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_161 = { .pt      = chiptest_dac9e1195a0d_pt_155,
-                                                                                  .pt_len  = 16,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_156,
-                                                                                  .aad_len = 16,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_157,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_158,
-                                                                                  .iv_len  = 12,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_159,
-                                                                                  .ct_len  = 16,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_160,
-                                                                                  .tag_len = 12,
-                                                                                  .tcId    = 22,
-                                                                                  .result  = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_tag_160[]   = { 0x0c, 0xc2, 0xc1, 0x5e, 0x0e, 0x93, 0x5a, 0x64, 0x9a, 0xfe, 0x4c, 0xce };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_161 = { .pt        = chiptest_dac9e1195a0d_pt_155,
+                                                                                  .pt_len    = 16,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_156,
+                                                                                  .aad_len   = 16,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_157,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_158,
+                                                                                  .nonce_len = 12,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_159,
+                                                                                  .ct_len    = 16,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_160,
+                                                                                  .tag_len   = 12,
+                                                                                  .tcId      = 22,
+                                                                                  .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_162[]                           = { 0x33, 0x23, 0x11, 0xb6, 0xae, 0xb2, 0x15, 0x2e,
                                                         0xb8, 0x44, 0x59, 0x4f, 0x41, 0xf8, 0xec, 0x69 };
 static const uint8_t chiptest_dac9e1195a0d_aad_163[]                          = { 0xa4, 0x08, 0xf7, 0x5d, 0xdc, 0x1a, 0x13, 0x31,
                                                          0x3d, 0xfb, 0x35, 0x5f, 0x79, 0xcc, 0x36, 0x55 };
 static const uint8_t chiptest_dac9e1195a0d_key_164[]                          = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_165[]  = { 0x63, 0x90, 0x36, 0xf0, 0xad, 0x89, 0x82, 0x51, 0x58, 0xb0, 0x49, 0xca };
-static const uint8_t chiptest_dac9e1195a0d_ct_166[]  = { 0x4f, 0x19, 0xc6, 0xa3, 0xbc, 0x09, 0x99, 0x34,
+static const uint8_t chiptest_dac9e1195a0d_nonce_165[] = { 0x63, 0x90, 0x36, 0xf0, 0xad, 0x89, 0x82, 0x51, 0x58, 0xb0, 0x49, 0xca };
+static const uint8_t chiptest_dac9e1195a0d_ct_166[]    = { 0x4f, 0x19, 0xc6, 0xa3, 0xbc, 0x09, 0x99, 0x34,
                                                         0xe3, 0x5b, 0x32, 0x9b, 0x89, 0xa8, 0x5e, 0x18 };
-static const uint8_t chiptest_dac9e1195a0d_tag_167[] = { 0xbd, 0x90, 0x92, 0xa8, 0xdb, 0x2e, 0x78, 0x0b,
+static const uint8_t chiptest_dac9e1195a0d_tag_167[]   = { 0xbd, 0x90, 0x92, 0xa8, 0xdb, 0x2e, 0x78, 0x0b,
                                                          0x5a, 0x93, 0xa0, 0xfb, 0xe3, 0x3a, 0x5a, 0x38 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_168 = { .pt      = chiptest_dac9e1195a0d_pt_162,
-                                                                                  .pt_len  = 16,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_163,
-                                                                                  .aad_len = 16,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_164,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_165,
-                                                                                  .iv_len  = 12,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_166,
-                                                                                  .ct_len  = 16,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_167,
-                                                                                  .tag_len = 16,
-                                                                                  .tcId    = 23,
-                                                                                  .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_dac9e1195a0d_pt_169[]  = { 0x3b, 0xc5, 0xc4, 0xda, 0x04, 0xd8, 0xa5, 0x15, 0x67, 0x9c, 0x5c,
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_168 = { .pt        = chiptest_dac9e1195a0d_pt_162,
+                                                                                  .pt_len    = 16,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_163,
+                                                                                  .aad_len   = 16,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_164,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_165,
+                                                                                  .nonce_len = 12,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_166,
+                                                                                  .ct_len    = 16,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_167,
+                                                                                  .tag_len   = 16,
+                                                                                  .tcId      = 23,
+                                                                                  .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_pt_169[]    = { 0x3b, 0xc5, 0xc4, 0xda, 0x04, 0xd8, 0xa5, 0x15, 0x67, 0x9c, 0x5c,
                                                         0x40, 0xc0, 0xfd, 0x7d, 0x9e, 0x2b, 0x52, 0x22, 0x3f, 0xeb, 0x1f,
                                                         0x61, 0x99, 0x78, 0xe7, 0xce, 0x84, 0xdc, 0x3f, 0xbe, 0x85, 0xf2 };
-static const uint8_t chiptest_dac9e1195a0d_aad_170[] = {};
-static const uint8_t chiptest_dac9e1195a0d_key_171[] = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
+static const uint8_t chiptest_dac9e1195a0d_aad_170[]   = {};
+static const uint8_t chiptest_dac9e1195a0d_key_171[]   = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_172[]  = { 0x7b, 0x05, 0xbc, 0x8b, 0xcf, 0xc1, 0x6c, 0xc1 };
-static const uint8_t chiptest_dac9e1195a0d_ct_173[]  = { 0xf1, 0x46, 0xa7, 0xb0, 0xf4, 0xff, 0x02, 0x3a, 0x23, 0xc3, 0xfe,
+static const uint8_t chiptest_dac9e1195a0d_nonce_172[] = { 0x7b, 0x05, 0xbc, 0x8b, 0xcf, 0xc1, 0x6c, 0xc1 };
+static const uint8_t chiptest_dac9e1195a0d_ct_173[]    = { 0xf1, 0x46, 0xa7, 0xb0, 0xf4, 0xff, 0x02, 0x3a, 0x23, 0xc3, 0xfe,
                                                         0xd5, 0x60, 0x4c, 0xdf, 0xe5, 0x09, 0x3e, 0x3c, 0x7b, 0x91, 0x4a,
                                                         0x68, 0xa5, 0xab, 0xff, 0x1a, 0x14, 0x96, 0x1e, 0x82, 0xb3, 0xb9 };
-static const uint8_t chiptest_dac9e1195a0d_tag_174[] = { 0x32, 0x6f, 0xff, 0xcc, 0xce, 0x78, 0x97, 0x57 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_175 = { .pt      = chiptest_dac9e1195a0d_pt_169,
-                                                                                  .pt_len  = 33,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_170,
-                                                                                  .aad_len = 0,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_171,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_172,
-                                                                                  .iv_len  = 8,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_173,
-                                                                                  .ct_len  = 33,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_174,
-                                                                                  .tag_len = 8,
-                                                                                  .tcId    = 24,
-                                                                                  .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_dac9e1195a0d_pt_176[]  = { 0x3b, 0xc5, 0xc4, 0xda, 0x04, 0xd8, 0xa5, 0x15, 0x67, 0x9c, 0x5c,
+static const uint8_t chiptest_dac9e1195a0d_tag_174[]   = { 0x32, 0x6f, 0xff, 0xcc, 0xce, 0x78, 0x97, 0x57 };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_175 = { .pt        = chiptest_dac9e1195a0d_pt_169,
+                                                                                  .pt_len    = 33,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_170,
+                                                                                  .aad_len   = 0,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_171,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_172,
+                                                                                  .nonce_len = 8,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_173,
+                                                                                  .ct_len    = 33,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_174,
+                                                                                  .tag_len   = 8,
+                                                                                  .tcId      = 24,
+                                                                                  .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_pt_176[]    = { 0x3b, 0xc5, 0xc4, 0xda, 0x04, 0xd8, 0xa5, 0x15, 0x67, 0x9c, 0x5c,
                                                         0x40, 0xc0, 0xfd, 0x7d, 0x9e, 0x2b, 0x52, 0x22, 0x3f, 0xeb, 0x1f,
                                                         0x61, 0x99, 0x78, 0xe7, 0xce, 0x84, 0xdc, 0x3f, 0xbe, 0x85, 0xf2 };
-static const uint8_t chiptest_dac9e1195a0d_aad_177[] = {};
-static const uint8_t chiptest_dac9e1195a0d_key_178[] = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
+static const uint8_t chiptest_dac9e1195a0d_aad_177[]   = {};
+static const uint8_t chiptest_dac9e1195a0d_key_178[]   = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_179[]  = { 0x7b, 0x05, 0xbc, 0x8b, 0xcf, 0xc1, 0x6c, 0xc1 };
-static const uint8_t chiptest_dac9e1195a0d_ct_180[]  = { 0xf1, 0x46, 0xa7, 0xb0, 0xf4, 0xff, 0x02, 0x3a, 0x23, 0xc3, 0xfe,
+static const uint8_t chiptest_dac9e1195a0d_nonce_179[] = { 0x7b, 0x05, 0xbc, 0x8b, 0xcf, 0xc1, 0x6c, 0xc1 };
+static const uint8_t chiptest_dac9e1195a0d_ct_180[]    = { 0xf1, 0x46, 0xa7, 0xb0, 0xf4, 0xff, 0x02, 0x3a, 0x23, 0xc3, 0xfe,
                                                         0xd5, 0x60, 0x4c, 0xdf, 0xe5, 0x09, 0x3e, 0x3c, 0x7b, 0x91, 0x4a,
                                                         0x68, 0xa5, 0xab, 0xff, 0x1a, 0x14, 0x96, 0x1e, 0x82, 0xb3, 0xb9 };
-static const uint8_t chiptest_dac9e1195a0d_tag_181[] = { 0x5d, 0xca, 0x99, 0xed, 0x22, 0x49, 0x97, 0x05, 0x48, 0x57, 0x6e, 0x8b };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_182 = { .pt      = chiptest_dac9e1195a0d_pt_176,
-                                                                                  .pt_len  = 33,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_177,
-                                                                                  .aad_len = 0,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_178,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_179,
-                                                                                  .iv_len  = 8,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_180,
-                                                                                  .ct_len  = 33,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_181,
-                                                                                  .tag_len = 12,
-                                                                                  .tcId    = 25,
-                                                                                  .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_dac9e1195a0d_pt_183[]  = { 0x3b, 0xc5, 0xc4, 0xda, 0x04, 0xd8, 0xa5, 0x15, 0x67, 0x9c, 0x5c,
+static const uint8_t chiptest_dac9e1195a0d_tag_181[]   = { 0x5d, 0xca, 0x99, 0xed, 0x22, 0x49, 0x97, 0x05, 0x48, 0x57, 0x6e, 0x8b };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_182 = { .pt        = chiptest_dac9e1195a0d_pt_176,
+                                                                                  .pt_len    = 33,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_177,
+                                                                                  .aad_len   = 0,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_178,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_179,
+                                                                                  .nonce_len = 8,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_180,
+                                                                                  .ct_len    = 33,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_181,
+                                                                                  .tag_len   = 12,
+                                                                                  .tcId      = 25,
+                                                                                  .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_pt_183[]    = { 0x3b, 0xc5, 0xc4, 0xda, 0x04, 0xd8, 0xa5, 0x15, 0x67, 0x9c, 0x5c,
                                                         0x40, 0xc0, 0xfd, 0x7d, 0x9e, 0x2b, 0x52, 0x22, 0x3f, 0xeb, 0x1f,
                                                         0x61, 0x99, 0x78, 0xe7, 0xce, 0x84, 0xdc, 0x3f, 0xbe, 0x85, 0xf2 };
-static const uint8_t chiptest_dac9e1195a0d_aad_184[] = {};
-static const uint8_t chiptest_dac9e1195a0d_key_185[] = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
+static const uint8_t chiptest_dac9e1195a0d_aad_184[]   = {};
+static const uint8_t chiptest_dac9e1195a0d_key_185[]   = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_186[]  = { 0x7b, 0x05, 0xbc, 0x8b, 0xcf, 0xc1, 0x6c, 0xc1 };
-static const uint8_t chiptest_dac9e1195a0d_ct_187[]  = { 0xf1, 0x46, 0xa7, 0xb0, 0xf4, 0xff, 0x02, 0x3a, 0x23, 0xc3, 0xfe,
+static const uint8_t chiptest_dac9e1195a0d_nonce_186[] = { 0x7b, 0x05, 0xbc, 0x8b, 0xcf, 0xc1, 0x6c, 0xc1 };
+static const uint8_t chiptest_dac9e1195a0d_ct_187[]    = { 0xf1, 0x46, 0xa7, 0xb0, 0xf4, 0xff, 0x02, 0x3a, 0x23, 0xc3, 0xfe,
                                                         0xd5, 0x60, 0x4c, 0xdf, 0xe5, 0x09, 0x3e, 0x3c, 0x7b, 0x91, 0x4a,
                                                         0x68, 0xa5, 0xab, 0xff, 0x1a, 0x14, 0x96, 0x1e, 0x82, 0xb3, 0xb9 };
-static const uint8_t chiptest_dac9e1195a0d_tag_188[] = { 0x31, 0x4c, 0xc7, 0xf3, 0x36, 0x41, 0x54, 0x55,
+static const uint8_t chiptest_dac9e1195a0d_tag_188[]   = { 0x31, 0x4c, 0xc7, 0xf3, 0x36, 0x41, 0x54, 0x55,
                                                          0xd8, 0xf5, 0xfb, 0x36, 0xea, 0x1b, 0x73, 0xd8 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_189 = { .pt      = chiptest_dac9e1195a0d_pt_183,
-                                                                                  .pt_len  = 33,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_184,
-                                                                                  .aad_len = 0,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_185,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_186,
-                                                                                  .iv_len  = 8,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_187,
-                                                                                  .ct_len  = 33,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_188,
-                                                                                  .tag_len = 16,
-                                                                                  .tcId    = 26,
-                                                                                  .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_dac9e1195a0d_pt_190[]  = { 0x58, 0x07, 0xa2, 0x32, 0x31, 0x77, 0xa6, 0xba, 0xc6, 0x77, 0x3c,
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_189 = { .pt        = chiptest_dac9e1195a0d_pt_183,
+                                                                                  .pt_len    = 33,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_184,
+                                                                                  .aad_len   = 0,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_185,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_186,
+                                                                                  .nonce_len = 8,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_187,
+                                                                                  .ct_len    = 33,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_188,
+                                                                                  .tag_len   = 16,
+                                                                                  .tcId      = 26,
+                                                                                  .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_pt_190[]    = { 0x58, 0x07, 0xa2, 0x32, 0x31, 0x77, 0xa6, 0xba, 0xc6, 0x77, 0x3c,
                                                         0xd9, 0x28, 0x9b, 0xc1, 0x20, 0x14, 0xb8, 0x95, 0xa4, 0xbc, 0xa7,
                                                         0x8f, 0x93, 0x50, 0x86, 0xe1, 0x49, 0x7a, 0x38, 0xcc, 0x02, 0x42 };
-static const uint8_t chiptest_dac9e1195a0d_aad_191[] = {};
-static const uint8_t chiptest_dac9e1195a0d_key_192[] = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
+static const uint8_t chiptest_dac9e1195a0d_aad_191[]   = {};
+static const uint8_t chiptest_dac9e1195a0d_key_192[]   = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_193[]  = { 0xee, 0xbc, 0x7d, 0x0c, 0xce, 0x8d, 0x7f, 0xd6, 0xa5, 0x72, 0x6e, 0x49 };
-static const uint8_t chiptest_dac9e1195a0d_ct_194[]  = { 0xb4, 0x48, 0x21, 0x1c, 0x9d, 0xa8, 0xc3, 0x31, 0x6c, 0x52, 0x69,
+static const uint8_t chiptest_dac9e1195a0d_nonce_193[] = { 0xee, 0xbc, 0x7d, 0x0c, 0xce, 0x8d, 0x7f, 0xd6, 0xa5, 0x72, 0x6e, 0x49 };
+static const uint8_t chiptest_dac9e1195a0d_ct_194[]    = { 0xb4, 0x48, 0x21, 0x1c, 0x9d, 0xa8, 0xc3, 0x31, 0x6c, 0x52, 0x69,
                                                         0xe5, 0xc4, 0xf6, 0x65, 0x78, 0x67, 0x3f, 0x1d, 0xfc, 0x03, 0x8a,
                                                         0x4f, 0x3f, 0x13, 0x2c, 0x85, 0x76, 0x2a, 0x89, 0x32, 0x06, 0xd4 };
-static const uint8_t chiptest_dac9e1195a0d_tag_195[] = { 0xae, 0x93, 0x77, 0x15, 0xa6, 0x5b, 0x80, 0xd5 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_196 = { .pt      = chiptest_dac9e1195a0d_pt_190,
-                                                                                  .pt_len  = 33,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_191,
-                                                                                  .aad_len = 0,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_192,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_193,
-                                                                                  .iv_len  = 12,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_194,
-                                                                                  .ct_len  = 33,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_195,
-                                                                                  .tag_len = 8,
-                                                                                  .tcId    = 27,
-                                                                                  .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_dac9e1195a0d_pt_197[]  = { 0x58, 0x07, 0xa2, 0x32, 0x31, 0x77, 0xa6, 0xba, 0xc6, 0x77, 0x3c,
+static const uint8_t chiptest_dac9e1195a0d_tag_195[]   = { 0xae, 0x93, 0x77, 0x15, 0xa6, 0x5b, 0x80, 0xd5 };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_196 = { .pt        = chiptest_dac9e1195a0d_pt_190,
+                                                                                  .pt_len    = 33,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_191,
+                                                                                  .aad_len   = 0,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_192,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_193,
+                                                                                  .nonce_len = 12,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_194,
+                                                                                  .ct_len    = 33,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_195,
+                                                                                  .tag_len   = 8,
+                                                                                  .tcId      = 27,
+                                                                                  .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_pt_197[]    = { 0x58, 0x07, 0xa2, 0x32, 0x31, 0x77, 0xa6, 0xba, 0xc6, 0x77, 0x3c,
                                                         0xd9, 0x28, 0x9b, 0xc1, 0x20, 0x14, 0xb8, 0x95, 0xa4, 0xbc, 0xa7,
                                                         0x8f, 0x93, 0x50, 0x86, 0xe1, 0x49, 0x7a, 0x38, 0xcc, 0x02, 0x42 };
-static const uint8_t chiptest_dac9e1195a0d_aad_198[] = {};
-static const uint8_t chiptest_dac9e1195a0d_key_199[] = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
+static const uint8_t chiptest_dac9e1195a0d_aad_198[]   = {};
+static const uint8_t chiptest_dac9e1195a0d_key_199[]   = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_200[]  = { 0xee, 0xbc, 0x7d, 0x0c, 0xce, 0x8d, 0x7f, 0xd6, 0xa5, 0x72, 0x6e, 0x49 };
-static const uint8_t chiptest_dac9e1195a0d_ct_201[]  = { 0xb4, 0x48, 0x21, 0x1c, 0x9d, 0xa8, 0xc3, 0x31, 0x6c, 0x52, 0x69,
+static const uint8_t chiptest_dac9e1195a0d_nonce_200[] = { 0xee, 0xbc, 0x7d, 0x0c, 0xce, 0x8d, 0x7f, 0xd6, 0xa5, 0x72, 0x6e, 0x49 };
+static const uint8_t chiptest_dac9e1195a0d_ct_201[]    = { 0xb4, 0x48, 0x21, 0x1c, 0x9d, 0xa8, 0xc3, 0x31, 0x6c, 0x52, 0x69,
                                                         0xe5, 0xc4, 0xf6, 0x65, 0x78, 0x67, 0x3f, 0x1d, 0xfc, 0x03, 0x8a,
                                                         0x4f, 0x3f, 0x13, 0x2c, 0x85, 0x76, 0x2a, 0x89, 0x32, 0x06, 0xd4 };
-static const uint8_t chiptest_dac9e1195a0d_tag_202[] = { 0xc4, 0xa7, 0xd3, 0x61, 0x19, 0xeb, 0x20, 0x96, 0xaf, 0x5b, 0x39, 0x73 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_203 = { .pt      = chiptest_dac9e1195a0d_pt_197,
-                                                                                  .pt_len  = 33,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_198,
-                                                                                  .aad_len = 0,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_199,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_200,
-                                                                                  .iv_len  = 12,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_201,
-                                                                                  .ct_len  = 33,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_202,
-                                                                                  .tag_len = 12,
-                                                                                  .tcId    = 28,
-                                                                                  .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_dac9e1195a0d_pt_204[]  = { 0x58, 0x07, 0xa2, 0x32, 0x31, 0x77, 0xa6, 0xba, 0xc6, 0x77, 0x3c,
+static const uint8_t chiptest_dac9e1195a0d_tag_202[]   = { 0xc4, 0xa7, 0xd3, 0x61, 0x19, 0xeb, 0x20, 0x96, 0xaf, 0x5b, 0x39, 0x73 };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_203 = { .pt        = chiptest_dac9e1195a0d_pt_197,
+                                                                                  .pt_len    = 33,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_198,
+                                                                                  .aad_len   = 0,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_199,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_200,
+                                                                                  .nonce_len = 12,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_201,
+                                                                                  .ct_len    = 33,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_202,
+                                                                                  .tag_len   = 12,
+                                                                                  .tcId      = 28,
+                                                                                  .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_pt_204[]    = { 0x58, 0x07, 0xa2, 0x32, 0x31, 0x77, 0xa6, 0xba, 0xc6, 0x77, 0x3c,
                                                         0xd9, 0x28, 0x9b, 0xc1, 0x20, 0x14, 0xb8, 0x95, 0xa4, 0xbc, 0xa7,
                                                         0x8f, 0x93, 0x50, 0x86, 0xe1, 0x49, 0x7a, 0x38, 0xcc, 0x02, 0x42 };
-static const uint8_t chiptest_dac9e1195a0d_aad_205[] = {};
-static const uint8_t chiptest_dac9e1195a0d_key_206[] = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
+static const uint8_t chiptest_dac9e1195a0d_aad_205[]   = {};
+static const uint8_t chiptest_dac9e1195a0d_key_206[]   = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_207[]  = { 0xee, 0xbc, 0x7d, 0x0c, 0xce, 0x8d, 0x7f, 0xd6, 0xa5, 0x72, 0x6e, 0x49 };
-static const uint8_t chiptest_dac9e1195a0d_ct_208[]  = { 0xb4, 0x48, 0x21, 0x1c, 0x9d, 0xa8, 0xc3, 0x31, 0x6c, 0x52, 0x69,
+static const uint8_t chiptest_dac9e1195a0d_nonce_207[] = { 0xee, 0xbc, 0x7d, 0x0c, 0xce, 0x8d, 0x7f, 0xd6, 0xa5, 0x72, 0x6e, 0x49 };
+static const uint8_t chiptest_dac9e1195a0d_ct_208[]    = { 0xb4, 0x48, 0x21, 0x1c, 0x9d, 0xa8, 0xc3, 0x31, 0x6c, 0x52, 0x69,
                                                         0xe5, 0xc4, 0xf6, 0x65, 0x78, 0x67, 0x3f, 0x1d, 0xfc, 0x03, 0x8a,
                                                         0x4f, 0x3f, 0x13, 0x2c, 0x85, 0x76, 0x2a, 0x89, 0x32, 0x06, 0xd4 };
-static const uint8_t chiptest_dac9e1195a0d_tag_209[] = { 0x09, 0xbd, 0x22, 0x93, 0x58, 0xcb, 0x85, 0x4a,
+static const uint8_t chiptest_dac9e1195a0d_tag_209[]   = { 0x09, 0xbd, 0x22, 0x93, 0x58, 0xcb, 0x85, 0x4a,
                                                          0x72, 0x2d, 0xc1, 0x5d, 0x98, 0x32, 0x7c, 0xe6 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_210 = { .pt      = chiptest_dac9e1195a0d_pt_204,
-                                                                                  .pt_len  = 33,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_205,
-                                                                                  .aad_len = 0,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_206,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_207,
-                                                                                  .iv_len  = 12,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_208,
-                                                                                  .ct_len  = 33,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_209,
-                                                                                  .tag_len = 16,
-                                                                                  .tcId    = 29,
-                                                                                  .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_dac9e1195a0d_pt_211[]  = { 0x84, 0x4f, 0xf8, 0x35, 0xe3, 0xac, 0x66, 0x7b, 0x28, 0x84, 0xf3,
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_210 = { .pt        = chiptest_dac9e1195a0d_pt_204,
+                                                                                  .pt_len    = 33,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_205,
+                                                                                  .aad_len   = 0,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_206,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_207,
+                                                                                  .nonce_len = 12,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_208,
+                                                                                  .ct_len    = 33,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_209,
+                                                                                  .tag_len   = 16,
+                                                                                  .tcId      = 29,
+                                                                                  .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_pt_211[]    = { 0x84, 0x4f, 0xf8, 0x35, 0xe3, 0xac, 0x66, 0x7b, 0x28, 0x84, 0xf3,
                                                         0x47, 0xf8, 0x88, 0xf5, 0x70, 0x91, 0x9d, 0xab, 0xc3, 0xd9, 0x75,
                                                         0x54, 0xe0, 0x87, 0x9c, 0xc5, 0x89, 0x43, 0x36, 0xcc, 0x19, 0x2d };
-static const uint8_t chiptest_dac9e1195a0d_aad_212[] = { 0x62, 0x55, 0xa0, 0x07, 0x9e, 0x72, 0xc9, 0x5c,
+static const uint8_t chiptest_dac9e1195a0d_aad_212[]   = { 0x62, 0x55, 0xa0, 0x07, 0x9e, 0x72, 0xc9, 0x5c,
                                                          0x20, 0xf7, 0x0b, 0x6a, 0x09, 0xbb, 0x54, 0x13 };
-static const uint8_t chiptest_dac9e1195a0d_key_213[] = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
+static const uint8_t chiptest_dac9e1195a0d_key_213[]   = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_214[]  = { 0x2d, 0xbf, 0xc3, 0xa1, 0x2e, 0x4d, 0x2a, 0x86 };
-static const uint8_t chiptest_dac9e1195a0d_ct_215[]  = { 0x2e, 0x6c, 0x47, 0x78, 0xf0, 0xcd, 0x09, 0x50, 0x95, 0xfa, 0xb4,
+static const uint8_t chiptest_dac9e1195a0d_nonce_214[] = { 0x2d, 0xbf, 0xc3, 0xa1, 0x2e, 0x4d, 0x2a, 0x86 };
+static const uint8_t chiptest_dac9e1195a0d_ct_215[]    = { 0x2e, 0x6c, 0x47, 0x78, 0xf0, 0xcd, 0x09, 0x50, 0x95, 0xfa, 0xb4,
                                                         0xfb, 0x68, 0xb5, 0x59, 0xbf, 0xe6, 0xff, 0x2d, 0x09, 0xea, 0x7b,
                                                         0x66, 0x45, 0xfc, 0x1a, 0x25, 0x59, 0x5f, 0xd4, 0x48, 0x3e, 0xea };
-static const uint8_t chiptest_dac9e1195a0d_tag_216[] = { 0xe9, 0xb7, 0x04, 0x88, 0xaa, 0xf0, 0x23, 0x91 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_217 = { .pt      = chiptest_dac9e1195a0d_pt_211,
-                                                                                  .pt_len  = 33,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_212,
-                                                                                  .aad_len = 16,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_213,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_214,
-                                                                                  .iv_len  = 8,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_215,
-                                                                                  .ct_len  = 33,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_216,
-                                                                                  .tag_len = 8,
-                                                                                  .tcId    = 30,
-                                                                                  .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_dac9e1195a0d_pt_218[]  = { 0x84, 0x4f, 0xf8, 0x35, 0xe3, 0xac, 0x66, 0x7b, 0x28, 0x84, 0xf3,
+static const uint8_t chiptest_dac9e1195a0d_tag_216[]   = { 0xe9, 0xb7, 0x04, 0x88, 0xaa, 0xf0, 0x23, 0x91 };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_217 = { .pt        = chiptest_dac9e1195a0d_pt_211,
+                                                                                  .pt_len    = 33,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_212,
+                                                                                  .aad_len   = 16,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_213,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_214,
+                                                                                  .nonce_len = 8,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_215,
+                                                                                  .ct_len    = 33,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_216,
+                                                                                  .tag_len   = 8,
+                                                                                  .tcId      = 30,
+                                                                                  .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_pt_218[]    = { 0x84, 0x4f, 0xf8, 0x35, 0xe3, 0xac, 0x66, 0x7b, 0x28, 0x84, 0xf3,
                                                         0x47, 0xf8, 0x88, 0xf5, 0x70, 0x91, 0x9d, 0xab, 0xc3, 0xd9, 0x75,
                                                         0x54, 0xe0, 0x87, 0x9c, 0xc5, 0x89, 0x43, 0x36, 0xcc, 0x19, 0x2d };
-static const uint8_t chiptest_dac9e1195a0d_aad_219[] = { 0x62, 0x55, 0xa0, 0x07, 0x9e, 0x72, 0xc9, 0x5c,
+static const uint8_t chiptest_dac9e1195a0d_aad_219[]   = { 0x62, 0x55, 0xa0, 0x07, 0x9e, 0x72, 0xc9, 0x5c,
                                                          0x20, 0xf7, 0x0b, 0x6a, 0x09, 0xbb, 0x54, 0x13 };
-static const uint8_t chiptest_dac9e1195a0d_key_220[] = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
+static const uint8_t chiptest_dac9e1195a0d_key_220[]   = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_221[]  = { 0x2d, 0xbf, 0xc3, 0xa1, 0x2e, 0x4d, 0x2a, 0x86 };
-static const uint8_t chiptest_dac9e1195a0d_ct_222[]  = { 0x2e, 0x6c, 0x47, 0x78, 0xf0, 0xcd, 0x09, 0x50, 0x95, 0xfa, 0xb4,
+static const uint8_t chiptest_dac9e1195a0d_nonce_221[] = { 0x2d, 0xbf, 0xc3, 0xa1, 0x2e, 0x4d, 0x2a, 0x86 };
+static const uint8_t chiptest_dac9e1195a0d_ct_222[]    = { 0x2e, 0x6c, 0x47, 0x78, 0xf0, 0xcd, 0x09, 0x50, 0x95, 0xfa, 0xb4,
                                                         0xfb, 0x68, 0xb5, 0x59, 0xbf, 0xe6, 0xff, 0x2d, 0x09, 0xea, 0x7b,
                                                         0x66, 0x45, 0xfc, 0x1a, 0x25, 0x59, 0x5f, 0xd4, 0x48, 0x3e, 0xea };
-static const uint8_t chiptest_dac9e1195a0d_tag_223[] = { 0x1e, 0xe1, 0xda, 0x23, 0xcf, 0x3d, 0x1d, 0xb0, 0xd2, 0x01, 0x0e, 0x3d };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_224 = { .pt      = chiptest_dac9e1195a0d_pt_218,
-                                                                                  .pt_len  = 33,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_219,
-                                                                                  .aad_len = 16,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_220,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_221,
-                                                                                  .iv_len  = 8,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_222,
-                                                                                  .ct_len  = 33,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_223,
-                                                                                  .tag_len = 12,
-                                                                                  .tcId    = 31,
-                                                                                  .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_dac9e1195a0d_pt_225[]  = { 0x84, 0x4f, 0xf8, 0x35, 0xe3, 0xac, 0x66, 0x7b, 0x28, 0x84, 0xf3,
+static const uint8_t chiptest_dac9e1195a0d_tag_223[]   = { 0x1e, 0xe1, 0xda, 0x23, 0xcf, 0x3d, 0x1d, 0xb0, 0xd2, 0x01, 0x0e, 0x3d };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_224 = { .pt        = chiptest_dac9e1195a0d_pt_218,
+                                                                                  .pt_len    = 33,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_219,
+                                                                                  .aad_len   = 16,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_220,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_221,
+                                                                                  .nonce_len = 8,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_222,
+                                                                                  .ct_len    = 33,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_223,
+                                                                                  .tag_len   = 12,
+                                                                                  .tcId      = 31,
+                                                                                  .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_pt_225[]    = { 0x84, 0x4f, 0xf8, 0x35, 0xe3, 0xac, 0x66, 0x7b, 0x28, 0x84, 0xf3,
                                                         0x47, 0xf8, 0x88, 0xf5, 0x70, 0x91, 0x9d, 0xab, 0xc3, 0xd9, 0x75,
                                                         0x54, 0xe0, 0x87, 0x9c, 0xc5, 0x89, 0x43, 0x36, 0xcc, 0x19, 0x2d };
-static const uint8_t chiptest_dac9e1195a0d_aad_226[] = { 0x62, 0x55, 0xa0, 0x07, 0x9e, 0x72, 0xc9, 0x5c,
+static const uint8_t chiptest_dac9e1195a0d_aad_226[]   = { 0x62, 0x55, 0xa0, 0x07, 0x9e, 0x72, 0xc9, 0x5c,
                                                          0x20, 0xf7, 0x0b, 0x6a, 0x09, 0xbb, 0x54, 0x13 };
-static const uint8_t chiptest_dac9e1195a0d_key_227[] = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
+static const uint8_t chiptest_dac9e1195a0d_key_227[]   = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_228[]  = { 0x2d, 0xbf, 0xc3, 0xa1, 0x2e, 0x4d, 0x2a, 0x86 };
-static const uint8_t chiptest_dac9e1195a0d_ct_229[]  = { 0x2e, 0x6c, 0x47, 0x78, 0xf0, 0xcd, 0x09, 0x50, 0x95, 0xfa, 0xb4,
+static const uint8_t chiptest_dac9e1195a0d_nonce_228[] = { 0x2d, 0xbf, 0xc3, 0xa1, 0x2e, 0x4d, 0x2a, 0x86 };
+static const uint8_t chiptest_dac9e1195a0d_ct_229[]    = { 0x2e, 0x6c, 0x47, 0x78, 0xf0, 0xcd, 0x09, 0x50, 0x95, 0xfa, 0xb4,
                                                         0xfb, 0x68, 0xb5, 0x59, 0xbf, 0xe6, 0xff, 0x2d, 0x09, 0xea, 0x7b,
                                                         0x66, 0x45, 0xfc, 0x1a, 0x25, 0x59, 0x5f, 0xd4, 0x48, 0x3e, 0xea };
-static const uint8_t chiptest_dac9e1195a0d_tag_230[] = { 0xa5, 0x63, 0x5f, 0x07, 0x86, 0xe5, 0x08, 0x8c,
+static const uint8_t chiptest_dac9e1195a0d_tag_230[]   = { 0xa5, 0x63, 0x5f, 0x07, 0x86, 0xe5, 0x08, 0x8c,
                                                          0xf9, 0x90, 0x07, 0x20, 0x59, 0x94, 0x5f, 0xe9 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_231 = { .pt      = chiptest_dac9e1195a0d_pt_225,
-                                                                                  .pt_len  = 33,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_226,
-                                                                                  .aad_len = 16,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_227,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_228,
-                                                                                  .iv_len  = 8,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_229,
-                                                                                  .ct_len  = 33,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_230,
-                                                                                  .tag_len = 16,
-                                                                                  .tcId    = 32,
-                                                                                  .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_dac9e1195a0d_pt_232[]  = { 0xd8, 0xc1, 0x36, 0xcc, 0x07, 0x01, 0x9d, 0x34, 0xcd, 0xca, 0xd0,
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_231 = { .pt        = chiptest_dac9e1195a0d_pt_225,
+                                                                                  .pt_len    = 33,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_226,
+                                                                                  .aad_len   = 16,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_227,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_228,
+                                                                                  .nonce_len = 8,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_229,
+                                                                                  .ct_len    = 33,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_230,
+                                                                                  .tag_len   = 16,
+                                                                                  .tcId      = 32,
+                                                                                  .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_pt_232[]    = { 0xd8, 0xc1, 0x36, 0xcc, 0x07, 0x01, 0x9d, 0x34, 0xcd, 0xca, 0xd0,
                                                         0xa0, 0x42, 0xfc, 0x3d, 0x75, 0x19, 0xe3, 0x0b, 0x5d, 0xdc, 0xb9,
                                                         0x10, 0xde, 0x53, 0xe6, 0x24, 0x12, 0x36, 0x36, 0xda, 0x52, 0x7b };
-static const uint8_t chiptest_dac9e1195a0d_aad_233[] = { 0x89, 0x3c, 0xd3, 0xe3, 0x53, 0x4d, 0xe7, 0x0d,
+static const uint8_t chiptest_dac9e1195a0d_aad_233[]   = { 0x89, 0x3c, 0xd3, 0xe3, 0x53, 0x4d, 0xe7, 0x0d,
                                                          0x0f, 0x29, 0x39, 0xe7, 0xae, 0x69, 0x62, 0x7d };
-static const uint8_t chiptest_dac9e1195a0d_key_234[] = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
+static const uint8_t chiptest_dac9e1195a0d_key_234[]   = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_235[]  = { 0xb9, 0xb2, 0xeb, 0x2f, 0x55, 0x59, 0xba, 0xfd, 0x5d, 0xbb, 0xda, 0xf3 };
-static const uint8_t chiptest_dac9e1195a0d_ct_236[]  = { 0xf9, 0x9f, 0x6a, 0x7c, 0x88, 0x86, 0x4d, 0x21, 0x2c, 0x12, 0x27,
+static const uint8_t chiptest_dac9e1195a0d_nonce_235[] = { 0xb9, 0xb2, 0xeb, 0x2f, 0x55, 0x59, 0xba, 0xfd, 0x5d, 0xbb, 0xda, 0xf3 };
+static const uint8_t chiptest_dac9e1195a0d_ct_236[]    = { 0xf9, 0x9f, 0x6a, 0x7c, 0x88, 0x86, 0x4d, 0x21, 0x2c, 0x12, 0x27,
                                                         0x91, 0x70, 0x23, 0xda, 0x36, 0xf1, 0xfa, 0x11, 0xf8, 0x26, 0x2d,
                                                         0x75, 0xb6, 0xc2, 0x0c, 0x4c, 0x19, 0xdb, 0x92, 0x14, 0xcc, 0x19 };
-static const uint8_t chiptest_dac9e1195a0d_tag_237[] = { 0x61, 0xaf, 0x0a, 0xf3, 0xe3, 0x2a, 0x8a, 0x82 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_238 = { .pt      = chiptest_dac9e1195a0d_pt_232,
-                                                                                  .pt_len  = 33,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_233,
-                                                                                  .aad_len = 16,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_234,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_235,
-                                                                                  .iv_len  = 12,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_236,
-                                                                                  .ct_len  = 33,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_237,
-                                                                                  .tag_len = 8,
-                                                                                  .tcId    = 33,
-                                                                                  .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_dac9e1195a0d_pt_239[]  = { 0xd8, 0xc1, 0x36, 0xcc, 0x07, 0x01, 0x9d, 0x34, 0xcd, 0xca, 0xd0,
+static const uint8_t chiptest_dac9e1195a0d_tag_237[]   = { 0x61, 0xaf, 0x0a, 0xf3, 0xe3, 0x2a, 0x8a, 0x82 };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_238 = { .pt        = chiptest_dac9e1195a0d_pt_232,
+                                                                                  .pt_len    = 33,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_233,
+                                                                                  .aad_len   = 16,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_234,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_235,
+                                                                                  .nonce_len = 12,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_236,
+                                                                                  .ct_len    = 33,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_237,
+                                                                                  .tag_len   = 8,
+                                                                                  .tcId      = 33,
+                                                                                  .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_pt_239[]    = { 0xd8, 0xc1, 0x36, 0xcc, 0x07, 0x01, 0x9d, 0x34, 0xcd, 0xca, 0xd0,
                                                         0xa0, 0x42, 0xfc, 0x3d, 0x75, 0x19, 0xe3, 0x0b, 0x5d, 0xdc, 0xb9,
                                                         0x10, 0xde, 0x53, 0xe6, 0x24, 0x12, 0x36, 0x36, 0xda, 0x52, 0x7b };
-static const uint8_t chiptest_dac9e1195a0d_aad_240[] = { 0x89, 0x3c, 0xd3, 0xe3, 0x53, 0x4d, 0xe7, 0x0d,
+static const uint8_t chiptest_dac9e1195a0d_aad_240[]   = { 0x89, 0x3c, 0xd3, 0xe3, 0x53, 0x4d, 0xe7, 0x0d,
                                                          0x0f, 0x29, 0x39, 0xe7, 0xae, 0x69, 0x62, 0x7d };
-static const uint8_t chiptest_dac9e1195a0d_key_241[] = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
+static const uint8_t chiptest_dac9e1195a0d_key_241[]   = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_242[]  = { 0xb9, 0xb2, 0xeb, 0x2f, 0x55, 0x59, 0xba, 0xfd, 0x5d, 0xbb, 0xda, 0xf3 };
-static const uint8_t chiptest_dac9e1195a0d_ct_243[]  = { 0xf9, 0x9f, 0x6a, 0x7c, 0x88, 0x86, 0x4d, 0x21, 0x2c, 0x12, 0x27,
+static const uint8_t chiptest_dac9e1195a0d_nonce_242[] = { 0xb9, 0xb2, 0xeb, 0x2f, 0x55, 0x59, 0xba, 0xfd, 0x5d, 0xbb, 0xda, 0xf3 };
+static const uint8_t chiptest_dac9e1195a0d_ct_243[]    = { 0xf9, 0x9f, 0x6a, 0x7c, 0x88, 0x86, 0x4d, 0x21, 0x2c, 0x12, 0x27,
                                                         0x91, 0x70, 0x23, 0xda, 0x36, 0xf1, 0xfa, 0x11, 0xf8, 0x26, 0x2d,
                                                         0x75, 0xb6, 0xc2, 0x0c, 0x4c, 0x19, 0xdb, 0x92, 0x14, 0xcc, 0x19 };
-static const uint8_t chiptest_dac9e1195a0d_tag_244[] = { 0x97, 0x66, 0x01, 0x50, 0x02, 0xd8, 0x68, 0x6c, 0x12, 0xd0, 0x2c, 0x3d };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_245 = { .pt      = chiptest_dac9e1195a0d_pt_239,
-                                                                                  .pt_len  = 33,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_240,
-                                                                                  .aad_len = 16,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_241,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_242,
-                                                                                  .iv_len  = 12,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_243,
-                                                                                  .ct_len  = 33,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_244,
-                                                                                  .tag_len = 12,
-                                                                                  .tcId    = 34,
-                                                                                  .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_dac9e1195a0d_pt_246[]  = { 0xd8, 0xc1, 0x36, 0xcc, 0x07, 0x01, 0x9d, 0x34, 0xcd, 0xca, 0xd0,
+static const uint8_t chiptest_dac9e1195a0d_tag_244[]   = { 0x97, 0x66, 0x01, 0x50, 0x02, 0xd8, 0x68, 0x6c, 0x12, 0xd0, 0x2c, 0x3d };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_245 = { .pt        = chiptest_dac9e1195a0d_pt_239,
+                                                                                  .pt_len    = 33,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_240,
+                                                                                  .aad_len   = 16,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_241,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_242,
+                                                                                  .nonce_len = 12,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_243,
+                                                                                  .ct_len    = 33,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_244,
+                                                                                  .tag_len   = 12,
+                                                                                  .tcId      = 34,
+                                                                                  .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_dac9e1195a0d_pt_246[]    = { 0xd8, 0xc1, 0x36, 0xcc, 0x07, 0x01, 0x9d, 0x34, 0xcd, 0xca, 0xd0,
                                                         0xa0, 0x42, 0xfc, 0x3d, 0x75, 0x19, 0xe3, 0x0b, 0x5d, 0xdc, 0xb9,
                                                         0x10, 0xde, 0x53, 0xe6, 0x24, 0x12, 0x36, 0x36, 0xda, 0x52, 0x7b };
-static const uint8_t chiptest_dac9e1195a0d_aad_247[] = { 0x89, 0x3c, 0xd3, 0xe3, 0x53, 0x4d, 0xe7, 0x0d,
+static const uint8_t chiptest_dac9e1195a0d_aad_247[]   = { 0x89, 0x3c, 0xd3, 0xe3, 0x53, 0x4d, 0xe7, 0x0d,
                                                          0x0f, 0x29, 0x39, 0xe7, 0xae, 0x69, 0x62, 0x7d };
-static const uint8_t chiptest_dac9e1195a0d_key_248[] = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
+static const uint8_t chiptest_dac9e1195a0d_key_248[]   = { 0x04, 0xe1, 0xaf, 0x8f, 0x15, 0xe2, 0x16, 0x4e,
                                                          0xdb, 0x2d, 0xfd, 0xfe, 0xa2, 0xc4, 0x8b, 0xcf };
-static const uint8_t chiptest_dac9e1195a0d_iv_249[]  = { 0xb9, 0xb2, 0xeb, 0x2f, 0x55, 0x59, 0xba, 0xfd, 0x5d, 0xbb, 0xda, 0xf3 };
-static const uint8_t chiptest_dac9e1195a0d_ct_250[]  = { 0xf9, 0x9f, 0x6a, 0x7c, 0x88, 0x86, 0x4d, 0x21, 0x2c, 0x12, 0x27,
+static const uint8_t chiptest_dac9e1195a0d_nonce_249[] = { 0xb9, 0xb2, 0xeb, 0x2f, 0x55, 0x59, 0xba, 0xfd, 0x5d, 0xbb, 0xda, 0xf3 };
+static const uint8_t chiptest_dac9e1195a0d_ct_250[]    = { 0xf9, 0x9f, 0x6a, 0x7c, 0x88, 0x86, 0x4d, 0x21, 0x2c, 0x12, 0x27,
                                                         0x91, 0x70, 0x23, 0xda, 0x36, 0xf1, 0xfa, 0x11, 0xf8, 0x26, 0x2d,
                                                         0x75, 0xb6, 0xc2, 0x0c, 0x4c, 0x19, 0xdb, 0x92, 0x14, 0xcc, 0x19 };
-static const uint8_t chiptest_dac9e1195a0d_tag_251[] = { 0x9e, 0x7b, 0x72, 0x96, 0x6c, 0x9d, 0xbc, 0x93,
+static const uint8_t chiptest_dac9e1195a0d_tag_251[]   = { 0x9e, 0x7b, 0x72, 0x96, 0x6c, 0x9d, 0xbc, 0x93,
                                                          0xdb, 0x0e, 0xa9, 0x92, 0xa0, 0x8c, 0x9c, 0xad };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_252 = { .pt      = chiptest_dac9e1195a0d_pt_246,
-                                                                                  .pt_len  = 33,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_247,
-                                                                                  .aad_len = 16,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_248,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_249,
-                                                                                  .iv_len  = 12,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_250,
-                                                                                  .ct_len  = 33,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_251,
-                                                                                  .tag_len = 16,
-                                                                                  .tcId    = 35,
-                                                                                  .result  = CHIP_NO_ERROR };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_252 = { .pt        = chiptest_dac9e1195a0d_pt_246,
+                                                                                  .pt_len    = 33,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_247,
+                                                                                  .aad_len   = 16,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_248,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_249,
+                                                                                  .nonce_len = 12,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_250,
+                                                                                  .ct_len    = 33,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_251,
+                                                                                  .tag_len   = 16,
+                                                                                  .tcId      = 35,
+                                                                                  .result    = CHIP_NO_ERROR };
 static const uint8_t chiptest_dac9e1195a0d_pt_253[]                           = { 0x31, 0x5e, 0x88, 0xf4, 0x83, 0x2d, 0x0c, 0x1d,
                                                         0xb4, 0xd6, 0x22, 0xa7, 0x49, 0x97, 0x27, 0x6e };
 static const uint8_t chiptest_dac9e1195a0d_aad_254[]                          = { 0x0f, 0x9d, 0xfc, 0x66, 0x19, 0x6e, 0xc5, 0x8b,
                                                          0xd9, 0x32, 0x8d, 0xc9, 0x4f, 0xea, 0x9f, 0xe2 };
 static const uint8_t chiptest_dac9e1195a0d_key_255[]                          = { 0xb0, 0x40, 0x51, 0x6c, 0xe6, 0x32, 0x48, 0xb3,
                                                          0xfc, 0xf5, 0x00, 0x98, 0x48, 0xc0, 0xdb, 0xf3 };
-static const uint8_t chiptest_dac9e1195a0d_iv_256[]  = { 0x30, 0x0d, 0xb6, 0x16, 0xc5, 0xb5, 0xe5, 0xde, 0xb4, 0xf8, 0x90, 0x79 };
-static const uint8_t chiptest_dac9e1195a0d_ct_257[]  = { 0x84, 0x15, 0x9c, 0xfd, 0xb7, 0xfd, 0xab, 0x6a,
+static const uint8_t chiptest_dac9e1195a0d_nonce_256[] = { 0x30, 0x0d, 0xb6, 0x16, 0xc5, 0xb5, 0xe5, 0xde, 0xb4, 0xf8, 0x90, 0x79 };
+static const uint8_t chiptest_dac9e1195a0d_ct_257[]    = { 0x84, 0x15, 0x9c, 0xfd, 0xb7, 0xfd, 0xab, 0x6a,
                                                         0x11, 0x3e, 0x66, 0x55, 0xfe, 0xf4, 0x17, 0x16 };
-static const uint8_t chiptest_dac9e1195a0d_tag_258[] = { 0xc8, 0x50, 0x01, 0xbe, 0xfc, 0x4d, 0xe3, 0x19,
+static const uint8_t chiptest_dac9e1195a0d_tag_258[]   = { 0xc8, 0x50, 0x01, 0xbe, 0xfc, 0x4d, 0xe3, 0x19,
                                                          0xea, 0x9f, 0x01, 0x6a, 0xde, 0xf5, 0x6f, 0xe3 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_259 = { .pt      = chiptest_dac9e1195a0d_pt_253,
-                                                                                  .pt_len  = 16,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_254,
-                                                                                  .aad_len = 16,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_255,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_256,
-                                                                                  .iv_len  = 12,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_257,
-                                                                                  .ct_len  = 16,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_258,
-                                                                                  .tag_len = 16,
-                                                                                  .tcId    = 36,
-                                                                                  .result  = CHIP_ERROR_INTERNAL };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_259 = { .pt        = chiptest_dac9e1195a0d_pt_253,
+                                                                                  .pt_len    = 16,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_254,
+                                                                                  .aad_len   = 16,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_255,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_256,
+                                                                                  .nonce_len = 12,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_257,
+                                                                                  .ct_len    = 16,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_258,
+                                                                                  .tag_len   = 16,
+                                                                                  .tcId      = 36,
+                                                                                  .result    = CHIP_ERROR_INTERNAL };
 static const uint8_t chiptest_dac9e1195a0d_pt_260[]                           = { 0x31, 0x5e, 0x88, 0xf4, 0x83, 0x2d, 0x0c, 0x1d,
                                                         0xb4, 0xd6, 0x22, 0xa7, 0x49, 0x97, 0x27, 0x6e };
 static const uint8_t chiptest_dac9e1195a0d_aad_261[]                          = { 0x0f, 0x9d, 0xfc, 0x66, 0x19, 0x6e, 0xc5, 0x8b,
                                                          0xd9, 0x32, 0x8d, 0xc9, 0x4f, 0xea, 0x9f, 0xe2 };
 static const uint8_t chiptest_dac9e1195a0d_key_262[]                          = { 0xb0, 0x40, 0x51, 0x6c, 0xe6, 0x32, 0x48, 0xb3,
                                                          0xfc, 0xf5, 0x00, 0x98, 0x48, 0xc0, 0xdb, 0xf3 };
-static const uint8_t chiptest_dac9e1195a0d_iv_263[]  = { 0x30, 0x0d, 0xb6, 0x16, 0xc5, 0xb5, 0xe5, 0xde, 0xb4, 0xf8, 0x90, 0x79 };
-static const uint8_t chiptest_dac9e1195a0d_ct_264[]  = { 0x85, 0x15, 0x9c, 0xfd, 0xb7, 0xfd, 0xab, 0x6a,
+static const uint8_t chiptest_dac9e1195a0d_nonce_263[] = { 0x30, 0x0d, 0xb6, 0x16, 0xc5, 0xb5, 0xe5, 0xde, 0xb4, 0xf8, 0x90, 0x79 };
+static const uint8_t chiptest_dac9e1195a0d_ct_264[]    = { 0x85, 0x15, 0x9c, 0xfd, 0xb7, 0xfd, 0xab, 0x6a,
                                                         0x11, 0x3e, 0x66, 0x55, 0xfe, 0xf4, 0x17, 0x16 };
-static const uint8_t chiptest_dac9e1195a0d_tag_265[] = { 0xc7, 0x50, 0x01, 0xbe, 0xfc, 0x4d, 0xe3, 0x19,
+static const uint8_t chiptest_dac9e1195a0d_tag_265[]   = { 0xc7, 0x50, 0x01, 0xbe, 0xfc, 0x4d, 0xe3, 0x19,
                                                          0xea, 0x9f, 0x01, 0x6a, 0xde, 0xf5, 0x6f, 0xe3 };
-static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_266 = { .pt      = chiptest_dac9e1195a0d_pt_260,
-                                                                                  .pt_len  = 16,
-                                                                                  .aad     = chiptest_dac9e1195a0d_aad_261,
-                                                                                  .aad_len = 16,
-                                                                                  .key     = chiptest_dac9e1195a0d_key_262,
-                                                                                  .key_len = 16,
-                                                                                  .iv      = chiptest_dac9e1195a0d_iv_263,
-                                                                                  .iv_len  = 12,
-                                                                                  .ct      = chiptest_dac9e1195a0d_ct_264,
-                                                                                  .ct_len  = 16,
-                                                                                  .tag     = chiptest_dac9e1195a0d_tag_265,
-                                                                                  .tag_len = 16,
-                                                                                  .tcId    = 37,
-                                                                                  .result  = CHIP_ERROR_INTERNAL };
+static const struct ccm_128_test_vector chiptest_dac9e1195a0d_test_vector_266 = { .pt        = chiptest_dac9e1195a0d_pt_260,
+                                                                                  .pt_len    = 16,
+                                                                                  .aad       = chiptest_dac9e1195a0d_aad_261,
+                                                                                  .aad_len   = 16,
+                                                                                  .key       = chiptest_dac9e1195a0d_key_262,
+                                                                                  .key_len   = 16,
+                                                                                  .nonce     = chiptest_dac9e1195a0d_nonce_263,
+                                                                                  .nonce_len = 12,
+                                                                                  .ct        = chiptest_dac9e1195a0d_ct_264,
+                                                                                  .ct_len    = 16,
+                                                                                  .tag       = chiptest_dac9e1195a0d_tag_265,
+                                                                                  .tag_len   = 16,
+                                                                                  .tcId      = 37,
+                                                                                  .result    = CHIP_ERROR_INTERNAL };
 static const struct ccm_128_test_vector * ccm_128_test_vectors[]              = {
     &chiptest_dac9e1195a0d_test_vector_7,   &chiptest_dac9e1195a0d_test_vector_14,  &chiptest_dac9e1195a0d_test_vector_21,
     &chiptest_dac9e1195a0d_test_vector_28,  &chiptest_dac9e1195a0d_test_vector_35,  &chiptest_dac9e1195a0d_test_vector_42,

--- a/src/crypto/tests/AES_CCM_256_test_vectors.h
+++ b/src/crypto/tests/AES_CCM_256_test_vectors.h
@@ -31,8 +31,8 @@ typedef struct ccm_test_vector
     size_t pt_len;
     const uint8_t * ct;
     size_t ct_len;
-    const uint8_t * iv;
-    size_t iv_len;
+    const uint8_t * nonce;
+    size_t nonce_len;
     const uint8_t * aad;
     size_t aad_len;
     const uint8_t * tag;
@@ -41,1619 +41,1592 @@ typedef struct ccm_test_vector
     CHIP_ERROR result;
 } ccm_test_vector;
 
-static const uint8_t chiptest_12cb0ed34854_key_1[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_key_1[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                        0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                        0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_2[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_3[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_4[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_5[] = {};
-static const uint8_t chiptest_12cb0ed34854_tag_6[] = { 0xfd, 0x9c, 0x65, 0x82, 0xe4, 0x1c, 0xfa, 0x32 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_7 = { .key     = chiptest_12cb0ed34854_key_1,
-                                                                            .key_len = 32,
-                                                                            .pt      = chiptest_12cb0ed34854_pt_2,
-                                                                            .pt_len  = 0,
-                                                                            .ct      = chiptest_12cb0ed34854_ct_3,
-                                                                            .ct_len  = 0,
-                                                                            .iv      = chiptest_12cb0ed34854_iv_4,
-                                                                            .iv_len  = 7,
-                                                                            .aad     = chiptest_12cb0ed34854_aad_5,
-                                                                            .aad_len = 0,
-                                                                            .tag     = chiptest_12cb0ed34854_tag_6,
-                                                                            .tag_len = 8,
-                                                                            .tcId    = 1,
-                                                                            .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_8[]  = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_pt_2[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_3[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_4[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_5[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_6[]   = { 0xfd, 0x9c, 0x65, 0x82, 0xe4, 0x1c, 0xfa, 0x32 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_7 = { .key       = chiptest_12cb0ed34854_key_1,
+                                                                            .key_len   = 32,
+                                                                            .pt        = chiptest_12cb0ed34854_pt_2,
+                                                                            .pt_len    = 0,
+                                                                            .ct        = chiptest_12cb0ed34854_ct_3,
+                                                                            .ct_len    = 0,
+                                                                            .nonce     = chiptest_12cb0ed34854_nonce_4,
+                                                                            .nonce_len = 7,
+                                                                            .aad       = chiptest_12cb0ed34854_aad_5,
+                                                                            .aad_len   = 0,
+                                                                            .tag       = chiptest_12cb0ed34854_tag_6,
+                                                                            .tag_len   = 8,
+                                                                            .tcId      = 1,
+                                                                            .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_8[]    = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                        0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                        0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_9[]   = {};
-static const uint8_t chiptest_12cb0ed34854_ct_10[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_11[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_12[] = {};
-static const uint8_t chiptest_12cb0ed34854_tag_13[] = { 0x0d, 0xf6, 0xaa, 0x1e, 0xe8, 0x81, 0x20, 0x1f, 0x44, 0xd4, 0x84, 0x54 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_14 = { .key     = chiptest_12cb0ed34854_key_8,
-                                                                             .key_len = 32,
-                                                                             .pt      = chiptest_12cb0ed34854_pt_9,
-                                                                             .pt_len  = 0,
-                                                                             .ct      = chiptest_12cb0ed34854_ct_10,
-                                                                             .ct_len  = 0,
-                                                                             .iv      = chiptest_12cb0ed34854_iv_11,
-                                                                             .iv_len  = 7,
-                                                                             .aad     = chiptest_12cb0ed34854_aad_12,
-                                                                             .aad_len = 0,
-                                                                             .tag     = chiptest_12cb0ed34854_tag_13,
-                                                                             .tag_len = 12,
-                                                                             .tcId    = 2,
-                                                                             .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_15[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_pt_9[]     = {};
+static const uint8_t chiptest_12cb0ed34854_ct_10[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_11[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_12[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_13[]   = { 0x0d, 0xf6, 0xaa, 0x1e, 0xe8, 0x81, 0x20, 0x1f, 0x44, 0xd4, 0x84, 0x54 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_14 = { .key       = chiptest_12cb0ed34854_key_8,
+                                                                             .key_len   = 32,
+                                                                             .pt        = chiptest_12cb0ed34854_pt_9,
+                                                                             .pt_len    = 0,
+                                                                             .ct        = chiptest_12cb0ed34854_ct_10,
+                                                                             .ct_len    = 0,
+                                                                             .nonce     = chiptest_12cb0ed34854_nonce_11,
+                                                                             .nonce_len = 7,
+                                                                             .aad       = chiptest_12cb0ed34854_aad_12,
+                                                                             .aad_len   = 0,
+                                                                             .tag       = chiptest_12cb0ed34854_tag_13,
+                                                                             .tag_len   = 12,
+                                                                             .tcId      = 2,
+                                                                             .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_15[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                         0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                         0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_16[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_17[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_18[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_19[] = {};
-static const uint8_t chiptest_12cb0ed34854_tag_20[] = { 0xe6, 0x85, 0x9c, 0x92, 0xca, 0x23, 0x66, 0xbe,
+static const uint8_t chiptest_12cb0ed34854_pt_16[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_17[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_18[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_19[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_20[]   = { 0xe6, 0x85, 0x9c, 0x92, 0xca, 0x23, 0x66, 0xbe,
                                                         0x08, 0xb5, 0xaa, 0xbd, 0x0e, 0x21, 0x96, 0xc1 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_21 = { .key     = chiptest_12cb0ed34854_key_15,
-                                                                             .key_len = 32,
-                                                                             .pt      = chiptest_12cb0ed34854_pt_16,
-                                                                             .pt_len  = 0,
-                                                                             .ct      = chiptest_12cb0ed34854_ct_17,
-                                                                             .ct_len  = 0,
-                                                                             .iv      = chiptest_12cb0ed34854_iv_18,
-                                                                             .iv_len  = 7,
-                                                                             .aad     = chiptest_12cb0ed34854_aad_19,
-                                                                             .aad_len = 0,
-                                                                             .tag     = chiptest_12cb0ed34854_tag_20,
-                                                                             .tag_len = 16,
-                                                                             .tcId    = 3,
-                                                                             .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_22[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_21 = { .key       = chiptest_12cb0ed34854_key_15,
+                                                                             .key_len   = 32,
+                                                                             .pt        = chiptest_12cb0ed34854_pt_16,
+                                                                             .pt_len    = 0,
+                                                                             .ct        = chiptest_12cb0ed34854_ct_17,
+                                                                             .ct_len    = 0,
+                                                                             .nonce     = chiptest_12cb0ed34854_nonce_18,
+                                                                             .nonce_len = 7,
+                                                                             .aad       = chiptest_12cb0ed34854_aad_19,
+                                                                             .aad_len   = 0,
+                                                                             .tag       = chiptest_12cb0ed34854_tag_20,
+                                                                             .tag_len   = 16,
+                                                                             .tcId      = 3,
+                                                                             .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_22[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                         0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                         0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_23[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_24[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_25[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_26[] = { 0x7c };
-static const uint8_t chiptest_12cb0ed34854_tag_27[] = { 0xe7, 0xbc, 0x88, 0x63, 0xab, 0x75, 0x31, 0x12 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_28 = { .key     = chiptest_12cb0ed34854_key_22,
-                                                                             .key_len = 32,
-                                                                             .pt      = chiptest_12cb0ed34854_pt_23,
-                                                                             .pt_len  = 0,
-                                                                             .ct      = chiptest_12cb0ed34854_ct_24,
-                                                                             .ct_len  = 0,
-                                                                             .iv      = chiptest_12cb0ed34854_iv_25,
-                                                                             .iv_len  = 7,
-                                                                             .aad     = chiptest_12cb0ed34854_aad_26,
-                                                                             .aad_len = 1,
-                                                                             .tag     = chiptest_12cb0ed34854_tag_27,
-                                                                             .tag_len = 8,
-                                                                             .tcId    = 4,
-                                                                             .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_29[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_pt_23[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_24[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_25[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_26[]   = { 0x7c };
+static const uint8_t chiptest_12cb0ed34854_tag_27[]   = { 0xe7, 0xbc, 0x88, 0x63, 0xab, 0x75, 0x31, 0x12 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_28 = { .key       = chiptest_12cb0ed34854_key_22,
+                                                                             .key_len   = 32,
+                                                                             .pt        = chiptest_12cb0ed34854_pt_23,
+                                                                             .pt_len    = 0,
+                                                                             .ct        = chiptest_12cb0ed34854_ct_24,
+                                                                             .ct_len    = 0,
+                                                                             .nonce     = chiptest_12cb0ed34854_nonce_25,
+                                                                             .nonce_len = 7,
+                                                                             .aad       = chiptest_12cb0ed34854_aad_26,
+                                                                             .aad_len   = 1,
+                                                                             .tag       = chiptest_12cb0ed34854_tag_27,
+                                                                             .tag_len   = 8,
+                                                                             .tcId      = 4,
+                                                                             .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_29[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                         0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                         0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_30[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_31[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_32[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_33[] = { 0x7c };
-static const uint8_t chiptest_12cb0ed34854_tag_34[] = { 0x96, 0xe8, 0x1c, 0x45, 0xea, 0xe6, 0x9a, 0xbe, 0x1e, 0x0c, 0x90, 0xe4 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_35 = { .key     = chiptest_12cb0ed34854_key_29,
-                                                                             .key_len = 32,
-                                                                             .pt      = chiptest_12cb0ed34854_pt_30,
-                                                                             .pt_len  = 0,
-                                                                             .ct      = chiptest_12cb0ed34854_ct_31,
-                                                                             .ct_len  = 0,
-                                                                             .iv      = chiptest_12cb0ed34854_iv_32,
-                                                                             .iv_len  = 7,
-                                                                             .aad     = chiptest_12cb0ed34854_aad_33,
-                                                                             .aad_len = 1,
-                                                                             .tag     = chiptest_12cb0ed34854_tag_34,
-                                                                             .tag_len = 12,
-                                                                             .tcId    = 5,
-                                                                             .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_36[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_pt_30[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_31[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_32[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_33[]   = { 0x7c };
+static const uint8_t chiptest_12cb0ed34854_tag_34[]   = { 0x96, 0xe8, 0x1c, 0x45, 0xea, 0xe6, 0x9a, 0xbe, 0x1e, 0x0c, 0x90, 0xe4 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_35 = { .key       = chiptest_12cb0ed34854_key_29,
+                                                                             .key_len   = 32,
+                                                                             .pt        = chiptest_12cb0ed34854_pt_30,
+                                                                             .pt_len    = 0,
+                                                                             .ct        = chiptest_12cb0ed34854_ct_31,
+                                                                             .ct_len    = 0,
+                                                                             .nonce     = chiptest_12cb0ed34854_nonce_32,
+                                                                             .nonce_len = 7,
+                                                                             .aad       = chiptest_12cb0ed34854_aad_33,
+                                                                             .aad_len   = 1,
+                                                                             .tag       = chiptest_12cb0ed34854_tag_34,
+                                                                             .tag_len   = 12,
+                                                                             .tcId      = 5,
+                                                                             .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_36[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                         0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                         0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_37[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_38[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_39[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_40[] = { 0x7c };
-static const uint8_t chiptest_12cb0ed34854_tag_41[] = { 0xfd, 0xe6, 0xa4, 0x32, 0x05, 0xb1, 0xe2, 0x74,
+static const uint8_t chiptest_12cb0ed34854_pt_37[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_38[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_39[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_40[]   = { 0x7c };
+static const uint8_t chiptest_12cb0ed34854_tag_41[]   = { 0xfd, 0xe6, 0xa4, 0x32, 0x05, 0xb1, 0xe2, 0x74,
                                                         0x20, 0x4c, 0x6e, 0x3f, 0x66, 0xd0, 0x69, 0xbd };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_42 = { .key     = chiptest_12cb0ed34854_key_36,
-                                                                             .key_len = 32,
-                                                                             .pt      = chiptest_12cb0ed34854_pt_37,
-                                                                             .pt_len  = 0,
-                                                                             .ct      = chiptest_12cb0ed34854_ct_38,
-                                                                             .ct_len  = 0,
-                                                                             .iv      = chiptest_12cb0ed34854_iv_39,
-                                                                             .iv_len  = 7,
-                                                                             .aad     = chiptest_12cb0ed34854_aad_40,
-                                                                             .aad_len = 1,
-                                                                             .tag     = chiptest_12cb0ed34854_tag_41,
-                                                                             .tag_len = 16,
-                                                                             .tcId    = 6,
-                                                                             .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_43[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_42 = { .key       = chiptest_12cb0ed34854_key_36,
+                                                                             .key_len   = 32,
+                                                                             .pt        = chiptest_12cb0ed34854_pt_37,
+                                                                             .pt_len    = 0,
+                                                                             .ct        = chiptest_12cb0ed34854_ct_38,
+                                                                             .ct_len    = 0,
+                                                                             .nonce     = chiptest_12cb0ed34854_nonce_39,
+                                                                             .nonce_len = 7,
+                                                                             .aad       = chiptest_12cb0ed34854_aad_40,
+                                                                             .aad_len   = 1,
+                                                                             .tag       = chiptest_12cb0ed34854_tag_41,
+                                                                             .tag_len   = 16,
+                                                                             .tcId      = 6,
+                                                                             .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_43[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                         0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                         0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_44[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_45[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_46[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_47[] = { 0xa1, 0xd0, 0x44, 0x40, 0xaa, 0x76, 0x31, 0x6e, 0x97, 0xdd, 0x6c,
+static const uint8_t chiptest_12cb0ed34854_pt_44[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_45[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_46[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_47[]   = { 0xa1, 0xd0, 0x44, 0x40, 0xaa, 0x76, 0x31, 0x6e, 0x97, 0xdd, 0x6c,
                                                         0xcb, 0x7f, 0x2e, 0xb2, 0x1f, 0x1f, 0x1d, 0x9d, 0x6b, 0x73, 0xde,
                                                         0xeb, 0x56, 0x04, 0xab, 0xb5, 0x6e, 0x45, 0x45, 0x54, 0x4d };
-static const uint8_t chiptest_12cb0ed34854_tag_48[] = { 0xcd, 0x32, 0xdf, 0x9d, 0xa5, 0xb5, 0x53, 0x2c };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_49 = { .key     = chiptest_12cb0ed34854_key_43,
-                                                                             .key_len = 32,
-                                                                             .pt      = chiptest_12cb0ed34854_pt_44,
-                                                                             .pt_len  = 0,
-                                                                             .ct      = chiptest_12cb0ed34854_ct_45,
-                                                                             .ct_len  = 0,
-                                                                             .iv      = chiptest_12cb0ed34854_iv_46,
-                                                                             .iv_len  = 7,
-                                                                             .aad     = chiptest_12cb0ed34854_aad_47,
-                                                                             .aad_len = 32,
-                                                                             .tag     = chiptest_12cb0ed34854_tag_48,
-                                                                             .tag_len = 8,
-                                                                             .tcId    = 7,
-                                                                             .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_50[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_tag_48[]   = { 0xcd, 0x32, 0xdf, 0x9d, 0xa5, 0xb5, 0x53, 0x2c };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_49 = { .key       = chiptest_12cb0ed34854_key_43,
+                                                                             .key_len   = 32,
+                                                                             .pt        = chiptest_12cb0ed34854_pt_44,
+                                                                             .pt_len    = 0,
+                                                                             .ct        = chiptest_12cb0ed34854_ct_45,
+                                                                             .ct_len    = 0,
+                                                                             .nonce     = chiptest_12cb0ed34854_nonce_46,
+                                                                             .nonce_len = 7,
+                                                                             .aad       = chiptest_12cb0ed34854_aad_47,
+                                                                             .aad_len   = 32,
+                                                                             .tag       = chiptest_12cb0ed34854_tag_48,
+                                                                             .tag_len   = 8,
+                                                                             .tcId      = 7,
+                                                                             .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_50[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                         0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                         0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_51[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_52[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_53[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_54[] = { 0xa1, 0xd0, 0x44, 0x40, 0xaa, 0x76, 0x31, 0x6e, 0x97, 0xdd, 0x6c,
+static const uint8_t chiptest_12cb0ed34854_pt_51[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_52[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_53[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_54[]   = { 0xa1, 0xd0, 0x44, 0x40, 0xaa, 0x76, 0x31, 0x6e, 0x97, 0xdd, 0x6c,
                                                         0xcb, 0x7f, 0x2e, 0xb2, 0x1f, 0x1f, 0x1d, 0x9d, 0x6b, 0x73, 0xde,
                                                         0xeb, 0x56, 0x04, 0xab, 0xb5, 0x6e, 0x45, 0x45, 0x54, 0x4d };
-static const uint8_t chiptest_12cb0ed34854_tag_55[] = { 0x98, 0x1b, 0x39, 0xe4, 0xd9, 0x48, 0xd0, 0x6c, 0x5c, 0x73, 0x24, 0x5f };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_56 = { .key     = chiptest_12cb0ed34854_key_50,
-                                                                             .key_len = 32,
-                                                                             .pt      = chiptest_12cb0ed34854_pt_51,
-                                                                             .pt_len  = 0,
-                                                                             .ct      = chiptest_12cb0ed34854_ct_52,
-                                                                             .ct_len  = 0,
-                                                                             .iv      = chiptest_12cb0ed34854_iv_53,
-                                                                             .iv_len  = 7,
-                                                                             .aad     = chiptest_12cb0ed34854_aad_54,
-                                                                             .aad_len = 32,
-                                                                             .tag     = chiptest_12cb0ed34854_tag_55,
-                                                                             .tag_len = 12,
-                                                                             .tcId    = 8,
-                                                                             .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_57[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_tag_55[]   = { 0x98, 0x1b, 0x39, 0xe4, 0xd9, 0x48, 0xd0, 0x6c, 0x5c, 0x73, 0x24, 0x5f };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_56 = { .key       = chiptest_12cb0ed34854_key_50,
+                                                                             .key_len   = 32,
+                                                                             .pt        = chiptest_12cb0ed34854_pt_51,
+                                                                             .pt_len    = 0,
+                                                                             .ct        = chiptest_12cb0ed34854_ct_52,
+                                                                             .ct_len    = 0,
+                                                                             .nonce     = chiptest_12cb0ed34854_nonce_53,
+                                                                             .nonce_len = 7,
+                                                                             .aad       = chiptest_12cb0ed34854_aad_54,
+                                                                             .aad_len   = 32,
+                                                                             .tag       = chiptest_12cb0ed34854_tag_55,
+                                                                             .tag_len   = 12,
+                                                                             .tcId      = 8,
+                                                                             .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_57[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                         0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                         0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_58[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_59[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_60[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_61[] = { 0xa1, 0xd0, 0x44, 0x40, 0xaa, 0x76, 0x31, 0x6e, 0x97, 0xdd, 0x6c,
+static const uint8_t chiptest_12cb0ed34854_pt_58[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_59[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_60[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_61[]   = { 0xa1, 0xd0, 0x44, 0x40, 0xaa, 0x76, 0x31, 0x6e, 0x97, 0xdd, 0x6c,
                                                         0xcb, 0x7f, 0x2e, 0xb2, 0x1f, 0x1f, 0x1d, 0x9d, 0x6b, 0x73, 0xde,
                                                         0xeb, 0x56, 0x04, 0xab, 0xb5, 0x6e, 0x45, 0x45, 0x54, 0x4d };
-static const uint8_t chiptest_12cb0ed34854_tag_62[] = { 0x3c, 0x0e, 0xc0, 0x5f, 0xa3, 0xbd, 0x3b, 0x44,
+static const uint8_t chiptest_12cb0ed34854_tag_62[]   = { 0x3c, 0x0e, 0xc0, 0x5f, 0xa3, 0xbd, 0x3b, 0x44,
                                                         0xd8, 0x91, 0x6d, 0x91, 0x0a, 0xb5, 0x65, 0xd9 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_63 = { .key     = chiptest_12cb0ed34854_key_57,
-                                                                             .key_len = 32,
-                                                                             .pt      = chiptest_12cb0ed34854_pt_58,
-                                                                             .pt_len  = 0,
-                                                                             .ct      = chiptest_12cb0ed34854_ct_59,
-                                                                             .ct_len  = 0,
-                                                                             .iv      = chiptest_12cb0ed34854_iv_60,
-                                                                             .iv_len  = 7,
-                                                                             .aad     = chiptest_12cb0ed34854_aad_61,
-                                                                             .aad_len = 32,
-                                                                             .tag     = chiptest_12cb0ed34854_tag_62,
-                                                                             .tag_len = 16,
-                                                                             .tcId    = 9,
-                                                                             .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_64[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_63 = { .key       = chiptest_12cb0ed34854_key_57,
+                                                                             .key_len   = 32,
+                                                                             .pt        = chiptest_12cb0ed34854_pt_58,
+                                                                             .pt_len    = 0,
+                                                                             .ct        = chiptest_12cb0ed34854_ct_59,
+                                                                             .ct_len    = 0,
+                                                                             .nonce     = chiptest_12cb0ed34854_nonce_60,
+                                                                             .nonce_len = 7,
+                                                                             .aad       = chiptest_12cb0ed34854_aad_61,
+                                                                             .aad_len   = 32,
+                                                                             .tag       = chiptest_12cb0ed34854_tag_62,
+                                                                             .tag_len   = 16,
+                                                                             .tcId      = 9,
+                                                                             .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_64[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                         0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                         0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_65[]  = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
+static const uint8_t chiptest_12cb0ed34854_pt_65[]    = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
                                                        0x04, 0x34, 0x34, 0xfc, 0x09, 0x1a, 0xda, 0xc7 };
-static const uint8_t chiptest_12cb0ed34854_ct_66[]  = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
+static const uint8_t chiptest_12cb0ed34854_ct_66[]    = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
                                                        0xa3, 0x77, 0x90, 0xf4, 0x7d, 0x48, 0xce, 0xf9 };
-static const uint8_t chiptest_12cb0ed34854_iv_67[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_68[] = {};
-static const uint8_t chiptest_12cb0ed34854_tag_69[] = { 0xdc, 0xd2, 0x22, 0xd3, 0xa8, 0xfe, 0x64, 0x31 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_70 = { .key     = chiptest_12cb0ed34854_key_64,
-                                                                             .key_len = 32,
-                                                                             .pt      = chiptest_12cb0ed34854_pt_65,
-                                                                             .pt_len  = 16,
-                                                                             .ct      = chiptest_12cb0ed34854_ct_66,
-                                                                             .ct_len  = 16,
-                                                                             .iv      = chiptest_12cb0ed34854_iv_67,
-                                                                             .iv_len  = 7,
-                                                                             .aad     = chiptest_12cb0ed34854_aad_68,
-                                                                             .aad_len = 0,
-                                                                             .tag     = chiptest_12cb0ed34854_tag_69,
-                                                                             .tag_len = 8,
-                                                                             .tcId    = 10,
-                                                                             .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_71[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_nonce_67[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_68[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_69[]   = { 0xdc, 0xd2, 0x22, 0xd3, 0xa8, 0xfe, 0x64, 0x31 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_70 = { .key       = chiptest_12cb0ed34854_key_64,
+                                                                             .key_len   = 32,
+                                                                             .pt        = chiptest_12cb0ed34854_pt_65,
+                                                                             .pt_len    = 16,
+                                                                             .ct        = chiptest_12cb0ed34854_ct_66,
+                                                                             .ct_len    = 16,
+                                                                             .nonce     = chiptest_12cb0ed34854_nonce_67,
+                                                                             .nonce_len = 7,
+                                                                             .aad       = chiptest_12cb0ed34854_aad_68,
+                                                                             .aad_len   = 0,
+                                                                             .tag       = chiptest_12cb0ed34854_tag_69,
+                                                                             .tag_len   = 8,
+                                                                             .tcId      = 10,
+                                                                             .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_71[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                         0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                         0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_72[]  = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
+static const uint8_t chiptest_12cb0ed34854_pt_72[]    = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
                                                        0x04, 0x34, 0x34, 0xfc, 0x09, 0x1a, 0xda, 0xc7 };
-static const uint8_t chiptest_12cb0ed34854_ct_73[]  = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
+static const uint8_t chiptest_12cb0ed34854_ct_73[]    = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
                                                        0xa3, 0x77, 0x90, 0xf4, 0x7d, 0x48, 0xce, 0xf9 };
-static const uint8_t chiptest_12cb0ed34854_iv_74[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_75[] = {};
-static const uint8_t chiptest_12cb0ed34854_tag_76[] = { 0xdf, 0x33, 0xdd, 0x45, 0x15, 0x16, 0x84, 0x18, 0x2e, 0x30, 0x64, 0x27 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_77 = { .key     = chiptest_12cb0ed34854_key_71,
-                                                                             .key_len = 32,
-                                                                             .pt      = chiptest_12cb0ed34854_pt_72,
-                                                                             .pt_len  = 16,
-                                                                             .ct      = chiptest_12cb0ed34854_ct_73,
-                                                                             .ct_len  = 16,
-                                                                             .iv      = chiptest_12cb0ed34854_iv_74,
-                                                                             .iv_len  = 7,
-                                                                             .aad     = chiptest_12cb0ed34854_aad_75,
-                                                                             .aad_len = 0,
-                                                                             .tag     = chiptest_12cb0ed34854_tag_76,
-                                                                             .tag_len = 12,
-                                                                             .tcId    = 11,
-                                                                             .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_78[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_nonce_74[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_75[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_76[]   = { 0xdf, 0x33, 0xdd, 0x45, 0x15, 0x16, 0x84, 0x18, 0x2e, 0x30, 0x64, 0x27 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_77 = { .key       = chiptest_12cb0ed34854_key_71,
+                                                                             .key_len   = 32,
+                                                                             .pt        = chiptest_12cb0ed34854_pt_72,
+                                                                             .pt_len    = 16,
+                                                                             .ct        = chiptest_12cb0ed34854_ct_73,
+                                                                             .ct_len    = 16,
+                                                                             .nonce     = chiptest_12cb0ed34854_nonce_74,
+                                                                             .nonce_len = 7,
+                                                                             .aad       = chiptest_12cb0ed34854_aad_75,
+                                                                             .aad_len   = 0,
+                                                                             .tag       = chiptest_12cb0ed34854_tag_76,
+                                                                             .tag_len   = 12,
+                                                                             .tcId      = 11,
+                                                                             .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_78[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                         0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                         0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_79[]  = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
+static const uint8_t chiptest_12cb0ed34854_pt_79[]    = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
                                                        0x04, 0x34, 0x34, 0xfc, 0x09, 0x1a, 0xda, 0xc7 };
-static const uint8_t chiptest_12cb0ed34854_ct_80[]  = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
+static const uint8_t chiptest_12cb0ed34854_ct_80[]    = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
                                                        0xa3, 0x77, 0x90, 0xf4, 0x7d, 0x48, 0xce, 0xf9 };
-static const uint8_t chiptest_12cb0ed34854_iv_81[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_82[] = {};
-static const uint8_t chiptest_12cb0ed34854_tag_83[] = { 0xdd, 0x5c, 0xac, 0xb1, 0x27, 0x41, 0xf5, 0x2b,
+static const uint8_t chiptest_12cb0ed34854_nonce_81[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_82[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_83[]   = { 0xdd, 0x5c, 0xac, 0xb1, 0x27, 0x41, 0xf5, 0x2b,
                                                         0xa4, 0x51, 0xef, 0x8b, 0x5e, 0x66, 0xac, 0x9e };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_84 = { .key     = chiptest_12cb0ed34854_key_78,
-                                                                             .key_len = 32,
-                                                                             .pt      = chiptest_12cb0ed34854_pt_79,
-                                                                             .pt_len  = 16,
-                                                                             .ct      = chiptest_12cb0ed34854_ct_80,
-                                                                             .ct_len  = 16,
-                                                                             .iv      = chiptest_12cb0ed34854_iv_81,
-                                                                             .iv_len  = 7,
-                                                                             .aad     = chiptest_12cb0ed34854_aad_82,
-                                                                             .aad_len = 0,
-                                                                             .tag     = chiptest_12cb0ed34854_tag_83,
-                                                                             .tag_len = 16,
-                                                                             .tcId    = 12,
-                                                                             .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_85[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_84 = { .key       = chiptest_12cb0ed34854_key_78,
+                                                                             .key_len   = 32,
+                                                                             .pt        = chiptest_12cb0ed34854_pt_79,
+                                                                             .pt_len    = 16,
+                                                                             .ct        = chiptest_12cb0ed34854_ct_80,
+                                                                             .ct_len    = 16,
+                                                                             .nonce     = chiptest_12cb0ed34854_nonce_81,
+                                                                             .nonce_len = 7,
+                                                                             .aad       = chiptest_12cb0ed34854_aad_82,
+                                                                             .aad_len   = 0,
+                                                                             .tag       = chiptest_12cb0ed34854_tag_83,
+                                                                             .tag_len   = 16,
+                                                                             .tcId      = 12,
+                                                                             .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_85[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                         0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                         0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_86[]  = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
+static const uint8_t chiptest_12cb0ed34854_pt_86[]    = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
                                                        0x04, 0x34, 0x34, 0xfc, 0x09, 0x1a, 0xda, 0xc7 };
-static const uint8_t chiptest_12cb0ed34854_ct_87[]  = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
+static const uint8_t chiptest_12cb0ed34854_ct_87[]    = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
                                                        0xa3, 0x77, 0x90, 0xf4, 0x7d, 0x48, 0xce, 0xf9 };
-static const uint8_t chiptest_12cb0ed34854_iv_88[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_89[] = { 0xda };
-static const uint8_t chiptest_12cb0ed34854_tag_90[] = { 0x84, 0x8d, 0x7b, 0xc1, 0x4a, 0x42, 0xbb, 0x56 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_91 = { .key     = chiptest_12cb0ed34854_key_85,
-                                                                             .key_len = 32,
-                                                                             .pt      = chiptest_12cb0ed34854_pt_86,
-                                                                             .pt_len  = 16,
-                                                                             .ct      = chiptest_12cb0ed34854_ct_87,
-                                                                             .ct_len  = 16,
-                                                                             .iv      = chiptest_12cb0ed34854_iv_88,
-                                                                             .iv_len  = 7,
-                                                                             .aad     = chiptest_12cb0ed34854_aad_89,
-                                                                             .aad_len = 1,
-                                                                             .tag     = chiptest_12cb0ed34854_tag_90,
-                                                                             .tag_len = 8,
-                                                                             .tcId    = 13,
-                                                                             .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_92[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_nonce_88[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_89[]   = { 0xda };
+static const uint8_t chiptest_12cb0ed34854_tag_90[]   = { 0x84, 0x8d, 0x7b, 0xc1, 0x4a, 0x42, 0xbb, 0x56 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_91 = { .key       = chiptest_12cb0ed34854_key_85,
+                                                                             .key_len   = 32,
+                                                                             .pt        = chiptest_12cb0ed34854_pt_86,
+                                                                             .pt_len    = 16,
+                                                                             .ct        = chiptest_12cb0ed34854_ct_87,
+                                                                             .ct_len    = 16,
+                                                                             .nonce     = chiptest_12cb0ed34854_nonce_88,
+                                                                             .nonce_len = 7,
+                                                                             .aad       = chiptest_12cb0ed34854_aad_89,
+                                                                             .aad_len   = 1,
+                                                                             .tag       = chiptest_12cb0ed34854_tag_90,
+                                                                             .tag_len   = 8,
+                                                                             .tcId      = 13,
+                                                                             .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_92[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                         0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                         0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_93[]  = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
+static const uint8_t chiptest_12cb0ed34854_pt_93[]    = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
                                                        0x04, 0x34, 0x34, 0xfc, 0x09, 0x1a, 0xda, 0xc7 };
-static const uint8_t chiptest_12cb0ed34854_ct_94[]  = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
+static const uint8_t chiptest_12cb0ed34854_ct_94[]    = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
                                                        0xa3, 0x77, 0x90, 0xf4, 0x7d, 0x48, 0xce, 0xf9 };
-static const uint8_t chiptest_12cb0ed34854_iv_95[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_96[] = { 0xda };
-static const uint8_t chiptest_12cb0ed34854_tag_97[] = { 0x43, 0x46, 0x00, 0xf5, 0xb7, 0xc5, 0x59, 0x85, 0x12, 0x79, 0xea, 0xfe };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_98 = { .key     = chiptest_12cb0ed34854_key_92,
-                                                                             .key_len = 32,
-                                                                             .pt      = chiptest_12cb0ed34854_pt_93,
-                                                                             .pt_len  = 16,
-                                                                             .ct      = chiptest_12cb0ed34854_ct_94,
-                                                                             .ct_len  = 16,
-                                                                             .iv      = chiptest_12cb0ed34854_iv_95,
-                                                                             .iv_len  = 7,
-                                                                             .aad     = chiptest_12cb0ed34854_aad_96,
-                                                                             .aad_len = 1,
-                                                                             .tag     = chiptest_12cb0ed34854_tag_97,
-                                                                             .tag_len = 12,
-                                                                             .tcId    = 14,
-                                                                             .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_99[]  = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_nonce_95[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_96[]   = { 0xda };
+static const uint8_t chiptest_12cb0ed34854_tag_97[]   = { 0x43, 0x46, 0x00, 0xf5, 0xb7, 0xc5, 0x59, 0x85, 0x12, 0x79, 0xea, 0xfe };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_98 = { .key       = chiptest_12cb0ed34854_key_92,
+                                                                             .key_len   = 32,
+                                                                             .pt        = chiptest_12cb0ed34854_pt_93,
+                                                                             .pt_len    = 16,
+                                                                             .ct        = chiptest_12cb0ed34854_ct_94,
+                                                                             .ct_len    = 16,
+                                                                             .nonce     = chiptest_12cb0ed34854_nonce_95,
+                                                                             .nonce_len = 7,
+                                                                             .aad       = chiptest_12cb0ed34854_aad_96,
+                                                                             .aad_len   = 1,
+                                                                             .tag       = chiptest_12cb0ed34854_tag_97,
+                                                                             .tag_len   = 12,
+                                                                             .tcId      = 14,
+                                                                             .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_99[]    = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                         0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                         0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_100[]  = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
+static const uint8_t chiptest_12cb0ed34854_pt_100[]    = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
                                                         0x04, 0x34, 0x34, 0xfc, 0x09, 0x1a, 0xda, 0xc7 };
-static const uint8_t chiptest_12cb0ed34854_ct_101[]  = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
+static const uint8_t chiptest_12cb0ed34854_ct_101[]    = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
                                                         0xa3, 0x77, 0x90, 0xf4, 0x7d, 0x48, 0xce, 0xf9 };
-static const uint8_t chiptest_12cb0ed34854_iv_102[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_103[] = { 0xda };
-static const uint8_t chiptest_12cb0ed34854_tag_104[] = { 0x10, 0x8d, 0x3c, 0xcf, 0xee, 0x1c, 0xed, 0xcd,
+static const uint8_t chiptest_12cb0ed34854_nonce_102[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_103[]   = { 0xda };
+static const uint8_t chiptest_12cb0ed34854_tag_104[]   = { 0x10, 0x8d, 0x3c, 0xcf, 0xee, 0x1c, 0xed, 0xcd,
                                                          0x1e, 0xef, 0x8c, 0x6b, 0xda, 0xbf, 0xa4, 0xf9 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_105 = { .key     = chiptest_12cb0ed34854_key_99,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_100,
-                                                                              .pt_len  = 16,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_101,
-                                                                              .ct_len  = 16,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_102,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_103,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_104,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 15,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_106[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_105 = { .key       = chiptest_12cb0ed34854_key_99,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_100,
+                                                                              .pt_len    = 16,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_101,
+                                                                              .ct_len    = 16,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_102,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_103,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_104,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 15,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_106[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_107[]  = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
+static const uint8_t chiptest_12cb0ed34854_pt_107[]    = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
                                                         0x04, 0x34, 0x34, 0xfc, 0x09, 0x1a, 0xda, 0xc7 };
-static const uint8_t chiptest_12cb0ed34854_ct_108[]  = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
+static const uint8_t chiptest_12cb0ed34854_ct_108[]    = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
                                                         0xa3, 0x77, 0x90, 0xf4, 0x7d, 0x48, 0xce, 0xf9 };
-static const uint8_t chiptest_12cb0ed34854_iv_109[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_110[] = { 0x67, 0xc0, 0xf4, 0xac, 0xb9, 0x6f, 0x73, 0x5e, 0xd0, 0xa2, 0xcf,
+static const uint8_t chiptest_12cb0ed34854_nonce_109[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_110[]   = { 0x67, 0xc0, 0xf4, 0xac, 0xb9, 0x6f, 0x73, 0x5e, 0xd0, 0xa2, 0xcf,
                                                          0x95, 0x8a, 0x7c, 0xc3, 0xc5, 0xf7, 0x96, 0xf5, 0xde, 0x40, 0xcd,
                                                          0x99, 0x8f, 0xdd, 0xb9, 0xa3, 0x0b, 0x2f, 0x6e, 0x74, 0x5f };
-static const uint8_t chiptest_12cb0ed34854_tag_111[] = { 0xee, 0xfd, 0x63, 0x48, 0xf1, 0x79, 0x34, 0x5f };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_112 = { .key     = chiptest_12cb0ed34854_key_106,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_107,
-                                                                              .pt_len  = 16,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_108,
-                                                                              .ct_len  = 16,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_109,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_110,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_111,
-                                                                              .tag_len = 8,
-                                                                              .tcId    = 16,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_113[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_tag_111[]   = { 0xee, 0xfd, 0x63, 0x48, 0xf1, 0x79, 0x34, 0x5f };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_112 = { .key       = chiptest_12cb0ed34854_key_106,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_107,
+                                                                              .pt_len    = 16,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_108,
+                                                                              .ct_len    = 16,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_109,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_110,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_111,
+                                                                              .tag_len   = 8,
+                                                                              .tcId      = 16,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_113[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_114[]  = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
+static const uint8_t chiptest_12cb0ed34854_pt_114[]    = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
                                                         0x04, 0x34, 0x34, 0xfc, 0x09, 0x1a, 0xda, 0xc7 };
-static const uint8_t chiptest_12cb0ed34854_ct_115[]  = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
+static const uint8_t chiptest_12cb0ed34854_ct_115[]    = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
                                                         0xa3, 0x77, 0x90, 0xf4, 0x7d, 0x48, 0xce, 0xf9 };
-static const uint8_t chiptest_12cb0ed34854_iv_116[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_117[] = { 0x67, 0xc0, 0xf4, 0xac, 0xb9, 0x6f, 0x73, 0x5e, 0xd0, 0xa2, 0xcf,
+static const uint8_t chiptest_12cb0ed34854_nonce_116[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_117[]   = { 0x67, 0xc0, 0xf4, 0xac, 0xb9, 0x6f, 0x73, 0x5e, 0xd0, 0xa2, 0xcf,
                                                          0x95, 0x8a, 0x7c, 0xc3, 0xc5, 0xf7, 0x96, 0xf5, 0xde, 0x40, 0xcd,
                                                          0x99, 0x8f, 0xdd, 0xb9, 0xa3, 0x0b, 0x2f, 0x6e, 0x74, 0x5f };
-static const uint8_t chiptest_12cb0ed34854_tag_118[] = { 0x19, 0xb6, 0x25, 0x1d, 0xbf, 0x0b, 0x07, 0x43, 0x46, 0xfc, 0xd1, 0x62 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_119 = { .key     = chiptest_12cb0ed34854_key_113,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_114,
-                                                                              .pt_len  = 16,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_115,
-                                                                              .ct_len  = 16,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_116,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_117,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_118,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 17,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_120[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_tag_118[]   = { 0x19, 0xb6, 0x25, 0x1d, 0xbf, 0x0b, 0x07, 0x43, 0x46, 0xfc, 0xd1, 0x62 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_119 = { .key       = chiptest_12cb0ed34854_key_113,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_114,
+                                                                              .pt_len    = 16,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_115,
+                                                                              .ct_len    = 16,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_116,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_117,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_118,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 17,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_120[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_121[]  = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
+static const uint8_t chiptest_12cb0ed34854_pt_121[]    = { 0xe4, 0xe6, 0xfe, 0x17, 0xc6, 0xd6, 0xd0, 0xc8,
                                                         0x04, 0x34, 0x34, 0xfc, 0x09, 0x1a, 0xda, 0xc7 };
-static const uint8_t chiptest_12cb0ed34854_ct_122[]  = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
+static const uint8_t chiptest_12cb0ed34854_ct_122[]    = { 0xb3, 0xf7, 0x94, 0x08, 0xd1, 0xdf, 0x32, 0x5d,
                                                         0xa3, 0x77, 0x90, 0xf4, 0x7d, 0x48, 0xce, 0xf9 };
-static const uint8_t chiptest_12cb0ed34854_iv_123[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_124[] = { 0x67, 0xc0, 0xf4, 0xac, 0xb9, 0x6f, 0x73, 0x5e, 0xd0, 0xa2, 0xcf,
+static const uint8_t chiptest_12cb0ed34854_nonce_123[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_124[]   = { 0x67, 0xc0, 0xf4, 0xac, 0xb9, 0x6f, 0x73, 0x5e, 0xd0, 0xa2, 0xcf,
                                                          0x95, 0x8a, 0x7c, 0xc3, 0xc5, 0xf7, 0x96, 0xf5, 0xde, 0x40, 0xcd,
                                                          0x99, 0x8f, 0xdd, 0xb9, 0xa3, 0x0b, 0x2f, 0x6e, 0x74, 0x5f };
-static const uint8_t chiptest_12cb0ed34854_tag_125[] = { 0x96, 0x42, 0x3d, 0x41, 0xbb, 0x98, 0x05, 0x37,
+static const uint8_t chiptest_12cb0ed34854_tag_125[]   = { 0x96, 0x42, 0x3d, 0x41, 0xbb, 0x98, 0x05, 0x37,
                                                          0x1f, 0x3f, 0x78, 0x4f, 0xa4, 0x76, 0xa4, 0x79 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_126 = { .key     = chiptest_12cb0ed34854_key_120,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_121,
-                                                                              .pt_len  = 16,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_122,
-                                                                              .ct_len  = 16,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_123,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_124,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_125,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 18,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_127[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_126 = { .key       = chiptest_12cb0ed34854_key_120,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_121,
+                                                                              .pt_len    = 16,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_122,
+                                                                              .ct_len    = 16,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_123,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_124,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_125,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 18,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_127[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_128[]  = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
+static const uint8_t chiptest_12cb0ed34854_pt_128[]    = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
                                                         0x99, 0x65, 0x6b, 0x47, 0x21, 0x50, 0xd8, 0xf5, 0x9a, 0xf1, 0x5f,
                                                         0xba, 0x7d, 0x49, 0xd7, 0xa3, 0x2b, 0x7f, 0xb4, 0x11, 0x30, 0x03 };
-static const uint8_t chiptest_12cb0ed34854_ct_129[]  = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
+static const uint8_t chiptest_12cb0ed34854_ct_129[]    = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
                                                         0x91, 0x11, 0x39, 0x53, 0x1f, 0x2b, 0x25, 0xec, 0xcf, 0x6a, 0x9c,
                                                         0xfd, 0x27, 0x9b, 0x16, 0x28, 0xcd, 0xa4, 0x5f, 0x58, 0xd0, 0x3e };
-static const uint8_t chiptest_12cb0ed34854_iv_130[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_131[] = {};
-static const uint8_t chiptest_12cb0ed34854_tag_132[] = { 0x0e, 0x87, 0x96, 0xd6, 0x32, 0xc9, 0xb3, 0x2e };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_133 = { .key     = chiptest_12cb0ed34854_key_127,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_128,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_129,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_130,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_131,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_132,
-                                                                              .tag_len = 8,
-                                                                              .tcId    = 19,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_134[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_nonce_130[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_131[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_132[]   = { 0x0e, 0x87, 0x96, 0xd6, 0x32, 0xc9, 0xb3, 0x2e };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_133 = { .key       = chiptest_12cb0ed34854_key_127,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_128,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_129,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_130,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_131,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_132,
+                                                                              .tag_len   = 8,
+                                                                              .tcId      = 19,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_134[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_135[]  = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
+static const uint8_t chiptest_12cb0ed34854_pt_135[]    = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
                                                         0x99, 0x65, 0x6b, 0x47, 0x21, 0x50, 0xd8, 0xf5, 0x9a, 0xf1, 0x5f,
                                                         0xba, 0x7d, 0x49, 0xd7, 0xa3, 0x2b, 0x7f, 0xb4, 0x11, 0x30, 0x03 };
-static const uint8_t chiptest_12cb0ed34854_ct_136[]  = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
+static const uint8_t chiptest_12cb0ed34854_ct_136[]    = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
                                                         0x91, 0x11, 0x39, 0x53, 0x1f, 0x2b, 0x25, 0xec, 0xcf, 0x6a, 0x9c,
                                                         0xfd, 0x27, 0x9b, 0x16, 0x28, 0xcd, 0xa4, 0x5f, 0x58, 0xd0, 0x3e };
-static const uint8_t chiptest_12cb0ed34854_iv_137[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_138[] = {};
-static const uint8_t chiptest_12cb0ed34854_tag_139[] = { 0x4f, 0x3a, 0x4c, 0x11, 0x07, 0x44, 0x86, 0x9e, 0xd1, 0x4d, 0x53, 0xaa };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_140 = { .key     = chiptest_12cb0ed34854_key_134,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_135,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_136,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_137,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_138,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_139,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 20,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_141[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_nonce_137[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_138[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_139[]   = { 0x4f, 0x3a, 0x4c, 0x11, 0x07, 0x44, 0x86, 0x9e, 0xd1, 0x4d, 0x53, 0xaa };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_140 = { .key       = chiptest_12cb0ed34854_key_134,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_135,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_136,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_137,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_138,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_139,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 20,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_141[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_142[]  = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
+static const uint8_t chiptest_12cb0ed34854_pt_142[]    = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
                                                         0x99, 0x65, 0x6b, 0x47, 0x21, 0x50, 0xd8, 0xf5, 0x9a, 0xf1, 0x5f,
                                                         0xba, 0x7d, 0x49, 0xd7, 0xa3, 0x2b, 0x7f, 0xb4, 0x11, 0x30, 0x03 };
-static const uint8_t chiptest_12cb0ed34854_ct_143[]  = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
+static const uint8_t chiptest_12cb0ed34854_ct_143[]    = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
                                                         0x91, 0x11, 0x39, 0x53, 0x1f, 0x2b, 0x25, 0xec, 0xcf, 0x6a, 0x9c,
                                                         0xfd, 0x27, 0x9b, 0x16, 0x28, 0xcd, 0xa4, 0x5f, 0x58, 0xd0, 0x3e };
-static const uint8_t chiptest_12cb0ed34854_iv_144[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_145[] = {};
-static const uint8_t chiptest_12cb0ed34854_tag_146[] = { 0xab, 0x73, 0x1f, 0xc8, 0x0a, 0xde, 0x38, 0xf1,
+static const uint8_t chiptest_12cb0ed34854_nonce_144[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_145[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_146[]   = { 0xab, 0x73, 0x1f, 0xc8, 0x0a, 0xde, 0x38, 0xf1,
                                                          0xa9, 0x84, 0x60, 0x6e, 0xae, 0x05, 0xa0, 0x2b };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_147 = { .key     = chiptest_12cb0ed34854_key_141,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_142,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_143,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_144,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_145,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_146,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 21,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_148[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_147 = { .key       = chiptest_12cb0ed34854_key_141,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_142,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_143,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_144,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_145,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_146,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 21,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_148[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_149[]  = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
+static const uint8_t chiptest_12cb0ed34854_pt_149[]    = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
                                                         0x99, 0x65, 0x6b, 0x47, 0x21, 0x50, 0xd8, 0xf5, 0x9a, 0xf1, 0x5f,
                                                         0xba, 0x7d, 0x49, 0xd7, 0xa3, 0x2b, 0x7f, 0xb4, 0x11, 0x30, 0x03 };
-static const uint8_t chiptest_12cb0ed34854_ct_150[]  = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
+static const uint8_t chiptest_12cb0ed34854_ct_150[]    = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
                                                         0x91, 0x11, 0x39, 0x53, 0x1f, 0x2b, 0x25, 0xec, 0xcf, 0x6a, 0x9c,
                                                         0xfd, 0x27, 0x9b, 0x16, 0x28, 0xcd, 0xa4, 0x5f, 0x58, 0xd0, 0x3e };
-static const uint8_t chiptest_12cb0ed34854_iv_151[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_152[] = { 0xf2 };
-static const uint8_t chiptest_12cb0ed34854_tag_153[] = { 0x5f, 0x5e, 0xce, 0x87, 0x2f, 0x03, 0xe5, 0x07 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_154 = { .key     = chiptest_12cb0ed34854_key_148,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_149,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_150,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_151,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_152,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_153,
-                                                                              .tag_len = 8,
-                                                                              .tcId    = 22,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_155[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_nonce_151[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_152[]   = { 0xf2 };
+static const uint8_t chiptest_12cb0ed34854_tag_153[]   = { 0x5f, 0x5e, 0xce, 0x87, 0x2f, 0x03, 0xe5, 0x07 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_154 = { .key       = chiptest_12cb0ed34854_key_148,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_149,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_150,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_151,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_152,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_153,
+                                                                              .tag_len   = 8,
+                                                                              .tcId      = 22,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_155[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_156[]  = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
+static const uint8_t chiptest_12cb0ed34854_pt_156[]    = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
                                                         0x99, 0x65, 0x6b, 0x47, 0x21, 0x50, 0xd8, 0xf5, 0x9a, 0xf1, 0x5f,
                                                         0xba, 0x7d, 0x49, 0xd7, 0xa3, 0x2b, 0x7f, 0xb4, 0x11, 0x30, 0x03 };
-static const uint8_t chiptest_12cb0ed34854_ct_157[]  = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
+static const uint8_t chiptest_12cb0ed34854_ct_157[]    = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
                                                         0x91, 0x11, 0x39, 0x53, 0x1f, 0x2b, 0x25, 0xec, 0xcf, 0x6a, 0x9c,
                                                         0xfd, 0x27, 0x9b, 0x16, 0x28, 0xcd, 0xa4, 0x5f, 0x58, 0xd0, 0x3e };
-static const uint8_t chiptest_12cb0ed34854_iv_158[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_159[] = { 0xf2 };
-static const uint8_t chiptest_12cb0ed34854_tag_160[] = { 0x48, 0x35, 0x5c, 0xc2, 0xb4, 0x61, 0x8b, 0xd2, 0x4e, 0xa3, 0xe4, 0xc0 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_161 = { .key     = chiptest_12cb0ed34854_key_155,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_156,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_157,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_158,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_159,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_160,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 23,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_162[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_nonce_158[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_159[]   = { 0xf2 };
+static const uint8_t chiptest_12cb0ed34854_tag_160[]   = { 0x48, 0x35, 0x5c, 0xc2, 0xb4, 0x61, 0x8b, 0xd2, 0x4e, 0xa3, 0xe4, 0xc0 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_161 = { .key       = chiptest_12cb0ed34854_key_155,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_156,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_157,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_158,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_159,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_160,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 23,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_162[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_163[]  = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
+static const uint8_t chiptest_12cb0ed34854_pt_163[]    = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
                                                         0x99, 0x65, 0x6b, 0x47, 0x21, 0x50, 0xd8, 0xf5, 0x9a, 0xf1, 0x5f,
                                                         0xba, 0x7d, 0x49, 0xd7, 0xa3, 0x2b, 0x7f, 0xb4, 0x11, 0x30, 0x03 };
-static const uint8_t chiptest_12cb0ed34854_ct_164[]  = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
+static const uint8_t chiptest_12cb0ed34854_ct_164[]    = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
                                                         0x91, 0x11, 0x39, 0x53, 0x1f, 0x2b, 0x25, 0xec, 0xcf, 0x6a, 0x9c,
                                                         0xfd, 0x27, 0x9b, 0x16, 0x28, 0xcd, 0xa4, 0x5f, 0x58, 0xd0, 0x3e };
-static const uint8_t chiptest_12cb0ed34854_iv_165[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_166[] = { 0xf2 };
-static const uint8_t chiptest_12cb0ed34854_tag_167[] = { 0xf0, 0x89, 0x5d, 0xfa, 0x19, 0x3e, 0x56, 0x29,
+static const uint8_t chiptest_12cb0ed34854_nonce_165[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_166[]   = { 0xf2 };
+static const uint8_t chiptest_12cb0ed34854_tag_167[]   = { 0xf0, 0x89, 0x5d, 0xfa, 0x19, 0x3e, 0x56, 0x29,
                                                          0x62, 0x25, 0x5e, 0x24, 0xf5, 0x76, 0x57, 0x73 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_168 = { .key     = chiptest_12cb0ed34854_key_162,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_163,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_164,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_165,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_166,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_167,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 24,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_169[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_168 = { .key       = chiptest_12cb0ed34854_key_162,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_163,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_164,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_165,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_166,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_167,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 24,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_169[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_170[]  = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
+static const uint8_t chiptest_12cb0ed34854_pt_170[]    = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
                                                         0x99, 0x65, 0x6b, 0x47, 0x21, 0x50, 0xd8, 0xf5, 0x9a, 0xf1, 0x5f,
                                                         0xba, 0x7d, 0x49, 0xd7, 0xa3, 0x2b, 0x7f, 0xb4, 0x11, 0x30, 0x03 };
-static const uint8_t chiptest_12cb0ed34854_ct_171[]  = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
+static const uint8_t chiptest_12cb0ed34854_ct_171[]    = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
                                                         0x91, 0x11, 0x39, 0x53, 0x1f, 0x2b, 0x25, 0xec, 0xcf, 0x6a, 0x9c,
                                                         0xfd, 0x27, 0x9b, 0x16, 0x28, 0xcd, 0xa4, 0x5f, 0x58, 0xd0, 0x3e };
-static const uint8_t chiptest_12cb0ed34854_iv_172[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_173[] = { 0x2d, 0x1e, 0x30, 0xdd, 0x3b, 0xbf, 0x40, 0xb2, 0xcd, 0x7c, 0x3d,
+static const uint8_t chiptest_12cb0ed34854_nonce_172[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_173[]   = { 0x2d, 0x1e, 0x30, 0xdd, 0x3b, 0xbf, 0x40, 0xb2, 0xcd, 0x7c, 0x3d,
                                                          0x57, 0x45, 0xd5, 0x36, 0xcf, 0x38, 0x5e, 0x8c, 0xe5, 0xea, 0xf9,
                                                          0x40, 0xf4, 0x79, 0xf9, 0x73, 0x0e, 0x4c, 0x55, 0xef, 0x87 };
-static const uint8_t chiptest_12cb0ed34854_tag_174[] = { 0x6a, 0x91, 0xf2, 0x05, 0xd1, 0x27, 0x02, 0x24 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_175 = { .key     = chiptest_12cb0ed34854_key_169,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_170,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_171,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_172,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_173,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_174,
-                                                                              .tag_len = 8,
-                                                                              .tcId    = 25,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_176[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_tag_174[]   = { 0x6a, 0x91, 0xf2, 0x05, 0xd1, 0x27, 0x02, 0x24 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_175 = { .key       = chiptest_12cb0ed34854_key_169,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_170,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_171,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_172,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_173,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_174,
+                                                                              .tag_len   = 8,
+                                                                              .tcId      = 25,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_176[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_177[]  = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
+static const uint8_t chiptest_12cb0ed34854_pt_177[]    = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
                                                         0x99, 0x65, 0x6b, 0x47, 0x21, 0x50, 0xd8, 0xf5, 0x9a, 0xf1, 0x5f,
                                                         0xba, 0x7d, 0x49, 0xd7, 0xa3, 0x2b, 0x7f, 0xb4, 0x11, 0x30, 0x03 };
-static const uint8_t chiptest_12cb0ed34854_ct_178[]  = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
+static const uint8_t chiptest_12cb0ed34854_ct_178[]    = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
                                                         0x91, 0x11, 0x39, 0x53, 0x1f, 0x2b, 0x25, 0xec, 0xcf, 0x6a, 0x9c,
                                                         0xfd, 0x27, 0x9b, 0x16, 0x28, 0xcd, 0xa4, 0x5f, 0x58, 0xd0, 0x3e };
-static const uint8_t chiptest_12cb0ed34854_iv_179[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_180[] = { 0x2d, 0x1e, 0x30, 0xdd, 0x3b, 0xbf, 0x40, 0xb2, 0xcd, 0x7c, 0x3d,
+static const uint8_t chiptest_12cb0ed34854_nonce_179[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_180[]   = { 0x2d, 0x1e, 0x30, 0xdd, 0x3b, 0xbf, 0x40, 0xb2, 0xcd, 0x7c, 0x3d,
                                                          0x57, 0x45, 0xd5, 0x36, 0xcf, 0x38, 0x5e, 0x8c, 0xe5, 0xea, 0xf9,
                                                          0x40, 0xf4, 0x79, 0xf9, 0x73, 0x0e, 0x4c, 0x55, 0xef, 0x87 };
-static const uint8_t chiptest_12cb0ed34854_tag_181[] = { 0xab, 0x65, 0x12, 0xab, 0x92, 0xf5, 0x89, 0x98, 0x5d, 0x72, 0xa0, 0xfd };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_182 = { .key     = chiptest_12cb0ed34854_key_176,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_177,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_178,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_179,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_180,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_181,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 26,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_183[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_tag_181[]   = { 0xab, 0x65, 0x12, 0xab, 0x92, 0xf5, 0x89, 0x98, 0x5d, 0x72, 0xa0, 0xfd };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_182 = { .key       = chiptest_12cb0ed34854_key_176,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_177,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_178,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_179,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_180,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_181,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 26,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_183[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_184[]  = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
+static const uint8_t chiptest_12cb0ed34854_pt_184[]    = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
                                                         0x99, 0x65, 0x6b, 0x47, 0x21, 0x50, 0xd8, 0xf5, 0x9a, 0xf1, 0x5f,
                                                         0xba, 0x7d, 0x49, 0xd7, 0xa3, 0x2b, 0x7f, 0xb4, 0x11, 0x30, 0x03 };
-static const uint8_t chiptest_12cb0ed34854_ct_185[]  = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
+static const uint8_t chiptest_12cb0ed34854_ct_185[]    = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
                                                         0x91, 0x11, 0x39, 0x53, 0x1f, 0x2b, 0x25, 0xec, 0xcf, 0x6a, 0x9c,
                                                         0xfd, 0x27, 0x9b, 0x16, 0x28, 0xcd, 0xa4, 0x5f, 0x58, 0xd0, 0x3e };
-static const uint8_t chiptest_12cb0ed34854_iv_186[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_187[] = { 0x2d, 0x1e, 0x30, 0xdd, 0x3b, 0xbf, 0x40, 0xb2, 0xcd, 0x7c, 0x3d,
+static const uint8_t chiptest_12cb0ed34854_nonce_186[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_187[]   = { 0x2d, 0x1e, 0x30, 0xdd, 0x3b, 0xbf, 0x40, 0xb2, 0xcd, 0x7c, 0x3d,
                                                          0x57, 0x45, 0xd5, 0x36, 0xcf, 0x38, 0x5e, 0x8c, 0xe5, 0xea, 0xf9,
                                                          0x40, 0xf4, 0x79, 0xf9, 0x73, 0x0e, 0x4c, 0x55, 0xef, 0x87 };
-static const uint8_t chiptest_12cb0ed34854_tag_188[] = { 0xe1, 0x75, 0xe0, 0x33, 0x4b, 0x4e, 0x23, 0x4c,
+static const uint8_t chiptest_12cb0ed34854_tag_188[]   = { 0xe1, 0x75, 0xe0, 0x33, 0x4b, 0x4e, 0x23, 0x4c,
                                                          0x1e, 0xce, 0x5c, 0x73, 0x9e, 0xd1, 0x2c, 0x28 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_189 = { .key     = chiptest_12cb0ed34854_key_183,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_184,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_185,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_186,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_187,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_188,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 27,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_190[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_189 = { .key       = chiptest_12cb0ed34854_key_183,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_184,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_185,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_186,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_187,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_188,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 27,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_190[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_191[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_192[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_193[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_194[]                      = {};
-static const uint8_t chiptest_12cb0ed34854_tag_195[]                      = { 0x42, 0x26, 0x5a, 0xcf, 0xad, 0xa3, 0x71, 0xd5 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_196 = { .key     = chiptest_12cb0ed34854_key_190,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_191,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_192,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_193,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_194,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_195,
-                                                                              .tag_len = 8,
-                                                                              .tcId    = 28,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_197[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_pt_191[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_192[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_193[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_194[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_195[]   = { 0x42, 0x26, 0x5a, 0xcf, 0xad, 0xa3, 0x71, 0xd5 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_196 = { .key       = chiptest_12cb0ed34854_key_190,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_191,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_192,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_193,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_194,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_195,
+                                                                              .tag_len   = 8,
+                                                                              .tcId      = 28,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_197[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_198[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_199[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_200[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_201[] = {};
-static const uint8_t chiptest_12cb0ed34854_tag_202[] = { 0x1c, 0xec, 0x5b, 0xff, 0xcf, 0xb4, 0xd7, 0x02, 0x34, 0xb3, 0xb0, 0x41 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_203 = { .key     = chiptest_12cb0ed34854_key_197,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_198,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_199,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_200,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_201,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_202,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 29,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_204[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_pt_198[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_199[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_200[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_201[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_202[]   = { 0x1c, 0xec, 0x5b, 0xff, 0xcf, 0xb4, 0xd7, 0x02, 0x34, 0xb3, 0xb0, 0x41 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_203 = { .key       = chiptest_12cb0ed34854_key_197,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_198,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_199,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_200,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_201,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_202,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 29,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_204[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_205[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_206[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_207[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_208[]                      = {};
-static const uint8_t chiptest_12cb0ed34854_tag_209[]                      = { 0x5d, 0x79, 0x73, 0xc2, 0x5f, 0xe1, 0x6d, 0x69,
+static const uint8_t chiptest_12cb0ed34854_pt_205[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_206[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_207[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_208[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_209[]   = { 0x5d, 0x79, 0x73, 0xc2, 0x5f, 0xe1, 0x6d, 0x69,
                                                          0x40, 0xfb, 0xca, 0xff, 0x79, 0x86, 0xe3, 0x3e };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_210 = { .key     = chiptest_12cb0ed34854_key_204,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_205,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_206,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_207,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_208,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_209,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 30,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_211[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_210 = { .key       = chiptest_12cb0ed34854_key_204,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_205,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_206,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_207,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_208,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_209,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 30,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_211[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_212[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_213[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_214[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_215[]                      = { 0xeb };
-static const uint8_t chiptest_12cb0ed34854_tag_216[]                      = { 0xaf, 0xc6, 0xf9, 0x48, 0xae, 0x21, 0xc2, 0x7c };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_217 = { .key     = chiptest_12cb0ed34854_key_211,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_212,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_213,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_214,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_215,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_216,
-                                                                              .tag_len = 8,
-                                                                              .tcId    = 31,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_218[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_pt_212[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_213[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_214[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_215[]   = { 0xeb };
+static const uint8_t chiptest_12cb0ed34854_tag_216[]   = { 0xaf, 0xc6, 0xf9, 0x48, 0xae, 0x21, 0xc2, 0x7c };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_217 = { .key       = chiptest_12cb0ed34854_key_211,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_212,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_213,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_214,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_215,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_216,
+                                                                              .tag_len   = 8,
+                                                                              .tcId      = 31,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_218[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_219[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_220[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_221[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_222[] = { 0xeb };
-static const uint8_t chiptest_12cb0ed34854_tag_223[] = { 0xd7, 0x71, 0x56, 0x7f, 0xee, 0x7b, 0x52, 0x2a, 0x95, 0x6a, 0x86, 0x5e };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_224 = { .key     = chiptest_12cb0ed34854_key_218,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_219,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_220,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_221,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_222,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_223,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 32,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_225[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_pt_219[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_220[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_221[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_222[]   = { 0xeb };
+static const uint8_t chiptest_12cb0ed34854_tag_223[]   = { 0xd7, 0x71, 0x56, 0x7f, 0xee, 0x7b, 0x52, 0x2a, 0x95, 0x6a, 0x86, 0x5e };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_224 = { .key       = chiptest_12cb0ed34854_key_218,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_219,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_220,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_221,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_222,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_223,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 32,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_225[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_226[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_227[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_228[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_229[]                      = { 0xeb };
-static const uint8_t chiptest_12cb0ed34854_tag_230[]                      = { 0x6a, 0x94, 0x0c, 0x32, 0x1a, 0xa4, 0x22, 0xd6,
+static const uint8_t chiptest_12cb0ed34854_pt_226[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_227[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_228[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_229[]   = { 0xeb };
+static const uint8_t chiptest_12cb0ed34854_tag_230[]   = { 0x6a, 0x94, 0x0c, 0x32, 0x1a, 0xa4, 0x22, 0xd6,
                                                          0x34, 0x6b, 0x83, 0x9f, 0x88, 0x90, 0x0d, 0xd0 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_231 = { .key     = chiptest_12cb0ed34854_key_225,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_226,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_227,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_228,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_229,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_230,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 33,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_232[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_231 = { .key       = chiptest_12cb0ed34854_key_225,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_226,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_227,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_228,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_229,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_230,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 33,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_232[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_233[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_234[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_235[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_236[] = { 0x7e, 0x39, 0xdd, 0x42, 0xab, 0xd1, 0xca, 0x47, 0x38, 0x3f, 0x31,
+static const uint8_t chiptest_12cb0ed34854_pt_233[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_234[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_235[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_236[]   = { 0x7e, 0x39, 0xdd, 0x42, 0xab, 0xd1, 0xca, 0x47, 0x38, 0x3f, 0x31,
                                                          0xb5, 0x2c, 0x12, 0x4a, 0x5d, 0xba, 0xc4, 0xfe, 0x43, 0xb3, 0x0d,
                                                          0xed, 0x71, 0xb6, 0xca, 0x05, 0x40, 0x14, 0xbf, 0xb6, 0x00 };
-static const uint8_t chiptest_12cb0ed34854_tag_237[] = { 0xa3, 0x8f, 0x71, 0x32, 0xfa, 0xb8, 0x43, 0xea };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_238 = { .key     = chiptest_12cb0ed34854_key_232,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_233,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_234,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_235,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_236,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_237,
-                                                                              .tag_len = 8,
-                                                                              .tcId    = 34,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_239[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_tag_237[]   = { 0xa3, 0x8f, 0x71, 0x32, 0xfa, 0xb8, 0x43, 0xea };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_238 = { .key       = chiptest_12cb0ed34854_key_232,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_233,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_234,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_235,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_236,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_237,
+                                                                              .tag_len   = 8,
+                                                                              .tcId      = 34,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_239[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_240[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_241[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_242[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_243[] = { 0x7e, 0x39, 0xdd, 0x42, 0xab, 0xd1, 0xca, 0x47, 0x38, 0x3f, 0x31,
+static const uint8_t chiptest_12cb0ed34854_pt_240[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_241[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_242[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_243[]   = { 0x7e, 0x39, 0xdd, 0x42, 0xab, 0xd1, 0xca, 0x47, 0x38, 0x3f, 0x31,
                                                          0xb5, 0x2c, 0x12, 0x4a, 0x5d, 0xba, 0xc4, 0xfe, 0x43, 0xb3, 0x0d,
                                                          0xed, 0x71, 0xb6, 0xca, 0x05, 0x40, 0x14, 0xbf, 0xb6, 0x00 };
-static const uint8_t chiptest_12cb0ed34854_tag_244[] = { 0x59, 0xe5, 0xf7, 0x0c, 0x8e, 0x86, 0x32, 0x6b, 0x61, 0x66, 0x77, 0x7c };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_245 = { .key     = chiptest_12cb0ed34854_key_239,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_240,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_241,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_242,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_243,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_244,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 35,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_246[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_tag_244[]   = { 0x59, 0xe5, 0xf7, 0x0c, 0x8e, 0x86, 0x32, 0x6b, 0x61, 0x66, 0x77, 0x7c };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_245 = { .key       = chiptest_12cb0ed34854_key_239,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_240,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_241,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_242,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_243,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_244,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 35,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_246[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_247[]  = {};
-static const uint8_t chiptest_12cb0ed34854_ct_248[]  = {};
-static const uint8_t chiptest_12cb0ed34854_iv_249[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_250[] = { 0x7e, 0x39, 0xdd, 0x42, 0xab, 0xd1, 0xca, 0x47, 0x38, 0x3f, 0x31,
+static const uint8_t chiptest_12cb0ed34854_pt_247[]    = {};
+static const uint8_t chiptest_12cb0ed34854_ct_248[]    = {};
+static const uint8_t chiptest_12cb0ed34854_nonce_249[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_250[]   = { 0x7e, 0x39, 0xdd, 0x42, 0xab, 0xd1, 0xca, 0x47, 0x38, 0x3f, 0x31,
                                                          0xb5, 0x2c, 0x12, 0x4a, 0x5d, 0xba, 0xc4, 0xfe, 0x43, 0xb3, 0x0d,
                                                          0xed, 0x71, 0xb6, 0xca, 0x05, 0x40, 0x14, 0xbf, 0xb6, 0x00 };
-static const uint8_t chiptest_12cb0ed34854_tag_251[] = { 0x25, 0x46, 0x20, 0x97, 0x7f, 0x47, 0xbf, 0xd6,
+static const uint8_t chiptest_12cb0ed34854_tag_251[]   = { 0x25, 0x46, 0x20, 0x97, 0x7f, 0x47, 0xbf, 0xd6,
                                                          0x74, 0x30, 0xf3, 0xed, 0x01, 0xbc, 0x6b, 0x31 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_252 = { .key     = chiptest_12cb0ed34854_key_246,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_247,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_248,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_249,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_250,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_251,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 36,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_253[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_252 = { .key       = chiptest_12cb0ed34854_key_246,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_247,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_248,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_249,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_250,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_251,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 36,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_253[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_254[]  = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
+static const uint8_t chiptest_12cb0ed34854_pt_254[]    = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
                                                         0x7f, 0xec, 0x3e, 0x96, 0xcc, 0x3f, 0x4a, 0x3c };
-static const uint8_t chiptest_12cb0ed34854_ct_255[]  = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_255[]    = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
                                                         0x87, 0x74, 0xa7, 0x42, 0x37, 0x8b, 0x4e, 0xd4 };
-static const uint8_t chiptest_12cb0ed34854_iv_256[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_257[]                      = {};
-static const uint8_t chiptest_12cb0ed34854_tag_258[]                      = { 0x43, 0xd5, 0xd9, 0x8c, 0xa0, 0xa2, 0x25, 0x50 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_259 = { .key     = chiptest_12cb0ed34854_key_253,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_254,
-                                                                              .pt_len  = 16,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_255,
-                                                                              .ct_len  = 16,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_256,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_257,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_258,
-                                                                              .tag_len = 8,
-                                                                              .tcId    = 37,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_260[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_nonce_256[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_257[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_258[]   = { 0x43, 0xd5, 0xd9, 0x8c, 0xa0, 0xa2, 0x25, 0x50 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_259 = { .key       = chiptest_12cb0ed34854_key_253,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_254,
+                                                                              .pt_len    = 16,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_255,
+                                                                              .ct_len    = 16,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_256,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_257,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_258,
+                                                                              .tag_len   = 8,
+                                                                              .tcId      = 37,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_260[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_261[]  = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
+static const uint8_t chiptest_12cb0ed34854_pt_261[]    = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
                                                         0x7f, 0xec, 0x3e, 0x96, 0xcc, 0x3f, 0x4a, 0x3c };
-static const uint8_t chiptest_12cb0ed34854_ct_262[]  = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_262[]    = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
                                                         0x87, 0x74, 0xa7, 0x42, 0x37, 0x8b, 0x4e, 0xd4 };
-static const uint8_t chiptest_12cb0ed34854_iv_263[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_264[] = {};
-static const uint8_t chiptest_12cb0ed34854_tag_265[] = { 0x80, 0x8f, 0x50, 0x04, 0xad, 0x52, 0xb0, 0x37, 0xbc, 0x38, 0xe1, 0xa5 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_266 = { .key     = chiptest_12cb0ed34854_key_260,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_261,
-                                                                              .pt_len  = 16,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_262,
-                                                                              .ct_len  = 16,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_263,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_264,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_265,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 38,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_267[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_nonce_263[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_264[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_265[]   = { 0x80, 0x8f, 0x50, 0x04, 0xad, 0x52, 0xb0, 0x37, 0xbc, 0x38, 0xe1, 0xa5 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_266 = { .key       = chiptest_12cb0ed34854_key_260,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_261,
+                                                                              .pt_len    = 16,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_262,
+                                                                              .ct_len    = 16,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_263,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_264,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_265,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 38,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_267[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_268[]  = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
+static const uint8_t chiptest_12cb0ed34854_pt_268[]    = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
                                                         0x7f, 0xec, 0x3e, 0x96, 0xcc, 0x3f, 0x4a, 0x3c };
-static const uint8_t chiptest_12cb0ed34854_ct_269[]  = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_269[]    = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
                                                         0x87, 0x74, 0xa7, 0x42, 0x37, 0x8b, 0x4e, 0xd4 };
-static const uint8_t chiptest_12cb0ed34854_iv_270[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_271[]                      = {};
-static const uint8_t chiptest_12cb0ed34854_tag_272[]                      = { 0x1f, 0x0b, 0x8f, 0x8b, 0x7d, 0xf5, 0x46, 0xa9,
+static const uint8_t chiptest_12cb0ed34854_nonce_270[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_271[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_272[]   = { 0x1f, 0x0b, 0x8f, 0x8b, 0x7d, 0xf5, 0x46, 0xa9,
                                                          0x93, 0x36, 0x6a, 0x02, 0x6f, 0x0c, 0x2d, 0x61 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_273 = { .key     = chiptest_12cb0ed34854_key_267,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_268,
-                                                                              .pt_len  = 16,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_269,
-                                                                              .ct_len  = 16,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_270,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_271,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_272,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 39,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_274[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_273 = { .key       = chiptest_12cb0ed34854_key_267,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_268,
+                                                                              .pt_len    = 16,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_269,
+                                                                              .ct_len    = 16,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_270,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_271,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_272,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 39,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_274[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_275[]  = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
+static const uint8_t chiptest_12cb0ed34854_pt_275[]    = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
                                                         0x7f, 0xec, 0x3e, 0x96, 0xcc, 0x3f, 0x4a, 0x3c };
-static const uint8_t chiptest_12cb0ed34854_ct_276[]  = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_276[]    = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
                                                         0x87, 0x74, 0xa7, 0x42, 0x37, 0x8b, 0x4e, 0xd4 };
-static const uint8_t chiptest_12cb0ed34854_iv_277[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_278[]                      = { 0xaa };
-static const uint8_t chiptest_12cb0ed34854_tag_279[]                      = { 0xd8, 0x57, 0x1b, 0x1e, 0x92, 0xf4, 0x58, 0x27 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_280 = { .key     = chiptest_12cb0ed34854_key_274,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_275,
-                                                                              .pt_len  = 16,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_276,
-                                                                              .ct_len  = 16,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_277,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_278,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_279,
-                                                                              .tag_len = 8,
-                                                                              .tcId    = 40,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_281[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_nonce_277[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_278[]   = { 0xaa };
+static const uint8_t chiptest_12cb0ed34854_tag_279[]   = { 0xd8, 0x57, 0x1b, 0x1e, 0x92, 0xf4, 0x58, 0x27 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_280 = { .key       = chiptest_12cb0ed34854_key_274,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_275,
+                                                                              .pt_len    = 16,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_276,
+                                                                              .ct_len    = 16,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_277,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_278,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_279,
+                                                                              .tag_len   = 8,
+                                                                              .tcId      = 40,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_281[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_282[]  = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
+static const uint8_t chiptest_12cb0ed34854_pt_282[]    = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
                                                         0x7f, 0xec, 0x3e, 0x96, 0xcc, 0x3f, 0x4a, 0x3c };
-static const uint8_t chiptest_12cb0ed34854_ct_283[]  = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_283[]    = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
                                                         0x87, 0x74, 0xa7, 0x42, 0x37, 0x8b, 0x4e, 0xd4 };
-static const uint8_t chiptest_12cb0ed34854_iv_284[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_285[] = { 0xaa };
-static const uint8_t chiptest_12cb0ed34854_tag_286[] = { 0xef, 0xbf, 0xf4, 0xb4, 0x81, 0xb8, 0xc3, 0xd4, 0x55, 0xed, 0x75, 0x11 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_287 = { .key     = chiptest_12cb0ed34854_key_281,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_282,
-                                                                              .pt_len  = 16,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_283,
-                                                                              .ct_len  = 16,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_284,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_285,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_286,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 41,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_288[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_nonce_284[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_285[]   = { 0xaa };
+static const uint8_t chiptest_12cb0ed34854_tag_286[]   = { 0xef, 0xbf, 0xf4, 0xb4, 0x81, 0xb8, 0xc3, 0xd4, 0x55, 0xed, 0x75, 0x11 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_287 = { .key       = chiptest_12cb0ed34854_key_281,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_282,
+                                                                              .pt_len    = 16,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_283,
+                                                                              .ct_len    = 16,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_284,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_285,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_286,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 41,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_288[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_289[]  = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
+static const uint8_t chiptest_12cb0ed34854_pt_289[]    = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
                                                         0x7f, 0xec, 0x3e, 0x96, 0xcc, 0x3f, 0x4a, 0x3c };
-static const uint8_t chiptest_12cb0ed34854_ct_290[]  = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_290[]    = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
                                                         0x87, 0x74, 0xa7, 0x42, 0x37, 0x8b, 0x4e, 0xd4 };
-static const uint8_t chiptest_12cb0ed34854_iv_291[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_292[]                      = { 0xaa };
-static const uint8_t chiptest_12cb0ed34854_tag_293[]                      = { 0x67, 0x15, 0x75, 0xcd, 0xb2, 0xd9, 0x80, 0xae,
+static const uint8_t chiptest_12cb0ed34854_nonce_291[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_292[]   = { 0xaa };
+static const uint8_t chiptest_12cb0ed34854_tag_293[]   = { 0x67, 0x15, 0x75, 0xcd, 0xb2, 0xd9, 0x80, 0xae,
                                                          0x02, 0x3a, 0x1f, 0xd6, 0xc1, 0xa6, 0x67, 0x52 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_294 = { .key     = chiptest_12cb0ed34854_key_288,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_289,
-                                                                              .pt_len  = 16,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_290,
-                                                                              .ct_len  = 16,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_291,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_292,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_293,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 42,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_295[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_294 = { .key       = chiptest_12cb0ed34854_key_288,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_289,
+                                                                              .pt_len    = 16,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_290,
+                                                                              .ct_len    = 16,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_291,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_292,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_293,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 42,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_295[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_296[]  = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
+static const uint8_t chiptest_12cb0ed34854_pt_296[]    = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
                                                         0x7f, 0xec, 0x3e, 0x96, 0xcc, 0x3f, 0x4a, 0x3c };
-static const uint8_t chiptest_12cb0ed34854_ct_297[]  = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_297[]    = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
                                                         0x87, 0x74, 0xa7, 0x42, 0x37, 0x8b, 0x4e, 0xd4 };
-static const uint8_t chiptest_12cb0ed34854_iv_298[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_299[] = { 0x97, 0x40, 0xdd, 0x5c, 0xa3, 0x0d, 0x59, 0x86, 0x7b, 0x01, 0x0f,
+static const uint8_t chiptest_12cb0ed34854_nonce_298[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_299[]   = { 0x97, 0x40, 0xdd, 0x5c, 0xa3, 0x0d, 0x59, 0x86, 0x7b, 0x01, 0x0f,
                                                          0xe3, 0x1a, 0xda, 0x21, 0x41, 0x4c, 0xfd, 0x30, 0xa4, 0x4a, 0x2a,
                                                          0xa0, 0x2a, 0x46, 0xcb, 0xfd, 0xaf, 0x94, 0x7e, 0x0a, 0x3b };
-static const uint8_t chiptest_12cb0ed34854_tag_300[] = { 0xcf, 0x82, 0x65, 0x1d, 0x06, 0x79, 0xae, 0x2f };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_301 = { .key     = chiptest_12cb0ed34854_key_295,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_296,
-                                                                              .pt_len  = 16,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_297,
-                                                                              .ct_len  = 16,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_298,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_299,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_300,
-                                                                              .tag_len = 8,
-                                                                              .tcId    = 43,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_302[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_tag_300[]   = { 0xcf, 0x82, 0x65, 0x1d, 0x06, 0x79, 0xae, 0x2f };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_301 = { .key       = chiptest_12cb0ed34854_key_295,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_296,
+                                                                              .pt_len    = 16,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_297,
+                                                                              .ct_len    = 16,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_298,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_299,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_300,
+                                                                              .tag_len   = 8,
+                                                                              .tcId      = 43,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_302[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_303[]  = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
+static const uint8_t chiptest_12cb0ed34854_pt_303[]    = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
                                                         0x7f, 0xec, 0x3e, 0x96, 0xcc, 0x3f, 0x4a, 0x3c };
-static const uint8_t chiptest_12cb0ed34854_ct_304[]  = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_304[]    = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
                                                         0x87, 0x74, 0xa7, 0x42, 0x37, 0x8b, 0x4e, 0xd4 };
-static const uint8_t chiptest_12cb0ed34854_iv_305[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_306[] = { 0x97, 0x40, 0xdd, 0x5c, 0xa3, 0x0d, 0x59, 0x86, 0x7b, 0x01, 0x0f,
+static const uint8_t chiptest_12cb0ed34854_nonce_305[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_306[]   = { 0x97, 0x40, 0xdd, 0x5c, 0xa3, 0x0d, 0x59, 0x86, 0x7b, 0x01, 0x0f,
                                                          0xe3, 0x1a, 0xda, 0x21, 0x41, 0x4c, 0xfd, 0x30, 0xa4, 0x4a, 0x2a,
                                                          0xa0, 0x2a, 0x46, 0xcb, 0xfd, 0xaf, 0x94, 0x7e, 0x0a, 0x3b };
-static const uint8_t chiptest_12cb0ed34854_tag_307[] = { 0x2c, 0x03, 0xb6, 0x3a, 0xf7, 0x2a, 0x9c, 0x39, 0x24, 0x55, 0xd3, 0x43 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_308 = { .key     = chiptest_12cb0ed34854_key_302,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_303,
-                                                                              .pt_len  = 16,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_304,
-                                                                              .ct_len  = 16,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_305,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_306,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_307,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 44,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_309[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_tag_307[]   = { 0x2c, 0x03, 0xb6, 0x3a, 0xf7, 0x2a, 0x9c, 0x39, 0x24, 0x55, 0xd3, 0x43 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_308 = { .key       = chiptest_12cb0ed34854_key_302,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_303,
+                                                                              .pt_len    = 16,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_304,
+                                                                              .ct_len    = 16,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_305,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_306,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_307,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 44,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_309[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_310[]  = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
+static const uint8_t chiptest_12cb0ed34854_pt_310[]    = { 0xae, 0x0d, 0x82, 0x7b, 0xb5, 0xc3, 0x76, 0x7a,
                                                         0x7f, 0xec, 0x3e, 0x96, 0xcc, 0x3f, 0x4a, 0x3c };
-static const uint8_t chiptest_12cb0ed34854_ct_311[]  = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_311[]    = { 0x62, 0xc5, 0x1e, 0x87, 0x8e, 0xc5, 0x90, 0xa4,
                                                         0x87, 0x74, 0xa7, 0x42, 0x37, 0x8b, 0x4e, 0xd4 };
-static const uint8_t chiptest_12cb0ed34854_iv_312[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_313[] = { 0x97, 0x40, 0xdd, 0x5c, 0xa3, 0x0d, 0x59, 0x86, 0x7b, 0x01, 0x0f,
+static const uint8_t chiptest_12cb0ed34854_nonce_312[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_313[]   = { 0x97, 0x40, 0xdd, 0x5c, 0xa3, 0x0d, 0x59, 0x86, 0x7b, 0x01, 0x0f,
                                                          0xe3, 0x1a, 0xda, 0x21, 0x41, 0x4c, 0xfd, 0x30, 0xa4, 0x4a, 0x2a,
                                                          0xa0, 0x2a, 0x46, 0xcb, 0xfd, 0xaf, 0x94, 0x7e, 0x0a, 0x3b };
-static const uint8_t chiptest_12cb0ed34854_tag_314[] = { 0x02, 0x24, 0xde, 0x7c, 0xeb, 0x9d, 0xe4, 0x6c,
+static const uint8_t chiptest_12cb0ed34854_tag_314[]   = { 0x02, 0x24, 0xde, 0x7c, 0xeb, 0x9d, 0xe4, 0x6c,
                                                          0xad, 0xee, 0xb9, 0x91, 0x17, 0x78, 0xdd, 0x5c };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_315 = { .key     = chiptest_12cb0ed34854_key_309,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_310,
-                                                                              .pt_len  = 16,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_311,
-                                                                              .ct_len  = 16,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_312,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_313,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_314,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 45,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_316[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_315 = { .key       = chiptest_12cb0ed34854_key_309,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_310,
+                                                                              .pt_len    = 16,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_311,
+                                                                              .ct_len    = 16,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_312,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_313,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_314,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 45,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_316[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_317[]  = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
+static const uint8_t chiptest_12cb0ed34854_pt_317[]    = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
                                                         0xc4, 0xd8, 0x8f, 0x58, 0x98, 0x58, 0x17, 0xcb, 0x02, 0xa5, 0xae,
                                                         0x72, 0x03, 0xce, 0x79, 0x9f, 0x73, 0x4d, 0xfd, 0x25, 0xfa, 0x9a };
-static const uint8_t chiptest_12cb0ed34854_ct_318[]  = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_318[]    = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
                                                         0x10, 0x23, 0x3b, 0x5c, 0x70, 0x85, 0x0e, 0x74, 0x40, 0xb9, 0x4b,
                                                         0x03, 0xad, 0xaa, 0xd7, 0x76, 0x6c, 0xe7, 0x13, 0xc5, 0x6d, 0xff };
-static const uint8_t chiptest_12cb0ed34854_iv_319[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_320[]                      = {};
-static const uint8_t chiptest_12cb0ed34854_tag_321[]                      = { 0xeb, 0x2e, 0x20, 0xb6, 0x30, 0x40, 0x48, 0x7e };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_322 = { .key     = chiptest_12cb0ed34854_key_316,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_317,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_318,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_319,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_320,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_321,
-                                                                              .tag_len = 8,
-                                                                              .tcId    = 46,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_323[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_nonce_319[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_320[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_321[]   = { 0xeb, 0x2e, 0x20, 0xb6, 0x30, 0x40, 0x48, 0x7e };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_322 = { .key       = chiptest_12cb0ed34854_key_316,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_317,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_318,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_319,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_320,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_321,
+                                                                              .tag_len   = 8,
+                                                                              .tcId      = 46,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_323[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_324[]  = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
+static const uint8_t chiptest_12cb0ed34854_pt_324[]    = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
                                                         0xc4, 0xd8, 0x8f, 0x58, 0x98, 0x58, 0x17, 0xcb, 0x02, 0xa5, 0xae,
                                                         0x72, 0x03, 0xce, 0x79, 0x9f, 0x73, 0x4d, 0xfd, 0x25, 0xfa, 0x9a };
-static const uint8_t chiptest_12cb0ed34854_ct_325[]  = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_325[]    = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
                                                         0x10, 0x23, 0x3b, 0x5c, 0x70, 0x85, 0x0e, 0x74, 0x40, 0xb9, 0x4b,
                                                         0x03, 0xad, 0xaa, 0xd7, 0x76, 0x6c, 0xe7, 0x13, 0xc5, 0x6d, 0xff };
-static const uint8_t chiptest_12cb0ed34854_iv_326[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_327[] = {};
-static const uint8_t chiptest_12cb0ed34854_tag_328[] = { 0x6a, 0xa7, 0xc4, 0x5d, 0x28, 0x5e, 0xce, 0x89, 0xd3, 0xe6, 0x99, 0x80 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_329 = { .key     = chiptest_12cb0ed34854_key_323,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_324,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_325,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_326,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_327,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_328,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 47,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_330[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_nonce_326[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_327[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_328[]   = { 0x6a, 0xa7, 0xc4, 0x5d, 0x28, 0x5e, 0xce, 0x89, 0xd3, 0xe6, 0x99, 0x80 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_329 = { .key       = chiptest_12cb0ed34854_key_323,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_324,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_325,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_326,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_327,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_328,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 47,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_330[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_331[]  = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
+static const uint8_t chiptest_12cb0ed34854_pt_331[]    = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
                                                         0xc4, 0xd8, 0x8f, 0x58, 0x98, 0x58, 0x17, 0xcb, 0x02, 0xa5, 0xae,
                                                         0x72, 0x03, 0xce, 0x79, 0x9f, 0x73, 0x4d, 0xfd, 0x25, 0xfa, 0x9a };
-static const uint8_t chiptest_12cb0ed34854_ct_332[]  = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_332[]    = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
                                                         0x10, 0x23, 0x3b, 0x5c, 0x70, 0x85, 0x0e, 0x74, 0x40, 0xb9, 0x4b,
                                                         0x03, 0xad, 0xaa, 0xd7, 0x76, 0x6c, 0xe7, 0x13, 0xc5, 0x6d, 0xff };
-static const uint8_t chiptest_12cb0ed34854_iv_333[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_334[]                      = {};
-static const uint8_t chiptest_12cb0ed34854_tag_335[]                      = { 0xfe, 0xbb, 0xb8, 0xc8, 0xf1, 0xce, 0x2a, 0xbd,
+static const uint8_t chiptest_12cb0ed34854_nonce_333[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_334[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_335[]   = { 0xfe, 0xbb, 0xb8, 0xc8, 0xf1, 0xce, 0x2a, 0xbd,
                                                          0x6f, 0x7e, 0x4c, 0x94, 0x20, 0x59, 0xc6, 0x50 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_336 = { .key     = chiptest_12cb0ed34854_key_330,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_331,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_332,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_333,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_334,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_335,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 48,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_337[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_336 = { .key       = chiptest_12cb0ed34854_key_330,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_331,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_332,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_333,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_334,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_335,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 48,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_337[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_338[]  = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
+static const uint8_t chiptest_12cb0ed34854_pt_338[]    = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
                                                         0xc4, 0xd8, 0x8f, 0x58, 0x98, 0x58, 0x17, 0xcb, 0x02, 0xa5, 0xae,
                                                         0x72, 0x03, 0xce, 0x79, 0x9f, 0x73, 0x4d, 0xfd, 0x25, 0xfa, 0x9a };
-static const uint8_t chiptest_12cb0ed34854_ct_339[]  = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_339[]    = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
                                                         0x10, 0x23, 0x3b, 0x5c, 0x70, 0x85, 0x0e, 0x74, 0x40, 0xb9, 0x4b,
                                                         0x03, 0xad, 0xaa, 0xd7, 0x76, 0x6c, 0xe7, 0x13, 0xc5, 0x6d, 0xff };
-static const uint8_t chiptest_12cb0ed34854_iv_340[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_341[]                      = { 0x2e };
-static const uint8_t chiptest_12cb0ed34854_tag_342[]                      = { 0xa6, 0xfe, 0xf8, 0xd7, 0x72, 0x8a, 0xb1, 0xe2 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_343 = { .key     = chiptest_12cb0ed34854_key_337,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_338,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_339,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_340,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_341,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_342,
-                                                                              .tag_len = 8,
-                                                                              .tcId    = 49,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_344[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_nonce_340[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_341[]   = { 0x2e };
+static const uint8_t chiptest_12cb0ed34854_tag_342[]   = { 0xa6, 0xfe, 0xf8, 0xd7, 0x72, 0x8a, 0xb1, 0xe2 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_343 = { .key       = chiptest_12cb0ed34854_key_337,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_338,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_339,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_340,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_341,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_342,
+                                                                              .tag_len   = 8,
+                                                                              .tcId      = 49,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_344[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_345[]  = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
+static const uint8_t chiptest_12cb0ed34854_pt_345[]    = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
                                                         0xc4, 0xd8, 0x8f, 0x58, 0x98, 0x58, 0x17, 0xcb, 0x02, 0xa5, 0xae,
                                                         0x72, 0x03, 0xce, 0x79, 0x9f, 0x73, 0x4d, 0xfd, 0x25, 0xfa, 0x9a };
-static const uint8_t chiptest_12cb0ed34854_ct_346[]  = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_346[]    = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
                                                         0x10, 0x23, 0x3b, 0x5c, 0x70, 0x85, 0x0e, 0x74, 0x40, 0xb9, 0x4b,
                                                         0x03, 0xad, 0xaa, 0xd7, 0x76, 0x6c, 0xe7, 0x13, 0xc5, 0x6d, 0xff };
-static const uint8_t chiptest_12cb0ed34854_iv_347[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_348[] = { 0x2e };
-static const uint8_t chiptest_12cb0ed34854_tag_349[] = { 0xc4, 0xce, 0x9d, 0xc5, 0xbc, 0x36, 0xb7, 0xa0, 0xc0, 0x35, 0x6f, 0xd6 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_350 = { .key     = chiptest_12cb0ed34854_key_344,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_345,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_346,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_347,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_348,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_349,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 50,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_351[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_nonce_347[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_348[]   = { 0x2e };
+static const uint8_t chiptest_12cb0ed34854_tag_349[]   = { 0xc4, 0xce, 0x9d, 0xc5, 0xbc, 0x36, 0xb7, 0xa0, 0xc0, 0x35, 0x6f, 0xd6 };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_350 = { .key       = chiptest_12cb0ed34854_key_344,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_345,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_346,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_347,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_348,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_349,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 50,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_351[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_352[]  = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
+static const uint8_t chiptest_12cb0ed34854_pt_352[]    = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
                                                         0xc4, 0xd8, 0x8f, 0x58, 0x98, 0x58, 0x17, 0xcb, 0x02, 0xa5, 0xae,
                                                         0x72, 0x03, 0xce, 0x79, 0x9f, 0x73, 0x4d, 0xfd, 0x25, 0xfa, 0x9a };
-static const uint8_t chiptest_12cb0ed34854_ct_353[]  = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_353[]    = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
                                                         0x10, 0x23, 0x3b, 0x5c, 0x70, 0x85, 0x0e, 0x74, 0x40, 0xb9, 0x4b,
                                                         0x03, 0xad, 0xaa, 0xd7, 0x76, 0x6c, 0xe7, 0x13, 0xc5, 0x6d, 0xff };
-static const uint8_t chiptest_12cb0ed34854_iv_354[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_355[]                      = { 0x2e };
-static const uint8_t chiptest_12cb0ed34854_tag_356[]                      = { 0xd4, 0x35, 0x7e, 0x1a, 0x3e, 0x22, 0xd0, 0x37,
+static const uint8_t chiptest_12cb0ed34854_nonce_354[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_355[]   = { 0x2e };
+static const uint8_t chiptest_12cb0ed34854_tag_356[]   = { 0xd4, 0x35, 0x7e, 0x1a, 0x3e, 0x22, 0xd0, 0x37,
                                                          0x25, 0x9d, 0x7b, 0xb0, 0x86, 0x32, 0x0a, 0x81 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_357 = { .key     = chiptest_12cb0ed34854_key_351,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_352,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_353,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_354,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_355,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_356,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 51,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_358[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_357 = { .key       = chiptest_12cb0ed34854_key_351,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_352,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_353,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_354,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_355,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_356,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 51,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_358[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_359[]  = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
+static const uint8_t chiptest_12cb0ed34854_pt_359[]    = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
                                                         0xc4, 0xd8, 0x8f, 0x58, 0x98, 0x58, 0x17, 0xcb, 0x02, 0xa5, 0xae,
                                                         0x72, 0x03, 0xce, 0x79, 0x9f, 0x73, 0x4d, 0xfd, 0x25, 0xfa, 0x9a };
-static const uint8_t chiptest_12cb0ed34854_ct_360[]  = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_360[]    = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
                                                         0x10, 0x23, 0x3b, 0x5c, 0x70, 0x85, 0x0e, 0x74, 0x40, 0xb9, 0x4b,
                                                         0x03, 0xad, 0xaa, 0xd7, 0x76, 0x6c, 0xe7, 0x13, 0xc5, 0x6d, 0xff };
-static const uint8_t chiptest_12cb0ed34854_iv_361[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_362[] = { 0x98, 0x5b, 0xf0, 0x38, 0x16, 0xe9, 0x29, 0xce, 0x66, 0x81, 0x0d,
+static const uint8_t chiptest_12cb0ed34854_nonce_361[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_362[]   = { 0x98, 0x5b, 0xf0, 0x38, 0x16, 0xe9, 0x29, 0xce, 0x66, 0x81, 0x0d,
                                                          0x7e, 0x1a, 0x78, 0x46, 0xc9, 0x1e, 0x05, 0x68, 0x6d, 0x0e, 0xcf,
                                                          0x8f, 0x94, 0x31, 0x0a, 0x37, 0xa1, 0xc0, 0x76, 0x1b, 0x04 };
-static const uint8_t chiptest_12cb0ed34854_tag_363[] = { 0x5f, 0x56, 0xb2, 0x9e, 0xc3, 0xdd, 0x21, 0x2d };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_364 = { .key     = chiptest_12cb0ed34854_key_358,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_359,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_360,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_361,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_362,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_363,
-                                                                              .tag_len = 8,
-                                                                              .tcId    = 52,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_365[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_tag_363[]   = { 0x5f, 0x56, 0xb2, 0x9e, 0xc3, 0xdd, 0x21, 0x2d };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_364 = { .key       = chiptest_12cb0ed34854_key_358,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_359,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_360,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_361,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_362,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_363,
+                                                                              .tag_len   = 8,
+                                                                              .tcId      = 52,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_365[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_366[]  = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
+static const uint8_t chiptest_12cb0ed34854_pt_366[]    = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
                                                         0xc4, 0xd8, 0x8f, 0x58, 0x98, 0x58, 0x17, 0xcb, 0x02, 0xa5, 0xae,
                                                         0x72, 0x03, 0xce, 0x79, 0x9f, 0x73, 0x4d, 0xfd, 0x25, 0xfa, 0x9a };
-static const uint8_t chiptest_12cb0ed34854_ct_367[]  = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_367[]    = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
                                                         0x10, 0x23, 0x3b, 0x5c, 0x70, 0x85, 0x0e, 0x74, 0x40, 0xb9, 0x4b,
                                                         0x03, 0xad, 0xaa, 0xd7, 0x76, 0x6c, 0xe7, 0x13, 0xc5, 0x6d, 0xff };
-static const uint8_t chiptest_12cb0ed34854_iv_368[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_369[] = { 0x98, 0x5b, 0xf0, 0x38, 0x16, 0xe9, 0x29, 0xce, 0x66, 0x81, 0x0d,
+static const uint8_t chiptest_12cb0ed34854_nonce_368[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_369[]   = { 0x98, 0x5b, 0xf0, 0x38, 0x16, 0xe9, 0x29, 0xce, 0x66, 0x81, 0x0d,
                                                          0x7e, 0x1a, 0x78, 0x46, 0xc9, 0x1e, 0x05, 0x68, 0x6d, 0x0e, 0xcf,
                                                          0x8f, 0x94, 0x31, 0x0a, 0x37, 0xa1, 0xc0, 0x76, 0x1b, 0x04 };
-static const uint8_t chiptest_12cb0ed34854_tag_370[] = { 0x11, 0xcf, 0x30, 0xd3, 0xdf, 0x32, 0x4b, 0xa0, 0xe4, 0x82, 0x64, 0x8a };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_371 = { .key     = chiptest_12cb0ed34854_key_365,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_366,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_367,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_368,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_369,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_370,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 53,
-                                                                              .result  = CHIP_NO_ERROR };
-static const uint8_t chiptest_12cb0ed34854_key_372[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_tag_370[]   = { 0x11, 0xcf, 0x30, 0xd3, 0xdf, 0x32, 0x4b, 0xa0, 0xe4, 0x82, 0x64, 0x8a };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_371 = { .key       = chiptest_12cb0ed34854_key_365,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_366,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_367,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_368,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_369,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_370,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 53,
+                                                                              .result    = CHIP_NO_ERROR };
+static const uint8_t chiptest_12cb0ed34854_key_372[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                          0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                          0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_373[]  = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
+static const uint8_t chiptest_12cb0ed34854_pt_373[]    = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
                                                         0xc4, 0xd8, 0x8f, 0x58, 0x98, 0x58, 0x17, 0xcb, 0x02, 0xa5, 0xae,
                                                         0x72, 0x03, 0xce, 0x79, 0x9f, 0x73, 0x4d, 0xfd, 0x25, 0xfa, 0x9a };
-static const uint8_t chiptest_12cb0ed34854_ct_374[]  = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_374[]    = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
                                                         0x10, 0x23, 0x3b, 0x5c, 0x70, 0x85, 0x0e, 0x74, 0x40, 0xb9, 0x4b,
                                                         0x03, 0xad, 0xaa, 0xd7, 0x76, 0x6c, 0xe7, 0x13, 0xc5, 0x6d, 0xff };
-static const uint8_t chiptest_12cb0ed34854_iv_375[]  = {
-    0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d, 0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9
-};
-static const uint8_t chiptest_12cb0ed34854_aad_376[] = { 0x98, 0x5b, 0xf0, 0x38, 0x16, 0xe9, 0x29, 0xce, 0x66, 0x81, 0x0d,
+static const uint8_t chiptest_12cb0ed34854_nonce_375[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                           0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_376[]   = { 0x98, 0x5b, 0xf0, 0x38, 0x16, 0xe9, 0x29, 0xce, 0x66, 0x81, 0x0d,
                                                          0x7e, 0x1a, 0x78, 0x46, 0xc9, 0x1e, 0x05, 0x68, 0x6d, 0x0e, 0xcf,
                                                          0x8f, 0x94, 0x31, 0x0a, 0x37, 0xa1, 0xc0, 0x76, 0x1b, 0x04 };
-static const uint8_t chiptest_12cb0ed34854_tag_377[] = { 0x07, 0x57, 0x3b, 0xc7, 0x7f, 0xa9, 0x58, 0x63,
+static const uint8_t chiptest_12cb0ed34854_tag_377[]   = { 0x07, 0x57, 0x3b, 0xc7, 0x7f, 0xa9, 0x58, 0x63,
                                                          0xde, 0xc4, 0x16, 0xd6, 0xbe, 0x3b, 0x1e, 0xb3 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_378 = { .key     = chiptest_12cb0ed34854_key_372,
-                                                                              .key_len = 32,
-                                                                              .pt      = chiptest_12cb0ed34854_pt_373,
-                                                                              .pt_len  = 33,
-                                                                              .ct      = chiptest_12cb0ed34854_ct_374,
-                                                                              .ct_len  = 33,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_375,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_376,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_377,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 54,
-                                                                              .result  = CHIP_NO_ERROR };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_379 = { .key     = chiptest_12cb0ed34854_key_1,
-                                                                              .key_len = 32,
-                                                                              .pt      = nullptr,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = nullptr,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_4,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_5,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_6,
-                                                                              .tag_len = 8,
-                                                                              .tcId    = 1,
-                                                                              .result  = CHIP_NO_ERROR };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_378 = { .key       = chiptest_12cb0ed34854_key_372,
+                                                                              .key_len   = 32,
+                                                                              .pt        = chiptest_12cb0ed34854_pt_373,
+                                                                              .pt_len    = 33,
+                                                                              .ct        = chiptest_12cb0ed34854_ct_374,
+                                                                              .ct_len    = 33,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_375,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_376,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_377,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 54,
+                                                                              .result    = CHIP_NO_ERROR };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_379 = { .key       = chiptest_12cb0ed34854_key_1,
+                                                                              .key_len   = 32,
+                                                                              .pt        = nullptr,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = nullptr,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_4,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_5,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_6,
+                                                                              .tag_len   = 8,
+                                                                              .tcId      = 1,
+                                                                              .result    = CHIP_NO_ERROR };
 
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_380 = { .key     = chiptest_12cb0ed34854_key_8,
-                                                                              .key_len = 32,
-                                                                              .pt      = nullptr,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = nullptr,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_11,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_12,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_13,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 2,
-                                                                              .result  = CHIP_NO_ERROR };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_380 = { .key       = chiptest_12cb0ed34854_key_8,
+                                                                              .key_len   = 32,
+                                                                              .pt        = nullptr,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = nullptr,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_11,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_12,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_13,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 2,
+                                                                              .result    = CHIP_NO_ERROR };
 
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_381 = { .key     = chiptest_12cb0ed34854_key_15,
-                                                                              .key_len = 32,
-                                                                              .pt      = nullptr,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = nullptr,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_18,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_19,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_20,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 3,
-                                                                              .result  = CHIP_NO_ERROR };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_381 = { .key       = chiptest_12cb0ed34854_key_15,
+                                                                              .key_len   = 32,
+                                                                              .pt        = nullptr,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = nullptr,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_18,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_19,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_20,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 3,
+                                                                              .result    = CHIP_NO_ERROR };
 
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_382 = { .key     = chiptest_12cb0ed34854_key_22,
-                                                                              .key_len = 32,
-                                                                              .pt      = nullptr,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = nullptr,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_25,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_26,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_27,
-                                                                              .tag_len = 8,
-                                                                              .tcId    = 4,
-                                                                              .result  = CHIP_NO_ERROR };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_382 = { .key       = chiptest_12cb0ed34854_key_22,
+                                                                              .key_len   = 32,
+                                                                              .pt        = nullptr,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = nullptr,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_25,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_26,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_27,
+                                                                              .tag_len   = 8,
+                                                                              .tcId      = 4,
+                                                                              .result    = CHIP_NO_ERROR };
 
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_383 = { .key     = chiptest_12cb0ed34854_key_29,
-                                                                              .key_len = 32,
-                                                                              .pt      = nullptr,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = nullptr,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_32,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_33,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_34,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 5,
-                                                                              .result  = CHIP_NO_ERROR };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_383 = { .key       = chiptest_12cb0ed34854_key_29,
+                                                                              .key_len   = 32,
+                                                                              .pt        = nullptr,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = nullptr,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_32,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_33,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_34,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 5,
+                                                                              .result    = CHIP_NO_ERROR };
 
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_384 = { .key     = chiptest_12cb0ed34854_key_36,
-                                                                              .key_len = 32,
-                                                                              .pt      = nullptr,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = nullptr,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_39,
-                                                                              .iv_len  = 7,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_40,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_41,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 6,
-                                                                              .result  = CHIP_NO_ERROR };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_384 = { .key       = chiptest_12cb0ed34854_key_36,
+                                                                              .key_len   = 32,
+                                                                              .pt        = nullptr,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = nullptr,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_39,
+                                                                              .nonce_len = 7,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_40,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_41,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 6,
+                                                                              .result    = CHIP_NO_ERROR };
 
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_385 = { .key     = chiptest_12cb0ed34854_key_190,
-                                                                              .key_len = 32,
-                                                                              .pt      = nullptr,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = nullptr,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_193,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_194,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_195,
-                                                                              .tag_len = 8,
-                                                                              .tcId    = 28,
-                                                                              .result  = CHIP_NO_ERROR };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_385 = { .key       = chiptest_12cb0ed34854_key_190,
+                                                                              .key_len   = 32,
+                                                                              .pt        = nullptr,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = nullptr,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_193,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_194,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_195,
+                                                                              .tag_len   = 8,
+                                                                              .tcId      = 28,
+                                                                              .result    = CHIP_NO_ERROR };
 
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_386 = { .key     = chiptest_12cb0ed34854_key_197,
-                                                                              .key_len = 32,
-                                                                              .pt      = nullptr,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = nullptr,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_200,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_201,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_202,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 29,
-                                                                              .result  = CHIP_NO_ERROR };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_386 = { .key       = chiptest_12cb0ed34854_key_197,
+                                                                              .key_len   = 32,
+                                                                              .pt        = nullptr,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = nullptr,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_200,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_201,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_202,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 29,
+                                                                              .result    = CHIP_NO_ERROR };
 
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_387 = { .key     = chiptest_12cb0ed34854_key_204,
-                                                                              .key_len = 32,
-                                                                              .pt      = nullptr,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = nullptr,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_207,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_208,
-                                                                              .aad_len = 0,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_209,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 30,
-                                                                              .result  = CHIP_NO_ERROR };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_387 = { .key       = chiptest_12cb0ed34854_key_204,
+                                                                              .key_len   = 32,
+                                                                              .pt        = nullptr,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = nullptr,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_207,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_208,
+                                                                              .aad_len   = 0,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_209,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 30,
+                                                                              .result    = CHIP_NO_ERROR };
 
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_388 = { .key     = chiptest_12cb0ed34854_key_218,
-                                                                              .key_len = 32,
-                                                                              .pt      = nullptr,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = nullptr,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_221,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_222,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_223,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 32,
-                                                                              .result  = CHIP_NO_ERROR };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_388 = { .key       = chiptest_12cb0ed34854_key_218,
+                                                                              .key_len   = 32,
+                                                                              .pt        = nullptr,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = nullptr,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_221,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_222,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_223,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 32,
+                                                                              .result    = CHIP_NO_ERROR };
 
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_389 = { .key     = chiptest_12cb0ed34854_key_225,
-                                                                              .key_len = 32,
-                                                                              .pt      = nullptr,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = nullptr,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_228,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_229,
-                                                                              .aad_len = 1,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_230,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 33,
-                                                                              .result  = CHIP_NO_ERROR };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_389 = { .key       = chiptest_12cb0ed34854_key_225,
+                                                                              .key_len   = 32,
+                                                                              .pt        = nullptr,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = nullptr,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_228,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_229,
+                                                                              .aad_len   = 1,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_230,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 33,
+                                                                              .result    = CHIP_NO_ERROR };
 
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_390 = { .key     = chiptest_12cb0ed34854_key_239,
-                                                                              .key_len = 32,
-                                                                              .pt      = nullptr,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = nullptr,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_242,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_243,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_244,
-                                                                              .tag_len = 12,
-                                                                              .tcId    = 35,
-                                                                              .result  = CHIP_NO_ERROR };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_390 = { .key       = chiptest_12cb0ed34854_key_239,
+                                                                              .key_len   = 32,
+                                                                              .pt        = nullptr,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = nullptr,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_242,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_243,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_244,
+                                                                              .tag_len   = 12,
+                                                                              .tcId      = 35,
+                                                                              .result    = CHIP_NO_ERROR };
 
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_391 = { .key     = chiptest_12cb0ed34854_key_246,
-                                                                              .key_len = 32,
-                                                                              .pt      = nullptr,
-                                                                              .pt_len  = 0,
-                                                                              .ct      = nullptr,
-                                                                              .ct_len  = 0,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_249,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_250,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_251,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 36,
-                                                                              .result  = CHIP_NO_ERROR };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_391 = { .key       = chiptest_12cb0ed34854_key_246,
+                                                                              .key_len   = 32,
+                                                                              .pt        = nullptr,
+                                                                              .pt_len    = 0,
+                                                                              .ct        = nullptr,
+                                                                              .ct_len    = 0,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_249,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_250,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_251,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 36,
+                                                                              .result    = CHIP_NO_ERROR };
 
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_392 = { .key     = chiptest_12cb0ed34854_key_246,
-                                                                              .key_len = 32,
-                                                                              .pt      = nullptr,
-                                                                              .pt_len  = 8,
-                                                                              .ct      = nullptr,
-                                                                              .ct_len  = 8,
-                                                                              .iv      = chiptest_12cb0ed34854_iv_249,
-                                                                              .iv_len  = 13,
-                                                                              .aad     = chiptest_12cb0ed34854_aad_250,
-                                                                              .aad_len = 32,
-                                                                              .tag     = chiptest_12cb0ed34854_tag_251,
-                                                                              .tag_len = 16,
-                                                                              .tcId    = 36,
-                                                                              .result  = CHIP_ERROR_INVALID_ARGUMENT };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_392 = { .key       = chiptest_12cb0ed34854_key_246,
+                                                                              .key_len   = 32,
+                                                                              .pt        = nullptr,
+                                                                              .pt_len    = 8,
+                                                                              .ct        = nullptr,
+                                                                              .ct_len    = 8,
+                                                                              .nonce     = chiptest_12cb0ed34854_nonce_249,
+                                                                              .nonce_len = 13,
+                                                                              .aad       = chiptest_12cb0ed34854_aad_250,
+                                                                              .aad_len   = 32,
+                                                                              .tag       = chiptest_12cb0ed34854_tag_251,
+                                                                              .tag_len   = 16,
+                                                                              .tcId      = 36,
+                                                                              .result    = CHIP_ERROR_INVALID_ARGUMENT };
 
 static const struct ccm_test_vector * ccm_test_vectors[] = {
     &chiptest_12cb0ed34854_test_vector_7,   &chiptest_12cb0ed34854_test_vector_14,  &chiptest_12cb0ed34854_test_vector_21,
@@ -1682,64 +1655,64 @@ static const struct ccm_test_vector * ccm_test_vectors[] = {
 };
 
 // These are some invalid vectors where the ct bits have been flipped.
-static const uint8_t chiptest_12cb0ed34854_key_3721[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_key_3721[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                           0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                           0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_3731[]  = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
+static const uint8_t chiptest_12cb0ed34854_pt_3731[]    = { 0xee, 0xc3, 0xe6, 0xc0, 0xe5, 0x62, 0xa7, 0xea, 0xe0, 0x5c, 0x3d,
                                                          0xc4, 0xd8, 0x8f, 0x58, 0x98, 0x58, 0x17, 0xcb, 0x02, 0xa5, 0xae,
                                                          0x72, 0x03, 0xce, 0x79, 0x9f, 0x73, 0x4d, 0xfd, 0x25, 0xfa, 0x9a };
-static const uint8_t chiptest_12cb0ed34854_ct_3741[]  = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
+static const uint8_t chiptest_12cb0ed34854_ct_3741[]    = { 0x22, 0x0b, 0x7a, 0x3c, 0xde, 0x64, 0x41, 0x34, 0x18, 0xc4, 0xa4,
                                                          0x10, 0x23, 0x3b, 0x5c, 0x71, 0x85, 0x0e, 0x74, 0x40, 0xb9, 0x4b,
                                                          0x03, 0xad, 0xaa, 0xd7, 0x76, 0x6c, 0xe7, 0x13, 0xc5, 0x6d, 0xff };
-static const uint8_t chiptest_12cb0ed34854_iv_3751[]  = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
-                                                         0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
-static const uint8_t chiptest_12cb0ed34854_aad_3761[] = { 0x98, 0x5b, 0xf0, 0x38, 0x16, 0xe9, 0x29, 0xce, 0x66, 0x81, 0x0d,
+static const uint8_t chiptest_12cb0ed34854_nonce_3751[] = { 0x95, 0xf9, 0x61, 0x8a, 0x2c, 0x8f, 0x0d,
+                                                            0x28, 0xb5, 0xbb, 0xe5, 0x8c, 0xe9 };
+static const uint8_t chiptest_12cb0ed34854_aad_3761[]   = { 0x98, 0x5b, 0xf0, 0x38, 0x16, 0xe9, 0x29, 0xce, 0x66, 0x81, 0x0d,
                                                           0x7e, 0x1a, 0x78, 0x46, 0xc9, 0x1e, 0x05, 0x68, 0x6d, 0x0e, 0xcf,
                                                           0x8f, 0x94, 0x31, 0x0a, 0x37, 0xa1, 0xc0, 0x76, 0x1b, 0x04 };
-static const uint8_t chiptest_12cb0ed34854_tag_3771[] = { 0x07, 0x57, 0x3b, 0xc7, 0x7f, 0xa9, 0x58, 0x63,
+static const uint8_t chiptest_12cb0ed34854_tag_3771[]   = { 0x07, 0x57, 0x3b, 0xc7, 0x7f, 0xa9, 0x58, 0x63,
                                                           0xde, 0xc4, 0x16, 0xd6, 0xbe, 0x3b, 0x1e, 0xb3 };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_3781 = { .key     = chiptest_12cb0ed34854_key_3721,
-                                                                               .key_len = 32,
-                                                                               .pt      = chiptest_12cb0ed34854_pt_3731,
-                                                                               .pt_len  = 33,
-                                                                               .ct      = chiptest_12cb0ed34854_ct_3741,
-                                                                               .ct_len  = 33,
-                                                                               .iv      = chiptest_12cb0ed34854_iv_3751,
-                                                                               .iv_len  = 13,
-                                                                               .aad     = chiptest_12cb0ed34854_aad_3761,
-                                                                               .aad_len = 32,
-                                                                               .tag     = chiptest_12cb0ed34854_tag_3771,
-                                                                               .tag_len = 16,
-                                                                               .tcId    = 54,
-                                                                               .result  = CHIP_ERROR_INTERNAL };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_3781 = { .key       = chiptest_12cb0ed34854_key_3721,
+                                                                               .key_len   = 32,
+                                                                               .pt        = chiptest_12cb0ed34854_pt_3731,
+                                                                               .pt_len    = 33,
+                                                                               .ct        = chiptest_12cb0ed34854_ct_3741,
+                                                                               .ct_len    = 33,
+                                                                               .nonce     = chiptest_12cb0ed34854_nonce_3751,
+                                                                               .nonce_len = 13,
+                                                                               .aad       = chiptest_12cb0ed34854_aad_3761,
+                                                                               .aad_len   = 32,
+                                                                               .tag       = chiptest_12cb0ed34854_tag_3771,
+                                                                               .tag_len   = 16,
+                                                                               .tcId      = 54,
+                                                                               .result    = CHIP_ERROR_INTERNAL };
 
-static const uint8_t chiptest_12cb0ed34854_key_1411[] = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
+static const uint8_t chiptest_12cb0ed34854_key_1411[]   = { 0x4a, 0x45, 0x65, 0x85, 0xb8, 0xd3, 0xd2, 0xf2, 0x39, 0x51, 0xf2,
                                                           0x74, 0xbd, 0x98, 0xe6, 0x65, 0x5e, 0xd5, 0x3f, 0x3c, 0xec, 0x05,
                                                           0xa4, 0x65, 0xd0, 0x20, 0xb0, 0xdf, 0x6a, 0x33, 0x45, 0xd5 };
-static const uint8_t chiptest_12cb0ed34854_pt_1421[]  = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
+static const uint8_t chiptest_12cb0ed34854_pt_1421[]    = { 0xcd, 0x59, 0xde, 0x72, 0x61, 0x2d, 0x17, 0x54, 0xf8, 0x26, 0xe1,
                                                          0x99, 0x65, 0x6b, 0x47, 0x21, 0x50, 0xd8, 0xf5, 0x9a, 0xf1, 0x5f,
                                                          0xba, 0x7d, 0x49, 0xd7, 0xa3, 0x2b, 0x7f, 0xb4, 0x11, 0x30, 0x03 };
-static const uint8_t chiptest_12cb0ed34854_ct_1431[]  = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
+static const uint8_t chiptest_12cb0ed34854_ct_1431[]    = { 0x9a, 0x48, 0xb4, 0x6d, 0x76, 0x24, 0xf5, 0xc1, 0x5f, 0x65, 0x45,
                                                          0x91, 0x11, 0x39, 0x53, 0x1f, 0x2b, 0x25, 0xed, 0xcf, 0x6a, 0x9c,
                                                          0xfd, 0x27, 0x9b, 0x16, 0x28, 0xcd, 0xa4, 0x5f, 0x58, 0xd0, 0x3e };
-static const uint8_t chiptest_12cb0ed34854_iv_1441[]  = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
-static const uint8_t chiptest_12cb0ed34854_aad_1451[] = {};
-static const uint8_t chiptest_12cb0ed34854_tag_1461[] = { 0xab, 0x73, 0x1f, 0xc8, 0x0a, 0xde, 0x38, 0xf1,
+static const uint8_t chiptest_12cb0ed34854_nonce_1441[] = { 0xaf, 0x38, 0xfc, 0xd0, 0x6b, 0x87, 0x80 };
+static const uint8_t chiptest_12cb0ed34854_aad_1451[]   = {};
+static const uint8_t chiptest_12cb0ed34854_tag_1461[]   = { 0xab, 0x73, 0x1f, 0xc8, 0x0a, 0xde, 0x38, 0xf1,
                                                           0xa9, 0x84, 0x60, 0x6e, 0xae, 0x05, 0xa0, 0x2b };
-static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_1471 = { .key     = chiptest_12cb0ed34854_key_1411,
-                                                                               .key_len = 32,
-                                                                               .pt      = chiptest_12cb0ed34854_pt_1421,
-                                                                               .pt_len  = 33,
-                                                                               .ct      = chiptest_12cb0ed34854_ct_1431,
-                                                                               .ct_len  = 33,
-                                                                               .iv      = chiptest_12cb0ed34854_iv_1441,
-                                                                               .iv_len  = 7,
-                                                                               .aad     = chiptest_12cb0ed34854_aad_1451,
-                                                                               .aad_len = 0,
-                                                                               .tag     = chiptest_12cb0ed34854_tag_1461,
-                                                                               .tag_len = 16,
-                                                                               .tcId    = 21,
-                                                                               .result  = CHIP_ERROR_INTERNAL };
+static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_1471 = { .key       = chiptest_12cb0ed34854_key_1411,
+                                                                               .key_len   = 32,
+                                                                               .pt        = chiptest_12cb0ed34854_pt_1421,
+                                                                               .pt_len    = 33,
+                                                                               .ct        = chiptest_12cb0ed34854_ct_1431,
+                                                                               .ct_len    = 33,
+                                                                               .nonce     = chiptest_12cb0ed34854_nonce_1441,
+                                                                               .nonce_len = 7,
+                                                                               .aad       = chiptest_12cb0ed34854_aad_1451,
+                                                                               .aad_len   = 0,
+                                                                               .tag       = chiptest_12cb0ed34854_tag_1461,
+                                                                               .tag_len   = 16,
+                                                                               .tcId      = 21,
+                                                                               .result    = CHIP_ERROR_INTERNAL };
 
 static const struct ccm_test_vector * ccm_invalid_test_vectors[] = { &chiptest_12cb0ed34854_test_vector_3781,
                                                                      &chiptest_12cb0ed34854_test_vector_1471 };

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -179,7 +179,7 @@ static void TestAES_CCM_256EncryptTestVectors(nlTestSuite * inSuite, void * inCo
             NL_TEST_ASSERT(inSuite, out_tag);
 
             CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->key_len,
-                                             vector->iv, vector->iv_len, out_ct_ptr, out_tag.Get(), vector->tag_len);
+                                             vector->nonce, vector->nonce_len, out_ct_ptr, out_tag.Get(), vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == vector->result);
 
             if (vector->result == CHIP_NO_ERROR)
@@ -223,7 +223,7 @@ static void TestAES_CCM_256DecryptTestVectors(nlTestSuite * inSuite, void * inCo
                 out_pt_ptr = out_pt.Get();
             }
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                             vector->key, vector->key_len, vector->iv, vector->iv_len, out_pt_ptr);
+                                             vector->key, vector->key_len, vector->nonce, vector->nonce_len, out_pt_ptr);
 
             NL_TEST_ASSERT(inSuite, err == vector->result);
 
@@ -259,8 +259,8 @@ static void TestAES_CCM_256EncryptNilKey(nlTestSuite * inSuite, void * inContext
             out_tag.Alloc(vector->tag_len);
             NL_TEST_ASSERT(inSuite, out_tag);
 
-            CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, nullptr, 32, vector->iv,
-                                             vector->iv_len, out_ct.Get(), out_tag.Get(), vector->tag_len);
+            CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, nullptr, 32, vector->nonce,
+                                             vector->nonce_len, out_ct.Get(), out_tag.Get(), vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -268,7 +268,7 @@ static void TestAES_CCM_256EncryptNilKey(nlTestSuite * inSuite, void * inContext
     NL_TEST_ASSERT(inSuite, numOfTestsRan > 0);
 }
 
-static void TestAES_CCM_256EncryptInvalidIVLen(nlTestSuite * inSuite, void * inContext)
+static void TestAES_CCM_256EncryptInvalidNonceLen(nlTestSuite * inSuite, void * inContext)
 {
     HeapChecker heapChecker(inSuite);
     int numOfTestVectors = ArraySize(ccm_test_vectors);
@@ -287,7 +287,7 @@ static void TestAES_CCM_256EncryptInvalidIVLen(nlTestSuite * inSuite, void * inC
             NL_TEST_ASSERT(inSuite, out_tag);
 
             CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->key_len,
-                                             vector->iv, 0, out_ct.Get(), out_tag.Get(), vector->tag_len);
+                                             vector->nonce, 0, out_ct.Get(), out_tag.Get(), vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -314,7 +314,7 @@ static void TestAES_CCM_256EncryptInvalidTagLen(nlTestSuite * inSuite, void * in
             NL_TEST_ASSERT(inSuite, out_tag);
 
             CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->key_len,
-                                             vector->iv, vector->iv_len, out_ct.Get(), out_tag.Get(), 13);
+                                             vector->nonce, vector->nonce_len, out_ct.Get(), out_tag.Get(), 13);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -337,7 +337,7 @@ static void TestAES_CCM_256DecryptInvalidKey(nlTestSuite * inSuite, void * inCon
             out_pt.Alloc(vector->pt_len);
             NL_TEST_ASSERT(inSuite, out_pt);
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                             nullptr, 32, vector->iv, vector->iv_len, out_pt.Get());
+                                             nullptr, 32, vector->nonce, vector->nonce_len, out_pt.Get());
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -345,7 +345,7 @@ static void TestAES_CCM_256DecryptInvalidKey(nlTestSuite * inSuite, void * inCon
     NL_TEST_ASSERT(inSuite, numOfTestsRan > 0);
 }
 
-static void TestAES_CCM_256DecryptInvalidIVLen(nlTestSuite * inSuite, void * inContext)
+static void TestAES_CCM_256DecryptInvalidNonceLen(nlTestSuite * inSuite, void * inContext)
 {
     HeapChecker heapChecker(inSuite);
     int numOfTestVectors = ArraySize(ccm_test_vectors);
@@ -360,7 +360,7 @@ static void TestAES_CCM_256DecryptInvalidIVLen(nlTestSuite * inSuite, void * inC
             out_pt.Alloc(vector->pt_len);
             NL_TEST_ASSERT(inSuite, out_pt);
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                             vector->key, vector->key_len, vector->iv, 0, out_pt.Get());
+                                             vector->key, vector->key_len, vector->nonce, 0, out_pt.Get());
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -383,7 +383,7 @@ static void TestAES_CCM_256DecryptInvalidTestVectors(nlTestSuite * inSuite, void
             out_pt.Alloc(vector->pt_len);
             NL_TEST_ASSERT(inSuite, out_pt);
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                             vector->key, vector->key_len, vector->iv, vector->iv_len, out_pt.Get());
+                                             vector->key, vector->key_len, vector->nonce, vector->nonce_len, out_pt.Get());
 
             bool arePTsEqual = memcmp(vector->pt, out_pt.Get(), vector->pt_len) == 0;
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INTERNAL);
@@ -412,7 +412,7 @@ static void TestAES_CCM_128EncryptTestVectors(nlTestSuite * inSuite, void * inCo
             NL_TEST_ASSERT(inSuite, out_tag);
 
             CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->key_len,
-                                             vector->iv, vector->iv_len, out_ct.Get(), out_tag.Get(), vector->tag_len);
+                                             vector->nonce, vector->nonce_len, out_ct.Get(), out_tag.Get(), vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == vector->result);
 
             if (vector->result == CHIP_NO_ERROR)
@@ -450,7 +450,7 @@ static void TestAES_CCM_128DecryptTestVectors(nlTestSuite * inSuite, void * inCo
             out_pt.Alloc(vector->pt_len);
             NL_TEST_ASSERT(inSuite, out_pt);
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                             vector->key, vector->key_len, vector->iv, vector->iv_len, out_pt.Get());
+                                             vector->key, vector->key_len, vector->nonce, vector->nonce_len, out_pt.Get());
 
             NL_TEST_ASSERT(inSuite, err == vector->result);
             if (vector->result == CHIP_NO_ERROR)
@@ -485,8 +485,8 @@ static void TestAES_CCM_128EncryptNilKey(nlTestSuite * inSuite, void * inContext
             out_tag.Alloc(vector->tag_len);
             NL_TEST_ASSERT(inSuite, out_tag);
 
-            CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, nullptr, 0, vector->iv,
-                                             vector->iv_len, out_ct.Get(), out_tag.Get(), vector->tag_len);
+            CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, nullptr, 0, vector->nonce,
+                                             vector->nonce_len, out_ct.Get(), out_tag.Get(), vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -494,7 +494,7 @@ static void TestAES_CCM_128EncryptNilKey(nlTestSuite * inSuite, void * inContext
     NL_TEST_ASSERT(inSuite, numOfTestsRan > 0);
 }
 
-static void TestAES_CCM_128EncryptInvalidIVLen(nlTestSuite * inSuite, void * inContext)
+static void TestAES_CCM_128EncryptInvalidNonceLen(nlTestSuite * inSuite, void * inContext)
 {
     HeapChecker heapChecker(inSuite);
     int numOfTestVectors = ArraySize(ccm_128_test_vectors);
@@ -513,7 +513,7 @@ static void TestAES_CCM_128EncryptInvalidIVLen(nlTestSuite * inSuite, void * inC
             NL_TEST_ASSERT(inSuite, out_tag);
 
             CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->key_len,
-                                             vector->iv, 0, out_ct.Get(), out_tag.Get(), vector->tag_len);
+                                             vector->nonce, 0, out_ct.Get(), out_tag.Get(), vector->tag_len);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -540,7 +540,7 @@ static void TestAES_CCM_128EncryptInvalidTagLen(nlTestSuite * inSuite, void * in
             NL_TEST_ASSERT(inSuite, out_tag);
 
             CHIP_ERROR err = AES_CCM_encrypt(vector->pt, vector->pt_len, vector->aad, vector->aad_len, vector->key, vector->key_len,
-                                             vector->iv, vector->iv_len, out_ct.Get(), out_tag.Get(), 13);
+                                             vector->nonce, vector->nonce_len, out_ct.Get(), out_tag.Get(), 13);
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -563,7 +563,7 @@ static void TestAES_CCM_128DecryptInvalidKey(nlTestSuite * inSuite, void * inCon
             out_pt.Alloc(vector->pt_len);
             NL_TEST_ASSERT(inSuite, out_pt);
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                             nullptr, 0, vector->iv, vector->iv_len, out_pt.Get());
+                                             nullptr, 0, vector->nonce, vector->nonce_len, out_pt.Get());
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -571,7 +571,7 @@ static void TestAES_CCM_128DecryptInvalidKey(nlTestSuite * inSuite, void * inCon
     NL_TEST_ASSERT(inSuite, numOfTestsRan > 0);
 }
 
-static void TestAES_CCM_128DecryptInvalidIVLen(nlTestSuite * inSuite, void * inContext)
+static void TestAES_CCM_128DecryptInvalidNonceLen(nlTestSuite * inSuite, void * inContext)
 {
     HeapChecker heapChecker(inSuite);
     int numOfTestVectors = ArraySize(ccm_128_test_vectors);
@@ -586,7 +586,7 @@ static void TestAES_CCM_128DecryptInvalidIVLen(nlTestSuite * inSuite, void * inC
             out_pt.Alloc(vector->pt_len);
             NL_TEST_ASSERT(inSuite, out_pt);
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                             vector->key, vector->key_len, vector->iv, 0, out_pt.Get());
+                                             vector->key, vector->key_len, vector->nonce, 0, out_pt.Get());
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -2221,18 +2221,18 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test encrypting AES-CCM-128 test vectors", TestAES_CCM_128EncryptTestVectors),
     NL_TEST_DEF("Test decrypting AES-CCM-128 test vectors", TestAES_CCM_128DecryptTestVectors),
     NL_TEST_DEF("Test encrypting AES-CCM-128 using nil key", TestAES_CCM_128EncryptNilKey),
-    NL_TEST_DEF("Test encrypting AES-CCM-128 using invalid IV", TestAES_CCM_128EncryptInvalidIVLen),
+    NL_TEST_DEF("Test encrypting AES-CCM-128 using invalid nonce", TestAES_CCM_128EncryptInvalidNonceLen),
     NL_TEST_DEF("Test encrypting AES-CCM-128 using invalid tag", TestAES_CCM_128EncryptInvalidTagLen),
     NL_TEST_DEF("Test decrypting AES-CCM-128 invalid key", TestAES_CCM_128DecryptInvalidKey),
-    NL_TEST_DEF("Test decrypting AES-CCM-128 invalid IV", TestAES_CCM_128DecryptInvalidIVLen),
+    NL_TEST_DEF("Test decrypting AES-CCM-128 invalid nonce", TestAES_CCM_128DecryptInvalidNonceLen),
     NL_TEST_DEF("Test decrypting AES-CCM-128 Containers", TestAES_CCM_128Containers),
     NL_TEST_DEF("Test encrypting AES-CCM-256 test vectors", TestAES_CCM_256EncryptTestVectors),
     NL_TEST_DEF("Test decrypting AES-CCM-256 test vectors", TestAES_CCM_256DecryptTestVectors),
     NL_TEST_DEF("Test encrypting AES-CCM-256 using nil key", TestAES_CCM_256EncryptNilKey),
-    NL_TEST_DEF("Test encrypting AES-CCM-256 using invalid IV", TestAES_CCM_256EncryptInvalidIVLen),
+    NL_TEST_DEF("Test encrypting AES-CCM-256 using invalid nonce", TestAES_CCM_256EncryptInvalidNonceLen),
     NL_TEST_DEF("Test encrypting AES-CCM-256 using invalid tag", TestAES_CCM_256EncryptInvalidTagLen),
     NL_TEST_DEF("Test decrypting AES-CCM-256 invalid key", TestAES_CCM_256DecryptInvalidKey),
-    NL_TEST_DEF("Test decrypting AES-CCM-256 invalid IV", TestAES_CCM_256DecryptInvalidIVLen),
+    NL_TEST_DEF("Test decrypting AES-CCM-256 invalid nonce", TestAES_CCM_256DecryptInvalidNonceLen),
     NL_TEST_DEF("Test decrypting AES-CCM-256 invalid vectors", TestAES_CCM_256DecryptInvalidTestVectors),
     NL_TEST_DEF("Test ASN.1 signature conversion routines", TestAsn1Conversions),
     NL_TEST_DEF("Test Integer to ASN.1 DER conversion", TestRawIntegerToDerValidCases),

--- a/src/transport/CryptoContext.h
+++ b/src/transport/CryptoContext.h
@@ -143,7 +143,7 @@ private:
     CryptoKey mKeys[KeyUsage::kNumCryptoKeys];
     Crypto::SymmetricKeyContext * mKeyContext = nullptr;
 
-    static CHIP_ERROR GetIV(const PacketHeader & header, uint8_t * iv, size_t len);
+    static CHIP_ERROR GetNonce(const PacketHeader & header, uint8_t * nonce, size_t len);
 
     // Use unencrypted header as additional authenticated data (AAD) during encryption and decryption.
     // The encryption operations includes AAD when message authentication tag is generated. This tag


### PR DESCRIPTION
#### Problem
As request at https://github.com/project-chip/connectedhomeip/pull/16098#discussion_r826038776
The spec calls it Nonce instead of IV

#### Change overview
Rename IV to nonce

#### Testing
Passed unit-tests