### PR TITLE
[EFR32] Clean up gn files for QRcode Lib

### DIFF
--- a/examples/light-switch-app/efr32/BUILD.gn
+++ b/examples/light-switch-app/efr32/BUILD.gn
@@ -66,6 +66,10 @@ declare_args() {
 if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
   show_qr_code = false
 }
+
+# Enables LCD on supported devices
+lcd_on = show_qr_code
+
 if (use_rs911x || use_wf200) {
   wifi_sdk_dir = "${chip_root}/third_party/efr32_sdk/repo/matter/wifi"
   if (use_rs911x) {
@@ -163,7 +167,6 @@ efr32_executable("light_switch_app") {
 
   deps = [
     ":sdk",
-    "${chip_root}/examples/common/QRCode",
     "${chip_root}/examples/light-switch-app/light-switch-common",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
@@ -218,9 +221,13 @@ efr32_executable("light_switch_app") {
     include_dirs += wf200_plat_incs
   }
 
-  if (show_qr_code) {
+  if (lcd_on) {
     sources += [ "${examples_plat_dir}/display/lcd.c" ]
     defines += [ "DISPLAY_ENABLED" ]
+    if (show_qr_code) {
+      defines += [ "QR_CODE_ENABLED" ]
+      deps += [ "${chip_root}/examples/common/QRCode" ]
+    }
   }
 
   if (chip_enable_pw_rpc) {

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -66,6 +66,10 @@ declare_args() {
 if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
   show_qr_code = false
 }
+
+# Enables LCD on supported devices
+lcd_on = show_qr_code
+
 if (use_rs911x || use_wf200) {
   wifi_sdk_dir = "${chip_root}/third_party/efr32_sdk/repo/matter/wifi"
   if (use_rs911x) {
@@ -215,11 +219,14 @@ efr32_executable("lighting_app") {
     include_dirs += wf200_plat_incs
   }
 
-  if (show_qr_code) {
+  if (lcd_on) {
     sources += [ "${examples_plat_dir}/display/lcd.c" ]
     defines += [ "DISPLAY_ENABLED" ]
+    if (show_qr_code) {
+      defines += [ "QR_CODE_ENABLED" ]
 
-    deps += [ "${chip_root}/examples/common/QRCode" ]
+      deps += [ "${chip_root}/examples/common/QRCode" ]
+    }
   }
 
   if (chip_enable_pw_rpc) {

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -161,7 +161,6 @@ efr32_executable("lighting_app") {
 
   deps = [
     ":sdk",
-    "${chip_root}/examples/common/QRCode",
     "${chip_root}/examples/lighting-app/lighting-common",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
@@ -219,6 +218,8 @@ efr32_executable("lighting_app") {
   if (show_qr_code) {
     sources += [ "${examples_plat_dir}/display/lcd.c" ]
     defines += [ "DISPLAY_ENABLED" ]
+
+    deps += [ "${chip_root}/examples/common/QRCode" ]
   }
 
   if (chip_enable_pw_rpc) {

--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -21,8 +21,10 @@
 #include "AppConfig.h"
 #include "AppEvent.h"
 #include "LEDWidget.h"
+#ifdef DISPLAY_ENABLED
 #include "lcd.h"
 #include "qrcodegen.h"
+#endif // DISPLAY_ENABLED
 #include "sl_simple_led_instances.h"
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -160,7 +160,6 @@ efr32_executable("lock_app") {
 
   deps = [
     ":sdk",
-    "${chip_root}/examples/common/QRCode",
     "${chip_root}/examples/lock-app/lock-common",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
@@ -220,8 +219,9 @@ efr32_executable("lock_app") {
 
   if (show_qr_code) {
     sources += [ "${examples_plat_dir}/display/lcd.c" ]
-
     defines += [ "DISPLAY_ENABLED" ]
+
+    deps += [ "${chip_root}/examples/common/QRCode" ]
   }
 
   if (chip_enable_pw_rpc) {

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -65,6 +65,10 @@ declare_args() {
 if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
   show_qr_code = false
 }
+
+# Enables LCD on supported devices
+lcd_on = show_qr_code
+
 if (use_rs911x || use_wf200) {
   wifi_sdk_dir = "${chip_root}/third_party/efr32_sdk/repo/matter/wifi"
   if (use_rs911x) {
@@ -217,11 +221,14 @@ efr32_executable("lock_app") {
     include_dirs += wf200_plat_incs
   }
 
-  if (show_qr_code) {
+  if (lcd_on) {
     sources += [ "${examples_plat_dir}/display/lcd.c" ]
     defines += [ "DISPLAY_ENABLED" ]
+    if (show_qr_code) {
+      defines += [ "QR_CODE_ENABLED" ]
 
-    deps += [ "${chip_root}/examples/common/QRCode" ]
+      deps += [ "${chip_root}/examples/common/QRCode" ]
+    }
   }
 
   if (chip_enable_pw_rpc) {

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -21,8 +21,10 @@
 #include "AppConfig.h"
 #include "AppEvent.h"
 #include "LEDWidget.h"
+#ifdef DISPLAY_ENABLED
 #include "lcd.h"
 #include "qrcodegen.h"
+#endif // DISPLAY_ENABLED
 #include "sl_simple_led_instances.h"
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>

--- a/examples/ota-requestor-app/efr32/BUILD.gn
+++ b/examples/ota-requestor-app/efr32/BUILD.gn
@@ -126,6 +126,8 @@ efr32_executable("ota_requestor_app") {
   if (show_qr_code) {
     sources += [ "${examples_plat_dir}/display/lcd.c" ]
     defines += [ "DISPLAY_ENABLED" ]
+
+    deps += [ "${chip_root}/examples/common/QRCode" ]
   }
 
   if (chip_enable_pw_rpc) {

--- a/examples/ota-requestor-app/efr32/BUILD.gn
+++ b/examples/ota-requestor-app/efr32/BUILD.gn
@@ -54,6 +54,9 @@ if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
   show_qr_code = false
 }
 
+# Enables LCD on supported devices
+lcd_on = show_qr_code
+
 efr32_sdk("sdk") {
   sources = [
     "${efr32_project_dir}/include/CHIPProjectConfig.h",
@@ -102,7 +105,6 @@ efr32_executable("ota_requestor_app") {
 
   deps = [
     ":sdk",
-    "${chip_root}/examples/common/QRCode",
     "${chip_root}/examples/ota-requestor-app/ota-requestor-common",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
@@ -123,11 +125,14 @@ efr32_executable("ota_requestor_app") {
     ]
   }
 
-  if (show_qr_code) {
+  if (lcd_on) {
     sources += [ "${examples_plat_dir}/display/lcd.c" ]
     defines += [ "DISPLAY_ENABLED" ]
+    if (show_qr_code) {
+      defines += [ "QR_CODE_ENABLED" ]
 
-    deps += [ "${chip_root}/examples/common/QRCode" ]
+      deps += [ "${chip_root}/examples/common/QRCode" ]
+    }
   }
 
   if (chip_enable_pw_rpc) {

--- a/examples/ota-requestor-app/efr32/src/AppTask.cpp
+++ b/examples/ota-requestor-app/efr32/src/AppTask.cpp
@@ -21,8 +21,10 @@
 #include "AppConfig.h"
 #include "AppEvent.h"
 #include "LEDWidget.h"
+#ifdef DISPLAY_ENABLED
 #include "lcd.h"
 #include "qrcodegen.h"
+#endif // DISPLAY_ENABLED
 #include "sl_simple_led_instances.h"
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>

--- a/examples/platform/efr32/display/lcd.c
+++ b/examples/platform/efr32/display/lcd.c
@@ -23,7 +23,11 @@
 
 #include "dmd.h"
 #include "glib.h"
+
+#if !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
 #include "qrcodegen.h"
+#endif // !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
+
 #include "sl_board_control.h"
 
 #define LCD_SIZE 128
@@ -32,10 +36,14 @@
 #define QR_CODE_BORDER_SIZE 0
 
 static GLIB_Context_t glibContext;
+#if !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
 static uint8_t qrCode[qrcodegen_BUFFER_LEN_FOR_VERSION(QR_CODE_VERSION)];
 static uint8_t workBuffer[qrcodegen_BUFFER_LEN_FOR_VERSION(QR_CODE_VERSION)];
+#endif // !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
 
+#if !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
 static void LCDFillRect(uint8_t x, uint8_t y, uint8_t w, uint8_t h);
+#endif // !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
 
 void initLCD(void)
 {
@@ -92,6 +100,7 @@ int LCD_update(void)
     return DMD_updateDisplay();
 }
 
+#if !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
 void LCDWriteQRCode(uint8_t * str)
 {
     if (!qrcodegen_encodeText((const char *) str, workBuffer, qrCode, qrcodegen_Ecc_LOW, QR_CODE_VERSION, QR_CODE_VERSION,
@@ -134,3 +143,4 @@ void LCDFillRect(uint8_t x, uint8_t y, uint8_t w, uint8_t h)
         }
     }
 }
+#endif // !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED

--- a/examples/platform/efr32/display/lcd.c
+++ b/examples/platform/efr32/display/lcd.c
@@ -24,9 +24,9 @@
 #include "dmd.h"
 #include "glib.h"
 
-#if !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
+#ifdef QR_CODE_ENABLED
 #include "qrcodegen.h"
-#endif // !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
+#endif // QR_CODE_ENABLED
 
 #include "sl_board_control.h"
 
@@ -36,14 +36,14 @@
 #define QR_CODE_BORDER_SIZE 0
 
 static GLIB_Context_t glibContext;
-#if !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
+#ifdef QR_CODE_ENABLED
 static uint8_t qrCode[qrcodegen_BUFFER_LEN_FOR_VERSION(QR_CODE_VERSION)];
 static uint8_t workBuffer[qrcodegen_BUFFER_LEN_FOR_VERSION(QR_CODE_VERSION)];
-#endif // !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
+#endif // QR_CODE_ENABLED
 
-#if !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
+#ifdef QR_CODE_ENABLED
 static void LCDFillRect(uint8_t x, uint8_t y, uint8_t w, uint8_t h);
-#endif // !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
+#endif // QR_CODE_ENABLED
 
 void initLCD(void)
 {
@@ -100,7 +100,7 @@ int LCD_update(void)
     return DMD_updateDisplay();
 }
 
-#if !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
+#ifdef QR_CODE_ENABLED
 void LCDWriteQRCode(uint8_t * str)
 {
     if (!qrcodegen_encodeText((const char *) str, workBuffer, qrCode, qrcodegen_Ecc_LOW, QR_CODE_VERSION, QR_CODE_VERSION,
@@ -143,4 +143,4 @@ void LCDFillRect(uint8_t x, uint8_t y, uint8_t w, uint8_t h)
         }
     }
 }
-#endif // !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
+#endif // QR_CODE_ENABLED

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -51,14 +51,19 @@ declare_args() {
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
 
-  # Enables LCD Qr Code on supported devices
+  # Enables Qr Code on supported devices
   show_qr_code = true
 }
+
+# Enables LCD on supported devices
+lcd_on = true
 
 # BRD4166A --> ThunderBoard Sense 2 (No LCD)
 if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
   show_qr_code = false
+  lcd_on = false
 }
+
 if (use_rs911x || use_wf200) {
   wifi_sdk_dir = "${chip_root}/third_party/efr32_sdk/repo/matter/wifi"
   if (use_rs911x) {
@@ -180,7 +185,6 @@ efr32_executable("window_app") {
   }
   deps = [
     ":sdk",
-    "${chip_root}/examples/common/QRCode",
     "${chip_root}/examples/window-app/common:window-common",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
@@ -205,13 +209,19 @@ efr32_executable("window_app") {
     }
   }
 
-  if (show_qr_code) {
+  if (lcd_on) {
     sources += [
       "${examples_plat_dir}/display/lcd.c",
       "src/LcdPainter.cpp",
     ]
-
     defines += [ "DISPLAY_ENABLED" ]
+
+    if (show_qr_code) {
+      deps += [ "${chip_root}/examples/common/QRCode" ]
+      defines += [ "QR_CODE_ENABLED=1" ]
+    } else {
+      defines += [ "QR_CODE_ENABLED=0" ]
+    }
   }
 
   if (enable_heap_monitoring) {

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -218,9 +218,7 @@ efr32_executable("window_app") {
 
     if (show_qr_code) {
       deps += [ "${chip_root}/examples/common/QRCode" ]
-      defines += [ "QR_CODE_ENABLED=1" ]
-    } else {
-      defines += [ "QR_CODE_ENABLED=0" ]
+      defines += [ "QR_CODE_ENABLED" ]
     }
   }
 

--- a/examples/window-app/efr32/src/WindowAppImpl.cpp
+++ b/examples/window-app/efr32/src/WindowAppImpl.cpp
@@ -433,7 +433,7 @@ void WindowAppImpl::UpdateLCD()
             LcdPainter::Paint(type, static_cast<uint8_t>(lift.Value()), static_cast<uint8_t>(tilt.Value()), mIcon);
         }
     }
-#if !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
+#ifdef QR_CODE_ENABLED
     else
     {
         if (GetQRCode(mQRCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)) == CHIP_NO_ERROR)
@@ -441,7 +441,7 @@ void WindowAppImpl::UpdateLCD()
             LCDWriteQRCode((uint8_t *) mQRCode.c_str());
         }
     }
-#endif // !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
+#endif // QR_CODE_ENABLED
 #endif // DISPLAY_ENABLED
 }
 

--- a/examples/window-app/efr32/src/WindowAppImpl.cpp
+++ b/examples/window-app/efr32/src/WindowAppImpl.cpp
@@ -26,7 +26,9 @@
 #include <lib/dnssd/Advertiser.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceLayer.h>
+#if QR_CODE_ENABLED
 #include <qrcodegen.h>
+#endif // QR_CODE_ENABLED
 #include <sl_simple_button_instances.h>
 #include <sl_simple_led_instances.h>
 #include <sl_system_kernel.h>
@@ -413,7 +415,7 @@ void WindowAppImpl::UpdateLCD()
     if (mState.isThreadProvisioned)
 #else
     if (mState.isWiFiProvisioned)
-#endif
+#endif // CHIP_ENABLE_OPENTHREAD
     {
         Cover & cover = GetCover();
         chip::app::DataModel::Nullable<uint16_t> lift;
@@ -431,6 +433,7 @@ void WindowAppImpl::UpdateLCD()
             LcdPainter::Paint(type, static_cast<uint8_t>(lift.Value()), static_cast<uint8_t>(tilt.Value()), mIcon);
         }
     }
+#if !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
     else
     {
         if (GetQRCode(mQRCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)) == CHIP_NO_ERROR)
@@ -438,7 +441,8 @@ void WindowAppImpl::UpdateLCD()
             LCDWriteQRCode((uint8_t *) mQRCode.c_str());
         }
     }
-#endif
+#endif // !defined(QR_CODE_ENABLED) || QR_CODE_ENABLED
+#endif // DISPLAY_ENABLED
 }
 
 void WindowAppImpl::OnMainLoop()

--- a/examples/window-app/efr32/src/WindowAppImpl.cpp
+++ b/examples/window-app/efr32/src/WindowAppImpl.cpp
@@ -26,7 +26,7 @@
 #include <lib/dnssd/Advertiser.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceLayer.h>
-#if QR_CODE_ENABLED
+#ifdef QR_CODE_ENABLED
 #include <qrcodegen.h>
 #endif // QR_CODE_ENABLED
 #include <sl_simple_button_instances.h>

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -175,7 +175,8 @@ template("efr32_sdk") {
     # USART include files
     if ((defined(invoker.chip_enable_pw_rpc) && invoker.chip_enable_pw_rpc) ||
         chip_build_libshell || enable_openthread_cli ||
-        (defined(invoker.show_qr_code) && invoker.show_qr_code)) {
+        (defined(invoker.show_qr_code) && invoker.show_qr_code) ||
+        (defined(invoker.lcd_on) && invoker.lcd_on)) {
       defines += [ "CONFIG_ENABLE_UART" ]
 
       _include_dirs += [
@@ -505,25 +506,24 @@ template("efr32_sdk") {
       }
     }
 
-    if (defined(invoker.show_qr_code)) {
-      if (invoker.show_qr_code) {
-        sources += [
-          "${efr32_sdk_root}/hardware/driver/memlcd/src/sl_memlcd.c",
-          "${efr32_sdk_root}/hardware/driver/memlcd/src/sl_memlcd_display.c",
-          "${efr32_sdk_root}/platform/middleware/glib/dmd/display/dmd_memlcd.c",
-          "${efr32_sdk_root}/platform/middleware/glib/glib/bmp.c",
-          "${efr32_sdk_root}/platform/middleware/glib/glib/glib.c",
-          "${efr32_sdk_root}/platform/middleware/glib/glib/glib_bitmap.c",
-          "${efr32_sdk_root}/platform/middleware/glib/glib/glib_circle.c",
-          "${efr32_sdk_root}/platform/middleware/glib/glib/glib_font_narrow_6x8.c",
-          "${efr32_sdk_root}/platform/middleware/glib/glib/glib_font_normal_8x8.c",
-          "${efr32_sdk_root}/platform/middleware/glib/glib/glib_font_number_16x20.c",
-          "${efr32_sdk_root}/platform/middleware/glib/glib/glib_line.c",
-          "${efr32_sdk_root}/platform/middleware/glib/glib/glib_polygon.c",
-          "${efr32_sdk_root}/platform/middleware/glib/glib/glib_rectangle.c",
-          "${efr32_sdk_root}/platform/middleware/glib/glib/glib_string.c",
-        ]
-      }
+    if ((defined(invoker.show_qr_code) && invoker.show_qr_code) ||
+        (defined(invoker.lcd_on) && invoker.lcd_on)) {
+      sources += [
+        "${efr32_sdk_root}/hardware/driver/memlcd/src/sl_memlcd.c",
+        "${efr32_sdk_root}/hardware/driver/memlcd/src/sl_memlcd_display.c",
+        "${efr32_sdk_root}/platform/middleware/glib/dmd/display/dmd_memlcd.c",
+        "${efr32_sdk_root}/platform/middleware/glib/glib/bmp.c",
+        "${efr32_sdk_root}/platform/middleware/glib/glib/glib.c",
+        "${efr32_sdk_root}/platform/middleware/glib/glib/glib_bitmap.c",
+        "${efr32_sdk_root}/platform/middleware/glib/glib/glib_circle.c",
+        "${efr32_sdk_root}/platform/middleware/glib/glib/glib_font_narrow_6x8.c",
+        "${efr32_sdk_root}/platform/middleware/glib/glib/glib_font_normal_8x8.c",
+        "${efr32_sdk_root}/platform/middleware/glib/glib/glib_font_number_16x20.c",
+        "${efr32_sdk_root}/platform/middleware/glib/glib/glib_line.c",
+        "${efr32_sdk_root}/platform/middleware/glib/glib/glib_polygon.c",
+        "${efr32_sdk_root}/platform/middleware/glib/glib/glib_rectangle.c",
+        "${efr32_sdk_root}/platform/middleware/glib/glib/glib_string.c",
+      ]
     }
     if (use_wf200) {
       sources += [


### PR DESCRIPTION
#### Problem
* QRCode lib was always added to the dependencies when it wasn't always necessar 
* Window app did not build when disabling QR Code

#### Change overview
* Move QRcode dependencies
* Fix Window app when not using the QR code

#### Testing
* Manual tests to validate no regressions where caused
* Manual tests with window-app to validate that it builds and works without the QR code
