### PR TITLE
Add clang variant to host builds

### DIFF
--- a/.github/workflows/fuzzing-build.yaml
+++ b/.github/workflows/fuzzing-build.yaml
@@ -124,7 +124,7 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
-                        --target darwin-x64-all-clusters-no-ble-asan-libfuzzer \
+                        --target darwin-x64-all-clusters-no-ble-asan-libfuzzer-clang \
                         build \
                         --copy-artifacts-to objdir-clone \
                      "

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
 
         strategy:
             matrix:
-                build_variant: [no-ble-tsan]
+                build_variant: [no-ble-tsan-clang]
                 chip_tool: ["", -same-event-loop]
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}
@@ -120,7 +120,7 @@ jobs:
 
         strategy:
             matrix:
-                build_variant: [no-ble-tsan, no-ble-asan]
+                build_variant: [no-ble-tsan-clang, no-ble-asan-clang]
                 chip_tool: ["", -same-event-loop]
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,7 +91,7 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
-                     --chip-tool ./out/linux-x64-chip-tool{CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \
+                     --chip-tool ./out/linux-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \
                      run \
                      --iterations 1 \
                      --all-clusters-app ./out/linux-x64-all-clusters-test-group-${BUILD_VARIANT}/chip-all-clusters-app \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -80,7 +80,7 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-chip-tool-${BUILD_VARIANT}${CHIP_TOOL_VARIANT} \
-                        --target linux-x64-all-clusters-${BUILD_VARIANT}-test-group \
+                        --target linux-x64-all-clusters-test-group-${BUILD_VARIANT} \
                         --target linux-x64-door-lock-${BUILD_VARIANT} \
                         --target linux-x64-tv-app-${BUILD_VARIANT} \
                         build \
@@ -94,7 +94,7 @@ jobs:
                      --chip-tool ./out/linux-x64-chip-tool-${BUILD_VARIANT}${CHIP_TOOL_VARIANT}/chip-tool \
                      run \
                      --iterations 1 \
-                     --all-clusters-app ./out/linux-x64-all-clusters-${BUILD_VARIANT}-test-group/chip-all-clusters-app \
+                     --all-clusters-app ./out/linux-x64-all-clusters-test-group-${BUILD_VARIANT}/chip-all-clusters-app \
                      --door-lock-app ./out/linux-x64-door-lock-${BUILD_VARIANT}/chip-door-lock-app \
                      --tv-app ./out/linux-x64-tv-app-${BUILD_VARIANT}/chip-tv-app \
                   "

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -79,7 +79,7 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
-                        --target linux-x64-chip-tool-${BUILD_VARIANT}${CHIP_TOOL_VARIANT} \
+                        --target linux-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT} \
                         --target linux-x64-all-clusters-test-group-${BUILD_VARIANT} \
                         --target linux-x64-door-lock-${BUILD_VARIANT} \
                         --target linux-x64-tv-app-${BUILD_VARIANT} \
@@ -91,7 +91,7 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
-                     --chip-tool ./out/linux-x64-chip-tool-${BUILD_VARIANT}${CHIP_TOOL_VARIANT}/chip-tool \
+                     --chip-tool ./out/linux-x64-chip-tool{CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \
                      run \
                      --iterations 1 \
                      --all-clusters-app ./out/linux-x64-all-clusters-test-group-${BUILD_VARIANT}/chip-all-clusters-app \
@@ -174,7 +174,7 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
-                        --target darwin-x64-chip-tool-${BUILD_VARIANT}${CHIP_TOOL_VARIANT} \
+                        --target darwin-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT} \
                         --target darwin-x64-all-clusters-${BUILD_VARIANT} \
                         build \
                         --copy-artifacts-to objdir-clone \
@@ -184,7 +184,7 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
-                     --chip-tool ./out/darwin-x64-chip-tool-${BUILD_VARIANT}${CHIP_TOOL_VARIANT}/chip-tool \
+                     --chip-tool ./out/darwin-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \
                      --target-skip-glob '{TestGroupMessaging,DL_*,TV_*}' \
                      run \
                      --iterations 1 \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -222,7 +222,7 @@ jobs:
 
         strategy:
             matrix:
-                build_variant: [no-ble-no-wifi-tsan]
+                build_variant: [no-ble-no-wifi-tsan-clang]
 
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}
@@ -300,7 +300,7 @@ jobs:
 
         strategy:
             matrix:
