### PR TITLE
[msg] Fix #13669 - Skip over MX and SX extension blocks.

### DIFF
--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -213,7 +213,6 @@ CHIP_ERROR PacketHeader::Decode(const uint8_t * const data, uint16_t size, uint1
     }
 
     octets_read = static_cast<uint16_t>(reader.OctetsRead());
-    // VerifyOrExit(octets_read == EncodeSizeBytes(), err = CHIP_ERROR_INTERNAL);
     *decode_len = octets_read;
 
 exit:
@@ -279,7 +278,6 @@ CHIP_ERROR PayloadHeader::Decode(const uint8_t * const data, uint16_t size, uint
     }
 
     octets_read = static_cast<uint16_t>(reader.OctetsRead());
-    // VerifyOrExit(octets_read == EncodeSizeBytes(), err = CHIP_ERROR_INTERNAL);
     *decode_len = octets_read;
 
 exit:

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -279,7 +279,7 @@ CHIP_ERROR PayloadHeader::Decode(const uint8_t * const data, uint16_t size, uint
     }
 
     octets_read = static_cast<uint16_t>(reader.OctetsRead());
-    VerifyOrExit(octets_read == EncodeSizeBytes(), err = CHIP_ERROR_INTERNAL);
+    //VerifyOrExit(octets_read == EncodeSizeBytes(), err = CHIP_ERROR_INTERNAL);
     *decode_len = octets_read;
 
 exit:

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -202,6 +202,16 @@ CHIP_ERROR PacketHeader::Decode(const uint8_t * const data, uint16_t size, uint1
         mDestinationGroupId.ClearValue();
     }
 
+    if (mSecFlags.Has(Header::SecFlagValues::kMsgExtensionFlag))
+    {
+        // If present, skip over Message Extension block.
+        // Spec 4.4.1.8. Message Extensions (variable)
+        uint16_t mxLength;
+        SuccessOrExit(err = reader.Read16(&mxLength).StatusCode());
+        VerifyOrExit(mxLength <= reader.Remaining(), err = CHIP_ERROR_INTERNAL);
+        reader.Skip(mxLength);
+    }
+
     octets_read = static_cast<uint16_t>(reader.OctetsRead());
     VerifyOrExit(octets_read == EncodeSizeBytes(), err = CHIP_ERROR_INTERNAL);
     *decode_len = octets_read;
@@ -256,6 +266,16 @@ CHIP_ERROR PayloadHeader::Decode(const uint8_t * const data, uint16_t size, uint
     else
     {
         mAckMessageCounter.ClearValue();
+    }
+
+    if (mExchangeFlags.Has(Header::ExFlagValues::kExchangeFlag_SecuredExtension))
+    {
+        // If present, skip over Secured Extension block.
+        // Spec 4.4.3.7. Secured Extensions (variable)
+        uint16_t sxLength;
+        SuccessOrExit(err = reader.Read16(&sxLength).StatusCode());
+        VerifyOrExit(sxLength <= reader.Remaining(), err = CHIP_ERROR_INTERNAL);
+        reader.Skip(sxLength);
     }
 
     octets_read = static_cast<uint16_t>(reader.OctetsRead());

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -213,7 +213,7 @@ CHIP_ERROR PacketHeader::Decode(const uint8_t * const data, uint16_t size, uint1
     }
 
     octets_read = static_cast<uint16_t>(reader.OctetsRead());
-    //VerifyOrExit(octets_read == EncodeSizeBytes(), err = CHIP_ERROR_INTERNAL);
+    // VerifyOrExit(octets_read == EncodeSizeBytes(), err = CHIP_ERROR_INTERNAL);
     *decode_len = octets_read;
 
 exit:
@@ -279,7 +279,7 @@ CHIP_ERROR PayloadHeader::Decode(const uint8_t * const data, uint16_t size, uint
     }
 
     octets_read = static_cast<uint16_t>(reader.OctetsRead());
-    //VerifyOrExit(octets_read == EncodeSizeBytes(), err = CHIP_ERROR_INTERNAL);
+    // VerifyOrExit(octets_read == EncodeSizeBytes(), err = CHIP_ERROR_INTERNAL);
     *decode_len = octets_read;
 
 exit:

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -213,7 +213,7 @@ CHIP_ERROR PacketHeader::Decode(const uint8_t * const data, uint16_t size, uint1
     }
 
     octets_read = static_cast<uint16_t>(reader.OctetsRead());
-    VerifyOrExit(octets_read == EncodeSizeBytes(), err = CHIP_ERROR_INTERNAL);
+    //VerifyOrExit(octets_read == EncodeSizeBytes(), err = CHIP_ERROR_INTERNAL);
     *decode_len = octets_read;
 
 exit:

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -71,6 +71,9 @@ enum class ExFlagValues : uint8_t
     /// Set when current message is requesting an acknowledgment from the recipient.
     kExchangeFlag_NeedsAck = 0x04,
 
+    /// Secured Extension block is present.
+    kExchangeFlag_SecuredExtension = 0x08,
+
     /// Set when a vendor id is prepended to the Message Protocol Id field.
     kExchangeFlag_VendorIdPresent = 0x10,
 };

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -418,102 +418,102 @@ struct TestVectorMsgExtensions
     uint8_t payloadOffset;
     uint8_t appPayloadOffset;
     uint16_t msgLength;
