### PR TITLE
Remove special characters from function names in code gen

### DIFF
--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -438,13 +438,13 @@ function asLowerCamelCase(label)
       && label.toUpperCase() != label) {
     str = str[0].toUpperCase() + str.substring(1);
   }
-  return str.replace(/[\.:]/g, '');
+  return str.replace(/[^A-Za-z0-9_]/g, '');
 }
 
 function asUpperCamelCase(label)
 {
   let str = string.toCamelCase(label, false);
-  return str.replace(/[\.:]/g, '');
+  return str.replace(/[^A-Za-z0-9_]/g, '');
 }
 
 function asMEI(prefix, suffix)


### PR DESCRIPTION
#### Problem
When special characters are added to the label in YAML test files, the code gen attempts to create a function with it, but C++ does not accept special characters as function names. See issue below:
https://github.com/project-chip/connectedhomeip/issues/16236

#### Change overview
- Update camel case functions to only include accepted characters.

#### Testing
- Generate all and de sure nothing was changed.
- Created Label with various special characters.
- Generated code from file that is in issue and compiled successfully.
