### PR TITLE
Remove un-used field in CommissioningComplete event

### DIFF
--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -442,7 +442,6 @@ struct ChipDeviceEvent final
         struct
         {
             CHIP_ERROR Status;
-            uint64_t PeerNodeId;
             FabricIndex PeerFabricIndex;
         } CommissioningComplete;
 

--- a/src/platform/DeviceControlServer.cpp
+++ b/src/platform/DeviceControlServer.cpp
@@ -39,7 +39,6 @@ CHIP_ERROR DeviceControlServer::CommissioningComplete(NodeId peerNodeId, FabricI
     VerifyOrReturnError(CHIP_NO_ERROR == mFailSafeContext.DisarmFailSafe(), CHIP_ERROR_INTERNAL);
     ChipDeviceEvent event;
     event.Type                                  = DeviceEventType::kCommissioningComplete;
-    event.CommissioningComplete.PeerNodeId      = peerNodeId;
     event.CommissioningComplete.PeerFabricIndex = accessingFabricIndex;
     event.CommissioningComplete.Status          = CHIP_NO_ERROR;
     return PlatformMgr().PostEvent(&event);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Commissioning is against a fabric, not a peer device, the PeeNodeID field in CommissioningComplete event struct does not make sense, and not used.

#### Change overview
Remove un-used field in CommissioningComplete event

#### Testing
How was this tested? (at least one bullet point required)
* Cleanup, the regression is covered by CI