### PR TITLE
Encode the user label list in place so that we can free the label lis…

### DIFF
--- a/src/app/clusters/user-label-server/user-label-server.cpp
+++ b/src/app/clusters/user-label-server/user-label-server.cpp
@@ -59,22 +59,31 @@ CHIP_ERROR UserLabelAttrAccess::ReadLabelList(EndpointId endpoint, AttributeValu
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    DeviceLayer::DeviceInfoProvider::UserLabelIterator * it = DeviceLayer::GetDeviceInfoProvider()->IterateUserLabel(endpoint);
+    DeviceLayer::DeviceInfoProvider * provider = DeviceLayer::GetDeviceInfoProvider();
 
-    if (it)
+    if (provider)
     {
-        err = aEncoder.EncodeList([&it](const auto & encoder) -> CHIP_ERROR {
-            UserLabel::Structs::LabelStruct::Type userlabel;
+        DeviceLayer::DeviceInfoProvider::UserLabelIterator * it = provider->IterateUserLabel(endpoint);
 
-            while (it->Next(userlabel))
-            {
-                ReturnErrorOnFailure(encoder.Encode(userlabel));
-            }
+        if (it)
+        {
+            err = aEncoder.EncodeList([&it](const auto & encoder) -> CHIP_ERROR {
+                UserLabel::Structs::LabelStruct::Type userlabel;
 
-            return CHIP_NO_ERROR;
-        });
+                while (it->Next(userlabel))
+                {
+                    ReturnErrorOnFailure(encoder.Encode(userlabel));
+                }
 
-        it->Release();
+                return CHIP_NO_ERROR;
+            });
+
+            it->Release();
+        }
+        else
+        {
+            err = aEncoder.EncodeEmptyList();
+        }
     }
     else
     {

--- a/src/app/clusters/user-label-server/user-label-server.cpp
+++ b/src/app/clusters/user-label-server/user-label-server.cpp
@@ -106,7 +106,7 @@ CHIP_ERROR UserLabelAttrAccess::WriteLabelList(const ConcreteDataAttributePath &
         Structs::LabelStruct::DecodableType entry;
         ReturnErrorOnFailure(aDecoder.Decode(entry));
 
-        return DeviceLayer::PlatformMgr().AppendUserLabelList(endpoint, entry);
+        return DeviceLayer::PlatformMgr().AppendUserLabel(endpoint, entry);
     }
     else
     {

--- a/src/include/platform/DeviceInfoProvider.h
+++ b/src/include/platform/DeviceInfoProvider.h
@@ -28,8 +28,9 @@
 namespace chip {
 namespace DeviceLayer {
 
-static constexpr size_t kMaxLabelNameLength  = 16;
-static constexpr size_t kMaxLabelValueLength = 16;
+static constexpr size_t kMaxUserLabelListLength = 10;
+static constexpr size_t kMaxLabelNameLength     = 16;
+static constexpr size_t kMaxLabelValueLength    = 16;
 
 class DeviceInfoProvider
 {
@@ -63,8 +64,10 @@ public:
     };
 
     using FixedLabelType = app::Clusters::FixedLabel::Structs::LabelStruct::Type;
+    using UserLabelType  = app::Clusters::UserLabel::Structs::LabelStruct::Type;
 
     using FixedLabelIterator = Iterator<FixedLabelType>;
+    using UserLabelIterator  = Iterator<UserLabelType>;
 
     DeviceInfoProvider() = default;
 
@@ -73,6 +76,9 @@ public:
     // Not copyable
     DeviceInfoProvider(const DeviceInfoProvider &) = delete;
     DeviceInfoProvider & operator=(const DeviceInfoProvider &) = delete;
+
+    CHIP_ERROR SetUserLabelList(EndpointId endpoint, const AttributeList<UserLabelType, kMaxUserLabelListLength> & labelList);
+    CHIP_ERROR AppendUserLabel(EndpointId endpoint, const UserLabelType & label);
 
     // Iterators
     /**
@@ -83,6 +89,12 @@ public:
      *  @retval nullptr if no iterator instances are available.
      */
     virtual FixedLabelIterator * IterateFixedLabel(EndpointId endpoint) = 0;
+    virtual UserLabelIterator * IterateUserLabel(EndpointId endpoint)   = 0;
+
+protected:
+    virtual CHIP_ERROR SetUserLabelAt(EndpointId endpoint, size_t index, const UserLabelType & userLabel) = 0;
+    virtual CHIP_ERROR SetUserLabelCount(EndpointId endpoint, size_t val)                                 = 0;
+    virtual CHIP_ERROR GetUserLabelCount(EndpointId endpoint, size_t & val)                               = 0;
 };
 
 /**

--- a/src/include/platform/DeviceInfoProvider.h
+++ b/src/include/platform/DeviceInfoProvider.h
@@ -112,7 +112,7 @@ protected:
     virtual CHIP_ERROR SetUserLabelCount(EndpointId endpoint, size_t val) = 0;
 
     /**
-     * @brief Get the total count of the UserLabelList on a given endpoint
+     * @brief Get the total length of the UserLabelList on a given endpoint
      *
      * @param endpoint - id of the UserLabelList.
      * @param val - output of the total count of the UserLabelList.

--- a/src/include/platform/DeviceInfoProvider.h
+++ b/src/include/platform/DeviceInfoProvider.h
@@ -92,9 +92,33 @@ public:
     virtual UserLabelIterator * IterateUserLabel(EndpointId endpoint)   = 0;
 
 protected:
+    /**
+     * @brief Set the UserLabel at the specified index of the UserLabelList on a given endpoint
+     *
+     * @param endpoint - id to UserLabelList on which to set the UserLabel.
+     * @param index - index within the UserLabelList for which to set the UserLabel.
+     * @param userLabel - user label to set.
+     * @return CHIP_NO_ERROR on success, other CHIP_ERROR values from implementation on other errors.
+     */
     virtual CHIP_ERROR SetUserLabelAt(EndpointId endpoint, size_t index, const UserLabelType & userLabel) = 0;
-    virtual CHIP_ERROR SetUserLabelCount(EndpointId endpoint, size_t val)                                 = 0;
-    virtual CHIP_ERROR GetUserLabelCount(EndpointId endpoint, size_t & val)                               = 0;
+
+    /**
+     * @brief Set the total count of the UserLabelList on a given endpoint
+     *
+     * @param endpoint - id of the UserLabelList.
+     * @param val - total count of the UserLabelList.
+     * @return CHIP_NO_ERROR on success, other CHIP_ERROR values from implementation on other errors.
+     */
+    virtual CHIP_ERROR SetUserLabelCount(EndpointId endpoint, size_t val) = 0;
+
+    /**
+     * @brief Get the total count of the UserLabelList on a given endpoint
+     *
+     * @param endpoint - id of the UserLabelList.
+     * @param val - output of the total count of the UserLabelList.
+     * @return CHIP_NO_ERROR on success, other CHIP_ERROR values from implementation on other errors.
+     */
+    virtual CHIP_ERROR GetUserLabelCount(EndpointId endpoint, size_t & val) = 0;
 };
 
 /**

--- a/src/include/platform/DeviceInfoProvider.h
+++ b/src/include/platform/DeviceInfoProvider.h
@@ -82,9 +82,9 @@ public:
 
     // Iterators
     /**
-     *  Creates an iterator that may be used to obtain the list of user labels associated with the given endpoint.
+     *  Creates an iterator that may be used to obtain the list of labels associated with the given endpoint.
      *  In order to release the allocated memory, the Release() method must be called after the iteration is finished.
-     *  Modifying the user label during the iteration is currently not supported, and may yield unexpected behaviour.
+     *  Modifying the label during the iteration is currently not supported, and may yield unexpected behaviour.
      *  @retval An instance of EndpointIterator on success
      *  @retval nullptr if no iterator instances are available.
      */
@@ -98,7 +98,8 @@ protected:
      * @param endpoint - id to UserLabelList on which to set the UserLabel.
      * @param index - index within the UserLabelList for which to set the UserLabel.
      * @param userLabel - user label to set.
-     * @return CHIP_NO_ERROR on success, other CHIP_ERROR values from implementation on other errors.
+     * @return CHIP_NO_ERROR on success, CHIP_ERROR_INVALID_KEY_ID if index exceed the range (Total length - 1),
+     *         or other CHIP_ERROR values from implementation on other errors.
      */
     virtual CHIP_ERROR SetUserLabelAt(EndpointId endpoint, size_t index, const UserLabelType & userLabel) = 0;
 
@@ -109,7 +110,7 @@ protected:
      * @param val - total count of the UserLabelList.
      * @return CHIP_NO_ERROR on success, other CHIP_ERROR values from implementation on other errors.
      */
-    virtual CHIP_ERROR SetUserLabelCount(EndpointId endpoint, size_t val) = 0;
+    virtual CHIP_ERROR SetUserLabelLength(EndpointId endpoint, size_t val) = 0;
 
     /**
      * @brief Get the total length of the UserLabelList on a given endpoint
@@ -118,7 +119,7 @@ protected:
      * @param val - output of the total count of the UserLabelList.
      * @return CHIP_NO_ERROR on success, other CHIP_ERROR values from implementation on other errors.
      */
-    virtual CHIP_ERROR GetUserLabelCount(EndpointId endpoint, size_t & val) = 0;
+    virtual CHIP_ERROR GetUserLabelLength(EndpointId endpoint, size_t & val) = 0;
 };
 
 /**

--- a/src/include/platform/DeviceInfoProvider.h
+++ b/src/include/platform/DeviceInfoProvider.h
@@ -103,7 +103,7 @@ protected:
     virtual CHIP_ERROR SetUserLabelAt(EndpointId endpoint, size_t index, const UserLabelType & userLabel) = 0;
 
     /**
-     * @brief Set the total count of the UserLabelList on a given endpoint
+     * @brief Set the total length of the UserLabelList on a given endpoint
      *
      * @param endpoint - id of the UserLabelList.
      * @param val - total count of the UserLabelList.

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -197,7 +197,7 @@ public:
 
     CHIP_ERROR SetUserLabelList(EndpointId endpoint,
                                 AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
-    CHIP_ERROR AppendUserLabelList(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label);
+    CHIP_ERROR AppendUserLabel(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label);
     CHIP_ERROR
     GetUserLabelList(EndpointId endpoint,
                      std::function<CHIP_ERROR(
@@ -465,10 +465,10 @@ PlatformManager::SetUserLabelList(EndpointId endpoint,
     return static_cast<ImplClass *>(this)->_SetUserLabelList(endpoint, labelList);
 }
 
-inline CHIP_ERROR PlatformManager::AppendUserLabelList(EndpointId endpoint,
-                                                       app::Clusters::UserLabel::Structs::LabelStruct::Type & label)
+inline CHIP_ERROR PlatformManager::AppendUserLabel(EndpointId endpoint,
+                                                   app::Clusters::UserLabel::Structs::LabelStruct::Type & label)
 {
-    return static_cast<ImplClass *>(this)->_AppendUserLabelList(endpoint, label);
+    return static_cast<ImplClass *>(this)->_AppendUserLabel(endpoint, label);
 }
 
 inline CHIP_ERROR PlatformManager::GetUserLabelList(

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include <functional>
 #include <platform/AttributeList.h>
 #include <platform/CHIPDeviceBuildConfig.h>
 #include <platform/CHIPDeviceEvent.h>
@@ -38,7 +37,6 @@ class DiscoveryImplPlatform;
 
 namespace DeviceLayer {
 
-static constexpr size_t kMaxUserLabels    = 10;
 static constexpr size_t kMaxLanguageTags  = 254; // Maximum number of entry type 'ARRAY' supports
 static constexpr size_t kMaxCalendarTypes = 12;
 
@@ -195,14 +193,6 @@ public:
     bool IsChipStackLockedByCurrentThread() const;
 #endif
 
-    CHIP_ERROR SetUserLabelList(EndpointId endpoint,
-                                AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
-    CHIP_ERROR AppendUserLabel(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label);
-    CHIP_ERROR
-    GetUserLabelList(EndpointId endpoint,
-                     std::function<CHIP_ERROR(
-                         const AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)>
-                         fp);
     CHIP_ERROR GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales);
     CHIP_ERROR GetSupportedCalendarTypes(
         AttributeList<app::Clusters::TimeFormatLocalization::CalendarType, kMaxCalendarTypes> & supportedCalendarTypes);
@@ -457,26 +447,6 @@ inline void PlatformManager::DispatchEvent(const ChipDeviceEvent * event)
 inline CHIP_ERROR PlatformManager::StartChipTimer(System::Clock::Timeout duration)
 {
     return static_cast<ImplClass *>(this)->_StartChipTimer(duration);
-}
-inline CHIP_ERROR
-PlatformManager::SetUserLabelList(EndpointId endpoint,
-                                  AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
-{
-    return static_cast<ImplClass *>(this)->_SetUserLabelList(endpoint, labelList);
-}
-
-inline CHIP_ERROR PlatformManager::AppendUserLabel(EndpointId endpoint,
-                                                   app::Clusters::UserLabel::Structs::LabelStruct::Type & label)
-{
-    return static_cast<ImplClass *>(this)->_AppendUserLabel(endpoint, label);
-}
-
-inline CHIP_ERROR PlatformManager::GetUserLabelList(
-    EndpointId endpoint,
-    std::function<CHIP_ERROR(const AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)>
-        fp)
-{
-    return static_cast<ImplClass *>(this)->_GetUserLabelList(endpoint, fp);
 }
 
 inline CHIP_ERROR PlatformManager::GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales)

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <functional>
 #include <platform/AttributeList.h>
 #include <platform/CHIPDeviceBuildConfig.h>
 #include <platform/CHIPDeviceEvent.h>
@@ -196,8 +197,12 @@ public:
 
     CHIP_ERROR SetUserLabelList(EndpointId endpoint,
                                 AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
-    CHIP_ERROR GetUserLabelList(EndpointId endpoint,
-                                AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
+    CHIP_ERROR AppendUserLabelList(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label);
+    CHIP_ERROR
+    GetUserLabelList(EndpointId endpoint,
+                     std::function<CHIP_ERROR(
+                         const AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)>
+                         fp);
     CHIP_ERROR GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales);
     CHIP_ERROR GetSupportedCalendarTypes(
         AttributeList<app::Clusters::TimeFormatLocalization::CalendarType, kMaxCalendarTypes> & supportedCalendarTypes);
@@ -460,11 +465,18 @@ PlatformManager::SetUserLabelList(EndpointId endpoint,
     return static_cast<ImplClass *>(this)->_SetUserLabelList(endpoint, labelList);
 }
 
-inline CHIP_ERROR
-PlatformManager::GetUserLabelList(EndpointId endpoint,
-                                  AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
+inline CHIP_ERROR PlatformManager::AppendUserLabelList(EndpointId endpoint,
+                                                       app::Clusters::UserLabel::Structs::LabelStruct::Type & label)
 {
-    return static_cast<ImplClass *>(this)->_GetUserLabelList(endpoint, labelList);
+    return static_cast<ImplClass *>(this)->_AppendUserLabelList(endpoint, label);
+}
+
+inline CHIP_ERROR PlatformManager::GetUserLabelList(
+    EndpointId endpoint,
+    std::function<CHIP_ERROR(const AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)>
+        fp)
+{
+    return static_cast<ImplClass *>(this)->_GetUserLabelList(endpoint, fp);
 }
 
 inline CHIP_ERROR PlatformManager::GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales)

--- a/src/include/platform/internal/GenericPlatformManagerImpl.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.h
@@ -62,7 +62,7 @@ protected:
 
     CHIP_ERROR _SetUserLabelList(EndpointId endpoint,
                                  AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
-    CHIP_ERROR _AppendUserLabelList(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label);
+    CHIP_ERROR _AppendUserLabel(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label);
     CHIP_ERROR
     _GetUserLabelList(EndpointId endpoint,
                       std::function<CHIP_ERROR(
@@ -96,8 +96,8 @@ inline CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_SetUserLabelList(
 
 template <class ImplClass>
 inline CHIP_ERROR
-GenericPlatformManagerImpl<ImplClass>::_AppendUserLabelList(EndpointId endpoint,
-                                                            app::Clusters::UserLabel::Structs::LabelStruct::Type & label)
+GenericPlatformManagerImpl<ImplClass>::_AppendUserLabel(EndpointId endpoint,
+                                                        app::Clusters::UserLabel::Structs::LabelStruct::Type & label)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/include/platform/internal/GenericPlatformManagerImpl.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.h
@@ -62,8 +62,12 @@ protected:
 
     CHIP_ERROR _SetUserLabelList(EndpointId endpoint,
                                  AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
-    CHIP_ERROR _GetUserLabelList(EndpointId endpoint,
-                                 AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
+    CHIP_ERROR _AppendUserLabelList(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label);
+    CHIP_ERROR
+    _GetUserLabelList(EndpointId endpoint,
+                      std::function<CHIP_ERROR(
+                          const AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)>
+                          fp);
     CHIP_ERROR _GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales);
     CHIP_ERROR _GetSupportedCalendarTypes(
         AttributeList<app::Clusters::TimeFormatLocalization::CalendarType, kMaxCalendarTypes> & supportedCalendarTypes);
@@ -91,8 +95,18 @@ inline CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_SetUserLabelList(
 }
 
 template <class ImplClass>
+inline CHIP_ERROR
+GenericPlatformManagerImpl<ImplClass>::_AppendUserLabelList(EndpointId endpoint,
+                                                            app::Clusters::UserLabel::Structs::LabelStruct::Type & label)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ImplClass>
 inline CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_GetUserLabelList(
-    EndpointId endpoint, AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
+    EndpointId endpoint,
+    std::function<CHIP_ERROR(const AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)>
+        fp)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/include/platform/internal/GenericPlatformManagerImpl.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.h
@@ -60,14 +60,6 @@ protected:
     void _ScheduleWork(AsyncWorkFunct workFunct, intptr_t arg);
     void _DispatchEvent(const ChipDeviceEvent * event);
 
-    CHIP_ERROR _SetUserLabelList(EndpointId endpoint,
-                                 AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
-    CHIP_ERROR _AppendUserLabel(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label);
-    CHIP_ERROR
-    _GetUserLabelList(EndpointId endpoint,
-                      std::function<CHIP_ERROR(
-                          const AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)>
-                          fp);
     CHIP_ERROR _GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales);
     CHIP_ERROR _GetSupportedCalendarTypes(
         AttributeList<app::Clusters::TimeFormatLocalization::CalendarType, kMaxCalendarTypes> & supportedCalendarTypes);
@@ -86,30 +78,6 @@ private:
 
 // Instruct the compiler to instantiate the template only when explicitly told to do so.
 extern template class GenericPlatformManagerImpl<PlatformManagerImpl>;
-
-template <class ImplClass>
-inline CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_SetUserLabelList(
-    EndpointId endpoint, AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-template <class ImplClass>
-inline CHIP_ERROR
-GenericPlatformManagerImpl<ImplClass>::_AppendUserLabel(EndpointId endpoint,
-                                                        app::Clusters::UserLabel::Structs::LabelStruct::Type & label)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-template <class ImplClass>
-inline CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_GetUserLabelList(
-    EndpointId endpoint,
-    std::function<CHIP_ERROR(const AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)>
-        fp)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
 
 template <class ImplClass>
 inline CHIP_ERROR

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -144,7 +144,7 @@ PlatformManagerImpl::_SetUserLabelList(
 }
 
 CHIP_ERROR
-PlatformManagerImpl::_AppendUserLabelList(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label)
+PlatformManagerImpl::_AppendUserLabel(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label)
 {
     return CHIP_NO_ERROR;
 }

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -137,19 +137,6 @@ CHIP_ERROR PlatformManagerImpl::_PostEvent(const ChipDeviceEvent * event)
 }
 
 CHIP_ERROR
-PlatformManagerImpl::_SetUserLabelList(
-    EndpointId endpoint, AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
-{
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR
-PlatformManagerImpl::_AppendUserLabel(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label)
-{
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR
 PlatformManagerImpl::_GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales)
 {
     // In Darwin simulation, return following hardcoded list of Strings that are valid values for the ActiveLocale.

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -144,6 +144,12 @@ PlatformManagerImpl::_SetUserLabelList(
 }
 
 CHIP_ERROR
+PlatformManagerImpl::_AppendUserLabelList(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label)
+{
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR
 PlatformManagerImpl::_GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales)
 {
     // In Darwin simulation, return following hardcoded list of Strings that are valid values for the ActiveLocale.

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -64,9 +64,6 @@ private:
     CHIP_ERROR _StartEventLoopTask();
     CHIP_ERROR _StopEventLoopTask();
 
-    CHIP_ERROR _SetUserLabelList(EndpointId endpoint,
-                                 AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
-    CHIP_ERROR _AppendUserLabel(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label);
     CHIP_ERROR _GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales);
     CHIP_ERROR _GetSupportedCalendarTypes(
         AttributeList<app::Clusters::TimeFormatLocalization::CalendarType, kMaxCalendarTypes> & supportedCalendarTypes);

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -66,6 +66,7 @@ private:
 
     CHIP_ERROR _SetUserLabelList(EndpointId endpoint,
                                  AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
+    CHIP_ERROR _AppendUserLabelList(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label);
     CHIP_ERROR _GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales);
     CHIP_ERROR _GetSupportedCalendarTypes(
         AttributeList<app::Clusters::TimeFormatLocalization::CalendarType, kMaxCalendarTypes> & supportedCalendarTypes);

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -66,7 +66,7 @@ private:
 
     CHIP_ERROR _SetUserLabelList(EndpointId endpoint,
                                  AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
-    CHIP_ERROR _AppendUserLabelList(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label);
+    CHIP_ERROR _AppendUserLabel(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label);
     CHIP_ERROR _GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales);
     CHIP_ERROR _GetSupportedCalendarTypes(
         AttributeList<app::Clusters::TimeFormatLocalization::CalendarType, kMaxCalendarTypes> & supportedCalendarTypes);

--- a/src/platform/DeviceInfoProvider.cpp
+++ b/src/platform/DeviceInfoProvider.cpp
@@ -40,7 +40,7 @@ CHIP_ERROR DeviceInfoProvider::SetUserLabelList(EndpointId endpoint,
 {
     size_t index = 0;
 
-    ReturnErrorOnFailure(SetUserLabelCount(endpoint, labelList.size()));
+    ReturnErrorOnFailure(SetUserLabelLength(endpoint, labelList.size()));
 
     for (const UserLabelType & label : labelList)
     {
@@ -52,10 +52,14 @@ CHIP_ERROR DeviceInfoProvider::SetUserLabelList(EndpointId endpoint,
 
 CHIP_ERROR DeviceInfoProvider::AppendUserLabel(EndpointId endpoint, const UserLabelType & label)
 {
-    size_t index;
+    size_t length;
 
-    ReturnErrorOnFailure(GetUserLabelCount(endpoint, index));
-    ReturnErrorOnFailure(SetUserLabelAt(endpoint, index + 1, label));
+    // Increase the size of UserLabelList by 1
+    ReturnErrorOnFailure(GetUserLabelLength(endpoint, length));
+    ReturnErrorOnFailure(SetUserLabelLength(endpoint, length + 1));
+
+    // Append the user label at the end of UserLabelList
+    ReturnErrorOnFailure(SetUserLabelAt(endpoint, length, label));
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/DeviceInfoProvider.cpp
+++ b/src/platform/DeviceInfoProvider.cpp
@@ -35,6 +35,31 @@ DeviceInfoProvider * gDeviceInfoProvider = nullptr;
 
 } // namespace
 
+CHIP_ERROR DeviceInfoProvider::SetUserLabelList(EndpointId endpoint,
+                                                const AttributeList<UserLabelType, kMaxUserLabelListLength> & labelList)
+{
+    size_t index = 0;
+
+    ReturnErrorOnFailure(SetUserLabelCount(endpoint, labelList.size()));
+
+    for (const UserLabelType & label : labelList)
+    {
+        ReturnErrorOnFailure(SetUserLabelAt(endpoint, index++, label));
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DeviceInfoProvider::AppendUserLabel(EndpointId endpoint, const UserLabelType & label)
+{
+    size_t index;
+
+    ReturnErrorOnFailure(GetUserLabelCount(endpoint, index));
+    ReturnErrorOnFailure(SetUserLabelAt(endpoint, index + 1, label));
+
+    return CHIP_NO_ERROR;
+}
+
 /**
  * Instance getter for the global DeviceInfoProvider.
  *

--- a/src/platform/Linux/DeviceInfoProviderImpl.cpp
+++ b/src/platform/Linux/DeviceInfoProviderImpl.cpp
@@ -105,13 +105,13 @@ bool DeviceInfoProviderImpl::FixedLabelIteratorImpl::Next(FixedLabelType & outpu
     }
 }
 
-CHIP_ERROR DeviceInfoProviderImpl::SetUserLabelCount(EndpointId endpoint, size_t val)
+CHIP_ERROR DeviceInfoProviderImpl::SetUserLabelLength(EndpointId endpoint, size_t val)
 {
     // TODO:: store the user label count.
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-CHIP_ERROR DeviceInfoProviderImpl::GetUserLabelCount(EndpointId endpoint, size_t & val)
+CHIP_ERROR DeviceInfoProviderImpl::GetUserLabelLength(EndpointId endpoint, size_t & val)
 {
     // TODO:: read the user label count. temporarily return the size of hardcoded labelList.
     val = 4;
@@ -136,7 +136,7 @@ DeviceInfoProviderImpl::UserLabelIteratorImpl::UserLabelIteratorImpl(DeviceInfoP
 {
     size_t total = 0;
 
-    ReturnOnFailure(mProvider.GetUserLabelCount(mEndpoint, total));
+    ReturnOnFailure(mProvider.GetUserLabelLength(mEndpoint, total));
     mTotal = total;
     mIndex = 0;
 }

--- a/src/platform/Linux/DeviceInfoProviderImpl.cpp
+++ b/src/platform/Linux/DeviceInfoProviderImpl.cpp
@@ -105,5 +105,96 @@ bool DeviceInfoProviderImpl::FixedLabelIteratorImpl::Next(FixedLabelType & outpu
     }
 }
 
+CHIP_ERROR DeviceInfoProviderImpl::SetUserLabelCount(EndpointId endpoint, size_t val)
+{
+    // TODO:: store the user label count.
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR DeviceInfoProviderImpl::GetUserLabelCount(EndpointId endpoint, size_t & val)
+{
+    // TODO:: read the user label count. temporarily return the size of hardcoded labelList.
+    val = 4;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DeviceInfoProviderImpl::SetUserLabelAt(EndpointId endpoint, size_t index, const UserLabelType & userLabel)
+{
+    // TODO:: store the user labelList, and read back stored user labelList if it has been set.
+    // Add yaml test to verify this.
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+DeviceInfoProvider::UserLabelIterator * DeviceInfoProviderImpl::IterateUserLabel(EndpointId endpoint)
+{
+    return new UserLabelIteratorImpl(*this, endpoint);
+}
+
+DeviceInfoProviderImpl::UserLabelIteratorImpl::UserLabelIteratorImpl(DeviceInfoProviderImpl & provider, EndpointId endpoint) :
+    mProvider(provider), mEndpoint(endpoint)
+{
+    size_t total = 0;
+
+    ReturnOnFailure(mProvider.GetUserLabelCount(mEndpoint, total));
+    mTotal = total;
+    mIndex = 0;
+}
+
+bool DeviceInfoProviderImpl::UserLabelIteratorImpl::Next(UserLabelType & output)
+{
+    // TODO:: get the user labelList from persistent storage, temporarily, use the following
+    // hardcoded labelList on all endpoints.
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    const char * labelPtr = nullptr;
+    const char * valuePtr = nullptr;
+
+    VerifyOrReturnError(mIndex < mTotal, false);
+
+    switch (mIndex)
+    {
+    case 0:
+        labelPtr = "room";
+        valuePtr = "bedroom 2";
+        break;
+    case 1:
+        labelPtr = "orientation";
+        valuePtr = "North";
+        break;
+    case 2:
+        labelPtr = "floor";
+        valuePtr = "2";
+        break;
+    case 3:
+        labelPtr = "direction";
+        valuePtr = "up";
+        break;
+    default:
+        err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+        break;
+    }
+
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(std::strlen(labelPtr) <= kMaxLabelNameLength, false);
+        VerifyOrReturnError(std::strlen(valuePtr) <= kMaxLabelValueLength, false);
+
+        Platform::CopyString(mUserLabelNameBuf, kMaxLabelNameLength + 1, labelPtr);
+        Platform::CopyString(mUserLabelValueBuf, kMaxLabelValueLength + 1, valuePtr);
+
+        output.label = CharSpan::fromCharString(mUserLabelNameBuf);
+        output.value = CharSpan::fromCharString(mUserLabelValueBuf);
+
+        mIndex++;
+
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Linux/DeviceInfoProviderImpl.h
+++ b/src/platform/Linux/DeviceInfoProviderImpl.h
@@ -29,6 +29,7 @@ public:
 
     // Iterators
     FixedLabelIterator * IterateFixedLabel(EndpointId endpoint) override;
+    UserLabelIterator * IterateUserLabel(EndpointId endpoint) override;
 
     static DeviceInfoProviderImpl & GetDefaultInstance();
 
@@ -47,6 +48,27 @@ protected:
         char mFixedLabelNameBuf[kMaxLabelNameLength + 1];
         char mFixedLabelValueBuf[kMaxLabelValueLength + 1];
     };
+
+    class UserLabelIteratorImpl : public UserLabelIterator
+    {
+    public:
+        UserLabelIteratorImpl(DeviceInfoProviderImpl & provider, EndpointId endpoint);
+        size_t Count() override { return mTotal; }
+        bool Next(UserLabelType & output) override;
+        void Release() override { delete this; }
+
+    private:
+        DeviceInfoProviderImpl & mProvider;
+        EndpointId mEndpoint = 0;
+        size_t mIndex        = 0;
+        size_t mTotal        = 0;
+        char mUserLabelNameBuf[kMaxLabelNameLength + 1];
+        char mUserLabelValueBuf[kMaxLabelValueLength + 1];
+    };
+
+    CHIP_ERROR SetUserLabelCount(EndpointId endpoint, size_t val) override;
+    CHIP_ERROR GetUserLabelCount(EndpointId endpoint, size_t & val) override;
+    CHIP_ERROR SetUserLabelAt(EndpointId endpoint, size_t index, const UserLabelType & userLabel) override;
 };
 
 } // namespace DeviceLayer

--- a/src/platform/Linux/DeviceInfoProviderImpl.h
+++ b/src/platform/Linux/DeviceInfoProviderImpl.h
@@ -66,8 +66,8 @@ protected:
         char mUserLabelValueBuf[kMaxLabelValueLength + 1];
     };
 
-    CHIP_ERROR SetUserLabelCount(EndpointId endpoint, size_t val) override;
-    CHIP_ERROR GetUserLabelCount(EndpointId endpoint, size_t & val) override;
+    CHIP_ERROR SetUserLabelLength(EndpointId endpoint, size_t val) override;
+    CHIP_ERROR GetUserLabelLength(EndpointId endpoint, size_t & val) override;
     CHIP_ERROR SetUserLabelAt(EndpointId endpoint, size_t index, const UserLabelType & userLabel) override;
 };
 

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -243,55 +243,6 @@ CHIP_ERROR PlatformManagerImpl::_Shutdown()
 }
 
 CHIP_ERROR
-PlatformManagerImpl::_SetUserLabelList(
-    EndpointId endpoint, AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
-{
-    // TODO:: store the user labelList, and read back stored user labelList if it has been set. Add yaml test to verify this.
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR
-PlatformManagerImpl::_AppendUserLabel(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label)
-{
-    // TODO:: store the user labelList, and read back stored user labelList if it has been set. Add yaml test to verify this.
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR
-PlatformManagerImpl::_GetUserLabelList(
-    EndpointId endpoint,
-    std::function<CHIP_ERROR(const AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)>
-        fp)
-{
-    DeviceLayer::AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, DeviceLayer::kMaxUserLabels> labelList;
-
-    // In Linux simulation, return following hardcoded labelList on all endpoints.
-    UserLabel::Structs::LabelStruct::Type room;
-    UserLabel::Structs::LabelStruct::Type orientation;
-    UserLabel::Structs::LabelStruct::Type floor;
-    UserLabel::Structs::LabelStruct::Type direction;
-
-    room.label = CharSpan::fromCharString("room");
-    room.value = CharSpan::fromCharString("bedroom 2");
-
-    orientation.label = CharSpan::fromCharString("orientation");
-    orientation.value = CharSpan::fromCharString("North");
-
-    floor.label = CharSpan::fromCharString("floor");
-    floor.value = CharSpan::fromCharString("2");
-
-    direction.label = CharSpan::fromCharString("direction");
-    direction.value = CharSpan::fromCharString("up");
-
-    labelList.add(room);
-    labelList.add(orientation);
-    labelList.add(floor);
-    labelList.add(direction);
-
-    return fp(labelList);
-}
-
-CHIP_ERROR
 PlatformManagerImpl::_GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales)
 {
     // In Linux simulation, return following hardcoded list of Strings that are valid values for the ActiveLocale.

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -251,7 +251,7 @@ PlatformManagerImpl::_SetUserLabelList(
 }
 
 CHIP_ERROR
-PlatformManagerImpl::_AppendUserLabelList(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label)
+PlatformManagerImpl::_AppendUserLabel(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label)
 {
     // TODO:: store the user labelList, and read back stored user labelList if it has been set. Add yaml test to verify this.
     return CHIP_NO_ERROR;

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -251,9 +251,20 @@ PlatformManagerImpl::_SetUserLabelList(
 }
 
 CHIP_ERROR
-PlatformManagerImpl::_GetUserLabelList(
-    EndpointId endpoint, AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
+PlatformManagerImpl::_AppendUserLabelList(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label)
 {
+    // TODO:: store the user labelList, and read back stored user labelList if it has been set. Add yaml test to verify this.
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR
+PlatformManagerImpl::_GetUserLabelList(
+    EndpointId endpoint,
+    std::function<CHIP_ERROR(const AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)>
+        fp)
+{
+    DeviceLayer::AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, DeviceLayer::kMaxUserLabels> labelList;
+
     // In Linux simulation, return following hardcoded labelList on all endpoints.
     UserLabel::Structs::LabelStruct::Type room;
     UserLabel::Structs::LabelStruct::Type orientation;
@@ -277,7 +288,7 @@ PlatformManagerImpl::_GetUserLabelList(
     labelList.add(floor);
     labelList.add(direction);
 
-    return CHIP_NO_ERROR;
+    return fp(labelList);
 }
 
 CHIP_ERROR

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -67,7 +67,7 @@ private:
     CHIP_ERROR _Shutdown();
     CHIP_ERROR _SetUserLabelList(EndpointId endpoint,
                                  AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
-    CHIP_ERROR _AppendUserLabelList(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label);
+    CHIP_ERROR _AppendUserLabel(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label);
     CHIP_ERROR
     _GetUserLabelList(EndpointId endpoint,
                       std::function<CHIP_ERROR(

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -65,14 +65,6 @@ private:
 
     CHIP_ERROR _InitChipStack();
     CHIP_ERROR _Shutdown();
-    CHIP_ERROR _SetUserLabelList(EndpointId endpoint,
-                                 AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
-    CHIP_ERROR _AppendUserLabel(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label);
-    CHIP_ERROR
-    _GetUserLabelList(EndpointId endpoint,
-                      std::function<CHIP_ERROR(
-                          const AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)>
-                          fp);
     CHIP_ERROR _GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales);
     CHIP_ERROR _GetSupportedCalendarTypes(
         AttributeList<app::Clusters::TimeFormatLocalization::CalendarType, kMaxCalendarTypes> & supportedCalendarTypes);

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -67,8 +67,12 @@ private:
     CHIP_ERROR _Shutdown();
     CHIP_ERROR _SetUserLabelList(EndpointId endpoint,
                                  AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
-    CHIP_ERROR _GetUserLabelList(EndpointId endpoint,
-                                 AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList);
+    CHIP_ERROR _AppendUserLabelList(EndpointId endpoint, app::Clusters::UserLabel::Structs::LabelStruct::Type & label);
+    CHIP_ERROR
+    _GetUserLabelList(EndpointId endpoint,
+                      std::function<CHIP_ERROR(
+                          const AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)>
+                          fp);
     CHIP_ERROR _GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales);
     CHIP_ERROR _GetSupportedCalendarTypes(
         AttributeList<app::Clusters::TimeFormatLocalization::CalendarType, kMaxCalendarTypes> & supportedCalendarTypes);

--- a/src/platform/fake/PlatformManagerImpl.h
+++ b/src/platform/fake/PlatformManagerImpl.h
@@ -106,8 +106,11 @@ private:
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
-    CHIP_ERROR _GetUserLabelList(EndpointId endpoint,
-                                 AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
+    CHIP_ERROR
+    _GetUserLabelList(EndpointId endpoint,
+                      std::function<CHIP_ERROR(
+                          const AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)>
+                          fp)
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }

--- a/src/platform/fake/PlatformManagerImpl.h
+++ b/src/platform/fake/PlatformManagerImpl.h
@@ -100,21 +100,6 @@ private:
 
     CHIP_ERROR _StartChipTimer(System::Clock::Timeout duration) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
-    CHIP_ERROR _SetUserLabelList(EndpointId endpoint,
-                                 AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)
-    {
-        return CHIP_ERROR_NOT_IMPLEMENTED;
-    }
-
-    CHIP_ERROR
-    _GetUserLabelList(EndpointId endpoint,
-                      std::function<CHIP_ERROR(
-                          const AttributeList<app::Clusters::UserLabel::Structs::LabelStruct::Type, kMaxUserLabels> & labelList)>
-                          fp)
-    {
-        return CHIP_ERROR_NOT_IMPLEMENTED;
-    }
-
     CHIP_ERROR _GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales)
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;


### PR DESCRIPTION
…t after usage

#### Problem
What is being fixed?  Examples:
* TCL hit problem when implementing  _GetUserLabelList API on their product
* Currently,  API _GetUserLabelList returns a AttributeList with a list of CharSpan, we can allocate space to store those labels load from persistent storage in _GetUserLabelList(labelList), but we can not free this memory before return of _GetUserLabelList. If we call free after _GetUserLabelList() is called at userLabel cluster server, we don't know the appropriate way to release the memory since different platform may uses different mechanism to allocate the memory.

* Fixes https://github.com/project-chip/connectedhomeip/issues/16362

#### Change overview
Encode the user label list in place so that we can free the label list after usage.

#### Testing
How was this tested? (at least one bullet point required)
```
yufengwang@yufengwang:~/connectedhomeip/out/debug/standalone$ ./chip-tool userlabel read label-list 12344321 0
....
[1647914868.797498][2411780:2411785] CHIP:DMG: ReportDataMessage =
[1647914868.797512][2411780:2411785] CHIP:DMG: {
[1647914868.797524][2411780:2411785] CHIP:DMG: 	AttributeReportIBs =
[1647914868.797544][2411780:2411785] CHIP:DMG: 	[
[1647914868.797557][2411780:2411785] CHIP:DMG: 		AttributeReportIB =
[1647914868.797576][2411780:2411785] CHIP:DMG: 		{
[1647914868.797589][2411780:2411785] CHIP:DMG: 			AttributeDataIB =
[1647914868.797603][2411780:2411785] CHIP:DMG: 			{
[1647914868.797619][2411780:2411785] CHIP:DMG: 				DataVersion = 0xed3f861c,
[1647914868.797633][2411780:2411785] CHIP:DMG: 				AttributePathIB =
[1647914868.797648][2411780:2411785] CHIP:DMG: 				{
[1647914868.797681][2411780:2411785] CHIP:DMG: 					Endpoint = 0x0,
[1647914868.797696][2411780:2411785] CHIP:DMG: 					Cluster = 0x41,
[1647914868.797711][2411780:2411785] CHIP:DMG: 					Attribute = 0x0000_0000,
[1647914868.797724][2411780:2411785] CHIP:DMG: 				}
[1647914868.797741][2411780:2411785] CHIP:DMG: 					
[1647914868.797755][2411780:2411785] CHIP:DMG: 					Data = [
[1647914868.797770][2411780:2411785] CHIP:DMG: 						
[1647914868.797785][2411780:2411785] CHIP:DMG: 					],
[1647914868.797799][2411780:2411785] CHIP:DMG: 			},
[1647914868.797816][2411780:2411785] CHIP:DMG: 			
[1647914868.797828][2411780:2411785] CHIP:DMG: 		},
[1647914868.797853][2411780:2411785] CHIP:DMG: 		
[1647914868.797865][2411780:2411785] CHIP:DMG: 		AttributeReportIB =
[1647914868.797885][2411780:2411785] CHIP:DMG: 		{
[1647914868.797897][2411780:2411785] CHIP:DMG: 			AttributeDataIB =
[1647914868.797911][2411780:2411785] CHIP:DMG: 			{
[1647914868.797925][2411780:2411785] CHIP:DMG: 				DataVersion = 0xed3f861c,
[1647914868.797938][2411780:2411785] CHIP:DMG: 				AttributePathIB =
[1647914868.797952][2411780:2411785] CHIP:DMG: 				{
[1647914868.797965][2411780:2411785] CHIP:DMG: 					Endpoint = 0x0,
[1647914868.797979][2411780:2411785] CHIP:DMG: 					Cluster = 0x41,
[1647914868.797994][2411780:2411785] CHIP:DMG: 					Attribute = 0x0000_0000,
[1647914868.798008][2411780:2411785] CHIP:DMG: 					ListIndex = Null,
[1647914868.798022][2411780:2411785] CHIP:DMG: 				}
[1647914868.798038][2411780:2411785] CHIP:DMG: 					
[1647914868.798051][2411780:2411785] CHIP:DMG: 					Data = 
[1647914868.798066][2411780:2411785] CHIP:DMG: 					{
[1647914868.798083][2411780:2411785] CHIP:DMG: 						0x0 = "room", 
[1647914868.798098][2411780:2411785] CHIP:DMG: 						0x1 = "bedroom 2", 
[1647914868.798113][2411780:2411785] CHIP:DMG: 					},
[1647914868.798127][2411780:2411785] CHIP:DMG: 			},
[1647914868.798146][2411780:2411785] CHIP:DMG: 			
[1647914868.798158][2411780:2411785] CHIP:DMG: 		},
[1647914868.798185][2411780:2411785] CHIP:DMG: 		
[1647914868.798197][2411780:2411785] CHIP:DMG: 		AttributeReportIB =
[1647914868.798216][2411780:2411785] CHIP:DMG: 		{
[1647914868.798228][2411780:2411785] CHIP:DMG: 			AttributeDataIB =
[1647914868.798241][2411780:2411785] CHIP:DMG: 			{
[1647914868.798255][2411780:2411785] CHIP:DMG: 				DataVersion = 0xed3f861c,
[1647914868.798268][2411780:2411785] CHIP:DMG: 				AttributePathIB =
[1647914868.798282][2411780:2411785] CHIP:DMG: 				{
[1647914868.798295][2411780:2411785] CHIP:DMG: 					Endpoint = 0x0,
[1647914868.798310][2411780:2411785] CHIP:DMG: 					Cluster = 0x41,
[1647914868.798325][2411780:2411785] CHIP:DMG: 					Attribute = 0x0000_0000,
[1647914868.798338][2411780:2411785] CHIP:DMG: 					ListIndex = Null,
[1647914868.798352][2411780:2411785] CHIP:DMG: 				}
[1647914868.798368][2411780:2411785] CHIP:DMG: 					
[1647914868.798382][2411780:2411785] CHIP:DMG: 					Data = 
[1647914868.798396][2411780:2411785] CHIP:DMG: 					{
[1647914868.798411][2411780:2411785] CHIP:DMG: 						0x0 = "orientation", 
[1647914868.798426][2411780:2411785] CHIP:DMG: 						0x1 = "North", 
[1647914868.798441][2411780:2411785] CHIP:DMG: 					},
[1647914868.798454][2411780:2411785] CHIP:DMG: 			},
[1647914868.798474][2411780:2411785] CHIP:DMG: 			
[1647914868.798486][2411780:2411785] CHIP:DMG: 		},
[1647914868.798512][2411780:2411785] CHIP:DMG: 		
[1647914868.798525][2411780:2411785] CHIP:DMG: 		AttributeReportIB =
[1647914868.798545][2411780:2411785] CHIP:DMG: 		{
[1647914868.798557][2411780:2411785] CHIP:DMG: 			AttributeDataIB =
[1647914868.798571][2411780:2411785] CHIP:DMG: 			{
[1647914868.798585][2411780:2411785] CHIP:DMG: 				DataVersion = 0xed3f861c,
[1647914868.798598][2411780:2411785] CHIP:DMG: 				AttributePathIB =
[1647914868.798612][2411780:2411785] CHIP:DMG: 				{
[1647914868.798626][2411780:2411785] CHIP:DMG: 					Endpoint = 0x0,
[1647914868.798640][2411780:2411785] CHIP:DMG: 					Cluster = 0x41,
[1647914868.798655][2411780:2411785] CHIP:DMG: 					Attribute = 0x0000_0000,
[1647914868.798669][2411780:2411785] CHIP:DMG: 					ListIndex = Null,
[1647914868.798682][2411780:2411785] CHIP:DMG: 				}
[1647914868.798698][2411780:2411785] CHIP:DMG: 					
[1647914868.798711][2411780:2411785] CHIP:DMG: 					Data = 
[1647914868.798726][2411780:2411785] CHIP:DMG: 					{
[1647914868.798741][2411780:2411785] CHIP:DMG: 						0x0 = "floor", 
[1647914868.798756][2411780:2411785] CHIP:DMG: 						0x1 = "2", 
[1647914868.798771][2411780:2411785] CHIP:DMG: 					},
[1647914868.798784][2411780:2411785] CHIP:DMG: 			},
[1647914868.798802][2411780:2411785] CHIP:DMG: 			
[1647914868.798814][2411780:2411785] CHIP:DMG: 		},
[1647914868.798840][2411780:2411785] CHIP:DMG: 		
[1647914868.798852][2411780:2411785] CHIP:DMG: 		AttributeReportIB =
[1647914868.798871][2411780:2411785] CHIP:DMG: 		{
[1647914868.798883][2411780:2411785] CHIP:DMG: 			AttributeDataIB =
[1647914868.798897][2411780:2411785] CHIP:DMG: 			{
[1647914868.798911][2411780:2411785] CHIP:DMG: 				DataVersion = 0xed3f861c,
[1647914868.798925][2411780:2411785] CHIP:DMG: 				AttributePathIB =
[1647914868.798938][2411780:2411785] CHIP:DMG: 				{
[1647914868.798952][2411780:2411785] CHIP:DMG: 					Endpoint = 0x0,
[1647914868.798966][2411780:2411785] CHIP:DMG: 					Cluster = 0x41,
[1647914868.798984][2411780:2411785] CHIP:DMG: 					Attribute = 0x0000_0000,
[1647914868.798998][2411780:2411785] CHIP:DMG: 					ListIndex = Null,
[1647914868.799011][2411780:2411785] CHIP:DMG: 				}
[1647914868.799027][2411780:2411785] CHIP:DMG: 					
[1647914868.799041][2411780:2411785] CHIP:DMG: 					Data = 
[1647914868.799056][2411780:2411785] CHIP:DMG: 					{
[1647914868.799071][2411780:2411785] CHIP:DMG: 						0x0 = "direction", 
[1647914868.799086][2411780:2411785] CHIP:DMG: 						0x1 = "up", 
[1647914868.799101][2411780:2411785] CHIP:DMG: 					},
[1647914868.799114][2411780:2411785] CHIP:DMG: 			},
[1647914868.799132][2411780:2411785] CHIP:DMG: 			
[1647914868.799145][2411780:2411785] CHIP:DMG: 		},
[1647914868.799175][2411780:2411785] CHIP:DMG: 		
[1647914868.799188][2411780:2411785] CHIP:DMG: 	],
[1647914868.799228][2411780:2411785] CHIP:DMG: 	
[1647914868.799241][2411780:2411785] CHIP:DMG: 	SuppressResponse = true, 
[1647914868.799254][2411780:2411785] CHIP:DMG: 	InteractionModelRevision = 1
[1647914868.799266][2411780:2411785] CHIP:DMG: }
[1647914868.799670][2411780:2411785] CHIP:TOO: Endpoint: 0 Cluster: 0x0000_0041 Attribute 0x0000_0000DataVersion: 3980363292
[1647914868.799722][2411780:2411785] CHIP:TOO:   label list: 4 entries
[1647914868.799750][2411780:2411785] CHIP:TOO:     [1]: {
[1647914868.799763][2411780:2411785] CHIP:TOO:       Label: room
[1647914868.799776][2411780:2411785] CHIP:TOO:       Value: bedroom 2
[1647914868.799788][2411780:2411785] CHIP:TOO:      }
[1647914868.799805][2411780:2411785] CHIP:TOO:     [2]: {
[1647914868.799817][2411780:2411785] CHIP:TOO:       Label: orientation
[1647914868.799828][2411780:2411785] CHIP:TOO:       Value: North
[1647914868.799840][2411780:2411785] CHIP:TOO:      }
[1647914868.799855][2411780:2411785] CHIP:TOO:     [3]: {
[1647914868.799866][2411780:2411785] CHIP:TOO:       Label: floor
[1647914868.799878][2411780:2411785] CHIP:TOO:       Value: 2
[1647914868.799889][2411780:2411785] CHIP:TOO:      }
[1647914868.799905][2411780:2411785] CHIP:TOO:     [4]: {
[1647914868.799916][2411780:2411785] CHIP:TOO:       Label: direction
[1647914868.799927][2411780:2411785] CHIP:TOO:       Value: up
[1647914868.799939][2411780:2411785] CHIP:TOO:      }
```
