### PR TITLE
[python] fix failed import Mapping on python 3.10

### DIFF
--- a/src/controller/python/chip/tlv/__init__.py
+++ b/src/controller/python/chip/tlv/__init__.py
@@ -29,7 +29,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import struct
-from collections import Mapping, Sequence, OrderedDict
+from collections import OrderedDict
+from collections.abc import Mapping, Sequence
 from enum import Enum
 
 TLV_TYPE_SIGNED_INTEGER = 0x00


### PR DESCRIPTION
Signed-off-by: kXuan <kxuanobj@gmail.com>

#### Problem
* Fix python controller failed on python 3.10
```
Traceback (most recent call last):
  File "/data/work/oppo/matter/oppo-lamp/third_party/connectedhomeip/src/app/ota_image_tool.py", line 41, in <module>
    from chip.tlv import TLVReader, TLVWriter, uint  # noqa: E402
  File "/data/work/oppo/matter/oppo-lamp/third_party/connectedhomeip/src/app/../controller/python/chip/tlv/__init__.py", line 32, in <module>
    from collections import Mapping, Sequence, OrderedDict
ImportError: cannot import name 'Mapping' from 'collections' (/usr/lib/python3.10/collections/__init__.py)
```

#### Change overview
Python 3.10 has removed some alias from `collections` module.  [Python 3.10 What's New](https://docs.python.org/3/whatsnew/3.10.html):

> Remove deprecated aliases to [Collections Abstract Base Classes](https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes) from the [collections](https://docs.python.org/3/library/collections.html#module-collections) module. (Contributed by Victor Stinner in [bpo-37324](https://bugs.python.org/issue37324).)

The python controller still use deprecated aliases, so it failed on python 3.10.

This patch fix this problem by import `Mapping`, `Sequence` from `collections.abc`.

#### Testing
How was this tested? (at least one bullet point required)
* Test locally by build ESP32 Ota Requestor demo with a python 3.10 installed system.
