### PR TITLE
Move to docker image 0.58 for cloudbuild all (required by nrf update)

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.5.56"
+    - name: "connectedhomeip/chip-build-vscode:0.5.58"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -12,7 +12,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.56"
+    - name: "connectedhomeip/chip-build-vscode:0.5.58"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:


### PR DESCRIPTION
#### Problem
Cloudbuild build-all fails with `cannot validate NCS revision`

#### Change overview
Move version 56 to 58.

#### Testing
N/A (external build). Trivial change.