### PR TITLE
[Python] Speedup REPL script

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -274,7 +274,7 @@ jobs:
             - name: Run Tests
               timeout-minutes: 30
               run: |
-                    scripts/run_in_build_env.sh './scripts/tests/run_python_test.py --app chip-all-clusters-app --factoryreset -- -t 3600 --disable-test ClusterObjectTests.TestTimedRequestTimeout'
+                    scripts/run_in_build_env.sh './scripts/tests/run_python_test.py --app chip-all-clusters-app --factoryreset --script-args "-t 3600 --disable-test ClusterObjectTests.TestTimedRequestTimeout"'
             - name: Uploading core files
               uses: actions/upload-artifact@v2
               if: ${{ failure() }} && ${{ !env.ACT }}
@@ -356,7 +356,7 @@ jobs:
             - name: Run Tests
               timeout-minutes: 30
               run: |
-                    scripts/run_in_build_env.sh './scripts/tests/run_python_test.py --app chip-all-clusters-app --factoryreset --app-params "--discriminator 3840 --interface-id -1" -- -t 3600 --disable-test ClusterObjectTests.TestTimedRequestTimeout'
+                    scripts/run_in_build_env.sh './scripts/tests/run_python_test.py --app chip-all-clusters-app --factoryreset --app-args "--discriminator 3840 --interface-id -1" --script-args "-t 3600 --disable-test ClusterObjectTests.TestTimedRequestTimeout"'
             - name: Uploading core files
               uses: actions/upload-artifact@v2
               if: ${{ failure() }} && ${{ !env.ACT }}

--- a/docs/guides/matter-repl.md
+++ b/docs/guides/matter-repl.md
@@ -224,16 +224,13 @@ example, you can run:
 It provides some extra options, for example:
 
 ```
-  --app TEXT         Local application to use, omit to use external apps, use
-                     a path for a specific binary or use a filename to search
-                     under the current matter checkout.
-
-  --factoryreset     Remove app config and repl configs (/tmp/chip* and
-                     /tmp/repl*) before running the tests.
-
-  --app-params TEXT  The extra parameters passed to the device.
-  --script PATH      Test script to use.
-  --help             Show this message and exit.
+optional arguments:
+  -h, --help                show this help message and exit
+  --app APP                 Local application to use, omit to use external apps, use a path for a specific binary or use a filename to search under the current matter checkout.
+  --factoryreset            Remove app config and repl configs (/tmp/chip* and /tmp/repl*) before running the tests.
+  --app-args APP_ARGS       The extra parameters passed to the device side app.
+  --script SCRIPT           Test script to use.
+  --script-args SCRIPT_ARGS Arguments for the REPL test script
 ```
 
 You can pass your own flags for mobile-device-test.py by appending them to the


### PR DESCRIPTION
The 'run_python_test' script was taking way too long to startup on my
machine (upwards of 7-8s).

That was because it was using the click package (which takes about 3-4
to start the application) as well as an extensive path search that was
being done to find the absolute path to the test script.

Fixes:

The former is a known issue with click, so shifted it back to well-test
argparse.

The latter was fixed by just deriving a relative path from where the
current script is running from.

Tests:
- Test now starts immediately, saving 7-8s.

