### PR TITLE
Increase resources and time for cloudbuild smoke test

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -99,7 +99,7 @@ steps:
 logsBucket: matter-build-automation-build-logs
 
 # Global timeout for all steps
-timeout: 7200s
+timeout: 9000s
 
 artifacts:
     objects:
@@ -109,4 +109,5 @@ artifacts:
 # Using higher CPU machines generally speeds up builds by > 4x (faster as we spend more time
 # building instead of docker download/checkout/bootstrap)
 options:
-    machineType: "E2_HIGHCPU_8"
+    machineType: "E2_HIGHCPU_32"
+    diskSizeGb: 200


### PR DESCRIPTION
#### Problem
Cloudbuild builds for smoke test are very close to 2h (sometimes timing out even).

#### Change overview
Bump resources available and increase timeouts. This should last a very long time now.

#### Testing
N/A - this is external validation.