### PR TITLE
Don't factory reset device if reboot with a pending arm failsafe

### DIFF
--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -139,6 +139,7 @@ bool emberAfGeneralCommissioningClusterArmFailSafeCallback(app::CommandHandler *
     Commands::ArmFailSafeResponse::Type response;
 
     /*
+     * If the fail-safe timer is in processing, then the fail-safe timer SHALL not be armed.
      * If the fail-safe timer was not currently armed, then the fail-safe timer SHALL be armed.
      * If the fail-safe timer was currently armed, and current accessing fabric matches the fail-safe
      * context’s Fabric Index, then the fail-safe timer SHALL be re-armed.
@@ -146,7 +147,8 @@ bool emberAfGeneralCommissioningClusterArmFailSafeCallback(app::CommandHandler *
 
     FabricIndex accessingFabricIndex = commandObj->GetAccessingFabricIndex();
 
-    if (!failSafeContext.IsFailSafeArmed() || failSafeContext.MatchesFabricIndex(accessingFabricIndex))
+    if (!failSafeContext.IsFailSafeBusy() &&
+        (!failSafeContext.IsFailSafeArmed() || failSafeContext.MatchesFabricIndex(accessingFabricIndex)))
     {
         CheckSuccess(failSafeContext.ArmFailSafe(accessingFabricIndex, System::Clock::Seconds16(commandData.expiryLengthSeconds)),
                      Failure);

--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -139,7 +139,7 @@ bool emberAfGeneralCommissioningClusterArmFailSafeCallback(app::CommandHandler *
     Commands::ArmFailSafeResponse::Type response;
 
     /*
-     * If the fail-safe timer is in processing, then the fail-safe timer SHALL not be armed.
+     * If the fail-safe timer is not fully disarmed, don't allow arming a new fail-safe.
      * If the fail-safe timer was not currently armed, then the fail-safe timer SHALL be armed.
      * If the fail-safe timer was currently armed, and current accessing fabric matches the fail-safe
      * context’s Fabric Index, then the fail-safe timer SHALL be re-armed.

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -648,12 +648,13 @@ bool emberAfOperationalCredentialsClusterAddNOCCallback(app::CommandHandler * co
     err = groups->SetKeySet(fabricIndex, compressed_fabric_id, keyset);
     VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
 
-    // We might have a new operational identity, so we should start advertising it right away.
-    app::DnssdServer::Instance().AdvertiseOperational();
-
     // The Fabric Index associated with the armed fail-safe context SHALL be updated to match the Fabric
     // Index just allocated.
-    failSafeContext.SetAddNocCommandInvoked(fabricIndex);
+    err = failSafeContext.SetAddNocCommandInvoked(fabricIndex);
+    VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
+
+    // We might have a new operational identity, so we should start advertising it right away.
+    app::DnssdServer::Instance().AdvertiseOperational();
 
 exit:
 
@@ -713,14 +714,15 @@ bool emberAfOperationalCredentialsClusterUpdateNOCCallback(app::CommandHandler *
 
     fabricIndex = fabric->GetFabricIndex();
 
+    // The Fabric Index associated with the armed fail-safe context SHALL be updated to match the Fabric
+    // Index associated with the UpdateNOC command being invoked.
+    err = failSafeContext.SetUpdateNocCommandInvoked(fabricIndex);
+    VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
+
     // We might have a new operational identity, so we should start advertising
     // it right away.  Also, we need to withdraw our old operational identity.
     // So we need to StartServer() here.
     app::DnssdServer::Instance().StartServer();
-
-    // The Fabric Index associated with the armed fail-safe context SHALL be updated to match the Fabric
-    // Index associated with the UpdateNOC command being invoked.
-    failSafeContext.SetUpdateNocCommandInvoked(fabricIndex);
 
 exit:
 

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -711,8 +711,7 @@ bool emberAfOperationalCredentialsClusterUpdateNOCCallback(app::CommandHandler *
     FabricInfo * fabric = RetrieveCurrentFabric(commandObj);
     VerifyOrExit(fabric != nullptr, nocResponse = ConvertToNOCResponseStatus(CHIP_ERROR_INVALID_FABRIC_ID));
 
-    // The Fabric Index associated with the armed fail-safe context SHALL be updated to match the Fabric
-    // Index associated with the UpdateNOC command being invoked.
+    // Flag on the fail-safe context that the UpdateNOC command was invoked.
     err = failSafeContext.SetUpdateNocCommandInvoked(fabricIndex);
     VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
 

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -629,6 +629,11 @@ bool emberAfOperationalCredentialsClusterAddNOCCallback(app::CommandHandler * co
     err = Server::GetInstance().GetFabricTable().Store(fabricIndex);
     VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
 
+    // The Fabric Index associated with the armed fail-safe context SHALL be updated to match the Fabric
+    // Index just allocated.
+    err = failSafeContext.SetAddNocCommandInvoked(fabricIndex);
+    VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
+
     // Keep this after other possible failures, so it doesn't need to be rolled back in case of
     // subsequent failures. This should only typically fail if there is no space for the new entry.
     err = CreateAccessControlEntryForNewFabricAdministrator(fabricIndex, commandData.caseAdminNode);
@@ -646,11 +651,6 @@ bool emberAfOperationalCredentialsClusterAddNOCCallback(app::CommandHandler * co
     memcpy(keyset.epoch_keys[0].key, ipkValue.data(), Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES);
     err = gFabricBeingCommissioned.GetCompressedId(compressed_fabric_id);
     err = groups->SetKeySet(fabricIndex, compressed_fabric_id, keyset);
-    VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
-
-    // The Fabric Index associated with the armed fail-safe context SHALL be updated to match the Fabric
-    // Index just allocated.
-    err = failSafeContext.SetAddNocCommandInvoked(fabricIndex);
     VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
 
     // We might have a new operational identity, so we should start advertising it right away.

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -29,6 +29,7 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <lib/support/Span.h>
 #include <platform/CHIPDeviceBuildConfig.h>
+#include <platform/FailSafeContext.h>
 #include <platform/PersistedStorage.h>
 #include <setup_payload/CHIPAdditionalDataPayloadBuildConfig.h>
 
@@ -134,6 +135,8 @@ public:
     virtual CHIP_ERROR GetUniqueId(char * buf, size_t bufSize)                         = 0;
     virtual CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen)        = 0;
     virtual CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize)                    = 0;
+    virtual CHIP_ERROR GetFailSafeArmed(bool & val)                                    = 0;
+    virtual CHIP_ERROR SetFailSafeArmed(bool val)                                      = 0;
 
     virtual CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) = 0;
 
@@ -176,8 +179,6 @@ protected:
 
     virtual CHIP_ERROR Init()                                                                                   = 0;
     virtual bool CanFactoryReset()                                                                              = 0;
-    virtual CHIP_ERROR GetFailSafeArmed(bool & val)                                                             = 0;
-    virtual CHIP_ERROR SetFailSafeArmed(bool val)                                                               = 0;
     virtual CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) = 0;
     virtual CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)  = 0;
 

--- a/src/include/platform/FailSafeContext.h
+++ b/src/include/platform/FailSafeContext.h
@@ -41,6 +41,8 @@ public:
      */
     CHIP_ERROR ArmFailSafe(FabricIndex accessingFabricIndex, System::Clock::Timeout expiryLength);
     CHIP_ERROR DisarmFailSafe();
+    void SetAddNocCommandInvoked(FabricIndex nocFabricIndex);
+    void SetUpdateNocCommandInvoked(FabricIndex nocFabricIndex);
 
     inline bool IsFailSafeArmed(FabricIndex accessingFabricIndex) const
     {
@@ -59,23 +61,13 @@ public:
     inline bool AddNocCommandHasBeenInvoked() { return mAddNocCommandHasBeenInvoked; }
     inline bool UpdateNocCommandHasBeenInvoked() { return mUpdateNocCommandHasBeenInvoked; }
 
-    inline void SetAddNocCommandInvoked(FabricIndex nocFabricIndex)
-    {
-        mAddNocCommandHasBeenInvoked = true;
-        mFabricIndex                 = nocFabricIndex;
-    }
-
-    inline void SetUpdateNocCommandInvoked(FabricIndex nocFabricIndex)
-    {
-        mUpdateNocCommandHasBeenInvoked = true;
-        mFabricIndex                    = nocFabricIndex;
-    }
-
     inline FabricIndex GetFabricIndex() const
     {
         VerifyOrDie(mFailSafeArmed);
         return mFabricIndex;
     }
+
+    static CHIP_ERROR LoadFromStorage(FabricIndex & fabricIndex, bool & addNocCommandInvoked, bool & updateNocCommandInvoked);
 
 private:
     // ===== Private members reserved for use by this class only.
@@ -87,8 +79,16 @@ private:
 
     // TODO:: Track the state of what was mutated during fail-safe.
 
+    static constexpr size_t FailSafeContextTLVMaxSize()
+    {
+        return TLV::EstimateStructOverhead(sizeof(FabricIndex), sizeof(bool), sizeof(bool));
+    }
+
     static void HandleArmFailSafe(System::Layer * layer, void * aAppState);
+
     void FailSafeTimerExpired();
+    CHIP_ERROR CommitToStorage();
+    CHIP_ERROR DeleteFromStorage();
 };
 
 } // namespace DeviceLayer

