### PR TITLE
Fix sleepy device communication by changing when the device is allowed to sleep

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -212,9 +212,11 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnPlatformEvent(const
         if (mDeviceType == ConnectivityManager::kThreadDeviceType_SleepyEndDevice && event->ThreadStateChange.RoleChanged)
         {
             otLinkModeConfig linkMode = otThreadGetLinkMode(mOTInst);
-            linkMode.mRxOnWhenIdle    = (otThreadGetDeviceRole(mOTInst) != OT_DEVICE_ROLE_CHILD); // Allow device to sleep only when it's connected to the thread network
+            linkMode.mRxOnWhenIdle    = (otThreadGetDeviceRole(mOTInst) !=
+                                      OT_DEVICE_ROLE_CHILD); // Allow device to sleep only when it's connected to the thread network
 
-            ChipLogProgress(DeviceLayer, "Role change for sleepy device - %s ", linkMode.mRxOnWhenIdle ? "It CANNOT sleep" : "It CAN sleep");
+            ChipLogProgress(DeviceLayer, "Role change for sleepy device - %s ",
+                            linkMode.mRxOnWhenIdle ? "It CANNOT sleep" : "It CAN sleep");
             otThreadSetLinkMode(mOTInst, linkMode);
         }
 

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -156,6 +156,8 @@ private:
     NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * mpConnectCallback;
     NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
 
+    ConnectivityManager::ThreadDeviceType mDeviceType;
+
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
     ConnectivityManager::SEDPollingConfig mPollingConfig;
     ConnectivityManager::SEDPollingMode mPollingMode = ConnectivityManager::SEDPollingMode::Idle;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -156,7 +156,7 @@ private:
     NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * mpConnectCallback;
     NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
 
-    ConnectivityManager::ThreadDeviceType mDeviceType;
+    ConnectivityManager::ThreadDeviceType mInitialDeviceType;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
     ConnectivityManager::SEDPollingConfig mPollingConfig;


### PR DESCRIPTION
#### Problem
Sleepy devices are configured at boot to be allowed to sleep .
During the commissioning process, once the device receives the thread network configurations, the device can go to sleep and if it does at the wrong moment it will never join the thread network causing the commission to fail.

#### Change overview
Only allow an Openthread SED to go to sleep when it's connected to the Openthread network (CHILD).

#### Testing
* Manual tests with efr32 MG12 and MG24 to confirm that the device can join the thread network and will only go sleep after it has successfully joined the thread network
