### PR TITLE
Wrap usages of src/ble/... with CONFIG_NETWORK_LAYER_BLE

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -51,7 +51,9 @@ using chip::kMinValidFabricIndex;
 using chip::RendezvousInformationFlag;
 using chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr;
 using chip::Inet::IPAddressType;
+#if CONFIG_NETWORK_LAYER_BLE
 using chip::Transport::BleListenParameters;
+#endif
 using chip::Transport::PeerAddress;
 using chip::Transport::UdpListenParameters;
 
@@ -255,7 +257,10 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
     app::DnssdServer::Instance().StartServer();
 #endif
 
-    err = mCASEServer.ListenForSessionEstablishment(&mExchangeMgr, &mTransports, chip::DeviceLayer::ConnectivityMgr().GetBleLayer(),
+    err = mCASEServer.ListenForSessionEstablishment(&mExchangeMgr, &mTransports, 
+#if CONFIG_NETWORK_LAYER_BLE
+        chip::DeviceLayer::ConnectivityMgr().GetBleLayer(),
+#endif
                                                     &mSessions, &mFabrics);
     SuccessOrExit(err);
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -259,7 +259,7 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
     app::DnssdServer::Instance().StartServer();
 #endif
 
-    err = mCASEServer.ListenForSessionEstablishment(&mExchangeMgr, &mTransports, 
+    err = mCASEServer.ListenForSessionEstablishment(&mExchangeMgr, &mTransports,
 #if CONFIG_NETWORK_LAYER_BLE
                                                     chip::DeviceLayer::ConnectivityMgr().GetBleLayer(),
 #endif

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -259,7 +259,7 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
 
     err = mCASEServer.ListenForSessionEstablishment(&mExchangeMgr, &mTransports, 
 #if CONFIG_NETWORK_LAYER_BLE
-        chip::DeviceLayer::ConnectivityMgr().GetBleLayer(),
+                                                    chip::DeviceLayer::ConnectivityMgr().GetBleLayer(),
 #endif
                                                     &mSessions, &mFabrics);
     SuccessOrExit(err);

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -25,7 +25,9 @@
 #include <app/server/EchoHandler.h>
 #include <app/util/DataModelHandler.h>
 
+#if CONFIG_NETWORK_LAYER_BLE
 #include <ble/BLEEndPoint.h>
+#endif
 #include <inet/IPAddress.h>
 #include <inet/InetError.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -175,7 +175,11 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
         // especially since it will interrupt other potential usages of BLE by the controller acting in a commissioning capacity.
         //
         ReturnErrorOnFailure(stateParams.caseServer->ListenForSessionEstablishment(
-            stateParams.exchangeMgr, stateParams.transportMgr, nullptr, stateParams.sessionMgr, stateParams.fabricTable));
+            stateParams.exchangeMgr, stateParams.transportMgr,
+#if CONFIG_NETWORK_LAYER_BLE
+            nullptr, 
+#endif
+            stateParams.sessionMgr, stateParams.fabricTable));
 
         //
         // We need to advertise the port that we're listening to for unsolicited messages over UDP. However, we have both a IPv4

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -174,12 +174,12 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
         // We pass in a nullptr for the BLELayer since we're not permitting usage of BLE in this server modality for the controller,
         // especially since it will interrupt other potential usages of BLE by the controller acting in a commissioning capacity.
         //
-        ReturnErrorOnFailure(stateParams.caseServer->ListenForSessionEstablishment(
-            stateParams.exchangeMgr, stateParams.transportMgr,
+        ReturnErrorOnFailure(
+            stateParams.caseServer->ListenForSessionEstablishment(stateParams.exchangeMgr, stateParams.transportMgr,
 #if CONFIG_NETWORK_LAYER_BLE
-            nullptr, 
+                                                                  nullptr,
 #endif
-            stateParams.sessionMgr, stateParams.fabricTable));
+                                                                  stateParams.sessionMgr, stateParams.fabricTable));
 
         //
         // We need to advertise the port that we're listening to for unsolicited messages over UDP. However, we have both a IPv4

--- a/src/include/platform/CHIPDeviceLayer.h
+++ b/src/include/platform/CHIPDeviceLayer.h
@@ -22,7 +22,6 @@
 
 #if !CHIP_DEVICE_LAYER_NONE
 
-#include <ble/BleLayer.h>
 #include <lib/core/CHIPCore.h>
 #include <platform/CHIPDeviceError.h>
 #include <platform/ConfigurationManager.h>

--- a/src/include/platform/internal/BLEManager.h
+++ b/src/include/platform/internal/BLEManager.h
@@ -119,7 +119,9 @@ inline CHIP_ERROR BLEManager::Init()
 
 inline CHIP_ERROR BLEManager::Shutdown()
 {
+#if CONFIG_NETWORK_LAYER_BLE
     ReturnErrorOnFailure(GetBleLayer()->Shutdown());
+#endif
     return static_cast<ImplClass *>(this)->_Shutdown();
 }
 

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -30,7 +30,10 @@ using namespace ::chip::Credentials;
 namespace chip {
 
 CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
-                                                     Ble::BleLayer * bleLayer, SessionManager * sessionManager,
+#if CONFIG_NETWORK_LAYER_BLE
+                                                     Ble::BleLayer * bleLayer,
+#endif
+                                                     SessionManager * sessionManager,
                                                      FabricTable * fabrics)
 {
     VerifyOrReturnError(transportMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -38,7 +41,9 @@ CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager 
     VerifyOrReturnError(sessionManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(fabrics != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
+#if CONFIG_NETWORK_LAYER_BLE
     mBleLayer        = bleLayer;
+#endif
     mSessionManager  = sessionManager;
     mFabrics         = fabrics;
     mExchangeManager = exchangeManager;

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -33,8 +33,7 @@ CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager 
 #if CONFIG_NETWORK_LAYER_BLE
                                                      Ble::BleLayer * bleLayer,
 #endif
-                                                     SessionManager * sessionManager,
-                                                     FabricTable * fabrics)
+                                                     SessionManager * sessionManager, FabricTable * fabrics)
 {
     VerifyOrReturnError(transportMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(exchangeManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -41,7 +41,7 @@ CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager 
     VerifyOrReturnError(fabrics != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
 #if CONFIG_NETWORK_LAYER_BLE
-    mBleLayer        = bleLayer;
+    mBleLayer = bleLayer;
 #endif
     mSessionManager  = sessionManager;
     mFabrics         = fabrics;

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
+#if CONFIG_NETWORK_LAYER_BLE
 #include <ble/BleLayer.h>
+#endif
 #include <messaging/ExchangeDelegate.h>
 #include <messaging/ExchangeMgr.h>
 #include <protocols/secure_channel/CASESession.h>
@@ -38,7 +40,10 @@ public:
     }
 
     CHIP_ERROR ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
-                                             Ble::BleLayer * bleLayer, SessionManager * sessionManager, FabricTable * fabrics);
+#if CONFIG_NETWORK_LAYER_BLE
+                                             Ble::BleLayer * bleLayer, 
+#endif
+                                             SessionManager * sessionManager, FabricTable * fabrics);
 
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
@@ -58,7 +63,9 @@ private:
     CASESession mPairingSession;
     uint16_t mSessionKeyId           = 0;
     SessionManager * mSessionManager = nullptr;
+#if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer        = nullptr;
+#endif
 
     FabricTable * mFabrics = nullptr;
     SessionIDAllocator mSessionIDAllocator;

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -64,7 +64,7 @@ private:
     uint16_t mSessionKeyId           = 0;
     SessionManager * mSessionManager = nullptr;
 #if CONFIG_NETWORK_LAYER_BLE
-    Ble::BleLayer * mBleLayer        = nullptr;
+    Ble::BleLayer * mBleLayer = nullptr;
 #endif
 
     FabricTable * mFabrics = nullptr;

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -41,7 +41,7 @@ public:
 
     CHIP_ERROR ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
 #if CONFIG_NETWORK_LAYER_BLE
-                                             Ble::BleLayer * bleLayer, 
+                                             Ble::BleLayer * bleLayer,
 #endif
                                              SessionManager * sessionManager, FabricTable * fabrics);
 

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -374,7 +374,10 @@ void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inConte
     gLoopback.mSentMessageCount = 0;
 
     NL_TEST_ASSERT(inSuite,
-                   gPairingServer.ListenForSessionEstablishment(&ctx.GetExchangeManager(), &ctx.GetTransportMgr(), nullptr,
+                   gPairingServer.ListenForSessionEstablishment(&ctx.GetExchangeManager(), &ctx.GetTransportMgr(), 
+#if CONFIG_NETWORK_LAYER_BLE
+                     nullptr,
+#endif
                                                                 &ctx.GetSecureSessionManager(), &gDeviceFabrics) == CHIP_NO_ERROR);
 
     ExchangeContext * contextCommissioner = ctx.NewUnauthenticatedExchangeToBob(pairingCommissioner);

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -376,7 +376,7 @@ void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inConte
     NL_TEST_ASSERT(inSuite,
                    gPairingServer.ListenForSessionEstablishment(&ctx.GetExchangeManager(), &ctx.GetTransportMgr(), 
 #if CONFIG_NETWORK_LAYER_BLE
-                     nullptr,
+                                                                nullptr,
 #endif
                                                                 &ctx.GetSecureSessionManager(), &gDeviceFabrics) == CHIP_NO_ERROR);
 

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -374,7 +374,7 @@ void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inConte
     gLoopback.mSentMessageCount = 0;
 
     NL_TEST_ASSERT(inSuite,
-                   gPairingServer.ListenForSessionEstablishment(&ctx.GetExchangeManager(), &ctx.GetTransportMgr(), 
+                   gPairingServer.ListenForSessionEstablishment(&ctx.GetExchangeManager(), &ctx.GetTransportMgr(),
 #if CONFIG_NETWORK_LAYER_BLE
                                                                 nullptr,
 #endif


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* When CONFIG_NETWORK_LAYER_BLE=0, src/ble/.. files will not be built, yet there are still usages of it that is unguarded by CONFIG_NETWORK_LAYER_BLE.

#### Change overview
* Guard usages of src/ble/... with CONFIG_NETWORK_LAYER_BLE.
* Remove the include of `src/ble` in CHIPDeviceLayer.h because it is not needed.

#### Testing
How was this tested? (at least one bullet point required)
* Build Matter locally
