### PR TITLE
use clang-tidy to modernize-use-override

### DIFF
--- a/src/app/CASEClientPool.h
+++ b/src/app/CASEClientPool.h
@@ -36,7 +36,7 @@ template <size_t N>
 class CASEClientPool : public CASEClientPoolDelegate
 {
 public:
-    ~CASEClientPool() { mClientPool.ReleaseAll(); }
+    ~CASEClientPool() override { mClientPool.ReleaseAll(); }
 
     CASEClient * Allocate(CASEClientInitParams params) override { return mClientPool.CreateObject(params); }
 

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -59,7 +59,7 @@ public:
      *
      * See Abort() for details on when that might occur.
      */
-    virtual ~CommandSender() { Abort(); }
+    ~CommandSender() override { Abort(); }
 
     /**
      * Gets the inner exchange context object, without ownership.

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -100,7 +100,7 @@ public:
     void SetRequiredSpaceforEvicted(size_t aRequiredSpace) { mRequiredSpaceForEvicted = aRequiredSpace; }
     size_t GetRequiredSpaceforEvicted() { return mRequiredSpaceForEvicted; }
 
-    virtual ~CircularEventBuffer() = default;
+    ~CircularEventBuffer() override = default;
 
 private:
     CircularEventBuffer * mpPrev = nullptr; ///< A pointer CircularEventBuffer storing events less important events

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -88,7 +88,7 @@ class DLL_EXPORT OperationalDeviceProxy : public DeviceProxy,
                                           public AddressResolve::NodeListener
 {
 public:
-    virtual ~OperationalDeviceProxy();
+    ~OperationalDeviceProxy() override;
     OperationalDeviceProxy(DeviceProxyInitParams & params, PeerId peerId) : mSecureSession(*this)
     {
         VerifyOrReturn(params.Validate() == CHIP_NO_ERROR);

--- a/src/app/OperationalDeviceProxyPool.h
+++ b/src/app/OperationalDeviceProxyPool.h
@@ -48,7 +48,7 @@ template <size_t N>
 class OperationalDeviceProxyPool : public OperationalDeviceProxyPoolDelegate
 {
 public:
-    ~OperationalDeviceProxyPool() { mDevicePool.ReleaseAll(); }
+    ~OperationalDeviceProxyPool() override { mDevicePool.ReleaseAll(); }
 
     OperationalDeviceProxy * Allocate(DeviceProxyInitParams & params, PeerId peerId) override
     {

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -202,7 +202,7 @@ public:
      *
      * OnDone() will not be called.
      */
-    virtual ~ReadClient();
+    ~ReadClient() override;
 
     /*
      * This forcibly closes the exchange context if a valid one is pointed to. Such a situation does

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -98,7 +98,7 @@ public:
      *
      * See Abort() for details on when that might occur.
      */
-    ~ReadHandler();
+    ~ReadHandler() override;
 
     /**
      *  Process a read/subscribe request.  Parts of the processing may end up being asynchronous, but the ReadHandler

--- a/src/app/TimedHandler.h
+++ b/src/app/TimedHandler.h
@@ -51,7 +51,7 @@ class TimedHandler : public Messaging::ExchangeDelegate
 {
 public:
     TimedHandler() {}
-    virtual ~TimedHandler() {}
+    ~TimedHandler() override {}
 
     // ExchangeDelegate implementation.
     CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * aExchangeContext, const PayloadHeader & aPayloadHeader,

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -232,7 +232,7 @@ public:
      *
      * See Abort() for details on when that might occur.
      */
-    virtual ~WriteClient() { Abort(); }
+    ~WriteClient() override { Abort(); }
 
 private:
     friend class TestWriteInteraction;

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -76,7 +76,7 @@ public:
 
     bool IsFree() const { return mState == State::Uninitialized; }
 
-    virtual ~WriteHandler() = default;
+    ~WriteHandler() override = default;
 
     CHIP_ERROR ProcessAttributeDataIBs(TLV::TLVReader & aAttributeDataIBsReader);
     CHIP_ERROR ProcessGroupAttributeDataIBs(TLV::TLVReader & aAttributeDataIBsReader);

--- a/src/app/tests/suites/commands/commissioner/CommissionerCommands.h
+++ b/src/app/tests/suites/commands/commissioner/CommissionerCommands.h
@@ -25,7 +25,7 @@ class CommissionerCommands : public chip::Controller::DevicePairingDelegate
 {
 public:
     CommissionerCommands(){};
-    virtual ~CommissionerCommands(){};
+    ~CommissionerCommands() override{};
 
     virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err)             = 0;
     virtual chip::Controller::DeviceCommissioner & GetCurrentCommissioner() = 0;

--- a/src/app/tests/suites/commands/discovery/DiscoveryCommands.h
+++ b/src/app/tests/suites/commands/discovery/DiscoveryCommands.h
@@ -47,7 +47,7 @@ class DiscoveryCommands : public chip::Dnssd::CommissioningResolveDelegate, publ
 {
 public:
     DiscoveryCommands(){};
-    virtual ~DiscoveryCommands(){};
+    ~DiscoveryCommands() override{};
 
     virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) = 0;
 

--- a/src/controller/AbstractDnssdDiscoveryController.h
+++ b/src/controller/AbstractDnssdDiscoveryController.h
@@ -40,7 +40,7 @@ class DLL_EXPORT AbstractDnssdDiscoveryController : public Dnssd::CommissioningR
 {
 public:
     AbstractDnssdDiscoveryController() {}
-    virtual ~AbstractDnssdDiscoveryController() {}
+    ~AbstractDnssdDiscoveryController() override {}
 
     void OnNodeDiscovered(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
 

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -29,13 +29,13 @@ class AutoCommissioner : public CommissioningDelegate
 {
 public:
     AutoCommissioner();
-    virtual ~AutoCommissioner();
+    ~AutoCommissioner() override;
     CHIP_ERROR SetCommissioningParameters(const CommissioningParameters & params) override;
     void SetOperationalCredentialsDelegate(OperationalCredentialsDelegate * operationalCredentialsDelegate) override;
 
-    virtual CHIP_ERROR StartCommissioning(DeviceCommissioner * commissioner, CommissioneeDeviceProxy * proxy) override;
+    CHIP_ERROR StartCommissioning(DeviceCommissioner * commissioner, CommissioneeDeviceProxy * proxy) override;
 
-    virtual CHIP_ERROR CommissioningStepFinished(CHIP_ERROR err, CommissioningDelegate::CommissioningReport report) override;
+    CHIP_ERROR CommissioningStepFinished(CHIP_ERROR err, CommissioningDelegate::CommissioningReport report) override;
 
 private:
     CommissioningStage GetNextCommissioningStage(CommissioningStage currentStage, CHIP_ERROR & lastErr);

--- a/src/controller/CHIPCommissionableNodeController.h
+++ b/src/controller/CHIPCommissionableNodeController.h
@@ -37,7 +37,7 @@ class DLL_EXPORT CommissionableNodeController : public AbstractDnssdDiscoveryCon
 {
 public:
     CommissionableNodeController(chip::Dnssd::Resolver * resolver = nullptr) : mResolver(resolver) {}
-    virtual ~CommissionableNodeController() {}
+    ~CommissionableNodeController() override {}
 
     CHIP_ERROR DiscoverCommissioners(Dnssd::DiscoveryFilter discoveryFilter = Dnssd::DiscoveryFilter());
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -172,7 +172,7 @@ class DLL_EXPORT DeviceController : public SessionRecoveryDelegate, public Abstr
 {
 public:
     DeviceController();
-    virtual ~DeviceController() {}
+    ~DeviceController() override {}
 
     enum class CommissioningWindowOption : uint8_t
     {
@@ -436,7 +436,7 @@ class DLL_EXPORT DeviceCommissioner : public DeviceController,
 {
 public:
     DeviceCommissioner();
-    ~DeviceCommissioner() {}
+    ~DeviceCommissioner() override {}
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY // make this commissioner discoverable
     /**

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -79,7 +79,7 @@ struct ControllerDeviceInitParams
 class CommissioneeDeviceProxy : public DeviceProxy, public SessionReleaseDelegate
 {
 public:
-    ~CommissioneeDeviceProxy();
+    ~CommissioneeDeviceProxy() override;
     CommissioneeDeviceProxy() : mSecureSession(*this) {}
     CommissioneeDeviceProxy(const CommissioneeDeviceProxy &) = delete;
 

--- a/src/controller/CommissionerDiscoveryController.h
+++ b/src/controller/CommissionerDiscoveryController.h
@@ -183,7 +183,7 @@ public:
      *
      * This code will call the registered UserPrompter's PromptForCommissionOKPermission
      */
-    void OnUserDirectedCommissioningRequest(UDCClientState state);
+    void OnUserDirectedCommissioningRequest(UDCClientState state) override;
 
     /**
      * This method should be called after the user has given consent for commissioning of the client

--- a/src/controller/ExampleOperationalCredentialsIssuer.h
+++ b/src/controller/ExampleOperationalCredentialsIssuer.h
@@ -52,7 +52,7 @@ public:
     // It is recommended that this index track the fabric index within which this issuer is operating.
     //
     ExampleOperationalCredentialsIssuer(uint32_t index = 0) { mIndex = index; }
-    virtual ~ExampleOperationalCredentialsIssuer() {}
+    ~ExampleOperationalCredentialsIssuer() override {}
 
     CHIP_ERROR GenerateNOCChain(const ByteSpan & csrElements, const ByteSpan & attestationSignature, const ByteSpan & DAC,
                                 const ByteSpan & PAI, const ByteSpan & PAA,

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -32,7 +32,7 @@ public:
     GroupDataProviderImpl(uint16_t maxGroupsPerFabric, uint16_t maxGroupKeysPerFabric) :
         GroupDataProvider(maxGroupsPerFabric, maxGroupKeysPerFabric)
     {}
-    virtual ~GroupDataProviderImpl() {}
+    ~GroupDataProviderImpl() override {}
 
     /**
      * @brief Set the storage implementation used for non-volatile storage of configuration data.

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -362,7 +362,7 @@ class P256Keypair : public P256KeypairBase
 {
 public:
     P256Keypair() {}
-    virtual ~P256Keypair();
+    ~P256Keypair() override;
 
     /**
      * @brief Initialize the keypair.

--- a/src/include/platform/NetworkCommissioning.h
+++ b/src/include/platform/NetworkCommissioning.h
@@ -272,7 +272,7 @@ public:
      */
     virtual void ScanNetworks(ByteSpan ssid, ScanCallback * callback) = 0;
 
-    virtual ~WiFiDriver() = default;
+    ~WiFiDriver() override = default;
 };
 
 class ThreadDriver : public Internal::WirelessDriver
@@ -302,7 +302,7 @@ public:
      */
     virtual void ScanNetworks(ScanCallback * callback) = 0;
 
-    virtual ~ThreadDriver() = default;
+    ~ThreadDriver() override = default;
 };
 
 class EthernetDriver : public Internal::BaseDriver

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -126,7 +126,7 @@ public:
 #endif
     void LogDeviceConfig() override;
 
-    virtual ~GenericConfigurationManagerImpl() = default;
+    ~GenericConfigurationManagerImpl() override = default;
 
 protected:
 #if CHIP_ENABLE_ROTATING_DEVICE_ID && defined(CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID)

--- a/src/inet/InetLayer.h
+++ b/src/inet/InetLayer.h
@@ -118,7 +118,7 @@ public:
     using EndPoint = typename EndPointImpl::EndPoint;
 
     EndPointManagerImplPool()  = default;
-    ~EndPointManagerImplPool() = default;
+    ~EndPointManagerImplPool() override = default;
 
     EndPoint * CreateEndPoint() override { return sEndPointPool.CreateObject(*this); }
     void ReleaseEndPoint(EndPoint * endPoint) override { sEndPointPool.ReleaseObject(static_cast<EndPointImpl *>(endPoint)); }

--- a/src/inet/InetLayer.h
+++ b/src/inet/InetLayer.h
@@ -117,7 +117,7 @@ public:
     using Manager  = EndPointManager<typename EndPointImpl::EndPoint>;
     using EndPoint = typename EndPointImpl::EndPoint;
 
-    EndPointManagerImplPool()  = default;
+    EndPointManagerImplPool()           = default;
     ~EndPointManagerImplPool() override = default;
 
     EndPoint * CreateEndPoint() override { return sEndPointPool.CreateObject(*this); }

--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.h
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.h
@@ -129,7 +129,7 @@ private:
 class Resolver : public ::chip::AddressResolve::Resolver, public Dnssd::OperationalResolveDelegate
 {
 public:
-    virtual ~Resolver() = default;
+    ~Resolver() override = default;
 
     // AddressResolve::Resolver
 

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -113,7 +113,7 @@ public:
         mResponseSender.AddQueryResponder(mQueryResponderAllocatorCommissionable.GetQueryResponder());
         mResponseSender.AddQueryResponder(mQueryResponderAllocatorCommissioner.GetQueryResponder());
     }
-    ~AdvertiserMinMdns() {}
+    ~AdvertiserMinMdns() override {}
 
     // Service advertiser
     CHIP_ERROR Init(chip::Inet::EndPointManager<chip::Inet::UDPEndPoint> * udpEndPointManager) override;

--- a/src/lib/dnssd/minimal_mdns/Server.h
+++ b/src/lib/dnssd/minimal_mdns/Server.h
@@ -234,7 +234,7 @@ class Server : private chip::PoolImpl<ServerBase::EndpointInfo, kCount, chip::Ob
 {
 public:
     Server() : ServerBase(*static_cast<ServerBase::EndpointInfoPoolType *>(this)) {}
-    ~Server() {}
+    ~Server() override {}
 };
 
 } // namespace Minimal

--- a/src/lib/dnssd/minimal_mdns/responders/QueryResponder.h
+++ b/src/lib/dnssd/minimal_mdns/responders/QueryResponder.h
@@ -239,7 +239,7 @@ class QueryResponderBase : public Responder // "_services._dns-sd._udp.local"
 public:
     /// Builds a new responder with the given storage for the response infos
     QueryResponderBase(Internal::QueryResponderInfo * infos, size_t infoSizes);
-    virtual ~QueryResponderBase() {}
+    ~QueryResponderBase() override {}
 
     /// Setup initial settings (clears all infos and sets up dns-sd query replies)
     void Init();

--- a/src/lib/support/PoolWrapper.h
+++ b/src/lib/support/PoolWrapper.h
@@ -74,26 +74,26 @@ public:
     static_assert(std::is_base_of<U, T>::value, "Interface type is not derived from Pool type");
 
     PoolProxy() {}
-    virtual ~PoolProxy() override {}
+    ~PoolProxy() override {}
 
-    virtual U * CreateObject(ConstructorArguments... args) override { return Impl().CreateObject(std::move(args)...); }
+    U * CreateObject(ConstructorArguments... args) override { return Impl().CreateObject(std::move(args)...); }
 
-    virtual void ReleaseObject(U * element) override { Impl().ReleaseObject(static_cast<T *>(element)); }
+    void ReleaseObject(U * element) override { Impl().ReleaseObject(static_cast<T *>(element)); }
 
-    virtual void ReleaseAll() override { Impl().ReleaseAll(); }
+    void ReleaseAll() override { Impl().ReleaseAll(); }
 
-    virtual void ResetObject(U * element, ConstructorArguments... args) override
+    void ResetObject(U * element, ConstructorArguments... args) override
     {
         return Impl().ResetObject(static_cast<T *>(element), std::move(args)...);
     }
 
 protected:
-    virtual Loop ForEachActiveObjectInner(void * context,
+    Loop ForEachActiveObjectInner(void * context,
                                           typename PoolInterface<U, ConstructorArguments...>::Lambda lambda) override
     {
         return Impl().ForEachActiveObject([&](T * target) { return lambda(context, static_cast<U *>(target)); });
     }
-    virtual Loop ForEachActiveObjectInner(void * context,
+    Loop ForEachActiveObjectInner(void * context,
                                           typename PoolInterface<U, ConstructorArguments...>::LambdaConst lambda) const override
     {
         return Impl().ForEachActiveObject([&](const T * target) { return lambda(context, static_cast<const U *>(target)); });
@@ -120,11 +120,11 @@ class PoolImpl : public PoolProxy<T, N, M, Interfaces>...
 {
 public:
     PoolImpl() {}
-    virtual ~PoolImpl() override {}
+    ~PoolImpl() override {}
 
 protected:
-    virtual ObjectPool<T, N, M> & Impl() override { return mImpl; }
-    virtual const ObjectPool<T, N, M> & Impl() const override { return mImpl; }
+    ObjectPool<T, N, M> & Impl() override { return mImpl; }
+    const ObjectPool<T, N, M> & Impl() const override { return mImpl; }
 
 private:
     ObjectPool<T, N, M> mImpl;

--- a/src/lib/support/PoolWrapper.h
+++ b/src/lib/support/PoolWrapper.h
@@ -88,13 +88,12 @@ public:
     }
 
 protected:
-    Loop ForEachActiveObjectInner(void * context,
-                                          typename PoolInterface<U, ConstructorArguments...>::Lambda lambda) override
+    Loop ForEachActiveObjectInner(void * context, typename PoolInterface<U, ConstructorArguments...>::Lambda lambda) override
     {
         return Impl().ForEachActiveObject([&](T * target) { return lambda(context, static_cast<U *>(target)); });
     }
     Loop ForEachActiveObjectInner(void * context,
-                                          typename PoolInterface<U, ConstructorArguments...>::LambdaConst lambda) const override
+                                  typename PoolInterface<U, ConstructorArguments...>::LambdaConst lambda) const override
     {
         return Impl().ForEachActiveObject([&](const T * target) { return lambda(context, static_cast<const U *>(target)); });
     }

--- a/src/messaging/ApplicationExchangeDispatch.h
+++ b/src/messaging/ApplicationExchangeDispatch.h
@@ -40,7 +40,7 @@ public:
     }
 
     ApplicationExchangeDispatch() {}
-    virtual ~ApplicationExchangeDispatch() {}
+    ~ApplicationExchangeDispatch() override {}
 
 protected:
     bool MessagePermitted(uint16_t protocol, uint8_t type) override;

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -68,7 +68,7 @@ public:
     ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, const SessionHandle & session, bool Initiator,
                     ExchangeDelegate * delegate);
 
-    ~ExchangeContext();
+    ~ExchangeContext() override;
 
     /**
      *  Determine whether the context is the initiator of the exchange.

--- a/src/platform/Linux/NetworkCommissioningDriver.h
+++ b/src/platform/Linux/NetworkCommissioningDriver.h
@@ -62,7 +62,7 @@ public:
         size_t Count() override;
         bool Next(Network & item) override;
         void Release() override { delete this; }
-        ~WiFiNetworkIterator() = default;
+        ~WiFiNetworkIterator() override = default;
 
     private:
         LinuxWiFiDriver * driver;
@@ -119,7 +119,7 @@ public:
         size_t Count() override;
         bool Next(Network & item) override;
         void Release() override { delete this; }
-        ~ThreadNetworkIterator() = default;
+        ~ThreadNetworkIterator() override = default;
 
     private:
         LinuxThreadDriver * driver;

--- a/src/protocols/bdx/TransferFacilitator.h
+++ b/src/protocols/bdx/TransferFacilitator.h
@@ -45,7 +45,7 @@ class TransferFacilitator : public Messaging::ExchangeDelegate
 {
 public:
     TransferFacilitator() : mExchangeCtx(nullptr), mSystemLayer(nullptr), mPollFreq(kDefaultPollFreq) {}
-    ~TransferFacilitator() = default;
+    ~TransferFacilitator() override = default;
 
 private:
     // Inherited from ExchangeContext

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -29,7 +29,7 @@ class CASEServer : public SessionEstablishmentDelegate, public Messaging::Exchan
 {
 public:
     CASEServer() {}
-    ~CASEServer()
+    ~CASEServer() override
     {
         if (mExchangeManager != nullptr)
         {

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -76,7 +76,7 @@ public:
     CASESession(CASESession &&)      = default;
     CASESession(const CASESession &) = default;
 
-    virtual ~CASESession();
+    ~CASESession() override;
 
     /**
      * @brief
@@ -142,7 +142,7 @@ public:
      * @param role        Role of the new session (initiator or responder)
      * @return CHIP_ERROR The result of session derivation
      */
-    virtual CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) override;
+    CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) override;
 
     /**
      * @brief Serialize the CASESession to the given cachableSession data structure for secure pairing

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -73,7 +73,7 @@ public:
     PASESession(PASESession &&)      = default;
     PASESession(const PASESession &) = delete;
 
-    virtual ~PASESession();
+    ~PASESession() override;
 
     // TODO: The SetPeerNodeId method should not be exposed; PASE sessions
     // should not need to be told their peer node ID

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.h
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.h
@@ -38,7 +38,7 @@ public:
     }
 
     SessionEstablishmentExchangeDispatch() {}
-    virtual ~SessionEstablishmentExchangeDispatch() {}
+    ~SessionEstablishmentExchangeDispatch() override {}
 
 protected:
     bool MessagePermitted(uint16_t protocol, uint8_t type) override;

--- a/src/system/SystemClock.h
+++ b/src/system/SystemClock.h
@@ -285,7 +285,7 @@ public:
 class ClockImpl : public ClockBase
 {
 public:
-    ~ClockImpl() = default;
+    ~ClockImpl() override = default;
     Microseconds64 GetMonotonicMicroseconds64() override;
     Milliseconds64 GetMonotonicMilliseconds64() override;
     CHIP_ERROR GetClock_RealTime(Microseconds64 & aCurTime) override;

--- a/src/system/SystemLayerImplSelect.h
+++ b/src/system/SystemLayerImplSelect.h
@@ -41,7 +41,7 @@ class LayerImplSelect : public LayerSocketsLoop
 {
 public:
     LayerImplSelect() = default;
-    ~LayerImplSelect() { VerifyOrDie(mLayerState.Destroy()); }
+    ~LayerImplSelect() override { VerifyOrDie(mLayerState.Destroy()); }
 
     // Layer overrides.
     CHIP_ERROR Init() override;

--- a/src/system/TLVPacketBufferBackingStore.h
+++ b/src/system/TLVPacketBufferBackingStore.h
@@ -42,7 +42,7 @@ public:
     {
         Init(std::move(buffer), useChainedBuffers);
     }
-    virtual ~TLVPacketBufferBackingStore() {}
+    ~TLVPacketBufferBackingStore() override {}
 
     /**
      * Take ownership of a backing packet buffer.

--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -48,7 +48,7 @@ public:
     {
         SetFabricIndex(fabricIndex);
     }
-    ~IncomingGroupSession()
+    ~IncomingGroupSession() override
     {
         NotifySessionReleased();
 #ifndef NDEBUG
@@ -113,7 +113,7 @@ public:
     {
         SetFabricIndex(fabricIndex);
     }
-    ~OutgoingGroupSession()
+    ~OutgoingGroupSession() override
     {
         NotifySessionReleased();
 #ifndef NDEBUG

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -71,7 +71,7 @@ public:
     {
         SetFabricIndex(fabric);
     }
-    ~SecureSession() { NotifySessionReleased(); }
+    ~SecureSession() override { NotifySessionReleased(); }
 
     SecureSession(SecureSession &&)      = delete;
     SecureSession(const SecureSession &) = delete;

--- a/src/transport/SessionHolder.h
+++ b/src/transport/SessionHolder.h
@@ -32,7 +32,7 @@ class SessionHolder : public SessionReleaseDelegate, public IntrusiveListNodeBas
 {
 public:
     SessionHolder() {}
-    ~SessionHolder();
+    ~SessionHolder() override;
 
     SessionHolder(const SessionHolder &);
     SessionHolder(SessionHolder && that);

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -56,7 +56,7 @@ public:
         mEphemeralInitiatorNodeId(ephemeralInitiatorNodeID), mSessionRole(sessionRole),
         mLastActivityTime(System::SystemClock().GetMonotonicTimestamp()), mMRPConfig(config)
     {}
-    ~UnauthenticatedSession() { NotifySessionReleased(); }
+    ~UnauthenticatedSession() override { NotifySessionReleased(); }
 
     UnauthenticatedSession(const UnauthenticatedSession &) = delete;
     UnauthenticatedSession & operator=(const UnauthenticatedSession &) = delete;

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -276,7 +276,7 @@ public:
             mConnectionsBuffer[i].Init(nullptr);
         }
     }
-    ~TCP() { mPendingPackets.ReleaseAll(); }
+    ~TCP() override { mPendingPackets.ReleaseAll(); }
 
 private:
     friend class TCPTest;


### PR DESCRIPTION
#### Problem
Override not consistently used. Generally it seems mostly destructors (not too bad) but a few instances in methods also seem off (redundant virtual and missing override)

#### Change overview
Ran:

```
./.environment/cipd/packages/pigweed/bin/run-clang-tidy -p ./out/linux-x64-chip-tool-clang/ -fix -checks modernize-use-override 'connectedhomeip/src/'
```

#### Testing
Automated tool ran. Visually this looks ok. CI can validate.