### PR TITLE
[OTA] Add a CLI option to support automatic image apply

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -95,6 +95,7 @@ ATWC
 AudioOutput
 auth
 AuthMode
+autoApplyImage
 autocompletion
 autoconnect
 autocrlf

--- a/examples/ota-requestor-app/linux/README.md
+++ b/examples/ota-requestor-app/linux/README.md
@@ -23,6 +23,7 @@ following command line options are available for the OTA Requestor application.
 | -c/--requestorCanConsent                              | If supplied, the RequestorCanConsent field of the QueryImage command is set to true. Otherwise, the value is determined by the driver.                                                                                                                                                         |
 | -f/--otaDownloadPath <file path>                      | If supplied, the OTA image is downloaded to the given fully-qualified file-path. Otherwise, the value defaults to /tmp/test.bin.                                                                                                                                                               |
 | -u/--userConsentState <granted \| denied \| deferred> | The user consent state for the first QueryImage command. For all subsequent commands, the value of granted will be used. <li> granted: Authorize OTA requestor to download an OTA image <li> denied: Forbid OTA requestor to download an OTA image <li> deferred: Defer obtaining user consent |
+| -a/--autoApplyImage                                   | If supplied, apply the image immediately after download. Otherwise, the OTA update is complete after image download.                                                                                                                                                                           |
 
 ## Software Image Header
 

--- a/src/app/clusters/ota-requestor/BDXDownloader.cpp
+++ b/src/app/clusters/ota-requestor/BDXDownloader.cpp
@@ -174,7 +174,7 @@ void BDXDownloader::OnDownloadTimeout()
     }
     else
     {
-        ChipLogError(BDX, "no download in progress");
+        ChipLogError(BDX, "No download in progress");
     }
 }
 
@@ -207,7 +207,7 @@ void BDXDownloader::EndDownload(CHIP_ERROR reason)
     }
     else
     {
-        ChipLogError(BDX, "no download in progress");
+        ChipLogError(BDX, "No download in progress");
     }
 }
 


### PR DESCRIPTION
#### Problem
After https://github.com/project-chip/connectedhomeip/pull/16482 lands, it will be very difficult to test basic OTA transfer as after image is downloaded, it will be automatically applied. If a dummy file (often used for testing) is transferred, this would cause the ota-requestor-app to terminate after each transfer.

Fixes: https://github.com/project-chip/connectedhomeip/issues/16500

#### Change overview
- Add a `--autoApplyImage` CLI option
- When the new option is supplied, it behaves the way it currently does (apply an image right after download)
- When the new option is not supplied, after image is downloaded, the OTA update is considered complete and goes back to idle state fo the next OTA update

#### Testing
- Verified that if no `--autoApplyImage` command line option is supplied, the state is transitioned back to idle and a new OTA update can be triggered
- Verified that if `--autoApplyImage` command line option is supplied, the driver will attempt to apply the image
