### PR TITLE
fix crash error because CommissionableDataProvider null

### DIFF
--- a/src/platform/android/AndroidChipPlatform-JNI.cpp
+++ b/src/platform/android/AndroidChipPlatform-JNI.cpp
@@ -99,6 +99,7 @@ void AndroidChipPlatformJNI_OnUnload(JavaVM * jvm, void * reserved)
 
 JNI_METHOD(void, initChipStack)(JNIEnv * env, jobject self)
 {
+    chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = chip::DeviceLayer::PlatformMgr().InitChipStack();
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Error initializing CHIP stack: %s", ErrorStr(err)));
 }
@@ -214,12 +215,7 @@ JNI_METHOD(void, setKeyValueStoreManager)(JNIEnv * env, jclass self, jobject man
 JNI_METHOD(void, setConfigurationManager)(JNIEnv * env, jclass self, jobject manager)
 {
     chip::DeviceLayer::StackLock lock;
-    chip::DeviceLayer::ConfigurationManagerImpl * configurationManagerImpl =
-        reinterpret_cast<chip::DeviceLayer::ConfigurationManagerImpl *>(&chip::DeviceLayer::ConfigurationMgr());
-    if (configurationManagerImpl != nullptr)
-    {
-        configurationManagerImpl->InitializeWithObject(manager);
-    }
+    chip::DeviceLayer::ConfigurationManagerImpl::GetDefaultInstance().InitializeWithObject(manager);
 }
 
 // for DiagnosticDataProviderManager

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -58,11 +58,6 @@ void ConfigurationManagerImpl::InitializeWithObject(jobject managerObject)
     AndroidConfig::InitializeWithObject(managerObject);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::Init()
-{
-    return CHIP_NO_ERROR;
-}
-
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/android/ConfigurationManagerImpl.h
+++ b/src/platform/android/ConfigurationManagerImpl.h
@@ -56,8 +56,6 @@ public:
 
 private:
     // ===== Members that implement the ConfigurationManager public interface.
-
-    CHIP_ERROR Init() override;
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset() override;
     void InitiateFactoryReset() override;

--- a/src/platform/android/java/chip/platform/AndroidChipPlatform.java
+++ b/src/platform/android/java/chip/platform/AndroidChipPlatform.java
@@ -28,13 +28,13 @@ public final class AndroidChipPlatform {
       ChipMdnsCallback chipMdnsCallback,
       DiagnosticDataProvider dataProvider) {
     // Order is important here: initChipStack() initializes the BLEManagerImpl, which depends on the
-    // BLEManager being set. setConfigurationManager() depends on the CHIP stack being initialized.
+    // BLEManager being set.
     setBLEManager(ble);
-    initChipStack();
     setKeyValueStoreManager(kvm);
     setConfigurationManager(cfg);
     setServiceResolver(resolver, chipMdnsCallback);
     setDiagnosticDataProviderManager(dataProvider);
+    initChipStack();
   }
 
   // for BLEManager


### PR DESCRIPTION
#### Problem
* Fix crash on startup at src/platform/CommissionableDataProvider.cpp, VerifyOrDie(gCommissionableDataProvider != nullptr);

#### Change overview
* It is because we do not call GenericPlatformManagerImpl<ImplClass>::_InitChipStack() --> GenericConfigurationManagerImpl<ConfigClass>::Init() on android at start up
* it is not called because there is a empty sub override
* it will set a default legacy impl there

#### Testing
* chip-tool paring/basic read
