### PR TITLE
Fix header dependency in CHIPCert

### DIFF
--- a/src/credentials/BUILD.gn
+++ b/src/credentials/BUILD.gn
@@ -70,9 +70,9 @@ static_library("credentials") {
   cflags = [ "-Wconversion" ]
 
   public_deps = [
-    "${chip_root}/src/asn1:asn1oid_header",
     "${chip_root}/src/crypto",
     "${chip_root}/src/lib/asn1",
+    "${chip_root}/src/lib/asn1:asn1oid_header",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/platform",

--- a/src/credentials/BUILD.gn
+++ b/src/credentials/BUILD.gn
@@ -70,6 +70,7 @@ static_library("credentials") {
   cflags = [ "-Wconversion" ]
 
   public_deps = [
+    "${chip_root}/src/asni:asn1oid_header",
     "${chip_root}/src/crypto",
     "${chip_root}/src/lib/asn1",
     "${chip_root}/src/lib/core",

--- a/src/credentials/BUILD.gn
+++ b/src/credentials/BUILD.gn
@@ -70,7 +70,7 @@ static_library("credentials") {
   cflags = [ "-Wconversion" ]
 
   public_deps = [
-    "${chip_root}/src/asni:asn1oid_header",
+    "${chip_root}/src/asn1:asn1oid_header",
     "${chip_root}/src/crypto",
     "${chip_root}/src/lib/asn1",
     "${chip_root}/src/lib/core",

--- a/src/credentials/BUILD.gn
+++ b/src/credentials/BUILD.gn
@@ -72,7 +72,6 @@ static_library("credentials") {
   public_deps = [
     "${chip_root}/src/crypto",
     "${chip_root}/src/lib/asn1",
-    "${chip_root}/src/lib/asn1:asn1oid_header",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/platform",

--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -69,6 +69,7 @@ chip_test_suite("tests") {
   cflags = [ "-Wconversion" ]
 
   public_deps = [
+    "${chip_root}/src/credentials",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support/jsontlv",
     "${chip_root}/src/platform",


### PR DESCRIPTION
#### Problem
Compile error in https://github.com/project-chip/connectedhomeip/runs/5626855242?check_suite_focus=true :

```
FAILED: mac_x64_gcc/obj/src/lib/support/tests/libSupportTests.TestTestPersistentStorageDelegate.cpp.o 
`pwd`/../scripts/helpers/clang-tidy-launcher.py g++ -MMD -MF mac_x64_gcc/obj/src/lib/support/tests/libSupportTests.TestTestPersistentStorageDelegate.cpp.o.d -Wconversion -target x86_64-apple-macos10.15 -O0 -g2 -fno-common -ffunction-sections -fdata-sections -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -Wall -Werror -Wextra -Wshadow -Wunreachable-code -Wvla -Wformat -Wformat-nonliteral -Wformat-security -Wno-deprecated-declarations -Wno-unknown-warning-option -Wno-maybe-uninitialized -Wno-missing-field-initializers -Wno-unused-parameter -Wno-psabi -Wno-cast-function-type -fdiagnostics-color -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -Wno-implicit-fallthrough -I/usr/local/Cellar/openssl@1.1/1.1.1m/include -fobjc-arc -std=gnu++14 -fno-rtti -Wnon-virtual-dtor -DCHIP_HAVE_CONFIG_H=1 -I../src/include -I../src -Imac_x64_gcc/gen/include -I../zzz_generated/app-common -I../config/standalone -I../third_party/nlassert/repo/include -I../third_party/nlio/repo/include -I../third_party/nlfaultinjection/repo/include -I../third_party/jsoncpp/repo/include -I../third_party/nlunit-test/repo/src -c ../src/lib/support/tests/TestTestPersistentStorageDelegate.cpp -o mac_x64_gcc/obj/src/lib/support/tests/libSupportTests.TestTestPersistentStorageDelegate.cpp.o
In file included from ../src/lib/support/tests/TestTestPersistentStorageDelegate.cpp:20:
In file included from ../src/lib/support/TestPersistentStorageDelegate.h:22:
In file included from ../src/credentials/FabricTable.h:27:
In file included from ../src/credentials/CHIPCert.h:34:
../src/lib/asn1/ASN1.h:30:10: fatal error: 'asn1/ASN1OID.h' file not found
#include <asn1/ASN1OID.h>
```

#### Change overview
Add dependency on generated header into src/credentials library.

#### Testing
Compilation will validate this.

Also used `ninja -t browse --port 8000 TestTestPersistentStorageDelegate` to validate dependency graph that shows in order:
  - tests/TestTestPersistentStorageDelegate
  - obj/src/credentials/lib/libCredentials.a
  - obj/src/lib/asn1/lib/libASN1.a
  - obj/src/lib/asn1/asn1oid_header.stamp

Which seems to indicate that the asn1 header is now a build dependency Also the asn1 header stamp shows as a edge dependecy to include a lot of tests.
