### PR TITLE
Add Network Commissioning cluster setup for Linux apps

### DIFF
--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -22,14 +22,24 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
+#include <app/clusters/network-commissioning/network-commissioning.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/Linux/NetworkCommissioningDriver.h>
 
 #if defined(PW_RPC_ENABLED)
 #include "Rpc.h"
 #endif // PW_RPC_ENABLED
 
 using namespace chip;
+using namespace chip::app;
 using namespace chip::app::Clusters;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+namespace {
+DeviceLayer::NetworkCommissioning::LinuxWiFiDriver sLinuxWiFiDriver;
+Clusters::NetworkCommissioning::Instance sWiFiNetworkCommissioningInstance(0, &sLinuxWiFiDriver);
+} // namespace
+#endif
 
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
                                        uint16_t size, uint8_t * value)
@@ -60,7 +70,12 @@ void emberAfOnOffClusterInitCallback(EndpointId endpoint)
     // TODO: implement any additional Cluster Server init actions
 }
 
-void ApplicationInit() {}
+void ApplicationInit()
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+    sWiFiNetworkCommissioningInstance.Init();
+#endif
+}
 
 int main(int argc, char * argv[])
 {

--- a/examples/thermostat/linux/main.cpp
+++ b/examples/thermostat/linux/main.cpp
@@ -21,11 +21,20 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/CommandHandler.h>
 #include <app/clusters/identify-server/identify-server.h>
+#include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/util/af.h>
+#include <platform/Linux/NetworkCommissioningDriver.h>
 
 using namespace chip;
 using namespace chip::app;
 // using namespace chip::app::Clusters;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+namespace {
+DeviceLayer::NetworkCommissioning::LinuxWiFiDriver sLinuxWiFiDriver;
+Clusters::NetworkCommissioning::Instance sWiFiNetworkCommissioningInstance(0, &sLinuxWiFiDriver);
+} // namespace
+#endif
 
 bool emberAfBasicClusterMfgSpecificPingCallback(chip::app::CommandHandler * commandObj)
 {
@@ -87,7 +96,12 @@ static Identify gIdentify1 = {
     chip::EndpointId{ 1 }, OnIdentifyStart, OnIdentifyStop, EMBER_ZCL_IDENTIFY_IDENTIFY_TYPE_VISIBLE_LED, OnTriggerEffect,
 };
 
-void ApplicationInit() {}
+void ApplicationInit()
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+    sWiFiNetworkCommissioningInstance.Init();
+#endif
+}
 
 int main(int argc, char * argv[])
 {


### PR DESCRIPTION
For issue #15261 the Linux lighting app failed to be commission by
chip-tool pairing ble-wifi command.
Based on the message in #14751, the Linux platform intented to
support WiFi network by default instead Thread.

This patch add Network Commissioning cluster setup for WiFi device for
thermostat-app and lighting-app.
