### PR TITLE
Hook up reports to the current controller in iOS CHIPTool.

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.h
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.h
@@ -13,6 +13,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface TemperatureSensorViewController : UIViewController
 
+/**
+ * Return the current controller, if any.
+ */
++ (nullable TemperatureSensorViewController *)currentController;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
@@ -18,12 +18,15 @@
 @property (nonatomic, strong) UIButton * sendReportingSetup;
 @end
 
+static TemperatureSensorViewController * _Nullable sCurrentController = nil;
+
 @implementation TemperatureSensorViewController
 
 // MARK: UIViewController methods
 
 - (void)viewDidLoad
 {
+    sCurrentController = self;
     [super viewDidLoad];
     [self setupUI];
 
@@ -31,6 +34,23 @@
     [self.view addGestureRecognizer:tap];
 
     [self readCurrentTemperature];
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+    sCurrentController = nil;
+    [super viewWillDisappear:animated];
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    sCurrentController = self;
+    [super viewDidAppear:animated];
+}
+
++ (nullable TemperatureSensorViewController *)currentController
+{
+    return sCurrentController;
 }
 
 - (IBAction)sendReportingSetup:(id)sender
@@ -216,7 +236,10 @@
                                              if (report.error != nil) {
                                                  NSLog(@"Error reading temperature: %@", report.error);
                                              } else {
-                                                 [self updateTempInUI:((NSNumber *) report.value).shortValue];
+                                                 __auto_type controller = [TemperatureSensorViewController currentController];
+                                                 if (controller != nil) {
+                                                     [controller updateTempInUI:((NSNumber *) report.value).shortValue];
+                                                 }
                                              }
                                          }
                                      }


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/16198

#### Problem
See #16198.

#### Change overview
Route the reports the whatever the currently active controller is, not to the controller that was active when the subscription was set up.

#### Testing
Did the steps from #16198, observed it working.