### PR TITLE
[Python] Fix UTF-8 Encoding for CommissionWifi in REPL

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -304,7 +304,7 @@ class ChipDeviceController():
 
         return self._ChipStack.Call(
             lambda: self._dmLib.pychip_DeviceController_SetWiFiCredentials(
-                ssid, credentials)
+                ssid.encode("utf-8"), credentials.encode("utf-8"))
         )
 
     def SetThreadOperationalDataset(self, threadOperationalDataset):


### PR DESCRIPTION
The CommissionWifi method was not correctly converting the encoding of
the passed in ssid and passphrase arguments to UTF-8 before passing it
down to the C++ layer.
