### PR TITLE
Do not check for multicast support when making DNSSD default advertise decisions.

### DIFF
--- a/examples/minimal-mdns/AllInterfaceListener.h
+++ b/examples/minimal-mdns/AllInterfaceListener.h
@@ -95,7 +95,7 @@ private:
             return false; // nothing to try.
         }
 
-        if (!mIterator.IsUp()) {
+        if (!mIterator.IsUp())
         {
             return true; // not a usable interface
         }

--- a/examples/minimal-mdns/AllInterfaceListener.h
+++ b/examples/minimal-mdns/AllInterfaceListener.h
@@ -88,16 +88,6 @@ private:
         }
     }
 
-    template <typename T>
-    inline bool MulticastOk(T & iterator)
-    {
-        return iterator.SupportsMulticast()
-#if INET_CONFIG_ENABLE_IPV4
-            || iterator.HasBroadcastAddress()
-#endif
-            ;
-    }
-
     bool SkipCurrentInterface()
     {
         if (!mIterator.HasCurrent())
@@ -105,7 +95,7 @@ private:
             return false; // nothing to try.
         }
 
-        if (!mIterator.IsUp() || !MulticastOk(mIterator))
+        if (!mIterator.IsUp()) {
         {
             return true; // not a usable interface
         }

--- a/examples/minimal-mdns/AllInterfaceListener.h
+++ b/examples/minimal-mdns/AllInterfaceListener.h
@@ -88,6 +88,16 @@ private:
         }
     }
 
+    template <typename T>
+    inline bool MulticastOk(T & iterator)
+    {
+        return iterator.SupportsMulticast()
+#if INET_CONFIG_ENABLE_IPV4
+            || iterator.HasBroadcastAddress()
+#endif
+            ;
+    }
+
     bool SkipCurrentInterface()
     {
         if (!mIterator.HasCurrent())
@@ -95,7 +105,7 @@ private:
             return false; // nothing to try.
         }
 
-        if (!mIterator.IsUp() || !mIterator.SupportsMulticast())
+        if (!mIterator.IsUp() || !MulticastOk(mIterator))
         {
             return true; // not a usable interface
         }

--- a/src/lib/dnssd/AllInterfacesListenIterator.h
+++ b/src/lib/dnssd/AllInterfacesListenIterator.h
@@ -24,22 +24,12 @@
 namespace chip {
 namespace Dnssd {
 
-template <typename T>
-inline bool MulticastOk(T & iterator)
-{
-    return iterator.SupportsMulticast()
-#if INET_CONFIG_ENABLE_IPV4
-        || iterator.HasBroadcastAddress()
-#endif
-        ;
-}
-
 /// Checks if the current interface is powered on
 /// and not local loopback.
 template <typename T>
 bool IsCurrentInterfaceUsable(T & iterator)
 {
-    if (!iterator.IsUp() || !MulticastOk(iterator))
+    if (!iterator.IsUp())
     {
         return false; // not a usable interface
     }

--- a/src/lib/dnssd/AllInterfacesListenIterator.h
+++ b/src/lib/dnssd/AllInterfacesListenIterator.h
@@ -24,12 +24,22 @@
 namespace chip {
 namespace Dnssd {
 
+template <typename T>
+inline bool MulticastOk(T & iterator)
+{
+    return iterator.SupportsMulticast()
+#if INET_CONFIG_ENABLE_IPV4
+        || iterator.HasBroadcastAddress()
+#endif
+        ;
+}
+
 /// Checks if the current interface is powered on
 /// and not local loopback.
 template <typename T>
 bool IsCurrentInterfaceUsable(T & iterator)
 {
-    if (!iterator.IsUp() || !iterator.SupportsMulticast())
+    if (!iterator.IsUp() || !MulticastOk(iterator))
     {
         return false; // not a usable interface
     }

--- a/src/lib/dnssd/MinimalMdnsServer.h
+++ b/src/lib/dnssd/MinimalMdnsServer.h
@@ -23,12 +23,23 @@ namespace chip {
 namespace Dnssd {
 
 namespace Internal {
+
+template <typename T>
+inline bool MulticastOk(T & iterator)
+{
+    return iterator.SupportsMulticast()
+#if INET_CONFIG_ENABLE_IPV4
+        || iterator.HasBroadcastAddress()
+#endif
+        ;
+}
+
 /// Checks if the current interface is powered on
 /// and not local loopback.
 template <typename T>
 bool IsCurrentInterfaceUsable(T & iterator)
 {
-    if (!iterator.IsUp() || !iterator.SupportsMulticast())
+    if (!iterator.IsUp() || !MulticastOk(iterator))
     {
         return false; // not a usable interface
     }

--- a/src/lib/dnssd/MinimalMdnsServer.h
+++ b/src/lib/dnssd/MinimalMdnsServer.h
@@ -24,22 +24,12 @@ namespace Dnssd {
 
 namespace Internal {
 
-template <typename T>
-inline bool MulticastOk(T & iterator)
-{
-    return iterator.SupportsMulticast()
-#if INET_CONFIG_ENABLE_IPV4
-        || iterator.HasBroadcastAddress()
-#endif
-        ;
-}
-
 /// Checks if the current interface is powered on
 /// and not local loopback.
 template <typename T>
 bool IsCurrentInterfaceUsable(T & iterator)
 {
-    if (!iterator.IsUp() || !MulticastOk(iterator))
+    if (!iterator.IsUp())
     {
         return false; // not a usable interface
     }


### PR DESCRIPTION
#### Problem
mDNS uses multicast, however the flag IFF_MULTICAST does not seem to be always set even if supporting it.
In particular, `tun0` interfaces used in podman (maybe docker too) will support multicast but will not advertise as such.

#### Change overview
Remove the multicast check completely. Our listen options are generally just "report failure" and will cope with partial errors anyway. We seem to want to try harder to work by default instead of being more conservative.


#### Testing
Was able to locally run a test for CHIP-Repl in an environment where IPv6 multicast was not working (due to podman setup which is harder to track down).