### PR TITLE
Updated OpCert Generation in the Operational Credentials Issuer.

### DIFF
--- a/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
+++ b/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
@@ -82,18 +82,7 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
                                                                                 MutableByteSpan & rcac, MutableByteSpan & icac,
                                                                                 MutableByteSpan & noc)
 {
-    ChipDN noc_dn;
-    ReturnErrorOnFailure(noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, fabricId));
-    ReturnErrorOnFailure(noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, nodeId));
-    ReturnErrorOnFailure(noc_dn.AddCATs(cats));
     ChipDN rcac_dn;
-    ReturnErrorOnFailure(rcac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, mIssuerId));
-
-    ChipLogProgress(Controller, "Generating NOC");
-    chip::Credentials::X509CertRequestParams noc_request = { 1, mNow, mNow + mValidity, noc_dn, rcac_dn };
-    ReturnErrorOnFailure(NewNodeOperationalX509Cert(noc_request, pubkey, mIssuer, noc));
-    icac.reduce_size(0);
-
     uint16_t rcacBufLen = static_cast<uint16_t>(std::min(rcac.size(), static_cast<size_t>(UINT16_MAX)));
     CHIP_ERROR err      = CHIP_NO_ERROR;
     PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
@@ -102,18 +91,32 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
     {
         // Found root certificate in the storage.
         rcac.reduce_size(rcacBufLen);
-        return CHIP_NO_ERROR;
+        ReturnErrorOnFailure(ExtractSubjectDNFromX509Cert(rcac, rcac_dn));
+    }
+    // If root certificate not found in the storage, generate new root certificate.
+    else
+    {
+        ReturnErrorOnFailure(rcac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, mIssuerId));
+
+        ChipLogProgress(Controller, "Generating RCAC");
+        chip::Credentials::X509CertRequestParams rcac_request = { 0, mNow, mNow + mValidity, rcac_dn, rcac_dn };
+        ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuer, rcac));
+
+        VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);
+        PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
+                          ReturnErrorOnFailure(mStorage->SyncSetKeyValue(key, rcac.data(), static_cast<uint16_t>(rcac.size()))));
     }
 
-    ChipLogProgress(Controller, "Generating RCAC");
-    chip::Credentials::X509CertRequestParams rcac_request = { 0, mNow, mNow + mValidity, rcac_dn, rcac_dn };
-    ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuer, rcac));
+    icac.reduce_size(0);
 
-    VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);
-    PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
-                      err = mStorage->SyncSetKeyValue(key, rcac.data(), static_cast<uint16_t>(rcac.size())));
+    ChipDN noc_dn;
+    ReturnErrorOnFailure(noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, fabricId));
+    ReturnErrorOnFailure(noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, nodeId));
+    ReturnErrorOnFailure(noc_dn.AddCATs(cats));
 
-    return err;
+    ChipLogProgress(Controller, "Generating NOC");
+    chip::Credentials::X509CertRequestParams noc_request = { 1, mNow, mNow + mValidity, noc_dn, rcac_dn };
+    return NewNodeOperationalX509Cert(noc_request, pubkey, mIssuer, noc);
 }
 
 CHIP_ERROR AndroidOperationalCredentialsIssuer::GenerateNOCChain(const ByteSpan & csrElements,

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -710,6 +710,36 @@ CHIP_ERROR ChipDN::GetCertFabricId(uint64_t & fabricId) const
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ChipDN::EncodeToTLV(TLVWriter & writer, Tag tag) const
+{
+    TLVType outerContainer;
+    uint8_t rdnCount = RDNCount();
+
+    ReturnErrorOnFailure(writer.StartContainer(tag, kTLVType_List, outerContainer));
+
+    for (uint8_t i = 0; i < rdnCount; i++)
+    {
+        // Derive the TLV tag number from the enum value assigned to the attribute type OID. For attributes that can be
+        // either UTF8String or PrintableString, use the high bit in the tag number to distinguish the two.
+        uint8_t tlvTagNum = GetOIDEnum(rdn[i].mAttrOID);
+        if (rdn[i].mAttrIsPrintableString)
+        {
+            tlvTagNum |= 0x80;
+        }
+
+        if (IsChipDNAttr(rdn[i].mAttrOID))
+        {
+            ReturnErrorOnFailure(writer.Put(ContextTag(tlvTagNum), rdn[i].mChipVal));
+        }
+        else
+        {
+            ReturnErrorOnFailure(writer.PutString(ContextTag(tlvTagNum), rdn[i].mString));
+        }
+    }
+
+    return writer.EndContainer(outerContainer);
+}
+
 CHIP_ERROR ChipDN::DecodeFromTLV(TLVReader & reader)
 {
     CHIP_ERROR err;
@@ -855,6 +885,100 @@ CHIP_ERROR ChipDN::EncodeToASN1(ASN1Writer & writer) const
         }
     }
     ASN1_END_SEQUENCE;
