### PR TITLE
Update darwin CHIPDevice API

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPAttributeCacheContainer.h
+++ b/src/darwin/Framework/CHIP/CHIPAttributeCacheContainer.h
@@ -21,6 +21,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class CHIPSubscribeParams;
+
 @interface CHIPAttributeCacheContainer : NSObject
 
 /**
@@ -28,11 +30,13 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param deviceController   device controller to retrieve connected device from
  * @param deviceId  device identifier of the device to cache attributes of
+ * @param params  subscription parameters
  * @param clientQueue  client queue to dispatch the completion handler through
  * @param completion  completion handler
  */
 - (void)subscribeWithDeviceController:(CHIPDeviceController *)deviceController
                              deviceId:(uint64_t)deviceId
+                               params:(CHIPSubscribeParams * _Nullable)params
                           clientQueue:(dispatch_queue_t)clientQueue
                            completion:(void (^)(NSError * _Nullable error))completion;
 
@@ -47,9 +51,9 @@ NS_ASSUME_NONNULL_BEGIN
  *                   "values" received by the block will have the same format of object as the one received by completion block
  *                   of CHIPDevice readAttributeWithEndpointId:clusterId:attributeId:clientQueue:completion method.
  */
-- (void)readAttributeWithEndpointId:(NSUInteger)endpointId
-                          clusterId:(NSUInteger)clusterId
-                        attributeId:(NSUInteger)attributeId
+- (void)readAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
+                          clusterId:(NSNumber * _Nullable)clusterId
+                        attributeId:(NSNumber * _Nullable)attributeId
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(void (^)(NSArray<NSDictionary<NSString *, id> *> * _Nullable values,
                                         NSError * _Nullable error))completion;

--- a/src/darwin/Framework/CHIP/CHIPDevice.h
+++ b/src/darwin/Framework/CHIP/CHIPDevice.h
@@ -20,8 +20,6 @@
 
 #import <Foundation/Foundation.h>
 
-@class CHIPSubscribeParams;
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -91,6 +89,9 @@ extern NSString * const kCHIPNullValueType;
 extern NSString * const kCHIPStructureValueType;
 extern NSString * const kCHIPArrayValueType;
 
+@class CHIPReadParams;
+@class CHIPSubscribeParams;
+
 @interface CHIPDevice : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -126,9 +127,10 @@ extern NSString * const kCHIPArrayValueType;
 /**
  * Read attribute in a designated attribute path
  */
-- (void)readAttributeWithEndpointId:(NSUInteger)endpointId
-                          clusterId:(NSUInteger)clusterId
-                        attributeId:(NSUInteger)attributeId
+- (void)readAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
+                          clusterId:(NSNumber * _Nullable)clusterId
+                        attributeId:(NSNumber * _Nullable)attributeId
+                             params:(CHIPReadParams * _Nullable)params
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(CHIPDeviceResponseHandler)completion;
 
@@ -137,11 +139,19 @@ extern NSString * const kCHIPArrayValueType;
  *
  * @param value       A data-value NSDictionary object as described in
  *                    CHIPDeviceResponseHandler.
+ *
+ * @param timeoutMs   timeout in milliseconds for timed write, or nil.
+ *
+ * @param completion  response handler will receive either values or error.
+ *
+ *                    Received values are an NSArray object with response-value element as described in
+ *                    readAttributeWithEndpointId:clusterId:attributeId:clientQueue:completion:.
  */
-- (void)writeAttributeWithEndpointId:(NSUInteger)endpointId
-                           clusterId:(NSUInteger)clusterId
-                         attributeId:(NSUInteger)attributeId
+- (void)writeAttributeWithEndpointId:(NSNumber *)endpointId
+                           clusterId:(NSNumber *)clusterId
+                         attributeId:(NSNumber *)attributeId
                                value:(id)value
+                   timedWriteTimeout:(NSNumber * _Nullable)timeoutMs
                          clientQueue:(dispatch_queue_t)clientQueue
                           completion:(CHIPDeviceResponseHandler)completion;
 
@@ -152,22 +162,28 @@ extern NSString * const kCHIPArrayValueType;
  *                      as described in the CHIPDeviceResponseHandler.
  *                      The attribute must be a Structure, i.e.,
  *                      the NSDictionary kCHIPTypeKey key must have the value kCHIPStructureValueType.
+ *
+ * @param timeoutMs   timeout in milliseconds for timed invoke, or nil.
+ *
+ * @param completion  response handler will receive either values or error.
  */
-- (void)invokeCommandWithEndpointId:(NSUInteger)endpointId
-                          clusterId:(NSUInteger)clusterId
-                          commandId:(NSUInteger)commandId
+- (void)invokeCommandWithEndpointId:(NSNumber *)endpointId
+                          clusterId:(NSNumber *)clusterId
+                          commandId:(NSNumber *)commandId
                       commandFields:(id)commandFields
+                 timedInvokeTimeout:(NSNumber * _Nullable)timeoutMs
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(CHIPDeviceResponseHandler)completion;
 
 /**
  * Subscribe an attribute in a designated attribute path
  */
-- (void)subscribeAttributeWithEndpointId:(NSUInteger)endpointId
-                               clusterId:(NSUInteger)clusterId
-                             attributeId:(NSUInteger)attributeId
-                             minInterval:(NSUInteger)minInterval
-                             maxInterval:(NSUInteger)maxInterval
+- (void)subscribeAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
+                               clusterId:(NSNumber * _Nullable)clusterId
+                             attributeId:(NSNumber * _Nullable)attributeId
+                             minInterval:(NSNumber *)minInterval
+                             maxInterval:(NSNumber *)maxInterval
+                                  params:(CHIPSubscribeParams * _Nullable)params
                              clientQueue:(dispatch_queue_t)clientQueue
                            reportHandler:(CHIPDeviceResponseHandler)reportHandler
                  subscriptionEstablished:(nullable void (^)(void))subscriptionEstablishedHandler;

--- a/src/darwin/Framework/CHIP/CHIPDevice.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevice.mm
@@ -17,6 +17,7 @@
 
 #import "CHIPAttributeTLVValueDecoder_Internal.h"
 #import "CHIPCallbackBridgeBase_internal.h"
+#import "CHIPCluster.h"
 #import "CHIPDevice_Internal.h"
 #import "CHIPError_Internal.h"
 #import "CHIPLogging.h"
@@ -717,9 +718,10 @@ private:
     Platform::UniquePtr<app::ReadClient> mReadClient;
 };
 
-- (void)readAttributeWithEndpointId:(NSUInteger)endpointId
-                          clusterId:(NSUInteger)clusterId
-                        attributeId:(NSUInteger)attributeId
+- (void)readAttributeWithEndpointId:(NSNumber *)endpointId
+                          clusterId:(NSNumber *)clusterId
+                        attributeId:(NSNumber *)attributeId
+                             params:(CHIPReadParams * _Nullable)params
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(CHIPDeviceResponseHandler)completion
 {
@@ -755,17 +757,23 @@ private:
                 }
             };
 
-            auto chipEndpointId = static_cast<chip::EndpointId>(endpointId);
-            auto chipClusterId = static_cast<chip::ClusterId>(clusterId);
-            auto chipAttributeId = static_cast<chip::AttributeId>(attributeId);
-
-            app::AttributePathParams attributePath(chipEndpointId, chipClusterId, chipAttributeId);
+            app::AttributePathParams attributePath;
+            if (endpointId) {
+                attributePath.mEndpointId = static_cast<chip::EndpointId>([endpointId unsignedShortValue]);
+            }
+            if (clusterId) {
+                attributePath.mClusterId = static_cast<chip::ClusterId>([clusterId unsignedLongValue]);
+            }
+            if (attributeId) {
+                attributePath.mAttributeId = static_cast<chip::AttributeId>([attributeId unsignedLongValue]);
+            }
             app::InteractionModelEngine * engine = app::InteractionModelEngine::GetInstance();
             CHIP_ERROR err = CHIP_NO_ERROR;
 
             chip::app::ReadPrepareParams readParams([self internalDevice]->GetSecureSession().Value());
             readParams.mpAttributePathParamsList = &attributePath;
             readParams.mAttributePathParamsListSize = 1;
+            readParams.mIsFabricFiltered = params == nil || params.fabricFiltered == nil || [params.fabricFiltered boolValue];
 
             auto onDone = [resultArray, resultSuccess, resultFailure, context, successCb, failureCb](
                               BufferedReadAttributeCallback<NSObjectData> * callback) {
@@ -790,7 +798,7 @@ private:
             };
 
             auto callback = chip::Platform::MakeUnique<BufferedReadAttributeCallback<NSObjectData>>(
-                chipClusterId, chipAttributeId, onSuccessCb, onFailureCb, onDone, nullptr);
+                attributePath.mClusterId, attributePath.mAttributeId, onSuccessCb, onFailureCb, onDone, nullptr);
             VerifyOrReturnError(callback != nullptr, CHIP_ERROR_NO_MEMORY);
 
             auto readClient = chip::Platform::MakeUnique<app::ReadClient>(engine, [self internalDevice]->GetExchangeManager(),
@@ -814,10 +822,11 @@ private:
         });
 }
 
-- (void)writeAttributeWithEndpointId:(NSUInteger)endpointId
-                           clusterId:(NSUInteger)clusterId
-                         attributeId:(NSUInteger)attributeId
+- (void)writeAttributeWithEndpointId:(NSNumber *)endpointId
+                           clusterId:(NSNumber *)clusterId
+                         attributeId:(NSNumber *)attributeId
                                value:(id)value
+                   timedWriteTimeout:(NSNumber * _Nullable)timeoutMs
                          clientQueue:(dispatch_queue_t)clientQueue
                           completion:(CHIPDeviceResponseHandler)completion
 {
@@ -873,9 +882,10 @@ private:
                   };
 
             return chip::Controller::WriteAttribute<NSObjectData>([self internalDevice]->GetSecureSession().Value(),
-                static_cast<chip::EndpointId>(endpointId), static_cast<chip::ClusterId>(clusterId),
-                static_cast<chip::AttributeId>(attributeId), NSObjectData(value), onSuccessCb, onFailureCb, NullOptional, onDoneCb,
-                NullOptional);
+                static_cast<chip::EndpointId>([endpointId unsignedShortValue]),
+                static_cast<chip::ClusterId>([clusterId unsignedLongValue]),
+                static_cast<chip::AttributeId>([attributeId unsignedLongValue]), NSObjectData(value), onSuccessCb, onFailureCb,
+                (timeoutMs == nil) ? NullOptional : Optional<uint16_t>([timeoutMs unsignedShortValue]), onDoneCb, NullOptional);
         });
 }
 
@@ -944,10 +954,11 @@ exit:
     }
 }
 
-- (void)invokeCommandWithEndpointId:(NSUInteger)endpointId
-                          clusterId:(NSUInteger)clusterId
-                          commandId:(NSUInteger)commandId
+- (void)invokeCommandWithEndpointId:(NSNumber *)endpointId
+                          clusterId:(NSNumber *)clusterId
+                          commandId:(NSNumber *)commandId
                       commandFields:(id)commandFields
+                 timedInvokeTimeout:(NSNumber * _Nullable)timeoutMs
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(CHIPDeviceResponseHandler)completion
 {
@@ -982,8 +993,9 @@ exit:
                 }
             };
 
-            app::CommandPathParams commandPath = { (chip::EndpointId) endpointId, 0, (chip::ClusterId) clusterId,
-                (chip::CommandId) commandId, (app::CommandPathFlags::kEndpointIdValid) };
+            app::CommandPathParams commandPath = { static_cast<chip::EndpointId>([endpointId unsignedShortValue]), 0,
+                static_cast<chip::ClusterId>([clusterId unsignedLongValue]),
+                static_cast<chip::CommandId>([commandId unsignedLongValue]), (app::CommandPathFlags::kEndpointIdValid) };
 
             auto decoder = chip::Platform::MakeUnique<NSObjectCommandCallback>(
                 commandPath.mClusterId, commandPath.mCommandId, onSuccessCb, onFailureCb);
@@ -1017,7 +1029,8 @@ exit:
                 = chip::Platform::MakeUnique<app::CommandSender>(decoder.get(), [self internalDevice]->GetExchangeManager(), false);
             VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_NO_MEMORY);
 
-            ReturnErrorOnFailure(commandSender->AddRequestData(commandPath, NSObjectData(commandFields), chip::NullOptional));
+            ReturnErrorOnFailure(commandSender->AddRequestData(commandPath, NSObjectData(commandFields),
+                (timeoutMs == nil) ? NullOptional : Optional<uint16_t>([timeoutMs unsignedShortValue])));
             ReturnErrorOnFailure(commandSender->SendCommandRequest([self internalDevice]->GetSecureSession().Value()));
 
             decoder.release();
@@ -1026,11 +1039,12 @@ exit:
         });
 }
 
-- (void)subscribeAttributeWithEndpointId:(NSUInteger)endpointId
-                               clusterId:(NSUInteger)clusterId
-                             attributeId:(NSUInteger)attributeId
-                             minInterval:(NSUInteger)minInterval
-                             maxInterval:(NSUInteger)maxInterval
+- (void)subscribeAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
+                               clusterId:(NSNumber * _Nullable)clusterId
+                             attributeId:(NSNumber * _Nullable)attributeId
+                             minInterval:(NSNumber *)minInterval
+                             maxInterval:(NSNumber *)maxInterval
+                                  params:(CHIPSubscribeParams * _Nullable)params
                              clientQueue:(dispatch_queue_t)clientQueue
                            reportHandler:(CHIPDeviceResponseHandler)reportHandler
                  subscriptionEstablished:(SubscriptionEstablishedHandler)subscriptionEstablishedHandler
