### PR TITLE
[chip-tool] Filter out non-commissionable devices

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -206,6 +206,9 @@ void PairingCommand::OnCommissioningComplete(NodeId nodeId, CHIP_ERROR err)
 
 void PairingCommand::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData)
 {
+    // Ignore nodes with closed comissioning window
+    VerifyOrReturn(nodeData.commissioningMode != 0);
+
     const uint16_t port = nodeData.port;
     char buf[chip::Inet::IPAddress::kMaxStringLength];
     nodeData.ipAddress[0].ToString(buf);


### PR DESCRIPTION
#### Problem
"pairing onnetwork" commands don't filter out devices with CM=0 TXT entry indicating closed commissioning window.

#### Change overview
Don't try to pair devices with CM=0.

#### Testing
Ran the command against a device in non-commissionable state.
