### PR TITLE
Guard BLE usage with CONFIG_NETWORK_LAYER_BLE

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -51,7 +51,9 @@ using chip::kMinValidFabricIndex;
 using chip::RendezvousInformationFlag;
 using chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr;
 using chip::Inet::IPAddressType;
+#if CONFIG_NETWORK_LAYER_BLE
 using chip::Transport::BleListenParameters;
+#endif
 using chip::Transport::PeerAddress;
 using chip::Transport::UdpListenParameters;
 
@@ -255,7 +257,10 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
     app::DnssdServer::Instance().StartServer();
 #endif
 
-    err = mCASEServer.ListenForSessionEstablishment(&mExchangeMgr, &mTransports, chip::DeviceLayer::ConnectivityMgr().GetBleLayer(),
+    err = mCASEServer.ListenForSessionEstablishment(&mExchangeMgr, &mTransports, 
+#if CONFIG_NETWORK_LAYER_BLE
+                                                    chip::DeviceLayer::ConnectivityMgr().GetBleLayer(),
+#endif
                                                     &mSessions, &mFabrics);
     SuccessOrExit(err);
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -39,7 +39,9 @@
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
 #include <transport/TransportMgrBase.h>
+#if CONFIG_NETWORK_LAYER_BLE
 #include <transport/raw/BLE.h>
+#endif
 #include <transport/raw/UDP.h>
 
 namespace chip {

--- a/src/include/platform/CHIPDeviceLayer.h
+++ b/src/include/platform/CHIPDeviceLayer.h
@@ -21,8 +21,9 @@
 #include <platform/CHIPDeviceConfig.h>
 
 #if !CHIP_DEVICE_LAYER_NONE
-
+#if CONFIG_NETWORK_LAYER_BLE
 #include <ble/BleLayer.h>
+#endif // CONFIG_NETWORK_LAYER_BLE
 #include <lib/core/CHIPCore.h>
 #include <platform/CHIPDeviceError.h>
 #include <platform/ConfigurationManager.h>

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -35,10 +35,12 @@
 
 namespace chip {
 
+#if CONFIG_NETWORK_LAYER_BLE
 namespace Ble {
 class BleLayer;
 class BLEEndPoint;
 } // namespace Ble
+#endif
 
 namespace DeviceLayer {
 
@@ -216,7 +218,9 @@ public:
 #endif
 
     // CHIPoBLE service methods
+#if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * GetBleLayer();
+#endif
     CHIPoBLEServiceMode GetCHIPoBLEServiceMode();
     CHIP_ERROR SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool IsBLEAdvertisingEnabled();
@@ -497,10 +501,12 @@ inline CHIP_ERROR ConnectivityManager::WriteThreadNetworkDiagnosticAttributeToTl
     return static_cast<ImplClass *>(this)->_WriteThreadNetworkDiagnosticAttributeToTlv(attributeId, encoder);
 }
 
+#if CONFIG_NETWORK_LAYER_BLE
 inline Ble::BleLayer * ConnectivityManager::GetBleLayer()
 {
     return static_cast<ImplClass *>(this)->_GetBleLayer();
 }
+#endif
 
 inline ConnectivityManager::CHIPoBLEServiceMode ConnectivityManager::GetCHIPoBLEServiceMode()
 {

--- a/src/include/platform/internal/BLEManager.h
+++ b/src/include/platform/internal/BLEManager.h
@@ -65,7 +65,9 @@ public:
     CHIP_ERROR SetDeviceName(const char * deviceName);
     uint16_t NumConnections();
     void OnPlatformEvent(const ChipDeviceEvent * event);
+#if CONFIG_NETWORK_LAYER_BLE
     chip::Ble::BleLayer * GetBleLayer();
+#endif
 
 protected:
     // Construction/destruction limited to subclasses.
@@ -119,7 +121,9 @@ inline CHIP_ERROR BLEManager::Init()
 
 inline CHIP_ERROR BLEManager::Shutdown()
 {
+#if CONFIG_NETWORK_LAYER_BLE
     ReturnErrorOnFailure(GetBleLayer()->Shutdown());
+#endif
     return static_cast<ImplClass *>(this)->_Shutdown();
 }
 
@@ -173,11 +177,12 @@ inline void BLEManager::OnPlatformEvent(const ChipDeviceEvent * event)
     return static_cast<ImplClass *>(this)->_OnPlatformEvent(event);
 }
 
+#if CONFIG_NETWORK_LAYER_BLE
 inline chip::Ble::BleLayer * BLEManager::GetBleLayer()
 {
     return static_cast<ImplClass *>(this)->_GetBleLayer();
 }
-
+#endif
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoBLE.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoBLE.h
@@ -52,7 +52,9 @@ class GenericConnectivityManagerImpl_NoBLE
 public:
     // ===== Methods that implement the ConnectivityManager abstract interface.
 
+#if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * _GetBleLayer(void);
+#endif
     ConnectivityManager::CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(ConnectivityManager::CHIPoBLEServiceMode val);
     bool _IsBLEAdvertisingEnabled(void);
@@ -68,11 +70,13 @@ private:
     ImplClass * Impl() { return static_cast<ImplClass *>(this); }
 };
 
+#if CONFIG_NETWORK_LAYER_BLE
 template <class ImplClass>
 inline Ble::BleLayer * GenericConnectivityManagerImpl_NoBLE<ImplClass>::_GetBleLayer(void)
 {
     return nullptr;
 }
+#endif
 
 template <class ImplClass>
 inline ConnectivityManager::CHIPoBLEServiceMode GenericConnectivityManagerImpl_NoBLE<ImplClass>::_GetCHIPoBLEServiceMode(void)

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -30,7 +30,10 @@ using namespace ::chip::Credentials;
 namespace chip {
 
 CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
-                                                     Ble::BleLayer * bleLayer, SessionManager * sessionManager,
+#if CONFIG_NETWORK_LAYER_BLE
+                                                     Ble::BleLayer * bleLayer, 
+#endif
+SessionManager * sessionManager,
                                                      FabricTable * fabrics)
 {
     VerifyOrReturnError(transportMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -38,7 +41,9 @@ CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager 
     VerifyOrReturnError(sessionManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(fabrics != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
+#if CONFIG_NETWORK_LAYER_BLE
     mBleLayer        = bleLayer;
+#endif
     mSessionManager  = sessionManager;
     mFabrics         = fabrics;
     mExchangeManager = exchangeManager;

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
+#if CONFIG_NETWORK_LAYER_BLE
 #include <ble/BleLayer.h>
+#endif
 #include <messaging/ExchangeDelegate.h>
 #include <messaging/ExchangeMgr.h>
 #include <protocols/secure_channel/CASESession.h>
@@ -38,7 +40,10 @@ public:
     }
 
     CHIP_ERROR ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
-                                             Ble::BleLayer * bleLayer, SessionManager * sessionManager, FabricTable * fabrics);
+#if CONFIG_NETWORK_LAYER_BLE
+                                             Ble::BleLayer * bleLayer, 
+#endif
+SessionManager * sessionManager, FabricTable * fabrics);
 
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
@@ -58,7 +63,9 @@ private:
     CASESession mPairingSession;
     uint16_t mSessionKeyId           = 0;
     SessionManager * mSessionManager = nullptr;
+#if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer        = nullptr;
+#endif
 
     FabricTable * mFabrics = nullptr;
     SessionIDAllocator mSessionIDAllocator;


### PR DESCRIPTION

#### Problem
* For targets with CONFIG_NETWORK_LAYER_BLE=0, we will hit a linking:
 ```ld: error: blaze-out/k8-fastbuild/bin/_solib_k8/libthird_Uparty_Sconnectedhomeip_Ssrc_Ssetup_Upayload_Slibsetup_Upayload.ifso: undefined reference to chip::Ble::BleLayer::CancelBleIncompleteConnection() [--no-allow-shlib-undefined]
ld: error: blaze-out/k8-fastbuild/bin/_solib_k8/libthird_Uparty_Sconnectedhomeip_Ssrc_Ssetup_Upayload_Slibsetup_Upayload.ifso: undefined reference to chip::Ble::BLEEndPoint::Close() [--no-allow-shlib-undefined]
ld: error: blaze-out/k8-fastbuild/bin/_solib_k8/libthird_Uparty_Sconnectedhomeip_Ssrc_Ssetup_Upayload_Slibsetup_Upayload.ifso: undefined reference to chip::Ble::BLEEndPoint::Send(chip::System::PacketBufferHandle&&) [--no-allow-shlib-undefined]
ld: error: blaze-out/k8-fastbuild/bin/_solib_k8/libthird_Uparty_Sconnectedhomeip_Ssrc_Ssetup_Upayload_Slibsetup_Upayload.ifso: undefined reference to chip::Ble::BLEEndPoint::StartConnect() [--no-allow-shlib-undefined]
```
#### Change overview
This is due to some usage of BleLayer are not guarded by CONFIG_NETWORK_LAYER_BLE
when they should so adding the guard for ble usage.

#### Testing
How was this tested? (at least one bullet point required)
* Tested locally with m5stack