### PR TITLE
Added logic to have a max retry count for providers returning a BUSY state

### DIFF
--- a/scripts/tests/ota_test.sh
+++ b/scripts/tests/ota_test.sh
@@ -65,10 +65,16 @@ timeout 30 grep -q "OTA image downloaded to" <(tail -n0 -f /tmp/ota/requestor-lo
 
 echo "Exiting, logs are in tmp/ota/"
 
-killall -e "$OTA_PROVIDER_APP" "$OTA_REQUESTOR_APP"
-
 if cmp "$OTA_DOWNLOAD_PATH" "$FIRMWARE_BIN"; then
-    echo Test passed && exit 0
+    TEST_RESULT="Test passed"
+    RETURN_VALUE=0
 else
-    echo Test failed && exit 1
+    TEST_RESULT="Test failed"
+    RETURN_VALUE=1
 fi
+
+killall -e "$OTA_PROVIDER_APP" "$OTA_REQUESTOR_APP"
+rm -f "$FIRMWARE_OTA" "$FIRMWARE_BIN" "$OTA_DOWNLOAD_PATH"
+
+echo "$TEST_RESULT"
+exit "$RETURN_VALUE"

--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
@@ -68,7 +68,7 @@ public:
     void ProcessAnnounceOTAProviders(const ProviderLocationType & providerLocation,
                                      app::Clusters::OtaSoftwareUpdateRequestor::OTAAnnouncementReason announcementReason) override;
     void SendQueryImage() override;
-    bool GetNextProviderLocation(ProviderLocationType & providerLocation) override;
+    bool GetNextProviderLocation(ProviderLocationType & providerLocation, bool & listExhausted) override;
 
 protected:
     void StartDefaultProviderTimer();
@@ -82,6 +82,9 @@ protected:
     OTAImageProcessorInterface * mImageProcessor = nullptr;
     uint32_t mOtaStartDelaySec                   = 0;
     uint32_t mPeriodicQueryTimeInterval = (24 * 60 * 60); // Timeout for querying providers on the default OTA provider list
+    // Maximum number of times to retry a BUSY OTA provider before moving to the next available one
+    static constexpr uint8_t kMaxBusyProviderRetryCount = 3;
+    uint8_t mProviderRetryCount; // Track retry count for the current provider
 };
 
 } // namespace DeviceLayer

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -475,7 +475,8 @@ void OTARequestor::TriggerImmediateQueryInternal()
 OTARequestorInterface::OTATriggerResult OTARequestor::TriggerImmediateQuery()
 {
     ProviderLocationType providerLocation;
-    if (mOtaRequestorDriver->GetNextProviderLocation(providerLocation) != true)
+    bool listExhausted = false;
+    if (mOtaRequestorDriver->GetNextProviderLocation(providerLocation, listExhausted) != true)
     {
         ChipLogError(SoftwareUpdate, "No OTA Providers available");
         return kNoProviderKnown;
@@ -786,6 +787,8 @@ CHIP_ERROR OTARequestor::SendNotifyUpdateAppliedRequest(OperationalDeviceProxy &
 
     Controller::OtaSoftwareUpdateProviderCluster cluster;
     cluster.Associate(&deviceProxy, mProviderLocation.Value().endpoint);
+
+    mProviderLocation.ClearValue(); // Clearing the last used provider location to start afresh on reboot
 
     return cluster.InvokeCommand(args, this, OnNotifyUpdateAppliedResponse, OnNotifyUpdateAppliedFailure);
 }

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -130,7 +130,6 @@ public:
             mUpdateToken = updateToken;
         }
 
-
         // Schedule the initializations that needs to be performed in the CHIP context
         DeviceLayer::PlatformMgr().ScheduleWork(InitState, reinterpret_cast<intptr_t>(this));
 
@@ -333,7 +332,10 @@ private:
     OTAUpdateStateEnum mCurrentUpdateState = OTAUpdateStateEnum::kUnknown;
     Server * mServer                       = nullptr;
     ProviderLocationList mDefaultOtaProviderList;
-    Optional<ProviderLocationType> mProviderLocation; // Provider location used for the current/last update in progress
+    // Provider location used for the current/last update in progress. Note that on reboot, this value will be read from the
+    // persistent storage (if available), used for sending the NotifyApplied message, and then cleared. This will ensure determinism
+    // in the OTARequestorDriver on reboot.
+    Optional<ProviderLocationType> mProviderLocation;
 };
 
 } // namespace chip

--- a/src/app/clusters/ota-requestor/OTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/OTARequestorDriver.h
@@ -128,7 +128,9 @@ public:
     // Driver picks the OTA Provider that should be used for the next query and update. The Provider is picked according to
     // the driver's internal logic such as, for example, traversing the default providers list.
     // Returns true if there is a Provider available for the next query, returns false otherwise.
-    virtual bool GetNextProviderLocation(ProviderLocationType & providerLocation) = 0;
+    // [in] listExhausted - set to TRUE if the list of providers has been traversed until the end and has looped
+    // back to the beginning.
+    virtual bool GetNextProviderLocation(ProviderLocationType & providerLocation, bool & listExhausted) = 0;
 };
 
 } // namespace chip


### PR DESCRIPTION
#### Problem
Fixes #15691 

#### Change overview
If an OTA provider returns a BUSY response, then it will be retried a MAX_RETRY_COUNT number of times before moving on. This will prevent the Requestor from being stuck on a single OTA provider forever.
With these changes, the QueryImage logic now tries the entire list of providers until either an OTA succeeds or the end-of-list is reached. Upon failure, the 24 hours timer kicks back in.
The last used provider is also cleared on every reboot to ensure a clean-slate beginning and this will also ensure that the list is always traversed from the beginning to the end, deterministically.

#### Testing
- Tested to ensure that the requestor moves on after hitting the max retry count.
- Ran the ota_test script on Linux.