-    const char *msg;
+    const char * msg;
 };
 
-#define HDR_LEN 8   ///< Message header length
-#define SRC_LEN 8   ///< Source Node ID length
-#define DST_LEN 8   ///< Destination Node ID length
-#define GID_LEN 2   ///< Group ID length
-#define MX_LEN 6    ///< Message Exchange block length
-#define SX_LEN 6    ///< Security Exchange block length
-#define PRO_LEN 6   ///< Protocol header length
-#define APP_LEN 2   ///< App payload length
+#define HDR_LEN 8 ///< Message header length
+#define SRC_LEN 8 ///< Source Node ID length
+#define DST_LEN 8 ///< Destination Node ID length
+#define GID_LEN 2 ///< Group ID length
+#define MX_LEN 6  ///< Message Exchange block length
+#define SX_LEN 6  ///< Security Exchange block length
+#define PRO_LEN 6 ///< Protocol header length
+#define APP_LEN 2 ///< App payload length
 
 struct TestVectorMsgExtensions theTestVectorMsgExtensions[] = {
     {
         // SRC=none, DST=none, MX=0, SX=0
-        .payloadOffset = HDR_LEN,
+        .payloadOffset    = HDR_LEN,
         .appPayloadOffset = PRO_LEN,
-        .msgLength = HDR_LEN + PRO_LEN + APP_LEN,
-        .msg = 
-            "\x00\x00\x00\x00\xCC\xCC\xCC\xCC"
-            "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
+        .msgLength        = HDR_LEN + PRO_LEN + APP_LEN,
+        .msg              = "\x00\x00\x00\x00\xCC\xCC\xCC\xCC"
+               "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
     },
     // ================== Test MX ==================
     {
         // SRC=none, DST=none, MX=1, SX=0
-        .payloadOffset = HDR_LEN + MX_LEN,
+        .payloadOffset    = HDR_LEN + MX_LEN,
         .appPayloadOffset = PRO_LEN,
-        .msgLength = HDR_LEN + MX_LEN + PRO_LEN + APP_LEN,
-        .msg = "\x00\x00\x00\x20\xCC\xCC\xCC\xCC\x04\x00\xE4\xE3\xE2\xE1"
-            "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
+        .msgLength        = HDR_LEN + MX_LEN + PRO_LEN + APP_LEN,
+        .msg              = "\x00\x00\x00\x20\xCC\xCC\xCC\xCC\x04\x00\xE4\xE3\xE2\xE1"
+               "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
     },
     {
         // SRC=1, DST=none, MX=1, SX=0
-        .payloadOffset = HDR_LEN + MX_LEN + SRC_LEN,
+        .payloadOffset    = HDR_LEN + MX_LEN + SRC_LEN,
         .appPayloadOffset = PRO_LEN,
-        .msgLength = HDR_LEN + MX_LEN + SRC_LEN + PRO_LEN + APP_LEN,
-        .msg = "\x04\x00\x00\x20\xCC\xCC\xCC\xCC\x11\x11\x11\x11\x11\x11\x11\x11\x04\x00\xE4\xE3\xE2\xE1"
-            "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
+        .msgLength        = HDR_LEN + MX_LEN + SRC_LEN + PRO_LEN + APP_LEN,
+        .msg              = "\x04\x00\x00\x20\xCC\xCC\xCC\xCC\x11\x11\x11\x11\x11\x11\x11\x11\x04\x00\xE4\xE3\xE2\xE1"
+               "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
     },
     {
         // SRC=none, DST=1, MX=1, SX=0
-        .payloadOffset = HDR_LEN + MX_LEN + DST_LEN,
+        .payloadOffset    = HDR_LEN + MX_LEN + DST_LEN,
         .appPayloadOffset = PRO_LEN,
-        .msgLength = HDR_LEN + MX_LEN + DST_LEN + PRO_LEN + APP_LEN,
-        .msg = "\x01\x00\x00\x20\xCC\xCC\xCC\xCC\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\x04\x00\xE4\xE3\xE2\xE1"
-            "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
+        .msgLength        = HDR_LEN + MX_LEN + DST_LEN + PRO_LEN + APP_LEN,
+        .msg              = "\x01\x00\x00\x20\xCC\xCC\xCC\xCC\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\x04\x00\xE4\xE3\xE2\xE1"
+               "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
     },
     {
         // SRC=1, DST=1, MX=1, SX=0
-        .payloadOffset = HDR_LEN + MX_LEN + SRC_LEN + DST_LEN,
+        .payloadOffset    = HDR_LEN + MX_LEN + SRC_LEN + DST_LEN,
         .appPayloadOffset = PRO_LEN,
-        .msgLength = HDR_LEN + MX_LEN + SRC_LEN + DST_LEN + PRO_LEN + APP_LEN,
-        .msg = "\x05\x00\x00\x20\xCC\xCC\xCC\xCC\x11\x11\x11\x11\x11\x11\x11\x11\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\x04\x00\xE4\xE3\xE2\xE1"
-            "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
+        .msgLength        = HDR_LEN + MX_LEN + SRC_LEN + DST_LEN + PRO_LEN + APP_LEN,
+        .msg = "\x05\x00\x00\x20\xCC\xCC\xCC\xCC\x11\x11\x11\x11\x11\x11\x11\x11\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\x04\x00\xE4\xE3"
+               "\xE2\xE1"
+               "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
     },
     {
         // SRC=none, DST=group, MX=1, SX=0
-        .payloadOffset = HDR_LEN + MX_LEN + GID_LEN,
+        .payloadOffset    = HDR_LEN + MX_LEN + GID_LEN,
         .appPayloadOffset = PRO_LEN,
-        .msgLength = HDR_LEN + MX_LEN + GID_LEN + PRO_LEN + APP_LEN,
-        .msg = "\x02\x00\x00\x21\xCC\xCC\xCC\xCC\xDD\xDD\x04\x00\xE4\xE3\xE2\xE1"
-            "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
+        .msgLength        = HDR_LEN + MX_LEN + GID_LEN + PRO_LEN + APP_LEN,
+        .msg              = "\x02\x00\x00\x21\xCC\xCC\xCC\xCC\xDD\xDD\x04\x00\xE4\xE3\xE2\xE1"
+               "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
     },
     {
         // SRC=1, DST=group, MX=1, SX=0
-        .payloadOffset = HDR_LEN + MX_LEN + SRC_LEN + GID_LEN,
+        .payloadOffset    = HDR_LEN + MX_LEN + SRC_LEN + GID_LEN,
         .appPayloadOffset = PRO_LEN,
-        .msgLength = HDR_LEN + MX_LEN + SRC_LEN + GID_LEN + PRO_LEN + APP_LEN,
-        .msg = "\x06\x00\x00\x21\xCC\xCC\xCC\xCC\x11\x11\x11\x11\x11\x11\x11\x11\xDD\xDD\x04\x00\xE4\xE3\xE2\xE1"
-            "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
+        .msgLength        = HDR_LEN + MX_LEN + SRC_LEN + GID_LEN + PRO_LEN + APP_LEN,
+        .msg              = "\x06\x00\x00\x21\xCC\xCC\xCC\xCC\x11\x11\x11\x11\x11\x11\x11\x11\xDD\xDD\x04\x00\xE4\xE3\xE2\xE1"
+               "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
     },
     // ================== Test SX ==================
     {
         // SRC=none, DST=none, MX=0, SX=1
-        .payloadOffset = HDR_LEN,
+        .payloadOffset    = HDR_LEN,
         .appPayloadOffset = PRO_LEN + SX_LEN,
-        .msgLength = HDR_LEN + PRO_LEN + SX_LEN + APP_LEN,
-        .msg = 
-            "\x00\x00\x00\x00\xCC\xCC\xCC\xCC"
-            "\x08\xCC\xEE\xEE\x66\x66\x04\x00\xE4\xE3\xE2\xE1\xBB\xBB",
+        .msgLength        = HDR_LEN + PRO_LEN + SX_LEN + APP_LEN,
+        .msg              = "\x00\x00\x00\x00\xCC\xCC\xCC\xCC"
+               "\x08\xCC\xEE\xEE\x66\x66\x04\x00\xE4\xE3\xE2\xE1\xBB\xBB",
     },
     {
         // SRC=none, DST=none, MX=1, SX=1
-        .payloadOffset = HDR_LEN + MX_LEN,
+        .payloadOffset    = HDR_LEN + MX_LEN,
         .appPayloadOffset = PRO_LEN + SX_LEN,
-        .msgLength = HDR_LEN + MX_LEN + PRO_LEN + SX_LEN + APP_LEN,
-        .msg = "\x00\x00\x00\x20\xCC\xCC\xCC\xCC\x04\x00\xE4\xE3\xE2\xE1"
-            "\x08\xCC\xEE\xEE\x66\x66\x04\x00\xE4\xE3\xE2\xE1\xBB\xBB",
+        .msgLength        = HDR_LEN + MX_LEN + PRO_LEN + SX_LEN + APP_LEN,
+        .msg              = "\x00\x00\x00\x20\xCC\xCC\xCC\xCC\x04\x00\xE4\xE3\xE2\xE1"
+               "\x08\xCC\xEE\xEE\x66\x66\x04\x00\xE4\xE3\xE2\xE1\xBB\xBB",
     },
     {
         // SRC=1, DST=1, MX=1, SX=1
-        .payloadOffset = HDR_LEN + MX_LEN + SRC_LEN + DST_LEN,
+        .payloadOffset    = HDR_LEN + MX_LEN + SRC_LEN + DST_LEN,
         .appPayloadOffset = PRO_LEN + SX_LEN,
-        .msgLength = HDR_LEN + MX_LEN + SRC_LEN + DST_LEN + PRO_LEN + SX_LEN + APP_LEN,
-        .msg = "\x05\x00\x00\x20\xCC\xCC\xCC\xCC\x11\x11\x11\x11\x11\x11\x11\x11\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\x04\x00\xE4\xE3\xE2\xE1"
-            "\x09\xCC\xEE\xEE\x66\x66\x04\x00\xE4\xE3\xE2\xE1\xBB\xBB",
+        .msgLength        = HDR_LEN + MX_LEN + SRC_LEN + DST_LEN + PRO_LEN + SX_LEN + APP_LEN,
+        .msg = "\x05\x00\x00\x20\xCC\xCC\xCC\xCC\x11\x11\x11\x11\x11\x11\x11\x11\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\x04\x00\xE4\xE3"
+               "\xE2\xE1"
+               "\x09\xCC\xEE\xEE\x66\x66\x04\x00\xE4\xE3\xE2\xE1\xBB\xBB",
     },
 };
 
