### PR TITLE
Guard raw/BLE.h usage with CONFIG_NETWORK_LAYER_BLE

### DIFF
--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -39,7 +39,9 @@
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
 #include <transport/TransportMgrBase.h>
+#if CONFIG_NETWORK_LAYER_BLE
 #include <transport/raw/BLE.h>
+#endif
 #include <transport/raw/UDP.h>
 
 namespace chip {


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Guard the include of raw/BLE.h with CONFIG_NETWORK_LAYER_BLE

#### Change overview
Guard the include of raw/BLE.h with CONFIG_NETWORK_LAYER_BLE

#### Testing
How was this tested? (at least one bullet point required)
* Build Matter locally
