### PR TITLE
Add ota provider/requestor to build_examples.py

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -154,8 +154,8 @@ def HostTargets():
         app_targets.append(target.Extend('minmdns', app=HostApp.MIN_MDNS))
         app_targets.append(target.Extend('door-lock', app=HostApp.LOCK))
         app_targets.append(target.Extend('shell', app=HostApp.SHELL))
-        app_targets.append(target.Extend('ota-provider-noble', app=HostApp.OTA_PROVIDER, enable_ble=False))
-        app_targets.append(target.Extend('ota-requestor-noble', app=HostApp.OTA_REQUESTOR, enable_ble=False))
+        app_targets.append(target.Extend('ota-provider', app=HostApp.OTA_PROVIDER, enable_ble=False))
+        app_targets.append(target.Extend('ota-requestor', app=HostApp.OTA_REQUESTOR, enable_ble=False))
 
     # Possible build variants. Note that number of potential
     # builds is exponential here

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -154,8 +154,8 @@ def HostTargets():
         app_targets.append(target.Extend('minmdns', app=HostApp.MIN_MDNS))
         app_targets.append(target.Extend('door-lock', app=HostApp.LOCK))
         app_targets.append(target.Extend('shell', app=HostApp.SHELL))
-        app_targets.append(target.Extend('ota-provider', app=HostApp.OTA_PROVIDER))
-        app_targets.append(target.Extend('ota-requestor', app=HostApp.OTA_REQUESTOR))
+        app_targets.append(target.Extend('ota-provider-noble', app=HostApp.OTA_PROVIDER, enable_ble=False))
+        app_targets.append(target.Extend('ota-requestor-noble', app=HostApp.OTA_REQUESTOR, enable_ble=False))
 
     # Possible build variants. Note that number of potential
     # builds is exponential here

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -154,8 +154,10 @@ def HostTargets():
         app_targets.append(target.Extend('minmdns', app=HostApp.MIN_MDNS))
         app_targets.append(target.Extend('door-lock', app=HostApp.LOCK))
         app_targets.append(target.Extend('shell', app=HostApp.SHELL))
-        app_targets.append(target.Extend('ota-provider', app=HostApp.OTA_PROVIDER, enable_ble=False))
-        app_targets.append(target.Extend('ota-requestor', app=HostApp.OTA_REQUESTOR, enable_ble=False))
+        app_targets.append(target.Extend(
+            'ota-provider', app=HostApp.OTA_PROVIDER, enable_ble=False))
+        app_targets.append(target.Extend(
+            'ota-requestor', app=HostApp.OTA_REQUESTOR, enable_ble=False))
 
     # Possible build variants. Note that number of potential
     # builds is exponential here

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -154,6 +154,8 @@ def HostTargets():
         app_targets.append(target.Extend('minmdns', app=HostApp.MIN_MDNS))
         app_targets.append(target.Extend('door-lock', app=HostApp.LOCK))
         app_targets.append(target.Extend('shell', app=HostApp.SHELL))
+        app_targets.append(target.Extend('ota-provider', app=HostApp.OTA_PROVIDER))
+        app_targets.append(target.Extend('ota-requestor', app=HostApp.OTA_REQUESTOR))
 
     # Possible build variants. Note that number of potential
     # builds is exponential here

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -102,11 +102,11 @@ class HostApp(Enum):
             yield 'chip-cert'
             yield 'chip-cert.map'
         elif self == HostApp.OTA_PROVIDER:
-            yield 'ota-requestor-app'
-            yield 'ota-requestor-app.map'
+            yield 'chip-ota-requestor-app'
+            yield 'chip-ota-requestor-app.map'
         elif self == HostApp.OTA_REQUESTOR:
-            yield 'ota-provider-app'
-            yield 'ota-provider-app.map'
+            yield 'chip-ota-provider-app'
+            yield 'chip-ota-provider-app.map'
         else:
             raise Exception('Unknown app type: %r' % self)
 

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -156,8 +156,7 @@ class HostBuilder(GnBuilder):
     def __init__(self, root, runner, app: HostApp, board=HostBoard.NATIVE, enable_ipv4=True,
                  enable_ble=True, use_tsan=False,  use_asan=False, separate_event_loop=True,
                  test_group=False, use_libfuzzer=False, use_clang=False,
-                 use_platform_mdns=False
-                 ):
+                 use_platform_mdns=False):
         super(HostBuilder, self).__init__(
             root=os.path.join(root, 'examples', app.ExamplePath()),
             runner=runner)

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -32,6 +32,8 @@ class HostApp(Enum):
     TESTS = auto()
     SHELL = auto()
     CERT_TOOL = auto()