--- a/src/include/platform/FailSafeContext.h
+++ b/src/include/platform/FailSafeContext.h
@@ -49,6 +49,8 @@ public:
         return mFailSafeArmed && MatchesFabricIndex(accessingFabricIndex);
     }
 
+    // Returns true if the fail-safe is in a state where commands that require an armed
+    // fail-safe can no longer execute, but a new fail-safe can't be armed yet.
     inline bool IsFailSafeBusy() const { return mFailSafeBusy; }
 
     inline bool IsFailSafeArmed() const { return mFailSafeArmed; }

--- a/src/include/platform/FailSafeContext.h
+++ b/src/include/platform/FailSafeContext.h
@@ -49,7 +49,11 @@ public:
         return mFailSafeArmed && MatchesFabricIndex(accessingFabricIndex);
     }
 
+    inline bool IsFailSafeBusy() const { return mFailSafeBusy; }
+
     inline bool IsFailSafeArmed() const { return mFailSafeArmed; }
+
+    inline void SetFailSafeBusy(bool val) { mFailSafeBusy = val; }
 
     inline bool MatchesFabricIndex(FabricIndex accessingFabricIndex) const
     {
@@ -74,6 +78,7 @@ private:
     // ===== Private members reserved for use by this class only.
 
     bool mFailSafeArmed                  = false;
+    bool mFailSafeBusy                   = false;
     bool mAddNocCommandHasBeenInvoked    = false;
     bool mUpdateNocCommandHasBeenInvoked = false;
     FabricIndex mFabricIndex             = kUndefinedFabricIndex;

--- a/src/include/platform/FailSafeContext.h
+++ b/src/include/platform/FailSafeContext.h
@@ -41,8 +41,8 @@ public:
      */
     CHIP_ERROR ArmFailSafe(FabricIndex accessingFabricIndex, System::Clock::Timeout expiryLength);
     CHIP_ERROR DisarmFailSafe();
-    void SetAddNocCommandInvoked(FabricIndex nocFabricIndex);
-    void SetUpdateNocCommandInvoked(FabricIndex nocFabricIndex);
+    CHIP_ERROR SetAddNocCommandInvoked(FabricIndex nocFabricIndex);
+    CHIP_ERROR SetUpdateNocCommandInvoked(FabricIndex nocFabricIndex);
 
     inline bool IsFailSafeArmed(FabricIndex accessingFabricIndex) const
     {
@@ -68,6 +68,7 @@ public:
     }
 
     static CHIP_ERROR LoadFromStorage(FabricIndex & fabricIndex, bool & addNocCommandInvoked, bool & updateNocCommandInvoked);
+    static CHIP_ERROR DeleteFromStorage();
 
 private:
     // ===== Private members reserved for use by this class only.
@@ -85,10 +86,10 @@ private:
     }
 
     static void HandleArmFailSafe(System::Layer * layer, void * aAppState);
+    static void HandleDisarmFailSafe(intptr_t arg);
 
     void FailSafeTimerExpired();
     CHIP_ERROR CommitToStorage();
-    CHIP_ERROR DeleteFromStorage();
 };
 
 } // namespace DeviceLayer

--- a/src/include/platform/FailSafeContext.h
+++ b/src/include/platform/FailSafeContext.h
@@ -93,8 +93,8 @@ private:
 
     /**
      * @brief
-     *  The callback function to be called asynchronously when "fail-safe timer"
-     *  expires. We use this function to conduct a sequence of clean-up works.
+     *  The callback function to be called asynchronously after various cleanup work has completed
+     *  to actually disarm the fail-safe.
      */
     static void HandleDisarmFailSafe(intptr_t arg);
 

