### PR TITLE
Reduce some of the linux build targets to build under 2 hours.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -157,9 +157,8 @@ jobs:
             - name: Setup Build, Run Build and Run Tests
               timeout-minutes: 90
               run: |
-                  for BUILD_TYPE  in fake gcc_release clang mbedtls; do
+                  for BUILD_TYPE  in gcc_release clang mbedtls; do
                       case $BUILD_TYPE in
-                          "fake") GN_ARGS='chip_device_platform="fake"';;
                           "gcc_release") GN_ARGS='is_debug=false';;
                           "clang") GN_ARGS='is_clang=true pw_command_launcher="`pwd`/../scripts/helpers/clang-tidy-launcher.py"';;
                           "mbedtls") GN_ARGS='chip_crypto="mbedtls"';;
@@ -191,18 +190,14 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --no-log-timestamps \
-                       --target linux-x64-all-clusters \
                        --target linux-x64-all-clusters-ipv6only \
-                       --target linux-x64-chip-tool \
                        --target linux-x64-chip-tool-ipv6only \
                        --target linux-x64-minmdns-ipv6only \
                        --target linux-x64-rpc-console \
-                       --target linux-x64-thermostat-ipv6only \
-                       --target linux-x64-tv-app-ipv6only \
                        build \
                     "
 
-            - name: Run fake linux tests
+            - name: Run fake linux tests with build_examples
               timeout-minutes: 15
               run: |
                   ./scripts/run_in_build_env.sh \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -99,7 +99,7 @@ jobs:
               timeout-minutes: 20
               run: scripts/run_in_build_env.sh "ninja -C ./out"
     build_linux:
-        name: Build on Linux (fake, gcc_release, clang, mbedtls, simulated)
+        name: Build on Linux (fake, gcc_release, clang, simulated)
         timeout-minutes: 120
 
         runs-on: ubuntu-latest
@@ -157,11 +157,10 @@ jobs:
             - name: Setup Build, Run Build and Run Tests
               timeout-minutes: 90
               run: |
-                  for BUILD_TYPE  in gcc_release clang mbedtls; do
+                  for BUILD_TYPE  in gcc_release clang; do
                       case $BUILD_TYPE in
                           "gcc_release") GN_ARGS='is_debug=false';;
                           "clang") GN_ARGS='is_clang=true pw_command_launcher="`pwd`/../scripts/helpers/clang-tidy-launcher.py"';;
-                          "mbedtls") GN_ARGS='chip_crypto="mbedtls"';;
                       esac
 
                       scripts/build/gn_gen.sh --args="$GN_ARGS"


### PR DESCRIPTION
#### Problem
Linux builds are timing out at 2 hours compilations.

#### Change overview
Several cleanups:
  - do not compile 'fake' using the GN script since build_examples already compiles and test fake.
  - remove several target compilations from build_examples - specifically keep only ipv6only variants since those are what we should generally support and they cover most use cases. Also skipped some examples (tv and thermostat)
  - remove mbedtls variant since that build is 100% covered by the unit-test CI step

There is still very high overlap between the UnitAndIntegrationTests CI step and this build - they both run unit tests, but for the remaining bits they have ever so slightly different arguments. Some future followups for dedups would be useful (e.g. running different sanitizers in the unit tests rather than the builds).

#### Testing
CI will validate. As this is a removal, change is generally safe.