### PR TITLE
Enable door lock and TV app tests on Darwin platform

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -176,6 +176,8 @@ jobs:
                      "./scripts/build/build_examples.py \
                         --target darwin-x64-chip-tool-${BUILD_VARIANT}${CHIP_TOOL_VARIANT} \
                         --target darwin-x64-all-clusters-${BUILD_VARIANT} \
+                        --target darwin-x64-door-lock-${BUILD_VARIANT} \
+                        --target darwin-x64-tv-app-${BUILD_VARIANT} \
                         build \
                         --copy-artifacts-to objdir-clone \
                      "
@@ -185,10 +187,12 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
                      --chip-tool ./out/darwin-x64-chip-tool-${BUILD_VARIANT}${CHIP_TOOL_VARIANT}/chip-tool \
-                     --target-skip-glob '{TestGroupMessaging,DL_*,TV_*}' \
+                     --target-skip-glob '{TestGroupMessaging}' \
                      run \
                      --iterations 1 \
                      --all-clusters-app ./out/darwin-x64-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
+                     --door-lock-app ./out/darwin-x64-door-lock-${BUILD_VARIANT}/chip-door-lock-app \
+                     --tv-app ./out/darwin-x64-tv-app-${BUILD_VARIANT}/chip-tv-app \
                   "
             - name: Uploading core files
               uses: actions/upload-artifact@v2


### PR DESCRIPTION
#### Problem

Darwin door lock and TV app tests are not checked during CI tests.
Closes #15905

#### Change overview

- enable TV and DL tests on CI for Darwin