--- a/src/include/platform/FailSafeContext.h
+++ b/src/include/platform/FailSafeContext.h
@@ -85,7 +85,17 @@ private:
         return TLV::EstimateStructOverhead(sizeof(FabricIndex), sizeof(bool), sizeof(bool));
     }
 
-    static void HandleArmFailSafe(System::Layer * layer, void * aAppState);
+    /**
+     * @brief
+     *  The callback function to be called when "fail-safe timer" expires.
+     */
+    static void HandleArmFailSafeTimer(System::Layer * layer, void * aAppState);
+
+    /**
+     * @brief
+     *  The callback function to be called asynchronously when "fail-safe timer"
+     *  expires. We use this function to conduct a sequence of clean-up works.
+     */
     static void HandleDisarmFailSafe(intptr_t arg);
 
     void FailSafeTimerExpired();

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -153,6 +153,9 @@ protected:
     virtual CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen)               = 0;
     virtual CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)          = 0;
     virtual void RunConfigUnitTest(void)                                                           = 0;
+
+private:
+    static void HandleFailSafeContextCleanup(intptr_t arg);
 };
 
 } // namespace Internal

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -37,6 +37,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>
 #include <platform/CommissionableDataProvider.h>
+#include <platform/DeviceControlServer.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/internal/GenericConfigurationManagerImpl.h>
 
@@ -274,6 +275,8 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::Init()
 
         err = PlatformMgr().PostEvent(&event);
         SuccessOrExit(err);
+
+        DeviceControlServer::DeviceControlSvr().GetFailSafeContext().SetFailSafeBusy(true);
 
         // Ensure HandleFailSafeContextCleanup runs after the timer-expired event has been processed.
         PlatformMgr().ScheduleWork(HandleFailSafeContextCleanup);
@@ -910,6 +913,8 @@ void GenericConfigurationManagerImpl<ConfigClass>::HandleFailSafeContextCleanup(
     {
         ChipLogError(DeviceLayer, "Failed to delete FailSafeContext from configuration");
     }
+
+    DeviceControlServer::DeviceControlSvr().GetFailSafeContext().SetFailSafeBusy(false);
 }
 
 } // namespace Internal

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -275,11 +275,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::Init()
         err = PlatformMgr().PostEvent(&event);
         SuccessOrExit(err);
 
-        err = SetFailSafeArmed(false);
-        SuccessOrExit(err);
-
-        err = FailSafeContext::DeleteFromStorage();
-        SuccessOrExit(err);
+        PlatformMgr().ScheduleWork(HandleFailSafeContextCleanup);
     }
 
 exit:
@@ -898,6 +894,20 @@ void GenericConfigurationManagerImpl<ConfigClass>::LogDeviceConfig()
             deviceType = 0;
         }
         ChipLogProgress(DeviceLayer, "  Device Type: %" PRIu32 " (0x%" PRIX32 ")", deviceType, deviceType);
+    }
+}
+
+template <class ConfigClass>
+void GenericConfigurationManagerImpl<ConfigClass>::HandleFailSafeContextCleanup(intptr_t arg)
+{
+    if (ConfigurationMgr().SetFailSafeArmed(false) != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to set FailSafeArmed config to false");
+    }
+
+    if (FailSafeContext::DeleteFromStorage() != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to delete FailSafeContext from config");
     }
 }
 

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -254,7 +254,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::Init()
     bool failSafeArmed;
 
     // If the fail-safe was armed when the device last shutdown, initiate cleanup based on the pending Fail Safe Context with
-    // which the fail-safe timer has been armed.
+    // which the fail-safe timer was armed.
     if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
         FabricIndex fabricIndex;

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -253,7 +253,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::Init()
 
     bool failSafeArmed;
 
-    // If the fail-safe was armed when the device last shutdown, initiate cleanup to the pending Fail Safe Context with
+    // If the fail-safe was armed when the device last shutdown, initiate cleanup based on the pending Fail Safe Context with
     // which the fail-safe timer has been armed.
     if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -275,6 +275,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::Init()
         err = PlatformMgr().PostEvent(&event);
         SuccessOrExit(err);
 
+        // Ensure HandleFailSafeContextCleanup runs after the timer-expired event has been processed.
         PlatformMgr().ScheduleWork(HandleFailSafeContextCleanup);
     }
 

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -907,7 +907,7 @@ void GenericConfigurationManagerImpl<ConfigClass>::HandleFailSafeContextCleanup(
 
     if (FailSafeContext::DeleteFromStorage() != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Failed to delete FailSafeContext from config");
+        ChipLogError(DeviceLayer, "Failed to delete FailSafeContext from configuration");
     }
 }
 

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -43,7 +43,7 @@ public:
     const char * FabricOpKey(FabricIndex fabric) { return Format("f/%x/o", fabric); }
 
     // FailSafeContext
-    const char * FailSafeContextKey() { return Format("fsc"); }
+    const char * FailSafeContextKey() { return Format("g/fsc"); }
 
     // Access Control List
 

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -42,6 +42,9 @@ public:
     const char * FabricMetadata(FabricIndex fabric) { return Format("f/%x/m", fabric); }
     const char * FabricOpKey(FabricIndex fabric) { return Format("f/%x/o", fabric); }
 
+    // FailSafeContext
+    const char * FailSafeContextKey() { return Format("fsc"); }
+
     // Access Control List
 
     const char * AccessControlList() { return Format("acl"); }

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -88,12 +88,29 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     err = Internal::GenericConfigurationManagerImpl<AmebaConfig>::Init();
     SuccessOrExit(err);
 
-    // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
+    // If the fail-safe was armed when the device last shutdown, initiate cleanup to the pending Fail Safe Context with
+    // which the fail-safe timer has been armed.
     if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
-        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        InitiateFactoryReset();
+        FabricIndex fabricIndex;
+        bool addNocCommandInvoked;
+        bool updateNocCommandInvoked;
+
+        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot");
+
+        err = FailSafeContext::LoadFromStorage(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
+        SuccessOrExit(err);
+
+        ChipDeviceEvent event;
+        event.Type                                                = DeviceEventType::kFailSafeTimerExpired;
+        event.FailSafeTimerExpired.PeerFabricIndex                = fabricIndex;
+        event.FailSafeTimerExpired.AddNocCommandHasBeenInvoked    = addNocCommandInvoked;
+        event.FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked = updateNocCommandInvoked;
+
+        err = PlatformMgr().PostEvent(&event);
+        SuccessOrExit(err);
     }
+
     err = CHIP_NO_ERROR;
 
 exit:

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -89,7 +89,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     SuccessOrExit(err);
 
     // If the fail-safe was armed when the device last shutdown, initiate cleanup based on the pending Fail Safe Context with