+    OTA_PROVIDER = auto()
+    OTA_REQUESTOR = auto()
 
     def ExamplePath(self):
         if self == HostApp.ALL_CLUSTERS:
@@ -56,6 +58,10 @@ class HostApp(Enum):
             return 'shell/standalone'
         elif self == HostApp.CERT_TOOL:
             return '..'
+        elif self == HostApp.OTA_PROVIDER:
+            return 'ota-provider-app/linux'
+        elif self == HostApp.OTA_REQUESTOR:
+            return 'ota-requestor-app/linux'
         else:
             raise Exception('Unknown app type: %r' % self)
 
@@ -95,6 +101,12 @@ class HostApp(Enum):
         elif self == HostApp.CERT_TOOL:
             yield 'chip-cert'
             yield 'chip-cert.map'
+        elif self == HostApp.OTA_PROVIDER:
+            yield 'ota-requestor-app'
+            yield 'ota-requestor-app.map'
+        elif self == HostApp.OTA_REQUESTOR:
+            yield 'ota-provider-app'
+            yield 'ota-provider-app.map'
         else:
             raise Exception('Unknown app type: %r' % self)
 

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -41,25 +41,25 @@ bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns-ipv6only'
 
-# Generating linux-arm64-ota-provider
+# Generating linux-arm64-ota-provider-noble
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-provider'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-provider-noble'
 
-# Generating linux-arm64-ota-provider-ipv6only
+# Generating linux-arm64-ota-provider-noble-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-provider-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-provider-noble-ipv6only'
 
-# Generating linux-arm64-ota-requestor
+# Generating linux-arm64-ota-requestor-noble
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor-noble'
 
-# Generating linux-arm64-ota-requestor-ipv6only
+# Generating linux-arm64-ota-requestor-noble-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor-noble-ipv6only'
 
 # Generating linux-arm64-shell
 bash -c '
@@ -114,17 +114,17 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Generating linux-x64-minmdns-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-minmdns-ipv6only
 
-# Generating linux-x64-ota-provider
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux {out}/linux-x64-ota-provider
+# Generating linux-x64-ota-provider-noble
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux --args=chip_config_network_layer_ble=false {out}/linux-x64-ota-provider-noble
 
-# Generating linux-x64-ota-provider-ipv6only
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-ota-provider-ipv6only
+# Generating linux-x64-ota-provider-noble-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false' {out}/linux-x64-ota-provider-noble-ipv6only
 
-# Generating linux-x64-ota-requestor
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux {out}/linux-x64-ota-requestor
+# Generating linux-x64-ota-requestor-noble
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux --args=chip_config_network_layer_ble=false {out}/linux-x64-ota-requestor-noble
 
-# Generating linux-x64-ota-requestor-ipv6only
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-ota-requestor-ipv6only
+# Generating linux-x64-ota-requestor-noble-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false' {out}/linux-x64-ota-requestor-noble-ipv6only
 
 # Generating linux-x64-rpc-console
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/common/pigweed/rpc_console {out}/linux-x64-rpc-console
@@ -174,17 +174,17 @@ ninja -C {out}/linux-arm64-minmdns
 # Building linux-arm64-minmdns-ipv6only
 ninja -C {out}/linux-arm64-minmdns-ipv6only
 
-# Building linux-arm64-ota-provider
-ninja -C {out}/linux-arm64-ota-provider
+# Building linux-arm64-ota-provider-noble
+ninja -C {out}/linux-arm64-ota-provider-noble
 
-# Building linux-arm64-ota-provider-ipv6only
-ninja -C {out}/linux-arm64-ota-provider-ipv6only
+# Building linux-arm64-ota-provider-noble-ipv6only
+ninja -C {out}/linux-arm64-ota-provider-noble-ipv6only
 
-# Building linux-arm64-ota-requestor
-ninja -C {out}/linux-arm64-ota-requestor
+# Building linux-arm64-ota-requestor-noble
+ninja -C {out}/linux-arm64-ota-requestor-noble
 
-# Building linux-arm64-ota-requestor-ipv6only
-ninja -C {out}/linux-arm64-ota-requestor-ipv6only
+# Building linux-arm64-ota-requestor-noble-ipv6only
+ninja -C {out}/linux-arm64-ota-requestor-noble-ipv6only
 
 # Building linux-arm64-shell
 ninja -C {out}/linux-arm64-shell