+
+exit:
+    return err;
+}
+
+CHIP_ERROR ChipDN::DecodeFromASN1(ASN1Reader & reader)
+{
+    CHIP_ERROR err;
+
+    // RDNSequence ::= SEQUENCE OF RelativeDistinguishedName
+    ASN1_PARSE_ENTER_SEQUENCE
+    {
+        while ((err = reader.Next()) == CHIP_NO_ERROR)
+        {
+            // RelativeDistinguishedName ::= SET SIZE (1..MAX) OF AttributeTypeAndValue
+            ASN1_ENTER_SET
+            {
+                // AttributeTypeAndValue ::= SEQUENCE
+                ASN1_PARSE_ENTER_SEQUENCE
+                {
+                    // type AttributeType
+                    // AttributeType ::= OBJECT IDENTIFIER
+                    OID attrOID;
+                    ASN1_PARSE_OBJECT_ID(attrOID);
+                    VerifyOrReturnError(GetOIDCategory(attrOID) == kOIDCategory_AttributeType, ASN1_ERROR_INVALID_ENCODING);
+
+                    // AttributeValue ::= ANY -- DEFINED BY AttributeType
+                    ASN1_PARSE_ANY;
+
+                    uint8_t attrTag = reader.GetTag();
+
+                    // Can only support UTF8String, PrintableString and IA5String.
+                    VerifyOrReturnError(reader.GetClass() == kASN1TagClass_Universal &&
+                                            (attrTag == kASN1UniversalTag_PrintableString ||
+                                             attrTag == kASN1UniversalTag_UTF8String || attrTag == kASN1UniversalTag_IA5String),
+                                        ASN1_ERROR_UNSUPPORTED_ENCODING);
+
+                    // CHIP attributes must be UTF8Strings.
+                    if (IsChipDNAttr(attrOID))
+                    {
+                        VerifyOrReturnError(attrTag == kASN1UniversalTag_UTF8String, ASN1_ERROR_INVALID_ENCODING);
+                    }
+
+                    // If 64-bit CHIP attribute.
+                    if (IsChip64bitDNAttr(attrOID))
+                    {
+                        uint64_t chipAttr;
+                        VerifyOrReturnError(Encoding::UppercaseHexToUint64(reinterpret_cast<const char *>(reader.GetValue()),
+                                                                           static_cast<size_t>(reader.GetValueLen()),
+                                                                           chipAttr) == sizeof(uint64_t),
+                                            ASN1_ERROR_INVALID_ENCODING);
+
+                        if (attrOID == chip::ASN1::kOID_AttributeType_ChipNodeId)
+                        {
+                            VerifyOrReturnError(IsOperationalNodeId(chipAttr), CHIP_ERROR_WRONG_CERT_DN);
+                        }
+                        else if (attrOID == chip::ASN1::kOID_AttributeType_ChipFabricId)
+                        {
+                            VerifyOrReturnError(IsValidFabricId(chipAttr), CHIP_ERROR_WRONG_CERT_DN);
+                        }
+
+                        ReturnErrorOnFailure(AddAttribute(attrOID, chipAttr));
+                    }
+                    // If 32-bit CHIP attribute.
+                    else if (IsChip32bitDNAttr(attrOID))
+                    {
+                        CASEAuthTag chipAttr;
+                        VerifyOrReturnError(Encoding::UppercaseHexToUint32(reinterpret_cast<const char *>(reader.GetValue()),
+                                                                           reader.GetValueLen(), chipAttr) == sizeof(CASEAuthTag),
+                                            ASN1_ERROR_INVALID_ENCODING);
+
+                        VerifyOrReturnError(IsValidCASEAuthTag(chipAttr), CHIP_ERROR_WRONG_CERT_DN);
+
+                        ReturnErrorOnFailure(AddAttribute(attrOID, chipAttr));
+                    }
+                    // Otherwise, it is a string.
+                    else
+                    {
+                        ReturnErrorOnFailure(AddAttribute(attrOID,
+                                                          CharSpan(Uint8::to_const_char(reader.GetValue()), reader.GetValueLen()),
+                                                          attrTag == kASN1UniversalTag_PrintableString));
+                    }
+                }
+                ASN1_EXIT_SEQUENCE;
+
+                // Only one AttributeTypeAndValue allowed per RDN.
+                err = reader.Next();
+                ReturnErrorCodeIf(err == CHIP_NO_ERROR, ASN1_ERROR_UNSUPPORTED_ENCODING);
+                VerifyOrReturnError(err == ASN1_END, err);
+            }
+            ASN1_EXIT_SET;
+        }
+    }
+    ASN1_EXIT_SEQUENCE;
 
 exit:
     return err;
@@ -1157,6 +1281,62 @@ CHIP_ERROR ExtractSKIDFromChipCert(const ByteSpan & chipCert, CertificateKeyId &
     skid = certData.mSubjectKeyId;
 
     return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ExtractSubjectDNFromChipCert(const ByteSpan & chipCert, ChipDN & dn)
+{
+    ChipCertificateSet certSet;
+    ChipCertificateData certData;
+
+    ReturnErrorOnFailure(certSet.Init(&certData, 1));
+
+    ReturnErrorOnFailure(certSet.LoadCert(chipCert, BitFlags<CertDecodeFlags>()));
+
+    dn = certData.mSubjectDN;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ExtractSubjectDNFromX509Cert(const ByteSpan & x509Cert, ChipDN & dn)
+{
+    CHIP_ERROR err;
+    ASN1Reader reader;
+
+    VerifyOrReturnError(CanCastTo<uint32_t>(x509Cert.size()), CHIP_ERROR_INVALID_ARGUMENT);
+
+    reader.Init(x509Cert);
+
+    // Certificate ::= SEQUENCE
+    ASN1_PARSE_ENTER_SEQUENCE
+    {
+        // tbsCertificate TBSCertificate,
+        // TBSCertificate ::= SEQUENCE
+        ASN1_PARSE_ENTER_SEQUENCE
+        {
+            // Skip version [0] EXPLICIT Version DEFAULT v1
+            ASN1_PARSE_ELEMENT(kASN1TagClass_ContextSpecific, 0);
+
+            // Skip serialNumber CertificateSerialNumber
+            ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_Integer);
+
+            // Skip signature AlgorithmIdentifier
+            ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_Sequence);
+
+            // Skip issuer Name
+            ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_Sequence);
+
+            // Skip validity Validity,
+            ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_Sequence);
+
+            // Decode subject Name,
+            ReturnErrorOnFailure(dn.DecodeFromASN1(reader));
+        }
+        ASN1_SKIP_AND_EXIT_SEQUENCE;
+    }
+    ASN1_SKIP_AND_EXIT_SEQUENCE;
+
+exit:
+    return err;
 }
 
 } // namespace Credentials

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -277,6 +277,11 @@ public:
     CHIP_ERROR GetCertFabricId(uint64_t & fabricId) const;
 
     /**
+     * @brief Encode ChipDN attributes in TLV form.
+     **/
+    CHIP_ERROR EncodeToTLV(chip::TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    /**
      * @brief Decode ChipDN attributes from TLV encoded format.
      *
      * @param reader  A TLVReader positioned at the ChipDN TLV list.
@@ -287,6 +292,13 @@ public:
      * @brief Encode ChipDN attributes in ASN1 form.
      **/
     CHIP_ERROR EncodeToASN1(ASN1::ASN1Writer & writer) const;
+
+    /**
+     * @brief Decode ChipDN attributes from ASN1 encoded format.
+     *
+     * @param reader  A ASN1Reader positioned at the ChipDN ASN1 list.
+     **/
+    CHIP_ERROR DecodeFromASN1(ASN1::ASN1Reader & reader);
 
     bool IsEqual(const ChipDN & other) const;
 
@@ -868,7 +880,7 @@ CHIP_ERROR ExtractNodeIdFabricIdFromOpCert(const ByteSpan & opcert, NodeId * nod
 /**
  * Extract Public Key from a chip certificate in ByteSpan TLV-encoded form.
  * This does not perform any sort of validation on the certificate structure
- * structure than parsing it.
+ * other than parsing it.
  *
  * Can return any error that can be returned from parsing the cert.
  */
@@ -877,11 +889,27 @@ CHIP_ERROR ExtractPublicKeyFromChipCert(const ByteSpan & chipCert, P256PublicKey
 /**
  * Extract Subject Key Identifier from a chip certificate in ByteSpan TLV-encoded form.
  * This does not perform any sort of validation on the certificate structure
- * structure than parsing it.
+ * other than parsing it.
  *
  * Can return any error that can be returned from parsing the cert.
  */
 CHIP_ERROR ExtractSKIDFromChipCert(const ByteSpan & chipCert, CertificateKeyId & skid);
+
+/**
+ * Extract Subject Distinguished Name (DN) from a chip certificate in ByteSpan TLV-encoded form.
+ * It is required that the certificate in the chipCert buffer stays valid while the `dn` output is used.
+ *
+ * Can return any error that can be returned from parsing the cert.
+ */
+CHIP_ERROR ExtractSubjectDNFromChipCert(const ByteSpan & chipCert, ChipDN & dn);
+
+/**
+ * Extract Subject Distinguished Name (DN) from a chip certificate in ByteSpan X509 DER-encoded form.
+ * It is required that the certificate in the chipCert buffer stays valid while the `dn` output is used.
+ *
+ * Can return any error that can be returned from converting and parsing the cert.
+ */
+CHIP_ERROR ExtractSubjectDNFromX509Cert(const ByteSpan & x509Cert, ChipDN & dn);
 
 } // namespace Credentials
 } // namespace chip

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
@@ -67,7 +67,7 @@ private:
     bool ToChipEpochTime(uint32_t offset, uint32_t & epoch);
 
     ChipP256KeypairPtr mIssuerKey;
-    uint32_t mIssuerId = 1234;
+    uint64_t mIssuerId = 1234;
 
     const uint32_t kCertificateValiditySecs = 365 * 24 * 60 * 60;
     const NSString * kCHIPCAKeyChainLabel = @"matter.nodeopcerts.CA:0";

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -87,14 +87,14 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::SetIssuerID(CHIPPersistentStorage
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    char issuerIdString[16];
-    uint16_t idStringLen = sizeof(issuerIdString);
-    if (CHIP_NO_ERROR != storage->SyncGetKeyValue(CHIP_COMMISSIONER_CA_ISSUER_ID, issuerIdString, idStringLen)) {
+    uint16_t issuerIdLen = sizeof(mIssuerId);
+    if (CHIP_NO_ERROR != storage->SyncGetKeyValue(CHIP_COMMISSIONER_CA_ISSUER_ID, &mIssuerId, issuerIdLen)) {
         mIssuerId = arc4random();
-        CHIP_LOG_ERROR("Assigned %d certificate issuer ID to the commissioner", mIssuerId);
+        mIssuerId = mIssuerId << 32 | arc4random();
+        CHIP_LOG_ERROR("Assigned %llx certificate issuer ID to the commissioner", mIssuerId);
         storage->SyncSetKeyValue(CHIP_COMMISSIONER_CA_ISSUER_ID, &mIssuerId, sizeof(mIssuerId));
     } else {
-        CHIP_LOG_ERROR("Found %d certificate issuer ID for the commissioner", mIssuerId);
+        CHIP_LOG_ERROR("Found %llx certificate issuer ID for the commissioner", mIssuerId);
     }
 
     return CHIP_NO_ERROR;
@@ -203,40 +203,37 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChainAfterValidation(N
         return CHIP_ERROR_INTERNAL;
     }
 
+    ChipDN rcac_dn;
+    if (!mGenerateRootCert) {
+        uint16_t rcacBufLen = static_cast<uint16_t>(std::min(rcac.size(), static_cast<size_t>(UINT16_MAX)));
+        PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
+            ReturnErrorOnFailure(mStorage->SyncGetKeyValue(key, rcac.data(), rcacBufLen)));
+        rcac.reduce_size(rcacBufLen);
+        ReturnErrorOnFailure(ExtractSubjectDNFromX509Cert(rcac, rcac_dn));
+    } else {
+        ReturnErrorOnFailure(rcac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, mIssuerId));
+        ReturnErrorOnFailure(rcac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, fabricId));
+
+        NSLog(@"Generating RCAC");
+        X509CertRequestParams rcac_request = { 0, validityStart, validityEnd, rcac_dn, rcac_dn };
+        ReturnErrorOnFailure(NewRootX509Cert(rcac_request, *mIssuerKey, rcac));
+
+        VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);
+        PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
+            ReturnErrorOnFailure(mStorage->SyncSetKeyValue(key, rcac.data(), static_cast<uint16_t>(rcac.size()))));
+
+        mGenerateRootCert = false;
+    }
+
+    icac.reduce_size(0);
+
     ChipDN noc_dn;
     ReturnErrorOnFailure(noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, fabricId));
     ReturnErrorOnFailure(noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, nodeId));
     ReturnErrorOnFailure(noc_dn.AddCATs(cats));