-                build_variant: [no-ble-no-wifi-tsan]
+                build_variant: [no-ble-no-wifi-tsan-clang]
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}
             TSAN_OPTIONS: "halt_on_error=1"

--- a/examples/all-clusters-app/linux/README.md
+++ b/examples/all-clusters-app/linux/README.md
@@ -8,13 +8,13 @@ This example supports compilation with libfuzzer enabled.
 
 To compile with libfuzzer enabled on Mac, run:
 
-    $ ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target darwin-x64-all-clusters-no-ble-asan-libfuzzer build"
+    $ ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target darwin-x64-all-clusters-no-ble-asan-libfuzzer-clang build"
 
 at the top level of the Matter tree.
 
 Similarly, to compile on Linux run:
 
-    $ ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-all-clusters-no-ble-asan-libfuzzer build"
+    $ ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target linux-x64-all-clusters-no-ble-asan-libfuzzer-clang build"
 
 ### Running libfuzzer-enabled binaries
 
@@ -22,11 +22,11 @@ Similarly, to compile on Linux run:
 
 To run the resulting binary with no particular inputs do:
 
-    $ ./out/darwin-x64-all-clusters-no-ble-asan-libfuzzer/chip-all-clusters-app-fuzzing
+    $ ./out/darwin-x64-all-clusters-no-ble-asan-libfuzzer-clang/chip-all-clusters-app-fuzzing
 
 or
 
-    $ ./out/linux-x64-all-clusters-no-ble-asan-libfuzzer/chip-all-clusters-app-fuzzing
+    $ ./out/linux-x64-all-clusters-no-ble-asan-libfuzzer-clang/chip-all-clusters-app-fuzzing
 
 If this crashes, it will output the input that caused the crash in a variety of
 formats, looking something like this:
@@ -44,11 +44,11 @@ To run the binary with a specific input, place the input bytes in a file (which
 a crashing run of the fuzzer does automatically). If `$(INPUT_FILE)` is the name
 of that file, then run:
 
-    $ ./out/darwin-x64-all-clusters-no-ble-asan-libfuzzer/chip-all-clusters-app-fuzzing $(INPUT_FILE)
+    $ ./out/darwin-x64-all-clusters-no-ble-asan-libfuzzer-clang/chip-all-clusters-app-fuzzing $(INPUT_FILE)
 
 or
 
-    $ ./out/linux-x64-all-clusters-no-ble-asan-libfuzzer/chip-all-clusters-app-fuzzing $(INPUT_FILE)
+    $ ./out/linux-x64-all-clusters-no-ble-asan-libfuzzer-clang/chip-all-clusters-app-fuzzing $(INPUT_FILE)
 
 #### Additional execution options.
 

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -248,6 +248,8 @@ def HostTargets():
     # builds is exponential here
     builder.AppendVariant(name="test-group", validator=AcceptNameWithSubstrings(
         ['-all-clusters', '-chip-tool']), test_group=True),
+    builder.AppendVariant(name="same-event-loop", validator=AcceptNameWithSubstrings(
+        ['-chip-tool']), separate_event_loop=False),
     builder.AppendVariant(name="ipv6only", enable_ipv4=False),
     builder.AppendVariant(name="no-ble", enable_ble=False),
     builder.AppendVariant(name="tsan", requires=["clang"], conflicts=[
@@ -256,8 +258,6 @@ def HostTargets():
                           'tsan'], use_asan=True),
     builder.AppendVariant(name="libfuzzer", requires=[
                           "clang"], use_libfuzzer=True),
-    builder.AppendVariant(name="same-event-loop", validator=AcceptNameWithSubstrings(
-        ['-chip-tool']), separate_event_loop=False),
     builder.AppendVariant(name="clang", use_clang=True),
 
     builder.WhitelistVariantNameForGlob('ipv6only')

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -246,6 +246,8 @@ def HostTargets():
 
     # Possible build variants. Note that number of potential
     # builds is exponential here
+    builder.AppendVariant(name="test-group", validator=AcceptNameWithSubstrings(
+        ['-all-clusters', '-chip-tool']), test_group=True),
     builder.AppendVariant(name="ipv6only", enable_ipv4=False),
     builder.AppendVariant(name="no-ble", enable_ble=False),
     builder.AppendVariant(name="tsan", requires=["clang"], conflicts=[
@@ -254,8 +256,6 @@ def HostTargets():
                           'tsan'], use_asan=True),
     builder.AppendVariant(name="libfuzzer", requires=[
                           "clang"], use_libfuzzer=True),
