### PR TITLE
Initialize the generic implementation ConfigurationManager base class.

### DIFF
--- a/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
@@ -65,6 +65,10 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     CHIP_ERROR err;
     bool failSafeArmed;
 
+    // Initialize the generic implementation base class.
+    err = Internal::GenericConfigurationManagerImpl<CC13X2_26X2Config>::Init();
+    ReturnErrorOnFailure(err);
+
     // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
     if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* The ConfigurationManager base class is not called on cc13x2 platform.

#### Change overview
Initialize the generic implementation ConfigurationManager base class.

#### Testing
How was this tested? (at least one bullet point required)
* No cc13x2 platform on hand, but it should boot fail if the ConfigurationManager base class init fail 
