### PR TITLE
Move FTD vs MTD define to each example script

### DIFF
--- a/examples/lighting-app/qpg/.gn
+++ b/examples/lighting-app/qpg/.gn
@@ -23,7 +23,6 @@ check_system_includes = true
 default_args = {
   target_cpu = "arm"
   target_os = "freertos"
-  chip_openthread_ftd = false
 
   import("//args.gni")
 }

--- a/examples/lighting-app/qpg/args.gni
+++ b/examples/lighting-app/qpg/args.gni
@@ -20,6 +20,7 @@ qpg_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 declare_args() {
   chip_enable_ota_requestor = true
+  chip_openthread_ftd = true
 
   # Disable lock tracking, since our FreeRTOS configuration does not set
   # INCLUDE_xSemaphoreGetMutexHolder

--- a/examples/lock-app/qpg/args.gni
+++ b/examples/lock-app/qpg/args.gni
@@ -20,6 +20,7 @@ qpg_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 declare_args() {
   chip_enable_ota_requestor = true
+  chip_openthread_ftd = false
 
   # Disable lock tracking, since our FreeRTOS configuration does not set
   # INCLUDE_xSemaphoreGetMutexHolder

--- a/examples/persistent-storage/qpg/args.gni
+++ b/examples/persistent-storage/qpg/args.gni
@@ -17,6 +17,7 @@ import("//build_overrides/chip.gni")
 import("${chip_root}/examples/platform/qpg/args.gni")
 qpg_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 chip_enable_openthread = false
+chip_openthread_ftd = false
 chip_system_config_use_open_thread_udp = false
 
 declare_args() {

--- a/examples/platform/qpg/args.gni
+++ b/examples/platform/qpg/args.gni
@@ -17,7 +17,6 @@ import("//build_overrides/chip.gni")
 import("${chip_root}/src/platform/qpg/args.gni")
 
 chip_enable_openthread = true
-chip_openthread_ftd = false
 openthread_project_core_config_file = "OpenThreadConfig.h"
 openthread_core_config_deps = []
 openthread_core_config_deps = [

--- a/examples/shell/qpg/args.gni
+++ b/examples/shell/qpg/args.gni
@@ -25,3 +25,5 @@ chip_build_libshell = true
 # Disable lock tracking, since our FreeRTOS configuration does not set
 # INCLUDE_xSemaphoreGetMutexHolder
 chip_stack_lock_tracking = "none"
+
+chip_openthread_ftd = false


### PR DESCRIPTION
#### Problem
Define chip_openthread_ftd individually for each example app and set lighting app to be FTD.

#### Change overview
GNI file changes to move the definition of chip_openthread_ftd argument from platform level to each example app.

#### Testing
Tested by compiling and running each example app to make sure they set the correct OT role.