-    builder.AppendVariant(name="test-group", validator=AcceptNameWithSubstrings(
-        ['-all-clusters', '-chip-tool']), test_group=True),
     builder.AppendVariant(name="same-event-loop", validator=AcceptNameWithSubstrings(
         ['-chip-tool']), separate_event_loop=False),
     builder.AppendVariant(name="clang", use_clang=True),

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -253,10 +253,8 @@ def HostTargets():
     builder.AppendVariant(name="ipv6only", enable_ipv4=False),
     builder.AppendVariant(name="no-ble", enable_ble=False),
     builder.AppendVariant(name="no-wifi", enable_wifi=False),
-    builder.AppendVariant(name="tsan", requires=["clang"], conflicts=[
-                          'asan'], use_tsan=True),
-    builder.AppendVariant(name="asan", requires=["clang"], conflicts=[
-                          'tsan'], use_asan=True),
+    builder.AppendVariant(name="tsan", conflicts=['asan'], use_tsan=True),
+    builder.AppendVariant(name="asan", conflicts=['tsan'], use_asan=True),
     builder.AppendVariant(name="libfuzzer", requires=[
                           "clang"], use_libfuzzer=True),
     builder.AppendVariant(name="clang", use_clang=True),

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -113,7 +113,7 @@ class AcceptNameWithSubstrings:
 
 
 class BuildVariant:
-    def __init__(self, name: str, validator=AcceptAnyName(), conflicts: List[str]=[], requires: List[str]=[], **buildargs):
+    def __init__(self, name: str, validator=AcceptAnyName(), conflicts: List[str] = [], requires: List[str] = [], **buildargs):
         self.name = name
         self.validator = validator
         self.conflicts = conflicts
@@ -126,6 +126,7 @@ def HasConflicts(items: List[BuildVariant]) -> bool:
         if (a.name in b.conflicts) or (b.name in a.conflicts):
             return True
     return False
+
 
 def AllRequirementsMet(items: List[BuildVariant]) -> bool:
     """
@@ -146,7 +147,8 @@ class VariantBuilder:
     """
 
     def __init__(self, targets: List[Target] = []):
-        self.targets = targets[:] # note the clone in case the default arg is used
+        # note the clone in case the default arg is used
+        self.targets = targets[:]
         self.variants = []
         self.glob_whitelist = []
 
@@ -246,9 +248,12 @@ def HostTargets():
     # builds is exponential here
     builder.AppendVariant(name="ipv6only", enable_ipv4=False),
     builder.AppendVariant(name="no-ble", enable_ble=False),
-    builder.AppendVariant(name="tsan", requires=["clang"], conflicts=['asan'], use_tsan=True),
-    builder.AppendVariant(name="asan", requires=["clang"], conflicts=['tsan'], use_asan=True),
-    builder.AppendVariant(name="libfuzzer", requires=["clang"], use_libfuzzer=True),
+    builder.AppendVariant(name="tsan", requires=["clang"], conflicts=[
+                          'asan'], use_tsan=True),
+    builder.AppendVariant(name="asan", requires=["clang"], conflicts=[
+                          'tsan'], use_asan=True),
+    builder.AppendVariant(name="libfuzzer", requires=[
+                          "clang"], use_libfuzzer=True),
     builder.AppendVariant(name="test-group", validator=AcceptNameWithSubstrings(
         ['-all-clusters', '-chip-tool']), test_group=True),
     builder.AppendVariant(name="same-event-loop", validator=AcceptNameWithSubstrings(

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -130,7 +130,6 @@ public:
             mUpdateToken = updateToken;
         }
 
-
         // Schedule the initializations that needs to be performed in the CHIP context
         DeviceLayer::PlatformMgr().ScheduleWork(InitState, reinterpret_cast<intptr_t>(this));
 


### PR DESCRIPTION
#### Problem
Need clang variant explicit in build_examples:
   - fuzzer, asan and msan require clang
   - running clang_tidy generally wants clang-compatible output

#### Change overview
Add clang variants, better dependency definitions for types

#### Testing
Manually inspected targets
Ran:

```
./scripts/build/build_examples.py --target linux-x64-all-clusters-no-ble-asan-libfuzzer-clang build
```

to test a compile