-    ChipDN rcac_dn;
-    ReturnErrorOnFailure(rcac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, mIssuerId));
-    ReturnErrorOnFailure(rcac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, fabricId));
 
     X509CertRequestParams noc_request = { 1, validityStart, validityEnd, noc_dn, rcac_dn };
-    ReturnErrorOnFailure(NewNodeOperationalX509Cert(noc_request, pubkey, *mIssuerKey, noc));
-    icac.reduce_size(0);
-
-    uint16_t rcacBufLen = static_cast<uint16_t>(std::min(rcac.size(), static_cast<size_t>(UINT16_MAX)));
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    if (!mGenerateRootCert) {
-        PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
-            err = mStorage->SyncGetKeyValue(key, rcac.data(), rcacBufLen));
-        if (err == CHIP_NO_ERROR) {
-            // Found root certificate in the storage.
-            rcac.reduce_size(rcacBufLen);
-            return CHIP_NO_ERROR;
-        }
-    }
-
-    X509CertRequestParams rcac_request = { 0, validityStart, validityEnd, rcac_dn, rcac_dn };
-    ReturnErrorOnFailure(NewRootX509Cert(rcac_request, *mIssuerKey, rcac));
-
-    VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);
-    PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
-        err = mStorage->SyncSetKeyValue(key, rcac.data(), static_cast<uint16_t>(rcac.size())));
-
-    mGenerateRootCert = false;
-
-    return err;
+    return NewNodeOperationalX509Cert(noc_request, pubkey, *mIssuerKey, noc);
 }
 
 CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChain(const chip::ByteSpan & csrElements,

--- a/src/lib/asn1/ASN1Macros.h
+++ b/src/lib/asn1/ASN1Macros.h
@@ -86,17 +86,27 @@
     }                                                                                                                              \
     while (0)
 
