### PR TITLE
[ESP32] Set-regulatory-config command is working on ESP32

### DIFF
--- a/src/platform/DeviceControlServer.cpp
+++ b/src/platform/DeviceControlServer.cpp
@@ -66,9 +66,7 @@ exit:
         ChipLogError(DeviceLayer, "SetRegulatoryConfig failed with error: %s", ErrorStr(err));
     }
 
-    // TODO(cecille): This command fails on ESP32, but it's blocking IP cluster-based commissioning so for now just return a success
-    // status.
-    return CHIP_NO_ERROR;
+    return err;
 }
 
 CHIP_ERROR DeviceControlServer::ConnectNetworkForOperational(ByteSpan networkID)


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Set-regulatory-config command is working on ESP32.
* MR #15240 fixed this todo.

#### Change overview
Set-regulatory-config command is working on ESP32.

#### Testing
* Manually tested set-regulatory-config command.
