### PR TITLE
[nrfconnect] Optimized external flash power consumption.

### DIFF
--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -146,9 +146,9 @@ CHIP_ERROR AppTask::Init()
 void AppTask::InitOTARequestor()
 {
 #if CONFIG_CHIP_OTA_REQUESTOR
-    mOTAImageProcessor.SetOTADownloader(&mBDXDownloader);
-    mBDXDownloader.SetImageProcessorDelegate(&mOTAImageProcessor);
-    mOTARequestorDriver.Init(&mOTARequestor, &mOTAImageProcessor);
+    OTAImageProcessorNrf::Get().SetOTADownloader(&mBDXDownloader);
+    mBDXDownloader.SetImageProcessorDelegate(&OTAImageProcessorNrf::Get());
+    mOTARequestorDriver.Init(&mOTARequestor, &OTAImageProcessorNrf::Get());
     mOTARequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
     mOTARequestor.Init(chip::Server::GetInstance(), mOTARequestorStorage, mOTARequestorDriver, mBDXDownloader);
     chip::SetRequestorInstance(&mOTARequestor);

--- a/examples/all-clusters-app/nrfconnect/main/include/AppTask.h
+++ b/examples/all-clusters-app/nrfconnect/main/include/AppTask.h
@@ -20,11 +20,11 @@
 #include <platform/CHIPDeviceLayer.h>
 
 #if CONFIG_CHIP_OTA_REQUESTOR
+#include "OTAUtil.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
-#include <platform/nrfconnect/OTAImageProcessorImpl.h>
 #endif
 
 struct k_timer;
@@ -76,7 +76,6 @@ private:
 #if CONFIG_CHIP_OTA_REQUESTOR
     chip::DefaultOTARequestorStorage mOTARequestorStorage;
     chip::DeviceLayer::GenericOTARequestorDriver mOTARequestorDriver;
-    chip::DeviceLayer::OTAImageProcessorImpl mOTAImageProcessor;
     chip::BDXDownloader mBDXDownloader;
     chip::OTARequestor mOTARequestor;
 #endif

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -40,11 +40,11 @@
 #include <system/SystemClock.h>
 
 #if CONFIG_CHIP_OTA_REQUESTOR
+#include "OTAUtil.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
-#include <platform/nrfconnect/OTAImageProcessorImpl.h>
 #endif
 
 #include <dk_buttons_and_leds.h>
@@ -88,7 +88,6 @@ bool sHaveBLEConnections  = false;
 #if CONFIG_CHIP_OTA_REQUESTOR
 DefaultOTARequestorStorage sRequestorStorage;
 GenericOTARequestorDriver sOTARequestorDriver;
-OTAImageProcessorImpl sOTAImageProcessor;
 chip::BDXDownloader sBDXDownloader;
 chip::OTARequestor sOTARequestor;
 #endif
@@ -202,9 +201,9 @@ CHIP_ERROR AppTask::Init()
 void AppTask::InitOTARequestor()
 {
 #if CONFIG_CHIP_OTA_REQUESTOR
-    sOTAImageProcessor.SetOTADownloader(&sBDXDownloader);
-    sBDXDownloader.SetImageProcessorDelegate(&sOTAImageProcessor);
-    sOTARequestorDriver.Init(&sOTARequestor, &sOTAImageProcessor);
+    OTAImageProcessorNrf::Get().SetOTADownloader(&sBDXDownloader);
+    sBDXDownloader.SetImageProcessorDelegate(&OTAImageProcessorNrf::Get());
+    sOTARequestorDriver.Init(&sOTARequestor, &OTAImageProcessorNrf::Get());
     sRequestorStorage.Init(Server::GetInstance().GetPersistentStorage());
     sOTARequestor.Init(Server::GetInstance(), sRequestorStorage, sOTARequestorDriver, sBDXDownloader);
     chip::SetRequestorInstance(&sOTARequestor);

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -36,11 +36,11 @@
 #include <system/SystemClock.h>
 
 #if CONFIG_CHIP_OTA_REQUESTOR
+#include "OTAUtil.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
-#include <platform/nrfconnect/OTAImageProcessorImpl.h>
 #endif
 
 #include <dk_buttons_and_leds.h>
@@ -77,7 +77,6 @@ bool sHaveBLEConnections  = false;
 #if CONFIG_CHIP_OTA_REQUESTOR
 DefaultOTARequestorStorage sRequestorStorage;
 GenericOTARequestorDriver sOTARequestorDriver;
-OTAImageProcessorImpl sOTAImageProcessor;
 chip::BDXDownloader sBDXDownloader;
 chip::OTARequestor sOTARequestor;
 #endif
@@ -183,9 +182,9 @@ CHIP_ERROR AppTask::Init()
 void AppTask::InitOTARequestor()
 {
 #if CONFIG_CHIP_OTA_REQUESTOR
-    sOTAImageProcessor.SetOTADownloader(&sBDXDownloader);
-    sBDXDownloader.SetImageProcessorDelegate(&sOTAImageProcessor);
-    sOTARequestorDriver.Init(&sOTARequestor, &sOTAImageProcessor);
+    OTAImageProcessorNrf::Get().SetOTADownloader(&sBDXDownloader);
+    sBDXDownloader.SetImageProcessorDelegate(&OTAImageProcessorNrf::Get());
+    sOTARequestorDriver.Init(&sOTARequestor, &OTAImageProcessorNrf::Get());
     sRequestorStorage.Init(Server::GetInstance().GetPersistentStorage());
     sOTARequestor.Init(Server::GetInstance(), sRequestorStorage, sOTARequestorDriver, sBDXDownloader);
     chip::SetRequestorInstance(&sOTARequestor);

--- a/examples/platform/nrfconnect/util/include/OTAUtil.h
+++ b/examples/platform/nrfconnect/util/include/OTAUtil.h
@@ -1,0 +1,37 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <platform/nrfconnect/OTAImageProcessorImpl.h>
+
+#ifdef CONFIG_CHIP_OTA_REQUESTOR
+namespace OTAImageProcessorNrf {
+// compile-time factory method
+inline chip::DeviceLayer::OTAImageProcessorImpl & Get()
+{
+#if CONFIG_PM_DEVICE && CONFIG_NORDIC_QSPI_NOR
+    static chip::DeviceLayer::ExtFlashHandler sQSPIHandler;
+    static chip::DeviceLayer::OTAImageProcessorImplPMDevice sOTAImageProcessor{ sQSPIHandler };
+#else
+    static chip::DeviceLayer::OTAImageProcessorImpl sOTAImageProcessor;
+#endif
+    return sOTAImageProcessor;
+}
+} // namespace OTAImageProcessorNrf
+
+#endif

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -37,11 +37,11 @@
 #include <system/SystemClock.h>
 
 #if CONFIG_CHIP_OTA_REQUESTOR
+#include "OTAUtil.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
-#include <platform/nrfconnect/OTAImageProcessorImpl.h>
 #endif
 
 #include <dk_buttons_and_leds.h>
@@ -80,7 +80,6 @@ bool sHaveBLEConnections  = false;
 #if CONFIG_CHIP_OTA_REQUESTOR
 DefaultOTARequestorStorage sRequestorStorage;
 GenericOTARequestorDriver sOTARequestorDriver;
-OTAImageProcessorImpl sOTAImageProcessor;
 chip::BDXDownloader sBDXDownloader;
 chip::OTARequestor sOTARequestor;
 #endif
@@ -180,9 +179,9 @@ CHIP_ERROR AppTask::Init()
 void AppTask::InitOTARequestor()
 {
 #if CONFIG_CHIP_OTA_REQUESTOR
-    sOTAImageProcessor.SetOTADownloader(&sBDXDownloader);
-    sBDXDownloader.SetImageProcessorDelegate(&sOTAImageProcessor);
-    sOTARequestorDriver.Init(&sOTARequestor, &sOTAImageProcessor);
+    OTAImageProcessorNrf::Get().SetOTADownloader(&sBDXDownloader);
+    sBDXDownloader.SetImageProcessorDelegate(&OTAImageProcessorNrf::Get());
+    sOTARequestorDriver.Init(&sOTARequestor, &OTAImageProcessorNrf::Get());
     sRequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
     sOTARequestor.Init(chip::Server::GetInstance(), sRequestorStorage, sOTARequestorDriver, sBDXDownloader);
     chip::SetRequestorInstance(&sOTARequestor);

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -37,11 +37,11 @@
 #include <system/SystemClock.h>
 
 #if CONFIG_CHIP_OTA_REQUESTOR
+#include "OTAUtil.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestor.h>
-#include <platform/nrfconnect/OTAImageProcessorImpl.h>
 #endif
 
 #include <dk_buttons_and_leds.h>
@@ -77,7 +77,6 @@ bool sHaveBLEConnections  = false;
 #if CONFIG_CHIP_OTA_REQUESTOR
 DefaultOTARequestorStorage sRequestorStorage;
 GenericOTARequestorDriver sOTARequestorDriver;
-OTAImageProcessorImpl sOTAImageProcessor;
 chip::BDXDownloader sBDXDownloader;
 chip::OTARequestor sOTARequestor;
 #endif
@@ -177,9 +176,9 @@ CHIP_ERROR AppTask::Init()
 void AppTask::InitOTARequestor()
 {
 #if CONFIG_CHIP_OTA_REQUESTOR
-    sOTAImageProcessor.SetOTADownloader(&sBDXDownloader);
-    sBDXDownloader.SetImageProcessorDelegate(&sOTAImageProcessor);
-    sOTARequestorDriver.Init(&sOTARequestor, &sOTAImageProcessor);
+    OTAImageProcessorNrf::Get().SetOTADownloader(&sBDXDownloader);
+    sBDXDownloader.SetImageProcessorDelegate(&OTAImageProcessorNrf::Get());
+    sOTARequestorDriver.Init(&sOTARequestor, &OTAImageProcessorNrf::Get());
     sRequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
     sOTARequestor.Init(chip::Server::GetInstance(), sRequestorStorage, sOTARequestorDriver, sBDXDownloader);
     chip::SetRequestorInstance(&sOTARequestor);

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.h
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.h
@@ -1,5 +1,4 @@
 /*
- *
  *    Copyright (c) 2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,6 +50,30 @@ private:
     OTAImageHeaderParser mHeaderParser;
     OTAImageContentHeaderParser mContentHeaderParser;
     uint8_t mBuffer[kBufferSize];
+};
+
+class ExtFlashHandler
+{
+public:
+    enum class Action : uint8_t
+    {
+        WAKE_UP,
+        SLEEP
+    };
+    virtual ~ExtFlashHandler() {}
+    virtual void DoAction(Action action);
+};
+
+class OTAImageProcessorImplPMDevice : public OTAImageProcessorImpl
+{
+public:
+    explicit OTAImageProcessorImplPMDevice(ExtFlashHandler & aHandler);
+    CHIP_ERROR PrepareDownload() override;
+    CHIP_ERROR Abort() override;
+    CHIP_ERROR Apply() override;
+
+private:
+    ExtFlashHandler & mHandler;
 };
 
 } // namespace DeviceLayer


### PR DESCRIPTION
#### Problem
* QSPI consumes ~1.8 mA in active mode
* this is default mode for nRF53, even if the external flash is not used (no DFU ongoing)
* such high power consumption is a no-go for SED

#### Change overview
Force the QSPI into sleep mode and wake it up only on demand, i.e. right before the DFU

#### Testing
* tested on nrf53 and lock-app example, i.e. measured the power consumption before/during/after DFU in SED configuration