@@ -1074,13 +1088,18 @@ exit:
             }
         };
 
-        auto chipEndpointId = static_cast<chip::EndpointId>(endpointId);
-        auto chipClusterId = static_cast<chip::ClusterId>(clusterId);
-        auto chipAttributeId = static_cast<chip::AttributeId>(attributeId);
-
         CHIPReadClientContainer * container = [[CHIPReadClientContainer alloc] init];
         container.deviceId = self.cppDevice->GetDeviceId();
-        container.pathParams = Platform::New<app::AttributePathParams>(chipEndpointId, chipClusterId, chipAttributeId);
+        container.pathParams = Platform::New<app::AttributePathParams>();
+        if (endpointId) {
+            container.pathParams->mEndpointId = static_cast<chip::EndpointId>([endpointId unsignedShortValue]);
+        }
+        if (clusterId) {
+            container.pathParams->mClusterId = static_cast<chip::ClusterId>([clusterId unsignedLongValue]);
+        }
+        if (attributeId) {
+            container.pathParams->mAttributeId = static_cast<chip::AttributeId>([attributeId unsignedLongValue]);
+        }
 
         app::InteractionModelEngine * engine = app::InteractionModelEngine::GetInstance();
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1088,6 +1107,11 @@ exit:
         chip::app::ReadPrepareParams readParams([self internalDevice]->GetSecureSession().Value());
         readParams.mpAttributePathParamsList = container.pathParams;
         readParams.mAttributePathParamsListSize = 1;
+        readParams.mMinIntervalFloorSeconds = static_cast<uint16_t>([minInterval unsignedShortValue]);
+        readParams.mMaxIntervalCeilingSeconds = static_cast<uint16_t>([maxInterval unsignedShortValue]);
+        readParams.mIsFabricFiltered = (params == nil || params.fabricFiltered == nil || [params.fabricFiltered boolValue]);
+        readParams.mKeepSubscriptions
+            = (params != nil && params.keepPreviousSubscriptions != nil && [params.keepPreviousSubscriptions boolValue]);
 
         auto onDone = [container](BufferedReadAttributeCallback<NSObjectData> * callback) {
             chip::Platform::Delete(callback);
@@ -1095,7 +1119,7 @@ exit:
         };
 
         auto callback = chip::Platform::MakeUnique<BufferedReadAttributeCallback<NSObjectData>>(
-            chipClusterId, chipAttributeId, onReportCb, onFailureCb, onDone, onEstablishedCb);
+            container.pathParams->mClusterId, container.pathParams->mAttributeId, onReportCb, onFailureCb, onDone, onEstablishedCb);
 
         auto readClient = Platform::New<app::ReadClient>(engine, [self internalDevice]->GetExchangeManager(),
             callback -> GetBufferedCallback(), chip::app::ReadClient::InteractionType::Subscribe);

--- a/src/darwin/Framework/CHIP/CHIPDeviceController+XPC.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController+XPC.h
@@ -17,6 +17,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import <CHIP/CHIPCluster.h>
 #import <CHIP/CHIPDeviceController.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -47,6 +48,26 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSArray<NSDictionary<NSString *, id> *> * _Nullable)decodeXPCResponseValues:
     (NSArray<NSDictionary<NSString *, id> *> * _Nullable)values;
 
+/**
+ * Returns a serialized read parameter object to send over XPC
+ */
++ (NSDictionary<NSString *, id> * _Nullable)encodeXPCReadParams:(CHIPReadParams *)params;
+
+/**
+ * Returns a deserialized read parameter object from an object received over XPC
+ */
++ (CHIPReadParams * _Nullable)decodeXPCReadParams:(NSDictionary<NSString *, id> * _Nullable)params;
+
+/**
+ * Returns a serialized subscribe parameter object to send over XPC
+ */
++ (NSDictionary<NSString *, id> * _Nullable)encodeXPCSubscribeParams:(CHIPSubscribeParams *)params;
+
+/**
+ * Returns a deserialized subscribe parameter object from an object received over XPC
+ */
++ (CHIPSubscribeParams * _Nullable)decodeXPCSubscribeParams:(NSDictionary<NSString *, id> * _Nullable)params;
+
 @end
 /**
  * Protocol that remote object must support over XPC
@@ -69,9 +90,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)readAttributeWithController:(id _Nullable)controller
                              nodeId:(uint64_t)nodeId
-                         endpointId:(NSUInteger)endpointId
-                          clusterId:(NSUInteger)clusterId
-                        attributeId:(NSUInteger)attributeId
+                         endpointId:(NSNumber * _Nullable)endpointId
+                          clusterId:(NSNumber * _Nullable)clusterId
+                        attributeId:(NSNumber * _Nullable)attributeId
+                             params:(NSDictionary<NSString *, id> * _Nullable)params
                          completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion;
 
 /**
@@ -79,10 +101,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)writeAttributeWithController:(id _Nullable)controller
                               nodeId:(uint64_t)nodeId
-                          endpointId:(NSUInteger)endpointId
-                           clusterId:(NSUInteger)clusterId
-                         attributeId:(NSUInteger)attributeId
+                          endpointId:(NSNumber *)endpointId
+                           clusterId:(NSNumber *)clusterId
+                         attributeId:(NSNumber *)attributeId
                                value:(id)value
+                   timedWriteTimeout:(NSNumber * _Nullable)timeoutMs
                           completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion;
 
 /**
@@ -90,10 +113,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)invokeCommandWithController:(id _Nullable)controller
                              nodeId:(uint64_t)nodeId
-                         endpointId:(NSUInteger)endpointId
-                          clusterId:(NSUInteger)clusterId
-                          commandId:(NSUInteger)commandId
+                         endpointId:(NSNumber *)endpointId
+                          clusterId:(NSNumber *)clusterId
+                          commandId:(NSNumber *)commandId
                              fields:(id)fields
+                 timedInvokeTimeout:(NSNumber * _Nullable)timeoutMs
                          completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion;
 
 /**
@@ -101,18 +125,25 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)subscribeAttributeWithController:(id _Nullable)controller
                                   nodeId:(uint64_t)nodeId
-                              endpointId:(NSUInteger)endpointId
-                               clusterId:(NSUInteger)clusterId
-                             attributeId:(NSUInteger)attributeId
-                             minInterval:(NSUInteger)minInterval
-                             maxInterval:(NSUInteger)maxInterval
+                              endpointId:(NSNumber * _Nullable)endpointId
+                               clusterId:(NSNumber * _Nullable)clusterId
+                             attributeId:(NSNumber * _Nullable)attributeId
+                             minInterval:(NSNumber *)minInterval
+                             maxInterval:(NSNumber *)maxInterval
+                                  params:(NSDictionary<NSString *, id> * _Nullable)params
                       establishedHandler:(void (^)(void))establishedHandler;
+
+/**
+ * Requests to stop reporting
+ */
+- (void)stopReportsWithController:(id _Nullable)controller nodeId:(uint64_t)nodeId completion:(void (^)(void))completion;
 
 /**
  * Requests a specific node attribute subscription into a cache
  */
 - (void)subscribeAttributeCacheWithController:(id _Nullable)controller
                                        nodeId:(uint64_t)nodeId
