### PR TITLE
[OTA] Remove global resolver initialization from OTA Requestor

### DIFF
--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -181,8 +181,6 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
 
 void ApplicationInit()
 {
-    chip::Dnssd::Resolver::Instance().Init(chip::DeviceLayer::UDPEndPointManager());
-
     // Initialize all OTA download components
     InitOTARequestor();
 }


### PR DESCRIPTION
#### Problem
After https://github.com/project-chip/connectedhomeip/pull/16230, the global resolver is already initialized in the Server class

#### Change overview
Remove the extraneous init call in the requestor app

#### Testing
Verified happy path for OTA transfer succeeds
