### PR TITLE
[window-covering] Fix compilation error on some compilers

### DIFF
--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -67,13 +67,13 @@ enum class OperationalState : uint8_t
 };
 static_assert(sizeof(OperationalState) == sizeof(uint8_t), "OperationalState Size is not correct");
 
+// Decoded components of the OperationalStatus attribute
 struct OperationalStatus
 {
-    OperationalState global : 2; // bit 0-1 M
-    OperationalState lift : 2;   // bit 2-3 LF
-    OperationalState tilt : 2;   // bit 4-5 TL
+    OperationalState global; // bit 0-1 M
+    OperationalState lift;   // bit 2-3 LF
+    OperationalState tilt;   // bit 4-5 TL
 };
-static_assert(sizeof(OperationalStatus) == sizeof(uint8_t), "OperationalStatus Size is not correct");
 
 struct SafetyStatus
 {


### PR DESCRIPTION
#### Problem
`OperationalStatus` structure contains enum class bitfields, which on some compilers (e.g. GCC prior to 9.3) generates
"is too small to hold all values of ‘enum class OperationalState’" warning. It is a default warning that cannot be suppressed.

#### Change overview
Since `OperationalStatus` it not stored directly in the attribute table, but it is rather used to exchange decoded
components of the attribute with the application, the bitfield usage is not really valuable. Switch to normal
structure members for greater portability.
Fixes #16057

#### Testing
CI only. Additionally, built all-clusters-app using a few different compiler versions.
