### PR TITLE
Move ESP jobs timeout to 90 minutes

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -26,7 +26,7 @@ jobs:
     # TODO ESP32 https://github.com/project-chip/connectedhomeip/issues/1510
     esp32:
         name: ESP32
-        timeout-minutes: 80
+        timeout-minutes: 90
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -111,7 +111,7 @@ jobs:
 
     esp32_1:
         name: ESP32_1
-        timeout-minutes: 70
+        timeout-minutes: 90
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'


### PR DESCRIPTION
#### Problem
ESP timeouts out at 70 minutes like here:

https://github.com/project-chip/connectedhomeip/runs/5631505435?check_suite_focus=true

#### Change overview
Increase timeout uniformly to 90 minutes

#### Testing
N/A (CI will validate)