### PR TITLE
Clang-tidy readability-else-after-return

### DIFF
--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -870,7 +870,7 @@ public:
         {
             return CHIP_NO_ERROR;
         }
-        else if (auto * storage = EntryStorage::Find(nullptr))
+        if (auto * storage = EntryStorage::Find(nullptr))
         {
             *storage = *mStorage;
             mStorage = storage;

--- a/src/app/AttributePathExpandIterator.cpp
+++ b/src/app/AttributePathExpandIterator.cpp
@@ -205,7 +205,7 @@ bool AttributePathExpandIterator::Next()
                     // Return true will skip the increment of mClusterIndex, mEndpointIndex and mpClusterInfo.
                     return true;
                 }
-                else if (mGlobalAttributeIndex < mGlobalAttributeEndIndex)
+                if (mGlobalAttributeIndex < mGlobalAttributeEndIndex)
                 {
                     // Return a path pointing to the next global attribute.
                     mOutputPath.mAttributeId = GlobalAttributesNotInMetadata[mGlobalAttributeIndex];

--- a/src/app/ChunkedWriteCallback.cpp
+++ b/src/app/ChunkedWriteCallback.cpp
@@ -38,10 +38,9 @@ void ChunkedWriteCallback::OnResponse(const WriteClient * apWriteClient, const C
             }
             return;
         }
-        
-                    // This is a response to another attribute write. Report the final result of last attribute write.
-            callback->OnResponse(apWriteClient, mLastAttributePath.Value(), mAttributeStatus);
-       
+
+        // This is a response to another attribute write. Report the final result of last attribute write.
+        callback->OnResponse(apWriteClient, mLastAttributePath.Value(), mAttributeStatus);
     }
 
     // This is the first report for a new attribute.  We assume it will never be a list item operation.

--- a/src/app/ChunkedWriteCallback.cpp
+++ b/src/app/ChunkedWriteCallback.cpp
@@ -38,11 +38,10 @@ void ChunkedWriteCallback::OnResponse(const WriteClient * apWriteClient, const C
             }
             return;
         }
-        else
-        {
-            // This is a response to another attribute write. Report the final result of last attribute write.
+        
+                    // This is a response to another attribute write. Report the final result of last attribute write.
             callback->OnResponse(apWriteClient, mLastAttributePath.Value(), mAttributeStatus);
-        }
+       
     }
 
     // This is the first report for a new attribute.  We assume it will never be a list item operation.

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -546,10 +546,9 @@ TLV::TLVWriter * CommandHandler::GetCommandDataIBTLVWriter()
     {
         return nullptr;
     }
-    else
-    {
-        return mInvokeResponseBuilder.GetInvokeResponses().GetInvokeResponse().GetCommand().GetWriter();
-    }
+    
+            return mInvokeResponseBuilder.GetInvokeResponses().GetInvokeResponse().GetCommand().GetWriter();
+   
 }
 
 FabricIndex CommandHandler::GetAccessingFabricIndex() const

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -546,9 +546,8 @@ TLV::TLVWriter * CommandHandler::GetCommandDataIBTLVWriter()
     {
         return nullptr;
     }
-    
-            return mInvokeResponseBuilder.GetInvokeResponses().GetInvokeResponse().GetCommand().GetWriter();
-   
+
+    return mInvokeResponseBuilder.GetInvokeResponses().GetInvokeResponse().GetCommand().GetWriter();
 }
 
 FabricIndex CommandHandler::GetAccessingFabricIndex() const

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -372,10 +372,9 @@ TLV::TLVWriter * CommandSender::GetCommandDataIBTLVWriter()
     {
         return nullptr;
     }
-    else
-    {
-        return mInvokeRequestBuilder.GetInvokeRequests().GetCommandData().GetWriter();
-    }
+    
+            return mInvokeRequestBuilder.GetInvokeRequests().GetCommandData().GetWriter();
+   
 }
 
 CHIP_ERROR CommandSender::HandleTimedStatus(const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload)

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -372,9 +372,8 @@ TLV::TLVWriter * CommandSender::GetCommandDataIBTLVWriter()
     {
         return nullptr;
     }
-    
-            return mInvokeRequestBuilder.GetInvokeRequests().GetCommandData().GetWriter();
-   
+
+    return mInvokeRequestBuilder.GetInvokeRequests().GetCommandData().GetWriter();
 }
 
 CHIP_ERROR CommandSender::HandleTimedStatus(const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload)

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -399,7 +399,7 @@ CHIP_ERROR EventManagement::CopyAndAdjustDeltaTime(const TLVReader & aReader, si
         // Does not go on the wire.
         return CHIP_NO_ERROR;
     }
-    else if ((aReader.GetTag() == TLV::ContextTag(to_underlying(EventDataIB::Tag::kSystemTimestamp))) && !(ctx->mpContext->mFirst))
+    if ((aReader.GetTag() == TLV::ContextTag(to_underlying(EventDataIB::Tag::kSystemTimestamp))) && !(ctx->mpContext->mFirst))
     {
         return ctx->mpWriter->Put(TLV::ContextTag(to_underlying(EventDataIB::Tag::kDeltaSystemTimestamp)),
                                   ctx->mpContext->mCurrentTime.mValue - ctx->mpContext->mPreviousTime.mValue);
@@ -501,12 +501,11 @@ CHIP_ERROR EventManagement::LogEventPrivate(EventLoggingDelegate * apDelegate, c
         {
             break;
         }
-        else
-        {
-            buffer = buffer->GetNextCircularEventBuffer();
+        
+                    buffer = buffer->GetNextCircularEventBuffer();
             assert(buffer != nullptr);
             // code guarantees that every PriorityLevel has a buffer destination.
-        }
+       
     }
 
     mBytesWritten += writer.GetLengthWritten();

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -501,11 +501,10 @@ CHIP_ERROR EventManagement::LogEventPrivate(EventLoggingDelegate * apDelegate, c
         {
             break;
         }
-        
-                    buffer = buffer->GetNextCircularEventBuffer();
-            assert(buffer != nullptr);
-            // code guarantees that every PriorityLevel has a buffer destination.
-       
+
+        buffer = buffer->GetNextCircularEventBuffer();
+        assert(buffer != nullptr);
+        // code guarantees that every PriorityLevel has a buffer destination.
     }
 
     mBytesWritten += writer.GetLengthWritten();

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -904,12 +904,11 @@ bool ReadClient::ResubscribeIfNeeded()
         ChipLogProgress(DataManagement, "Fail to resubscribe with error %" CHIP_ERROR_FORMAT, err.Format());
         return false;
     }
-    else
-    {
-        ChipLogProgress(DataManagement,
+    
+            ChipLogProgress(DataManagement,
                         "Will try to Resubscribe to %02x:" ChipLogFormatX64 " at retry index %" PRIu32 " after %" PRIu32 "ms",
                         mFabricIndex, ChipLogValueX64(mPeerNodeId), mNumRetries, intervalMsec);
-    }
+   
     return true;
 }
 

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -904,11 +904,11 @@ bool ReadClient::ResubscribeIfNeeded()
         ChipLogProgress(DataManagement, "Fail to resubscribe with error %" CHIP_ERROR_FORMAT, err.Format());
         return false;
     }
-    
-            ChipLogProgress(DataManagement,
-                        "Will try to Resubscribe to %02x:" ChipLogFormatX64 " at retry index %" PRIu32 " after %" PRIu32 "ms",
-                        mFabricIndex, ChipLogValueX64(mPeerNodeId), mNumRetries, intervalMsec);
-   
+
+    ChipLogProgress(DataManagement,
+                    "Will try to Resubscribe to %02x:" ChipLogFormatX64 " at retry index %" PRIu32 " after %" PRIu32 "ms",
+                    mFabricIndex, ChipLogValueX64(mPeerNodeId), mNumRetries, intervalMsec);
+
     return true;
 }
 

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -322,10 +322,9 @@ CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath &
         }
         return err;
     }
-    else // We are writing a non-list attribute, or we are writing a single element of a list.
-    {
-        return PutSinglePreencodedAttributeWritePayload(attributePath, data);
-    }
+    // We are writing a non-list attribute, or we are writing a single element of a list.
+            return PutSinglePreencodedAttributeWritePayload(attributePath, data);
+   
 }
 
 const char * WriteClient::GetStateStr() const

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -323,8 +323,7 @@ CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath &
         return err;
     }
     // We are writing a non-list attribute, or we are writing a single element of a list.
-            return PutSinglePreencodedAttributeWritePayload(attributePath, data);
-   
+    return PutSinglePreencodedAttributeWritePayload(attributePath, data);
 }
 
 const char * WriteClient::GetStateStr() const

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -196,10 +196,9 @@ public:
                                           attributePath.mClusterId, attributePath.mAttributeId, aDataVersion),
                 value);
         }
