### PR TITLE
Ensure ResolverProxy maintains callbacks until init is called. Ensure…

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -197,6 +197,8 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
     err = chip::app::InteractionModelEngine::GetInstance()->Init(&mExchangeMgr);
     SuccessOrExit(err);
 
+    chip::Dnssd::Resolver::Instance().Init(DeviceLayer::UDPEndPointManager());
+
 #if CHIP_CONFIG_ENABLE_SERVER_IM_EVENT
     // Initialize event logging subsystem
     {

--- a/src/lib/dnssd/ResolverProxy.h
+++ b/src/lib/dnssd/ResolverProxy.h
@@ -86,6 +86,24 @@ public:
         ReturnErrorOnFailure(chip::Dnssd::Resolver::Instance().Init(udpEndPoint));
         VerifyOrReturnError(mDelegate == nullptr, CHIP_ERROR_INCORRECT_STATE);
         mDelegate = chip::Platform::New<ResolverDelegateProxy>();
+
+        if (mDelegate != nullptr)
+        {
+            if (mPreInitOperationalDelegate != nullptr)
+            {
+                ChipLogProgress(Discovery, "Setting operational delegate post init");
+                mDelegate->SetOperationalDelegate(mPreInitOperationalDelegate);
+                mPreInitOperationalDelegate = nullptr;
+            }
+
+            if (mPreInitCommissioningDelegate != nullptr)
+            {
+                ChipLogProgress(Discovery, "Setting commissioning delegate post init");
+                mDelegate->SetCommissioningDelegate(mPreInitCommissioningDelegate);
+                mPreInitCommissioningDelegate = nullptr;
+            }
+        }
+
         return mDelegate != nullptr ? CHIP_NO_ERROR : CHIP_ERROR_NO_MEMORY;
     }
 
@@ -97,7 +115,8 @@ public:
         }
         else
         {
-            ChipLogError(Discovery, "Failed to proxy operational discovery: missing delegate");
+            ChipLogProgress(Discovery, "Delaying proxy of operational discovery: missing delegate");
+            mPreInitOperationalDelegate = delegate;
         }
     }
 
@@ -109,7 +128,8 @@ public:
         }
         else
         {
-            ChipLogError(Discovery, "Failed to proxy commissioning discovery: missing delegate");
+            ChipLogError(Discovery, "Delaying proxy of commissioning discovery: missing delegate");
+            mPreInitCommissioningDelegate = delegate;
         }
     }
 
@@ -127,7 +147,9 @@ public:
     CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
 
 private:
-    ResolverDelegateProxy * mDelegate = nullptr;
+    ResolverDelegateProxy * mDelegate                            = nullptr;
+    OperationalResolveDelegate * mPreInitOperationalDelegate     = nullptr;
+    CommissioningResolveDelegate * mPreInitCommissioningDelegate = nullptr;
 };
 
 } // namespace Dnssd


### PR DESCRIPTION
… server  app always initializes the global resolver

#### Problem
OTA on thread does not work (address resolution fails):
   - need to guarantee that address resolver is initialized
   - `ResolverProxy` will only store callbacks after it is initialized, but initialization is async and happens late (e.g. on SRP init, which is only available very late, after thread is set up and working).

#### Change overview
- Make `ResolverProxy` store callbacks until init is called
- Ensure server app initializes the global resolver.

#### Testing
Manual OTA announcement on a EFR device.