### PR TITLE
Use ephemeral ports for chip-tool by default.

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -49,7 +49,13 @@ CHIP_ERROR CHIPCommand::Run()
 
     chip::Controller::FactoryInitParams factoryInitParams;
     factoryInitParams.fabricIndependentStorage = &mDefaultStorage;
-    factoryInitParams.listenPort               = static_cast<uint16_t>(mDefaultStorage.GetListenPort() + CurrentCommissionerId());
+    uint16_t port                              = mDefaultStorage.GetListenPort();
+    if (port != 0)
+    {
+        // Make sure different commissioners run on different ports.
+        port = static_cast<uint16_t>(port + CurrentCommissionerId());
+    }
+    factoryInitParams.listenPort = port;
     ReturnLogErrorOnFailure(DeviceControllerFactory::GetInstance().Init(factoryInitParams));
 
     // TODO(issue #15209): Replace this trust store with file-based trust store

--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -167,9 +167,8 @@ uint16_t PersistentStorage::GetListenPort()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    // By default chip-tool listens on CHIP_PORT + 1. This is done in order to avoid
-    // having 2 servers listening on CHIP_PORT when one runs an accessory server locally.
-    uint16_t chipListenPort = static_cast<uint16_t>(CHIP_PORT + 1);
+    // By default chip-tool listens on an ephemeral port.
+    uint16_t chipListenPort = 0;
 
     char value[6];
     uint16_t size = static_cast<uint16_t>(sizeof(value));


### PR DESCRIPTION
#### Problem
chip-tool uses fixed port numbers.

#### Change overview
Stop doing that.

#### Testing
Verified that I can run two instances of chip-tool using the same fabric in parallel on the same laptop.