### PR TITLE
Resolve optional attribute with response

### DIFF
--- a/examples/chip-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_cluster.zapt
@@ -318,8 +318,17 @@ class {{filename}}Suite: public TestCommand
     {
         chip::app::StatusIB status(error);
         {{#if response.error}}
+          {{#if optional}}
+          if (status.mStatus == chip::Protocols::InteractionModel::Status::UnsupportedAttribute){
+            {{#unless async}}NextTest();{{/unless}}
+          } else {
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), {{response.error}}));
+            {{#unless async}}NextTest();{{/unless}}
+          }
+          {{else}}
           VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), {{response.error}}));
           {{#unless async}}NextTest();{{/unless}}
+          {{/if}}
         {{else}}
           {{#if optional}}(status.mStatus == chip::Protocols::InteractionModel::Status::UnsupportedAttribute) ? NextTest() : {{/if}}ThrowFailureResponse();
         {{/if}}


### PR DESCRIPTION
#### Problem
When using optional and error response in YAML and there is no attribute, the test fails. See issue below:
https://github.com/project-chip/connectedhomeip/issues/16303

#### Change overview
- Handle optional attribute before checking for error status.

#### Testing
- Removed attribute in all clusters app.
- Ran test with expected failure response. 