@@ -231,17 +231,17 @@ ninja -C {out}/linux-x64-minmdns
 # Building linux-x64-minmdns-ipv6only
 ninja -C {out}/linux-x64-minmdns-ipv6only
 
-# Building linux-x64-ota-provider
-ninja -C {out}/linux-x64-ota-provider
+# Building linux-x64-ota-provider-noble
+ninja -C {out}/linux-x64-ota-provider-noble
 
-# Building linux-x64-ota-provider-ipv6only
-ninja -C {out}/linux-x64-ota-provider-ipv6only
+# Building linux-x64-ota-provider-noble-ipv6only
+ninja -C {out}/linux-x64-ota-provider-noble-ipv6only
 
-# Building linux-x64-ota-requestor
-ninja -C {out}/linux-x64-ota-requestor
+# Building linux-x64-ota-requestor-noble
+ninja -C {out}/linux-x64-ota-requestor-noble
 
-# Building linux-x64-ota-requestor-ipv6only
-ninja -C {out}/linux-x64-ota-requestor-ipv6only
+# Building linux-x64-ota-requestor-noble-ipv6only
+ninja -C {out}/linux-x64-ota-requestor-noble-ipv6only
 
 # Building linux-x64-rpc-console
 ninja -C {out}/linux-x64-rpc-console

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -41,25 +41,25 @@ bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns-ipv6only'
 
-# Generating linux-arm64-ota-provider-noble
+# Generating linux-arm64-ota-provider
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-provider-noble'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-provider'
 
-# Generating linux-arm64-ota-provider-noble-ipv6only
+# Generating linux-arm64-ota-provider-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-provider-noble-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-provider-ipv6only'
 
-# Generating linux-arm64-ota-requestor-noble
+# Generating linux-arm64-ota-requestor
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor-noble'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor'
 
-# Generating linux-arm64-ota-requestor-noble-ipv6only
+# Generating linux-arm64-ota-requestor-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor-noble-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor-ipv6only'
 
 # Generating linux-arm64-shell
 bash -c '
@@ -114,17 +114,17 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Generating linux-x64-minmdns-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-minmdns-ipv6only
 
-# Generating linux-x64-ota-provider-noble
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux --args=chip_config_network_layer_ble=false {out}/linux-x64-ota-provider-noble
+# Generating linux-x64-ota-provider
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux --args=chip_config_network_layer_ble=false {out}/linux-x64-ota-provider
 
-# Generating linux-x64-ota-provider-noble-ipv6only
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false' {out}/linux-x64-ota-provider-noble-ipv6only
+# Generating linux-x64-ota-provider-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false' {out}/linux-x64-ota-provider-ipv6only
 
-# Generating linux-x64-ota-requestor-noble
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux --args=chip_config_network_layer_ble=false {out}/linux-x64-ota-requestor-noble
+# Generating linux-x64-ota-requestor
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux --args=chip_config_network_layer_ble=false {out}/linux-x64-ota-requestor
 
-# Generating linux-x64-ota-requestor-noble-ipv6only
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false' {out}/linux-x64-ota-requestor-noble-ipv6only
+# Generating linux-x64-ota-requestor-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false' {out}/linux-x64-ota-requestor-ipv6only
 
 # Generating linux-x64-rpc-console
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/common/pigweed/rpc_console {out}/linux-x64-rpc-console
@@ -174,17 +174,17 @@ ninja -C {out}/linux-arm64-minmdns
 # Building linux-arm64-minmdns-ipv6only
 ninja -C {out}/linux-arm64-minmdns-ipv6only
 
-# Building linux-arm64-ota-provider-noble
-ninja -C {out}/linux-arm64-ota-provider-noble
+# Building linux-arm64-ota-provider
+ninja -C {out}/linux-arm64-ota-provider
 
-# Building linux-arm64-ota-provider-noble-ipv6only
-ninja -C {out}/linux-arm64-ota-provider-noble-ipv6only
+# Building linux-arm64-ota-provider-ipv6only
+ninja -C {out}/linux-arm64-ota-provider-ipv6only
 
-# Building linux-arm64-ota-requestor-noble
-ninja -C {out}/linux-arm64-ota-requestor-noble
+# Building linux-arm64-ota-requestor
+ninja -C {out}/linux-arm64-ota-requestor
 