-        else
-        {
-            return EncodeAttribute(attributePath, value.Value());
-        }
+        
+                    return EncodeAttribute(attributePath, value.Value());
+       
     }
 
     /**

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -196,9 +196,8 @@ public:
                                           attributePath.mClusterId, attributePath.mAttributeId, aDataVersion),
                 value);
         }
-        
-                    return EncodeAttribute(attributePath, value.Value());
-       
+
+        return EncodeAttribute(attributePath, value.Value());
     }
 
     /**

--- a/src/app/data-model/DecodableList.h
+++ b/src/app/data-model/DecodableList.h
@@ -134,9 +134,8 @@ public:
             {
                 return CHIP_NO_ERROR;
             }
-            
-                            return mStatus;
-           
+
+            return mStatus;
         }
 
     private:
@@ -193,9 +192,8 @@ public:
             *size = 0;
             return CHIP_NO_ERROR;
         }
-        
-                    return mReader.CountRemainingInContainer(size);
-       
+
+        return mReader.CountRemainingInContainer(size);
     }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader)

--- a/src/app/data-model/DecodableList.h
+++ b/src/app/data-model/DecodableList.h
@@ -134,10 +134,9 @@ public:
             {
                 return CHIP_NO_ERROR;
             }
-            else
-            {
-                return mStatus;
-            }
+            
+                            return mStatus;
+           
         }
 
     private:
@@ -194,10 +193,9 @@ public:
             *size = 0;
             return CHIP_NO_ERROR;
         }
-        else
-        {
-            return mReader.CountRemainingInContainer(size);
-        }
+        
+                    return mReader.CountRemainingInContainer(size);
+       
     }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader)

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -763,9 +763,9 @@ CHIP_ERROR Engine::ScheduleEventDelivery(ConcreteEventPath & aPath, uint32_t aBy
         ChipLogDetail(DataManagement, "urgent event schedule run");
         return ScheduleRun();
     }
-    
-            return ScheduleBufferPressureEventDelivery(aBytesWritten);
-   
+
+    return ScheduleBufferPressureEventDelivery(aBytesWritten);
+
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -763,10 +763,9 @@ CHIP_ERROR Engine::ScheduleEventDelivery(ConcreteEventPath & aPath, uint32_t aBy
         ChipLogDetail(DataManagement, "urgent event schedule run");
         return ScheduleRun();
     }
-    else
-    {
-        return ScheduleBufferPressureEventDelivery(aBytesWritten);
-    }
+    
+            return ScheduleBufferPressureEventDelivery(aBytesWritten);
+   
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -122,11 +122,10 @@ private:
                 {
                     return CHIP_ERROR_INVALID_ARGUMENT;
                 }
-                else
-                {
-                    // When size is zero, let's give a non-nullptr to the KVS backend
+                
+                                    // When size is zero, let's give a non-nullptr to the KVS backend
                     buffer = &emptyPlaceholder;
-                }
+               
             }
 
             size_t bytesRead = 0;

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -122,10 +122,9 @@ private:
                 {
                     return CHIP_ERROR_INVALID_ARGUMENT;
                 }
-                
-                                    // When size is zero, let's give a non-nullptr to the KVS backend
-                    buffer = &emptyPlaceholder;
-               
+
+                // When size is zero, let's give a non-nullptr to the KVS backend
+                buffer = &emptyPlaceholder;
             }
 
             size_t bytesRead = 0;

--- a/src/app/tests/suites/pics/PICSBooleanExpressionParser.cpp
+++ b/src/app/tests/suites/pics/PICSBooleanExpressionParser.cpp
@@ -121,10 +121,9 @@ bool PICSBooleanExpressionParser::EvaluateExpression(std::vector<std::string> & 
         bool rightExpr = EvaluateExpression(tokens, PICS, index);
         return leftExpr || rightExpr;
     }
-    
-            ChipLogError(chipTool, "Unknown token: '%s'", token.c_str());
-        chipDie();
-   
+
+    ChipLogError(chipTool, "Unknown token: '%s'", token.c_str());
+    chipDie();
 }
 
 bool PICSBooleanExpressionParser::EvaluateSubExpression(std::vector<std::string> & tokens, std::map<std::string, bool> & PICS,
@@ -150,16 +149,15 @@ bool PICSBooleanExpressionParser::EvaluateSubExpression(std::vector<std::string>
         bool expr = EvaluateSubExpression(tokens, PICS, index);
         return !expr;
     }
-    
-            index++;
 
-        if (PICS.find(token) == PICS.end())
-        {
-            // By default, let's consider that if a PICS item is not defined, it is |false|.
-            // It allows to create a file that only contains enabled features.
-            return false;
-        }
+    index++;
 
-        return PICS[token];
-   
+    if (PICS.find(token) == PICS.end())
+    {
+        // By default, let's consider that if a PICS item is not defined, it is |false|.
+        // It allows to create a file that only contains enabled features.
+        return false;
+    }
+
+    return PICS[token];
 }

--- a/src/app/tests/suites/pics/PICSBooleanExpressionParser.cpp
+++ b/src/app/tests/suites/pics/PICSBooleanExpressionParser.cpp
@@ -121,11 +121,10 @@ bool PICSBooleanExpressionParser::EvaluateExpression(std::vector<std::string> & 
         bool rightExpr = EvaluateExpression(tokens, PICS, index);
         return leftExpr || rightExpr;
     }
-    else
-    {
-        ChipLogError(chipTool, "Unknown token: '%s'", token.c_str());
+    
+            ChipLogError(chipTool, "Unknown token: '%s'", token.c_str());
         chipDie();
-    }
+   
 }
 
 bool PICSBooleanExpressionParser::EvaluateSubExpression(std::vector<std::string> & tokens, std::map<std::string, bool> & PICS,
@@ -151,9 +150,8 @@ bool PICSBooleanExpressionParser::EvaluateSubExpression(std::vector<std::string>
         bool expr = EvaluateSubExpression(tokens, PICS, index);
         return !expr;
     }
-    else
-    {
-        index++;
+    
+            index++;
 
         if (PICS.find(token) == PICS.end())
         {
@@ -163,5 +161,5 @@ bool PICSBooleanExpressionParser::EvaluateSubExpression(std::vector<std::string>
         }
 
         return PICS[token];
-    }
+   
 }

--- a/src/app/tests/suites/pics/PICSBooleanExpressionParser.cpp
+++ b/src/app/tests/suites/pics/PICSBooleanExpressionParser.cpp
@@ -115,7 +115,7 @@ bool PICSBooleanExpressionParser::EvaluateExpression(std::vector<std::string> & 
         bool rightExpr = EvaluateExpression(tokens, PICS, index);
         return leftExpr && rightExpr;
     }
-    else if (token == "||")
+    if (token == "||")
     {
         index++;
         bool rightExpr = EvaluateExpression(tokens, PICS, index);
@@ -145,7 +145,7 @@ bool PICSBooleanExpressionParser::EvaluateSubExpression(std::vector<std::string>
         index++;
         return expr;
     }
-    else if (token == "!")
+    if (token == "!")
     {
         index++;
         bool expr = EvaluateSubExpression(tokens, PICS, index);

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -195,9 +195,8 @@ EmberStatus emberAfEventControlSetDelayQS(EmberEventControl * control, uint32_t 
     {
         return emberEventControlSetDelayMS(control, delayQs << 8);
     }
-    
-            return EMBER_BAD_ARGUMENT;
-   
+
+    return EMBER_BAD_ARGUMENT;
 }
 
 EmberStatus emberAfEventControlSetDelayMinutes(EmberEventControl * control, uint16_t delayM)
@@ -206,9 +205,8 @@ EmberStatus emberAfEventControlSetDelayMinutes(EmberEventControl * control, uint
     {
         return emberEventControlSetDelayMS(control, static_cast<uint32_t>(delayM) << 16);
     }
-    
-            return EMBER_BAD_ARGUMENT;
-   
+
+    return EMBER_BAD_ARGUMENT;
 }
 
 EmberStatus emberAfScheduleTickExtended(EndpointId endpoint, ClusterId clusterId, bool isClient, uint32_t delayMs,

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -195,10 +195,9 @@ EmberStatus emberAfEventControlSetDelayQS(EmberEventControl * control, uint32_t 
     {
         return emberEventControlSetDelayMS(control, delayQs << 8);
     }
-    else
-    {
-        return EMBER_BAD_ARGUMENT;
-    }
+    
+            return EMBER_BAD_ARGUMENT;
+   
 }
 
 EmberStatus emberAfEventControlSetDelayMinutes(EmberEventControl * control, uint16_t delayM)
@@ -207,10 +206,9 @@ EmberStatus emberAfEventControlSetDelayMinutes(EmberEventControl * control, uint
     {
         return emberEventControlSetDelayMS(control, static_cast<uint32_t>(delayM) << 16);
     }
-    else
-    {
-        return EMBER_BAD_ARGUMENT;
-    }
+    
+            return EMBER_BAD_ARGUMENT;
+   
 }
 
 EmberStatus emberAfScheduleTickExtended(EndpointId endpoint, ClusterId clusterId, bool isClient, uint32_t delayMs,

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -370,18 +370,17 @@ EmberAfStatus emAfClusterPreAttributeChangedCallback(const app::ConcreteAttribut
     {
         return EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE;
     }
-    
-            EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
-        // Casting and calling a function pointer on the same line results in ignoring the return
-        // of the call on gcc-arm-none-eabi-9-2019-q4-major
-        EmberAfClusterPreAttributeChangedCallback f = (EmberAfClusterPreAttributeChangedCallback)(
-            emberAfFindClusterFunction(cluster, CLUSTER_MASK_PRE_ATTRIBUTE_CHANGED_FUNCTION));
-        if (f != NULL)
-        {
-            status = f(attributePath, attributeType, size, value);
-        }
-        return status;
-   
+
+    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    // Casting and calling a function pointer on the same line results in ignoring the return
+    // of the call on gcc-arm-none-eabi-9-2019-q4-major
+    EmberAfClusterPreAttributeChangedCallback f = (EmberAfClusterPreAttributeChangedCallback)(
+        emberAfFindClusterFunction(cluster, CLUSTER_MASK_PRE_ATTRIBUTE_CHANGED_FUNCTION));
+    if (f != NULL)
+    {
+        status = f(attributePath, attributeType, size, value);
+    }
+    return status;
 }
 
 static void initializeEndpoint(EmberAfDefinedEndpoint * definedEndpoint)
@@ -622,17 +621,16 @@ EmberAfStatus emAfReadOrWriteAttribute(EmberAfAttributeSearchRecord * attRecord,
                                                   : emberAfExternalAttributeReadCallback(attRecord->endpoint, attRecord->clusterId,
                                                                                          am, buffer, emberAfAttributeSize(am)));
                                 }
-                                
-                                                                    // Internal storage is only supported for fixed endpoints
-                                    if (!isDynamicEndpoint)
-                                    {
-                                        return typeSensitiveMemCopy(attRecord->clusterId, dst, src, am, write, readLength);
-                                    }
-                                    else
-                                    {
-                                        return EMBER_ZCL_STATUS_FAILURE;
-                                    }
-                               
+
+                                // Internal storage is only supported for fixed endpoints
+                                if (!isDynamicEndpoint)
+                                {
+                                    return typeSensitiveMemCopy(attRecord->clusterId, dst, src, am, write, readLength);
+                                }
+                                else
+                                {
+                                    return EMBER_ZCL_STATUS_FAILURE;
+                                }
                             }
                         }
                         else
@@ -748,9 +746,8 @@ bool emberAfContainsServerFromIndex(uint16_t index, ClusterId clusterId)
     {
         return false;
     }
-    
-            return emberAfFindClusterInType(emAfEndpoints[index].endpointType, clusterId, CLUSTER_MASK_SERVER);
-   
+
+    return emberAfFindClusterInType(emAfEndpoints[index].endpointType, clusterId, CLUSTER_MASK_SERVER);
 }
 
 namespace chip {
@@ -794,9 +791,8 @@ const EmberAfCluster * emberAfFindCluster(EndpointId endpoint, ClusterId cluster
     {
         return NULL;
     }
-    
-            return emberAfFindClusterInType(emAfEndpoints[ep].endpointType, clusterId, mask);
-   
+
+    return emberAfFindClusterInType(emAfEndpoints[ep].endpointType, clusterId, mask);
 }
 
 // Returns cluster within the endpoint; Does not ignore disabled endpoints

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -370,9 +370,8 @@ EmberAfStatus emAfClusterPreAttributeChangedCallback(const app::ConcreteAttribut
     {
         return EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE;
     }
-    else
-    {
-        EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    
+            EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
         // Casting and calling a function pointer on the same line results in ignoring the return
         // of the call on gcc-arm-none-eabi-9-2019-q4-major
         EmberAfClusterPreAttributeChangedCallback f = (EmberAfClusterPreAttributeChangedCallback)(
@@ -382,7 +381,7 @@ EmberAfStatus emAfClusterPreAttributeChangedCallback(const app::ConcreteAttribut
             status = f(attributePath, attributeType, size, value);
         }
         return status;
-    }
+   
 }
 
 static void initializeEndpoint(EmberAfDefinedEndpoint * definedEndpoint)
@@ -623,9 +622,8 @@ EmberAfStatus emAfReadOrWriteAttribute(EmberAfAttributeSearchRecord * attRecord,
                                                   : emberAfExternalAttributeReadCallback(attRecord->endpoint, attRecord->clusterId,
                                                                                          am, buffer, emberAfAttributeSize(am)));
                                 }
-                                else
-                                {
-                                    // Internal storage is only supported for fixed endpoints
+                                
+                                                                    // Internal storage is only supported for fixed endpoints
                                     if (!isDynamicEndpoint)
                                     {
                                         return typeSensitiveMemCopy(attRecord->clusterId, dst, src, am, write, readLength);
@@ -634,7 +632,7 @@ EmberAfStatus emAfReadOrWriteAttribute(EmberAfAttributeSearchRecord * attRecord,
                                     {
                                         return EMBER_ZCL_STATUS_FAILURE;
                                     }
-                                }
+                               
                             }
                         }
                         else
@@ -750,10 +748,9 @@ bool emberAfContainsServerFromIndex(uint16_t index, ClusterId clusterId)
     {
         return false;
     }
-    else
-    {
-        return emberAfFindClusterInType(emAfEndpoints[index].endpointType, clusterId, CLUSTER_MASK_SERVER);
-    }
+    
+            return emberAfFindClusterInType(emAfEndpoints[index].endpointType, clusterId, CLUSTER_MASK_SERVER);
+   
 }
 
 namespace chip {
@@ -797,10 +794,9 @@ const EmberAfCluster * emberAfFindCluster(EndpointId endpoint, ClusterId cluster
     {
         return NULL;
     }
-    else
-    {
-        return emberAfFindClusterInType(emAfEndpoints[ep].endpointType, clusterId, mask);
-    }
+    
+            return emberAfFindClusterInType(emAfEndpoints[ep].endpointType, clusterId, mask);
+   
 }
 
 // Returns cluster within the endpoint; Does not ignore disabled endpoints

--- a/src/app/util/binding-table.cpp
+++ b/src/app/util/binding-table.cpp
@@ -64,22 +64,21 @@ CHIP_ERROR BindingTable::Add(const EmberBindingTableEntry & entry)
         mBindingTable[newIndex].type = EMBER_UNUSED_BINDING;
         return error;
     }
-    
-            if (mTail == kNextNullIndex)
-        {
-            mTail = newIndex;
-            mHead = newIndex;
-        }
-        else
-        {
-            mNextIndex[mTail]    = newIndex;
-            mNextIndex[newIndex] = kNextNullIndex;
-            mTail                = newIndex;
-        }
 
-        mSize++;
-        return CHIP_NO_ERROR;
-   
+    if (mTail == kNextNullIndex)
+    {
+        mTail = newIndex;
+        mHead = newIndex;
+    }
+    else
+    {
+        mNextIndex[mTail]    = newIndex;
+        mNextIndex[newIndex] = kNextNullIndex;
+        mTail                = newIndex;
+    }
+
+    mSize++;
+    return CHIP_NO_ERROR;
 }
 
 const EmberBindingTableEntry & BindingTable::GetAt(uint8_t index)

--- a/src/app/util/binding-table.cpp
+++ b/src/app/util/binding-table.cpp
@@ -64,9 +64,8 @@ CHIP_ERROR BindingTable::Add(const EmberBindingTableEntry & entry)
         mBindingTable[newIndex].type = EMBER_UNUSED_BINDING;
         return error;
     }
-    else
-    {
-        if (mTail == kNextNullIndex)
+    
+            if (mTail == kNextNullIndex)
         {
             mTail = newIndex;
             mHead = newIndex;
@@ -80,7 +79,7 @@ CHIP_ERROR BindingTable::Add(const EmberBindingTableEntry & entry)
 
         mSize++;
         return CHIP_NO_ERROR;
-    }
+   
 }
 
 const EmberBindingTableEntry & BindingTable::GetAt(uint8_t index)

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -482,10 +482,9 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, b
             {
                 return CHIP_NO_ERROR;
             }
-            else
-            {
-                return SendFailureStatus(aPath, aAttributeReports, Protocols::InteractionModel::Status::UnsupportedAccess, nullptr);
-            }
+            
+                            return SendFailureStatus(aPath, aAttributeReports, Protocols::InteractionModel::Status::UnsupportedAccess, nullptr);
+           
         }
     }
 
@@ -969,10 +968,9 @@ bool IsClusterDataVersionEqual(const ConcreteClusterPath & aConcreteClusterPath,
                      aConcreteClusterPath.mEndpointId, ChipLogValueMEI(aConcreteClusterPath.mClusterId));
         return false;
     }
-    else
-    {
-        return (*(version)) == aRequiredVersion;
-    }
+    
+            return (*(version)) == aRequiredVersion;
+   
 }
 
 } // namespace app

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -482,9 +482,8 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, b
             {
                 return CHIP_NO_ERROR;
             }
-            
-                            return SendFailureStatus(aPath, aAttributeReports, Protocols::InteractionModel::Status::UnsupportedAccess, nullptr);
-           
+
+            return SendFailureStatus(aPath, aAttributeReports, Protocols::InteractionModel::Status::UnsupportedAccess, nullptr);
         }
     }
 
@@ -968,9 +967,8 @@ bool IsClusterDataVersionEqual(const ConcreteClusterPath & aConcreteClusterPath,
                      aConcreteClusterPath.mEndpointId, ChipLogValueMEI(aConcreteClusterPath.mClusterId));
         return false;
     }
-    
-            return (*(version)) == aRequiredVersion;
-   
+
+    return (*(version)) == aRequiredVersion;
 }
 
 } // namespace app

--- a/src/app/util/message.cpp
+++ b/src/app/util/message.cpp
@@ -102,9 +102,8 @@ uint16_t * emberAfPutInt16uInResp(uint16_t value)
     {
         return (uint16_t *) low;
     }
-    
-            return NULL;
-   
+
+    return NULL;
 }
 
 uint32_t * emberAfPutInt32uInResp(uint32_t value)
@@ -118,9 +117,8 @@ uint32_t * emberAfPutInt32uInResp(uint32_t value)
     {
         return (uint32_t *) a;
     }
-    
-            return NULL;
-   
+
+    return NULL;
 }
 
 uint32_t * emberAfPutInt24uInResp(uint32_t value)
@@ -133,9 +131,8 @@ uint32_t * emberAfPutInt24uInResp(uint32_t value)
     {
         return (uint32_t *) a;
     }
-    
-            return NULL;
-   
+
+    return NULL;
 }
 
 uint8_t * emberAfPutBlockInResp(const uint8_t * data, uint16_t length)
@@ -146,9 +143,8 @@ uint8_t * emberAfPutBlockInResp(const uint8_t * data, uint16_t length)
         appResponseLength = static_cast<uint16_t>(appResponseLength + length);
         return &appResponseData[appResponseLength - length];
     }
-    
-            return NULL;
-   
+
+    return NULL;
 }
 
 uint8_t * emberAfPutStringInResp(const uint8_t * buffer)
@@ -168,9 +164,8 @@ uint8_t * emberAfPutDateInResp(EmberAfDate * value)
     {
         return a;
     }
-    
-            return NULL;
-   
+
+    return NULL;
 }
 
 void emberAfPutInt16sInResp(int16_t value)

--- a/src/app/util/message.cpp
+++ b/src/app/util/message.cpp
@@ -102,10 +102,9 @@ uint16_t * emberAfPutInt16uInResp(uint16_t value)
     {
         return (uint16_t *) low;
     }
-    else
-    {
-        return NULL;
-    }
+    
+            return NULL;
+   
 }
 
 uint32_t * emberAfPutInt32uInResp(uint32_t value)
@@ -119,10 +118,9 @@ uint32_t * emberAfPutInt32uInResp(uint32_t value)
     {
         return (uint32_t *) a;
     }
-    else
-    {
-        return NULL;
-    }
+    
+            return NULL;
+   
 }
 
 uint32_t * emberAfPutInt24uInResp(uint32_t value)
@@ -135,10 +133,9 @@ uint32_t * emberAfPutInt24uInResp(uint32_t value)
     {
         return (uint32_t *) a;
     }
-    else
-    {
-        return NULL;
-    }
+    
+            return NULL;
+   
 }
 
 uint8_t * emberAfPutBlockInResp(const uint8_t * data, uint16_t length)
@@ -149,10 +146,9 @@ uint8_t * emberAfPutBlockInResp(const uint8_t * data, uint16_t length)
         appResponseLength = static_cast<uint16_t>(appResponseLength + length);
         return &appResponseData[appResponseLength - length];
     }
-    else
-    {
-        return NULL;
-    }
+    
+            return NULL;
+   
 }
 
 uint8_t * emberAfPutStringInResp(const uint8_t * buffer)
@@ -172,10 +168,9 @@ uint8_t * emberAfPutDateInResp(EmberAfDate * value)
     {
         return a;
     }
-    else
-    {
-        return NULL;
-    }
+    
+            return NULL;
+   
 }
 
 void emberAfPutInt16sInResp(int16_t value)

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -316,9 +316,8 @@ uint16_t emberAfGetMfgCodeFromCurrentCommand(void)
     {
         return emberAfCurrentCommand()->mfgCode;
     }
-    
-            return EMBER_AF_NULL_MANUFACTURER_CODE;
-   
+
+    return EMBER_AF_NULL_MANUFACTURER_CODE;
 }
 
 uint8_t emberAfNextSequence(void)

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -316,10 +316,9 @@ uint16_t emberAfGetMfgCodeFromCurrentCommand(void)
     {
         return emberAfCurrentCommand()->mfgCode;
     }
-    else
-    {
-        return EMBER_AF_NULL_MANUFACTURER_CODE;
-    }
+    
+            return EMBER_AF_NULL_MANUFACTURER_CODE;
+   
 }
 
 uint8_t emberAfNextSequence(void)
@@ -365,7 +364,7 @@ void emAfApplyRetryOverride(EmberApsOption * options)
     {
         return;
     }
-    else if (emberAfApsRetryOverride == EMBER_AF_RETRY_OVERRIDE_SET)
+    if (emberAfApsRetryOverride == EMBER_AF_RETRY_OVERRIDE_SET)
     {
         *options |= EMBER_APS_OPTION_RETRY;
     }
@@ -399,7 +398,7 @@ void emAfApplyDisableDefaultResponse(uint8_t * frame_control)
     {
         return;
     }
-    else if (emAfDisableDefaultResponse == EMBER_AF_DISABLE_DEFAULT_RESPONSE_ONE_SHOT)
+    if (emAfDisableDefaultResponse == EMBER_AF_DISABLE_DEFAULT_RESPONSE_ONE_SHOT)
     {
         emAfDisableDefaultResponse = emAfSavedDisableDefaultResponseVale;
         *frame_control |= ZCL_DISABLE_DEFAULT_RESPONSE_MASK;
@@ -551,7 +550,7 @@ int8_t emberAfCompareValues(const uint8_t * val1, const uint8_t * val2, uint16_t
             {
                 return 1;
             }
-            else if (accum1 < accum2)
+            if (accum1 < accum2)
             {
                 return -1;
             }
@@ -576,7 +575,7 @@ int8_t emberAfCompareValues(const uint8_t * val1, const uint8_t * val2, uint16_t
             {
                 return 1;
             }
-            else if (k > j)
+            if (k > j)
             {
                 return -1;
             }

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -143,7 +143,7 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStage(CommissioningStag
                 return CommissioningStage::kWiFiNetworkSetup;
             }
             if (mParams.GetThreadOperationalDataset().HasValue() &&
-                     mDeviceCommissioningInfo.network.thread.endpoint != kInvalidEndpointId)
+                mDeviceCommissioningInfo.network.thread.endpoint != kInvalidEndpointId)
             {
                 return CommissioningStage::kThreadNetworkSetup;
             }

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -142,7 +142,7 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStage(CommissioningStag
             {
                 return CommissioningStage::kWiFiNetworkSetup;
             }
-            else if (mParams.GetThreadOperationalDataset().HasValue() &&
+            if (mParams.GetThreadOperationalDataset().HasValue() &&
                      mDeviceCommissioningInfo.network.thread.endpoint != kInvalidEndpointId)
             {
                 return CommissioningStage::kThreadNetworkSetup;

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -150,12 +150,11 @@ public:
                                                               requestData, onSuccessCb, onFailureCb, aTimedWriteTimeoutMs, onDoneCb,
                                                               aDataVersion);
         }
-        else
-        {
-            return chip::Controller::WriteAttribute<AttrType>(mDevice->GetSecureSession().Value(), mEndpoint, clusterId,
+        
+                    return chip::Controller::WriteAttribute<AttrType>(mDevice->GetSecureSession().Value(), mEndpoint, clusterId,
                                                               attributeId, requestData, onSuccessCb, onFailureCb,
                                                               aTimedWriteTimeoutMs, onDoneCb, aDataVersion);
-        }
+       
     }
 
     template <typename AttributeInfo>

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -150,11 +150,10 @@ public:
                                                               requestData, onSuccessCb, onFailureCb, aTimedWriteTimeoutMs, onDoneCb,
                                                               aDataVersion);
         }
-        
-                    return chip::Controller::WriteAttribute<AttrType>(mDevice->GetSecureSession().Value(), mEndpoint, clusterId,
-                                                              attributeId, requestData, onSuccessCb, onFailureCb,
-                                                              aTimedWriteTimeoutMs, onDoneCb, aDataVersion);
-       
+
+        return chip::Controller::WriteAttribute<AttrType>(mDevice->GetSecureSession().Value(), mEndpoint, clusterId, attributeId,
+                                                          requestData, onSuccessCb, onFailureCb, aTimedWriteTimeoutMs, onDoneCb,
+                                                          aDataVersion);
     }
 
     template <typename AttributeInfo>

--- a/src/controller/CHIPCommissionableNodeController.cpp
+++ b/src/controller/CHIPCommissionableNodeController.cpp
@@ -40,12 +40,11 @@ CHIP_ERROR CommissionableNodeController::DiscoverCommissioners(Dnssd::DiscoveryF
         mDNSResolver.SetCommissioningDelegate(this);
         return mDNSResolver.FindCommissioners(discoveryFilter);
     }
-    
-    #if CONFIG_DEVICE_LAYER
-        ReturnErrorOnFailure(mResolver->Init(DeviceLayer::UDPEndPointManager()));
+
+#if CONFIG_DEVICE_LAYER
+    ReturnErrorOnFailure(mResolver->Init(DeviceLayer::UDPEndPointManager()));
 #endif
-        return mResolver->FindCommissioners(discoveryFilter);
-   
+    return mResolver->FindCommissioners(discoveryFilter);
 }
 
 const Dnssd::DiscoveredNodeData * CommissionableNodeController::GetDiscoveredCommissioner(int idx)

--- a/src/controller/CHIPCommissionableNodeController.cpp
+++ b/src/controller/CHIPCommissionableNodeController.cpp
@@ -40,13 +40,12 @@ CHIP_ERROR CommissionableNodeController::DiscoverCommissioners(Dnssd::DiscoveryF
         mDNSResolver.SetCommissioningDelegate(this);
         return mDNSResolver.FindCommissioners(discoveryFilter);
     }
-    else
-    {
-#if CONFIG_DEVICE_LAYER
+    
+    #if CONFIG_DEVICE_LAYER
         ReturnErrorOnFailure(mResolver->Init(DeviceLayer::UDPEndPointManager()));
 #endif
         return mResolver->FindCommissioners(discoveryFilter);
-    }
+   
 }
 
 const Dnssd::DiscoveredNodeData * CommissionableNodeController::GetDiscoveredCommissioner(int idx)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1112,16 +1112,15 @@ void DeviceCommissioner::OnDeviceAttestationInformationVerification(void * conte
             commissioner->CommissioningStageComplete(CHIP_ERROR_NOT_IMPLEMENTED, report);
             return;
         }
-        
-                    ChipLogError(Controller,
-                         "Failed in verifying 'Attestation Information' command received from the device: err %hu. Look at "
-                         "AttestationVerificationResult enum to understand the errors",
-                         static_cast<uint16_t>(result));
-            // Go look at AttestationVerificationResult enum in src/credentials/attestation_verifier/DeviceAttestationVerifier.h to
-            // understand the errors.
-            commissioner->CommissioningStageComplete(CHIP_ERROR_INTERNAL, report);
-            return;
-       
+
+        ChipLogError(Controller,
+                     "Failed in verifying 'Attestation Information' command received from the device: err %hu. Look at "
+                     "AttestationVerificationResult enum to understand the errors",
+                     static_cast<uint16_t>(result));
+        // Go look at AttestationVerificationResult enum in src/credentials/attestation_verifier/DeviceAttestationVerifier.h to
+        // understand the errors.
+        commissioner->CommissioningStageComplete(CHIP_ERROR_INTERNAL, report);
+        return;
     }
 
     ChipLogProgress(Controller, "Successfully validated 'Attestation Information' command received from the device.");

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1112,9 +1112,8 @@ void DeviceCommissioner::OnDeviceAttestationInformationVerification(void * conte
             commissioner->CommissioningStageComplete(CHIP_ERROR_NOT_IMPLEMENTED, report);
             return;
         }
-        else
-        {
-            ChipLogError(Controller,
+        
+                    ChipLogError(Controller,
                          "Failed in verifying 'Attestation Information' command received from the device: err %hu. Look at "
                          "AttestationVerificationResult enum to understand the errors",
                          static_cast<uint16_t>(result));
@@ -1122,7 +1121,7 @@ void DeviceCommissioner::OnDeviceAttestationInformationVerification(void * conte
             // understand the errors.
             commissioner->CommissioningStageComplete(CHIP_ERROR_INTERNAL, report);
             return;
-        }
+       
     }
 
     ChipLogProgress(Controller, "Successfully validated 'Attestation Information' command received from the device.");

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -526,10 +526,9 @@ bool ChipRDN::IsEqual(const ChipRDN & other) const
     {
         return mChipVal == other.mChipVal;
     }
-    else
-    {
-        return mString.data_equal(other.mString);
-    }
+    
+            return mString.data_equal(other.mString);
+   
 }
 
 ChipDN::ChipDN() {}

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -526,9 +526,8 @@ bool ChipRDN::IsEqual(const ChipRDN & other) const
     {
         return mChipVal == other.mChipVal;
     }
-    
-            return mString.data_equal(other.mString);
-   
+
+    return mString.data_equal(other.mString);
 }
 
 ChipDN::ChipDN() {}

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -929,13 +929,12 @@ CHIP_ERROR GroupDataProviderImpl::SetGroupInfo(chip::FabricIndex fabric_index, c
         group.SetName(info.name);
         return group.Save(mStorage);
     }
-    else
-    {
-        // New group_id
+    
+            // New group_id
         group.group_id = info.group_id;
         group.SetName(info.name);
         return SetGroupInfoAt(fabric_index, fabric.group_count, group);
-    }
+   
 }
 
 CHIP_ERROR GroupDataProviderImpl::GetGroupInfo(chip::FabricIndex fabric_index, chip::GroupId group_id, GroupInfo & info)
@@ -985,7 +984,7 @@ CHIP_ERROR GroupDataProviderImpl::SetGroupInfoAt(chip::FabricIndex fabric_index,
         // Update existing entry
         return group.Save(mStorage);
     }
-    else if (index < fabric.group_count)
+    if (index < fabric.group_count)
     {
         // Replace existing entry with a new group
         GroupData old_group;
@@ -1631,16 +1630,15 @@ CHIP_ERROR GroupDataProviderImpl::SetKeySet(chip::FabricIndex fabric_index, cons
         // Update existing keyset info, keep next
         return keyset.Save(mStorage);
     }
-    else
-    {
-        // New keyset, insert first
+    
+            // New keyset, insert first
         keyset.next = fabric.first_keyset;
         ReturnErrorOnFailure(keyset.Save(mStorage));
         // Update fabric
         fabric.keyset_count++;
         fabric.first_keyset = in_keyset.keyset_id;
         return fabric.Save(mStorage);
-    }
+   
 }
 
 CHIP_ERROR GroupDataProviderImpl::GetKeySet(chip::FabricIndex fabric_index, uint16_t target_id, KeySet & out_keyset)

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -929,12 +929,11 @@ CHIP_ERROR GroupDataProviderImpl::SetGroupInfo(chip::FabricIndex fabric_index, c
         group.SetName(info.name);
         return group.Save(mStorage);
     }
-    
-            // New group_id
-        group.group_id = info.group_id;
-        group.SetName(info.name);
-        return SetGroupInfoAt(fabric_index, fabric.group_count, group);
-   
+
+    // New group_id
+    group.group_id = info.group_id;
+    group.SetName(info.name);
+    return SetGroupInfoAt(fabric_index, fabric.group_count, group);
 }
 
 CHIP_ERROR GroupDataProviderImpl::GetGroupInfo(chip::FabricIndex fabric_index, chip::GroupId group_id, GroupInfo & info)
@@ -1630,15 +1629,14 @@ CHIP_ERROR GroupDataProviderImpl::SetKeySet(chip::FabricIndex fabric_index, cons
         // Update existing keyset info, keep next
         return keyset.Save(mStorage);
     }
-    
-            // New keyset, insert first
-        keyset.next = fabric.first_keyset;
-        ReturnErrorOnFailure(keyset.Save(mStorage));
-        // Update fabric
-        fabric.keyset_count++;
-        fabric.first_keyset = in_keyset.keyset_id;
-        return fabric.Save(mStorage);
-   
+
+    // New keyset, insert first
+    keyset.next = fabric.first_keyset;
+    ReturnErrorOnFailure(keyset.Save(mStorage));
+    // Update fabric
+    fabric.keyset_count++;
+    fabric.first_keyset = in_keyset.keyset_id;
+    return fabric.Save(mStorage);
 }
 
 CHIP_ERROR GroupDataProviderImpl::GetKeySet(chip::FabricIndex fabric_index, uint16_t target_id, KeySet & out_keyset)

--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -67,11 +67,10 @@ CHIP_ERROR ReadDerLength(Reader & reader, uint8_t & length)
         // We only support lengths of 0..255 over 2 bytes
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
-    else
-    {
-        // Next byte has length 0..255.
+    
+            // Next byte has length 0..255.
         return reader.Read8(&length).StatusCode();
-    }
+   
 }
 
 /**

--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -67,10 +67,9 @@ CHIP_ERROR ReadDerLength(Reader & reader, uint8_t & length)
         // We only support lengths of 0..255 over 2 bytes
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
-    
-            // Next byte has length 0..255.
-        return reader.Read8(&length).StatusCode();
-   
+
+    // Next byte has length 0..255.
+    return reader.Read8(&length).StatusCode();
 }
 
 /**

--- a/src/inet/TCPEndPointImplSockets.cpp
+++ b/src/inet/TCPEndPointImplSockets.cpp
@@ -1030,9 +1030,8 @@ void TCPEndPointImplSockets::HandleIncomingConnection()
         {
             return;
         }
-        
-                    err = CHIP_ERROR_POSIX(errno);
-       
+
+        err = CHIP_ERROR_POSIX(errno);
     }
 
     // If there's no callback available, fail with an error.

--- a/src/inet/TCPEndPointImplSockets.cpp
+++ b/src/inet/TCPEndPointImplSockets.cpp
@@ -1030,10 +1030,9 @@ void TCPEndPointImplSockets::HandleIncomingConnection()
         {
             return;
         }
-        else
-        {
-            err = CHIP_ERROR_POSIX(errno);
-        }
+        
+                    err = CHIP_ERROR_POSIX(errno);
+       
     }
 
     // If there's no callback available, fail with an error.

--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -85,9 +85,8 @@ IpScore ScoreIpAddress(const Inet::IPAddress & ip, Inet::InterfaceId interfaceId
 
         return IpScore::kOtherIpv6;
     }
-    
-            return IpScore::kIpv4;
-   
+
+    return IpScore::kIpv4;
 }
 
 } // namespace

--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -63,7 +63,7 @@ IpScore ScoreIpAddress(const Inet::IPAddress & ip, Inet::InterfaceId interfaceId
             {
                 return IpScore::kGlobalUnicastWithSharedPrefix;
             }
-            else if (ip.IsIPv6ULA())
+            if (ip.IsIPv6ULA())
             {
                 return IpScore::kUniqueLocalWithSharedPrefix;
             }
@@ -85,10 +85,9 @@ IpScore ScoreIpAddress(const Inet::IPAddress & ip, Inet::InterfaceId interfaceId
 
         return IpScore::kOtherIpv6;
     }
-    else
-    {
-        return IpScore::kIpv4;
-    }
+    
+            return IpScore::kIpv4;
+   
 }
 
 } // namespace
@@ -142,7 +141,7 @@ System::Clock::Timeout NodeLookupHandle::NextEventTimeout(System::Clock::Timesta
     {
         return mRequest.GetMinLookupTime() - elapsed;
     }
-    else if (elapsed < mRequest.GetMaxLookupTime())
+    if (elapsed < mRequest.GetMaxLookupTime())
     {
         return mRequest.GetMaxLookupTime() - elapsed;
     }

--- a/src/lib/address_resolve/tool.cpp
+++ b/src/lib/address_resolve/tool.cpp
@@ -141,7 +141,7 @@ extern "C" int main(int argc, const char ** argv)
         ChipLogError(NotSpecified, "Please specify a command, or 'help' for help.");
         return -1;
     }
-    else if (strcasecmp(argv[1], "help") == 0 || strcasecmp(argv[1], "--help") == 0 || strcasecmp(argv[1], "-h") == 0)
+    if (strcasecmp(argv[1], "help") == 0 || strcasecmp(argv[1], "--help") == 0 || strcasecmp(argv[1], "-h") == 0)
     {
         fputs(sHelp, stdout);
         return 0;
@@ -158,9 +158,8 @@ extern "C" int main(int argc, const char ** argv)
     {
         return Cmd_Node(argc - 2, argv + 2) ? 0 : 1;
     }
-    else
-    {
-        ChipLogError(NotSpecified, "Unrecognized command: %s", argv[1]);
+    
+            ChipLogError(NotSpecified, "Unrecognized command: %s", argv[1]);
         return 1;
-    }
+   
 }

--- a/src/lib/address_resolve/tool.cpp
+++ b/src/lib/address_resolve/tool.cpp
@@ -158,8 +158,7 @@ extern "C" int main(int argc, const char ** argv)
     {
         return Cmd_Node(argc - 2, argv + 2) ? 0 : 1;
     }
-    
-            ChipLogError(NotSpecified, "Unrecognized command: %s", argv[1]);
-        return 1;
-   
+
+    ChipLogError(NotSpecified, "Unrecognized command: %s", argv[1]);
+    return 1;
 }

--- a/src/lib/asn1/ASN1Reader.cpp
+++ b/src/lib/asn1/ASN1Reader.cpp
@@ -342,7 +342,7 @@ CHIP_ERROR DumpASN1(ASN1Reader & asn1Parser, const char * prefix, const char * i
                     nestLevel--;
                     continue;
                 }
-                                    break;
+                break;
             }
             printf("ASN1Reader::Next() failed: %" CHIP_ERROR_FORMAT "\n", err.Format());
             return err;

--- a/src/lib/asn1/ASN1Reader.cpp
+++ b/src/lib/asn1/ASN1Reader.cpp
@@ -342,8 +342,7 @@ CHIP_ERROR DumpASN1(ASN1Reader & asn1Parser, const char * prefix, const char * i
                     nestLevel--;
                     continue;
                 }
-                else
-                    break;
+                                    break;
             }
             printf("ASN1Reader::Next() failed: %" CHIP_ERROR_FORMAT "\n", err.Format());
             return err;

--- a/src/lib/asn1/ASN1Writer.cpp
+++ b/src/lib/asn1/ASN1Writer.cpp
@@ -282,8 +282,7 @@ CHIP_ERROR ASN1Writer::PutTime(const ASN1UniversalTime & val)
     //
     if (val.Year >= 2050)
         return PutValue(kASN1TagClass_Universal, kASN1UniversalTag_GeneralizedTime, false, buf, 15);
-    else
-        return PutValue(kASN1TagClass_Universal, kASN1UniversalTag_UTCTime, false, buf + 2, 13);
+            return PutValue(kASN1TagClass_Universal, kASN1UniversalTag_UTCTime, false, buf + 2, 13);
 }
 
 CHIP_ERROR ASN1Writer::PutNull()

--- a/src/lib/asn1/ASN1Writer.cpp
+++ b/src/lib/asn1/ASN1Writer.cpp
@@ -282,7 +282,7 @@ CHIP_ERROR ASN1Writer::PutTime(const ASN1UniversalTime & val)
     //
     if (val.Year >= 2050)
         return PutValue(kASN1TagClass_Universal, kASN1UniversalTag_GeneralizedTime, false, buf, 15);
-            return PutValue(kASN1TagClass_Universal, kASN1UniversalTag_UTCTime, false, buf + 2, 13);
+    return PutValue(kASN1TagClass_Universal, kASN1UniversalTag_UTCTime, false, buf + 2, 13);
 }
 
 CHIP_ERROR ASN1Writer::PutNull()

--- a/src/lib/dnssd/ActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/ActiveResolveAttempts.cpp
@@ -110,7 +110,7 @@ void ActiveResolveAttempts::MarkPending(const ScheduledAttempt & attempt)
             entryToUse = entry;
             continue;
         }
-        else if (entryToUse->attempt.IsEmpty())
+        if (entryToUse->attempt.IsEmpty())
         {
             continue;
         }

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -627,9 +627,8 @@ FullQName AdvertiserMinMdns::GetOperationalTxtEntries(const OperationalAdvertisi
     {
         return allocator->AllocateQNameFromArray(mEmptyTextEntries, 1);
     }
-    
-            return allocator->AllocateQNameFromArray(txtFields, numTxtFields);
-   
+
+    return allocator->AllocateQNameFromArray(txtFields, numTxtFields);
 }
 
 FullQName AdvertiserMinMdns::GetCommissioningTxtEntries(const CommissionAdvertisingParameters & params)
@@ -706,9 +705,8 @@ FullQName AdvertiserMinMdns::GetCommissioningTxtEntries(const CommissionAdvertis
     {
         return allocator->AllocateQNameFromArray(mEmptyTextEntries, 1);
     }
-    
-            return allocator->AllocateQNameFromArray(txtFields, numTxtFields);
-   
+
+    return allocator->AllocateQNameFromArray(txtFields, numTxtFields);
 }
 
 bool AdvertiserMinMdns::ShouldAdvertiseOn(const chip::Inet::InterfaceId id, const chip::Inet::IPAddress & addr)

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -627,10 +627,9 @@ FullQName AdvertiserMinMdns::GetOperationalTxtEntries(const OperationalAdvertisi
     {
         return allocator->AllocateQNameFromArray(mEmptyTextEntries, 1);
     }
-    else
-    {
-        return allocator->AllocateQNameFromArray(txtFields, numTxtFields);
-    }
+    
+            return allocator->AllocateQNameFromArray(txtFields, numTxtFields);
+   
 }
 
 FullQName AdvertiserMinMdns::GetCommissioningTxtEntries(const CommissionAdvertisingParameters & params)
@@ -707,10 +706,9 @@ FullQName AdvertiserMinMdns::GetCommissioningTxtEntries(const CommissionAdvertis
     {
         return allocator->AllocateQNameFromArray(mEmptyTextEntries, 1);
     }
-    else
-    {
-        return allocator->AllocateQNameFromArray(txtFields, numTxtFields);
-    }
+    
+            return allocator->AllocateQNameFromArray(txtFields, numTxtFields);
+   
 }
 
 bool AdvertiserMinMdns::ShouldAdvertiseOn(const chip::Inet::InterfaceId id, const chip::Inet::IPAddress & addr)

--- a/src/lib/dnssd/DnssdCache.h
+++ b/src/lib/dnssd/DnssdCache.h
@@ -160,7 +160,7 @@ private:
                     MarkEntryUnused(entry);
                     break; // return nullptr
                 }
-                                    return &entry;
+                return &entry;
             }
             if (entry.mPeerId != nullPeerId && entry.mExpiryTime < current_time)
             {

--- a/src/lib/dnssd/DnssdCache.h
+++ b/src/lib/dnssd/DnssdCache.h
@@ -160,8 +160,7 @@ private:
                     MarkEntryUnused(entry);
                     break; // return nullptr
                 }
-                else
-                    return &entry;
+                                    return &entry;
             }
             if (entry.mPeerId != nullPeerId && entry.mExpiryTime < current_time)
             {

--- a/src/lib/dnssd/MinimalMdnsServer.h
+++ b/src/lib/dnssd/MinimalMdnsServer.h
@@ -84,10 +84,9 @@ public:
         {
             return *Instance().mReplacementServer;
         }
-        else
-        {
-            return Instance().mServer;
-        }
+        
+                    return Instance().mServer;
+       
     }
 
     /// Calls Server().Listen() on all available interfaces

--- a/src/lib/dnssd/MinimalMdnsServer.h
+++ b/src/lib/dnssd/MinimalMdnsServer.h
@@ -84,9 +84,8 @@ public:
         {
             return *Instance().mReplacementServer;
         }
-        
-                    return Instance().mServer;
-       
+
+        return Instance().mServer;
     }
 
     /// Calls Server().Listen() on all available interfaces

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -318,9 +318,8 @@ struct DiscoveryFilter
         {
             return (instanceName != nullptr) && (other.instanceName != nullptr) && (strcmp(instanceName, other.instanceName) == 0);
         }
-        
-                    return code == other.code;
-       
+
+        return code == other.code;
     }
 };
 enum class DiscoveryType

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -318,10 +318,9 @@ struct DiscoveryFilter
         {
             return (instanceName != nullptr) && (other.instanceName != nullptr) && (strcmp(instanceName, other.instanceName) == 0);
         }
-        else
-        {
-            return code == other.code;
-        }
+        
+                    return code == other.code;
+       
     }
 };
 enum class DiscoveryType

--- a/src/lib/support/BytesCircularBuffer.cpp
+++ b/src/lib/support/BytesCircularBuffer.cpp
@@ -80,9 +80,8 @@ size_t BytesCircularBuffer::StorageUsed() const
     {
         return mDataEnd - mDataStart;
     }
-    
-            return mCapacity + mDataEnd - mDataStart;
-   
+
+    return mCapacity + mDataEnd - mDataStart;
 }
 
 CHIP_ERROR BytesCircularBuffer::Push(const ByteSpan & payload)

--- a/src/lib/support/BytesCircularBuffer.cpp
+++ b/src/lib/support/BytesCircularBuffer.cpp
@@ -80,10 +80,9 @@ size_t BytesCircularBuffer::StorageUsed() const
     {
         return mDataEnd - mDataStart;
     }
-    else
-    {
-        return mCapacity + mDataEnd - mDataStart;
-    }
+    
+            return mCapacity + mDataEnd - mDataStart;
+   
 }
 
 CHIP_ERROR BytesCircularBuffer::Push(const ByteSpan & payload)

--- a/src/lib/support/BytesToHex.cpp
+++ b/src/lib/support/BytesToHex.cpp
@@ -34,10 +34,9 @@ char NibbleToHex(uint8_t nibble, bool uppercase)
     {
         return static_cast<char>((x - 10) + (uppercase ? 'A' : 'a'));
     }
-    else
-    {
-        return static_cast<char>(x + '0');
-    }
+    
+            return static_cast<char>(x + '0');
+   
 }
 
 CHIP_ERROR MakeU8FromAsciiHex(const char * src, const size_t srcLen, uint8_t * val, BitFlags<HexFlags> flags)
@@ -104,7 +103,7 @@ CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_he
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
-    else if (src_size > ((SIZE_MAX - 1) / 2u))
+    if (src_size > ((SIZE_MAX - 1) / 2u))
     {
         // Output would overflow a size_t, let's bail out to avoid computation wraparounds below.
         // This condition will hit with slightly less than the very max, but is unlikely to

--- a/src/lib/support/BytesToHex.cpp
+++ b/src/lib/support/BytesToHex.cpp
@@ -34,9 +34,8 @@ char NibbleToHex(uint8_t nibble, bool uppercase)
     {
         return static_cast<char>((x - 10) + (uppercase ? 'A' : 'a'));
     }
-    
-            return static_cast<char>(x + '0');
-   
+
+    return static_cast<char>(x + '0');
 }
 
 CHIP_ERROR MakeU8FromAsciiHex(const char * src, const size_t srcLen, uint8_t * val, BitFlags<HexFlags> flags)

--- a/src/lib/support/Pool.cpp
+++ b/src/lib/support/Pool.cpp
@@ -50,10 +50,9 @@ void * StaticAllocatorBitmap::Allocate()
                     IncreaseUsage();
                     return At(word * kBitChunkSize + offset);
                 }
-                else
-                {
-                    value = usage.load(std::memory_order_relaxed); // if there is a race, update new usage
-                }
+                
+                                    value = usage.load(std::memory_order_relaxed); // if there is a race, update new usage
+               
             }
         }
     }

--- a/src/lib/support/Pool.cpp
+++ b/src/lib/support/Pool.cpp
@@ -50,9 +50,8 @@ void * StaticAllocatorBitmap::Allocate()
                     IncreaseUsage();
                     return At(word * kBitChunkSize + offset);
                 }
-                
-                                    value = usage.load(std::memory_order_relaxed); // if there is a race, update new usage
-               
+
+                value = usage.load(std::memory_order_relaxed); // if there is a race, update new usage
             }
         }
     }

--- a/src/lib/support/Pool.h
+++ b/src/lib/support/Pool.h
@@ -222,8 +222,7 @@ public:
         T * element = static_cast<T *>(Allocate());
         if (element != nullptr)
             return new (element) T(std::forward<Args>(args)...);
-        else
-            return nullptr;
+                    return nullptr;
     }
 
     void ReleaseObject(T * element)

--- a/src/lib/support/Pool.h
+++ b/src/lib/support/Pool.h
@@ -222,7 +222,7 @@ public:
         T * element = static_cast<T *>(Allocate());
         if (element != nullptr)
             return new (element) T(std::forward<Args>(args)...);
-                    return nullptr;
+        return nullptr;
     }
 
     void ReleaseObject(T * element)

--- a/src/lib/support/ThreadOperationalDataset.cpp
+++ b/src/lib/support/ThreadOperationalDataset.cpp
@@ -498,8 +498,7 @@ const ThreadTLV * OperationalDataset::Locate(uint8_t aType) const
     {
         if (tlv->GetType() == aType)
             break;
-        else
-            tlv = tlv->GetNext();
+                    tlv = tlv->GetNext();
     }
 
     assert(tlv < reinterpret_cast<const ThreadTLV *>(&mData[sizeof(mData)]));

--- a/src/lib/support/ThreadOperationalDataset.cpp
+++ b/src/lib/support/ThreadOperationalDataset.cpp
@@ -498,7 +498,7 @@ const ThreadTLV * OperationalDataset::Locate(uint8_t aType) const
     {
         if (tlv->GetType() == aType)
             break;
-                    tlv = tlv->GetNext();
+        tlv = tlv->GetNext();
     }
 
     assert(tlv < reinterpret_cast<const ThreadTLV *>(&mData[sizeof(mData)]));

--- a/src/lib/support/Variant.h
+++ b/src/lib/support/Variant.h
@@ -73,10 +73,9 @@ struct VariantCurry<Index, T, Ts...>
         {
             return *reinterpret_cast<const T *>(this_v) == *reinterpret_cast<const T *>(that_v);
         }
-        else
-        {
-            return VariantCurry<Index + 1, Ts...>::Equal(type_t, that_v, this_v);
-        }
+        
+                    return VariantCurry<Index + 1, Ts...>::Equal(type_t, that_v, this_v);
+       
     }
 };
 

--- a/src/lib/support/Variant.h
+++ b/src/lib/support/Variant.h
@@ -73,9 +73,8 @@ struct VariantCurry<Index, T, Ts...>
         {
             return *reinterpret_cast<const T *>(this_v) == *reinterpret_cast<const T *>(that_v);
         }
-        
-                    return VariantCurry<Index + 1, Ts...>::Equal(type_t, that_v, this_v);
-       
+
+        return VariantCurry<Index + 1, Ts...>::Equal(type_t, that_v, this_v);
     }
 };
 

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -490,11 +490,10 @@ CHIP_ERROR ExchangeContext::HandleMessage(uint32_t messageCounter, const Payload
     {
         return mDelegate->OnMessageReceived(this, payloadHeader, std::move(msgBuf));
     }
-    
-            DefaultOnMessageReceived(this, payloadHeader.GetProtocolID(), payloadHeader.GetMessageType(), messageCounter,
-                                 std::move(msgBuf));
-        return CHIP_NO_ERROR;
-   
+
+    DefaultOnMessageReceived(this, payloadHeader.GetProtocolID(), payloadHeader.GetMessageType(), messageCounter,
+                             std::move(msgBuf));
+    return CHIP_NO_ERROR;
 }
 
 void ExchangeContext::MessageHandled()

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -490,12 +490,11 @@ CHIP_ERROR ExchangeContext::HandleMessage(uint32_t messageCounter, const Payload
     {
         return mDelegate->OnMessageReceived(this, payloadHeader, std::move(msgBuf));
     }
-    else
-    {
-        DefaultOnMessageReceived(this, payloadHeader.GetProtocolID(), payloadHeader.GetMessageType(), messageCounter,
+    
+            DefaultOnMessageReceived(this, payloadHeader.GetProtocolID(), payloadHeader.GetMessageType(), messageCounter,
                                  std::move(msgBuf));
         return CHIP_NO_ERROR;
-    }
+   
 }
 
 void ExchangeContext::MessageHandled()

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -156,9 +156,8 @@ CHIP_ERROR ReliableMessageContext::HandleNeedsAckInner(uint32_t messageCounter, 
         return err;
     }
     // Otherwise, the message IS NOT a duplicate.
-    else
-    {
-        if (IsAckPending())
+    
+            if (IsAckPending())
         {
             ChipLogDetail(ExchangeManager,
                           "Pending ack queue full; forcing tx of solitary ack for MessageCounter:" ChipLogFormatMessageCounter
@@ -173,7 +172,7 @@ CHIP_ERROR ReliableMessageContext::HandleNeedsAckInner(uint32_t messageCounter, 
         using namespace System::Clock::Literals;
         mNextAckTime = System::SystemClock().GetMonotonicTimestamp() + CHIP_CONFIG_RMP_DEFAULT_ACK_TIMEOUT;
         return CHIP_NO_ERROR;
-    }
+   
 }
 
 CHIP_ERROR ReliableMessageContext::SendStandaloneAckMessage()

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -156,23 +156,22 @@ CHIP_ERROR ReliableMessageContext::HandleNeedsAckInner(uint32_t messageCounter, 
         return err;
     }
     // Otherwise, the message IS NOT a duplicate.
-    
-            if (IsAckPending())
-        {
-            ChipLogDetail(ExchangeManager,
-                          "Pending ack queue full; forcing tx of solitary ack for MessageCounter:" ChipLogFormatMessageCounter
-                          " on exchange " ChipLogFormatExchange,
-                          mPendingPeerAckMessageCounter, ChipLogValueExchange(GetExchangeContext()));
-            // Send the Ack for the currently pending Ack in a SecureChannel::StandaloneAck message.
-            ReturnErrorOnFailure(SendStandaloneAckMessage());
-        }
 
-        // Replace the Pending ack message counter.
-        SetPendingPeerAckMessageCounter(messageCounter);
-        using namespace System::Clock::Literals;
-        mNextAckTime = System::SystemClock().GetMonotonicTimestamp() + CHIP_CONFIG_RMP_DEFAULT_ACK_TIMEOUT;
-        return CHIP_NO_ERROR;
-   
+    if (IsAckPending())
+    {
+        ChipLogDetail(ExchangeManager,
+                      "Pending ack queue full; forcing tx of solitary ack for MessageCounter:" ChipLogFormatMessageCounter
+                      " on exchange " ChipLogFormatExchange,
+                      mPendingPeerAckMessageCounter, ChipLogValueExchange(GetExchangeContext()));
+        // Send the Ack for the currently pending Ack in a SecureChannel::StandaloneAck message.
+        ReturnErrorOnFailure(SendStandaloneAckMessage());
+    }
+
+    // Replace the Pending ack message counter.
+    SetPendingPeerAckMessageCounter(messageCounter);
+    using namespace System::Clock::Literals;
+    mNextAckTime = System::SystemClock().GetMonotonicTimestamp() + CHIP_CONFIG_RMP_DEFAULT_ACK_TIMEOUT;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ReliableMessageContext::SendStandaloneAckMessage()

--- a/src/platform/Linux/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Linux/KeyValueStoreManagerImpl.cpp
@@ -52,7 +52,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     {
         return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     }
-    else if ((err != CHIP_NO_ERROR) && (err != CHIP_ERROR_BUFFER_TOO_SMALL))
+    if ((err != CHIP_NO_ERROR) && (err != CHIP_ERROR_BUFFER_TOO_SMALL))
     {
         return err;
     }

--- a/src/platform/Linux/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Linux/KeyValueStoreManagerImpl.cpp
@@ -56,7 +56,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     {
         return err;
     }
-    else if (offset_bytes > read_size)
+    if (offset_bytes > read_size)
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }

--- a/src/platform/Linux/NetworkCommissioningThreadDriver.cpp
+++ b/src/platform/Linux/NetworkCommissioningThreadDriver.cpp
@@ -98,7 +98,7 @@ Status LinuxThreadDriver::RemoveNetwork(ByteSpan networkId)
     {
         return Status::kNetworkNotFound;
     }
-    else if (mStagingNetwork.GetExtendedPanId(extpanid) != CHIP_NO_ERROR)
+    if (mStagingNetwork.GetExtendedPanId(extpanid) != CHIP_NO_ERROR)
     {
         return Status::kUnknownError;
     }
@@ -116,7 +116,7 @@ Status LinuxThreadDriver::ReorderNetwork(ByteSpan networkId, uint8_t index)
     {
         return Status::kNetworkNotFound;
     }
-    else if (mStagingNetwork.GetExtendedPanId(extpanid) != CHIP_NO_ERROR)
+    if (mStagingNetwork.GetExtendedPanId(extpanid) != CHIP_NO_ERROR)
     {
         return Status::kUnknownError;
     }

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -426,7 +426,7 @@ ConnectivityManager::ThreadDeviceType ThreadStackManagerImpl::_GetThreadDeviceTy
     {
         return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_NotSupported;
     }
-    else if (strcmp(role.get(), kOpenthreadDeviceRoleChild) == 0)
+    if (strcmp(role.get(), kOpenthreadDeviceRoleChild) == 0)
     {
         std::unique_ptr<GVariant, GVariantDeleter> linkMode(openthread_io_openthread_border_router_dup_link_mode(mProxy.get()));
         if (!linkMode)

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -450,11 +450,10 @@ ConnectivityManager::ThreadDeviceType ThreadStackManagerImpl::_GetThreadDeviceTy
     {
         return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_Router;
     }
-    else
-    {
-        ChipLogError(DeviceLayer, "Unknown Thread role: %s", role.get());
+    
+            ChipLogError(DeviceLayer, "Unknown Thread role: %s", role.get());
         return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_NotSupported;
-    }
+   
 }
 
 CHIP_ERROR ThreadStackManagerImpl::_SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType)

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -446,7 +446,7 @@ ConnectivityManager::ThreadDeviceType ThreadStackManagerImpl::_GetThreadDeviceTy
         }
         return type;
     }
-    else if (strcmp(role.get(), kOpenthreadDeviceRoleLeader) == 0 || strcmp(role.get(), kOpenthreadDeviceRoleRouter) == 0)
+    if (strcmp(role.get(), kOpenthreadDeviceRoleLeader) == 0 || strcmp(role.get(), kOpenthreadDeviceRoleRouter) == 0)
     {
         return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_Router;
     }

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -450,10 +450,9 @@ ConnectivityManager::ThreadDeviceType ThreadStackManagerImpl::_GetThreadDeviceTy
     {
         return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_Router;
     }
-    
-            ChipLogError(DeviceLayer, "Unknown Thread role: %s", role.get());
-        return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_NotSupported;
-   
+
+    ChipLogError(DeviceLayer, "Unknown Thread role: %s", role.get());
+    return ConnectivityManager::ThreadDeviceType::kThreadDeviceType_NotSupported;
 }
 
 CHIP_ERROR ThreadStackManagerImpl::_SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType)

--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -95,7 +95,7 @@ CHIP_ERROR MessageCounterManager::OnMessageReceived(Messaging::ExchangeContext *
     {
         return HandleMsgCounterSyncReq(exchangeContext, std::move(msgBuf));
     }
-    else if (payloadHeader.HasMessageType(Protocols::SecureChannel::MsgType::MsgCounterSyncRsp))
+    if (payloadHeader.HasMessageType(Protocols::SecureChannel::MsgType::MsgCounterSyncRsp))
     {
         return HandleMsgCounterSyncResp(exchangeContext, std::move(msgBuf));
     }

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -219,7 +219,7 @@ CHIP_ERROR LayerImplSelect::StartWatchingSocket(int fd, SocketWatchToken * token
             // Duplicate registration is an error.
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
-        else if ((w.mFD == kInvalidFd) && (watch == nullptr))
+        if ((w.mFD == kInvalidFd) && (watch == nullptr))
         {
             watch = &w;
         }

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -320,11 +320,10 @@ CHIP_ERROR SessionManager::SendPreparedMessage(const SessionHandle & sessionHand
     {
         return mTransportMgr->SendMessage(*destination, std::move(msgBuf));
     }
-    else
-    {
-        ChipLogError(Inet, "The transport manager is not initialized. Unable to send the message");
+    
+            ChipLogError(Inet, "The transport manager is not initialized. Unable to send the message");
         return CHIP_ERROR_INCORRECT_STATE;
-    }
+   
 }
 
 void SessionManager::ExpirePairing(const SessionHandle & sessionHandle)

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -320,10 +320,9 @@ CHIP_ERROR SessionManager::SendPreparedMessage(const SessionHandle & sessionHand
     {
         return mTransportMgr->SendMessage(*destination, std::move(msgBuf));
     }
-    
-            ChipLogError(Inet, "The transport manager is not initialized. Unable to send the message");
-        return CHIP_ERROR_INCORRECT_STATE;
-   
+
+    ChipLogError(Inet, "The transport manager is not initialized. Unable to send the message");
+    return CHIP_ERROR_INCORRECT_STATE;
 }
 
 void SessionManager::ExpirePairing(const SessionHandle & sessionHandle)

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -302,10 +302,9 @@ private:
         {
             return mGlobalEncryptedMessageCounter;
         }
-        else
-        {
-            return state.GetSessionMessageCounter().GetLocalMessageCounter();
-        }
+        
+                    return state.GetSessionMessageCounter().GetLocalMessageCounter();
+       
     }
 };
 

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -302,9 +302,8 @@ private:
         {
             return mGlobalEncryptedMessageCounter;
         }
-        
-                    return state.GetSessionMessageCounter().GetLocalMessageCounter();
-       
+
+        return state.GetSessionMessageCounter().GetLocalMessageCounter();
     }
 };
 

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -101,10 +101,9 @@ public:
         {
             return kUndefinedNodeId;
         }
-        else
-        {
-            return mEphemeralInitiatorNodeId;
-        }
+        
+                    return mEphemeralInitiatorNodeId;
+       
     }
 
     SessionRole GetSessionRole() const { return mSessionRole; }
@@ -158,10 +157,9 @@ public:
         {
             return MakeOptional<SessionHandle>(*result);
         }
-        else
-        {
-            return Optional<SessionHandle>::Missing();
-        }
+        
+                    return Optional<SessionHandle>::Missing();
+       
     }
 
     CHECK_RETURN_VALUE Optional<SessionHandle> FindInitiator(NodeId ephemeralInitiatorNodeID)
@@ -171,10 +169,9 @@ public:
         {
             return MakeOptional<SessionHandle>(*result);
         }
-        else
-        {
-            return Optional<SessionHandle>::Missing();
-        }
+        
+                    return Optional<SessionHandle>::Missing();
+       
     }
 
     CHECK_RETURN_VALUE Optional<SessionHandle> AllocInitiator(NodeId ephemeralInitiatorNodeID, const PeerAddress & peerAddress,
@@ -187,10 +184,9 @@ public:
             result->SetPeerAddress(peerAddress);
             return MakeOptional<SessionHandle>(*result);
         }
-        else
-        {
-            return Optional<SessionHandle>::Missing();
-        }
+        
+                    return Optional<SessionHandle>::Missing();
+       
     }
 
 private:

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -101,9 +101,8 @@ public:
         {
             return kUndefinedNodeId;
         }
-        
-                    return mEphemeralInitiatorNodeId;
-       
+
+        return mEphemeralInitiatorNodeId;
     }
 
     SessionRole GetSessionRole() const { return mSessionRole; }
@@ -157,9 +156,8 @@ public:
         {
             return MakeOptional<SessionHandle>(*result);
         }
-        
-                    return Optional<SessionHandle>::Missing();
-       
+
+        return Optional<SessionHandle>::Missing();
     }
 
     CHECK_RETURN_VALUE Optional<SessionHandle> FindInitiator(NodeId ephemeralInitiatorNodeID)
@@ -169,9 +167,8 @@ public:
         {
             return MakeOptional<SessionHandle>(*result);
         }
-        
-                    return Optional<SessionHandle>::Missing();
-       
+
+        return Optional<SessionHandle>::Missing();
     }
 
     CHECK_RETURN_VALUE Optional<SessionHandle> AllocInitiator(NodeId ephemeralInitiatorNodeID, const PeerAddress & peerAddress,
@@ -184,9 +181,8 @@ public:
             result->SetPeerAddress(peerAddress);
             return MakeOptional<SessionHandle>(*result);
         }
-        
-                    return Optional<SessionHandle>::Missing();
-       
+
+        return Optional<SessionHandle>::Missing();
     }
 
 private:

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -192,10 +192,9 @@ CHIP_ERROR TCPBase::SendMessage(const Transport::PeerAddress & address, System::
     {
         return connection->mEndPoint->Send(std::move(msgBuf));
     }
-    else
-    {
-        return SendAfterConnect(address, std::move(msgBuf));
-    }
+    
+            return SendAfterConnect(address, std::move(msgBuf));
+   
 }
 
 CHIP_ERROR TCPBase::SendAfterConnect(const PeerAddress & addr, System::PacketBufferHandle && msg)
@@ -272,7 +271,7 @@ CHIP_ERROR TCPBase::ProcessReceivedBuffer(Inet::TCPEndPoint * endPoint, const Pe
             // We don't have enough data to read the message size. Wait until there's more.
             return CHIP_NO_ERROR;
         }
-        else if (err != CHIP_NO_ERROR)
+        if (err != CHIP_NO_ERROR)
         {
             return err;
         }

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -192,9 +192,8 @@ CHIP_ERROR TCPBase::SendMessage(const Transport::PeerAddress & address, System::
     {
         return connection->mEndPoint->Send(std::move(msgBuf));
     }
-    
-            return SendAfterConnect(address, std::move(msgBuf));
-   
+
+    return SendAfterConnect(address, std::move(msgBuf));
 }
 
 CHIP_ERROR TCPBase::SendAfterConnect(const PeerAddress & addr, System::PacketBufferHandle && msg)

--- a/src/transport/raw/UDP.cpp
+++ b/src/transport/raw/UDP.cpp
@@ -142,11 +142,10 @@ CHIP_ERROR UDP::MulticastGroupJoinLeave(const Transport::PeerAddress & address, 
         ChipLogProgress(Inet, "Joining Multicast Group with address %s", addressStr);
         return mUDPEndPoint->JoinMulticastGroup(mUDPEndPoint->GetBoundInterface(), address.GetIPAddress());
     }
-    else
-    {
-        ChipLogProgress(Inet, "Leaving Multicast Group with address %s", addressStr);
+    
+            ChipLogProgress(Inet, "Leaving Multicast Group with address %s", addressStr);
         return mUDPEndPoint->LeaveMulticastGroup(mUDPEndPoint->GetBoundInterface(), address.GetIPAddress());
-    }
+   
 }
 
 } // namespace Transport

--- a/src/transport/raw/UDP.cpp
+++ b/src/transport/raw/UDP.cpp
@@ -142,10 +142,9 @@ CHIP_ERROR UDP::MulticastGroupJoinLeave(const Transport::PeerAddress & address, 
         ChipLogProgress(Inet, "Joining Multicast Group with address %s", addressStr);
         return mUDPEndPoint->JoinMulticastGroup(mUDPEndPoint->GetBoundInterface(), address.GetIPAddress());
     }
-    
-            ChipLogProgress(Inet, "Leaving Multicast Group with address %s", addressStr);
-        return mUDPEndPoint->LeaveMulticastGroup(mUDPEndPoint->GetBoundInterface(), address.GetIPAddress());
-   
+
+    ChipLogProgress(Inet, "Leaving Multicast Group with address %s", addressStr);
+    return mUDPEndPoint->LeaveMulticastGroup(mUDPEndPoint->GetBoundInterface(), address.GetIPAddress());
 }
 
 } // namespace Transport

--- a/third_party/inipp/repo/inipp/inipp/inipp.h
+++ b/third_party/inipp/repo/inipp/inipp/inipp.h
@@ -79,9 +79,8 @@ inline bool extract(const std::basic_string<CharT> & value, T & dst) {
 		dst = result;
 		return true;
 	}
-	else {
-		return false;
-	}
+			return false;
+
 }
 
 template <typename CharT>
@@ -135,7 +134,7 @@ public:
 				if (front == char_comment) {
 					continue;
 				}
-				else if (front == char_section_start) {
+				if (front == char_section_start) {
 					if (line.back() == char_section_end)
 						section = line.substr(1, length - 2);
 					else


### PR DESCRIPTION
#### Problem

else when not needed increases indent level. Clang can fix that

#### Change overview
Ran:

```
./.environment/cipd/packages/pigweed/bin/run-clang-tidy -p ./out/linux-x64-chip-tool-clang/ -fix -checks readability-else-after-return 'connectedhomeip/src/'
```

#### Testing
Automated tool run. Visually inspecting changes looked ok. CI will validate run/compilation.