### PR TITLE
Remove access control temporary override

### DIFF
--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -206,11 +206,14 @@ CHIP_ERROR AccessControl::Check(const SubjectDescriptor & subjectDescriptor, con
     }
 #endif
 
-    // TODO(#13867): this will go away
-    if (mDelegate->TemporaryCheckOverride())
     {
-        ChipLogProgress(DataManagement, "AccessControl: temporary check override (this will go away)");
-        return CHIP_NO_ERROR;
+        CHIP_ERROR result = mDelegate->Check(subjectDescriptor, requestPath, requestPrivilege);
+        if (result != CHIP_ERROR_NOT_IMPLEMENTED)
+        {
+            ChipLogProgress(DataManagement, "AccessControl: %s (delegate)",
+                            (result == CHIP_NO_ERROR) ? "allowed" : (result == CHIP_ERROR_ACCESS_DENIED) ? "denied" : "error");
+            return result;
+        }
     }
 
     // Operational PASE not supported for v1.0, so PASE implies commissioning, which has highest privilege.
@@ -318,6 +321,7 @@ CHIP_ERROR AccessControl::Check(const SubjectDescriptor & subjectDescriptor, con
         }
 
         // Entry passed all checks: access is allowed.
+        ChipLogProgress(DataManagement, "AccessControl: allowed");
         return CHIP_NO_ERROR;
     }
 

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -341,12 +341,19 @@ public:
         // Iteration
         virtual CHIP_ERROR Entries(EntryIterator & iterator, const FabricIndex * fabricIndex) const { return CHIP_NO_ERROR; }
 
+        // Check
+        // Return CHIP_NO_ERROR if allowed, CHIP_ERROR_ACCESS_DENIED if denied,
+        // CHIP_ERROR_NOT_IMPLEMENTED to use the default check algorithm (against entries),
+        // or any other CHIP_ERROR if another error occurred.
+        virtual CHIP_ERROR Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath,
+                                 Privilege requestPrivilege)
+        {
+            return CHIP_ERROR_ACCESS_DENIED;
+        }
+
         // Listening
         virtual void SetListener(Listener & listener) { mListener = &listener; }
         virtual void ClearListener() { mListener = nullptr; }
-
-        // TODO(#13867): this will go away
-        virtual bool TemporaryCheckOverride() const { return false; }
 
     private:
         Listener * mListener = nullptr;

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -40,6 +40,8 @@ using chip::kUndefinedNodeId;
 using chip::Access::AccessControl;
 using chip::Access::AuthMode;
 using chip::Access::Privilege;
+using chip::Access::RequestPath;
+using chip::Access::SubjectDescriptor;
 
 using Entry         = chip::Access::AccessControl::Entry;
 using EntryIterator = chip::Access::AccessControl::EntryIterator;
@@ -1235,6 +1237,12 @@ public:
             return CHIP_NO_ERROR;
         }
         return CHIP_ERROR_BUFFER_TOO_SMALL;
+    }
+
+    CHIP_ERROR Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath,
+                     Privilege requestPrivilege) override
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
 public:

--- a/src/access/examples/PermissiveAccessControlDelegate.cpp
+++ b/src/access/examples/PermissiveAccessControlDelegate.cpp
@@ -59,8 +59,12 @@ public:
     // Iteration
     CHIP_ERROR Entries(EntryIterator & iterator, const FabricIndex * fabricIndex) const override { return CHIP_NO_ERROR; }
 
-    // TODO(#13867): this will go away
-    bool TemporaryCheckOverride() const override { return true; }
+    // Check
+    CHIP_ERROR Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath,
+                     Privilege requestPrivilege) override
+    {
+        return CHIP_NO_ERROR;
+    }
 };
 
 } // namespace


### PR DESCRIPTION
#### Problem
Temporary override needs to be removed (issue #13867)

Also, controllers would like to provide custom implementations of
AccessControl::Check without having a cluster, ACL entries, etc.

#### Change overview
The delegate can now override the check, or proceed with
the standard check.

The "empty" default delegate now denies access, by
implementing check to return "deny."

The "permissive" example delegate still permits access, by
implementing check to return "allow."

The "normal" example delegate still performs a standard check,
by implementing check to return "not implemented" so the
standard check is performed.

#### Testing
How was this tested? (at least one bullet point required)
* Unit tests pass on Linux
* Ran against all-clusters-app via chip-tool on Linux