-# Building linux-arm64-ota-requestor-noble-ipv6only
-ninja -C {out}/linux-arm64-ota-requestor-noble-ipv6only
+# Building linux-arm64-ota-requestor-ipv6only
+ninja -C {out}/linux-arm64-ota-requestor-ipv6only
 
 # Building linux-arm64-shell
 ninja -C {out}/linux-arm64-shell
@@ -231,17 +231,17 @@ ninja -C {out}/linux-x64-minmdns
 # Building linux-x64-minmdns-ipv6only
 ninja -C {out}/linux-x64-minmdns-ipv6only
 
-# Building linux-x64-ota-provider-noble
-ninja -C {out}/linux-x64-ota-provider-noble
+# Building linux-x64-ota-provider
+ninja -C {out}/linux-x64-ota-provider
 
-# Building linux-x64-ota-provider-noble-ipv6only
-ninja -C {out}/linux-x64-ota-provider-noble-ipv6only
+# Building linux-x64-ota-provider-ipv6only
+ninja -C {out}/linux-x64-ota-provider-ipv6only
 
-# Building linux-x64-ota-requestor-noble
-ninja -C {out}/linux-x64-ota-requestor-noble
+# Building linux-x64-ota-requestor
+ninja -C {out}/linux-x64-ota-requestor
 
-# Building linux-x64-ota-requestor-noble-ipv6only
-ninja -C {out}/linux-x64-ota-requestor-noble-ipv6only
+# Building linux-x64-ota-requestor-ipv6only
+ninja -C {out}/linux-x64-ota-requestor-ipv6only
 
 # Building linux-x64-rpc-console
 ninja -C {out}/linux-x64-rpc-console

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -41,6 +41,26 @@ bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns-ipv6only'
 
+# Generating linux-arm64-ota-provider
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-provider'
+
+# Generating linux-arm64-ota-provider-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-provider-ipv6only'
+
+# Generating linux-arm64-ota-requestor
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor'
+
+# Generating linux-arm64-ota-requestor-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor-ipv6only'
+
 # Generating linux-arm64-shell
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
@@ -94,6 +114,18 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Generating linux-x64-minmdns-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-minmdns-ipv6only
 
+# Generating linux-x64-ota-provider
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux {out}/linux-x64-ota-provider
+
+# Generating linux-x64-ota-provider-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-ota-provider-ipv6only
+
+# Generating linux-x64-ota-requestor
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux {out}/linux-x64-ota-requestor
+
+# Generating linux-x64-ota-requestor-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-ota-requestor-ipv6only
+
 # Generating linux-x64-rpc-console
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/common/pigweed/rpc_console {out}/linux-x64-rpc-console
 
@@ -142,6 +174,18 @@ ninja -C {out}/linux-arm64-minmdns
 # Building linux-arm64-minmdns-ipv6only
 ninja -C {out}/linux-arm64-minmdns-ipv6only
 
+# Building linux-arm64-ota-provider
+ninja -C {out}/linux-arm64-ota-provider
+
+# Building linux-arm64-ota-provider-ipv6only
+ninja -C {out}/linux-arm64-ota-provider-ipv6only
+
+# Building linux-arm64-ota-requestor
+ninja -C {out}/linux-arm64-ota-requestor
+
+# Building linux-arm64-ota-requestor-ipv6only
+ninja -C {out}/linux-arm64-ota-requestor-ipv6only
+
 # Building linux-arm64-shell
 ninja -C {out}/linux-arm64-shell
 
@@ -186,6 +230,18 @@ ninja -C {out}/linux-x64-minmdns
 
 # Building linux-x64-minmdns-ipv6only
 ninja -C {out}/linux-x64-minmdns-ipv6only
+
+# Building linux-x64-ota-provider
+ninja -C {out}/linux-x64-ota-provider
+
+# Building linux-x64-ota-provider-ipv6only
+ninja -C {out}/linux-x64-ota-provider-ipv6only
+
+# Building linux-x64-ota-requestor
+ninja -C {out}/linux-x64-ota-requestor
+
+# Building linux-x64-ota-requestor-ipv6only
+ninja -C {out}/linux-x64-ota-requestor-ipv6only
 
 # Building linux-x64-rpc-console
 ninja -C {out}/linux-x64-rpc-console


### PR DESCRIPTION
#### Problem
Build instructions only use `gn_build_example.py`.

#### Change overview
Add build_example support for ota requestor/provider.

#### Testing
Manualy compile.