### PR TITLE
Fix Linux example discriminators to default to 3840

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -177,6 +177,24 @@ CHIP_ERROR InitCommissionableDataProvider(LinuxCommissionableDataProvider & prov
         // properly to the commissioner later, PASE will succeed.
     }
 
+    if (options.discriminator.HasValue())
+    {
+        options.payload.discriminator = options.discriminator.Value();
+    }
+    else
+    {
+        uint16_t defaultTestDiscriminator = 0;
+        chip::DeviceLayer::TestOnlyCommissionableDataProvider TestOnlyCommissionableDataProvider;
+        VerifyOrDie(TestOnlyCommissionableDataProvider.GetSetupDiscriminator(defaultTestDiscriminator) == CHIP_NO_ERROR);
+
+        ChipLogError(Support,
+                    "*** WARNING: Using temporary test discriminator %u due to --discriminator not "
+                    "given on command line. This is temporary and will disappear. Please update your scripts "
+                    "to explicitly configure discriminator. ***",
+                    static_cast<unsigned>(defaultTestDiscriminator));
+        options.payload.discriminator = defaultTestDiscriminator;
+    }
+
     // Default to minimum PBKDF iterations
     uint32_t spake2pIterationCount = chip::Crypto::kSpake2p_Min_PBKDF_Iterations;
     if (options.spake2pIterations != 0)

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -188,10 +188,10 @@ CHIP_ERROR InitCommissionableDataProvider(LinuxCommissionableDataProvider & prov
         VerifyOrDie(TestOnlyCommissionableDataProvider.GetSetupDiscriminator(defaultTestDiscriminator) == CHIP_NO_ERROR);
 
         ChipLogError(Support,
-                    "*** WARNING: Using temporary test discriminator %u due to --discriminator not "
-                    "given on command line. This is temporary and will disappear. Please update your scripts "
-                    "to explicitly configure discriminator. ***",
-                    static_cast<unsigned>(defaultTestDiscriminator));
+                     "*** WARNING: Using temporary test discriminator %u due to --discriminator not "
+                     "given on command line. This is temporary and will disappear. Please update your scripts "
+                     "to explicitly configure discriminator. ***",
+                     static_cast<unsigned>(defaultTestDiscriminator));
         options.payload.discriminator = defaultTestDiscriminator;
     }
 

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -239,7 +239,7 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
         }
         else
         {
-            LinuxDeviceOptions::GetInstance().payload.discriminator = value;
+            LinuxDeviceOptions::GetInstance().discriminator.SetValue(value) ;
         }
         break;
     }

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -239,7 +239,7 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
         }
         else
         {
-            LinuxDeviceOptions::GetInstance().discriminator.SetValue(value) ;
+            LinuxDeviceOptions::GetInstance().discriminator.SetValue(value);
         }
         break;
     }

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -36,6 +36,7 @@
 struct LinuxDeviceOptions
 {
     chip::SetupPayload payload;
+    chip::Optional<uint16_t> discriminator;
     chip::Optional<std::vector<uint8_t>> spake2pVerifier;
     chip::Optional<std::vector<uint8_t>> spake2pSalt;
     uint32_t spake2pIterations          = 0; // When not provided (0), will default elsewhere


### PR DESCRIPTION
#### Problem
- Previous change lost the "default" discriminator people
  were using for a long time (3840) from when all-clusters-app
  is run without specifying the discriminator argument.
- All users should always specify a non-default discriminator,
  but bringing back the "default" temporarily to avoid
  issues in test procedures.
- Cert tests and proper usage of testing scripts always explicitly
  set discriminator, so the issue does not arise in CI

#### Change overview
- Make default 3840 again, instead of 0

#### Testing
- Running all-clusters-app with no args uses 3840
- Cert tests pass