@@ -537,7 +537,7 @@ void TestMsgExtensionsDecode(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT(inSuite, packetHeader.Decode(msg->Start(), msg->DataLength(), &decodeSize) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, decodeSize == testEntry->payloadOffset);
 
-        NL_TEST_ASSERT(inSuite, payloadHeader.Decode(msg->Start()+decodeSize, msg->DataLength(), &decodeSize) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, payloadHeader.Decode(msg->Start() + decodeSize, msg->DataLength(), &decodeSize) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, decodeSize == testEntry->appPayloadOffset);
     }
 }

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -415,80 +415,106 @@ void TestSpecComplianceDecode(nlTestSuite * inSuite, void * inContext)
 
 struct TestVectorMsgExtensions
 {
-    uint16_t mxLength;
-    uint16_t sxLength;
     uint8_t payloadOffset;
+    uint8_t appPayloadOffset;
     uint16_t msgLength;
     const char *msg;
 };
 
+#define HDR_LEN 8   ///< Message header length
+#define SRC_LEN 8   ///< Source Node ID length
+#define DST_LEN 8   ///< Destination Node ID length
+#define GID_LEN 2   ///< Group ID length
+#define MX_LEN 6    ///< Message Exchange block length
+#define SX_LEN 6    ///< Security Exchange block length
+#define PRO_LEN 6   ///< Protocol header length
+#define APP_LEN 2   ///< App payload length
+
 struct TestVectorMsgExtensions theTestVectorMsgExtensions[] = {
     {
-        // SRC=none, DST=none, MX=0
-        .mxLength = 0,
-        .sxLength = 0,
-        .payloadOffset = 8,
-        .msgLength = 8,
-        .msg = "\x00\x00\x00\x00\xCC\xCC\xCC\xCC",
+        // SRC=none, DST=none, MX=0, SX=0
+        .payloadOffset = HDR_LEN,
+        .appPayloadOffset = PRO_LEN,
+        .msgLength = HDR_LEN + PRO_LEN + APP_LEN,
+        .msg = 
+            "\x00\x00\x00\x00\xCC\xCC\xCC\xCC"
+            "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
+    },
+    // ================== Test MX ==================
+    {
+        // SRC=none, DST=none, MX=1, SX=0
+        .payloadOffset = HDR_LEN + MX_LEN,
+        .appPayloadOffset = PRO_LEN,
+        .msgLength = HDR_LEN + MX_LEN + PRO_LEN + APP_LEN,
+        .msg = "\x00\x00\x00\x20\xCC\xCC\xCC\xCC\x04\x00\xE4\xE3\xE2\xE1"
+            "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
     },
     {
-        // SRC=none, DST=none, MX=1
-        .mxLength = 4,
-        .sxLength = 0,
-        .payloadOffset = 8 + 6,
-        .msgLength = 16,
-        .msg = "\x00\x00\x00\x20\xCC\xCC\xCC\xCC\x04\x00\xE4\xE3\xE2\xE1\xBB\xBB",
+        // SRC=1, DST=none, MX=1, SX=0
+        .payloadOffset = HDR_LEN + MX_LEN + SRC_LEN,
+        .appPayloadOffset = PRO_LEN,
+        .msgLength = HDR_LEN + MX_LEN + SRC_LEN + PRO_LEN + APP_LEN,
+        .msg = "\x04\x00\x00\x20\xCC\xCC\xCC\xCC\x11\x11\x11\x11\x11\x11\x11\x11\x04\x00\xE4\xE3\xE2\xE1"
+            "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
     },
     {
-        // SRC=1, DST=none, MX=1
-        .mxLength = 4,
-        .sxLength = 0,
-        .payloadOffset = 8 + 8 + 6,
-        .msgLength = 16 + 8,
-        .msg = "\x04\x00\x00\x20\xCC\xCC\xCC\xCC\x11\x11\x11\x11\x11\x11\x11\x11\x04\x00\xE4\xE3\xE2\xE1\xBB\xBB",
+        // SRC=none, DST=1, MX=1, SX=0
+        .payloadOffset = HDR_LEN + MX_LEN + DST_LEN,
+        .appPayloadOffset = PRO_LEN,
+        .msgLength = HDR_LEN + MX_LEN + DST_LEN + PRO_LEN + APP_LEN,
+        .msg = "\x01\x00\x00\x20\xCC\xCC\xCC\xCC\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\x04\x00\xE4\xE3\xE2\xE1"
+            "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
     },
     {
-        // SRC=none, DST=1, MX=1
-        .mxLength = 4,
-        .sxLength = 0,
-        .payloadOffset = 8 + 8 + 6,
-        .msgLength = 16 + 8,
-        .msg = "\x01\x00\x00\x20\xCC\xCC\xCC\xCC\x11\x11\x11\x11\x11\x11\x11\x11\x04\x00\xE4\xE3\xE2\xE1\xBB\xBB",
+        // SRC=1, DST=1, MX=1, SX=0
+        .payloadOffset = HDR_LEN + MX_LEN + SRC_LEN + DST_LEN,
+        .appPayloadOffset = PRO_LEN,
+        .msgLength = HDR_LEN + MX_LEN + SRC_LEN + DST_LEN + PRO_LEN + APP_LEN,
+        .msg = "\x05\x00\x00\x20\xCC\xCC\xCC\xCC\x11\x11\x11\x11\x11\x11\x11\x11\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\x04\x00\xE4\xE3\xE2\xE1"
+            "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
     },
     {
-        // SRC=none, DST=group, MX=1
-        .mxLength = 4,
-        .sxLength = 0,
-        .payloadOffset = 8 + 2 + 6,
-        .msgLength = 16 + 2,
-        .msg = "\x02\x00\x00\x21\xCC\xCC\xCC\xCC\x66\x66\x04\x00\xE4\xE3\xE2\xE1\xBB\xBB",
+        // SRC=none, DST=group, MX=1, SX=0
+        .payloadOffset = HDR_LEN + MX_LEN + GID_LEN,
+        .appPayloadOffset = PRO_LEN,
+        .msgLength = HDR_LEN + MX_LEN + GID_LEN + PRO_LEN + APP_LEN,
+        .msg = "\x02\x00\x00\x21\xCC\xCC\xCC\xCC\xDD\xDD\x04\x00\xE4\xE3\xE2\xE1"
+            "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
     },
     {
-        // SRC=1, DST=group, MX=1
-        .mxLength = 4,
-        .sxLength = 0,
-        .payloadOffset = 8 + 8 + 2 + 6,
-        .msgLength = 16 + 8 + 2,
-        .msg = "\x06\x00\x00\x21\xCC\xCC\xCC\xCC\x11\x11\x11\x11\x11\x11\x11\x11\x66\x66\x04\x00\xE4\xE3\xE2\xE1\xBB\xBB",
+        // SRC=1, DST=group, MX=1, SX=0
+        .payloadOffset = HDR_LEN + MX_LEN + SRC_LEN + GID_LEN,
+        .appPayloadOffset = PRO_LEN,
+        .msgLength = HDR_LEN + MX_LEN + SRC_LEN + GID_LEN + PRO_LEN + APP_LEN,
+        .msg = "\x06\x00\x00\x21\xCC\xCC\xCC\xCC\x11\x11\x11\x11\x11\x11\x11\x11\xDD\xDD\x04\x00\xE4\xE3\xE2\xE1"
+            "\x01\xCC\xEE\xEE\x66\x66\xBB\xBB",
     },
-
-/*
-    // SX test vectors
+    // ================== Test SX ==================
     {
-        .mxLength = 0,
-        .sxLength = 4,
-        .payloadOffset = 8 + 6,
-        .msgLength = 20,
-        .msg = "\x00\x00\x00\x00\xCC\xCC\xCC\xCC\x08\xCC\xEE\xEE\x66\x66\x04\x00\xE4\xE3\xE2\xE1",
+        // SRC=none, DST=none, MX=0, SX=1
+        .payloadOffset = HDR_LEN,
+        .appPayloadOffset = PRO_LEN + SX_LEN,
+        .msgLength = HDR_LEN + PRO_LEN + SX_LEN + APP_LEN,
+        .msg = 
+            "\x00\x00\x00\x00\xCC\xCC\xCC\xCC"
+            "\x08\xCC\xEE\xEE\x66\x66\x04\x00\xE4\xE3\xE2\xE1\xBB\xBB",
     },
     {
-        .mxLength = 4,
-        .sxLength = 4,
-        .payloadOffset = 8 + 6 + 6,
-        .msgLength = 26,
-        .msg = "\x00\x00\x00\x20\xCC\xCC\xCC\xCC\x04\x00\xE4\xE3\xE2\xE1\x08\xCC\xEE\xEE\x66\x66\x04\x00\xE4\xE3\xE2\xE1",
+        // SRC=none, DST=none, MX=1, SX=1
+        .payloadOffset = HDR_LEN + MX_LEN,
+        .appPayloadOffset = PRO_LEN + SX_LEN,
+        .msgLength = HDR_LEN + MX_LEN + PRO_LEN + SX_LEN + APP_LEN,
+        .msg = "\x00\x00\x00\x20\xCC\xCC\xCC\xCC\x04\x00\xE4\xE3\xE2\xE1"
+            "\x08\xCC\xEE\xEE\x66\x66\x04\x00\xE4\xE3\xE2\xE1\xBB\xBB",
     },
-*/
+    {
+        // SRC=1, DST=1, MX=1, SX=1
+        .payloadOffset = HDR_LEN + MX_LEN + SRC_LEN + DST_LEN,
+        .appPayloadOffset = PRO_LEN + SX_LEN,
+        .msgLength = HDR_LEN + MX_LEN + SRC_LEN + DST_LEN + PRO_LEN + SX_LEN + APP_LEN,
+        .msg = "\x05\x00\x00\x20\xCC\xCC\xCC\xCC\x11\x11\x11\x11\x11\x11\x11\x11\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\x04\x00\xE4\xE3\xE2\xE1"
+            "\x09\xCC\xEE\xEE\x66\x66\x04\x00\xE4\xE3\xE2\xE1\xBB\xBB",
+    },
 };
 
 const unsigned theTestVectorMsgExtensionsLength = sizeof(theTestVectorMsgExtensions) / sizeof(struct TestVectorMsgExtensions);
