### PR TITLE
[Python] Make some REPL outputs clearer

### DIFF
--- a/docs/guides/repl/Matter - Multi Fabric Commissioning.ipynb
+++ b/docs/guides/repl/Matter - Multi Fabric Commissioning.ipynb
@@ -41,23 +41,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "b351b723-9849-430d-ad4e-f699897416d1",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<subprocess.Popen at 0x109e2b160>"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os, subprocess\n",
     "\n",
@@ -262,14 +251,14 @@
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
        "<span style=\"font-weight: bold\">[</span>\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">chip.FabricAdmin.FabricAdmin</span><span style=\"color: #000000; text-decoration-color: #000000\"> object at </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x10a68dee0</span><span style=\"font-weight: bold\">&gt;</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">chip.FabricAdmin.FabricAdmin</span><span style=\"color: #000000; text-decoration-color: #000000\"> object at </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x7feacf3d1dc0</span><span style=\"font-weight: bold\">&gt;</span>\n",
        "<span style=\"font-weight: bold\">]</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
        "\n",
        "\u001b[1m[\u001b[0m\n",
-       "\u001b[2;32m│   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mchip.FabricAdmin.FabricAdmin\u001b[0m\u001b[39m object at \u001b[0m\u001b[1;36m0x10a68dee0\u001b[0m\u001b[1m>\u001b[0m\n",
+       "\u001b[2;32m│   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mchip.FabricAdmin.FabricAdmin\u001b[0m\u001b[39m object at \u001b[0m\u001b[1;36m0x7feacf3d1dc0\u001b[0m\u001b[1m>\u001b[0m\n",
        "\u001b[1m]\u001b[0m\n"
       ]
      },
@@ -282,6 +271,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e2156fef",
+   "metadata": {},
+   "source": [
+    "You can check the underlying fabric info by typing the name directly in the repl."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "a5c5b564-2d16-4790-8659-a7f7f304df98",
@@ -290,11 +287,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">chip.ChipDeviceCtrl.ChipDeviceController</span><span style=\"color: #000000; text-decoration-color: #000000\"> object at </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x10a6c6040</span><span style=\"font-weight: bold\">&gt;</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">Controller</span><span style=\"color: #000000; text-decoration-color: #000000\"> for Fabric </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0000000000000001</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">(</span><span style=\"color: #000000; text-decoration-color: #000000\">Compressed Fabric Id: b75777b5840b9309</span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">)</span><span style=\"font-weight: bold\">&gt;</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[1m<\u001b[0m\u001b[1;95mchip.ChipDeviceCtrl.ChipDeviceController\u001b[0m\u001b[39m object at \u001b[0m\u001b[1;36m0x10a6c6040\u001b[0m\u001b[1m>\u001b[0m\n"
+       "\u001b[1m<\u001b[0m\u001b[1;95mController\u001b[0m\u001b[39m for Fabric \u001b[0m\u001b[1;36m0000000000000001\u001b[0m\u001b[39m \u001b[0m\u001b[1;39m(\u001b[0m\u001b[39mCompressed Fabric Id: b75777b5840b9309\u001b[0m\u001b[1;39m)\u001b[0m\u001b[1m>\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -325,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "b8b08b57-61a7-4c3e-8acc-cf4d78a67f55",
    "metadata": {},
    "outputs": [],
@@ -367,15 +364,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-01-25 16:59:00 johnsj-macbookpro1.roam.corp.google.com chip.CTL[27921] ERROR Unable to find country code, defaulting to WW\n",
-      "2022-01-25 16:59:00 johnsj-macbookpro1.roam.corp.google.com chip.SC[27921] ERROR The device does not support GetClock_RealTimeMS() API. This will eventually result in CASE session setup failures.\n"
+      "2022-03-21 17:50:16 songguo.sha.corp.google.com chip.CTL[2635279] ERROR Unable to find country code, defaulting to XX\n",
+      "2022-03-21 17:50:16 songguo.sha.corp.google.com chip.DL[2635279] ERROR Avahi resolve found\n",
+      "2022-03-21 17:50:16 songguo.sha.corp.google.com chip.SC[2635279] ERROR The device does not support GetClock_RealTimeMS() API. This will eventually result in CASE session setup failures.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Node address has been updated\n",
       "Commissioning complete\n"
      ]
     },
@@ -409,7 +406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "830e3421-45a6-435f-9617-bbf34f7c3fe0",
    "metadata": {
     "tags": []
@@ -422,14 +419,15 @@
        "<span style=\"font-weight: bold\">{</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>: <span style=\"font-weight: bold\">{</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.clusters.Objects.OperationalCredentials'</span><span style=\"font-weight: bold\">&gt;</span>: <span style=\"font-weight: bold\">{</span>\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.clusters.Objects.OperationalCredentials.Attributes.FabricsList'</span><span style=\"font-weight: bold\">&gt;</span>: <span style=\"font-weight: bold\">[</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.clusters.Attribute.DataVersion'</span><span style=\"font-weight: bold\">&gt;</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2299082310</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.clusters.Objects.OperationalCredentials.Attributes.Fabrics'</span><span style=\"font-weight: bold\">&gt;</span>: <span style=\"font-weight: bold\">[</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">FabricDescriptor</span><span style=\"font-weight: bold\">(</span>\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricIndex</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">rootPublicKey</span>=<span style=\"color: #008000; text-decoration-color: #008000\">b'\\x04\\xa2\\x88}\\xbd\\xdb\\xd4\\xbc^U\\xa3\\xcef\\xf7\\x92\\xbe\\xa7X;E\\xb8-Y\\x12^$\\xe0\\x1bS\\xf9\\x9a\\x8f\\xacvj\\xfa!&amp;m6\\x00\\xe3\\xd1\\x85o\\x1b\\x9eH\\xabC?\\xd8\\xec\\x08lH\\xb5X\\x1f:u\\xb0\\xfbj\\x98'</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">vendorId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">27168</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">rootPublicKey</span>=<span style=\"color: #008000; text-decoration-color: #008000\">b'\\x04\\xba\\x07f\\xa8`\\xfeh\\xefe\\x9eh\\n\\xda\\x93\\xb4nc\\xdb\\xcb\\x89\\xc2x]I\\xaf#\\x8c\\xbc\\xa7~5\\x14$\\xd7h\\x84\\x03\\xf0-,A\\x06\\xcd\\xa0\\xc8\\t\\xca\\xa7!\\x06\\xefc!B`3\\xe9H\\xfa\\xf9\\x97):\\x11'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">vendorId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">28446</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">nodeId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">label</span>=<span style=\"color: #008000; text-decoration-color: #008000\">''</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">label</span>=<span style=\"color: #008000; text-decoration-color: #008000\">''</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricIndex</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"font-weight: bold\">)</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">]</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"font-weight: bold\">}</span>\n",
@@ -442,14 +440,15 @@
        "\u001b[1m{\u001b[0m\n",
        "\u001b[2;32m│   \u001b[0m\u001b[1;36m0\u001b[0m: \u001b[1m{\u001b[0m\n",
        "\u001b[2;32m│   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.clusters.Objects.OperationalCredentials'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1m{\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.clusters.Objects.OperationalCredentials.Attributes.FabricsList'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1m[\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.clusters.Attribute.DataVersion'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1;36m2299082310\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.clusters.Objects.OperationalCredentials.Attributes.Fabrics'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1m[\u001b[0m\n",
        "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;35mFabricDescriptor\u001b[0m\u001b[1m(\u001b[0m\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricIndex\u001b[0m=\u001b[1;36m1\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mrootPublicKey\u001b[0m=\u001b[32mb\u001b[0m\u001b[32m'\\x04\\xa2\\x88\u001b[0m\u001b[32m}\u001b[0m\u001b[32m\\xbd\\xdb\\xd4\\xbc^U\\xa3\\xcef\\xf7\\x92\\xbe\\xa7X;E\\xb8-Y\\x12^$\\xe0\\x1bS\\xf9\\x9a\\x8f\\xacvj\\xfa!&m6\\x00\\xe3\\xd1\\x85o\\x1b\\x9eH\\xabC?\\xd8\\xec\\x08lH\\xb5X\\x1f:u\\xb0\\xfbj\\x98'\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mvendorId\u001b[0m=\u001b[1;36m27168\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mrootPublicKey\u001b[0m=\u001b[32mb\u001b[0m\u001b[32m'\\x04\\xba\\x07f\\xa8`\\xfeh\\xefe\\x9eh\\n\\xda\\x93\\xb4nc\\xdb\\xcb\\x89\\xc2x\u001b[0m\u001b[32m]\u001b[0m\u001b[32mI\\xaf#\\x8c\\xbc\\xa7~5\\x14$\\xd7h\\x84\\x03\\xf0-,A\\x06\\xcd\\xa0\\xc8\\t\\xca\\xa7!\\x06\\xefc!B`3\\xe9H\\xfa\\xf9\\x97\u001b[0m\u001b[32m)\u001b[0m\u001b[32m:\\x11'\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mvendorId\u001b[0m=\u001b[1;36m28446\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricId\u001b[0m=\u001b[1;36m1\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mnodeId\u001b[0m=\u001b[1;36m2\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mlabel\u001b[0m=\u001b[32m''\u001b[0m\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mlabel\u001b[0m=\u001b[32m''\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricIndex\u001b[0m=\u001b[1;36m1\u001b[0m\n",
        "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1m)\u001b[0m\n",
        "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m]\u001b[0m\n",
        "\u001b[2;32m│   │   \u001b[0m\u001b[1m}\u001b[0m\n",
