### PR TITLE
Do not use CommissioningComplete to signal failsafe timer expired

### DIFF
--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -507,12 +507,6 @@ void DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * event, intptr_t ar
     }
     else if (event->Type == DeviceLayer::DeviceEventType::kCommissioningComplete)
     {
-        if (event->CommissioningComplete.Status != CHIP_NO_ERROR)
-        {
-            ChipLogError(AppServer, "Commissioning is not successfully Complete");
-            return;
-        }
-
         ReturnOnFailure(gTargetVideoPlayerInfo.Initialize(event->CommissioningComplete.PeerNodeId,
                                                           event->CommissioningComplete.PeerFabricIndex));
 

--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -72,8 +72,9 @@ public:
                     DeviceLayer::NetworkCommissioning::ThreadScanResponseIterator * networks) override;
 
 private:
-    static void _OnCommissioningComplete(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
-    void OnCommissioningComplete(CHIP_ERROR err);
+    static void OnPlatformEventHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
+    void OnCommissioningComplete();
+    void OnFailSafeTimerExpired();
 
     const BitFlags<NetworkCommissioningFeature> mFeatureFlags;
 

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -267,12 +267,12 @@ void FailSafeCleanup(const chip::DeviceLayer::ChipDeviceEvent * event)
 {
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Call to FailSafeCleanup");
 
-    FabricIndex fabricIndex = event->CommissioningComplete.PeerFabricIndex;
+    FabricIndex fabricIndex = event->FailSafeTimerExpired.PeerFabricIndex;
 
     // If an AddNOC or UpdateNOC command has been successfully invoked, terminate all CASE sessions associated with the Fabric
     // whose Fabric Index is recorded in the Fail-Safe context (see ArmFailSafe Command) by clearing any associated Secure
     // Session Context at the Server.
-    if (event->CommissioningComplete.AddNocCommandHasBeenInvoked || event->CommissioningComplete.UpdateNocCommandHasBeenInvoked)
+    if (event->FailSafeTimerExpired.AddNocCommandHasBeenInvoked || event->FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked)
     {
         CASESessionManager * caseSessionManager = Server::GetInstance().GetCASESessionManager();
         if (caseSessionManager)
@@ -289,7 +289,7 @@ void FailSafeCleanup(const chip::DeviceLayer::ChipDeviceEvent * event)
     // If an AddNOC command had been successfully invoked, achieve the equivalent effect of invoking the RemoveFabric command
     // against the Fabric Index stored in the Fail-Safe Context for the Fabric Index that was the subject of the AddNOC
     // command.
-    if (event->CommissioningComplete.AddNocCommandHasBeenInvoked)
+    if (event->FailSafeTimerExpired.AddNocCommandHasBeenInvoked)
     {
         Server::GetInstance().GetFabricTable().Delete(fabricIndex);
     }
@@ -297,7 +297,7 @@ void FailSafeCleanup(const chip::DeviceLayer::ChipDeviceEvent * event)
     // If an UpdateNOC command had been successfully invoked, revert the state of operational key pair, NOC and ICAC for that
     // Fabric to the state prior to the Fail-Safe timer being armed, for the Fabric Index that was the subject of the UpdateNOC
     // command.
-    if (event->CommissioningComplete.UpdateNocCommandHasBeenInvoked)
+    if (event->FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked)
     {
         // TODO: Revert the state of operational key pair, NOC and ICAC
     }
@@ -305,12 +305,9 @@ void FailSafeCleanup(const chip::DeviceLayer::ChipDeviceEvent * event)
 
 void OnPlatformEventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
 {
-    if (event->Type == DeviceLayer::DeviceEventType::kCommissioningComplete)
+    if (event->Type == DeviceLayer::DeviceEventType::kFailSafeTimerExpired)
     {
-        if (event->CommissioningComplete.Status != CHIP_NO_ERROR)
-        {
-            FailSafeCleanup(event);
-        }
+        FailSafeCleanup(event);
     }
 }
 

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -55,17 +55,13 @@ void CommissioningWindowManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEv
 {
     if (event->Type == DeviceLayer::DeviceEventType::kCommissioningComplete)
     {
-        if (event->CommissioningComplete.Status == CHIP_NO_ERROR)
-        {
-            ChipLogProgress(AppServer, "Commissioning completed successfully");
-            Cleanup();
-        }
-        else
-        {
-            ChipLogError(AppServer, "Commissioning failed with error %" CHIP_ERROR_FORMAT,
-                         event->CommissioningComplete.Status.Format());
-            OnSessionEstablishmentError(event->CommissioningComplete.Status);
-        }
+        ChipLogProgress(AppServer, "Commissioning completed successfully");
+        Cleanup();
+    }
+    else if (event->Type == DeviceLayer::DeviceEventType::kFailSafeTimerExpired)
+    {
+        ChipLogError(AppServer, "Failsafe timer expired");
+        OnSessionEstablishmentError(CHIP_ERROR_TIMEOUT);
     }
     else if (event->Type == DeviceLayer::DeviceEventType::kOperationalNetworkEnabled)
     {

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -453,6 +453,7 @@ struct ChipDeviceEvent final
         struct
         {
             uint64_t PeerNodeId;
+            FabricIndex PeerFabricIndex;
         } CommissioningComplete;
 
         struct

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -216,9 +216,15 @@ enum PublicEventTypes
     kInterfaceIpAddressChanged,
 
     /**
-     * Commissioning has completed either through timer expiry or by a call to the general commissioning cluster command.
+     * Commissioning has completed by a call to the general commissioning cluster command.
      */
     kCommissioningComplete,
+
+    /**
+     * Signals that the fail-safe timer expires before the CommissioningComplete command is
+     * successfully invoked.
+     */
+    kFailSafeTimerExpired,
 
     /**
      *
@@ -446,12 +452,15 @@ struct ChipDeviceEvent final
 
         struct
         {
-            CHIP_ERROR Status;
             uint64_t PeerNodeId;
+        } CommissioningComplete;
+
+        struct
+        {
             FabricIndex PeerFabricIndex;
             bool AddNocCommandHasBeenInvoked;
             bool UpdateNocCommandHasBeenInvoked;
-        } CommissioningComplete;
+        } FailSafeTimerExpired;
 
         struct
         {

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -221,7 +221,7 @@ enum PublicEventTypes
     kCommissioningComplete,
 
     /**
-     * Signals that the fail-safe timer expires before the CommissioningComplete command is
+     * Signals that the fail-safe timer expired before the CommissioningComplete command was
      * successfully invoked.
      */
     kFailSafeTimerExpired,

--- a/src/include/platform/FailSafeContext.h
+++ b/src/include/platform/FailSafeContext.h
@@ -88,7 +88,7 @@ private:
     // TODO:: Track the state of what was mutated during fail-safe.
 
     static void HandleArmFailSafe(System::Layer * layer, void * aAppState);
-    void CommissioningFailedTimerComplete();
+    void FailSafeTimerExpired();
 };
 
 } // namespace DeviceLayer

--- a/src/platform/DeviceControlServer.cpp
+++ b/src/platform/DeviceControlServer.cpp
@@ -40,12 +40,8 @@ CHIP_ERROR DeviceControlServer::CommissioningComplete(NodeId peerNodeId, FabricI
 
     ChipDeviceEvent event;
 
-    event.Type                                                 = DeviceEventType::kCommissioningComplete;
-    event.CommissioningComplete.PeerNodeId                     = peerNodeId;
-    event.CommissioningComplete.PeerFabricIndex                = accessingFabricIndex;
-    event.CommissioningComplete.AddNocCommandHasBeenInvoked    = mFailSafeContext.AddNocCommandHasBeenInvoked();
-    event.CommissioningComplete.UpdateNocCommandHasBeenInvoked = mFailSafeContext.UpdateNocCommandHasBeenInvoked();
-    event.CommissioningComplete.Status                         = CHIP_NO_ERROR;
+    event.Type                             = DeviceEventType::kCommissioningComplete;
+    event.CommissioningComplete.PeerNodeId = peerNodeId;
 
     return PlatformMgr().PostEvent(&event);
 }

--- a/src/platform/DeviceControlServer.cpp
+++ b/src/platform/DeviceControlServer.cpp
@@ -40,8 +40,9 @@ CHIP_ERROR DeviceControlServer::CommissioningComplete(NodeId peerNodeId, FabricI
 
     ChipDeviceEvent event;
 
-    event.Type                             = DeviceEventType::kCommissioningComplete;
-    event.CommissioningComplete.PeerNodeId = peerNodeId;
+    event.Type                                  = DeviceEventType::kCommissioningComplete;
+    event.CommissioningComplete.PeerNodeId      = peerNodeId;
+    event.CommissioningComplete.PeerFabricIndex = accessingFabricIndex;
 
     return PlatformMgr().PostEvent(&event);
 }

--- a/src/platform/FailSafeContext.cpp
+++ b/src/platform/FailSafeContext.cpp
@@ -30,18 +30,17 @@ namespace DeviceLayer {
 void FailSafeContext::HandleArmFailSafe(System::Layer * layer, void * aAppState)
 {
     FailSafeContext * context = reinterpret_cast<FailSafeContext *>(aAppState);
-    context->CommissioningFailedTimerComplete();
+    context->FailSafeTimerExpired();
 }
 
-void FailSafeContext::CommissioningFailedTimerComplete()
+void FailSafeContext::FailSafeTimerExpired()
 {
     ChipDeviceEvent event;
-    event.Type                                                 = DeviceEventType::kCommissioningComplete;
-    event.CommissioningComplete.PeerFabricIndex                = mFabricIndex;
-    event.CommissioningComplete.AddNocCommandHasBeenInvoked    = mAddNocCommandHasBeenInvoked;
-    event.CommissioningComplete.UpdateNocCommandHasBeenInvoked = mUpdateNocCommandHasBeenInvoked;
-    event.CommissioningComplete.Status                         = CHIP_ERROR_TIMEOUT;
-    CHIP_ERROR status                                          = PlatformMgr().PostEvent(&event);
+    event.Type                                                = DeviceEventType::kFailSafeTimerExpired;
+    event.FailSafeTimerExpired.PeerFabricIndex                = mFabricIndex;
+    event.FailSafeTimerExpired.AddNocCommandHasBeenInvoked    = mAddNocCommandHasBeenInvoked;
+    event.FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked = mUpdateNocCommandHasBeenInvoked;
+    CHIP_ERROR status                                         = PlatformMgr().PostEvent(&event);
 
     mFailSafeArmed                  = false;
     mAddNocCommandHasBeenInvoked    = false;


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently we use CommissioningComplete to indicate both when a commissioning is successfully completed and the FailSafe Timer expired with a CHIP error. This is not right, we should use a dedicated event to convey on what actually happen.

#### Change overview
1. Introduce FailSafeTimerExpired event to signal FailSafeTimer exipred
2. Remove CHIP_ERROR from CommissioningComplete

#### Testing
How was this tested? (at least one bullet point required)
On Server Side:
sudo rm -rf /tmp/chip_*
./chip-all-clusters-app

On Client Side:
sudo rm /tmp/chip_*
./chip-tool pairing onnetwork 12344321 20202021

Commissioning complete without error.