@@ -497,6 +523,7 @@ void TestMsgExtensionsDecode(nlTestSuite * inSuite, void * inContext)
 {
     struct TestVectorMsgExtensions * testEntry;
     PacketHeader packetHeader;
+    PayloadHeader payloadHeader;
     uint16_t decodeSize;
 
     NL_TEST_ASSERT(inSuite, chip::Platform::MemoryInit() == CHIP_NO_ERROR);
@@ -509,6 +536,9 @@ void TestMsgExtensionsDecode(nlTestSuite * inSuite, void * inContext)
 
         NL_TEST_ASSERT(inSuite, packetHeader.Decode(msg->Start(), msg->DataLength(), &decodeSize) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, decodeSize == testEntry->payloadOffset);
+
+        NL_TEST_ASSERT(inSuite, payloadHeader.Decode(msg->Start()+decodeSize, msg->DataLength(), &decodeSize) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, decodeSize == testEntry->appPayloadOffset);
     }
 }
 

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -306,7 +306,18 @@ void TestPayloadHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext
     }
 }
 
-#define MAX_FIXED_HEADER_SIZE (8 + 8 + 8)
+constexpr size_t HDR_LEN = 8; ///< Message header length
+constexpr size_t SRC_LEN = 8; ///< Source Node ID length
+constexpr size_t DST_LEN = 8; ///< Destination Node ID length
+constexpr size_t GID_LEN = 2; ///< Group ID length
+constexpr size_t MX_LEN  = 6; ///< Message Exchange block length
+constexpr size_t SX_LEN  = 6; ///< Security Exchange block length
+constexpr size_t PRO_LEN = 6; ///< Protocol header length
+constexpr size_t APP_LEN = 2; ///< App payload length
+
+/// Size of fixed portion of message header + max source node id + max destination node id.
+constexpr size_t MAX_FIXED_HEADER_SIZE = (HDR_LEN + SRC_LEN + DST_LEN);
+
 struct SpecComplianceTestVector
 {
     uint8_t encoded[MAX_FIXED_HEADER_SIZE]; // Fixed header + max source id + max dest id
@@ -420,15 +431,6 @@ struct TestVectorMsgExtensions
     uint16_t msgLength;
     const char * msg;
 };
-
-#define HDR_LEN 8 ///< Message header length
-#define SRC_LEN 8 ///< Source Node ID length
-#define DST_LEN 8 ///< Destination Node ID length
-#define GID_LEN 2 ///< Group ID length
-#define MX_LEN 6  ///< Message Exchange block length
-#define SX_LEN 6  ///< Security Exchange block length
-#define PRO_LEN 6 ///< Protocol header length
-#define APP_LEN 2 ///< App payload length
 
 struct TestVectorMsgExtensions theTestVectorMsgExtensions[] = {
     {


### PR DESCRIPTION
#### Problem
Fix #13669 

#### Change overview
Skip over Message and Secured extensions in `::Decode`.

#### Testing
CI
Unit tests added