### PR TITLE
Make sure to call connection callbacks in synchronous failure

### DIFF
--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -98,6 +98,10 @@ CHIP_ERROR OperationalDeviceProxy::Connect(Callback::Callback<OnDeviceConnected>
     if (err != CHIP_NO_ERROR && onFailure != nullptr)
     {
         onFailure->mCall(onFailure->mContext, mPeerId, err);
+
+        DequeueConnectionSuccessCallbacks(/* executeCallback */ false);
+        DequeueConnectionFailureCallbacks(err, /* executeCallback */ true);
+        CloseCASESession();
     }
 
     return err;


### PR DESCRIPTION
#### Problem

If OperationalDeviceProxy::Connect fails synchronously it does not call
pending failure callbacks except for the argument to the current call.

This leads to unanswered connection requests as FindOrEstablishSession
immediately calls ReleaseSession() after such a failure, which deletes
the proxy.

#### Change overview

Make sure to call pending callbacks on synchronous failure.

#### Testing

Connect to an non-routable address, which fails synchronously in sendmsg()
in the resolve callback. Application is still notified of failure.
