### PR TITLE
Don't lose enableServerInteractions state when controller restarts.

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -55,8 +55,11 @@ CHIP_ERROR DeviceControllerFactory::Init(FactoryInitParams params)
         return CHIP_NO_ERROR;
     }
 
+    // Save our initialization state that we can't recover later from a
+    // created-but-shut-down system state.
     mListenPort               = params.listenPort;
     mFabricIndependentStorage = params.fabricIndependentStorage;
+    mEnableServerInteractions = params.enableServerInteractions;
 
     CHIP_ERROR err = InitSystemState(params);
 
@@ -74,9 +77,10 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState()
 #if CONFIG_NETWORK_LAYER_BLE
         params.bleLayer = mSystemState->BleLayer();
 #endif
+        params.listenPort               = mListenPort;
+        params.fabricIndependentStorage = mFabricIndependentStorage;
+        params.enableServerInteractions = mEnableServerInteractions;
     }
-
-    params.fabricIndependentStorage = mFabricIndependentStorage;
 
     return InitSystemState(params);
 }
@@ -128,12 +132,12 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     //
     ReturnErrorOnFailure(stateParams.transportMgr->Init(Transport::UdpListenParameters(stateParams.udpEndPointManager)
                                                             .SetAddressType(Inet::IPAddressType::kIPv6)
-                                                            .SetListenPort(mListenPort)
+                                                            .SetListenPort(params.listenPort)
 #if INET_CONFIG_ENABLE_IPV4
                                                             ,
                                                         Transport::UdpListenParameters(stateParams.udpEndPointManager)
                                                             .SetAddressType(Inet::IPAddressType::kIPv4)
-                                                            .SetListenPort(mListenPort)
+                                                            .SetListenPort(params.listenPort)
 #endif
 #if CONFIG_NETWORK_LAYER_BLE
                                                             ,

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -182,6 +182,7 @@ private:
     uint16_t mListenPort;
     DeviceControllerSystemState * mSystemState            = nullptr;
     PersistentStorageDelegate * mFabricIndependentStorage = nullptr;
+    bool mEnableServerInteractions                        = false;
 };
 
 } // namespace Controller


### PR DESCRIPTION
When we shut down and restart the last controller, we shut down and
reinitialize the system state.  Since we were not storing the
enableServerInteractions state in either the SystemState or the
CHIPDeviceControllerFactory, it was getting lost during this process.

The fix is to store the state in CHIPDeviceControllerFactory.

#### Problem
See above.

#### Change overview
See above.

#### Testing
In iOS CHIPTool app, verified that after I go through the QR code screen and pair a device the device can open a CASE session to CHIPTool.  Without this change it can't.