### PR TITLE
[Android] Return JSON in wildcard interactions

### DIFF
--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -253,7 +253,8 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
     chip::JniClass attributeStateJniCls(attributeStateCls);
     jmethodID attributeStateCtor = env->GetMethodID(attributeStateCls, "<init>", "(Ljava/lang/Object;[BLjava/lang/String;)V");
     VerifyOrReturn(attributeStateCtor != nullptr, ChipLogError(Controller, "Could not find AttributeState constructor"));
-    jobject attributeStateObj = env->NewObject(attributeStateCls, attributeStateCtor, value, jniByteArray.jniValue(), jsonString.jniValue());
+    jobject attributeStateObj =
+        env->NewObject(attributeStateCls, attributeStateCtor, value, jniByteArray.jniValue(), jsonString.jniValue());
     VerifyOrReturn(attributeStateObj != nullptr, ChipLogError(Controller, "Could not create AttributeState object"));
 
     // Add AttributeState to NodeState

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -24,6 +24,7 @@
 #include <lib/support/ErrorStr.h>
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
+#include <lib/support/jsontlv/TlvJson.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/PlatformManager.h>
 #include <type_traits>
@@ -214,8 +215,10 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
 
     TLV::TLVReader readerForJavaObject;
     TLV::TLVReader readerForJavaTLV;
+    TLV::TLVReader readerForJson;
     readerForJavaObject.Init(*apData);
     readerForJavaTLV.Init(*apData);
+    readerForJson.Init(*apData);
 
     jobject value = DecodeAttributeValue(aPath, readerForJavaObject, &err);
     // If we don't know this attribute, just skip it.
@@ -238,14 +241,19 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
     size = writer.GetLengthWritten();
     chip::ByteArray jniByteArray(env, reinterpret_cast<jbyte *>(buffer.get()), size);
 
+    // Convert TLV to JSON
+    Json::Value json;
+    err = TlvToJson(readerForJson, json);
+    UtfString jsonString(env, JsonToString(json).c_str());
+
     // Create AttributeState object
     jclass attributeStateCls;
     err = JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/model/AttributeState", attributeStateCls);
     VerifyOrReturn(attributeStateCls != nullptr, ChipLogError(Controller, "Could not find AttributeState class"));
     chip::JniClass attributeStateJniCls(attributeStateCls);
-    jmethodID attributeStateCtor = env->GetMethodID(attributeStateCls, "<init>", "(Ljava/lang/Object;[B)V");
+    jmethodID attributeStateCtor = env->GetMethodID(attributeStateCls, "<init>", "(Ljava/lang/Object;[BLjava/lang/String;)V");
     VerifyOrReturn(attributeStateCtor != nullptr, ChipLogError(Controller, "Could not find AttributeState constructor"));
-    jobject attributeStateObj = env->NewObject(attributeStateCls, attributeStateCtor, value, jniByteArray.jniValue());
+    jobject attributeStateObj = env->NewObject(attributeStateCls, attributeStateCtor, value, jniByteArray.jniValue(), jsonString.jniValue());
     VerifyOrReturn(attributeStateObj != nullptr, ChipLogError(Controller, "Could not create AttributeState object"));
 
     // Add AttributeState to NodeState

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -49,6 +49,7 @@ shared_library("jni") {
     "${chip_root}/src/credentials:default_attestation_verifier",
     "${chip_root}/src/inet",
     "${chip_root}/src/lib",
+    "${chip_root}/src/lib/support/jsontlv",
     "${chip_root}/src/platform",
     "${chip_root}/src/platform/android",
   ]

--- a/src/controller/java/src/chip/devicecontroller/model/AttributeState.java
+++ b/src/controller/java/src/chip/devicecontroller/model/AttributeState.java
@@ -17,14 +17,26 @@
  */
 package chip.devicecontroller.model;
 
-/** Represents the reported value of an attribute in object form AND TLV. */
+import android.util.Log;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/** Represents the reported value of an attribute in object form, TLV and JSON. */
 public final class AttributeState {
+  private static final String TAG = "AttributeState";
+
   private Object valueObject;
   private byte[] tlv;
+  private JSONObject json;
 
-  public AttributeState(Object valueObject, byte[] tlv) {
+  public AttributeState(Object valueObject, byte[] tlv, String jsonString) {
     this.valueObject = valueObject;
     this.tlv = tlv;
+    try {
+      this.json = new JSONObject(jsonString);
+    } catch (JSONException ex) {
+      Log.e(TAG, "Error parsing JSON string", ex);
+    }
   }
 
   public Object getValue() {
@@ -36,5 +48,9 @@ public final class AttributeState {
    */
   public byte[] getTlv() {
     return tlv;
+  }
+
+  public JSONObject getJson() {
+    return json;
   }
 }


### PR DESCRIPTION
#### Problem
* Now that the TLV to JSON converter is implemented, we can return JSON alongside TLV and the object representation in the wildcard interaction callback.

#### Change overview
* Add a JSONObject field to `AttributeState`, populated in the constructor by a JSON string.
* Update JNI code to call new constructor.

#### Testing
* Call wildcard read/subscribe and verified that correct JSON objects are returned.