+                                       params:(NSDictionary<NSString *, id> * _Nullable)params
                                    completion:(void (^)(NSError * _Nullable error))completion;
 
 /**
@@ -120,9 +151,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)readAttributeCacheWithController:(id _Nullable)controller
                                   nodeId:(uint64_t)nodeId
-                              endpointId:(NSUInteger)endpointId
-                               clusterId:(NSUInteger)clusterId
-                             attributeId:(NSUInteger)attributeId
+                              endpointId:(NSNumber * _Nullable)endpointId
+                               clusterId:(NSNumber * _Nullable)clusterId
+                             attributeId:(NSNumber * _Nullable)attributeId
                               completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion;
 
 @end

--- a/src/darwin/Framework/CHIP/CHIPDeviceControllerOverXPC+AttributeCache.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceControllerOverXPC+AttributeCache.h
@@ -21,14 +21,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class CHIPSubscribeParams;
+
 @interface CHIPDeviceControllerOverXPC (AttributeCache)
 
-- (void)subscribeAttributeCacheWithNodeId:(uint64_t)nodeId completion:(void (^)(NSError * _Nullable error))completion;
+- (void)subscribeAttributeCacheWithNodeId:(uint64_t)nodeId
+                                   params:(CHIPSubscribeParams * _Nullable)params
+                               completion:(void (^)(NSError * _Nullable error))completion;
 
 - (void)readAttributeCacheWithNodeId:(uint64_t)nodeId
-                          endpointId:(NSUInteger)endpointId
-                           clusterId:(NSUInteger)clusterId
-                         attributeId:(NSUInteger)attributeId
+                          endpointId:(NSNumber * _Nullable)endpointId
+                           clusterId:(NSNumber * _Nullable)clusterId
+                         attributeId:(NSNumber * _Nullable)attributeId
                           completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion;
 
 @end

--- a/src/darwin/Framework/CHIP/CHIPDeviceControllerOverXPC+AttributeCache.m
+++ b/src/darwin/Framework/CHIP/CHIPDeviceControllerOverXPC+AttributeCache.m
@@ -24,7 +24,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation CHIPDeviceControllerOverXPC (AttributeCache)
 
-- (void)subscribeAttributeCacheWithNodeId:(uint64_t)nodeId completion:(void (^)(NSError * _Nullable error))completion
+- (void)subscribeAttributeCacheWithNodeId:(uint64_t)nodeId
+                                   params:(CHIPSubscribeParams * _Nullable)params
+                               completion:(void (^)(NSError * _Nullable error))completion
 {
     dispatch_async(self.workQueue, ^{
         dispatch_group_t group = dispatch_group_create();
@@ -56,6 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
                     if (handle) {
                         [handle.proxy subscribeAttributeCacheWithController:self.controllerId
                                                                      nodeId:nodeId
+                                                                     params:[CHIPDeviceController encodeXPCSubscribeParams:params]
                                                                  completion:^(NSError * _Nullable error) {
                                                                      if (error) {
                                                                          CHIP_LOG_ERROR("Attribute cache subscription for "
@@ -84,9 +87,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)readAttributeCacheWithNodeId:(uint64_t)nodeId
-                          endpointId:(NSUInteger)endpointId
-                           clusterId:(NSUInteger)clusterId
-                         attributeId:(NSUInteger)attributeId
+                          endpointId:(NSNumber * _Nullable)endpointId
+                           clusterId:(NSNumber * _Nullable)clusterId
+                         attributeId:(NSNumber * _Nullable)attributeId
                           completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion
 {
     dispatch_async(self.workQueue, ^{

--- a/src/darwin/Framework/CHIPTests/CHIPDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPDeviceTests.m
@@ -207,9 +207,10 @@ static CHIPDevice * GetConnectedDevice(void)
     CHIPDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributeWithEndpointId:0xffff
-                              clusterId:29
-                            attributeId:0
+    [device readAttributeWithEndpointId:nil
+                              clusterId:@29
+                            attributeId:@0
+                                 params:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
                                  NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
@@ -248,10 +249,11 @@ static CHIPDevice * GetConnectedDevice(void)
 
     NSDictionary * writeValue = [NSDictionary
         dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:200], @"value", nil];
-    [device writeAttributeWithEndpointId:1
-                               clusterId:8
-                             attributeId:17
+    [device writeAttributeWithEndpointId:@1
+                               clusterId:@8
+                             attributeId:@17
                                    value:writeValue
+                       timedWriteTimeout:nil
                              clientQueue:queue
                               completion:^(id _Nullable values, NSError * _Nullable error) {
                                   NSLog(@"write attribute: Brightness values: %@, error: %@", values, error);
@@ -295,10 +297,11 @@ static CHIPDevice * GetConnectedDevice(void)
             @{ @"contextTag" : @1, @"data" : @ { @"type" : @"UnsignedInteger", @"value" : @10 } }
         ]
     };
-    [device invokeCommandWithEndpointId:1
-                              clusterId:8
-                              commandId:4
+    [device invokeCommandWithEndpointId:@1
+                              clusterId:@8
+                              commandId:@4
                           commandFields:fields
+                     timedInvokeTimeout:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
                                  NSLog(@"invoke command: MoveToLevelWithOnOff values: %@, error: %@", values, error);
@@ -326,41 +329,6 @@ static CHIPDevice * GetConnectedDevice(void)
 
 static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable error) = nil;
 
-#if !MANUAL_INDIVIDUAL_TEST
-- (void)test004_SubscribeOnly
-{
-    CHIPDevice * device = GetConnectedDevice();
-    dispatch_queue_t queue = dispatch_get_main_queue();
-
-    // Subscribe
-    XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointId:1
-        clusterId:6
-        attributeId:0
-        minInterval:1
-        maxInterval:10
-        clientQueue:queue
-        reportHandler:^(id _Nullable values, NSError * _Nullable error) {
-            NSLog(@"report attribute: OnOff values: %@, error: %@", values, error);
-
-            if (globalReportHandler) {
-                __auto_type callback = globalReportHandler;
-                callback(values, error);
-            }
-        }
-        subscriptionEstablished:^{
-            NSLog(@"subscribe attribute: OnOff established");
-            [expectation fulfill];
-        }];
-
-    // Wait till establishment
-    [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:kTimeoutInSeconds];
-}
-#endif
-
-// Report behavior is erratic on the accessory side at the moment.
-// Hence this test is enabled only for individual manual test.
-#if MANUAL_INDIVIDUAL_TEST
 - (void)test005_Subscribe
 {
 #if MANUAL_INDIVIDUAL_TEST
@@ -370,14 +338,14 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     CHIPDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-#if MANUAL_INDIVIDUAL_TEST
     // Subscribe
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointId:1
-        clusterId:6
-        attributeId:0
-        minInterval:1
-        maxInterval:10
+    [device subscribeAttributeWithEndpointId:@1
+        clusterId:@6
+        attributeId:@0
+        minInterval:@1
+        maxInterval:@10
+        params:nil
         clientQueue:queue
         reportHandler:^(id _Nullable values, NSError * _Nullable error) {
             NSLog(@"report attribute: OnOff values: %@, error: %@", values, error);
@@ -394,14 +362,13 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Wait till establishment
     [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:kTimeoutInSeconds];
-#endif
 
     // Set up expectation for report
     XCTestExpectation * reportExpectation = [self expectationWithDescription:@"report received"];
-    globalReportHandler = ^(id _Nullable value, NSError * _Nullable error) {
+    globalReportHandler = ^(id _Nullable values, NSError * _Nullable error) {
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
-        XCTAssertTrue([value isKindOfClass:[NSArray class]]);
-        NSDictionary * result = value[0];
+        XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+        NSDictionary * result = values[0];
         CHIPAttributePath * path = result[@"attributePath"];
         XCTAssertEqual([path.endpoint unsignedIntegerValue], 1);
         XCTAssertEqual([path.cluster unsignedIntegerValue], 6);
@@ -417,10 +384,11 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Send commands to trigger attribute change
     XCTestExpectation * commandExpectation = [self expectationWithDescription:@"command responded"];
     NSDictionary * fields = @{ @"type" : @"Structure", @"value" : [NSArray array] };
-    [device invokeCommandWithEndpointId:1
-                              clusterId:6
-                              commandId:1
+    [device invokeCommandWithEndpointId:@1
+                              clusterId:@6
+                              commandId:@1
                           commandFields:fields
+                     timedInvokeTimeout:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
                                  NSLog(@"invoke command: On values: %@, error: %@", values, error);
@@ -448,10 +416,10 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Set up expectation for 2nd report
     reportExpectation = [self expectationWithDescription:@"receive OnOff attribute report"];
-    globalReportHandler = ^(id _Nullable value, NSError * _Nullable error) {
+    globalReportHandler = ^(id _Nullable values, NSError * _Nullable error) {
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], 0);
-        XCTAssertTrue([value isKindOfClass:[NSArray class]]);
-        NSDictionary * result = value[0];
+        XCTAssertTrue([values isKindOfClass:[NSArray class]]);
+        NSDictionary * result = values[0];
         CHIPAttributePath * path = result[@"attributePath"];
         XCTAssertEqual([path.endpoint unsignedIntegerValue], 1);
         XCTAssertEqual([path.cluster unsignedIntegerValue], 6);
@@ -466,10 +434,11 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to trigger attribute change
     fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
-    [device invokeCommandWithEndpointId:1
-                              clusterId:6
-                              commandId:0
+    [device invokeCommandWithEndpointId:@1
+                              clusterId:@6
+                              commandId:@0
                           commandFields:fields
+                     timedInvokeTimeout:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
                                  NSLog(@"invoke command: On values: %@, error: %@", values, error);
@@ -500,7 +469,6 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
                                          }];
     [self waitForExpectations:@[ expectation ] timeout:kTimeoutInSeconds];
 }
-#endif
 
 - (void)test006_ReadAttributeFailure
 {
@@ -514,9 +482,10 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     dispatch_queue_t queue = dispatch_get_main_queue();
 
     [device
-        readAttributeWithEndpointId:0
-                          clusterId:10000
-                        attributeId:0
+        readAttributeWithEndpointId:@0
+                          clusterId:@10000
+                        attributeId:@0
+                             params:nil
                         clientQueue:queue
                          completion:^(id _Nullable values, NSError * _Nullable error) {
                              NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
@@ -543,10 +512,11 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     NSDictionary * writeValue = [NSDictionary
         dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:200], @"value", nil];
-    [device writeAttributeWithEndpointId:1
-                               clusterId:8
-                             attributeId:10000
+    [device writeAttributeWithEndpointId:@1
+                               clusterId:@8
+                             attributeId:@10000
                                    value:writeValue
+                       timedWriteTimeout:nil
                              clientQueue:queue
                               completion:^(id _Nullable values, NSError * _Nullable error) {
                                   NSLog(@"write attribute: Brightness values: %@, error: %@", values, error);
@@ -573,28 +543,28 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     CHIPDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    NSDictionary *fields = [NSDictionary dictionaryWithObjectsAndKeys:
-                            @"Structure", @"type",
-                            [NSArray arrayWithObjects:
-                             [NSDictionary dictionaryWithObjectsAndKeys:
-                              [NSNumber numberWithUnsignedInteger:0], @"tag",
-                              [NSDictionary dictionaryWithObjectsAndKeys:
-                               @"UnsignedInteger", @"type",
-                               [NSNumber numberWithUnsignedInteger:0], @"value", nil], @"value", nil],
-                             [NSDictionary dictionaryWithObjectsAndKeys:
-                              [NSNumber numberWithUnsignedInteger:1], @"tag",
-                              [NSDictionary dictionaryWithObjectsAndKeys:
-                               @"UnsignedInteger", @"type",
-                               [NSNumber numberWithUnsignedInteger:10], @"value", nil], @"value", nil],
-                             nil], @"value", nil];
-    [device invokeCommandWithEndpointId:1 clusterId:8 commandId:40000 commandFields:fields clientQueue:queue completion:^(id _Nullable values, NSError * _Nullable error) {
-        NSLog(@"invoke command: MoveToLevelWithOnOff values: %@, error: %@", values, error);
+    NSDictionary * fields = @{
+        @"type" : @"Structure",
+        @"value" : @[
+            @{ @"contextTag" : @0, @"data" : @ { @"type" : @"UnsignedInteger", @"value" : @0 } },
+            @{ @"contextTag" : @1, @"data" : @ { @"type" : @"UnsignedInteger", @"value" : @10 } }
+        ]
+    };
+    [device
+        invokeCommandWithEndpointId:@1
+                          clusterId:@8
+                          commandId:@40000
+                      commandFields:fields
+                 timedInvokeTimeout:nil
+                        clientQueue:queue
+                         completion:^(id _Nullable values, NSError * _Nullable error) {
+                             NSLog(@"invoke command: MoveToLevelWithOnOff values: %@, error: %@", values, error);
 
-        XCTAssertNil(values);
-        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], EMBER_ZCL_STATUS_UNSUPPORTED_COMMAND);
+                             XCTAssertNil(values);
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:error], EMBER_ZCL_STATUS_UNSUPPORTED_COMMAND);
 
-        [expectation fulfill];
-    }];
+                             [expectation fulfill];
+                         }];
 
     [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:kTimeoutInSeconds];
 }
@@ -629,11 +599,12 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
                                          }];
     [self waitForExpectations:@[ cleanSubscriptionExpectation ] timeout:kTimeoutInSeconds];
 
-    [device subscribeAttributeWithEndpointId:10000
-        clusterId:6
-        attributeId:0
-        minInterval:2
-        maxInterval:10
+    [device subscribeAttributeWithEndpointId:@10000
+        clusterId:@6
+        attributeId:@0
+        minInterval:@2
+        maxInterval:@10
+        params:nil
         clientQueue:queue
         reportHandler:^(id _Nullable values, NSError * _Nullable error) {
             NSLog(@"report attribute: OnOff values: %@, error: %@", values, error);
@@ -665,9 +636,10 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     CHIPDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributeWithEndpointId:1
-                              clusterId:29
-                            attributeId:0xffffffff
+    [device readAttributeWithEndpointId:@1
+                              clusterId:@29
+                            attributeId:nil
+                                 params:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
                                  NSLog(@"read attribute: DeviceType values: %@, error: %@", values, error);
@@ -718,6 +690,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Subscribing...");
     [attributeCacheContainer subscribeWithDeviceController:controller
                                                   deviceId:kDeviceId
+                                                    params:nil
                                                clientQueue:queue
                                                 completion:^(NSError * _Nullable error) {
                                                     NSLog(@"Subscription complete with error: %@", error);
@@ -814,9 +787,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from cache using generic path...");
     cacheExpectation = [self expectationWithDescription:@"Attribute cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:1
-                          clusterId:6
-                        attributeId:0
+        readAttributeWithEndpointId:@1
+                          clusterId:@6
+                        attributeId:@0
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read attribute cache value: %@, error %@", values, error);
@@ -837,9 +810,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from cache using wildcard endpoint...");
     cacheExpectation = [self expectationWithDescription:@"Attribute cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:0xffff
-                          clusterId:6
-                        attributeId:0
+        readAttributeWithEndpointId:nil
+                          clusterId:@6
+                        attributeId:@0
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read attribute cache value: %@, error %@", values, error);
@@ -859,9 +832,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from cache using wildcard cluster ID...");
     cacheExpectation = [self expectationWithDescription:@"Attribute cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:1
-                          clusterId:0xffffffff
-                        attributeId:0
+        readAttributeWithEndpointId:@1
+                          clusterId:nil
+                        attributeId:@0
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read attribute cache value: %@, error %@", values, error);
@@ -880,9 +853,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from cache using wildcard attribute ID...");
     cacheExpectation = [self expectationWithDescription:@"Attribute cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:1
-                          clusterId:6
-                        attributeId:0xffffffff
+        readAttributeWithEndpointId:@1
+                          clusterId:@6
+                        attributeId:nil
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read attribute cache value: %@, error %@", values, error);
@@ -902,9 +875,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from cache using wildcard endpoint ID and cluster ID...");
     cacheExpectation = [self expectationWithDescription:@"Attribute cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:0xffff
-                          clusterId:0xffffffff
-                        attributeId:0
+        readAttributeWithEndpointId:nil
+                          clusterId:nil
+                        attributeId:@0
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read attribute cache value: %@, error %@", values, error);
@@ -933,11 +906,12 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointId:1
-        clusterId:6
-        attributeId:0
-        minInterval:1
-        maxInterval:10
+    [device subscribeAttributeWithEndpointId:@1
+        clusterId:@6
+        attributeId:@0
+        minInterval:@1
+        maxInterval:@10
+        params:nil
         clientQueue:queue
         reportHandler:^(id _Nullable values, NSError * _Nullable error) {
             NSLog(@"report attribute: OnOff values: %@, error: %@", values, error);
@@ -976,10 +950,11 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Send commands to trigger attribute change
     XCTestExpectation * commandExpectation = [self expectationWithDescription:@"command responded"];
     NSDictionary * fields = @{ @"type" : @"Structure", @"value" : [NSArray array] };
-    [device invokeCommandWithEndpointId:1
-                              clusterId:6
-                              commandId:1
+    [device invokeCommandWithEndpointId:@1
+                              clusterId:@6
+                              commandId:@1
                           commandFields:fields
+                     timedInvokeTimeout:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
                                  NSLog(@"invoke command: On values: %@, error: %@", values, error);
@@ -1042,11 +1017,12 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
     __block void (^reportHandler)(id _Nullable values, NSError * _Nullable error) = nil;
 
-    [device subscribeAttributeWithEndpointId:1
-        clusterId:6
-        attributeId:0xffffffff
-        minInterval:2
-        maxInterval:10
+    [device subscribeAttributeWithEndpointId:@1
+        clusterId:@6
+        attributeId:@0xffffffff
+        minInterval:@2
+        maxInterval:@10
+        params:nil
         clientQueue:queue
         reportHandler:^(id _Nullable values, NSError * _Nullable error) {
             NSLog(@"Subscribe all - report attribute values: %@, error: %@, report handler: %d", values, error,
@@ -1085,10 +1061,11 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Send commands to set attribute state to a known state
     XCTestExpectation * commandExpectation = [self expectationWithDescription:@"command responded"];
     NSDictionary * fields = @{ @"type" : @"Structure", @"value" : @[] };
-    [device invokeCommandWithEndpointId:1
-                              clusterId:6
-                              commandId:0
+    [device invokeCommandWithEndpointId:@1
+                              clusterId:@6
+                              commandId:@0
                           commandFields:fields
+                     timedInvokeTimeout:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
                                  NSLog(@"invoke command: On values: %@, error: %@", values, error);
@@ -1114,10 +1091,11 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Send commands to trigger attribute change
     commandExpectation = [self expectationWithDescription:@"command responded"];
     fields = @{ @"type" : @"Structure", @"value" : @[] };
-    [device invokeCommandWithEndpointId:1
-                              clusterId:6
-                              commandId:1
+    [device invokeCommandWithEndpointId:@1
+                              clusterId:@6
+                              commandId:@1
                           commandFields:fields
+                     timedInvokeTimeout:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
                                  NSLog(@"invoke command: On values: %@, error: %@", values, error);
@@ -1162,10 +1140,11 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Send command to trigger attribute change
     commandExpectation = [self expectationWithDescription:@"command responded"];
     fields = @{ @"type" : @"Structure", @"value" : @[] };
-    [device invokeCommandWithEndpointId:1
-                              clusterId:6
-                              commandId:0
+    [device invokeCommandWithEndpointId:@1
+                              clusterId:@6
+                              commandId:@0
                           commandFields:fields
+                     timedInvokeTimeout:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
                                  NSLog(@"invoke command: On values: %@, error: %@", values, error);

--- a/src/darwin/Framework/CHIPTests/CHIPXPCProtocolTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPXPCProtocolTests.m
@@ -90,18 +90,24 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     (uint64_t fabricId, void (^completion)(id _Nullable controller, NSError * _Nullable error));
 @property (readwrite, strong) void (^handleGetAnySharedRemoteController)
     (void (^completion)(id _Nullable controller, NSError * _Nullable error));
-@property (readwrite, strong) void (^handleReadAttribute)(id controller, uint64_t nodeId, NSUInteger endpointId,
-    NSUInteger clusterId, NSUInteger attributeId, void (^completion)(id _Nullable values, NSError * _Nullable error));
-@property (readwrite, strong) void (^handleWriteAttribute)(id controller, uint64_t nodeId, NSUInteger endpointId,
-    NSUInteger clusterId, NSUInteger attributeId, id value, void (^completion)(id _Nullable values, NSError * _Nullable error));
-@property (readwrite, strong) void (^handleInvokeCommand)(id controller, uint64_t nodeId, NSUInteger endpointId,
-    NSUInteger clusterId, NSUInteger commandId, id fields, void (^completion)(id _Nullable values, NSError * _Nullable error));
-@property (readwrite, strong) void (^handleSubscribeAttribute)(id controller, uint64_t nodeId, NSUInteger endpointId,
-    NSUInteger clusterId, NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void));
+@property (readwrite, strong) void (^handleReadAttribute)(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId,
+    NSNumber * _Nullable clusterId, NSNumber * _Nullable attributeId, CHIPReadParams * _Nullable params,
+    void (^completion)(id _Nullable values, NSError * _Nullable error));
+@property (readwrite, strong) void (^handleWriteAttribute)
+    (id controller, uint64_t nodeId, NSNumber * endpointId, NSNumber * clusterId, NSNumber * attributeId, id value,
+        NSNumber * _Nullable timedWriteTimeout, void (^completion)(id _Nullable values, NSError * _Nullable error));
+@property (readwrite, strong) void (^handleInvokeCommand)
+    (id controller, uint64_t nodeId, NSNumber * endpointId, NSNumber * clusterId, NSNumber * commandId, id fields,
+        NSNumber * _Nullable timedInvokeTimeout, void (^completion)(id _Nullable values, NSError * _Nullable error));
+@property (readwrite, strong) void (^handleSubscribeAttribute)(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId,
+    NSNumber * _Nullable clusterId, NSNumber * _Nullable attributeId, NSNumber * minInterval, NSNumber * maxInterval,
+    CHIPSubscribeParams * _Nullable params, void (^establishedHandler)(void));
+@property (readwrite, strong) void (^handleStopReports)(id controller, uint64_t nodeId, void (^completion)(void));
 @property (readwrite, strong) void (^handleSubscribeAttributeCache)
-    (id controller, uint64_t nodeId, void (^completion)(NSError * _Nullable error));
-@property (readwrite, strong) void (^handleReadAttributeCache)(id controller, uint64_t nodeId, NSUInteger endpointId,
-    NSUInteger clusterId, NSUInteger attributeId, void (^completion)(id _Nullable values, NSError * _Nullable error));
+    (id controller, uint64_t nodeId, CHIPSubscribeParams * _Nullable params, void (^completion)(NSError * _Nullable error));
+@property (readwrite, strong) void (^handleReadAttributeCache)
+    (id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, void (^completion)(id _Nullable values, NSError * _Nullable error));
 
 @end
 
@@ -147,76 +153,90 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
 - (void)readAttributeWithController:(id)controller
                              nodeId:(uint64_t)nodeId
-                         endpointId:(NSUInteger)endpointId
-                          clusterId:(NSUInteger)clusterId
-                        attributeId:(NSUInteger)attributeId
+                         endpointId:(NSNumber * _Nullable)endpointId
+                          clusterId:(NSNumber * _Nullable)clusterId
+                        attributeId:(NSNumber * _Nullable)attributeId
+                             params:(NSDictionary<NSString *, id> * _Nullable)params
                          completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         XCTAssertNotNil(self.handleReadAttribute);
-        self.handleReadAttribute(controller, nodeId, endpointId, clusterId, attributeId, completion);
+        self.handleReadAttribute(
+            controller, nodeId, endpointId, clusterId, attributeId, [CHIPDeviceController decodeXPCReadParams:params], completion);
     });
 }
 
 - (void)writeAttributeWithController:(id)controller
                               nodeId:(uint64_t)nodeId
-                          endpointId:(NSUInteger)endpointId
-                           clusterId:(NSUInteger)clusterId
-                         attributeId:(NSUInteger)attributeId
+                          endpointId:(NSNumber *)endpointId
+                           clusterId:(NSNumber *)clusterId
+                         attributeId:(NSNumber *)attributeId
                                value:(id)value
+                   timedWriteTimeout:(NSNumber * _Nullable)timeoutMs
                           completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         XCTAssertNotNil(self.handleWriteAttribute);
-        self.handleWriteAttribute(controller, nodeId, endpointId, clusterId, attributeId, value, completion);
+        self.handleWriteAttribute(controller, nodeId, endpointId, clusterId, attributeId, value, timeoutMs, completion);
     });
 }
 
 - (void)invokeCommandWithController:(id)controller
                              nodeId:(uint64_t)nodeId
-                         endpointId:(NSUInteger)endpointId
-                          clusterId:(NSUInteger)clusterId
-                          commandId:(NSUInteger)commandId
+                         endpointId:(NSNumber *)endpointId
+                          clusterId:(NSNumber *)clusterId
+                          commandId:(NSNumber *)commandId
                              fields:(id)fields
+                 timedInvokeTimeout:(NSNumber * _Nullable)timeoutMs
                          completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         XCTAssertNotNil(self.handleInvokeCommand);
-        self.handleInvokeCommand(controller, nodeId, endpointId, clusterId, commandId, fields, completion);
+        self.handleInvokeCommand(controller, nodeId, endpointId, clusterId, commandId, fields, timeoutMs, completion);
     });
 }
 
 - (void)subscribeAttributeWithController:(id)controller
                                   nodeId:(uint64_t)nodeId
-                              endpointId:(NSUInteger)endpointId
-                               clusterId:(NSUInteger)clusterId
-                             attributeId:(NSUInteger)attributeId
-                             minInterval:(NSUInteger)minInterval
-                             maxInterval:(NSUInteger)maxInterval
+                              endpointId:(NSNumber * _Nullable)endpointId
+                               clusterId:(NSNumber * _Nullable)clusterId
+                             attributeId:(NSNumber * _Nullable)attributeId
+                             minInterval:(NSNumber *)minInterval
+                             maxInterval:(NSNumber *)maxInterval
+                                  params:(NSDictionary<NSString *, id> * _Nullable)params
                       establishedHandler:(void (^)(void))establishedHandler
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         XCTAssertNotNil(self.handleSubscribeAttribute);
-        self.handleSubscribeAttribute(
-            controller, nodeId, endpointId, clusterId, attributeId, minInterval, maxInterval, establishedHandler);
+        self.handleSubscribeAttribute(controller, nodeId, endpointId, clusterId, attributeId, minInterval, maxInterval,
+            [CHIPDeviceController decodeXPCSubscribeParams:params], establishedHandler);
+    });
+}
+
+- (void)stopReportsWithController:(id)controller nodeId:(uint64_t)nodeId completion:(void (^)(void))completion
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        XCTAssertNotNil(self.handleStopReports);
+        self.handleStopReports(controller, nodeId, completion);
     });
 }
 
 - (void)subscribeAttributeCacheWithController:(id _Nullable)controller
                                        nodeId:(uint64_t)nodeId
+                                       params:(NSDictionary<NSString *, id> * _Nullable)params
                                    completion:(void (^)(NSError * _Nullable error))completion
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         XCTAssertNotNil(self.handleSubscribeAttributeCache);
-        self.handleSubscribeAttributeCache(controller, nodeId, completion);
+        self.handleSubscribeAttributeCache(controller, nodeId, [CHIPDeviceController decodeXPCSubscribeParams:params], completion);
     });
 }
 
 - (void)readAttributeCacheWithController:(id _Nullable)controller
                                   nodeId:(uint64_t)nodeId
-                              endpointId:(NSUInteger)endpointId
-                               clusterId:(NSUInteger)clusterId
-                             attributeId:(NSUInteger)attributeId
+                              endpointId:(NSNumber * _Nullable)endpointId
+                               clusterId:(NSNumber * _Nullable)clusterId
+                             attributeId:(NSNumber * _Nullable)attributeId
                               completion:(void (^)(id _Nullable values, NSError * _Nullable error))completion
 {
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -253,13 +273,13 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 - (void)testReadAttributeSuccess
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myAttributeId = 300;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
     NSArray * myValues = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
 
@@ -267,13 +287,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
 
     __auto_type uuid = self.controllerUUID;
-    _handleReadAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId, NSUInteger attributeId,
+    _handleReadAttribute = ^(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, CHIPReadParams * _Nullable params,
         void (^completion)(id _Nullable values, NSError * _Nullable error)) {
         XCTAssertTrue([controller isEqualToString:uuid]);
         XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
+        XCTAssertNil(params);
         [callExpectation fulfill];
         completion([CHIPDeviceController encodeXPCResponseValues:myValues], nil);
     };
@@ -287,6 +309,69 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                   [device readAttributeWithEndpointId:myEndpointId
                                                             clusterId:myClusterId
                                                           attributeId:myAttributeId
+                                                               params:nil
+                                                          clientQueue:dispatch_get_main_queue()
+                                                           completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                               NSLog(@"Read value: %@", value);
+                                                               XCTAssertNotNil(value);
+                                                               XCTAssertNil(error);
+                                                               XCTAssertTrue([myValues isEqualTo:value]);
+                                                               [responseExpectation fulfill];
+                                                               self.xpcDisconnectExpectation =
+                                                                   [self expectationWithDescription:@"XPC Disconnected"];
+                                                           }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, responseExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // When read is done, connection should have been released
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testReadAttributeWithParamsSuccess
+{
+    uint64_t myNodeId = 9876543210;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
+    NSArray * myValues = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
+    } ];
+    CHIPReadParams * myParams = [[CHIPReadParams alloc] init];
+    myParams.fabricFiltered = @NO;
+
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
+
+    __auto_type uuid = self.controllerUUID;
+    _handleReadAttribute = ^(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, CHIPReadParams * _Nullable params,
+        void (^completion)(id _Nullable values, NSError * _Nullable error)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
+        XCTAssertNotNil(params);
+        XCTAssertEqual([params.fabricFiltered boolValue], [myParams.fabricFiltered boolValue]);
+        [callExpectation fulfill];
+        completion([CHIPDeviceController encodeXPCResponseValues:myValues], nil);
+    };
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Reading...");
+                                  [device readAttributeWithEndpointId:myEndpointId
+                                                            clusterId:myClusterId
+                                                          attributeId:myAttributeId
+                                                               params:myParams
                                                           clientQueue:dispatch_get_main_queue()
                                                            completion:^(id _Nullable value, NSError * _Nullable error) {
                                                                NSLog(@"Read value: %@", value);
@@ -309,21 +394,23 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 - (void)testReadAttributeFailure
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myAttributeId = 300;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
     NSError * myError = [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
 
     __auto_type uuid = self.controllerUUID;
-    _handleReadAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId, NSUInteger attributeId,
+    _handleReadAttribute = ^(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, CHIPReadParams * _Nullable params,
         void (^completion)(id _Nullable values, NSError * _Nullable error)) {
         XCTAssertTrue([controller isEqualToString:uuid]);
         XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
+        XCTAssertNil(params);
         [callExpectation fulfill];
         completion(nil, myError);
     };
@@ -337,6 +424,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                   [device readAttributeWithEndpointId:myEndpointId
                                                             clusterId:myClusterId
                                                           attributeId:myAttributeId
+                                                               params:nil
                                                           clientQueue:dispatch_get_main_queue()
                                                            completion:^(id _Nullable value, NSError * _Nullable error) {
                                                                NSLog(@"Read value: %@", value);
@@ -358,29 +446,30 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 - (void)testWriteAttributeSuccess
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myAttributeId = 300;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
     NSDictionary * myValue =
         [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithInteger:654321], @"value", nil];
     NSArray * myResults = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]]
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId]
     } ];
 
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
 
     __auto_type uuid = self.controllerUUID;
-    _handleWriteAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId, NSUInteger attributeId,
-        id value, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
+    _handleWriteAttribute = ^(id controller, uint64_t nodeId, NSNumber * endpointId, NSNumber * clusterId, NSNumber * attributeId,
+        id value, NSNumber * _Nullable timedWriteTimeout, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
         XCTAssertTrue([controller isEqualToString:uuid]);
         XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
         XCTAssertTrue([value isEqualTo:myValue]);
+        XCTAssertNil(timedWriteTimeout);
         [callExpectation fulfill];
         completion([CHIPDeviceController encodeXPCResponseValues:myResults], nil);
     };
@@ -395,6 +484,70 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                                              clusterId:myClusterId
                                                            attributeId:myAttributeId
                                                                  value:myValue
+                                                     timedWriteTimeout:nil
+                                                           clientQueue:dispatch_get_main_queue()
+                                                            completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                                NSLog(@"Write response: %@", value);
+                                                                XCTAssertNotNil(value);
+                                                                XCTAssertNil(error);
+                                                                XCTAssertTrue([myResults isEqualTo:value]);
+                                                                [responseExpectation fulfill];
+                                                                self.xpcDisconnectExpectation =
+                                                                    [self expectationWithDescription:@"XPC Disconnected"];
+                                                            }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, responseExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // When write is done, connection should have been released
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testTimedWriteAttributeSuccess
+{
+    uint64_t myNodeId = 9876543210;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
+    NSDictionary * myValue =
+        [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithInteger:654321], @"value", nil];
+    NSNumber * myTimedWriteTimeout = @1234;
+    NSArray * myResults = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId]
+    } ];
+
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
+
+    __auto_type uuid = self.controllerUUID;
+    _handleWriteAttribute = ^(id controller, uint64_t nodeId, NSNumber * endpointId, NSNumber * clusterId, NSNumber * attributeId,
+        id value, NSNumber * _Nullable timedWriteTimeout, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
+        XCTAssertTrue([value isEqualTo:myValue]);
+        XCTAssertNotNil(timedWriteTimeout);
+        XCTAssertEqual([timedWriteTimeout unsignedShortValue], [myTimedWriteTimeout unsignedShortValue]);
+        [callExpectation fulfill];
+        completion([CHIPDeviceController encodeXPCResponseValues:myResults], nil);
+    };
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Writing...");
+                                  [device writeAttributeWithEndpointId:myEndpointId
+                                                             clusterId:myClusterId
+                                                           attributeId:myAttributeId
+                                                                 value:myValue
+                                                     timedWriteTimeout:myTimedWriteTimeout
                                                            clientQueue:dispatch_get_main_queue()
                                                             completion:^(id _Nullable value, NSError * _Nullable error) {
                                                                 NSLog(@"Write response: %@", value);
@@ -417,9 +570,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 - (void)testWriteAttributeFailure
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myAttributeId = 300;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
     NSDictionary * myValue =
         [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithInteger:654321], @"value", nil];
     NSError * myError = [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil];
@@ -427,14 +580,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
 
     __auto_type uuid = self.controllerUUID;
-    _handleWriteAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId, NSUInteger attributeId,
-        id value, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
+    _handleWriteAttribute = ^(id controller, uint64_t nodeId, NSNumber * endpointId, NSNumber * clusterId, NSNumber * attributeId,
+        id value, NSNumber * _Nullable timedWriteTimeout, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
         XCTAssertTrue([controller isEqualToString:uuid]);
         XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
         XCTAssertTrue([value isEqualTo:myValue]);
+        XCTAssertNil(timedWriteTimeout);
         [callExpectation fulfill];
         completion(nil, myError);
     };
@@ -449,6 +603,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                                              clusterId:myClusterId
                                                            attributeId:myAttributeId
                                                                  value:myValue
+                                                     timedWriteTimeout:nil
                                                            clientQueue:dispatch_get_main_queue()
                                                             completion:^(id _Nullable value, NSError * _Nullable error) {
                                                                 NSLog(@"Write response: %@", value);
@@ -470,33 +625,33 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 - (void)testInvokeCommandSuccess
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myCommandId = 300;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myCommandId = @300;
     NSDictionary * myFields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type",
                                             [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:@"Float", @"Type",
                                                                                    [NSNumber numberWithFloat:1.0], @"value", nil]],
                                             @"value", nil];
-    NSArray * myResults = @[ @{
-        @"commandPath" : [CHIPCommandPath commandPathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                          clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                          commandId:[NSNumber numberWithUnsignedInteger:myCommandId]]
-    } ];
+    NSArray * myResults = @[
+        @{ @"commandPath" : [CHIPCommandPath commandPathWithEndpointId:myEndpointId clusterId:myClusterId commandId:myCommandId] }
+    ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
 
     __auto_type uuid = self.controllerUUID;
-    _handleInvokeCommand = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId, NSUInteger commandId,
-        id commandFields, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
-        XCTAssertTrue([controller isEqualToString:uuid]);
-        XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(commandId, myCommandId);
-        XCTAssertTrue([commandFields isEqualTo:myFields]);
-        [callExpectation fulfill];
-        completion([CHIPDeviceController encodeXPCResponseValues:myResults], nil);
-    };
+    _handleInvokeCommand
+        = ^(id controller, uint64_t nodeId, NSNumber * endpointId, NSNumber * clusterId, NSNumber * commandId, id commandFields,
+            NSNumber * _Nullable timedInvokeTimeout, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
+              XCTAssertTrue([controller isEqualToString:uuid]);
+              XCTAssertEqual(nodeId, myNodeId);
+              XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+              XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+              XCTAssertEqual([commandId unsignedLongValue], [myCommandId unsignedLongValue]);
+              XCTAssertTrue([commandFields isEqualTo:myFields]);
+              XCTAssertNil(timedInvokeTimeout);
+              [callExpectation fulfill];
+              completion([CHIPDeviceController encodeXPCResponseValues:myResults], nil);
+          };
 
     [_remoteDeviceController getConnectedDevice:myNodeId
                                           queue:dispatch_get_main_queue()
@@ -508,6 +663,70 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                                             clusterId:myClusterId
                                                             commandId:myCommandId
                                                         commandFields:myFields
+                                                   timedInvokeTimeout:nil
+                                                          clientQueue:dispatch_get_main_queue()
+                                                           completion:^(id _Nullable value, NSError * _Nullable error) {
+                                                               NSLog(@"Command response: %@", value);
+                                                               XCTAssertNotNil(value);
+                                                               XCTAssertNil(error);
+                                                               XCTAssertTrue([myResults isEqualTo:value]);
+                                                               [responseExpectation fulfill];
+                                                               self.xpcDisconnectExpectation =
+                                                                   [self expectationWithDescription:@"XPC Disconnected"];
+                                                           }];
+                              }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, responseExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // When command is done, connection should have been released
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testTimedInvokeCommandSuccess
+{
+    uint64_t myNodeId = 9876543210;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myCommandId = @300;
+    NSNumber * myTimedInvokeTimeout = @5678;
+    NSDictionary * myFields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type",
+                                            [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:@"Float", @"Type",
+                                                                                   [NSNumber numberWithFloat:1.0], @"value", nil]],
+                                            @"value", nil];
+    NSArray * myResults = @[
+        @{ @"commandPath" : [CHIPCommandPath commandPathWithEndpointId:myEndpointId clusterId:myClusterId commandId:myCommandId] }
+    ];
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
+
+    __auto_type uuid = self.controllerUUID;
+    _handleInvokeCommand
+        = ^(id controller, uint64_t nodeId, NSNumber * endpointId, NSNumber * clusterId, NSNumber * commandId, id commandFields,
+            NSNumber * _Nullable timedInvokeTimeout, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
+              XCTAssertTrue([controller isEqualToString:uuid]);
+              XCTAssertEqual(nodeId, myNodeId);
+              XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+              XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+              XCTAssertEqual([commandId unsignedLongValue], [myCommandId unsignedLongValue]);
+              XCTAssertTrue([commandFields isEqualTo:myFields]);
+              XCTAssertNotNil(timedInvokeTimeout);
+              XCTAssertEqual([timedInvokeTimeout unsignedShortValue], [myTimedInvokeTimeout unsignedShortValue]);
+              [callExpectation fulfill];
+              completion([CHIPDeviceController encodeXPCResponseValues:myResults], nil);
+          };
+
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  XCTAssertNotNil(device);
+                                  XCTAssertNil(error);
+                                  NSLog(@"Device acquired. Invoking command...");
+                                  [device invokeCommandWithEndpointId:myEndpointId
+                                                            clusterId:myClusterId
+                                                            commandId:myCommandId
+                                                        commandFields:myFields
+                                                   timedInvokeTimeout:myTimedInvokeTimeout
                                                           clientQueue:dispatch_get_main_queue()
                                                            completion:^(id _Nullable value, NSError * _Nullable error) {
                                                                NSLog(@"Command response: %@", value);
@@ -530,9 +749,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 - (void)testInvokeCommandFailure
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myCommandId = 300;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myCommandId = @300;
     NSDictionary * myFields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type",
                                             [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:@"Float", @"Type",
                                                                                    [NSNumber numberWithFloat:1.0], @"value", nil]],
@@ -542,17 +761,19 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
 
     __auto_type uuid = self.controllerUUID;
-    _handleInvokeCommand = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId, NSUInteger commandId,
-        id commandFields, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
-        XCTAssertTrue([controller isEqualToString:uuid]);
-        XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(commandId, myCommandId);
-        XCTAssertTrue([commandFields isEqualTo:myFields]);
-        [callExpectation fulfill];
-        completion(nil, myError);
-    };
+    _handleInvokeCommand
+        = ^(id controller, uint64_t nodeId, NSNumber * endpointId, NSNumber * clusterId, NSNumber * commandId, id commandFields,
+            NSNumber * _Nullable timedInvokeTimeout, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
+              XCTAssertTrue([controller isEqualToString:uuid]);
+              XCTAssertEqual(nodeId, myNodeId);
+              XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+              XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+              XCTAssertEqual([commandId unsignedLongValue], [myCommandId unsignedLongValue]);
+              XCTAssertTrue([commandFields isEqualTo:myFields]);
+              XCTAssertNil(timedInvokeTimeout);
+              [callExpectation fulfill];
+              completion(nil, myError);
+          };
 
     [_remoteDeviceController getConnectedDevice:myNodeId
                                           queue:dispatch_get_main_queue()
@@ -564,6 +785,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                                             clusterId:myClusterId
                                                             commandId:myCommandId
                                                         commandFields:myFields
+                                                   timedInvokeTimeout:nil
                                                           clientQueue:dispatch_get_main_queue()
                                                            completion:^(id _Nullable value, NSError * _Nullable error) {
                                                                NSLog(@"Command response: %@", value);
@@ -585,15 +807,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 - (void)testSubscribeAttributeSuccess
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myAttributeId = 300;
-    NSUInteger myMinInterval = 5;
-    NSUInteger myMaxInterval = 60;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
+    NSNumber * myMinInterval = @5;
+    NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -601,15 +823,17 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Report sent"];
 
     __auto_type uuid = self.controllerUUID;
-    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
-        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, NSNumber * minInterval, NSNumber * maxInterval, CHIPSubscribeParams * _Nullable params,
+        void (^establishedHandler)(void)) {
         XCTAssertTrue([controller isEqualToString:uuid]);
         XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(attributeId, myAttributeId);
-        XCTAssertEqual(minInterval, myMinInterval);
-        XCTAssertEqual(maxInterval, myMaxInterval);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
+        XCTAssertEqual([minInterval unsignedShortValue], [myMinInterval unsignedShortValue]);
+        XCTAssertEqual([maxInterval unsignedShortValue], [myMaxInterval unsignedShortValue]);
+        XCTAssertNil(params);
         [callExpectation fulfill];
         establishedHandler();
     };
@@ -628,6 +852,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                  attributeId:myAttributeId
                  minInterval:myMinInterval
                  maxInterval:myMaxInterval
+                 params:nil
                  clientQueue:dispatch_get_main_queue()
                  reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                      NSLog(@"Report value: %@", values);
@@ -656,9 +881,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -668,6 +893,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Setup stop report handler
+    XCTestExpectation * stopExpectation = [self expectationWithDescription:@"Reports stopped"];
+    _handleStopReports = ^(id _Nullable controller, uint64_t nodeId, void (^completion)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        completion();
+        [stopExpectation fulfill];
+    };
 
     // Deregister report handler
     [_remoteDeviceController getConnectedDevice:myNodeId
@@ -681,41 +915,45 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                               }];
 
     // Wait for disconnection
-    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    [self waitForExpectations:@[ _xpcDisconnectExpectation, stopExpectation ] timeout:kTimeoutInSeconds];
     XCTAssertNil(_xpcConnection);
 }
 
-- (void)testBadlyFormattedReport
+- (void)testSubscribeAttributeWithParamsSuccess
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myAttributeId = 300;
-    NSUInteger myMinInterval = 5;
-    NSUInteger myMaxInterval = 60;
-    // Incorrect serialized report value. Report should have ben a single NSDictionary
-    __block id myReport = @{
-        @"attributePath" : @[
-            [NSNumber numberWithUnsignedInteger:myEndpointId], [NSNumber numberWithUnsignedInteger:myClusterId],
-            [NSNumber numberWithUnsignedInteger:myAttributeId]
-        ],
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
+    NSNumber * myMinInterval = @5;
+    NSNumber * myMaxInterval = @60;
+    CHIPSubscribeParams * myParams = [[CHIPSubscribeParams alloc] init];
+    myParams.fabricFiltered = @NO;
+    myParams.keepPreviousSubscriptions = @NO;
+    __block NSArray * myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
-    };
+    } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
-    __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Unexpected report sent"];
-    reportExpectation.inverted = YES;
+    __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Report sent"];
 
     __auto_type uuid = self.controllerUUID;
-    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
-        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, NSNumber * minInterval, NSNumber * maxInterval, CHIPSubscribeParams * _Nullable params,
+        void (^establishedHandler)(void)) {
         XCTAssertTrue([controller isEqualToString:uuid]);
         XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(attributeId, myAttributeId);
-        XCTAssertEqual(minInterval, myMinInterval);
-        XCTAssertEqual(maxInterval, myMaxInterval);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
+        XCTAssertEqual([minInterval unsignedShortValue], [myMinInterval unsignedShortValue]);
+        XCTAssertEqual([maxInterval unsignedShortValue], [myMaxInterval unsignedShortValue]);
+        XCTAssertNotNil(params);
+        XCTAssertEqual([params.fabricFiltered boolValue], [myParams.fabricFiltered boolValue]);
+        XCTAssertEqual([params.keepPreviousSubscriptions boolValue], [myParams.keepPreviousSubscriptions boolValue]);
         [callExpectation fulfill];
         establishedHandler();
     };
@@ -734,6 +972,122 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                  attributeId:myAttributeId
                  minInterval:myMinInterval
                  maxInterval:myMaxInterval
+                 params:myParams
+                 clientQueue:dispatch_get_main_queue()
+                 reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                     NSLog(@"Report value: %@", values);
+                     XCTAssertNotNil(values);
+                     XCTAssertNil(error);
+                     XCTAssertTrue([myReport isEqualTo:values]);
+                     [reportExpectation fulfill];
+                 }
+                 subscriptionEstablished:^{
+                     [establishExpectation fulfill];
+                 }];
+         }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, establishExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // Inject report
+    id<CHIPDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Inject another report
+    reportExpectation = [self expectationWithDescription:@"2nd report sent"];
+    myReport = @[ @{
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
+    } ];
+    [clientObject handleReportWithController:uuid
+                                      nodeId:myNodeId
+                                      values:[CHIPDeviceController encodeXPCResponseValues:myReport]
+                                       error:nil];
+
+    // Wait for report
+    [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Setup stop report handler
+    XCTestExpectation * stopExpectation = [self expectationWithDescription:@"Reports stopped"];
+    _handleStopReports = ^(id _Nullable controller, uint64_t nodeId, void (^completion)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        completion();
+        [stopExpectation fulfill];
+    };
+
+    // Deregister report handler
+    [_remoteDeviceController getConnectedDevice:myNodeId
+                                          queue:dispatch_get_main_queue()
+                              completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                                  NSLog(@"Device acquired. Deregistering...");
+                                  [device deregisterReportHandlersWithClientQueue:dispatch_get_main_queue()
+                                                                       completion:^{
+                                                                           NSLog(@"Deregistered");
+                                                                       }];
+                              }];
+
+    // Wait for disconnection
+    [self waitForExpectations:@[ _xpcDisconnectExpectation, stopExpectation ] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testBadlyFormattedReport
+{
+    uint64_t myNodeId = 9876543210;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
+    NSNumber * myMinInterval = @5;
+    NSNumber * myMaxInterval = @60;
+    // Incorrect serialized report value. Report should have ben a single NSDictionary
+    __block id myReport = @{
+        @"attributePath" : @[ myEndpointId, myClusterId, myAttributeId ],
+        @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
+    };
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * establishExpectation = [self expectationWithDescription:@"Established called"];
+    __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Unexpected report sent"];
+    reportExpectation.inverted = YES;
+
+    __auto_type uuid = self.controllerUUID;
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, NSNumber * minInterval, NSNumber * maxInterval, CHIPSubscribeParams * _Nullable params,
+        void (^establishedHandler)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
+        XCTAssertEqual([minInterval unsignedShortValue], [myMinInterval unsignedShortValue]);
+        XCTAssertEqual([maxInterval unsignedShortValue], [myMaxInterval unsignedShortValue]);
+        XCTAssertNil(params);
+        [callExpectation fulfill];
+        establishedHandler();
+    };
+
+    _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
+
+    [_remoteDeviceController
+        getConnectedDevice:myNodeId
+                     queue:dispatch_get_main_queue()
+         completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+             XCTAssertNotNil(device);
+             XCTAssertNil(error);
+             NSLog(@"Device acquired. Subscribing...");
+             [device subscribeAttributeWithEndpointId:myEndpointId
+                 clusterId:myClusterId
+                 attributeId:myAttributeId
+                 minInterval:myMinInterval
+                 maxInterval:myMaxInterval
+                 params:nil
                  clientQueue:dispatch_get_main_queue()
                  reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                      NSLog(@"Report value: %@", values);
@@ -759,9 +1113,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"Report sent"];
     myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -771,6 +1125,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Setup stop report handler
+    XCTestExpectation * stopExpectation = [self expectationWithDescription:@"Reports stopped"];
+    _handleStopReports = ^(id _Nullable controller, uint64_t nodeId, void (^completion)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        completion();
+        [stopExpectation fulfill];
+    };
 
     // Deregister report handler
     _xpcDisconnectExpectation.inverted = NO;
@@ -785,22 +1148,22 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                               }];
 
     // Wait for disconnection
-    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    [self waitForExpectations:@[ _xpcDisconnectExpectation, stopExpectation ] timeout:kTimeoutInSeconds];
     XCTAssertNil(_xpcConnection);
 }
 
 - (void)testReportWithUnrelatedEndpointId
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myAttributeId = 300;
-    NSUInteger myMinInterval = 5;
-    NSUInteger myMaxInterval = 60;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
+    NSNumber * myMinInterval = @5;
+    NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId + 1]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:@([myEndpointId unsignedShortValue] + 1)
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -809,15 +1172,17 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     reportExpectation.inverted = YES;
 
     __auto_type uuid = self.controllerUUID;
-    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
-        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, NSNumber * minInterval, NSNumber * maxInterval, CHIPSubscribeParams * _Nullable params,
+        void (^establishedHandler)(void)) {
         XCTAssertTrue([controller isEqualToString:uuid]);
         XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(attributeId, myAttributeId);
-        XCTAssertEqual(minInterval, myMinInterval);
-        XCTAssertEqual(maxInterval, myMaxInterval);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
+        XCTAssertEqual([minInterval unsignedShortValue], [myMinInterval unsignedShortValue]);
+        XCTAssertEqual([maxInterval unsignedShortValue], [myMaxInterval unsignedShortValue]);
+        XCTAssertNil(params);
         [callExpectation fulfill];
         establishedHandler();
     };
@@ -836,6 +1201,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                  attributeId:myAttributeId
                  minInterval:myMinInterval
                  maxInterval:myMaxInterval
+                 params:nil
                  clientQueue:dispatch_get_main_queue()
                  reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                      NSLog(@"Report value: %@", values);
@@ -864,9 +1230,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -876,6 +1242,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Setup stop report handler
+    XCTestExpectation * stopExpectation = [self expectationWithDescription:@"Reports stopped"];
+    _handleStopReports = ^(id _Nullable controller, uint64_t nodeId, void (^completion)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        completion();
+        [stopExpectation fulfill];
+    };
 
     // Deregister report handler
     [_remoteDeviceController getConnectedDevice:myNodeId
@@ -889,22 +1264,22 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                               }];
 
     // Wait for disconnection
-    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    [self waitForExpectations:@[ _xpcDisconnectExpectation, stopExpectation ] timeout:kTimeoutInSeconds];
     XCTAssertNil(_xpcConnection);
 }
 
 - (void)testReportWithUnrelatedClusterId
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myAttributeId = 300;
-    NSUInteger myMinInterval = 5;
-    NSUInteger myMaxInterval = 60;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
+    NSNumber * myMinInterval = @5;
+    NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId + 1]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:@([myClusterId unsignedLongValue] + 1)
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -913,15 +1288,17 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     reportExpectation.inverted = YES;
 
     __auto_type uuid = self.controllerUUID;
-    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
-        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, NSNumber * minInterval, NSNumber * maxInterval, CHIPSubscribeParams * _Nullable params,
+        void (^establishedHandler)(void)) {
         XCTAssertTrue([controller isEqualToString:uuid]);
         XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(attributeId, myAttributeId);
-        XCTAssertEqual(minInterval, myMinInterval);
-        XCTAssertEqual(maxInterval, myMaxInterval);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
+        XCTAssertEqual([minInterval unsignedShortValue], [myMinInterval unsignedShortValue]);
+        XCTAssertEqual([maxInterval unsignedShortValue], [myMaxInterval unsignedShortValue]);
+        XCTAssertNil(params);
         [callExpectation fulfill];
         establishedHandler();
     };
@@ -940,6 +1317,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                  attributeId:myAttributeId
                  minInterval:myMinInterval
                  maxInterval:myMaxInterval
+                 params:nil
                  clientQueue:dispatch_get_main_queue()
                  reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                      NSLog(@"Report value: %@", values);
@@ -968,9 +1346,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -980,6 +1358,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Setup stop report handler
+    XCTestExpectation * stopExpectation = [self expectationWithDescription:@"Reports stopped"];
+    _handleStopReports = ^(id _Nullable controller, uint64_t nodeId, void (^completion)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        completion();
+        [stopExpectation fulfill];
+    };
 
     // Deregister report handler
     [_remoteDeviceController getConnectedDevice:myNodeId
@@ -993,22 +1380,22 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                               }];
 
     // Wait for disconnection
-    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    [self waitForExpectations:@[ _xpcDisconnectExpectation, stopExpectation ] timeout:kTimeoutInSeconds];
     XCTAssertNil(_xpcConnection);
 }
 
 - (void)testReportWithUnrelatedAttributeId
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myAttributeId = 300;
-    NSUInteger myMinInterval = 5;
-    NSUInteger myMaxInterval = 60;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
+    NSNumber * myMinInterval = @5;
+    NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId + 1]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:@([myAttributeId unsignedLongValue] + 1)],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1017,15 +1404,17 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     reportExpectation.inverted = YES;
 
     __auto_type uuid = self.controllerUUID;
-    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
-        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, NSNumber * minInterval, NSNumber * maxInterval, CHIPSubscribeParams * _Nullable params,
+        void (^establishedHandler)(void)) {
         XCTAssertTrue([controller isEqualToString:uuid]);
         XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(attributeId, myAttributeId);
-        XCTAssertEqual(minInterval, myMinInterval);
-        XCTAssertEqual(maxInterval, myMaxInterval);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
+        XCTAssertEqual([minInterval unsignedShortValue], [myMinInterval unsignedShortValue]);
+        XCTAssertEqual([maxInterval unsignedShortValue], [myMaxInterval unsignedShortValue]);
+        XCTAssertNil(params);
         [callExpectation fulfill];
         establishedHandler();
     };
@@ -1044,6 +1433,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                  attributeId:myAttributeId
                  minInterval:myMinInterval
                  maxInterval:myMaxInterval
+                 params:nil
                  clientQueue:dispatch_get_main_queue()
                  reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                      NSLog(@"Report value: %@", values);
@@ -1072,9 +1462,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -1084,6 +1474,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Setup stop report handler
+    XCTestExpectation * stopExpectation = [self expectationWithDescription:@"Reports stopped"];
+    _handleStopReports = ^(id _Nullable controller, uint64_t nodeId, void (^completion)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        completion();
+        [stopExpectation fulfill];
+    };
 
     // Deregister report handler
     [_remoteDeviceController getConnectedDevice:myNodeId
@@ -1097,22 +1496,22 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                               }];
 
     // Wait for disconnection
-    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    [self waitForExpectations:@[ _xpcDisconnectExpectation, stopExpectation ] timeout:kTimeoutInSeconds];
     XCTAssertNil(_xpcConnection);
 }
 
 - (void)testReportWithUnrelatedNode
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myAttributeId = 300;
-    NSUInteger myMinInterval = 5;
-    NSUInteger myMaxInterval = 60;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
+    NSNumber * myMinInterval = @5;
+    NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1121,15 +1520,17 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     reportExpectation.inverted = YES;
 
     __auto_type uuid = self.controllerUUID;
-    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
-        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, NSNumber * minInterval, NSNumber * maxInterval, CHIPSubscribeParams * _Nullable params,
+        void (^establishedHandler)(void)) {
         XCTAssertTrue([controller isEqualToString:uuid]);
         XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(attributeId, myAttributeId);
-        XCTAssertEqual(minInterval, myMinInterval);
-        XCTAssertEqual(maxInterval, myMaxInterval);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
+        XCTAssertEqual([minInterval unsignedShortValue], [myMinInterval unsignedShortValue]);
+        XCTAssertEqual([maxInterval unsignedShortValue], [myMaxInterval unsignedShortValue]);
+        XCTAssertNil(params);
         [callExpectation fulfill];
         establishedHandler();
     };
@@ -1148,6 +1549,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                  attributeId:myAttributeId
                  minInterval:myMinInterval
                  maxInterval:myMaxInterval
+                 params:nil
                  clientQueue:dispatch_get_main_queue()
                  reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                      NSLog(@"Report value: %@", values);
@@ -1176,9 +1578,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -1188,6 +1590,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Setup stop report handler
+    XCTestExpectation * stopExpectation = [self expectationWithDescription:@"Reports stopped"];
+    _handleStopReports = ^(id _Nullable controller, uint64_t nodeId, void (^completion)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        completion();
+        [stopExpectation fulfill];
+    };
 
     // Deregister report handler
     [_remoteDeviceController getConnectedDevice:myNodeId
@@ -1201,22 +1612,22 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                               }];
 
     // Wait for disconnection
-    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    [self waitForExpectations:@[ _xpcDisconnectExpectation, stopExpectation ] timeout:kTimeoutInSeconds];
     XCTAssertNil(_xpcConnection);
 }
 
 - (void)testSubscribeMultiEndpoints
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myAttributeId = 300;
-    NSUInteger myMinInterval = 5;
-    NSUInteger myMaxInterval = 60;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
+    NSNumber * myMinInterval = @5;
+    NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1224,15 +1635,17 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Report sent"];
 
     __auto_type uuid = self.controllerUUID;
-    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
-        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, NSNumber * minInterval, NSNumber * maxInterval, CHIPSubscribeParams * _Nullable params,
+        void (^establishedHandler)(void)) {
         XCTAssertTrue([controller isEqualToString:uuid]);
         XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, 0xffff);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(attributeId, myAttributeId);
-        XCTAssertEqual(minInterval, myMinInterval);
-        XCTAssertEqual(maxInterval, myMaxInterval);
+        XCTAssertNil(endpointId);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
+        XCTAssertEqual([minInterval unsignedShortValue], [myMinInterval unsignedShortValue]);
+        XCTAssertEqual([maxInterval unsignedShortValue], [myMaxInterval unsignedShortValue]);
+        XCTAssertNil(params);
         [callExpectation fulfill];
         establishedHandler();
     };
@@ -1246,11 +1659,12 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
              XCTAssertNotNil(device);
              XCTAssertNil(error);
              NSLog(@"Device acquired. Subscribing...");
-             [device subscribeAttributeWithEndpointId:0xffff
+             [device subscribeAttributeWithEndpointId:nil
                  clusterId:myClusterId
                  attributeId:myAttributeId
                  minInterval:myMinInterval
                  maxInterval:myMaxInterval
+                 params:nil
                  clientQueue:dispatch_get_main_queue()
                  reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                      NSLog(@"Report value: %@", values);
@@ -1279,9 +1693,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -1291,6 +1705,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Setup stop report handler
+    XCTestExpectation * stopExpectation = [self expectationWithDescription:@"Reports stopped"];
+    _handleStopReports = ^(id _Nullable controller, uint64_t nodeId, void (^completion)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        completion();
+        [stopExpectation fulfill];
+    };
 
     // Deregister report handler
     [_remoteDeviceController getConnectedDevice:myNodeId
@@ -1304,22 +1727,22 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                               }];
 
     // Wait for disconnection
-    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    [self waitForExpectations:@[ _xpcDisconnectExpectation, stopExpectation ] timeout:kTimeoutInSeconds];
     XCTAssertNil(_xpcConnection);
 }
 
 - (void)testSubscribeMultiClusters
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myAttributeId = 300;
-    NSUInteger myMinInterval = 5;
-    NSUInteger myMaxInterval = 60;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
+    NSNumber * myMinInterval = @5;
+    NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1327,15 +1750,17 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Report sent"];
 
     __auto_type uuid = self.controllerUUID;
-    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
-        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, NSNumber * minInterval, NSNumber * maxInterval, CHIPSubscribeParams * _Nullable params,
+        void (^establishedHandler)(void)) {
         XCTAssertTrue([controller isEqualToString:uuid]);
         XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, 0xffffffff);
-        XCTAssertEqual(attributeId, myAttributeId);
-        XCTAssertEqual(minInterval, myMinInterval);
-        XCTAssertEqual(maxInterval, myMaxInterval);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertNil(clusterId);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
+        XCTAssertEqual([minInterval unsignedShortValue], [myMinInterval unsignedShortValue]);
+        XCTAssertEqual([maxInterval unsignedShortValue], [myMaxInterval unsignedShortValue]);
+        XCTAssertNil(params);
         [callExpectation fulfill];
         establishedHandler();
     };
@@ -1350,10 +1775,11 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
              XCTAssertNil(error);
              NSLog(@"Device acquired. Subscribing...");
              [device subscribeAttributeWithEndpointId:myEndpointId
-                 clusterId:0xffffffff
+                 clusterId:nil
                  attributeId:myAttributeId
                  minInterval:myMinInterval
                  maxInterval:myMaxInterval
+                 params:nil
                  clientQueue:dispatch_get_main_queue()
                  reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                      NSLog(@"Report value: %@", values);
@@ -1382,9 +1808,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -1394,6 +1820,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Setup stop report handler
+    XCTestExpectation * stopExpectation = [self expectationWithDescription:@"Reports stopped"];
+    _handleStopReports = ^(id _Nullable controller, uint64_t nodeId, void (^completion)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        completion();
+        [stopExpectation fulfill];
+    };
 
     // Deregister report handler
     [_remoteDeviceController getConnectedDevice:myNodeId
@@ -1407,22 +1842,22 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                               }];
 
     // Wait for disconnection
-    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    [self waitForExpectations:@[ _xpcDisconnectExpectation, stopExpectation ] timeout:kTimeoutInSeconds];
     XCTAssertNil(_xpcConnection);
 }
 
 - (void)testSubscribeMultiAttributes
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myAttributeId = 300;
-    NSUInteger myMinInterval = 5;
-    NSUInteger myMaxInterval = 60;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
+    NSNumber * myMinInterval = @5;
+    NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1430,15 +1865,17 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     __block XCTestExpectation * reportExpectation = [self expectationWithDescription:@"Report sent"];
 
     __auto_type uuid = self.controllerUUID;
-    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
-        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, NSNumber * minInterval, NSNumber * maxInterval, CHIPSubscribeParams * _Nullable params,
+        void (^establishedHandler)(void)) {
         XCTAssertTrue([controller isEqualToString:uuid]);
         XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(attributeId, 0xffffffff);
-        XCTAssertEqual(minInterval, myMinInterval);
-        XCTAssertEqual(maxInterval, myMaxInterval);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertNil(attributeId);
+        XCTAssertEqual([minInterval unsignedShortValue], [myMinInterval unsignedShortValue]);
+        XCTAssertEqual([maxInterval unsignedShortValue], [myMaxInterval unsignedShortValue]);
+        XCTAssertNil(params);
         [callExpectation fulfill];
         establishedHandler();
     };
@@ -1454,9 +1891,10 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
              NSLog(@"Device acquired. Subscribing...");
              [device subscribeAttributeWithEndpointId:myEndpointId
                  clusterId:myClusterId
-                 attributeId:0xffffffff
+                 attributeId:nil
                  minInterval:myMinInterval
                  maxInterval:myMaxInterval
+                 params:nil
                  clientQueue:dispatch_get_main_queue()
                  reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                      NSLog(@"Report value: %@", values);
@@ -1485,9 +1923,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -1497,6 +1935,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     // Wait for report
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kTimeoutInSeconds];
+
+    // Setup stop report handler
+    XCTestExpectation * stopExpectation = [self expectationWithDescription:@"Reports stopped"];
+    _handleStopReports = ^(id _Nullable controller, uint64_t nodeId, void (^completion)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, myNodeId);
+        completion();
+        [stopExpectation fulfill];
+    };
 
     // Deregister report handler
     [_remoteDeviceController getConnectedDevice:myNodeId
@@ -1510,39 +1957,41 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                               }];
 
     // Wait for disconnection
-    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    [self waitForExpectations:@[ _xpcDisconnectExpectation, stopExpectation ] timeout:kTimeoutInSeconds];
     XCTAssertNil(_xpcConnection);
 }
 
 - (void)testMutiSubscriptions
 {
     uint64_t nodeIds[] = { 9876543210, 9876543211 };
-    NSUInteger endpointIds[] = { 100, 150 };
-    NSUInteger clusterIds[] = { 200, 250 };
-    NSUInteger attributeIds[] = { 300, 350 };
-    NSUInteger minIntervals[] = { 5, 7 };
-    NSUInteger maxIntervals[] = { 60, 68 };
+    NSNumber * endpointIds[] = { @100, @150 };
+    NSNumber * clusterIds[] = { @200, @250 };
+    NSNumber * attributeIds[] = { @300, @350 };
+    NSNumber * minIntervals[] = { @5, @7 };
+    NSNumber * maxIntervals[] = { @60, @68 };
     __block uint64_t myNodeId = nodeIds[0];
-    __block NSUInteger myEndpointId = endpointIds[0];
-    __block NSUInteger myClusterId = clusterIds[0];
-    __block NSUInteger myAttributeId = attributeIds[0];
-    __block NSUInteger myMinInterval = minIntervals[0];
-    __block NSUInteger myMaxInterval = maxIntervals[0];
+    __block NSNumber * myEndpointId = endpointIds[0];
+    __block NSNumber * myClusterId = clusterIds[0];
+    __block NSNumber * myAttributeId = attributeIds[0];
+    __block NSNumber * myMinInterval = minIntervals[0];
+    __block NSNumber * myMaxInterval = maxIntervals[0];
     __block NSArray<NSArray *> * myReports;
     __block XCTestExpectation * callExpectation;
     __block XCTestExpectation * establishExpectation;
     __block NSArray<XCTestExpectation *> * reportExpectations;
 
     __auto_type uuid = self.controllerUUID;
-    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
-        NSUInteger attributeId, NSUInteger minInterval, NSUInteger maxInterval, void (^establishedHandler)(void)) {
+    _handleSubscribeAttribute = ^(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, NSNumber * minInterval, NSNumber * maxInterval, CHIPSubscribeParams * _Nullable params,
+        void (^establishedHandler)(void)) {
         XCTAssertTrue([controller isEqualToString:uuid]);
         XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(attributeId, myAttributeId);
-        XCTAssertEqual(minInterval, myMinInterval);
-        XCTAssertEqual(maxInterval, myMaxInterval);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
+        XCTAssertEqual([minInterval unsignedShortValue], [myMinInterval unsignedShortValue]);
+        XCTAssertEqual([maxInterval unsignedShortValue], [myMaxInterval unsignedShortValue]);
+        XCTAssertNil(params);
         [callExpectation fulfill];
         establishedHandler();
     };
@@ -1571,6 +2020,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                      attributeId:myAttributeId
                      minInterval:myMinInterval
                      maxInterval:myMaxInterval
+                     params:nil
                      clientQueue:dispatch_get_main_queue()
                      reportHandler:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                          NSLog(@"Subscriber [%d] report value: %@", i, values);
@@ -1597,17 +2047,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             [self expectationWithDescription:[NSString stringWithFormat:@"Report(%d) for second subscriber sent", count]], nil];
         myReports = @[
             @[ @{
-                @"attributePath" :
-                    [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:endpointIds[0]]
-                                                         clusterId:[NSNumber numberWithUnsignedInteger:clusterIds[0]]
-                                                       attributeId:[NSNumber numberWithUnsignedInteger:attributeIds[0]]],
+                @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:endpointIds[0]
+                                                                        clusterId:clusterIds[0]
+                                                                      attributeId:attributeIds[0]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:123456 + count * 100] }
             } ],
             @[ @{
-                @"attributePath" :
-                    [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:endpointIds[1]]
-                                                         clusterId:[NSNumber numberWithUnsignedInteger:clusterIds[1]]
-                                                       attributeId:[NSNumber numberWithUnsignedInteger:attributeIds[1]]],
+                @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:endpointIds[1]
+                                                                        clusterId:clusterIds[1]
+                                                                      attributeId:attributeIds[1]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:123457 + count * 100] }
             } ]
         ];
@@ -1623,9 +2071,19 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
         [self waitForExpectations:reportExpectations timeout:kTimeoutInSeconds];
     }
 
+    // Setup stop report handler
+    XCTestExpectation * stopExpectation = [self expectationWithDescription:@"Reports stopped"];
+    __auto_type nodeToStop = nodeIds[0];
+    _handleStopReports = ^(id _Nullable controller, uint64_t nodeId, void (^completion)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, nodeToStop);
+        completion();
+        [stopExpectation fulfill];
+    };
+
     // Deregister report handler for first subscriber
     __auto_type deregisterExpectation = [self expectationWithDescription:@"First subscriber deregistered"];
-    [_remoteDeviceController getConnectedDevice:nodeIds[0]
+    [_remoteDeviceController getConnectedDevice:nodeToStop
                                           queue:dispatch_get_main_queue()
                               completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
                                   NSLog(@"Device acquired. Deregistering...");
@@ -1636,7 +2094,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                                                        }];
                               }];
 
-    [self waitForExpectations:[NSArray arrayWithObject:deregisterExpectation] timeout:kTimeoutInSeconds];
+    [self waitForExpectations:@[ stopExpectation, deregisterExpectation ] timeout:kTimeoutInSeconds];
 
     // Inject reports
     for (int count = 0; count < 1; count++) {
@@ -1647,17 +2105,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
         reportExpectations[0].inverted = YES;
         myReports = @[
             @[ @{
-                @"attributePath" :
-                    [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:endpointIds[0]]
-                                                         clusterId:[NSNumber numberWithUnsignedInteger:clusterIds[0]]
-                                                       attributeId:[NSNumber numberWithUnsignedInteger:attributeIds[0]]],
+                @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:endpointIds[0]
+                                                                        clusterId:clusterIds[0]
+                                                                      attributeId:attributeIds[0]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:223456 + count * 100] }
             } ],
             @[ @{
-                @"attributePath" :
-                    [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:endpointIds[1]]
-                                                         clusterId:[NSNumber numberWithUnsignedInteger:clusterIds[1]]
-                                                       attributeId:[NSNumber numberWithUnsignedInteger:attributeIds[1]]],
+                @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:endpointIds[1]
+                                                                        clusterId:clusterIds[1]
+                                                                      attributeId:attributeIds[1]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:223457 + count * 100] }
             } ]
         ];
@@ -1673,9 +2129,19 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
         [self waitForExpectations:reportExpectations timeout:kTimeoutInSeconds];
     }
 
+    // Setup stop report handler
+    stopExpectation = [self expectationWithDescription:@"Reports stopped"];
+    nodeToStop = nodeIds[1];
+    _handleStopReports = ^(id _Nullable controller, uint64_t nodeId, void (^completion)(void)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual(nodeId, nodeToStop);
+        completion();
+        [stopExpectation fulfill];
+    };
+
     // Deregister report handler for second subscriber
     __auto_type secondDeregisterExpectation = [self expectationWithDescription:@"Second subscriber deregistered"];
-    [_remoteDeviceController getConnectedDevice:nodeIds[1]
+    [_remoteDeviceController getConnectedDevice:nodeToStop
                                           queue:dispatch_get_main_queue()
                               completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
                                   NSLog(@"Device acquired. Deregistering...");
@@ -1687,7 +2153,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                               }];
 
     // Wait for deregistration and disconnection
-    [self waitForExpectations:[NSArray arrayWithObjects:secondDeregisterExpectation, _xpcDisconnectExpectation, nil]
+    [self waitForExpectations:@[ secondDeregisterExpectation, _xpcDisconnectExpectation, stopExpectation ]
                       timeout:kTimeoutInSeconds];
     XCTAssertNil(_xpcConnection);
 
@@ -1701,17 +2167,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
         reportExpectations[1].inverted = YES;
         myReports = @[
             @[ @{
-                @"attributePath" :
-                    [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:endpointIds[0]]
-                                                         clusterId:[NSNumber numberWithUnsignedInteger:clusterIds[0]]
-                                                       attributeId:[NSNumber numberWithUnsignedInteger:attributeIds[0]]],
+                @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:endpointIds[0]
+                                                                        clusterId:clusterIds[0]
+                                                                      attributeId:attributeIds[0]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:223456 + count * 100] }
             } ],
             @[ @{
-                @"attributePath" :
-                    [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:endpointIds[1]]
-                                                         clusterId:[NSNumber numberWithUnsignedInteger:clusterIds[1]]
-                                                       attributeId:[NSNumber numberWithUnsignedInteger:attributeIds[1]]],
+                @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:endpointIds[1]
+                                                                        clusterId:clusterIds[1]
+                                                                      attributeId:attributeIds[1]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:223457 + count * 100] }
             } ]
         ];
@@ -1767,17 +2231,58 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     __auto_type uuid = self.controllerUUID;
     __auto_type attributeCacheContainer = [[CHIPAttributeCacheContainer alloc] init];
-    _handleSubscribeAttributeCache = ^(id controller, uint64_t nodeId, void (^completion)(NSError * _Nullable error)) {
-        NSLog(@"Subscribe attribute cache called");
-        XCTAssertTrue([controller isEqualToString:uuid]);
-        XCTAssertEqual(nodeId, myNodeId);
-        [callExpectation fulfill];
-        completion(nil);
-    };
+    _handleSubscribeAttributeCache
+        = ^(id controller, uint64_t nodeId, CHIPSubscribeParams * _Nullable params, void (^completion)(NSError * _Nullable error)) {
+              NSLog(@"Subscribe attribute cache called");
+              XCTAssertTrue([controller isEqualToString:uuid]);
+              XCTAssertEqual(nodeId, myNodeId);
+              XCTAssertNil(params);
+              [callExpectation fulfill];
+              completion(nil);
+          };
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
     [attributeCacheContainer subscribeWithDeviceController:_remoteDeviceController
                                                   deviceId:myNodeId
+                                                    params:nil
+                                               clientQueue:dispatch_get_main_queue()
+                                                completion:^(NSError * _Nullable error) {
+                                                    NSLog(@"Subscribe completion called with error: %@", error);
+                                                    XCTAssertNil(error);
+                                                    [responseExpectation fulfill];
+                                                }];
+
+    [self waitForExpectations:@[ callExpectation, responseExpectation, self.xpcDisconnectExpectation ] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
+}
+
+- (void)testSubscribeAttributeCacheWithParamsSuccess
+{
+    uint64_t myNodeId = 9876543210;
+    CHIPSubscribeParams * myParams = [[CHIPSubscribeParams alloc] init];
+    myParams.fabricFiltered = @YES;
+    myParams.keepPreviousSubscriptions = @YES;
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
+
+    __auto_type uuid = self.controllerUUID;
+    __auto_type attributeCacheContainer = [[CHIPAttributeCacheContainer alloc] init];
+    _handleSubscribeAttributeCache
+        = ^(id controller, uint64_t nodeId, CHIPSubscribeParams * _Nullable params, void (^completion)(NSError * _Nullable error)) {
+              NSLog(@"Subscribe attribute cache called");
+              XCTAssertTrue([controller isEqualToString:uuid]);
+              XCTAssertEqual(nodeId, myNodeId);
+              XCTAssertNotNil(params);
+              XCTAssertEqual([params.fabricFiltered boolValue], [myParams.fabricFiltered boolValue]);
+              XCTAssertEqual([params.keepPreviousSubscriptions boolValue], [myParams.keepPreviousSubscriptions boolValue]);
+              [callExpectation fulfill];
+              completion(nil);
+          };
+
+    _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
+    [attributeCacheContainer subscribeWithDeviceController:_remoteDeviceController
+                                                  deviceId:myNodeId
+                                                    params:myParams
                                                clientQueue:dispatch_get_main_queue()
                                                 completion:^(NSError * _Nullable error) {
                                                     NSLog(@"Subscribe completion called with error: %@", error);
@@ -1798,17 +2303,20 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     __auto_type uuid = self.controllerUUID;
     __auto_type attributeCacheContainer = [[CHIPAttributeCacheContainer alloc] init];
-    _handleSubscribeAttributeCache = ^(id controller, uint64_t nodeId, void (^completion)(NSError * _Nullable error)) {
-        NSLog(@"Subscribe attribute cache called");
-        XCTAssertTrue([controller isEqualToString:uuid]);
-        XCTAssertEqual(nodeId, myNodeId);
-        [callExpectation fulfill];
-        completion(myError);
-    };
+    _handleSubscribeAttributeCache
+        = ^(id controller, uint64_t nodeId, CHIPSubscribeParams * _Nullable params, void (^completion)(NSError * _Nullable error)) {
+              NSLog(@"Subscribe attribute cache called");
+              XCTAssertTrue([controller isEqualToString:uuid]);
+              XCTAssertEqual(nodeId, myNodeId);
+              XCTAssertNil(params);
+              [callExpectation fulfill];
+              completion(myError);
+          };
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
     [attributeCacheContainer subscribeWithDeviceController:_remoteDeviceController
                                                   deviceId:myNodeId
+                                                    params:nil
                                                clientQueue:dispatch_get_main_queue()
                                                 completion:^(NSError * _Nullable error) {
                                                     NSLog(@"Subscribe completion called with error: %@", error);
@@ -1823,13 +2331,13 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 - (void)testReadAttributeCacheSuccess
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myAttributeId = 300;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
     NSArray * myValues = @[ @{
-        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:[NSNumber numberWithUnsignedInteger:myEndpointId]
-                                                                clusterId:[NSNumber numberWithUnsignedInteger:myClusterId]
-                                                              attributeId:[NSNumber numberWithUnsignedInteger:myAttributeId]],
+        @"attributePath" : [CHIPAttributePath attributePathWithEndpointId:myEndpointId
+                                                                clusterId:myClusterId
+                                                              attributeId:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
 
@@ -1839,27 +2347,30 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     __auto_type uuid = self.controllerUUID;
     __auto_type attributeCacheContainer = [[CHIPAttributeCacheContainer alloc] init];
-    _handleSubscribeAttributeCache = ^(id controller, uint64_t nodeId, void (^completion)(NSError * _Nullable error)) {
-        NSLog(@"Subscribe attribute cache called");
-        XCTAssertTrue([controller isEqualToString:uuid]);
-        XCTAssertEqual(nodeId, myNodeId);
-        completion(nil);
-    };
+    _handleSubscribeAttributeCache
+        = ^(id controller, uint64_t nodeId, CHIPSubscribeParams * _Nullable params, void (^completion)(NSError * _Nullable error)) {
+              NSLog(@"Subscribe attribute cache called");
+              XCTAssertTrue([controller isEqualToString:uuid]);
+              XCTAssertEqual(nodeId, myNodeId);
+              XCTAssertNil(params);
+              completion(nil);
+          };
 
-    _handleReadAttributeCache = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
-        NSUInteger attributeId, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
+    _handleReadAttributeCache = ^(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
         NSLog(@"Read attribute cache called");
         XCTAssertTrue([controller isEqualToString:uuid]);
         XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
         [callExpectation fulfill];
         completion([CHIPDeviceController encodeXPCResponseValues:myValues], nil);
     };
 
     [attributeCacheContainer subscribeWithDeviceController:_remoteDeviceController
                                                   deviceId:myNodeId
+                                                    params:nil
                                                clientQueue:dispatch_get_main_queue()
                                                 completion:^(NSError * _Nullable error) {
                                                     NSLog(@"Subscribe completion called with error: %@", error);
@@ -1888,9 +2399,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 - (void)testReadAttributeCacheFailure
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myAttributeId = 300;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
     NSError * myError = [NSError errorWithDomain:CHIPErrorDomain code:CHIPErrorCodeGeneralError userInfo:nil];
     XCTestExpectation * subscribeExpectation = [self expectationWithDescription:@"Cache subscription complete"];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1898,27 +2409,30 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     __auto_type uuid = self.controllerUUID;
     __auto_type attributeCacheContainer = [[CHIPAttributeCacheContainer alloc] init];
-    _handleSubscribeAttributeCache = ^(id controller, uint64_t nodeId, void (^completion)(NSError * _Nullable error)) {
-        NSLog(@"Subscribe attribute cache called");
-        XCTAssertTrue([controller isEqualToString:uuid]);
-        XCTAssertEqual(nodeId, myNodeId);
-        completion(nil);
-    };
+    _handleSubscribeAttributeCache
+        = ^(id controller, uint64_t nodeId, CHIPSubscribeParams * _Nullable params, void (^completion)(NSError * _Nullable error)) {
+              NSLog(@"Subscribe attribute cache called");
+              XCTAssertTrue([controller isEqualToString:uuid]);
+              XCTAssertEqual(nodeId, myNodeId);
+              XCTAssertNil(params);
+              completion(nil);
+          };
 
-    _handleReadAttributeCache = ^(id controller, uint64_t nodeId, NSUInteger endpointId, NSUInteger clusterId,
-        NSUInteger attributeId, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
+    _handleReadAttributeCache = ^(id controller, uint64_t nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
+        NSNumber * _Nullable attributeId, void (^completion)(id _Nullable values, NSError * _Nullable error)) {
         NSLog(@"Read attribute cache called");
         XCTAssertTrue([controller isEqualToString:uuid]);
         XCTAssertEqual(nodeId, myNodeId);
-        XCTAssertEqual(endpointId, myEndpointId);
-        XCTAssertEqual(clusterId, myClusterId);
-        XCTAssertEqual(attributeId, myAttributeId);
+        XCTAssertEqual([endpointId unsignedShortValue], [myEndpointId unsignedShortValue]);
+        XCTAssertEqual([clusterId unsignedLongValue], [myClusterId unsignedLongValue]);
+        XCTAssertEqual([attributeId unsignedLongValue], [myAttributeId unsignedLongValue]);
         [callExpectation fulfill];
         completion(nil, myError);
     };
 
     [attributeCacheContainer subscribeWithDeviceController:_remoteDeviceController
                                                   deviceId:myNodeId
+                                                    params:nil
                                                clientQueue:dispatch_get_main_queue()
                                                 completion:^(NSError * _Nullable error) {
                                                     NSLog(@"Subscribe completion called with error: %@", error);
@@ -1946,9 +2460,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 - (void)testXPCConnectionFailure
 {
     uint64_t myNodeId = 9876543210;
-    NSUInteger myEndpointId = 100;
-    NSUInteger myClusterId = 200;
-    NSUInteger myAttributeId = 300;
+    NSNumber * myEndpointId = @100;
+    NSNumber * myClusterId = @200;
+    NSNumber * myAttributeId = @300;
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"Read response received"];
 
     // Test with a device controller which wouldn't connect to XPC listener successfully
@@ -1966,6 +2480,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                   [device readAttributeWithEndpointId:myEndpointId
                                                             clusterId:myClusterId
                                                           attributeId:myAttributeId
+                                                               params:nil
                                                           clientQueue:dispatch_get_main_queue()
                                                            completion:^(id _Nullable value, NSError * _Nullable error) {
                                                                NSLog(@"Read value: %@", value);


### PR DESCRIPTION
#### Problem
* Addresses a subset of #15930

#### Change overview
Update Darwin CHIPDevice generic read/write/command/subscribe API.
* Use NSNumber parameters instead of NSUInteger params
* Add CHIPReadParams/CHIPSubscribeParams
* Fix subscribe interval params
* Add timedWriteTimeout and timedInvokeTimeout params

#### Testing
* Tests were updated to test the modified API.