@@ -462,7 +461,7 @@
     }
    ],
    "source": [
-    "await devCtrl.ReadAttribute(2, [(Clusters.OperationalCredentials.Attributes.FabricsList)], fabricFiltered=False)"
+    "await devCtrl.ReadAttribute(2, [(Clusters.OperationalCredentials.Attributes.Fabrics)], fabricFiltered=False)"
    ]
   },
   {
@@ -483,7 +482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "9f7d6810-6d8e-47c9-8795-b4bc8777e963",
    "metadata": {},
    "outputs": [
@@ -510,7 +509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "f211c5be-665b-4630-9570-a44a6f17f358",
    "metadata": {},
    "outputs": [
@@ -530,12 +529,19 @@
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"font-weight: bold\">}</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"font-weight: bold\">}</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"color: #008000; text-decoration-color: #008000\">'sdk-config'</span>: <span style=\"font-weight: bold\">{</span>\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'ExampleOpCredsCAKey1'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'BKKIfb3b1LxeVaPOZveSvqdYO0W4LVkSXiTgG1P5mo+sdmr6ISZtNgDj0YVvG55Iq0M/2OwIbEi1WB86dbD7apgpj13h8fueMKMfErM65jMAsAPBcPEhnVc3JJ6m7K4Qq0ORAwBgAABhAAAAAAAAAA=='</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'ExampleOpCredsICAKey1'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'BCwMgmSo2C1vhjBR642H5nieC/jJManFAW54QhdovJhdySYZn96XJoBNyouhoGf9rn0SipgIhmvHPcPqDrDwcAXiQyB87caIuz5DJ3v7KHHLquGmdv5pNpZ4IhqDomt/2kORAwBgAABhAAAAAAAAAA=='</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'ExampleCAIntermediateCert1'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'MIIB2TCCAYCgAwIBAgIBADAKBggqhkjOPQQDAjBEMSAwHgYKKwYBBAGConwBBAwQMDAwMDAwMDAwMDAwMDAwMDEgMB4GCisGAQQBgqJ8AQUMEDAwMDAwMDAwMDAwMDAwMDEwHhcNMjEwMTAxMDAwMDAwWhcNMzAxMjMwMDAwMDAwWjBEMSAwHgYKKwYBBAGConwBAwwQMDAwMDAwMDAwMDAwMDAwMTEgMB4GCisGAQQBgqJ8AQUMEDAwMDAwMDAwMDAwMDAwMDEwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQsDIJkqNgtb4YwUeuNh+Z4ngv4yTGpxQFueEIXaLyYXckmGZ/elyaATcqLoaBn/a59EoqYCIZrxz3D6g6w8HAFo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUcPz5CkZJujm2U0jL0G1lZwoJXD0wHwYDVR0jBBgwFoAUfvAKJyeJwjao2nq+Q3ayf27KXrUwCgYIKoZIzj0EAwIDRwAwRAIgEaX5gBqc5b8eswqDDlc2IQ+wLKfbsONC3FzsuwLCBNkCIAyn32oaFV0YCN9GeiUpYvqbypnMWQGnffF85v7wKhBX'</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'ExampleCARootCert1'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'MIIB2jCCAYCgAwIBAgIBADAKBggqhkjOPQQDAjBEMSAwHgYKKwYBBAGConwBBAwQMDAwMDAwMDAwMDAwMDAwMDEgMB4GCisGAQQBgqJ8AQUMEDAwMDAwMDAwMDAwMDAwMDEwHhcNMjEwMTAxMDAwMDAwWhcNMzAxMjMwMDAwMDAwWjBEMSAwHgYKKwYBBAGConwBBAwQMDAwMDAwMDAwMDAwMDAwMDEgMB4GCisGAQQBgqJ8AQUMEDAwMDAwMDAwMDAwMDAwMDEwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASiiH2929S8XlWjzmb3kr6nWDtFuC1ZEl4k4BtT+ZqPrHZq+iEmbTYA49GFbxueSKtDP9jsCGxItVgfOnWw+2qYo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUfvAKJyeJwjao2nq+Q3ayf27KXrUwHwYDVR0jBBgwFoAUfvAKJyeJwjao2nq+Q3ayf27KXrUwCgYIKoZIzj0EAwIDSAAwRQIgMzvVbqCxT+xJOpxN9HUSYZYdExmkRLN2Jl9vLijLc+sCIQDAxLgwwuxGNPtWJ/dY4kGqpWwNNbq9pEkmQ//t2KhfBg=='</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'ExampleOpCredsCAKey2'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'BJ1gkAlp0ZrmBkQiko2ces/p86N1qCB30y+tdT5HrWEBqgPh6SVNnZfe5ZMjzJZFp/J1K+7MSDF7QeAgKrQYwcAcV1G9fnqw9anHoj+EW2k9xqw0b4bWXE9f2xKfWWb/ykCSAwBgAABhAAAAAAAAAA=='</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'ExampleOpCredsICAKey2'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'BMktytxSOcWsbMcZ6WrjsODvTRKcLWZjo8bt8CDUqfhoHLFqrmahTQnH4rY8gjRpKRBw/Yw2YpEodcaLyC1V+cC2VvZrLqLVW8uRNPkVxcojVHAXYAGCRp6CW4kQ+zBtNUCSAwBgAABhAAAAAAAAAA=='</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'gcc'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'6AMAAA=='</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'gdc'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'6AMAAA=='</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'ExampleOpCredsCAKey1'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'BLoHZqhg/mjvZZ5oCtqTtG5j28uJwnhdSa8jjLynfjUUJNdohAPwLSxBBs2gyAnKpyEG72MhQmAz6Uj6+ZcpOhEiwYZIs1Zs8jTWTwIfrnpBbKivp6iocOqEF14G0KLoOw=='</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'ExampleOpCredsICAKey1'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'BJDYC+BfoNm9VtxmUwt2UdGbsJvjF6NUMSTW/gdXMr9YwlGNd2WaJ5vTGb9pS4tWPOsCjqsRmhtLVuAWe68jniOjjr64anP1DcFQiSxOsrWmwlghxN4ps6oRdh1+wLIZ/A=='</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'ExampleCAIntermediateCert1'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'MIIBlTCCATygAwIBAgIBADAKBggqhkjOPQQDAjAiMSAwHgYKKwYBBAGConwBBAwQMDAwMDAwMDAwMDAwMDAwMDAeFw0yMTAxMDEwMDAwMDBaFw0zMDEyMzAwMDAwMDBaMCIxIDAeBgorBgEEAYKifAEDDBAwMDAwMDAwMDAwMDAwMDAxMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEkNgL4F+g2b1W3GZTC3ZR0Zuwm+MXo1QxJNb+B1cyv1jCUY13ZZonm9MZv2lLi1Y86wKOqxGaG0tW4BZ7ryOeI6NjMGEwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFPx8CeluC/tiLeUZyboeJHaibmnZMB8GA1UdIwQYMBaAFHV8XorSBpWQpPrTWaniIKzUMQQUMAoGCCqGSM49BAMCA0cAMEQCIDZarzIwBowTlNEEYOG+W2qAiv0+7a8WZrV+4Oj8imfwAiB7uMT2Cu2grqAychG6QGyn9pirJb1ITc6rohp3kcJzZQ=='</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'ExampleCARootCert1'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'MIIBljCCATygAwIBAgIBADAKBggqhkjOPQQDAjAiMSAwHgYKKwYBBAGConwBBAwQMDAwMDAwMDAwMDAwMDAwMDAeFw0yMTAxMDEwMDAwMDBaFw0zMDEyMzAwMDAwMDBaMCIxIDAeBgorBgEEAYKifAEEDBAwMDAwMDAwMDAwMDAwMDAwMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEugdmqGD+aO9lnmgK2pO0bmPby4nCeF1JryOMvKd+NRQk12iEA/AtLEEGzaDICcqnIQbvYyFCYDPpSPr5lyk6EaNjMGEwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFHV8XorSBpWQpPrTWaniIKzUMQQUMB8GA1UdIwQYMBaAFHV8XorSBpWQpPrTWaniIKzUMQQUMAoGCCqGSM49BAMCA0gAMEUCIQDOKet8M81frd8SE9jEKGBoG8fP9EyELJU8rcr7imjFbQIgPPYKXr+qYmLu0UgdwG1gYA4DgwtroeBq08lXLI4vmiA='</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'f/1/r'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'FTABAQAkAgE3AyQUABgmBIAigScmBYAlTTo3BiQUABgkBwEkCAEwCUEEugdmqGD+aO9lnmgK2pO0bmPby4nCeF1JryOMvKd+NRQk12iEA/AtLEEGzaDICcqnIQbvYyFCYDPpSPr5lyk6ETcKNQEpARgkAmAwBBR1fF6K0gaVkKT601mp4iCs1DEEFDAFFHV8XorSBpWQpPrTWaniIKzUMQQUGDALQM4p63wzzV+t3xIT2MQoYGgbx8/0TIQslTytyvuKaMVtPPYKXr+qYmLu0UgdwG1gYA4DgwtroeBq08lXLI4vmiAY'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'f/1/i'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'FTABAQAkAgE3AyQUABgmBIAigScmBYAlTTo3BiQTARgkBwEkCAEwCUEEkNgL4F+g2b1W3GZTC3ZR0Zuwm+MXo1QxJNb+B1cyv1jCUY13ZZonm9MZv2lLi1Y86wKOqxGaG0tW4BZ7ryOeIzcKNQEpARgkAmAwBBT8fAnpbgv7Yi3lGcm6HiR2om5p2TAFFHV8XorSBpWQpPrTWaniIKzUMQQUGDALQDZarzIwBowTlNEEYOG+W2qAiv0+7a8WZrV+4Oj8imfwe7jE9grtoK6gMnIRukBsp/aYqyW9SE3Oq6Iad5HCc2UY'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'f/1/n'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'FTABAQEkAgE3AyQTARgmBIAigScmBYAlTTo3BiQVASQRARgkBwEkCAEwCUEE7H1GfRAQAFIDbiSZ1dtU0Il6MbDWj7BAsn7x7ipBGMTremwb6wHJTgdYOn3TiLQyemtGpVPHSSrT/U0Eu/zXTDcKNQEoARgkAgE2AwQCBAEYMAQUlsEJfINpYHDYm44rs12a69sOI5EwBRT8fAnpbgv7Yi3lGcm6HiR2om5p2RgwC0Cxs6rv3m/CSr/Vvl6nqpjP+/UZlldwCzyTStX0bzxnLduY7WZMo8We5zSzW3y6/DwQ1jgzNKu+hBti1BeHZYCyGA=='</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'f/1/o'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'FSQAATABYQTsfUZ9EBAAUgNuJJnV21TQiXoxsNaPsECyfvHuKkEYxOt6bBvrAclOB1g6fdOItDJ6a0alU8dJKtP9TQS7/NdMMlYH6llXytrjsG6QE8BgxWH1eA1jFzzVpFQVwjbhH7kY'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'f/1/m'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'FSUAHm8sAQAY'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'ExampleOpCredsCAKey2'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'BFXPy14Sye6FHxUEBSC3ZyT5A6V9JA376ysIqynHsvlNhcoVwau6SW+orHgQid3/STqlOx4VbHjtINkkYNyrKlt7VJaWA6n3jSUbGQPIepAyZMy01tRmLtLcuO+r+F9UPw=='</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'ExampleOpCredsICAKey2'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'BMyJDqEcQpKfxOGH3RHaaIPJNTLjAhpvpq2HhCR4Y9tsdx0P6HhsCa5IHKE1qwZ8jgMrVLX+/Jv7vPGQOKDd+OvEs4PtAus9Z7wPohnLLKIjfTrLssJIr+cKR3/dQ24fEg=='</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"font-weight: bold\">}</span>\n",
        "<span style=\"font-weight: bold\">}</span>\n",
        "</pre>\n"
@@ -554,12 +560,19 @@
        "\u001b[2;32m│   │   \u001b[0m\u001b[1m}\u001b[0m\n",
        "\u001b[2;32m│   \u001b[0m\u001b[1m}\u001b[0m,\n",
        "\u001b[2;32m│   \u001b[0m\u001b[32m'sdk-config'\u001b[0m: \u001b[1m{\u001b[0m\n",
-       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'ExampleOpCredsCAKey1'\u001b[0m: \u001b[32m'BKKIfb3b1LxeVaPOZveSvqdYO0W4LVkSXiTgG1P5mo+sdmr6ISZtNgDj0YVvG55Iq0M/2OwIbEi1WB86dbD7apgpj13h8fueMKMf\u001b[0m\u001b[32mErM65jMAsAPBcPEhnVc3JJ6m7K4Qq0ORAwBgAABhAAAAAAAAAA\u001b[0m\u001b[32m=='\u001b[0m,\n",
-       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'ExampleOpCredsICAKey1'\u001b[0m: \u001b[32m'BCwMgmSo2C1vhjBR642H5nieC/jJManFAW54QhdovJhdySYZn96XJoBNyouhoGf9rn0SipgIhmvHPcPqDrDwcAXiQyB87caIuz5DJ3v7KHHLquGmdv5pNpZ4IhqDomt/\u001b[0m\u001b[32m2kORAwBgAABhAAAAAAAAAA\u001b[0m\u001b[32m=='\u001b[0m,\n",
-       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'ExampleCAIntermediateCert1'\u001b[0m: \u001b[32m'MIIB2TCCAYCgAwIBAgIBADAKBggqhkjOPQQDAjBEMSAwHgYKKwYBBAGConwBBAwQMDAwMDAwMDAwMDAwMDAwMDEgMB4GCisGAQQBgqJ8AQUMEDAwMDAwMDAwMDAwMDAwMDEwHhcNMjEwMTAxMDAwMDAwWhcNMzAxMjMwMDAwMDAwWjBEMSAwHgYKKwYBBAGConwBAwwQMDAwMDAwMDAwMDAwMDAwMTEgMB4GCisGAQQBgqJ8AQUMEDAwMDAwMDAwMDAwMDAwMDEwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQsDIJkqNgtb4YwUeuNh+Z4ngv4yTGpxQFueEIXaLyYXckmGZ/elyaATcqLoaBn/a59EoqYCIZrxz3D6g6w8HAFo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUcPz5CkZJujm2U0jL0G1lZwoJXD0wHwYDVR0jBBgwFoAUfvAKJyeJwjao2nq+Q3ayf27KXrUwCgYIKoZIzj0EAwIDRwAwRAIgEaX5gBqc5b8eswqDDlc2IQ+wLKfbsONC3FzsuwLCBNkCIAyn32oaFV0YCN9GeiUpYvqbypnMWQGnffF85v7wKhBX'\u001b[0m,\n",
-       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'ExampleCARootCert1'\u001b[0m: \u001b[32m'MIIB2jCCAYCgAwIBAgIBADAKBggqhkjOPQQDAjBEMSAwHgYKKwYBBAGConwBBAwQMDAwMDAwMDAwMDAwMDAwMDEgMB4GCisGAQQBgqJ8AQUMEDAwMDAwMDAwMDAwMDAwMDEwHhcNMjEwMTAxMDAwMDAwWhcNMzAxMjMwMDAwMDAwWjBEMSAwHgYKKwYBBAGConwBBAwQMDAwMDAwMDAwMDAwMDAwMDEgMB4GCisGAQQBgqJ8AQUMEDAwMDAwMDAwMDAwMDAwMDEwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASiiH2929S8XlWjzmb3kr6nWDtFuC1ZEl4k4BtT+ZqPrHZq+iEmbTYA49GFbxueSKtDP9jsCGxItVgfOnWw+2qYo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUfvAKJyeJwjao2nq+Q3ayf27KXrUwHwYDVR0jBBgwFoAUfvAKJyeJwjao2nq+Q3ayf27KXrUwCgYIKoZIzj0EAwIDSAAwRQIgMzvVbqCxT+xJOpxN9HUSYZYdExmkRLN2Jl9vLijLc+sCIQDAxLgwwuxGNPtWJ/dY4kGqpWwNNbq9pEkmQ//\u001b[0m\u001b[32mt2KhfBg\u001b[0m\u001b[32m=='\u001b[0m,\n",
-       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'ExampleOpCredsCAKey2'\u001b[0m: \u001b[32m'BJ1gkAlp0ZrmBkQiko2ces/p86N1qCB30y+tdT5HrWEBqgPh6SVNnZfe5ZMjzJZFp/J1K+7MSDF7QeAgKrQYwcAcV1G9fnqw9anHoj+EW2k9xqw0b4bWXE9f2xKfWWb/\u001b[0m\u001b[32mykCSAwBgAABhAAAAAAAAAA\u001b[0m\u001b[32m=='\u001b[0m,\n",
-       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'ExampleOpCredsICAKey2'\u001b[0m: \u001b[32m'BMktytxSOcWsbMcZ6WrjsODvTRKcLWZjo8bt8CDUqfhoHLFqrmahTQnH4rY8gjRpKRBw/Yw2YpEodcaLyC1V+cC2VvZrLqLVW8uRNPkVxcojVHAXYAGCRp6CW4kQ+\u001b[0m\u001b[32mzBtNUCSAwBgAABhAAAAAAAAAA\u001b[0m\u001b[32m=='\u001b[0m\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'gcc'\u001b[0m: \u001b[32m'\u001b[0m\u001b[32m6AMAAA\u001b[0m\u001b[32m=='\u001b[0m,\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'gdc'\u001b[0m: \u001b[32m'\u001b[0m\u001b[32m6AMAAA\u001b[0m\u001b[32m=='\u001b[0m,\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'ExampleOpCredsCAKey1'\u001b[0m: \u001b[32m'BLoHZqhg/mjvZZ5oCtqTtG5j28uJwnhdSa8jjLynfjUUJNdohAPwLSxBBs2gyAnKpyEG72MhQmAz6Uj6+\u001b[0m\u001b[32mZcpOhEiwYZIs1Zs8jTWTwIfrnpBbKivp6iocOqEF14G0KLoOw\u001b[0m\u001b[32m=='\u001b[0m,\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'ExampleOpCredsICAKey1'\u001b[0m: \u001b[32m'BJDYC+BfoNm9VtxmUwt2UdGbsJvjF6NUMSTW/gdXMr9YwlGNd2WaJ5vTGb9pS4tWPOsCjqsRmhtLVuAWe68jniOjjr64anP1DcFQiSxOsrWmwlghxN4ps6oRdh1+wLIZ/\u001b[0m\u001b[32mA\u001b[0m\u001b[32m=='\u001b[0m,\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'ExampleCAIntermediateCert1'\u001b[0m: \u001b[32m'MIIBlTCCATygAwIBAgIBADAKBggqhkjOPQQDAjAiMSAwHgYKKwYBBAGConwBBAwQMDAwMDAwMDAwMDAwMDAwMDAeFw0yMTAxMDEwMDAwMDBaFw0zMDEyMzAwMDAwMDBaMCIxIDAeBgorBgEEAYKifAEDDBAwMDAwMDAwMDAwMDAwMDAxMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEkNgL4F+g2b1W3GZTC3ZR0Zuwm+MXo1QxJNb+B1cyv1jCUY13ZZonm9MZv2lLi1Y86wKOqxGaG0tW4BZ7ryOeI6NjMGEwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFPx8CeluC/tiLeUZyboeJHaibmnZMB8GA1UdIwQYMBaAFHV8XorSBpWQpPrTWaniIKzUMQQUMAoGCCqGSM49BAMCA0cAMEQCIDZarzIwBowTlNEEYOG+W2qAiv0+7a8WZrV+4Oj8\u001b[0m\u001b[32mimfwAiB7uMT2Cu2grqAychG6QGyn9pirJb1ITc6rohp3kcJzZQ\u001b[0m\u001b[32m=='\u001b[0m,\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'ExampleCARootCert1'\u001b[0m: \u001b[32m'MIIBljCCATygAwIBAgIBADAKBggqhkjOPQQDAjAiMSAwHgYKKwYBBAGConwBBAwQMDAwMDAwMDAwMDAwMDAwMDAeFw0yMTAxMDEwMDAwMDBaFw0zMDEyMzAwMDAwMDBaMCIxIDAeBgorBgEEAYKifAEEDBAwMDAwMDAwMDAwMDAwMDAwMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEugdmqGD+aO9lnmgK2pO0bmPby4nCeF1JryOMvKd+NRQk12iEA/AtLEEGzaDICcqnIQbvYyFCYDPpSPr5lyk6EaNjMGEwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFHV8XorSBpWQpPrTWaniIKzUMQQUMB8GA1UdIwQYMBaAFHV8XorSBpWQpPrTWaniIKzUMQQUMAoGCCqGSM49BAMCA0gAMEUCIQDOKet8M81frd8SE9jEKGBoG8fP9EyELJU8rcr7imjFbQIgPPYKXr+\u001b[0m\u001b[32mqYmLu0UgdwG1gYA4DgwtroeBq08lXLI4vmiA\u001b[0m\u001b[32m='\u001b[0m,\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'f/1/r'\u001b[0m: \u001b[32m'FTABAQAkAgE3AyQUABgmBIAigScmBYAlTTo3BiQUABgkBwEkCAEwCUEEugdmqGD+aO9lnmgK2pO0bmPby4nCeF1JryOMvKd+NRQk12iEA/AtLEEGzaDICcqnIQbvYyFCYDPpSPr5lyk6ETcKNQEpARgkAmAwBBR1fF6K0gaVkKT601mp4iCs1DEEFDAFFHV8XorSBpWQpPrTWaniIKzUMQQUGDALQM4p63wzzV+t3xIT2MQoYGgbx8/0TIQslTytyvuKaMVtPPYKXr+qYmLu0UgdwG1gYA4DgwtroeBq08lXLI4vmiAY'\u001b[0m,\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'f/1/i'\u001b[0m: \u001b[32m'FTABAQAkAgE3AyQUABgmBIAigScmBYAlTTo3BiQTARgkBwEkCAEwCUEEkNgL4F+g2b1W3GZTC3ZR0Zuwm+MXo1QxJNb+B1cyv1jCUY13ZZonm9MZv2lLi1Y86wKOqxGaG0tW4BZ7ryOeIzcKNQEpARgkAmAwBBT8fAnpbgv7Yi3lGcm6HiR2om5p2TAFFHV8XorSBpWQpPrTWaniIKzUMQQUGDALQDZarzIwBowTlNEEYOG+W2qAiv0+7a8WZrV+4Oj8imfwe7jE9grtoK6gMnIRukBsp/aYqyW9SE3Oq6Iad5HCc2UY'\u001b[0m,\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'f/1/n'\u001b[0m: \u001b[32m'FTABAQEkAgE3AyQTARgmBIAigScmBYAlTTo3BiQVASQRARgkBwEkCAEwCUEE7H1GfRAQAFIDbiSZ1dtU0Il6MbDWj7BAsn7x7ipBGMTremwb6wHJTgdYOn3TiLQyemtGpVPHSSrT/U0Eu/zXTDcKNQEoARgkAgE2AwQCBAEYMAQUlsEJfINpYHDYm44rs12a69sOI5EwBRT8fAnpbgv7Yi3lGcm6HiR2om5p2RgwC0Cxs6rv3m/CSr/Vvl6nqpjP+/UZlldwCzyTStX0bzxnLduY7WZMo8We5zSzW3y6/DwQ1jgzNKu+\u001b[0m\u001b[32mhBti1BeHZYCyGA\u001b[0m\u001b[32m=='\u001b[0m,\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'f/1/o'\u001b[0m: \u001b[32m'FSQAATABYQTsfUZ9EBAAUgNuJJnV21TQiXoxsNaPsECyfvHuKkEYxOt6bBvrAclOB1g6fdOItDJ6a0alU8dJKtP9TQS7/NdMMlYH6llXytrjsG6QE8BgxWH1eA1jFzzVpFQVwjbhH7kY'\u001b[0m,\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'f/1/m'\u001b[0m: \u001b[32m'FSUAHm8sAQAY'\u001b[0m,\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'ExampleOpCredsCAKey2'\u001b[0m: \u001b[32m'BFXPy14Sye6FHxUEBSC3ZyT5A6V9JA376ysIqynHsvlNhcoVwau6SW+orHgQid3/STqlOx4VbHjtINkkYNyrKlt7VJaWA6n3jSUbGQPIepAyZMy01tRmLtLcuO+r+\u001b[0m\u001b[32mF9UPw\u001b[0m\u001b[32m=='\u001b[0m,\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[32m'ExampleOpCredsICAKey2'\u001b[0m: \u001b[32m'BMyJDqEcQpKfxOGH3RHaaIPJNTLjAhpvpq2HhCR4Y9tsdx0P6HhsCa5IHKE1qwZ8jgMrVLX+/Jv7vPGQOKDd+OvEs4PtAus9Z7wPohnLLKIjfTrLssJIr+cKR3/\u001b[0m\u001b[32mdQ24fEg\u001b[0m\u001b[32m=='\u001b[0m\n",
        "\u001b[2;32m│   \u001b[0m\u001b[1m}\u001b[0m\n",
        "\u001b[1m}\u001b[0m\n"
       ]
@@ -574,22 +587,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "15bb2c3e-9051-421c-8769-4a59e4b2fc73",
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-03-21 17:51:28 songguo.sha.corp.google.com chip.DL[2635279] ERROR Cannot set hostname on this system, continue anyway...\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Allocating new controller with FabricId: 2(2), NodeId: 1\n"
+      "Allocating new controller with FabricId: 2(2), NodeId: 2\n"
      ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">Controller</span><span style=\"color: #000000; text-decoration-color: #000000\"> for Fabric </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0000000000000002</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">(</span><span style=\"color: #000000; text-decoration-color: #000000\">Compressed Fabric Id: b68c0efe11caa83c</span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">)</span><span style=\"font-weight: bold\">&gt;</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m<\u001b[0m\u001b[1;95mController\u001b[0m\u001b[39m for Fabric \u001b[0m\u001b[1;36m0000000000000002\u001b[0m\u001b[39m \u001b[0m\u001b[1;39m(\u001b[0m\u001b[39mCompressed Fabric Id: b68c0efe11caa83c\u001b[0m\u001b[1;39m)\u001b[0m\u001b[1m>\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "devCtrl2 = fabric2.NewController()"
+    "devCtrl2 = fabric2.NewController()\n",
+    "devCtrl2"
    ]
   },
   {
@@ -602,17 +636,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "id": "7902ab28-3c74-4717-8522-f6c4a17c5efe",
    "metadata": {},
    "outputs": [],
    "source": [
-    "await devCtrl.SendCommand(2, 0, Clusters.AdministratorCommissioning.Commands.OpenBasicCommissioningWindow(100))"
+    "await devCtrl.SendCommand(2, 0, Clusters.AdministratorCommissioning.Commands.OpenBasicCommissioningWindow(100), timedRequestTimeoutMs=1000)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "1c57c8ff-5ae9-4fdd-9fb8-4eda0e297db2",
    "metadata": {},
    "outputs": [
@@ -628,7 +662,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Node address has been updated\n",
       "Commissioning complete\n"
      ]
     },
@@ -662,7 +695,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "id": "0c087a70-d852-4329-958d-d91a1bdbffaf",
    "metadata": {},
    "outputs": [
@@ -673,22 +706,23 @@
        "<span style=\"font-weight: bold\">{</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>: <span style=\"font-weight: bold\">{</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.clusters.Objects.OperationalCredentials'</span><span style=\"font-weight: bold\">&gt;</span>: <span style=\"font-weight: bold\">{</span>\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.clusters.Objects.OperationalCredentials.Attributes.FabricsList'</span><span style=\"font-weight: bold\">&gt;</span>: <span style=\"font-weight: bold\">[</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.clusters.Attribute.DataVersion'</span><span style=\"font-weight: bold\">&gt;</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2299082327</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.clusters.Objects.OperationalCredentials.Attributes.Fabrics'</span><span style=\"font-weight: bold\">&gt;</span>: <span style=\"font-weight: bold\">[</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">FabricDescriptor</span><span style=\"font-weight: bold\">(</span>\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricIndex</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">rootPublicKey</span>=<span style=\"color: #008000; text-decoration-color: #008000\">b'\\x04\\xa2\\x88}\\xbd\\xdb\\xd4\\xbc^U\\xa3\\xcef\\xf7\\x92\\xbe\\xa7X;E\\xb8-Y\\x12^$\\xe0\\x1bS\\xf9\\x9a\\x8f\\xacvj\\xfa!&amp;m6\\x00\\xe3\\xd1\\x85o\\x1b\\x9eH\\xabC?\\xd8\\xec\\x08lH\\xb5X\\x1f:u\\xb0\\xfbj\\x98'</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">vendorId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">27168</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">rootPublicKey</span>=<span style=\"color: #008000; text-decoration-color: #008000\">b'\\x04\\xba\\x07f\\xa8`\\xfeh\\xefe\\x9eh\\n\\xda\\x93\\xb4nc\\xdb\\xcb\\x89\\xc2x]I\\xaf#\\x8c\\xbc\\xa7~5\\x14$\\xd7h\\x84\\x03\\xf0-,A\\x06\\xcd\\xa0\\xc8\\t\\xca\\xa7!\\x06\\xefc!B`3\\xe9H\\xfa\\xf9\\x97):\\x11'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">vendorId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">28446</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">nodeId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">label</span>=<span style=\"color: #008000; text-decoration-color: #008000\">''</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">label</span>=<span style=\"color: #008000; text-decoration-color: #008000\">''</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricIndex</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"font-weight: bold\">)</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">FabricDescriptor</span><span style=\"font-weight: bold\">(</span>\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricIndex</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">rootPublicKey</span>=<span style=\"color: #008000; text-decoration-color: #008000\">b'\\x04\\x9d`\\x90\\ti\\xd1\\x9a\\xe6\\x06D\"\\x92\\x8d\\x9cz\\xcf\\xe9\\xf3\\xa3u\\xa8 w\\xd3/\\xadu&gt;G\\xada\\x01\\xaa\\x03\\xe1\\xe9%M\\x9d\\x97\\xde\\xe5\\x93#\\xcc\\x96E\\xa7\\xf2u+\\xee\\xccH1{A\\xe0 *\\xb4\\x18\\xc1\\xc0'</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">vendorId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">28544</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">rootPublicKey</span>=<span style=\"color: #008000; text-decoration-color: #008000\">b'\\x04U\\xcf\\xcb^\\x12\\xc9\\xee\\x85\\x1f\\x15\\x04\\x05 \\xb7g$\\xf9\\x03\\xa5}$\\r\\xfb\\xeb+\\x08\\xab)\\xc7\\xb2\\xf9M\\x85\\xca\\x15\\xc1\\xab\\xbaIo\\xa8\\xacx\\x10\\x89\\xdd\\xffI:\\xa5;\\x1e\\x15lx\\xed \\xd9$`\\xdc\\xab*['</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">vendorId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">56886</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">nodeId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">label</span>=<span style=\"color: #008000; text-decoration-color: #008000\">''</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">label</span>=<span style=\"color: #008000; text-decoration-color: #008000\">''</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricIndex</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"font-weight: bold\">)</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">]</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"font-weight: bold\">}</span>\n",
@@ -701,22 +735,23 @@
        "\u001b[1m{\u001b[0m\n",
        "\u001b[2;32m│   \u001b[0m\u001b[1;36m0\u001b[0m: \u001b[1m{\u001b[0m\n",
        "\u001b[2;32m│   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.clusters.Objects.OperationalCredentials'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1m{\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.clusters.Objects.OperationalCredentials.Attributes.FabricsList'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1m[\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.clusters.Attribute.DataVersion'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1;36m2299082327\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.clusters.Objects.OperationalCredentials.Attributes.Fabrics'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1m[\u001b[0m\n",
        "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;35mFabricDescriptor\u001b[0m\u001b[1m(\u001b[0m\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricIndex\u001b[0m=\u001b[1;36m1\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mrootPublicKey\u001b[0m=\u001b[32mb\u001b[0m\u001b[32m'\\x04\\xa2\\x88\u001b[0m\u001b[32m}\u001b[0m\u001b[32m\\xbd\\xdb\\xd4\\xbc^U\\xa3\\xcef\\xf7\\x92\\xbe\\xa7X;E\\xb8-Y\\x12^$\\xe0\\x1bS\\xf9\\x9a\\x8f\\xacvj\\xfa!&m6\\x00\\xe3\\xd1\\x85o\\x1b\\x9eH\\xabC?\\xd8\\xec\\x08lH\\xb5X\\x1f:u\\xb0\\xfbj\\x98'\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mvendorId\u001b[0m=\u001b[1;36m27168\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mrootPublicKey\u001b[0m=\u001b[32mb\u001b[0m\u001b[32m'\\x04\\xba\\x07f\\xa8`\\xfeh\\xefe\\x9eh\\n\\xda\\x93\\xb4nc\\xdb\\xcb\\x89\\xc2x\u001b[0m\u001b[32m]\u001b[0m\u001b[32mI\\xaf#\\x8c\\xbc\\xa7~5\\x14$\\xd7h\\x84\\x03\\xf0-,A\\x06\\xcd\\xa0\\xc8\\t\\xca\\xa7!\\x06\\xefc!B`3\\xe9H\\xfa\\xf9\\x97\u001b[0m\u001b[32m)\u001b[0m\u001b[32m:\\x11'\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mvendorId\u001b[0m=\u001b[1;36m28446\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricId\u001b[0m=\u001b[1;36m1\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mnodeId\u001b[0m=\u001b[1;36m2\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mlabel\u001b[0m=\u001b[32m''\u001b[0m\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mlabel\u001b[0m=\u001b[32m''\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricIndex\u001b[0m=\u001b[1;36m1\u001b[0m\n",
        "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1m)\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;35mFabricDescriptor\u001b[0m\u001b[1m(\u001b[0m\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricIndex\u001b[0m=\u001b[1;36m2\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mrootPublicKey\u001b[0m=\u001b[32mb\u001b[0m\u001b[32m'\\x04\\x9d`\\x90\\ti\\xd1\\x9a\\xe6\\x06D\"\\x92\\x8d\\x9cz\\xcf\\xe9\\xf3\\xa3u\\xa8 w\\xd3/\\xadu>G\\xada\\x01\\xaa\\x03\\xe1\\xe9%M\\x9d\\x97\\xde\\xe5\\x93#\\xcc\\x96E\\xa7\\xf2u+\\xee\\xccH1\u001b[0m\u001b[32m{\u001b[0m\u001b[32mA\\xe0 *\\xb4\\x18\\xc1\\xc0'\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mvendorId\u001b[0m=\u001b[1;36m28544\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mrootPublicKey\u001b[0m=\u001b[32mb\u001b[0m\u001b[32m'\\x04U\\xcf\\xcb^\\x12\\xc9\\xee\\x85\\x1f\\x15\\x04\\x05 \\xb7g$\\xf9\\x03\\xa5\u001b[0m\u001b[32m}\u001b[0m\u001b[32m$\\r\\xfb\\xeb+\\x08\\xab\u001b[0m\u001b[32m)\u001b[0m\u001b[32m\\xc7\\xb2\\xf9M\\x85\\xca\\x15\\xc1\\xab\\xbaIo\\xa8\\xacx\\x10\\x89\\xdd\\xffI:\\xa5;\\x1e\\x15lx\\xed \\xd9$`\\xdc\\xab*\u001b[0m\u001b[32m[\u001b[0m\u001b[32m'\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mvendorId\u001b[0m=\u001b[1;36m56886\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricId\u001b[0m=\u001b[1;36m2\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mnodeId\u001b[0m=\u001b[1;36m2\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mlabel\u001b[0m=\u001b[32m''\u001b[0m\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mlabel\u001b[0m=\u001b[32m''\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricIndex\u001b[0m=\u001b[1;36m2\u001b[0m\n",
        "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1m)\u001b[0m\n",
        "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m]\u001b[0m\n",
        "\u001b[2;32m│   │   \u001b[0m\u001b[1m}\u001b[0m\n",
@@ -729,7 +764,7 @@
     }
    ],
    "source": [
-    "await devCtrl2.ReadAttribute(2, [(Clusters.OperationalCredentials.Attributes.FabricsList)], fabricFiltered=False)"
+    "await devCtrl2.ReadAttribute(2, [(Clusters.OperationalCredentials.Attributes.Fabrics)], fabricFiltered=False)"
    ]
   },
   {
@@ -746,7 +781,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "id": "d44f5ab8-c59f-4fdb-9a26-081f6799c512",
    "metadata": {},
    "outputs": [
@@ -965,25 +1000,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 19,
    "id": "45ee5838-b1e9-4ba8-b804-c3efc9d352d0",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022-01-25 16:59:00 johnsj-macbookpro1.roam.corp.google.com chip.SC[27921] ERROR The device does not support GetClock_RealTimeMS() API. This will eventually result in CASE session setup failures.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Node address has been updated\n",
-      "Established CASE with Device\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -991,22 +1011,23 @@
        "<span style=\"font-weight: bold\">{</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>: <span style=\"font-weight: bold\">{</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.clusters.Objects.OperationalCredentials'</span><span style=\"font-weight: bold\">&gt;</span>: <span style=\"font-weight: bold\">{</span>\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.clusters.Objects.OperationalCredentials.Attributes.FabricsList'</span><span style=\"font-weight: bold\">&gt;</span>: <span style=\"font-weight: bold\">[</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.clusters.Attribute.DataVersion'</span><span style=\"font-weight: bold\">&gt;</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2299082347</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.clusters.Objects.OperationalCredentials.Attributes.Fabrics'</span><span style=\"font-weight: bold\">&gt;</span>: <span style=\"font-weight: bold\">[</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">FabricDescriptor</span><span style=\"font-weight: bold\">(</span>\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricIndex</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">rootPublicKey</span>=<span style=\"color: #008000; text-decoration-color: #008000\">b'\\x04\\xa2\\x88}\\xbd\\xdb\\xd4\\xbc^U\\xa3\\xcef\\xf7\\x92\\xbe\\xa7X;E\\xb8-Y\\x12^$\\xe0\\x1bS\\xf9\\x9a\\x8f\\xacvj\\xfa!&amp;m6\\x00\\xe3\\xd1\\x85o\\x1b\\x9eH\\xabC?\\xd8\\xec\\x08lH\\xb5X\\x1f:u\\xb0\\xfbj\\x98'</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">vendorId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">27168</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">rootPublicKey</span>=<span style=\"color: #008000; text-decoration-color: #008000\">b'\\x04\\xba\\x07f\\xa8`\\xfeh\\xefe\\x9eh\\n\\xda\\x93\\xb4nc\\xdb\\xcb\\x89\\xc2x]I\\xaf#\\x8c\\xbc\\xa7~5\\x14$\\xd7h\\x84\\x03\\xf0-,A\\x06\\xcd\\xa0\\xc8\\t\\xca\\xa7!\\x06\\xefc!B`3\\xe9H\\xfa\\xf9\\x97):\\x11'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">vendorId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">28446</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">nodeId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">label</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Fabric1Label'</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">label</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Fabric1Label'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricIndex</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"font-weight: bold\">)</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">FabricDescriptor</span><span style=\"font-weight: bold\">(</span>\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricIndex</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">rootPublicKey</span>=<span style=\"color: #008000; text-decoration-color: #008000\">b'\\x04\\x9d`\\x90\\ti\\xd1\\x9a\\xe6\\x06D\"\\x92\\x8d\\x9cz\\xcf\\xe9\\xf3\\xa3u\\xa8 w\\xd3/\\xadu&gt;G\\xada\\x01\\xaa\\x03\\xe1\\xe9%M\\x9d\\x97\\xde\\xe5\\x93#\\xcc\\x96E\\xa7\\xf2u+\\xee\\xccH1{A\\xe0 *\\xb4\\x18\\xc1\\xc0'</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">vendorId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">28544</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">rootPublicKey</span>=<span style=\"color: #008000; text-decoration-color: #008000\">b'\\x04U\\xcf\\xcb^\\x12\\xc9\\xee\\x85\\x1f\\x15\\x04\\x05 \\xb7g$\\xf9\\x03\\xa5}$\\r\\xfb\\xeb+\\x08\\xab)\\xc7\\xb2\\xf9M\\x85\\xca\\x15\\xc1\\xab\\xbaIo\\xa8\\xacx\\x10\\x89\\xdd\\xffI:\\xa5;\\x1e\\x15lx\\xed \\xd9$`\\xdc\\xab*['</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">vendorId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">56886</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">nodeId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">label</span>=<span style=\"color: #008000; text-decoration-color: #008000\">''</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">label</span>=<span style=\"color: #008000; text-decoration-color: #008000\">''</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricIndex</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"font-weight: bold\">)</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">]</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"font-weight: bold\">}</span>\n",
@@ -1019,22 +1040,23 @@
        "\u001b[1m{\u001b[0m\n",
        "\u001b[2;32m│   \u001b[0m\u001b[1;36m0\u001b[0m: \u001b[1m{\u001b[0m\n",
        "\u001b[2;32m│   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.clusters.Objects.OperationalCredentials'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1m{\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.clusters.Objects.OperationalCredentials.Attributes.FabricsList'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1m[\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.clusters.Attribute.DataVersion'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1;36m2299082347\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.clusters.Objects.OperationalCredentials.Attributes.Fabrics'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1m[\u001b[0m\n",
        "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;35mFabricDescriptor\u001b[0m\u001b[1m(\u001b[0m\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricIndex\u001b[0m=\u001b[1;36m1\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mrootPublicKey\u001b[0m=\u001b[32mb\u001b[0m\u001b[32m'\\x04\\xa2\\x88\u001b[0m\u001b[32m}\u001b[0m\u001b[32m\\xbd\\xdb\\xd4\\xbc^U\\xa3\\xcef\\xf7\\x92\\xbe\\xa7X;E\\xb8-Y\\x12^$\\xe0\\x1bS\\xf9\\x9a\\x8f\\xacvj\\xfa!&m6\\x00\\xe3\\xd1\\x85o\\x1b\\x9eH\\xabC?\\xd8\\xec\\x08lH\\xb5X\\x1f:u\\xb0\\xfbj\\x98'\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mvendorId\u001b[0m=\u001b[1;36m27168\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mrootPublicKey\u001b[0m=\u001b[32mb\u001b[0m\u001b[32m'\\x04\\xba\\x07f\\xa8`\\xfeh\\xefe\\x9eh\\n\\xda\\x93\\xb4nc\\xdb\\xcb\\x89\\xc2x\u001b[0m\u001b[32m]\u001b[0m\u001b[32mI\\xaf#\\x8c\\xbc\\xa7~5\\x14$\\xd7h\\x84\\x03\\xf0-,A\\x06\\xcd\\xa0\\xc8\\t\\xca\\xa7!\\x06\\xefc!B`3\\xe9H\\xfa\\xf9\\x97\u001b[0m\u001b[32m)\u001b[0m\u001b[32m:\\x11'\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mvendorId\u001b[0m=\u001b[1;36m28446\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricId\u001b[0m=\u001b[1;36m1\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mnodeId\u001b[0m=\u001b[1;36m2\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mlabel\u001b[0m=\u001b[32m'Fabric1Label'\u001b[0m\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mlabel\u001b[0m=\u001b[32m'Fabric1Label'\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricIndex\u001b[0m=\u001b[1;36m1\u001b[0m\n",
        "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1m)\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;35mFabricDescriptor\u001b[0m\u001b[1m(\u001b[0m\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricIndex\u001b[0m=\u001b[1;36m2\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mrootPublicKey\u001b[0m=\u001b[32mb\u001b[0m\u001b[32m'\\x04\\x9d`\\x90\\ti\\xd1\\x9a\\xe6\\x06D\"\\x92\\x8d\\x9cz\\xcf\\xe9\\xf3\\xa3u\\xa8 w\\xd3/\\xadu>G\\xada\\x01\\xaa\\x03\\xe1\\xe9%M\\x9d\\x97\\xde\\xe5\\x93#\\xcc\\x96E\\xa7\\xf2u+\\xee\\xccH1\u001b[0m\u001b[32m{\u001b[0m\u001b[32mA\\xe0 *\\xb4\\x18\\xc1\\xc0'\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mvendorId\u001b[0m=\u001b[1;36m28544\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mrootPublicKey\u001b[0m=\u001b[32mb\u001b[0m\u001b[32m'\\x04U\\xcf\\xcb^\\x12\\xc9\\xee\\x85\\x1f\\x15\\x04\\x05 \\xb7g$\\xf9\\x03\\xa5\u001b[0m\u001b[32m}\u001b[0m\u001b[32m$\\r\\xfb\\xeb+\\x08\\xab\u001b[0m\u001b[32m)\u001b[0m\u001b[32m\\xc7\\xb2\\xf9M\\x85\\xca\\x15\\xc1\\xab\\xbaIo\\xa8\\xacx\\x10\\x89\\xdd\\xffI:\\xa5;\\x1e\\x15lx\\xed \\xd9$`\\xdc\\xab*\u001b[0m\u001b[32m[\u001b[0m\u001b[32m'\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mvendorId\u001b[0m=\u001b[1;36m56886\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricId\u001b[0m=\u001b[1;36m2\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mnodeId\u001b[0m=\u001b[1;36m2\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mlabel\u001b[0m=\u001b[32m''\u001b[0m\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mlabel\u001b[0m=\u001b[32m''\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricIndex\u001b[0m=\u001b[1;36m2\u001b[0m\n",
        "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1m)\u001b[0m\n",
        "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m]\u001b[0m\n",
        "\u001b[2;32m│   │   \u001b[0m\u001b[1m}\u001b[0m\n",
@@ -1048,7 +1070,7 @@
    ],
    "source": [
     "await devCtrl.SendCommand(2, 0, Clusters.OperationalCredentials.Commands.UpdateFabricLabel(\"Fabric1Label\"))\n",
-    "await devCtrl.ReadAttribute(2, [(Clusters.OperationalCredentials.Attributes.FabricsList)], fabricFiltered=False)"
+    "await devCtrl.ReadAttribute(2, [(Clusters.OperationalCredentials.Attributes.Fabrics)], fabricFiltered=False)"
    ]
   },
   {
@@ -1063,7 +1085,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 22,
    "id": "5d88cb17-bdda-418f-94ca-83d746c162b0",
    "metadata": {},
    "outputs": [
@@ -1071,16 +1093,22 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-01-25 16:59:00 johnsj-macbookpro1.roam.corp.google.com chip.SC[27921] ERROR The device does not support GetClock_RealTimeMS() API. This will eventually result in CASE session setup failures.\n"
+      "2022-03-21 17:53:10 songguo.sha.corp.google.com chip.DL[2635279] ERROR Cannot set hostname on this system, continue anyway...\n",
+      "2022-03-21 17:53:10 songguo.sha.corp.google.com chip.DL[2635279] ERROR Avahi resolve found\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Allocating new controller with FabricId: 2(2), NodeId: 1\n",
-      "Node address has been updated\n",
-      "Established CASE with Device\n"
+      "Allocating new controller with FabricId: 2(2), NodeId: 2\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-03-21 17:53:10 songguo.sha.corp.google.com chip.SC[2635279] ERROR The device does not support GetClock_RealTimeMS() API. This will eventually result in CASE session setup failures.\n"
      ]
     },
     {
@@ -1090,22 +1118,23 @@
        "<span style=\"font-weight: bold\">{</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>: <span style=\"font-weight: bold\">{</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.clusters.Objects.OperationalCredentials'</span><span style=\"font-weight: bold\">&gt;</span>: <span style=\"font-weight: bold\">{</span>\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.clusters.Objects.OperationalCredentials.Attributes.FabricsList'</span><span style=\"font-weight: bold\">&gt;</span>: <span style=\"font-weight: bold\">[</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.clusters.Attribute.DataVersion'</span><span style=\"font-weight: bold\">&gt;</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2299082367</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.clusters.Objects.OperationalCredentials.Attributes.Fabrics'</span><span style=\"font-weight: bold\">&gt;</span>: <span style=\"font-weight: bold\">[</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">FabricDescriptor</span><span style=\"font-weight: bold\">(</span>\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricIndex</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">rootPublicKey</span>=<span style=\"color: #008000; text-decoration-color: #008000\">b'\\x04\\xa2\\x88}\\xbd\\xdb\\xd4\\xbc^U\\xa3\\xcef\\xf7\\x92\\xbe\\xa7X;E\\xb8-Y\\x12^$\\xe0\\x1bS\\xf9\\x9a\\x8f\\xacvj\\xfa!&amp;m6\\x00\\xe3\\xd1\\x85o\\x1b\\x9eH\\xabC?\\xd8\\xec\\x08lH\\xb5X\\x1f:u\\xb0\\xfbj\\x98'</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">vendorId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">27168</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">rootPublicKey</span>=<span style=\"color: #008000; text-decoration-color: #008000\">b'\\x04\\xba\\x07f\\xa8`\\xfeh\\xefe\\x9eh\\n\\xda\\x93\\xb4nc\\xdb\\xcb\\x89\\xc2x]I\\xaf#\\x8c\\xbc\\xa7~5\\x14$\\xd7h\\x84\\x03\\xf0-,A\\x06\\xcd\\xa0\\xc8\\t\\xca\\xa7!\\x06\\xefc!B`3\\xe9H\\xfa\\xf9\\x97):\\x11'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">vendorId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">28446</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">nodeId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">label</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Fabric1Label'</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">label</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Fabric1Label'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricIndex</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"font-weight: bold\">)</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">FabricDescriptor</span><span style=\"font-weight: bold\">(</span>\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricIndex</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">rootPublicKey</span>=<span style=\"color: #008000; text-decoration-color: #008000\">b'\\x04\\x9d`\\x90\\ti\\xd1\\x9a\\xe6\\x06D\"\\x92\\x8d\\x9cz\\xcf\\xe9\\xf3\\xa3u\\xa8 w\\xd3/\\xadu&gt;G\\xada\\x01\\xaa\\x03\\xe1\\xe9%M\\x9d\\x97\\xde\\xe5\\x93#\\xcc\\x96E\\xa7\\xf2u+\\xee\\xccH1{A\\xe0 *\\xb4\\x18\\xc1\\xc0'</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">vendorId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">28544</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">rootPublicKey</span>=<span style=\"color: #008000; text-decoration-color: #008000\">b'\\x04U\\xcf\\xcb^\\x12\\xc9\\xee\\x85\\x1f\\x15\\x04\\x05 \\xb7g$\\xf9\\x03\\xa5}$\\r\\xfb\\xeb+\\x08\\xab)\\xc7\\xb2\\xf9M\\x85\\xca\\x15\\xc1\\xab\\xbaIo\\xa8\\xacx\\x10\\x89\\xdd\\xffI:\\xa5;\\x1e\\x15lx\\xed \\xd9$`\\xdc\\xab*['</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">vendorId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">56886</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">nodeId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">label</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Fabric2Label'</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">label</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Fabric2Label'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">fabricIndex</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"font-weight: bold\">)</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">]</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"font-weight: bold\">}</span>\n",
@@ -1118,22 +1147,23 @@
        "\u001b[1m{\u001b[0m\n",
        "\u001b[2;32m│   \u001b[0m\u001b[1;36m0\u001b[0m: \u001b[1m{\u001b[0m\n",
        "\u001b[2;32m│   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.clusters.Objects.OperationalCredentials'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1m{\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.clusters.Objects.OperationalCredentials.Attributes.FabricsList'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1m[\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.clusters.Attribute.DataVersion'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1;36m2299082367\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.clusters.Objects.OperationalCredentials.Attributes.Fabrics'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1m[\u001b[0m\n",
        "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;35mFabricDescriptor\u001b[0m\u001b[1m(\u001b[0m\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricIndex\u001b[0m=\u001b[1;36m1\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mrootPublicKey\u001b[0m=\u001b[32mb\u001b[0m\u001b[32m'\\x04\\xa2\\x88\u001b[0m\u001b[32m}\u001b[0m\u001b[32m\\xbd\\xdb\\xd4\\xbc^U\\xa3\\xcef\\xf7\\x92\\xbe\\xa7X;E\\xb8-Y\\x12^$\\xe0\\x1bS\\xf9\\x9a\\x8f\\xacvj\\xfa!&m6\\x00\\xe3\\xd1\\x85o\\x1b\\x9eH\\xabC?\\xd8\\xec\\x08lH\\xb5X\\x1f:u\\xb0\\xfbj\\x98'\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mvendorId\u001b[0m=\u001b[1;36m27168\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mrootPublicKey\u001b[0m=\u001b[32mb\u001b[0m\u001b[32m'\\x04\\xba\\x07f\\xa8`\\xfeh\\xefe\\x9eh\\n\\xda\\x93\\xb4nc\\xdb\\xcb\\x89\\xc2x\u001b[0m\u001b[32m]\u001b[0m\u001b[32mI\\xaf#\\x8c\\xbc\\xa7~5\\x14$\\xd7h\\x84\\x03\\xf0-,A\\x06\\xcd\\xa0\\xc8\\t\\xca\\xa7!\\x06\\xefc!B`3\\xe9H\\xfa\\xf9\\x97\u001b[0m\u001b[32m)\u001b[0m\u001b[32m:\\x11'\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mvendorId\u001b[0m=\u001b[1;36m28446\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricId\u001b[0m=\u001b[1;36m1\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mnodeId\u001b[0m=\u001b[1;36m2\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mlabel\u001b[0m=\u001b[32m'Fabric1Label'\u001b[0m\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mlabel\u001b[0m=\u001b[32m'Fabric1Label'\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricIndex\u001b[0m=\u001b[1;36m1\u001b[0m\n",
        "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1m)\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;35mFabricDescriptor\u001b[0m\u001b[1m(\u001b[0m\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricIndex\u001b[0m=\u001b[1;36m2\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mrootPublicKey\u001b[0m=\u001b[32mb\u001b[0m\u001b[32m'\\x04\\x9d`\\x90\\ti\\xd1\\x9a\\xe6\\x06D\"\\x92\\x8d\\x9cz\\xcf\\xe9\\xf3\\xa3u\\xa8 w\\xd3/\\xadu>G\\xada\\x01\\xaa\\x03\\xe1\\xe9%M\\x9d\\x97\\xde\\xe5\\x93#\\xcc\\x96E\\xa7\\xf2u+\\xee\\xccH1\u001b[0m\u001b[32m{\u001b[0m\u001b[32mA\\xe0 *\\xb4\\x18\\xc1\\xc0'\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mvendorId\u001b[0m=\u001b[1;36m28544\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mrootPublicKey\u001b[0m=\u001b[32mb\u001b[0m\u001b[32m'\\x04U\\xcf\\xcb^\\x12\\xc9\\xee\\x85\\x1f\\x15\\x04\\x05 \\xb7g$\\xf9\\x03\\xa5\u001b[0m\u001b[32m}\u001b[0m\u001b[32m$\\r\\xfb\\xeb+\\x08\\xab\u001b[0m\u001b[32m)\u001b[0m\u001b[32m\\xc7\\xb2\\xf9M\\x85\\xca\\x15\\xc1\\xab\\xbaIo\\xa8\\xacx\\x10\\x89\\xdd\\xffI:\\xa5;\\x1e\\x15lx\\xed \\xd9$`\\xdc\\xab*\u001b[0m\u001b[32m[\u001b[0m\u001b[32m'\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mvendorId\u001b[0m=\u001b[1;36m56886\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricId\u001b[0m=\u001b[1;36m2\u001b[0m,\n",
        "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mnodeId\u001b[0m=\u001b[1;36m2\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mlabel\u001b[0m=\u001b[32m'Fabric2Label'\u001b[0m\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mlabel\u001b[0m=\u001b[32m'Fabric2Label'\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   │   \u001b[0m\u001b[33mfabricIndex\u001b[0m=\u001b[1;36m2\u001b[0m\n",
        "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1m)\u001b[0m\n",
        "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m]\u001b[0m\n",
        "\u001b[2;32m│   │   \u001b[0m\u001b[1m}\u001b[0m\n",
@@ -1148,12 +1178,12 @@
    "source": [
     "devCtrl2 = fabricAdmins[1].NewController()\n",
     "await devCtrl2.SendCommand(2, 0, Clusters.OperationalCredentials.Commands.UpdateFabricLabel(\"Fabric2Label\"))\n",
-    "await devCtrl2.ReadAttribute(2, [(Clusters.OperationalCredentials.Attributes.FabricsList)], fabricFiltered=False)"
+    "await devCtrl2.ReadAttribute(2, [(Clusters.OperationalCredentials.Attributes.Fabrics)], fabricFiltered=False)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 21,
    "id": "4ecb4ab4-bb7a-4941-8080-34783028fce0",
    "metadata": {},
    "outputs": [],
@@ -1166,7 +1196,7 @@
   "kernelspec": {
    "display_name": "matter-env",
    "language": "python",
-   "name": "matter-env"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1178,7 +1208,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2+chromium.10"
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,

--- a/docs/guides/repl/Matter - REPL Intro.ipynb
+++ b/docs/guides/repl/Matter - REPL Intro.ipynb
@@ -143,26 +143,6 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #af00ff; text-decoration-color: #af00ff\">Restoring FabricAdmin from storage to manage FabricId </span><span style=\"color: #af00ff; text-decoration-color: #af00ff; font-weight: bold\">2</span><span style=\"color: #af00ff; text-decoration-color: #af00ff\">, FabricIndex </span><span style=\"color: #af00ff; text-decoration-color: #af00ff; font-weight: bold\">2</span><span style=\"color: #af00ff; text-decoration-color: #af00ff\">...</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[38;5;129mRestoring FabricAdmin from storage to manage FabricId \u001b[0m\u001b[1;38;5;129m2\u001b[0m\u001b[38;5;129m, FabricIndex \u001b[0m\u001b[1;38;5;129m2\u001b[0m\u001b[38;5;129m...\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "New FabricAdmin: FabricId: 2(2)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">Fabric Admins have been loaded and are available at </span><span style=\"color: #800000; text-decoration-color: #800000\">fabricAdmins</span>\n",
        "</pre>\n"
@@ -456,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "b36f41dd-d5e2-447e-a9a4-f1eab7d92bec",
    "metadata": {
     "scrolled": true,
@@ -468,25 +448,31 @@
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #000080; text-decoration-color: #000080\">╭─────────────────── </span><span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'chip.ChipDeviceCtrl.ChipDeviceController'</span><span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">&gt;</span><span style=\"color: #000080; text-decoration-color: #000080\"> ────────────────────╮</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> <span style=\"color: #008000; text-decoration-color: #008000\">╭───────────────────────────────────────────────────────────────────────────────────────╮</span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> <span style=\"color: #008000; text-decoration-color: #008000\">│</span> <span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">chip.ChipDeviceCtrl.ChipDeviceController</span><span style=\"color: #000000; text-decoration-color: #000000\"> object at </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x1143b3910</span><span style=\"font-weight: bold\">&gt;</span>                      <span style=\"color: #008000; text-decoration-color: #008000\">│</span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> <span style=\"color: #008000; text-decoration-color: #008000\">│</span> <span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">Controller</span><span style=\"color: #000000; text-decoration-color: #000000\"> for Fabric </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0000000000000001</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">(</span><span style=\"color: #000000; text-decoration-color: #000000\">Compressed Fabric Id: 3b98917fa01213cf</span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">)</span><span style=\"font-weight: bold\">&gt;</span>     <span style=\"color: #008000; text-decoration-color: #008000\">│</span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> <span style=\"color: #008000; text-decoration-color: #008000\">╰───────────────────────────────────────────────────────────────────────────────────────╯</span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                                                                           <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">activeList</span> = <span style=\"font-weight: bold\">{</span>                                             <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                                 <span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">chip.ChipDeviceCtrl.ChipDeviceController</span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #000000; text-decoration-color: #000000\">object at </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x1143b3910</span><span style=\"font-weight: bold\">&gt;</span>                        <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                                 <span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">Controller</span><span style=\"color: #000000; text-decoration-color: #000000\"> for Fabric </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0000000000000001</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span>  <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">(</span><span style=\"color: #000000; text-decoration-color: #000000\">Compressed Fabric Id: 3b98917fa01213cf</span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">)</span><span style=\"font-weight: bold\">&gt;</span>     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"font-weight: bold\">}</span>                                             <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                   <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">devCtrl</span> = <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">c_void_p</span><span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">140320379576320</span><span style=\"font-weight: bold\">)</span>                     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                   <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">devCtrl</span> = <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">c_void_p</span><span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">140655615556032</span><span style=\"font-weight: bold\">)</span>                     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                  <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">isActive</span> = <span style=\"color: #00ff00; text-decoration-color: #00ff00; font-style: italic\">True</span>                                          <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                     <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">state</span> = <span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">DCState.IDLE:</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span><span style=\"font-weight: bold\">&gt;</span>                             <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>        <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">cbHandleCommissioningCompleteFunct</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">cbHandleCommissioningCompleteFunct</span><span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">...</span><span style=\"font-weight: bold\">)</span>   <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>          <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">cbHandleKeyExchangeCompleteFunct</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">cbHandleKeyExchangeCompleteFunct</span><span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">...</span><span style=\"font-weight: bold\">)</span>     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                 <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">cbOnAddressUpdateComplete</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">cbOnAddressUpdateComplete</span><span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">...</span><span style=\"font-weight: bold\">)</span>            <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                             <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">CheckIsActive</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">CheckIsActive</span><span style=\"font-weight: bold\">()</span>:                          <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                        <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">CloseBLEConnection</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">CloseBLEConnection</span><span style=\"font-weight: bold\">()</span>:                     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                              <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">CloseSession</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">CloseSession</span><span style=\"font-weight: bold\">(</span>nodeid<span style=\"font-weight: bold\">)</span>:                     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">Commission</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">Commission</span><span style=\"font-weight: bold\">(</span>nodeid<span style=\"font-weight: bold\">)</span>:                       <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                              <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">CommissionIP</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">CommissionIP</span><span style=\"font-weight: bold\">(</span>ipaddr, setupPinCode,        <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             nodeid<span style=\"font-weight: bold\">)</span>:                                      <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                          <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">CommissionThread</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">CommissionThread</span><span style=\"font-weight: bold\">(</span>discriminator,           <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             setupPinCode, nodeId,                         <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             threadOperationalDataset: bytes<span style=\"font-weight: bold\">)</span>: <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Commissions</span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">a Thread device over BLE</span>                      <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                            <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">CommissionWiFi</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">CommissionWiFi</span><span style=\"font-weight: bold\">(</span>discriminator,             <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             setupPinCode, nodeId, ssid, credentials<span style=\"font-weight: bold\">)</span>:     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Commissions a WiFi device over BLE</span>            <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">ConnectBLE</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">ConnectBLE</span><span style=\"font-weight: bold\">(</span>discriminator, setupPinCode,   <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             nodeid<span style=\"font-weight: bold\">)</span>:                                      <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">ConnectBle</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">ConnectBle</span><span style=\"font-weight: bold\">(</span>bleConnection<span style=\"font-weight: bold\">)</span>:                <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
@@ -511,6 +497,7 @@
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                  <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">GetIPForDiscoveredDevice</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">GetIPForDiscoveredDevice</span><span style=\"font-weight: bold\">(</span>idx, addrStr,    <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             length<span style=\"font-weight: bold\">)</span>:                                      <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                              <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">GetLogFilter</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">GetLogFilter</span><span style=\"font-weight: bold\">()</span>:                           <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                   <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">GetTestCommissionerUsed</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">GetTestCommissionerUsed</span><span style=\"font-weight: bold\">()</span>:                <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                               <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">IsConnected</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">IsConnected</span><span style=\"font-weight: bold\">()</span>:                            <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                   <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">OpenCommissioningWindow</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">OpenCommissioningWindow</span><span style=\"font-weight: bold\">(</span>nodeid, timeout,  <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             iteration, discriminator, option<span style=\"font-weight: bold\">)</span>:            <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
@@ -524,9 +511,11 @@
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             Type<span style=\"font-weight: bold\">[</span>chip.clusters.ClusterObjects.Cluster<span style=\"font-weight: bold\">]]</span>,  <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             Tuple<span style=\"font-weight: bold\">[</span>int,                                    <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             Type<span style=\"font-weight: bold\">[</span>chip.clusters.ClusterObjects.ClusterAtt… <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             returnClusterObject: bool = <span style=\"color: #ff0000; text-decoration-color: #ff0000; font-style: italic\">False</span>,            <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             reportInterval: Tuple<span style=\"font-weight: bold\">[</span>int, int<span style=\"font-weight: bold\">]</span> = <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>,       <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             fabricFiltered: bool = <span style=\"color: #00ff00; text-decoration-color: #00ff00; font-style: italic\">True</span><span style=\"font-weight: bold\">)</span>:                 <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             dataVersionFilters: List<span style=\"font-weight: bold\">[</span>Tuple<span style=\"font-weight: bold\">[</span>int,           <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             Type<span style=\"font-weight: bold\">[</span>chip.clusters.ClusterObjects.Cluster<span style=\"font-weight: bold\">]</span>,   <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             int<span style=\"font-weight: bold\">]]</span> = <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>, returnClusterObject: bool =     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #ff0000; text-decoration-color: #ff0000; font-style: italic\">False</span>, reportInterval: Tuple<span style=\"font-weight: bold\">[</span>int, int<span style=\"font-weight: bold\">]</span> =      <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>, fabricFiltered: bool = <span style=\"color: #00ff00; text-decoration-color: #00ff00; font-style: italic\">True</span><span style=\"font-weight: bold\">)</span>:           <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Read a list of attributes from a target node</span>  <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                                                                           <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">nodeId: Target's Node ID</span>                      <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
@@ -577,38 +566,42 @@
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    When not provided, a read request will be</span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">sent.</span>                                         <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                 <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">ReadEvent</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">ReadEvent</span><span style=\"font-weight: bold\">(</span>nodeid: int, events:            <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             List<span style=\"font-weight: bold\">[</span>Union<span style=\"font-weight: bold\">[</span>NoneType, Tuple<span style=\"font-weight: bold\">[</span>int<span style=\"font-weight: bold\">]</span>,              <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             List<span style=\"font-weight: bold\">[</span>Union<span style=\"font-weight: bold\">[</span>NoneType, Tuple<span style=\"font-weight: bold\">[</span>str, int<span style=\"font-weight: bold\">]</span>,         <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             Tuple<span style=\"font-weight: bold\">[</span>int, int<span style=\"font-weight: bold\">]</span>,                              <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             Tuple<span style=\"font-weight: bold\">[</span>Type<span style=\"font-weight: bold\">[</span>chip.clusters.ClusterObjects.Clus… <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             int<span style=\"font-weight: bold\">]</span>,                                         <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             Tuple<span style=\"font-weight: bold\">[</span>Type<span style=\"font-weight: bold\">[</span>chip.clusters.ClusterObjects.Clus… <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             Tuple<span style=\"font-weight: bold\">[</span>int,                                    <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             Type<span style=\"font-weight: bold\">[</span>chip.clusters.ClusterObjects.Cluster<span style=\"font-weight: bold\">]]</span>,  <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             Tuple<span style=\"font-weight: bold\">[</span>int,                                    <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             int<span style=\"font-weight: bold\">]</span>, Tuple<span style=\"font-weight: bold\">[</span>int,                              <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             Type<span style=\"font-weight: bold\">[</span>chip.clusters.ClusterObjects.Cluster<span style=\"font-weight: bold\">]</span>,   <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             int<span style=\"font-weight: bold\">]</span>, Tuple<span style=\"font-weight: bold\">[</span>int,                              <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             Type<span style=\"font-weight: bold\">[</span>chip.clusters.ClusterObjects.ClusterEve… <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             reportInterval: Tuple<span style=\"font-weight: bold\">[</span>int, int<span style=\"font-weight: bold\">]</span> = <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span><span style=\"font-weight: bold\">)</span>:      <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             int<span style=\"font-weight: bold\">]]]</span>, reportInterval: Tuple<span style=\"font-weight: bold\">[</span>int, int<span style=\"font-weight: bold\">]</span> =     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span><span style=\"font-weight: bold\">)</span>:                                        <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Read a list of events from a target node</span>      <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                                                                           <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">nodeId: Target's Node ID</span>                      <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">events: A list of tuples of varying types </span>    <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">depending on the type of read being </span>          <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">requested:</span>                                    <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">(</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">endpoint, Clusters.ClusterA.EventA</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">)</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:    </span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">(</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">endpoint, Clusters.ClusterA.EventA, </span>     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">urgent</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">)</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:       Endpoint = specific,    </span>       <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Cluster = specific,   Event = specific, </span>      <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Urgent = </span><span style=\"color: #7fff7f; text-decoration-color: #7fff7f; font-style: italic\">True</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">/</span><span style=\"color: #ff7f7f; text-decoration-color: #ff7f7f; font-style: italic\">False</span>                           <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">(</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">endpoint, Clusters.ClusterA, urgent</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">)</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:   </span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Endpoint = specific,    Cluster = specific,  </span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Event = specific</span>                              <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">(</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">endpoint, Clusters.ClusterA</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">)</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:           </span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Endpoint = specific,    Cluster = specific,  </span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Event = *</span>                                     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">(</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Clusters.ClusterA.EventA</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">)</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:              </span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Event = *, Urgent = </span><span style=\"color: #7fff7f; text-decoration-color: #7fff7f; font-style: italic\">True</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">/</span><span style=\"color: #ff7f7f; text-decoration-color: #ff7f7f; font-style: italic\">False</span>                <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">(</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Clusters.ClusterA.EventA, urgent</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">)</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:      </span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Endpoint = *,           Cluster = specific,  </span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Event = specific</span>                              <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Event = specific, Urgent = </span><span style=\"color: #7fff7f; text-decoration-color: #7fff7f; font-style: italic\">True</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">/</span><span style=\"color: #ff7f7f; text-decoration-color: #ff7f7f; font-style: italic\">False</span>         <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    endpoint:                                </span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Endpoint = specific,    Cluster = *,         </span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Event = *</span>                                     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Event = *, Urgent = </span><span style=\"color: #7fff7f; text-decoration-color: #7fff7f; font-style: italic\">True</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">/</span><span style=\"color: #ff7f7f; text-decoration-color: #ff7f7f; font-style: italic\">False</span>                <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    Clusters.ClusterA:                       </span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Endpoint = *,           Cluster = specific,  </span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Event = *</span>                                     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Event = *, Urgent = </span><span style=\"color: #7fff7f; text-decoration-color: #7fff7f; font-style: italic\">True</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">/</span><span style=\"color: #ff7f7f; text-decoration-color: #ff7f7f; font-style: italic\">False</span>                <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    </span><span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">'*'</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> or </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">()</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:                               </span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Endpoint = *,           Cluster = *,         </span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Event = *</span>                                     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Event = *, Urgent = </span><span style=\"color: #7fff7f; text-decoration-color: #7fff7f; font-style: italic\">True</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">/</span><span style=\"color: #ff7f7f; text-decoration-color: #ff7f7f; font-style: italic\">False</span>                <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                                                                           <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">The cluster and events specified above are to</span> <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">be selected from the generated cluster </span>       <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
@@ -658,7 +651,7 @@
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                            <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">WriteAttribute</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">WriteAttribute</span><span style=\"font-weight: bold\">(</span>nodeid: int, attributes:   <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             List<span style=\"font-weight: bold\">[</span>Tuple<span style=\"font-weight: bold\">[</span>int,                               <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             chip.clusters.ClusterObjects.ClusterAttribut… <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             timedRequestTimeoutMs: int = <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span><span style=\"font-weight: bold\">)</span>:           <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             int<span style=\"font-weight: bold\">]]</span>, timedRequestTimeoutMs: int = <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span><span style=\"font-weight: bold\">)</span>:    <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Write a list of attributes on a target node.</span>  <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                                                                           <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">nodeId: Target's Node ID</span>                      <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
@@ -684,32 +677,38 @@
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             <span style=\"color: #808000; text-decoration-color: #808000\">blocking</span>=<span style=\"color: #00ff00; text-decoration-color: #00ff00; font-style: italic\">True</span><span style=\"font-weight: bold\">)</span>:                               <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                         <span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">ZCLWriteAttribute</span> = <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">ZCLWriteAttribute</span><span style=\"font-weight: bold\">(</span>cluster: str,           <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             attribute: str, nodeid, endpoint, groupid,    <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             value, <span style=\"color: #808000; text-decoration-color: #808000\">blocking</span>=<span style=\"color: #00ff00; text-decoration-color: #00ff00; font-style: italic\">True</span><span style=\"font-weight: bold\">)</span>:                        <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
+       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                             value, <span style=\"color: #808000; text-decoration-color: #808000\">dataVersion</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, <span style=\"color: #808000; text-decoration-color: #808000\">blocking</span>=<span style=\"color: #00ff00; text-decoration-color: #00ff00; font-style: italic\">True</span><span style=\"font-weight: bold\">)</span>:         <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">╰───────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
        "\u001b[34m╭─\u001b[0m\u001b[34m────────────────── \u001b[0m\u001b[1;34m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'chip.ChipDeviceCtrl.ChipDeviceController'\u001b[0m\u001b[1;34m>\u001b[0m\u001b[34m ───────────────────\u001b[0m\u001b[34m─╮\u001b[0m\n",
        "\u001b[34m│\u001b[0m \u001b[32m╭───────────────────────────────────────────────────────────────────────────────────────╮\u001b[0m \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m \u001b[32m│\u001b[0m \u001b[1m<\u001b[0m\u001b[1;95mchip.ChipDeviceCtrl.ChipDeviceController\u001b[0m\u001b[39m object at \u001b[0m\u001b[1;36m0x1143b3910\u001b[0m\u001b[1m>\u001b[0m                      \u001b[32m│\u001b[0m \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m \u001b[32m│\u001b[0m \u001b[1m<\u001b[0m\u001b[1;95mController\u001b[0m\u001b[39m for Fabric \u001b[0m\u001b[1;36m0000000000000001\u001b[0m\u001b[39m \u001b[0m\u001b[1;39m(\u001b[0m\u001b[39mCompressed Fabric Id: 3b98917fa01213cf\u001b[0m\u001b[1;39m)\u001b[0m\u001b[1m>\u001b[0m     \u001b[32m│\u001b[0m \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m \u001b[32m╰───────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                                                                           \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                \u001b[3;33mactiveList\u001b[0m = \u001b[1m{\u001b[0m                                             \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                                 \u001b[1m<\u001b[0m\u001b[1;95mchip.ChipDeviceCtrl.ChipDeviceController\u001b[0m \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             \u001b[39mobject at \u001b[0m\u001b[1;36m0x1143b3910\u001b[0m\u001b[1m>\u001b[0m                        \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                                 \u001b[1m<\u001b[0m\u001b[1;95mController\u001b[0m\u001b[39m for Fabric \u001b[0m\u001b[1;36m0000000000000001\u001b[0m\u001b[39m \u001b[0m  \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[1;39m(\u001b[0m\u001b[39mCompressed Fabric Id: 3b98917fa01213cf\u001b[0m\u001b[1;39m)\u001b[0m\u001b[1m>\u001b[0m     \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[1m}\u001b[0m                                             \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                   \u001b[3;33mdevCtrl\u001b[0m = \u001b[1;35mc_void_p\u001b[0m\u001b[1m(\u001b[0m\u001b[1;36m140320379576320\u001b[0m\u001b[1m)\u001b[0m                     \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                   \u001b[3;33mdevCtrl\u001b[0m = \u001b[1;35mc_void_p\u001b[0m\u001b[1m(\u001b[0m\u001b[1;36m140655615556032\u001b[0m\u001b[1m)\u001b[0m                     \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                  \u001b[3;33misActive\u001b[0m = \u001b[3;92mTrue\u001b[0m                                          \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                     \u001b[3;33mstate\u001b[0m = \u001b[1m<\u001b[0m\u001b[1;95mDCState.IDLE:\u001b[0m\u001b[39m \u001b[0m\u001b[1;36m1\u001b[0m\u001b[1m>\u001b[0m                             \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m        \u001b[3;33mcbHandleCommissioningCompleteFunct\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mcbHandleCommissioningCompleteFunct\u001b[0m\u001b[1m(\u001b[0m\u001b[33m...\u001b[0m\u001b[1m)\u001b[0m   \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m          \u001b[3;33mcbHandleKeyExchangeCompleteFunct\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mcbHandleKeyExchangeCompleteFunct\u001b[0m\u001b[1m(\u001b[0m\u001b[33m...\u001b[0m\u001b[1m)\u001b[0m     \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                 \u001b[3;33mcbOnAddressUpdateComplete\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mcbOnAddressUpdateComplete\u001b[0m\u001b[1m(\u001b[0m\u001b[33m...\u001b[0m\u001b[1m)\u001b[0m            \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                             \u001b[3;33mCheckIsActive\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mCheckIsActive\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m:                          \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                        \u001b[3;33mCloseBLEConnection\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mCloseBLEConnection\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m:                     \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                              \u001b[3;33mCloseSession\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mCloseSession\u001b[0m\u001b[1m(\u001b[0mnodeid\u001b[1m)\u001b[0m:                     \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                \u001b[3;33mCommission\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mCommission\u001b[0m\u001b[1m(\u001b[0mnodeid\u001b[1m)\u001b[0m:                       \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                              \u001b[3;33mCommissionIP\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mCommissionIP\u001b[0m\u001b[1m(\u001b[0mipaddr, setupPinCode,        \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             nodeid\u001b[1m)\u001b[0m:                                      \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                          \u001b[3;33mCommissionThread\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mCommissionThread\u001b[0m\u001b[1m(\u001b[0mdiscriminator,           \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             setupPinCode, nodeId,                         \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             threadOperationalDataset: bytes\u001b[1m)\u001b[0m: \u001b[2mCommissions\u001b[0m \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[2ma Thread device over BLE\u001b[0m                      \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                            \u001b[3;33mCommissionWiFi\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mCommissionWiFi\u001b[0m\u001b[1m(\u001b[0mdiscriminator,             \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             setupPinCode, nodeId, ssid, credentials\u001b[1m)\u001b[0m:     \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[2mCommissions a WiFi device over BLE\u001b[0m            \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                \u001b[3;33mConnectBLE\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mConnectBLE\u001b[0m\u001b[1m(\u001b[0mdiscriminator, setupPinCode,   \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             nodeid\u001b[1m)\u001b[0m:                                      \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                \u001b[3;33mConnectBle\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mConnectBle\u001b[0m\u001b[1m(\u001b[0mbleConnection\u001b[1m)\u001b[0m:                \u001b[34m│\u001b[0m\n",
@@ -734,6 +733,7 @@
        "\u001b[34m│\u001b[0m                  \u001b[3;33mGetIPForDiscoveredDevice\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mGetIPForDiscoveredDevice\u001b[0m\u001b[1m(\u001b[0midx, addrStr,    \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             length\u001b[1m)\u001b[0m:                                      \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                              \u001b[3;33mGetLogFilter\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mGetLogFilter\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m:                           \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                   \u001b[3;33mGetTestCommissionerUsed\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mGetTestCommissionerUsed\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m:                \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                               \u001b[3;33mIsConnected\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mIsConnected\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m:                            \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                   \u001b[3;33mOpenCommissioningWindow\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mOpenCommissioningWindow\u001b[0m\u001b[1m(\u001b[0mnodeid, timeout,  \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             iteration, discriminator, option\u001b[1m)\u001b[0m:            \u001b[34m│\u001b[0m\n",
@@ -747,9 +747,11 @@
        "\u001b[34m│\u001b[0m                                             Type\u001b[1m[\u001b[0mchip.clusters.ClusterObjects.Cluster\u001b[1m]\u001b[0m\u001b[1m]\u001b[0m,  \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             Tuple\u001b[1m[\u001b[0mint,                                    \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             Type\u001b[1m[\u001b[0mchip.clusters.ClusterObjects.ClusterAtt… \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             returnClusterObject: bool = \u001b[3;91mFalse\u001b[0m,            \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             reportInterval: Tuple\u001b[1m[\u001b[0mint, int\u001b[1m]\u001b[0m = \u001b[3;35mNone\u001b[0m,       \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             fabricFiltered: bool = \u001b[3;92mTrue\u001b[0m\u001b[1m)\u001b[0m:                 \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             dataVersionFilters: List\u001b[1m[\u001b[0mTuple\u001b[1m[\u001b[0mint,           \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             Type\u001b[1m[\u001b[0mchip.clusters.ClusterObjects.Cluster\u001b[1m]\u001b[0m,   \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             int\u001b[1m]\u001b[0m\u001b[1m]\u001b[0m = \u001b[3;35mNone\u001b[0m, returnClusterObject: bool =     \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[3;91mFalse\u001b[0m, reportInterval: Tuple\u001b[1m[\u001b[0mint, int\u001b[1m]\u001b[0m =      \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[3;35mNone\u001b[0m, fabricFiltered: bool = \u001b[3;92mTrue\u001b[0m\u001b[1m)\u001b[0m:           \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2mRead a list of attributes from a target node\u001b[0m  \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                                                                           \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2mnodeId: Target's Node ID\u001b[0m                      \u001b[34m│\u001b[0m\n",
@@ -800,38 +802,42 @@
        "\u001b[34m│\u001b[0m                                             \u001b[2m    When not provided, a read request will be\u001b[0m \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2msent.\u001b[0m                                         \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                 \u001b[3;33mReadEvent\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mReadEvent\u001b[0m\u001b[1m(\u001b[0mnodeid: int, events:            \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             List\u001b[1m[\u001b[0mUnion\u001b[1m[\u001b[0mNoneType, Tuple\u001b[1m[\u001b[0mint\u001b[1m]\u001b[0m,              \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             List\u001b[1m[\u001b[0mUnion\u001b[1m[\u001b[0mNoneType, Tuple\u001b[1m[\u001b[0mstr, int\u001b[1m]\u001b[0m,         \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             Tuple\u001b[1m[\u001b[0mint, int\u001b[1m]\u001b[0m,                              \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             Tuple\u001b[1m[\u001b[0mType\u001b[1m[\u001b[0mchip.clusters.ClusterObjects.Clus… \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             int\u001b[1m]\u001b[0m,                                         \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             Tuple\u001b[1m[\u001b[0mType\u001b[1m[\u001b[0mchip.clusters.ClusterObjects.Clus… \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             Tuple\u001b[1m[\u001b[0mint,                                    \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             Type\u001b[1m[\u001b[0mchip.clusters.ClusterObjects.Cluster\u001b[1m]\u001b[0m\u001b[1m]\u001b[0m,  \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             Tuple\u001b[1m[\u001b[0mint,                                    \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             int\u001b[1m]\u001b[0m, Tuple\u001b[1m[\u001b[0mint,                              \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             Type\u001b[1m[\u001b[0mchip.clusters.ClusterObjects.Cluster\u001b[1m]\u001b[0m,   \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             int\u001b[1m]\u001b[0m, Tuple\u001b[1m[\u001b[0mint,                              \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             Type\u001b[1m[\u001b[0mchip.clusters.ClusterObjects.ClusterEve… \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             reportInterval: Tuple\u001b[1m[\u001b[0mint, int\u001b[1m]\u001b[0m = \u001b[3;35mNone\u001b[0m\u001b[1m)\u001b[0m:      \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             int\u001b[1m]\u001b[0m\u001b[1m]\u001b[0m\u001b[1m]\u001b[0m, reportInterval: Tuple\u001b[1m[\u001b[0mint, int\u001b[1m]\u001b[0m =     \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[3;35mNone\u001b[0m\u001b[1m)\u001b[0m:                                        \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2mRead a list of events from a target node\u001b[0m      \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                                                                           \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2mnodeId: Target's Node ID\u001b[0m                      \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2mevents: A list of tuples of varying types \u001b[0m    \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2mdepending on the type of read being \u001b[0m          \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2mrequested:\u001b[0m                                    \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             \u001b[2m    \u001b[0m\u001b[1;2m(\u001b[0m\u001b[2mendpoint, Clusters.ClusterA.EventA\u001b[0m\u001b[1;2m)\u001b[0m\u001b[2m:    \u001b[0m \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[2m    \u001b[0m\u001b[1;2m(\u001b[0m\u001b[2mendpoint, Clusters.ClusterA.EventA, \u001b[0m     \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[2murgent\u001b[0m\u001b[1;2m)\u001b[0m\u001b[2m:       Endpoint = specific,    \u001b[0m       \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[2mCluster = specific,   Event = specific, \u001b[0m      \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[2mUrgent = \u001b[0m\u001b[2;3;92mTrue\u001b[0m\u001b[2m/\u001b[0m\u001b[2;3;91mFalse\u001b[0m                           \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[2m    \u001b[0m\u001b[1;2m(\u001b[0m\u001b[2mendpoint, Clusters.ClusterA, urgent\u001b[0m\u001b[1;2m)\u001b[0m\u001b[2m:   \u001b[0m \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2mEndpoint = specific,    Cluster = specific,  \u001b[0m \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             \u001b[2mEvent = specific\u001b[0m                              \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             \u001b[2m    \u001b[0m\u001b[1;2m(\u001b[0m\u001b[2mendpoint, Clusters.ClusterA\u001b[0m\u001b[1;2m)\u001b[0m\u001b[2m:           \u001b[0m \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             \u001b[2mEndpoint = specific,    Cluster = specific,  \u001b[0m \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             \u001b[2mEvent = *\u001b[0m                                     \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             \u001b[2m    \u001b[0m\u001b[1;2m(\u001b[0m\u001b[2mClusters.ClusterA.EventA\u001b[0m\u001b[1;2m)\u001b[0m\u001b[2m:              \u001b[0m \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[2mEvent = *, Urgent = \u001b[0m\u001b[2;3;92mTrue\u001b[0m\u001b[2m/\u001b[0m\u001b[2;3;91mFalse\u001b[0m                \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[2m    \u001b[0m\u001b[1;2m(\u001b[0m\u001b[2mClusters.ClusterA.EventA, urgent\u001b[0m\u001b[1;2m)\u001b[0m\u001b[2m:      \u001b[0m \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2mEndpoint = *,           Cluster = specific,  \u001b[0m \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             \u001b[2mEvent = specific\u001b[0m                              \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[2mEvent = specific, Urgent = \u001b[0m\u001b[2;3;92mTrue\u001b[0m\u001b[2m/\u001b[0m\u001b[2;3;91mFalse\u001b[0m         \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2m    endpoint:                                \u001b[0m \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2mEndpoint = specific,    Cluster = *,         \u001b[0m \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             \u001b[2mEvent = *\u001b[0m                                     \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[2mEvent = *, Urgent = \u001b[0m\u001b[2;3;92mTrue\u001b[0m\u001b[2m/\u001b[0m\u001b[2;3;91mFalse\u001b[0m                \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2m    Clusters.ClusterA:                       \u001b[0m \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2mEndpoint = *,           Cluster = specific,  \u001b[0m \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             \u001b[2mEvent = *\u001b[0m                                     \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[2mEvent = *, Urgent = \u001b[0m\u001b[2;3;92mTrue\u001b[0m\u001b[2m/\u001b[0m\u001b[2;3;91mFalse\u001b[0m                \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2m    \u001b[0m\u001b[2;32m'*'\u001b[0m\u001b[2m or \u001b[0m\u001b[1;2m(\u001b[0m\u001b[1;2m)\u001b[0m\u001b[2m:                               \u001b[0m \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2mEndpoint = *,           Cluster = *,         \u001b[0m \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             \u001b[2mEvent = *\u001b[0m                                     \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             \u001b[2mEvent = *, Urgent = \u001b[0m\u001b[2;3;92mTrue\u001b[0m\u001b[2m/\u001b[0m\u001b[2;3;91mFalse\u001b[0m                \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                                                                           \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2mThe cluster and events specified above are to\u001b[0m \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2mbe selected from the generated cluster \u001b[0m       \u001b[34m│\u001b[0m\n",
@@ -881,7 +887,7 @@
        "\u001b[34m│\u001b[0m                            \u001b[3;33mWriteAttribute\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mWriteAttribute\u001b[0m\u001b[1m(\u001b[0mnodeid: int, attributes:   \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             List\u001b[1m[\u001b[0mTuple\u001b[1m[\u001b[0mint,                               \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             chip.clusters.ClusterObjects.ClusterAttribut… \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             timedRequestTimeoutMs: int = \u001b[3;35mNone\u001b[0m\u001b[1m)\u001b[0m:           \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             int\u001b[1m]\u001b[0m\u001b[1m]\u001b[0m, timedRequestTimeoutMs: int = \u001b[3;35mNone\u001b[0m\u001b[1m)\u001b[0m:    \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2mWrite a list of attributes on a target node.\u001b[0m  \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                                                                           \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             \u001b[2mnodeId: Target's Node ID\u001b[0m                      \u001b[34m│\u001b[0m\n",
@@ -907,7 +913,7 @@
        "\u001b[34m│\u001b[0m                                             \u001b[33mblocking\u001b[0m=\u001b[3;92mTrue\u001b[0m\u001b[1m)\u001b[0m:                               \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                         \u001b[3;33mZCLWriteAttribute\u001b[0m = \u001b[3;96mdef \u001b[0m\u001b[1;31mZCLWriteAttribute\u001b[0m\u001b[1m(\u001b[0mcluster: str,           \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                             attribute: str, nodeid, endpoint, groupid,    \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                             value, \u001b[33mblocking\u001b[0m=\u001b[3;92mTrue\u001b[0m\u001b[1m)\u001b[0m:                        \u001b[34m│\u001b[0m\n",
+       "\u001b[34m│\u001b[0m                                             value, \u001b[33mdataVersion\u001b[0m=\u001b[1;36m0\u001b[0m, \u001b[33mblocking\u001b[0m=\u001b[3;92mTrue\u001b[0m\u001b[1m)\u001b[0m:         \u001b[34m│\u001b[0m\n",
        "\u001b[34m╰───────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
       ]
      },
@@ -917,7 +923,7 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #000080; text-decoration-color: #000080\">╭─────────── </span><span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">function</span><span style=\"color: #000000; text-decoration-color: #000000\"> mattersetlog at </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x115ea1670</span><span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">&gt;</span><span style=\"color: #000080; text-decoration-color: #000080\"> ───────────╮</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #000080; text-decoration-color: #000080\">╭───────── </span><span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">function</span><span style=\"color: #000000; text-decoration-color: #000000\"> mattersetlog at </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x7fed282cb700</span><span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">&gt;</span><span style=\"color: #000080; text-decoration-color: #000080\"> ──────────╮</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">mattersetlog</span><span style=\"font-weight: bold\">(</span>level<span style=\"font-weight: bold\">)</span>:                                     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                                              <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">35</span><span style=\"font-style: italic\"> attribute(s) not shown.</span> Run <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">inspect</span><span style=\"font-weight: bold\">(</span>inspect<span style=\"font-weight: bold\">)</span> for options. <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
@@ -925,7 +931,7 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[34m╭─\u001b[0m\u001b[34m────────── \u001b[0m\u001b[1;34m<\u001b[0m\u001b[1;95mfunction\u001b[0m\u001b[39m mattersetlog at \u001b[0m\u001b[1;36m0x115ea1670\u001b[0m\u001b[1;34m>\u001b[0m\u001b[34m ──────────\u001b[0m\u001b[34m─╮\u001b[0m\n",
+       "\u001b[34m╭─\u001b[0m\u001b[34m──────── \u001b[0m\u001b[1;34m<\u001b[0m\u001b[1;95mfunction\u001b[0m\u001b[39m mattersetlog at \u001b[0m\u001b[1;36m0x7fed282cb700\u001b[0m\u001b[1;34m>\u001b[0m\u001b[34m ─────────\u001b[0m\u001b[34m─╮\u001b[0m\n",
        "\u001b[34m│\u001b[0m \u001b[3;96mdef \u001b[0m\u001b[1;31mmattersetlog\u001b[0m\u001b[1m(\u001b[0mlevel\u001b[1m)\u001b[0m:                                     \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                                              \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m \u001b[1;36m35\u001b[0m\u001b[3m attribute(s) not shown.\u001b[0m Run \u001b[1;35minspect\u001b[0m\u001b[1m(\u001b[0minspect\u001b[1m)\u001b[0m for options. \u001b[34m│\u001b[0m\n",
@@ -938,7 +944,7 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #000080; text-decoration-color: #000080\">╭───────────────── </span><span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">function</span><span style=\"color: #000000; text-decoration-color: #000000\"> mattersetdebug at </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x115ea1700</span><span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">&gt;</span><span style=\"color: #000080; text-decoration-color: #000080\"> ──────────────────╮</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #000080; text-decoration-color: #000080\">╭──────────────── </span><span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">function</span><span style=\"color: #000000; text-decoration-color: #000000\"> mattersetdebug at </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x7fed282cb8b0</span><span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">&gt;</span><span style=\"color: #000080; text-decoration-color: #000080\"> ────────────────╮</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">mattersetdebug</span><span style=\"font-weight: bold\">(</span>enableDebugMode: bool = <span style=\"color: #00ff00; text-decoration-color: #00ff00; font-style: italic\">True</span><span style=\"font-weight: bold\">)</span>:                           <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                                                             <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> <span style=\"color: #008080; text-decoration-color: #008080\">Enables debug mode that is utilized by some Matter modules</span>                  <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
@@ -950,7 +956,7 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[34m╭─\u001b[0m\u001b[34m──────────────── \u001b[0m\u001b[1;34m<\u001b[0m\u001b[1;95mfunction\u001b[0m\u001b[39m mattersetdebug at \u001b[0m\u001b[1;36m0x115ea1700\u001b[0m\u001b[1;34m>\u001b[0m\u001b[34m ─────────────────\u001b[0m\u001b[34m─╮\u001b[0m\n",
+       "\u001b[34m╭─\u001b[0m\u001b[34m─────────────── \u001b[0m\u001b[1;34m<\u001b[0m\u001b[1;95mfunction\u001b[0m\u001b[39m mattersetdebug at \u001b[0m\u001b[1;36m0x7fed282cb8b0\u001b[0m\u001b[1;34m>\u001b[0m\u001b[34m ───────────────\u001b[0m\u001b[34m─╮\u001b[0m\n",
        "\u001b[34m│\u001b[0m \u001b[3;96mdef \u001b[0m\u001b[1;31mmattersetdebug\u001b[0m\u001b[1m(\u001b[0menableDebugMode: bool = \u001b[3;92mTrue\u001b[0m\u001b[1m)\u001b[0m:                           \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m                                                                             \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m \u001b[36mEnables debug mode that is utilized by some Matter modules\u001b[0m                  \u001b[34m│\u001b[0m\n",
@@ -979,14 +985,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "537404ad-cf20-4ce8-9cd6-037c397339ee",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #000080; text-decoration-color: #000080\">╭─ </span><span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">bound</span><span style=\"color: #000000; text-decoration-color: #000000\"> method ChipDeviceController.SendCommand of &lt;chip.ChipDeviceCtrl.ChipDeviceControl</span><span style=\"color: #000080; text-decoration-color: #000080\">─╮</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #000080; text-decoration-color: #000080\">╭─ </span><span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">bound</span><span style=\"color: #000000; text-decoration-color: #000000\"> method ChipDeviceController.SendCommand of &lt;Controller for Fabric </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">000000000000000</span><span style=\"color: #000080; text-decoration-color: #000080\">─╮</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> <span style=\"color: #00ffff; text-decoration-color: #00ffff; font-style: italic\">def </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">ChipDeviceController.SendCommand</span><span style=\"font-weight: bold\">(</span>nodeid: int, endpoint: int, payload:                 <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> chip.clusters.ClusterObjects.ClusterCommand, <span style=\"color: #808000; text-decoration-color: #808000\">responseType</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>, timedRequestTimeoutMs:    <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
        "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> int = <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span><span style=\"font-weight: bold\">)</span>:                                                                              <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
@@ -1005,7 +1011,7 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[34m╭─\u001b[0m\u001b[34m \u001b[0m\u001b[1;34m<\u001b[0m\u001b[1;95mbound\u001b[0m\u001b[39m method ChipDeviceController.SendCommand of <chip.ChipDeviceCtrl.ChipDeviceControl\u001b[0m\u001b[34m─╮\u001b[0m\n",
+       "\u001b[34m╭─\u001b[0m\u001b[34m \u001b[0m\u001b[1;34m<\u001b[0m\u001b[1;95mbound\u001b[0m\u001b[39m method ChipDeviceController.SendCommand of <Controller for Fabric \u001b[0m\u001b[1;36m000000000000000\u001b[0m\u001b[34m─╮\u001b[0m\n",
        "\u001b[34m│\u001b[0m \u001b[3;96mdef \u001b[0m\u001b[1;31mChipDeviceController.SendCommand\u001b[0m\u001b[1m(\u001b[0mnodeid: int, endpoint: int, payload:                 \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m chip.clusters.ClusterObjects.ClusterCommand, \u001b[33mresponseType\u001b[0m=\u001b[3;35mNone\u001b[0m, timedRequestTimeoutMs:    \u001b[34m│\u001b[0m\n",
        "\u001b[34m│\u001b[0m int = \u001b[3;35mNone\u001b[0m\u001b[1m)\u001b[0m:                                                                              \u001b[34m│\u001b[0m\n",
@@ -1043,7 +1049,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "331b1d7b-02c7-4415-9583-630973024de7",
    "metadata": {},
    "outputs": [],
@@ -1082,7 +1088,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "8282f584-bd20-4b2b-b8f9-ea72cf6c4820",
    "metadata": {},
    "outputs": [
@@ -1128,13 +1134,176 @@
     "a = {'value': [1, 2, 3, 4, [1, 2]]}\n",
     "a"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac6e2fa8",
+   "metadata": {},
+   "source": [
+    "# Check DocString for Clusters\n",
+    "\n",
+    "There are generated docstring for all clusters, you can check them by call `inspect()` on it, or `print(SomeCluster.__doc__)` directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "040c72d5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Attributes:\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>: OnOff bool\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">16384</span>: GlobalSceneControl typing.Optional\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">16385</span>: OnTime typing.Optional\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">16386</span>: OffWaitTime typing.Optional\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">16387</span>: StartUpOnOff typing.Optional\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">65528</span>: ServerGeneratedCommandList typing.List\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">65529</span>: ClientGeneratedCommandList typing.List\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">65531</span>: AttributeList typing.List\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">65532</span>: FeatureMap typing.Optional\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">65533</span>: ClusterRevision uint\n",
+       "Commands: \n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Off</span><span style=\"font-weight: bold\">()</span>\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">On</span><span style=\"font-weight: bold\">()</span>\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Toggle</span><span style=\"font-weight: bold\">()</span>\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">64</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">OffWithEffect</span><span style=\"font-weight: bold\">(</span>effectId: <span style=\"color: #008000; text-decoration-color: #008000\">'OnOff.Enums.OnOffEffectIdentifier'</span> = <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, effectVariant: \n",
+       "<span style=\"color: #008000; text-decoration-color: #008000\">'OnOff.Enums.OnOffDelayedAllOffEffectVariant'</span> = <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span><span style=\"font-weight: bold\">)</span>\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">65</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">OnWithRecallGlobalScene</span><span style=\"font-weight: bold\">()</span>\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">66</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">OnWithTimedOff</span><span style=\"font-weight: bold\">(</span>onOffControl: <span style=\"color: #008000; text-decoration-color: #008000\">'uint'</span> = <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, onTime: <span style=\"color: #008000; text-decoration-color: #008000\">'uint'</span> = <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, offWaitTime: <span style=\"color: #008000; text-decoration-color: #008000\">'uint'</span> \n",
+       "= <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span><span style=\"font-weight: bold\">)</span>\n",
+       "Enums: \n",
+       "        OnOffDelayedAllOffEffectVariant\n",
+       "        OnOffDyingLightEffectVariant\n",
+       "        OnOffEffectIdentifier\n",
+       "\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Attributes:\n",
+       "        \u001b[1;36m0\u001b[0m: OnOff bool\n",
+       "        \u001b[1;36m16384\u001b[0m: GlobalSceneControl typing.Optional\n",
+       "        \u001b[1;36m16385\u001b[0m: OnTime typing.Optional\n",
+       "        \u001b[1;36m16386\u001b[0m: OffWaitTime typing.Optional\n",
+       "        \u001b[1;36m16387\u001b[0m: StartUpOnOff typing.Optional\n",
+       "        \u001b[1;36m65528\u001b[0m: ServerGeneratedCommandList typing.List\n",
+       "        \u001b[1;36m65529\u001b[0m: ClientGeneratedCommandList typing.List\n",
+       "        \u001b[1;36m65531\u001b[0m: AttributeList typing.List\n",
+       "        \u001b[1;36m65532\u001b[0m: FeatureMap typing.Optional\n",
+       "        \u001b[1;36m65533\u001b[0m: ClusterRevision uint\n",
+       "Commands: \n",
+       "        \u001b[1;36m0\u001b[0m: \u001b[1;35mOff\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m\n",
+       "        \u001b[1;36m1\u001b[0m: \u001b[1;35mOn\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m\n",
+       "        \u001b[1;36m2\u001b[0m: \u001b[1;35mToggle\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m\n",
+       "        \u001b[1;36m64\u001b[0m: \u001b[1;35mOffWithEffect\u001b[0m\u001b[1m(\u001b[0meffectId: \u001b[32m'OnOff.Enums.OnOffEffectIdentifier'\u001b[0m = \u001b[1;36m0\u001b[0m, effectVariant: \n",
+       "\u001b[32m'OnOff.Enums.OnOffDelayedAllOffEffectVariant'\u001b[0m = \u001b[1;36m0\u001b[0m\u001b[1m)\u001b[0m\n",
+       "        \u001b[1;36m65\u001b[0m: \u001b[1;35mOnWithRecallGlobalScene\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m\n",
+       "        \u001b[1;36m66\u001b[0m: \u001b[1;35mOnWithTimedOff\u001b[0m\u001b[1m(\u001b[0monOffControl: \u001b[32m'uint'\u001b[0m = \u001b[1;36m0\u001b[0m, onTime: \u001b[32m'uint'\u001b[0m = \u001b[1;36m0\u001b[0m, offWaitTime: \u001b[32m'uint'\u001b[0m \n",
+       "= \u001b[1;36m0\u001b[0m\u001b[1m)\u001b[0m\n",
+       "Enums: \n",
+       "        OnOffDelayedAllOffEffectVariant\n",
+       "        OnOffDyingLightEffectVariant\n",
+       "        OnOffEffectIdentifier\n",
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "print(Clusters.OnOff.__doc__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eadf0d99",
+   "metadata": {},
+   "source": [
+    "You can check commands, attributes, events, enums or structs under some cluster separately."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "0daac32b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>: <span style=\"font-weight: bold\">(</span>Require Timed Invoke<span style=\"font-weight: bold\">)</span> <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">OpenCommissioningWindow</span><span style=\"font-weight: bold\">(</span>commissioningTimeout: <span style=\"color: #008000; text-decoration-color: #008000\">'uint'</span> = <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, \n",
+       "PAKEVerifier: <span style=\"color: #008000; text-decoration-color: #008000\">'bytes'</span> = <span style=\"color: #008000; text-decoration-color: #008000\">b''</span>, discriminator: <span style=\"color: #008000; text-decoration-color: #008000\">'uint'</span> = <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, iterations: <span style=\"color: #008000; text-decoration-color: #008000\">'uint'</span> = <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, salt: <span style=\"color: #008000; text-decoration-color: #008000\">'bytes'</span>\n",
+       "= <span style=\"color: #008000; text-decoration-color: #008000\">b''</span><span style=\"font-weight: bold\">)</span>\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>: <span style=\"font-weight: bold\">(</span>Require Timed Invoke<span style=\"font-weight: bold\">)</span> <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">OpenBasicCommissioningWindow</span><span style=\"font-weight: bold\">(</span>commissioningTimeout: <span style=\"color: #008000; text-decoration-color: #008000\">'uint'</span> =\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span><span style=\"font-weight: bold\">)</span>\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2</span>: <span style=\"font-weight: bold\">(</span>Require Timed Invoke<span style=\"font-weight: bold\">)</span> <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">RevokeCommissioning</span><span style=\"font-weight: bold\">()</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "        \u001b[1;36m0\u001b[0m: \u001b[1m(\u001b[0mRequire Timed Invoke\u001b[1m)\u001b[0m \u001b[1;35mOpenCommissioningWindow\u001b[0m\u001b[1m(\u001b[0mcommissioningTimeout: \u001b[32m'uint'\u001b[0m = \u001b[1;36m0\u001b[0m, \n",
+       "PAKEVerifier: \u001b[32m'bytes'\u001b[0m = \u001b[32mb''\u001b[0m, discriminator: \u001b[32m'uint'\u001b[0m = \u001b[1;36m0\u001b[0m, iterations: \u001b[32m'uint'\u001b[0m = \u001b[1;36m0\u001b[0m, salt: \u001b[32m'bytes'\u001b[0m\n",
+       "= \u001b[32mb''\u001b[0m\u001b[1m)\u001b[0m\n",
+       "        \u001b[1;36m1\u001b[0m: \u001b[1m(\u001b[0mRequire Timed Invoke\u001b[1m)\u001b[0m \u001b[1;35mOpenBasicCommissioningWindow\u001b[0m\u001b[1m(\u001b[0mcommissioningTimeout: \u001b[32m'uint'\u001b[0m =\n",
+       "\u001b[1;36m0\u001b[0m\u001b[1m)\u001b[0m\n",
+       "        \u001b[1;36m2\u001b[0m: \u001b[1m(\u001b[0mRequire Timed Invoke\u001b[1m)\u001b[0m \u001b[1;35mRevokeCommissioning\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "print(Clusters.AdministratorCommissioning.Commands.__doc__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "cb348316",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>: Acl typing.List<span style=\"font-weight: bold\">[</span>AccessControl.Structs.AccessControlEntry<span style=\"font-weight: bold\">]</span>\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>: Extension typing.List<span style=\"font-weight: bold\">[</span>AccessControl.Structs.ExtensionEntry<span style=\"font-weight: bold\">]</span>\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">65528</span>: ServerGeneratedCommandList typing.List\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">65529</span>: ClientGeneratedCommandList typing.List\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">65531</span>: AttributeList typing.List\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">65532</span>: FeatureMap typing.Optional\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">65533</span>: ClusterRevision uint\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "        \u001b[1;36m0\u001b[0m: Acl typing.List\u001b[1m[\u001b[0mAccessControl.Structs.AccessControlEntry\u001b[1m]\u001b[0m\n",
+       "        \u001b[1;36m1\u001b[0m: Extension typing.List\u001b[1m[\u001b[0mAccessControl.Structs.ExtensionEntry\u001b[1m]\u001b[0m\n",
+       "        \u001b[1;36m65528\u001b[0m: ServerGeneratedCommandList typing.List\n",
+       "        \u001b[1;36m65529\u001b[0m: ClientGeneratedCommandList typing.List\n",
+       "        \u001b[1;36m65531\u001b[0m: AttributeList typing.List\n",
+       "        \u001b[1;36m65532\u001b[0m: FeatureMap typing.Optional\n",
+       "        \u001b[1;36m65533\u001b[0m: ClusterRevision uint\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "print(Clusters.AccessControl.Attributes.__doc__)"
+   ]
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "f7fd7085b4be428477fa1342305f4ebb7800cfd7c4438123a54b78fc013e2c1b"
+  },
   "kernelspec": {
    "display_name": "matter-env",
    "language": "python",
-   "name": "matter-env"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1146,7 +1315,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2+chromium.10"
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -26,7 +26,7 @@ from ctypes import CFUNCTYPE, c_char_p, c_size_t, c_void_p, c_uint64, c_uint32, 
 import construct
 from rich.pretty import pprint
 
-from .ClusterObjects import Cluster, ClusterAttributeDescriptor, ClusterEvent
+from .ClusterObjects import Cluster, ClusterAttributeDescriptor, ClusterEvent, ClusterObject
 import chip.exceptions
 import chip.interaction_model
 import chip.tlv
@@ -293,7 +293,7 @@ def _BuildAttributeIndex():
     This is acceptable during init, but unacceptable when the server returns lots of attributes at the same time.
     '''
     for clusterName, obj in inspect.getmembers(sys.modules['chip.clusters.Objects']):
-        if ('chip.clusters.Objects' in str(obj)) and inspect.isclass(obj):
+        if inspect.isclass(obj) and obj.__module__ == 'chip.clusters.Objects' and issubclass(obj, Cluster):
             for objName, subclass in inspect.getmembers(obj):
                 if inspect.isclass(subclass) and (('Attributes') in str(subclass)):
                     for attributeName, attribute in inspect.getmembers(subclass):
@@ -314,7 +314,7 @@ def _BuildClusterIndex():
     ''' Build internal cluster index for locating the corresponding cluster object by path in the future.
     '''
     for clusterName, obj in inspect.getmembers(sys.modules['chip.clusters.Objects']):
-        if ('chip.clusters.Objects' in str(obj)) and inspect.isclass(obj):
+        if inspect.isclass(obj) and obj.__module__ == 'chip.clusters.Objects' and issubclass(obj, Cluster):
             _ClusterIndex[obj.id] = obj
 
 


### PR DESCRIPTION
#### Change overview
- Generate docstring for cluster objects automatically.
- Add `__repr__` and `__str__` for device controller object instances. (`Controller for Fabric xxxxx (Compressed Fabric Id xxxx)`)
- Update the docs to make them up-to-date.
- Add the doc for this change in the doc.
- Move some functions in src/controller/python/chip/ChipDeviceCtrl.py to module wide.

#### Testing
Executed the docs/guides/repl/Matter - Multi Fabric Commissioning.ipynb and docs/guides/repl/Matter - REPL Intro.ipynb