### PR TITLE
Remove some unused commissioning states.

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -201,9 +201,6 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStage(CommissioningStag
     case CommissioningStage::kSendComplete:
         return CommissioningStage::kCleanup;
 
-    // Currently unimplemented.
-    case CommissioningStage::kConfigACL:
-        return CommissioningStage::kError;
     // Neither of these have a next stage so return kError;
     case CommissioningStage::kCleanup:
     case CommissioningStage::kError:

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2002,9 +2002,6 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         SendOperationalCertificate(proxy, params.GetNoc().Value(), params.GetIcac().Value(), params.GetIpk().Value(),
                                    params.GetAdminSubject().Value());
         break;
-    case CommissioningStage::kConfigACL:
-        // TODO: Implement
-        break;
     case CommissioningStage::kWiFiNetworkSetup: {
         if (!params.GetWiFiCredentials().HasValue())
         {

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -33,9 +33,6 @@ enum CommissioningStage : uint8_t
     kSecurePairing,
     kReadCommissioningInfo,
     kArmFailsafe,
-    // kConfigTime,  // NOT YET IMPLEMENTED
-    // kConfigTimeZone,  // NOT YET IMPLEMENTED
-    // kConfigDST,  // NOT YET IMPLEMENTED
     kConfigRegulatory,
     kSendPAICertificateRequest,
     kSendDACCertificateRequest,
@@ -52,7 +49,6 @@ enum CommissioningStage : uint8_t
     kFindOperational,
     kSendComplete,
     kCleanup,
-    kConfigACL,
 };
 
 struct WiFiCredentials


### PR DESCRIPTION
#### Problem
ACL entries get added automatically when the NOC is added. The commissioner was previously required to set the ACL, but this is not required in a general commissioning any more. Commissioners that wish to adjust the ACLs may adjust them through cluster commands either by providing a custom CommissioningDelegate or by adjusting the ACLs after commissioning has completed.

#### Change overview
Removes unused commissioning states.

#### Testing
Covered by cirque tests.
