### PR TITLE
[ESP32] Fixed lock-app crash

### DIFF
--- a/examples/lock-app/esp32/main/AppTask.cpp
+++ b/examples/lock-app/esp32/main/AppTask.cpp
@@ -103,7 +103,7 @@ CHIP_ERROR AppTask::Init()
 
     sLockLED.Set(!BoltLockMgr().IsUnlocked());
 
-    UpdateClusterState();
+    chip::DeviceLayer::SystemLayer().ScheduleWork(UpdateClusterState, nullptr);
 
     ConfigurationMgr().LogDeviceConfig();
 
@@ -462,7 +462,7 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
 }
 
 /* if unlocked then it locked it first*/
-void AppTask::UpdateClusterState(void)
+void AppTask::UpdateClusterState(chip::System::Layer *, void * context)
 {
     uint8_t newValue = !BoltLockMgr().IsUnlocked();
 

--- a/examples/lock-app/esp32/main/include/AppTask.h
+++ b/examples/lock-app/esp32/main/include/AppTask.h
@@ -65,7 +65,7 @@ private:
     static void LockActionEventHandler(AppEvent * aEvent);
     static void TimerEventHandler(TimerHandle_t xTimer);
 
-    static void UpdateClusterState(void);
+    static void UpdateClusterState(chip::System::Layer *, void * context);
 
     void StartTimer(uint32_t aTimeoutMs);
 


### PR DESCRIPTION
#### Problem
* ESP32 lock-app was crashing.
* chip stack was locked by some thread.

#### Change overview
Fixed lock-app crash

#### Testing
Manually tested lock-app