-    // which the fail-safe timer has been armed.
+    // which the fail-safe timer was armed.
     if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
         FabricIndex fabricIndex;

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -47,7 +47,6 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
     uint32_t rebootCount;
-    bool failSafeArmed;
 
     // Force initialization of NVS namespaces if they doesn't already exist.
     err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipFactory);
@@ -87,29 +86,6 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     // Initialize the generic implementation base class.
     err = Internal::GenericConfigurationManagerImpl<AmebaConfig>::Init();
     SuccessOrExit(err);
-
-    // If the fail-safe was armed when the device last shutdown, initiate cleanup based on the pending Fail Safe Context with
-    // which the fail-safe timer was armed.
-    if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
-    {
-        FabricIndex fabricIndex;
-        bool addNocCommandInvoked;
-        bool updateNocCommandInvoked;
-
-        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot");
-
-        err = FailSafeContext::LoadFromStorage(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
-        SuccessOrExit(err);
-
-        ChipDeviceEvent event;
-        event.Type                                                = DeviceEventType::kFailSafeTimerExpired;
-        event.FailSafeTimerExpired.PeerFabricIndex                = fabricIndex;
-        event.FailSafeTimerExpired.AddNocCommandHasBeenInvoked    = addNocCommandInvoked;
-        event.FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked = updateNocCommandInvoked;
-
-        err = PlatformMgr().PostEvent(&event);
-        SuccessOrExit(err);
-    }
 
     err = CHIP_NO_ERROR;
 

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -88,7 +88,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     err = Internal::GenericConfigurationManagerImpl<AmebaConfig>::Init();
     SuccessOrExit(err);
 
-    // If the fail-safe was armed when the device last shutdown, initiate cleanup to the pending Fail Safe Context with
+    // If the fail-safe was armed when the device last shutdown, initiate cleanup based on the pending Fail Safe Context with
     // which the fail-safe timer has been armed.
     if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {

--- a/src/platform/EFR32/ConfigurationManagerImpl.cpp
+++ b/src/platform/EFR32/ConfigurationManagerImpl.cpp
@@ -50,7 +50,6 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
 CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
-    bool failSafeArmed;
 
     // Initialize the generic implementation base class.
     err = Internal::GenericConfigurationManagerImpl<EFR32Config>::Init();
@@ -63,29 +62,6 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     // In this case, we keep Reset control at default setting
     rebootCause = RMU_ResetCauseGet();
     RMU_ResetCauseClear();
-
-    // If the fail-safe was armed when the device last shutdown, initiate cleanup to the pending Fail Safe Context with
-    // which the fail-safe timer has been armed.
-    if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
-    {
-        FabricIndex fabricIndex;
-        bool addNocCommandInvoked;
-        bool updateNocCommandInvoked;
-
-        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot");
-
-        err = FailSafeContext::LoadFromStorage(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
-        SuccessOrExit(err);
-
-        ChipDeviceEvent event;
-        event.Type                                                = DeviceEventType::kFailSafeTimerExpired;
-        event.FailSafeTimerExpired.PeerFabricIndex                = fabricIndex;
-        event.FailSafeTimerExpired.AddNocCommandHasBeenInvoked    = addNocCommandInvoked;
-        event.FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked = updateNocCommandInvoked;
-
-        err = PlatformMgr().PostEvent(&event);
-        SuccessOrExit(err);
-    }
 
     err = CHIP_NO_ERROR;
 

--- a/src/platform/EFR32/ConfigurationManagerImpl.cpp
+++ b/src/platform/EFR32/ConfigurationManagerImpl.cpp
@@ -64,12 +64,29 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     rebootCause = RMU_ResetCauseGet();
     RMU_ResetCauseClear();
 
-    // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
+    // If the fail-safe was armed when the device last shutdown, initiate cleanup to the pending Fail Safe Context with
+    // which the fail-safe timer has been armed.
     if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
-        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        InitiateFactoryReset();
+        FabricIndex fabricIndex;
+        bool addNocCommandInvoked;
+        bool updateNocCommandInvoked;
+
+        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot");
+
+        err = FailSafeContext::LoadFromStorage(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
+        SuccessOrExit(err);
+
+        ChipDeviceEvent event;
+        event.Type                                                = DeviceEventType::kFailSafeTimerExpired;
+        event.FailSafeTimerExpired.PeerFabricIndex                = fabricIndex;
+        event.FailSafeTimerExpired.AddNocCommandHasBeenInvoked    = addNocCommandInvoked;
+        event.FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked = updateNocCommandInvoked;
+
+        err = PlatformMgr().PostEvent(&event);
+        SuccessOrExit(err);
     }
+
     err = CHIP_NO_ERROR;
 
 exit:

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -112,12 +112,29 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_FACTORY_PROVISIONING
 
-    // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
+    // If the fail-safe was armed when the device last shutdown, initiate cleanup to the pending Fail Safe Context with
+    // which the fail-safe timer has been armed.
     if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
-        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        InitiateFactoryReset();
+        FabricIndex fabricIndex;
+        bool addNocCommandInvoked;
+        bool updateNocCommandInvoked;
+
+        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot");
+
+        err = FailSafeContext::LoadFromStorage(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
+        SuccessOrExit(err);
+
+        ChipDeviceEvent event;
+        event.Type                                                = DeviceEventType::kFailSafeTimerExpired;
+        event.FailSafeTimerExpired.PeerFabricIndex                = fabricIndex;
+        event.FailSafeTimerExpired.AddNocCommandHasBeenInvoked    = addNocCommandInvoked;
+        event.FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked = updateNocCommandInvoked;
+
+        err = PlatformMgr().PostEvent(&event);
+        SuccessOrExit(err);
     }
+
     err = CHIP_NO_ERROR;
 
 exit:

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -60,7 +60,6 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
     uint32_t rebootCount;
-    bool failSafeArmed;
 
     // Force initialization of NVS namespaces if they doesn't already exist.
     err = ESP32Config::EnsureNamespace(ESP32Config::kConfigNamespace_ChipFactory);
@@ -111,29 +110,6 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     }
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_FACTORY_PROVISIONING
-
-    // If the fail-safe was armed when the device last shutdown, initiate cleanup to the pending Fail Safe Context with
-    // which the fail-safe timer has been armed.
-    if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
-    {
-        FabricIndex fabricIndex;
-        bool addNocCommandInvoked;
-        bool updateNocCommandInvoked;
-
-        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot");
-
-        err = FailSafeContext::LoadFromStorage(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
-        SuccessOrExit(err);
-
-        ChipDeviceEvent event;
-        event.Type                                                = DeviceEventType::kFailSafeTimerExpired;
-        event.FailSafeTimerExpired.PeerFabricIndex                = fabricIndex;
-        event.FailSafeTimerExpired.AddNocCommandHasBeenInvoked    = addNocCommandInvoked;
-        event.FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked = updateNocCommandInvoked;
-
-        err = PlatformMgr().PostEvent(&event);
-        SuccessOrExit(err);
-    }
 
     err = CHIP_NO_ERROR;
 

--- a/src/platform/FailSafeContext.cpp
+++ b/src/platform/FailSafeContext.cpp
@@ -45,6 +45,7 @@ void FailSafeContext::HandleDisarmFailSafe(intptr_t arg)
 {
     FailSafeContext * this_ = reinterpret_cast<FailSafeContext *>(arg);
 
+    this_->mFailSafeBusy                   = false;
     this_->mFailSafeArmed                  = false;
     this_->mAddNocCommandHasBeenInvoked    = false;
     this_->mUpdateNocCommandHasBeenInvoked = false;
@@ -73,6 +74,8 @@ void FailSafeContext::FailSafeTimerExpired()
     {
         ChipLogError(DeviceLayer, "Failed to post commissioning complete: %" CHIP_ERROR_FORMAT, status.Format());
     }
+
+    mFailSafeBusy = true;
 
     PlatformMgr().ScheduleWork(HandleDisarmFailSafe, reinterpret_cast<intptr_t>(this));
 }

--- a/src/platform/FailSafeContext.cpp
+++ b/src/platform/FailSafeContext.cpp
@@ -22,10 +22,19 @@
 
 #include <platform/FailSafeContext.h>
 
+#include <lib/support/SafeInt.h>
 #include <platform/ConfigurationManager.h>
 
 namespace chip {
 namespace DeviceLayer {
+
+namespace {
+constexpr const char kFailSafeContextKey[] = "kFailSafeContextKey";
+
+constexpr TLV::Tag kFabricIndexTag      = TLV::ContextTag(0);
+constexpr TLV::Tag kAddNocCommandTag    = TLV::ContextTag(1);
+constexpr TLV::Tag kUpdateNocCommandTag = TLV::ContextTag(2);
+} // anonymous namespace
 
 void FailSafeContext::HandleArmFailSafe(System::Layer * layer, void * aAppState)
 {
@@ -45,6 +54,7 @@ void FailSafeContext::FailSafeTimerExpired()
     mFailSafeArmed                  = false;
     mAddNocCommandHasBeenInvoked    = false;
     mUpdateNocCommandHasBeenInvoked = false;
+    ConfigurationMgr().SetFailSafeArmed(false);
 
     if (status != CHIP_NO_ERROR)
     {
@@ -56,7 +66,14 @@ CHIP_ERROR FailSafeContext::ArmFailSafe(FabricIndex accessingFabricIndex, System
 {
     mFailSafeArmed = true;
     mFabricIndex   = accessingFabricIndex;
+    ConfigurationMgr().SetFailSafeArmed(true);
     DeviceLayer::SystemLayer().StartTimer(expiryLength, HandleArmFailSafe, this);
+
+    if (CommitToStorage() != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to commit the fabricIndex of FailSafeContext to persistent storage");
+    }
+
     return CHIP_NO_ERROR;
 }
 
@@ -65,8 +82,88 @@ CHIP_ERROR FailSafeContext::DisarmFailSafe()
     mFailSafeArmed                  = false;
     mAddNocCommandHasBeenInvoked    = false;
     mUpdateNocCommandHasBeenInvoked = false;
+    ConfigurationMgr().SetFailSafeArmed(false);
     DeviceLayer::SystemLayer().CancelTimer(HandleArmFailSafe, this);
+
+    if (DeleteFromStorage() != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to delete the captured FailSafeContext from persistent storage");
+    }
+
     return CHIP_NO_ERROR;
+}
+
+void FailSafeContext::SetAddNocCommandInvoked(FabricIndex nocFabricIndex)
+{
+    mAddNocCommandHasBeenInvoked = true;
+    mFabricIndex                 = nocFabricIndex;
+
+    if (CommitToStorage() != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to commit the AddNocCommandHasBeenInvoked of FailSafeContext to persistent storage");
+    }
+}
+
+void FailSafeContext::SetUpdateNocCommandInvoked(FabricIndex nocFabricIndex)
+{
+    mUpdateNocCommandHasBeenInvoked = true;
+    mFabricIndex                    = nocFabricIndex;
+
+    if (CommitToStorage() != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to commit the UpdateNocCommandHasBeenInvoked of FailSafeContext to persistent storage");
+    }
+}
+
+CHIP_ERROR FailSafeContext::CommitToStorage()
+{
+    uint8_t buf[FailSafeContextTLVMaxSize()];
+    TLV::TLVWriter writer;
+    writer.Init(buf);
+
+    TLV::TLVType outerType;
+    ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerType));
+    ReturnErrorOnFailure(writer.Put(kFabricIndexTag, mFabricIndex));
+    ReturnErrorOnFailure(writer.Put(kAddNocCommandTag, mAddNocCommandHasBeenInvoked));
+    ReturnErrorOnFailure(writer.Put(kUpdateNocCommandTag, mUpdateNocCommandHasBeenInvoked));
+    ReturnErrorOnFailure(writer.EndContainer(outerType));
+
+    const auto failSafeContextTLVLength = writer.GetLengthWritten();
+    VerifyOrReturnError(CanCastTo<uint16_t>(failSafeContextTLVLength), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    return PersistedStorage::KeyValueStoreMgr().Put(kFailSafeContextKey, buf, static_cast<uint16_t>(failSafeContextTLVLength));
+}
+
+CHIP_ERROR FailSafeContext::LoadFromStorage(FabricIndex & fabricIndex, bool & addNocCommandInvoked, bool & updateNocCommandInvoked)
+{
+    uint8_t buf[FailSafeContextTLVMaxSize()];
+    ReturnErrorOnFailure(PersistedStorage::KeyValueStoreMgr().Get(kFailSafeContextKey, buf, sizeof(buf)));
+
+    TLV::ContiguousBufferTLVReader reader;
+    reader.Init(buf, sizeof(buf));
+    ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag()));
+
+    TLV::TLVType containerType;
+    ReturnErrorOnFailure(reader.EnterContainer(containerType));
+
+    ReturnErrorOnFailure(reader.Next(kFabricIndexTag));
+    ReturnErrorOnFailure(reader.Get(fabricIndex));
+
+    ReturnErrorOnFailure(reader.Next(kAddNocCommandTag));
+    ReturnErrorOnFailure(reader.Get(addNocCommandInvoked));
+
+    ReturnErrorOnFailure(reader.Next(kUpdateNocCommandTag));
+    ReturnErrorOnFailure(reader.Get(updateNocCommandInvoked));
+
+    ReturnErrorOnFailure(reader.VerifyEndOfContainer());
+    ReturnErrorOnFailure(reader.ExitContainer(containerType));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR FailSafeContext::DeleteFromStorage()
+{
+    return PersistedStorage::KeyValueStoreMgr().Delete(kFailSafeContextKey);
 }
 
 } // namespace DeviceLayer

--- a/src/platform/FailSafeContext.cpp
+++ b/src/platform/FailSafeContext.cpp
@@ -73,9 +73,9 @@ CHIP_ERROR FailSafeContext::ArmFailSafe(FabricIndex accessingFabricIndex, System
     mFailSafeArmed = true;
     mFabricIndex   = accessingFabricIndex;
 
-    ReturnErrorOnFailure(ConfigurationMgr().SetFailSafeArmed(true));
     ReturnErrorOnFailure(DeviceLayer::SystemLayer().StartTimer(expiryLength, HandleArmFailSafe, this));
     ReturnErrorOnFailure(CommitToStorage());
+    ReturnErrorOnFailure(ConfigurationMgr().SetFailSafeArmed(true));
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/FailSafeContext.cpp
+++ b/src/platform/FailSafeContext.cpp
@@ -72,7 +72,7 @@ void FailSafeContext::FailSafeTimerExpired()
 
     if (status != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Failed to post commissioning complete: %" CHIP_ERROR_FORMAT, status.Format());
+        ChipLogError(DeviceLayer, "Failed to post fail-safe timer expired: %" CHIP_ERROR_FORMAT, status.Format());
     }
 
     mFailSafeBusy = true;

--- a/src/platform/FailSafeContext.cpp
+++ b/src/platform/FailSafeContext.cpp
@@ -45,10 +45,7 @@ void FailSafeContext::HandleDisarmFailSafe(intptr_t arg)
 {
     FailSafeContext * this_ = reinterpret_cast<FailSafeContext *>(arg);
 
-    this_->mFailSafeBusy                   = false;
-    this_->mFailSafeArmed                  = false;
-    this_->mAddNocCommandHasBeenInvoked    = false;
-    this_->mUpdateNocCommandHasBeenInvoked = false;
+    this_->mFailSafeBusy = false;
 
     if (ConfigurationMgr().SetFailSafeArmed(false) != CHIP_NO_ERROR)
     {
@@ -69,6 +66,10 @@ void FailSafeContext::FailSafeTimerExpired()
     event.FailSafeTimerExpired.AddNocCommandHasBeenInvoked    = mAddNocCommandHasBeenInvoked;
     event.FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked = mUpdateNocCommandHasBeenInvoked;
     CHIP_ERROR status                                         = PlatformMgr().PostEvent(&event);
+
+    mFailSafeArmed                  = false;
+    mAddNocCommandHasBeenInvoked    = false;
+    mUpdateNocCommandHasBeenInvoked = false;
 
     if (status != CHIP_NO_ERROR)
     {

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -106,11 +106,27 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
         SuccessOrExit(err);
     }
 
-    // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
+    // If the fail-safe was armed when the device last shutdown, initiate cleanup to the pending Fail Safe Context with
+    // which the fail-safe timer has been armed.
     if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
-        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        InitiateFactoryReset();
+        FabricIndex fabricIndex;
+        bool addNocCommandInvoked;
+        bool updateNocCommandInvoked;
+
+        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot");
+
+        err = FailSafeContext::LoadFromStorage(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
+        SuccessOrExit(err);
+
+        ChipDeviceEvent event;
+        event.Type                                                = DeviceEventType::kFailSafeTimerExpired;
+        event.FailSafeTimerExpired.PeerFabricIndex                = fabricIndex;
+        event.FailSafeTimerExpired.AddNocCommandHasBeenInvoked    = addNocCommandInvoked;
+        event.FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked = updateNocCommandInvoked;
+
+        err = PlatformMgr().PostEvent(&event);
+        SuccessOrExit(err);
     }
 
     err = CHIP_NO_ERROR;

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -51,7 +51,6 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
     uint32_t rebootCount;
-    bool failSafeArmed;
 
     // Initialize the generic implementation base class.
     err = Internal::GenericConfigurationManagerImpl<ZephyrConfig>::Init();
@@ -83,29 +82,6 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     {
         // The first boot after factory reset of the Node.
         err = StoreRebootCount(1);
-        SuccessOrExit(err);
-    }
-
-    // If the fail-safe was armed when the device last shutdown, initiate cleanup to the pending Fail Safe Context with
-    // which the fail-safe timer has been armed.
-    if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
-    {
-        FabricIndex fabricIndex;
-        bool addNocCommandInvoked;
-        bool updateNocCommandInvoked;
-
-        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot");
-
-        err = FailSafeContext::LoadFromStorage(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
-        SuccessOrExit(err);
-
-        ChipDeviceEvent event;
-        event.Type                                                = DeviceEventType::kFailSafeTimerExpired;
-        event.FailSafeTimerExpired.PeerFabricIndex                = fabricIndex;
-        event.FailSafeTimerExpired.AddNocCommandHasBeenInvoked    = addNocCommandInvoked;
-        event.FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked = updateNocCommandInvoked;
-
-        err = PlatformMgr().PostEvent(&event);
         SuccessOrExit(err);
     }
 

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -86,11 +86,27 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
         SuccessOrExit(err);
     }
 
-    // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
+    // If the fail-safe was armed when the device last shutdown, initiate cleanup to the pending Fail Safe Context with
+    // which the fail-safe timer has been armed.
     if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
-        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        InitiateFactoryReset();
+        FabricIndex fabricIndex;
+        bool addNocCommandInvoked;
+        bool updateNocCommandInvoked;
+
+        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot");
+
+        err = FailSafeContext::LoadFromStorage(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
+        SuccessOrExit(err);
+
+        ChipDeviceEvent event;
+        event.Type                                                = DeviceEventType::kFailSafeTimerExpired;
+        event.FailSafeTimerExpired.PeerFabricIndex                = fabricIndex;
+        event.FailSafeTimerExpired.AddNocCommandHasBeenInvoked    = addNocCommandInvoked;
+        event.FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked = updateNocCommandInvoked;
+
+        err = PlatformMgr().PostEvent(&event);
+        SuccessOrExit(err);
     }
 
     err = CHIP_NO_ERROR;

--- a/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
@@ -63,19 +63,9 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
 CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
-    bool failSafeArmed;
 
     // Initialize the generic implementation base class.
     err = Internal::GenericConfigurationManagerImpl<CC13X2_26X2Config>::Init();
-    ReturnErrorOnFailure(err);
-
-    // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
-    if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
-    {
-        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        InitiateFactoryReset();
-    }
-    err = CHIP_NO_ERROR;
 
 exit:
     return err;

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
@@ -50,7 +50,6 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
 CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
-    bool failSafeArmed;
     uint32_t rebootCount = 0;
 
     if (K32WConfig::ConfigValueExists(K32WConfig::kCounterKey_RebootCount))
@@ -85,29 +84,6 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     SuccessOrExit(err);
 
     // TODO: Initialize the global GroupKeyStore object here
-
-    // If the fail-safe was armed when the device last shutdown, initiate cleanup to the pending Fail Safe Context with
-    // which the fail-safe timer has been armed.
-    if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
-    {
-        FabricIndex fabricIndex;
-        bool addNocCommandInvoked;
-        bool updateNocCommandInvoked;
-
-        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot");
-
-        err = FailSafeContext::LoadFromStorage(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
-        SuccessOrExit(err);
-
-        ChipDeviceEvent event;
-        event.Type                                                = DeviceEventType::kFailSafeTimerExpired;
-        event.FailSafeTimerExpired.PeerFabricIndex                = fabricIndex;
-        event.FailSafeTimerExpired.AddNocCommandHasBeenInvoked    = addNocCommandInvoked;
-        event.FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked = updateNocCommandInvoked;
-
-        err = PlatformMgr().PostEvent(&event);
-        SuccessOrExit(err);
-    }
 
     err = CHIP_NO_ERROR;
 

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
@@ -86,12 +86,29 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
     // TODO: Initialize the global GroupKeyStore object here
 
-    // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
+    // If the fail-safe was armed when the device last shutdown, initiate cleanup to the pending Fail Safe Context with
+    // which the fail-safe timer has been armed.
     if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
-        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        InitiateFactoryReset();
+        FabricIndex fabricIndex;
+        bool addNocCommandInvoked;
+        bool updateNocCommandInvoked;
+
+        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot");
+
+        err = FailSafeContext::LoadFromStorage(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
+        SuccessOrExit(err);
+
+        ChipDeviceEvent event;
+        event.Type                                                = DeviceEventType::kFailSafeTimerExpired;
+        event.FailSafeTimerExpired.PeerFabricIndex                = fabricIndex;
+        event.FailSafeTimerExpired.AddNocCommandHasBeenInvoked    = addNocCommandInvoked;
+        event.FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked = updateNocCommandInvoked;
+
+        err = PlatformMgr().PostEvent(&event);
+        SuccessOrExit(err);
     }
+
     err = CHIP_NO_ERROR;
 
 exit:

--- a/src/platform/qpg/ConfigurationManagerImpl.cpp
+++ b/src/platform/qpg/ConfigurationManagerImpl.cpp
@@ -50,38 +50,10 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
 CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
-    bool failSafeArmed;
 
     // Initialize the generic implementation base class.
     err = Internal::GenericConfigurationManagerImpl<QPGConfig>::Init();
-    SuccessOrExit(err);
 
-    // If the fail-safe was armed when the device last shutdown, initiate cleanup to the pending Fail Safe Context with
-    // which the fail-safe timer has been armed.
-    if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
-    {
-        FabricIndex fabricIndex;
-        bool addNocCommandInvoked;
-        bool updateNocCommandInvoked;
-
-        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot");
-
-        err = FailSafeContext::LoadFromStorage(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
-        SuccessOrExit(err);
-
-        ChipDeviceEvent event;
-        event.Type                                                = DeviceEventType::kFailSafeTimerExpired;
-        event.FailSafeTimerExpired.PeerFabricIndex                = fabricIndex;
-        event.FailSafeTimerExpired.AddNocCommandHasBeenInvoked    = addNocCommandInvoked;
-        event.FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked = updateNocCommandInvoked;
-
-        err = PlatformMgr().PostEvent(&event);
-        SuccessOrExit(err);
-    }
-
-    err = CHIP_NO_ERROR;
-
-exit:
     return err;
 }
 

--- a/src/platform/qpg/ConfigurationManagerImpl.cpp
+++ b/src/platform/qpg/ConfigurationManagerImpl.cpp
@@ -56,12 +56,29 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     err = Internal::GenericConfigurationManagerImpl<QPGConfig>::Init();
     SuccessOrExit(err);
 
-    // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
+    // If the fail-safe was armed when the device last shutdown, initiate cleanup to the pending Fail Safe Context with
+    // which the fail-safe timer has been armed.
     if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
-        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        InitiateFactoryReset();
+        FabricIndex fabricIndex;
+        bool addNocCommandInvoked;
+        bool updateNocCommandInvoked;
+
+        ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot");
+
+        err = FailSafeContext::LoadFromStorage(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
+        SuccessOrExit(err);
+
+        ChipDeviceEvent event;
+        event.Type                                                = DeviceEventType::kFailSafeTimerExpired;
+        event.FailSafeTimerExpired.PeerFabricIndex                = fabricIndex;
+        event.FailSafeTimerExpired.AddNocCommandHasBeenInvoked    = addNocCommandInvoked;
+        event.FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked = updateNocCommandInvoked;
+
+        err = PlatformMgr().PostEvent(&event);
+        SuccessOrExit(err);
     }
+
     err = CHIP_NO_ERROR;
 
 exit:

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -40,6 +40,8 @@ using namespace chip::Logging;
 using namespace chip::Inet;
 using namespace chip::DeviceLayer;
 
+namespace {
+
 // =================================
 //      Unit tests
 // =================================
@@ -205,6 +207,22 @@ static void TestConfigurationMgr_GetPrimaryMACAddress(nlTestSuite * inSuite, voi
     //      expecially if running in emulators (zephyr and qemu)
 }
 
+static void TestConfigurationMgr_GetFailSafeArmed(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err     = CHIP_NO_ERROR;
+    bool failSafeArmed = false;
+
+    err = ConfigurationMgr().SetFailSafeArmed(true);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = ConfigurationMgr().GetFailSafeArmed(failSafeArmed);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, failSafeArmed == true);
+
+    err = ConfigurationMgr().SetFailSafeArmed(false);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
 /**
  *   Test Suite. It lists all the test functions.
  */
@@ -221,6 +239,7 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test ConfigurationMgr::CountryCode", TestConfigurationMgr_CountryCode),
     NL_TEST_DEF("Test ConfigurationMgr::Breadcrumb", TestConfigurationMgr_Breadcrumb),
     NL_TEST_DEF("Test ConfigurationMgr::GetPrimaryMACAddress", TestConfigurationMgr_GetPrimaryMACAddress),
+    NL_TEST_DEF("Test ConfigurationMgr::GetFailSafeArmed", TestConfigurationMgr_GetFailSafeArmed),
     NL_TEST_SENTINEL()
 };
 
@@ -245,6 +264,11 @@ int TestConfigurationMgr_Teardown(void * inContext)
     return SUCCESS;
 }
 
+} // namespace
+
+/**
+ *  Main
+ */
 int TestConfigurationMgr()
 {
     nlTestSuite theSuite = { "ConfigurationMgr tests", &sTests[0], TestConfigurationMgr_Setup, TestConfigurationMgr_Teardown };

--- a/src/platform/tests/TestFailSafeContext.cpp
+++ b/src/platform/tests/TestFailSafeContext.cpp
@@ -82,12 +82,14 @@ static void TestFailSafeContext_NocCommandInvoked(nlTestSuite * inSuite, void * 
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, failSafeContext.GetFabricIndex() == kTestAccessingFabricIndex1);
 
-    failSafeContext.SetAddNocCommandInvoked(kTestAccessingFabricIndex2);
+    err = failSafeContext.SetAddNocCommandInvoked(kTestAccessingFabricIndex2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, failSafeContext.NocCommandHasBeenInvoked() == true);
     NL_TEST_ASSERT(inSuite, failSafeContext.AddNocCommandHasBeenInvoked() == true);
     NL_TEST_ASSERT(inSuite, failSafeContext.GetFabricIndex() == kTestAccessingFabricIndex2);
 
-    failSafeContext.SetUpdateNocCommandInvoked(kTestAccessingFabricIndex1);
+    err = failSafeContext.SetUpdateNocCommandInvoked(kTestAccessingFabricIndex1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, failSafeContext.NocCommandHasBeenInvoked() == true);
     NL_TEST_ASSERT(inSuite, failSafeContext.UpdateNocCommandHasBeenInvoked() == true);
     NL_TEST_ASSERT(inSuite, failSafeContext.GetFabricIndex() == kTestAccessingFabricIndex1);
@@ -106,10 +108,12 @@ static void TestFailSafeContext_CommitToStorage(nlTestSuite * inSuite, void * in
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, failSafeContext.GetFabricIndex() == kTestAccessingFabricIndex1);
 
-    failSafeContext.SetAddNocCommandInvoked(kTestAccessingFabricIndex1);
+    err = failSafeContext.SetAddNocCommandInvoked(kTestAccessingFabricIndex1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, failSafeContext.AddNocCommandHasBeenInvoked() == true);
 
-    failSafeContext.SetUpdateNocCommandInvoked(kTestAccessingFabricIndex1);
+    err = failSafeContext.SetUpdateNocCommandInvoked(kTestAccessingFabricIndex1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, failSafeContext.UpdateNocCommandHasBeenInvoked() == true);
 
     FabricIndex fabricIndex;

--- a/src/platform/tests/TestFailSafeContext.cpp
+++ b/src/platform/tests/TestFailSafeContext.cpp
@@ -93,6 +93,37 @@ static void TestFailSafeContext_NocCommandInvoked(nlTestSuite * inSuite, void * 
     NL_TEST_ASSERT(inSuite, failSafeContext.GetFabricIndex() == kTestAccessingFabricIndex1);
 
     err = failSafeContext.DisarmFailSafe();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+static void TestFailSafeContext_CommitToStorage(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    FailSafeContext & failSafeContext = DeviceControlServer::DeviceControlSvr().GetFailSafeContext();
+
+    err = failSafeContext.ArmFailSafe(kTestAccessingFabricIndex1, System::Clock::Seconds16(1));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, failSafeContext.GetFabricIndex() == kTestAccessingFabricIndex1);
+
+    failSafeContext.SetAddNocCommandInvoked(kTestAccessingFabricIndex1);
+    NL_TEST_ASSERT(inSuite, failSafeContext.AddNocCommandHasBeenInvoked() == true);
+
+    failSafeContext.SetUpdateNocCommandInvoked(kTestAccessingFabricIndex1);
+    NL_TEST_ASSERT(inSuite, failSafeContext.UpdateNocCommandHasBeenInvoked() == true);
+
+    FabricIndex fabricIndex;
+    bool addNocCommandInvoked;
+    bool updateNocCommandInvoked;
+
+    err = FailSafeContext::LoadFromStorage(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, fabricIndex == kTestAccessingFabricIndex1);
+    NL_TEST_ASSERT(inSuite, addNocCommandInvoked == true);
+    NL_TEST_ASSERT(inSuite, updateNocCommandInvoked == true);
+
+    err = failSafeContext.DisarmFailSafe();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
 /**
@@ -102,7 +133,10 @@ static const nlTest sTests[] = {
 
     NL_TEST_DEF("Test PlatformMgr::Init", TestPlatformMgr_Init),
     NL_TEST_DEF("Test FailSafeContext::ArmFailSafe", TestFailSafeContext_ArmFailSafe),
-    NL_TEST_DEF("Test FailSafeContext::NocCommandInvoked", TestFailSafeContext_NocCommandInvoked), NL_TEST_SENTINEL()
+    NL_TEST_DEF("Test FailSafeContext::NocCommandInvoked", TestFailSafeContext_NocCommandInvoked),
+    NL_TEST_DEF("Test FailSafeContext::CommitToStorage", TestFailSafeContext_CommitToStorage),
+
+    NL_TEST_SENTINEL()
 };
 
 /**


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, we conduct full factory reset when detect a pending armfailsafe during reboot, there is not correct since it will reset all fabrics's state

* we should only clean up the works done for the fabric which has been armed failsafe. 

#### Change overview
Only clean up the works done for the fabric which has been armed failsafe. 

#### Testing
How was this tested? (at least one bullet point required)
* Added unit tests to verify the FailSafeContext can be preserved to persistent storage during ArmFailSafe and Retrieved later 