+#define ASN1_SKIP_AND_EXIT_CONSTRUCTED                                                                                             \
+    ASN1_ERR = ASN1_READER.ExitConstructedType();                                                                                  \
+    SuccessOrExit(ASN1_ERR);                                                                                                       \
+    }                                                                                                                              \
+    while (0)
+
 #define ASN1_PARSE_ENTER_SEQUENCE ASN1_PARSE_ENTER_CONSTRUCTED(kASN1TagClass_Universal, kASN1UniversalTag_Sequence)
 
 #define ASN1_ENTER_SEQUENCE ASN1_ENTER_CONSTRUCTED(kASN1TagClass_Universal, kASN1UniversalTag_Sequence)
 
 #define ASN1_EXIT_SEQUENCE ASN1_EXIT_CONSTRUCTED
 
+#define ASN1_SKIP_AND_EXIT_SEQUENCE ASN1_SKIP_AND_EXIT_CONSTRUCTED
+
 #define ASN1_PARSE_ENTER_SET ASN1_PARSE_ENTER_CONSTRUCTED(kASN1TagClass_Universal, kASN1UniversalTag_Set)
 
 #define ASN1_ENTER_SET ASN1_ENTER_CONSTRUCTED(kASN1TagClass_Universal, kASN1UniversalTag_Set)
 
 #define ASN1_EXIT_SET ASN1_EXIT_CONSTRUCTED
+
+#define ASN1_SKIP_AND_EXIT_SET ASN1_SKIP_AND_EXIT_CONSTRUCTED
 
 #define ASN1_ENTER_ENCAPSULATED(CLASS, TAG)                                                                                        \
     do                                                                                                                             \


### PR DESCRIPTION
#### Problem
In the current implementation when ICAC and RCAC are
found in the storage the Subject DN for these certificates is generated
separately. This might be an issue if after software update the way
Subject DN is generated is changed.

#### Change overview
The proper implementation is to extract Subject DN from ICAC and RCAC
if they are found in the device memory.

#### Testing
existing tests