### PR TITLE
Fixed swapped app names for ota requestor/provider in build_examples

### DIFF
--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -102,11 +102,11 @@ class HostApp(Enum):
             yield 'chip-cert'
             yield 'chip-cert.map'
         elif self == HostApp.OTA_PROVIDER:
-            yield 'chip-ota-requestor-app'
-            yield 'chip-ota-requestor-app.map'
-        elif self == HostApp.OTA_REQUESTOR:
             yield 'chip-ota-provider-app'
             yield 'chip-ota-provider-app.map'
+        elif self == HostApp.OTA_REQUESTOR:
+            yield 'chip-ota-requestor-app'
+            yield 'chip-ota-requestor-app.map'
         else:
             raise Exception('Unknown app type: %r' % self)
 


### PR DESCRIPTION
#### Problem
Typo in app names prevents build archive creation.

#### Change overview
Fixed the swapped paths

#### Testing
RAN:

```
./scripts/build/build_examples.py --enable-flashbundle --target linux-x64-ota-requestor build --copy-artifacts-to /tmp/test
```