### PR TITLE
Add a watchdog timer to catch OTA process getting stuck

### DIFF
--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
@@ -409,7 +409,7 @@ void GenericOTARequestorDriver::StartPeriodicQueryTimer()
 
 void GenericOTARequestorDriver::StopPeriodicQueryTimer()
 {
-    ChipLogProgress(SoftwareUpdate, "Stopping the Default Provider timer");
+    ChipLogProgress(SoftwareUpdate, "Stopping the Periodic Query timer");
     CancelDelayedAction(
         [](System::Layer *, void * context) {
             (static_cast<GenericOTARequestorDriver *>(context))->PeriodicQueryTimerHandler(nullptr, context);
@@ -471,8 +471,6 @@ void GenericOTARequestorDriver::StopWatchdogTimer()
 
 void GenericOTARequestorDriver::StartSelectedTimer(SelectedTimer timer)
 {
-    ChipLogProgress(SoftwareUpdate, "//is: StartSelectedTimer");
-
     switch (timer)
     {
         case SelectedTimer::kPeriodicQueryTimer:
@@ -488,8 +486,6 @@ void GenericOTARequestorDriver::StartSelectedTimer(SelectedTimer timer)
 
 void GenericOTARequestorDriver::StopSelectedTimer(SelectedTimer timer)
 {
-    ChipLogProgress(SoftwareUpdate, "//is: StopSelectedTimer");
-
     switch (timer)
     {
         case SelectedTimer::kPeriodicQueryTimer:

--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
@@ -392,12 +392,8 @@ void GenericOTARequestorDriver::StopPeriodicQueryTimer()
 
 void GenericOTARequestorDriver::WatchdogTimerHandler(System::Layer * systemLayer, void * appState)
 {
-    ChipLogProgress(SoftwareUpdate, "Watchdog timer handler is invoked");
-
-    OTAUpdateStateEnum currentState = mRequestor->GetCurrentUpdateState();
-
     ChipLogError(SoftwareUpdate, "Watchdog timer detects state stuck at %u. Cancelling download and resetting state.",
-                 to_underlying(currentState));
+                 to_underlying(mRequestor->GetCurrentUpdateState()));
 
     // Something went wrong and OTA requestor is stuck in a non-idle state for too long.
     // Let's just cancel download, reset state, and re-start periodic query timer.

--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
@@ -395,36 +395,35 @@ void GenericOTARequestorDriver::WatchdogTimerHandler(System::Layer * systemLayer
     ChipLogProgress(SoftwareUpdate, "Watchdog timer handler is invoked");
 
     OTAUpdateStateEnum currentState = mRequestor->GetCurrentUpdateState();
-    
-    switch(currentState)
+
+    switch (currentState)
     {
-        case OTAUpdateStateEnum::kIdle:
-        case OTAUpdateStateEnum::kUnknown:
-            // OTA Requestor is not stuck in non-idle state.  Restart watchdog timer.
-            StartWatchdogTimer();
-            break;
-        case OTAUpdateStateEnum::kQuerying:
-        case OTAUpdateStateEnum::kDelayedOnQuery:
-        case OTAUpdateStateEnum::kDownloading:
-        case OTAUpdateStateEnum::kApplying:
-        case OTAUpdateStateEnum::kDelayedOnApply:
-            UpdateDiscontinued();
-            mRequestor->CancelImageUpdate();
-            mRequestor->Reset();
-            StartPeriodicQueryTimer();
-            break;
-        case OTAUpdateStateEnum::kRollingBack:
-        case OTAUpdateStateEnum::kDelayedOnUserConsent:
-            mRequestor->Reset();
-            StartPeriodicQueryTimer();
-            break;
+    case OTAUpdateStateEnum::kIdle:
+    case OTAUpdateStateEnum::kUnknown:
+        // OTA Requestor is not stuck in non-idle state.  Restart watchdog timer.
+        StartWatchdogTimer();
+        break;
+    case OTAUpdateStateEnum::kQuerying:
+    case OTAUpdateStateEnum::kDelayedOnQuery:
+    case OTAUpdateStateEnum::kDownloading:
+    case OTAUpdateStateEnum::kApplying:
+    case OTAUpdateStateEnum::kDelayedOnApply:
+        UpdateDiscontinued();
+        mRequestor->CancelImageUpdate();
+        mRequestor->Reset();
+        StartPeriodicQueryTimer();
+        break;
+    case OTAUpdateStateEnum::kRollingBack:
+    case OTAUpdateStateEnum::kDelayedOnUserConsent:
+        mRequestor->Reset();
+        StartPeriodicQueryTimer();
+        break;
     }
 }
 
 void GenericOTARequestorDriver::StartWatchdogTimer()
 {
-    ChipLogProgress(SoftwareUpdate, "Starting the watchdog timer, timeout: %u seconds",
-                    (unsigned int) mWatchdogTimeInterval);
+    ChipLogProgress(SoftwareUpdate, "Starting the watchdog timer, timeout: %u seconds", (unsigned int) mWatchdogTimeInterval);
     ScheduleDelayedAction(
         System::Clock::Seconds32(mWatchdogTimeInterval),
         [](System::Layer *, void * context) {
@@ -447,14 +446,14 @@ void GenericOTARequestorDriver::StartSelectedTimer(SelectedTimer timer)
 {
     switch (timer)
     {
-        case SelectedTimer::kPeriodicQueryTimer:
-            StopWatchdogTimer();
-            StartPeriodicQueryTimer();
-            break;
-        case SelectedTimer::kWatchdogTimer:
-            StopPeriodicQueryTimer();
-            StartWatchdogTimer();
-            break;
+    case SelectedTimer::kPeriodicQueryTimer:
+        StopWatchdogTimer();
+        StartPeriodicQueryTimer();
+        break;
+    case SelectedTimer::kWatchdogTimer:
+        StopPeriodicQueryTimer();
+        StartWatchdogTimer();
+        break;
     }
 }
 
@@ -462,14 +461,14 @@ void GenericOTARequestorDriver::StopSelectedTimer(SelectedTimer timer)
 {
     switch (timer)
     {
-        case SelectedTimer::kPeriodicQueryTimer:
-            StopPeriodicQueryTimer();
-            StartWatchdogTimer();
-            break;
-        case SelectedTimer::kWatchdogTimer:
-            StopWatchdogTimer();
-            StartPeriodicQueryTimer();
-            break;
+    case SelectedTimer::kPeriodicQueryTimer:
+        StopPeriodicQueryTimer();
+        StartWatchdogTimer();
+        break;
+    case SelectedTimer::kWatchdogTimer:
+        StopWatchdogTimer();
+        StartPeriodicQueryTimer();
+        break;
     }
 }
 

--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
@@ -134,8 +134,6 @@ IdleStateReason GenericOTARequestorDriver::MapErrorToIdleStateReason(CHIP_ERROR 
 
 void GenericOTARequestorDriver::HandleStateTransition(OTAUpdateStateEnum currentUpdateState, OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: GenericOTARequestorDriver::HandleStateTransition");
-
     if ((newState == OTAUpdateStateEnum::kIdle) && (currentUpdateState != OTAUpdateStateEnum::kIdle))
     {
         IdleStateReason idleStateReason = MapErrorToIdleStateReason(error);
@@ -397,7 +395,7 @@ void GenericOTARequestorDriver::PeriodicQueryTimerHandler(System::Layer * system
 
 void GenericOTARequestorDriver::StartPeriodicQueryTimer()
 {
-    ChipLogProgress(SoftwareUpdate, "Starting the Default Provider timer, timeout: %u seconds",
+    ChipLogProgress(SoftwareUpdate, "Starting the periodic query timer, timeout: %u seconds",
                     (unsigned int) mPeriodicQueryTimeInterval);
     ScheduleDelayedAction(
         System::Clock::Seconds32(mPeriodicQueryTimeInterval),
@@ -419,7 +417,7 @@ void GenericOTARequestorDriver::StopPeriodicQueryTimer()
 
 void GenericOTARequestorDriver::WatchdogTimerHandler(System::Layer * systemLayer, void * appState)
 {
-    ChipLogProgress(SoftwareUpdate, "Default watchdog timer handler is invoked");
+    ChipLogProgress(SoftwareUpdate, "Watchdog timer handler is invoked");
 
     OTAUpdateStateEnum currentState = mRequestor->GetCurrentUpdateState();
     
@@ -435,7 +433,8 @@ void GenericOTARequestorDriver::WatchdogTimerHandler(System::Layer * systemLayer
         case OTAUpdateStateEnum::kDownloading:
         case OTAUpdateStateEnum::kApplying:
         case OTAUpdateStateEnum::kDelayedOnApply:
-            UpdateCancelled();
+            UpdateDiscontinued();
+            mRequestor->CancelImageUpdate();
             mRequestor->Reset();
             StartPeriodicQueryTimer();
             break;

--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
@@ -85,7 +85,7 @@ void GenericOTARequestorDriver::Init(OTARequestorInterface * requestor, OTAImage
     else
     {
         // Start the first periodic query timer
-        StartDefaultProviderTimer();
+        StartPeriodicQueryTimer();
     }
 }
 
@@ -118,35 +118,10 @@ bool GenericOTARequestorDriver::ProviderLocationsEqual(const ProviderLocationTyp
 
 void GenericOTARequestorDriver::HandleError(UpdateFailureState state, CHIP_ERROR error) {}
 
-IdleStateReason GenericOTARequestorDriver::MapErrorToIdleStateReason(CHIP_ERROR error)
+void GenericOTARequestorDriver::HandleIdleStateExit()
 {
-    if (error == CHIP_NO_ERROR)
-    {
-        return IdleStateReason::kIdle;
-    }
-    else if (error == CHIP_ERROR_CONNECTION_CLOSED_UNEXPECTEDLY)
-    {
-        return IdleStateReason::kInvalidSession;
-    }
-
-    return IdleStateReason::kUnknown;
-}
-
-void GenericOTARequestorDriver::HandleStateTransition(OTAUpdateStateEnum currentUpdateState, OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error)
-{
-    if ((newState == OTAUpdateStateEnum::kIdle) && (currentUpdateState != OTAUpdateStateEnum::kIdle))
-    {
-        IdleStateReason idleStateReason = MapErrorToIdleStateReason(error);
-
-        // Inform the driver that the OTARequestor has entered the Idle state
-        HandleIdleState(idleStateReason); 
-    }
-    else if(((currentUpdateState == OTAUpdateStateEnum::kIdle) || (currentUpdateState == OTAUpdateStateEnum::kUnknown)) &&
-            (newState != OTAUpdateStateEnum::kIdle))
-    {
-        // Start watchdog timer to monitor new Query Image session
-        StartSelectedTimer(SelectedTimer::kWatchdogTimer);
-    }
+    // Start watchdog timer to monitor new Query Image session
+    StartSelectedTimer(SelectedTimer::kWatchdogTimer);
 }
 
 void GenericOTARequestorDriver::HandleIdleState(IdleStateReason reason)

--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
@@ -207,7 +207,7 @@ void GenericOTARequestorDriver::UpdateNotFound(UpdateNotFoundReason reason, Syst
     else
     {
         ChipLogProgress(SoftwareUpdate, "UpdateNotFound, not scheduling further retries");
-        StartPeriodicQueryTimer();
+        StartSelectedTimer(SelectedTimer::kPeriodicQueryTimer);
     }
 }
 
@@ -404,8 +404,6 @@ void GenericOTARequestorDriver::WatchdogTimerHandler(System::Layer * systemLayer
         // Scheduling periodic timer here just in case.
         StartPeriodicQueryTimer();
         break;
-    case OTAUpdateStateEnum::kQuerying:
-    case OTAUpdateStateEnum::kDelayedOnQuery:
     case OTAUpdateStateEnum::kDownloading:
     case OTAUpdateStateEnum::kApplying:
     case OTAUpdateStateEnum::kDelayedOnApply:
@@ -413,6 +411,8 @@ void GenericOTARequestorDriver::WatchdogTimerHandler(System::Layer * systemLayer
         mRequestor->CancelImageUpdate();
         StartPeriodicQueryTimer();
         break;
+    case OTAUpdateStateEnum::kQuerying:
+    case OTAUpdateStateEnum::kDelayedOnQuery:
     case OTAUpdateStateEnum::kRollingBack:
     case OTAUpdateStateEnum::kDelayedOnUserConsent:
         mRequestor->Reset();

--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
@@ -79,7 +79,6 @@ protected:
     void StopWatchdogTimer();
     void WatchdogTimerHandler(System::Layer * systemLayer, void * appState);
     void StartSelectedTimer(SelectedTimer timer);
-    void StopSelectedTimer(SelectedTimer timer);
     void ScheduleDelayedAction(System::Clock::Seconds32 delay, System::TimerCompleteCallback action, void * aAppState);
     void CancelDelayedAction(System::TimerCompleteCallback action, void * aAppState);
     bool ProviderLocationsEqual(const ProviderLocationType & a, const ProviderLocationType & b);

--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
@@ -56,7 +56,7 @@ public:
     bool CanConsent() override;
     uint16_t GetMaxDownloadBlockSize() override;
     void HandleError(UpdateFailureState state, CHIP_ERROR error) override;
-    void HandleStateTransition(OTAUpdateStateEnum currentUpdateState, OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error = CHIP_NO_ERROR) override;
+    void HandleIdleStateExit() override;
     void HandleIdleState(IdleStateReason reason) override;
     void UpdateAvailable(const UpdateDescription & update, System::Clock::Seconds32 delay) override;
     void UpdateNotFound(UpdateNotFoundReason reason, System::Clock::Seconds32 delay) override;
@@ -83,8 +83,6 @@ protected:
     void ScheduleDelayedAction(System::Clock::Seconds32 delay, System::TimerCompleteCallback action, void * aAppState);
     void CancelDelayedAction(System::TimerCompleteCallback action, void * aAppState);
     bool ProviderLocationsEqual(const ProviderLocationType & a, const ProviderLocationType & b);
-    // Map a CHIP_ERROR to an IdleStateReason enum type
-    IdleStateReason MapErrorToIdleStateReason(CHIP_ERROR error);
 
     OTARequestorInterface * mRequestor           = nullptr;
     OTAImageProcessorInterface * mImageProcessor = nullptr;

--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.h
@@ -56,6 +56,7 @@ public:
     bool CanConsent() override;
     uint16_t GetMaxDownloadBlockSize() override;
     void HandleError(UpdateFailureState state, CHIP_ERROR error) override;
+    void HandleStateTransition(OTAUpdateStateEnum currentUpdateState, OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error = CHIP_NO_ERROR) override;
     void HandleIdleState(IdleStateReason reason) override;
     void UpdateAvailable(const UpdateDescription & update, System::Clock::Seconds32 delay) override;
     void UpdateNotFound(UpdateNotFoundReason reason, System::Clock::Seconds32 delay) override;
@@ -71,17 +72,25 @@ public:
     bool GetNextProviderLocation(ProviderLocationType & providerLocation, bool & listExhausted) override;
 
 protected:
-    void StartDefaultProviderTimer();
-    void StopDefaultProviderTimer();
-    void DefaultProviderTimerHandler(System::Layer * systemLayer, void * appState);
+    void StartPeriodicQueryTimer();
+    void StopPeriodicQueryTimer();
+    void PeriodicQueryTimerHandler(System::Layer * systemLayer, void * appState);
+    void StartWatchdogTimer();
+    void StopWatchdogTimer();
+    void WatchdogTimerHandler(System::Layer * systemLayer, void * appState);
+    void StartSelectedTimer(SelectedTimer timer);
+    void StopSelectedTimer(SelectedTimer timer);
     void ScheduleDelayedAction(System::Clock::Seconds32 delay, System::TimerCompleteCallback action, void * aAppState);
     void CancelDelayedAction(System::TimerCompleteCallback action, void * aAppState);
     bool ProviderLocationsEqual(const ProviderLocationType & a, const ProviderLocationType & b);
+    // Map a CHIP_ERROR to an IdleStateReason enum type
+    IdleStateReason MapErrorToIdleStateReason(CHIP_ERROR error);
 
     OTARequestorInterface * mRequestor           = nullptr;
     OTAImageProcessorInterface * mImageProcessor = nullptr;
     uint32_t mOtaStartDelaySec                   = 0;
     uint32_t mPeriodicQueryTimeInterval = (24 * 60 * 60); // Timeout for querying providers on the default OTA provider list
+    uint32_t mWatchdogTimeInterval = (6 * 60 * 60); // Timeout (in seconds) for checking if Requestor has reverted back to idle mode
     // Maximum number of times to retry a BUSY OTA provider before moving to the next available one
     static constexpr uint8_t kMaxBusyProviderRetryCount = 3;
     uint8_t mProviderRetryCount; // Track retry count for the current provider

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -104,6 +104,8 @@ OTARequestorInterface * GetRequestorInstance()
 
 void OTARequestor::InitState(intptr_t context)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::InitState");
+
     OTARequestor * requestorCore = reinterpret_cast<OTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
@@ -114,6 +116,8 @@ void OTARequestor::InitState(intptr_t context)
     //   resetting the states appropriately, including the current update state.
     OtaRequestorServerSetUpdateState(requestorCore->mCurrentUpdateState);
     OtaRequestorServerSetUpdateStateProgress(app::DataModel::NullNullable);
+
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::InitState exit");
 }
 
 CHIP_ERROR OTARequestor::Init(Server & server, OTARequestorStorage & storage, OTARequestorDriver & driver,
@@ -138,6 +142,8 @@ CHIP_ERROR OTARequestor::Init(Server & server, OTARequestorStorage & storage, OT
 
 void OTARequestor::OnQueryImageResponse(void * context, const QueryImageResponse::DecodableType & response)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnQueryImageResponse");
+
     LogQueryImageResponse(response);
 
     OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
@@ -212,10 +218,14 @@ void OTARequestor::OnQueryImageResponse(void * context, const QueryImageResponse
         requestorCore->RecordErrorUpdateState(UpdateFailureState::kQuerying, CHIP_ERROR_BAD_REQUEST);
         break;
     }
+
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnQueryImageResponse Exit");
 }
 
 void OTARequestor::OnQueryImageFailure(void * context, CHIP_ERROR error)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnQueryImageFailure");
+    
     OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
@@ -230,10 +240,14 @@ void OTARequestor::OnQueryImageFailure(void * context, CHIP_ERROR error)
     }
 
     requestorCore->RecordErrorUpdateState(UpdateFailureState::kQuerying, error);
+
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnQueryImageFailure Exit");
 }
 
 void OTARequestor::OnApplyUpdateResponse(void * context, const ApplyUpdateResponse::DecodableType & response)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnApplyUpdateResponse");
+
     LogApplyUpdateResponse(response);
 
     OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
@@ -253,26 +267,39 @@ void OTARequestor::OnApplyUpdateResponse(void * context, const ApplyUpdateRespon
         requestorCore->mOtaRequestorDriver->UpdateDiscontinued();
         break;
     }
+
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnApplyUpdateResponse Exit");
 }
 
 void OTARequestor::OnApplyUpdateFailure(void * context, CHIP_ERROR error)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnApplyUpdateFailure");
+
     OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
     ChipLogDetail(SoftwareUpdate, "ApplyUpdate failure response %" CHIP_ERROR_FORMAT, error.Format());
     requestorCore->RecordErrorUpdateState(UpdateFailureState::kApplying, error);
+
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnApplyUpdateFailure Exit");
 }
 
-void OTARequestor::OnNotifyUpdateAppliedResponse(void * context, const app::DataModel::NullObjectType & response) {}
+void OTARequestor::OnNotifyUpdateAppliedResponse(void * context, const app::DataModel::NullObjectType & response) 
+{
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnNotifyUpdateAppliedResponse - Does nothing");
+}
 
 void OTARequestor::OnNotifyUpdateAppliedFailure(void * context, CHIP_ERROR error)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnNotifyUpdateAppliedFailure");
+
     OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
     ChipLogDetail(SoftwareUpdate, "NotifyUpdateApplied failure response %" CHIP_ERROR_FORMAT, error.Format());
     requestorCore->RecordErrorUpdateState(UpdateFailureState::kNotifying, error);
+
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnNotifyUpdateAppliedFailure Exit");
 }
 
 void OTARequestor::Reset()
@@ -295,6 +322,8 @@ EmberAfStatus OTARequestor::HandleAnnounceOTAProvider(app::CommandHandler * comm
                                                       const app::ConcreteCommandPath & commandPath,
                                                       const AnnounceOtaProvider::DecodableType & commandData)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::HandleAnnounceOTAProvider");
+
     auto & announcementReason = commandData.announcementReason;
 
     ChipLogProgress(SoftwareUpdate, "OTA Requestor received AnnounceOTAProvider");
@@ -321,11 +350,15 @@ EmberAfStatus OTARequestor::HandleAnnounceOTAProvider(app::CommandHandler * comm
 
     mOtaRequestorDriver->ProcessAnnounceOTAProviders(providerLocation, announcementReason);
 
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::HandleAnnounceOTAProvider Exit");
+
     return EMBER_ZCL_STATUS_SUCCESS;
 }
 
 void OTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::ConnectToProvider");
+    
     if (mServer == nullptr)
     {
         ChipLogError(SoftwareUpdate, "Server not set");
@@ -363,10 +396,13 @@ void OTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
         RecordErrorUpdateState(UpdateFailureState::kUnknown, CHIP_ERROR_INCORRECT_STATE);
         return;
     }
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::ConnectToProvider Exit");
 }
 
 void OTARequestor::DisconnectFromProvider()
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::DisconnectFromProvider");
+
     if (mServer == nullptr)
     {
         ChipLogError(SoftwareUpdate, "Server not set");
@@ -390,17 +426,24 @@ void OTARequestor::DisconnectFromProvider()
     }
 
     mCASESessionManager->ReleaseSession(fabricInfo->GetPeerIdForNode(mProviderLocation.Value().providerNodeID));
+
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::DisconnectFromProvider Exit");
 }
 
 // Requestor is directed to cancel image update in progress. All the Requestor state is
 // cleared, UpdateState is reset to Idle
 void OTARequestor::CancelImageUpdate()
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::CancelImageUpdate");
+
     mBdxDownloader->EndDownload(CHIP_ERROR_CONNECTION_ABORTED);
 
     mOtaRequestorDriver->UpdateCancelled();
 
+    //is: replace with reset()
     RecordNewUpdateState(OTAUpdateStateEnum::kIdle, OTAChangeReasonEnum::kUnknown);
+
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::CancelImageUpdate Exit");
 }
 
 CHIP_ERROR OTARequestor::GetUpdateStateProgressAttribute(EndpointId endpointId, app::DataModel::Nullable<uint8_t> & progress)
@@ -419,6 +462,8 @@ CHIP_ERROR OTARequestor::GetUpdateStateAttribute(EndpointId endpointId, OTAUpdat
 // Called whenever FindOrEstablishSession is successful
 void OTARequestor::OnConnected(void * context, OperationalDeviceProxy * deviceProxy)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnConnected");
+
     OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
     VerifyOrDie(deviceProxy != nullptr);
@@ -472,11 +517,15 @@ void OTARequestor::OnConnected(void * context, OperationalDeviceProxy * devicePr
     default:
         break;
     }
+
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnConnected Exit");
 }
 
 // Called whenever FindOrEstablishSession fails
 void OTARequestor::OnConnectionFailure(void * context, PeerId peerId, CHIP_ERROR error)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnConnectionFailure");
+
     OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
@@ -497,21 +546,29 @@ void OTARequestor::OnConnectionFailure(void * context, PeerId peerId, CHIP_ERROR
     default:
         break;
     }
+
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnConnectionFailure Exit");
 }
 
 // Sends the QueryImage command to the Provider currently set in the OTARequestor
 void OTARequestor::TriggerImmediateQueryInternal()
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::TriggerImmediateQueryInternal");
+
     // We are now connecting to a provider for the purpose of sending a QueryImage,
     // treat this as a move to the Querying state
     RecordNewUpdateState(OTAUpdateStateEnum::kQuerying, OTAChangeReasonEnum::kSuccess);
 
     ConnectToProvider(kQueryImage);
+
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::TriggerImmediateQueryInternal Exit");
 }
 
 // Sends the QueryImage command to the next available Provider
 OTARequestorInterface::OTATriggerResult OTARequestor::TriggerImmediateQuery()
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::TriggerImmediateQuery");
+
     ProviderLocationType providerLocation;
     bool listExhausted = false;
     if (mOtaRequestorDriver->GetNextProviderLocation(providerLocation, listExhausted) != true)
@@ -525,22 +582,30 @@ OTARequestorInterface::OTATriggerResult OTARequestor::TriggerImmediateQuery()
     // Go through the driver as it has additional logic to execute
     mOtaRequestorDriver->SendQueryImage();
 
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::TriggerImmediateQuery Exit");
+
     return kTriggerSuccessful;
 }
 
 void OTARequestor::DownloadUpdate()
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::DownloadUpdate");
+
     RecordNewUpdateState(OTAUpdateStateEnum::kDownloading, OTAChangeReasonEnum::kSuccess);
     ConnectToProvider(kDownload);
 }
 
 void OTARequestor::DownloadUpdateDelayedOnUserConsent()
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::DownloadUpdateDelayedOnUserConsent");
+
     RecordNewUpdateState(OTAUpdateStateEnum::kDelayedOnUserConsent, OTAChangeReasonEnum::kSuccess);
 }
 
 void OTARequestor::ApplyUpdate()
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::ApplyUpdate");
+
     RecordNewUpdateState(OTAUpdateStateEnum::kApplying, OTAChangeReasonEnum::kSuccess);
 
     // If image is successfully applied, the device will reboot so persist all relevant data
@@ -551,6 +616,8 @@ void OTARequestor::ApplyUpdate()
 
 void OTARequestor::NotifyUpdateApplied()
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::NotifyUpdateApplied");
+
     // Log the VersionApplied event
     uint16_t productId;
     if (DeviceLayer::ConfigurationMgr().GetProductId(productId) != CHIP_NO_ERROR)
@@ -567,6 +634,8 @@ void OTARequestor::NotifyUpdateApplied()
 
 CHIP_ERROR OTARequestor::ClearDefaultOtaProviderList(FabricIndex fabricIndex)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::ClearDefaultOtaProviderList");
+
     CHIP_ERROR error = mDefaultOtaProviderList.Delete(fabricIndex);
 
     // Ignore the error if no entry for the associated fabric index has been found.
@@ -578,6 +647,8 @@ CHIP_ERROR OTARequestor::ClearDefaultOtaProviderList(FabricIndex fabricIndex)
 
 CHIP_ERROR OTARequestor::AddDefaultOtaProvider(const ProviderLocationType & providerLocation)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::AddDefaultOtaProvider");
+
     // Look for an entry with the same fabric index indicated
     auto iterator = mDefaultOtaProviderList.Begin();
     while (iterator.Next())
@@ -597,14 +668,18 @@ CHIP_ERROR OTARequestor::AddDefaultOtaProvider(const ProviderLocationType & prov
 
 void OTARequestor::OnDownloadStateChanged(OTADownloader::State state, OTAChangeReasonEnum reason)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnDownloadStateChanged");
+
     VerifyOrDie(mOtaRequestorDriver != nullptr);
 
     switch (state)
     {
     case OTADownloader::State::kComplete:
+        ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnDownloadStateChanged - OTADownloader::State::kComplete");
         mOtaRequestorDriver->UpdateDownloaded();
         break;
     case OTADownloader::State::kIdle:
+        ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnDownloadStateChanged - OTADownloader::State::kIdle");
         if (reason != OTAChangeReasonEnum::kSuccess)
         {
             // TODO: Should we call some driver API to give it a chance to reschedule?
@@ -622,22 +697,10 @@ void OTARequestor::OnUpdateProgressChanged(Nullable<uint8_t> percent)
     OtaRequestorServerSetUpdateStateProgress(percent);
 }
 
-IdleStateReason OTARequestor::MapErrorToIdleStateReason(CHIP_ERROR error)
-{
-    if (error == CHIP_NO_ERROR)
-    {
-        return IdleStateReason::kIdle;
-    }
-    else if (error == CHIP_ERROR_CONNECTION_CLOSED_UNEXPECTEDLY)
-    {
-        return IdleStateReason::kInvalidSession;
-    }
-
-    return IdleStateReason::kUnknown;
-}
-
 void OTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::RecordNewUpdateState");
+
     // Set server UpdateState attribute
     OtaRequestorServerSetUpdateState(newState);
 
@@ -658,19 +721,25 @@ void OTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeRe
     }
     OtaRequestorServerOnStateTransition(mCurrentUpdateState, newState, reason, targetSoftwareVersion);
 
-    if ((newState == OTAUpdateStateEnum::kIdle) && (mCurrentUpdateState != OTAUpdateStateEnum::kIdle))
-    {
-        IdleStateReason idleStateReason = MapErrorToIdleStateReason(error);
+    //if ((newState == OTAUpdateStateEnum::kIdle) && (mCurrentUpdateState != OTAUpdateStateEnum::kIdle))
+    //{
+    //    IdleStateReason idleStateReason = MapErrorToIdleStateReason(error);
 
         // Inform the driver that the OTARequestor has entered the Idle state
-        mOtaRequestorDriver->HandleIdleState(idleStateReason);
-    }
+        //mOtaRequestorDriver->HandleIdleState(idleStateReason); 
+    //} 
+    mOtaRequestorDriver->HandleStateTransition(mCurrentUpdateState, newState, reason, error);
 
     mCurrentUpdateState = newState;
+
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::RecordNewUpdateState Exit");
 }
 
 void OTARequestor::RecordErrorUpdateState(UpdateFailureState failureState, CHIP_ERROR error, OTAChangeReasonEnum reason)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::RecordErrorUpdateState failureState %d reason %d", 
+            to_underlying(failureState), to_underlying(reason));
+
     // Inform driver of the error
     mOtaRequestorDriver->HandleError(failureState, error);
 
@@ -683,6 +752,8 @@ void OTARequestor::RecordErrorUpdateState(UpdateFailureState failureState, CHIP_
 
     // Whenever an error occurs, always reset to Idle state
     RecordNewUpdateState(OTAUpdateStateEnum::kIdle, reason, error);
+
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::RecordErrorUpdateState Exit");
 }
 
 CHIP_ERROR OTARequestor::GenerateUpdateToken()
@@ -705,6 +776,8 @@ CHIP_ERROR OTARequestor::GenerateUpdateToken()
 
 CHIP_ERROR OTARequestor::SendQueryImageRequest(OperationalDeviceProxy & deviceProxy)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::SendQueryImageRequest");
+
     VerifyOrReturnError(mProviderLocation.HasValue(), CHIP_ERROR_INCORRECT_STATE);
 
     constexpr OTADownloadProtocol kProtocolsSupported[] = { OTADownloadProtocol::kBDXSynchronous };
@@ -742,6 +815,8 @@ CHIP_ERROR OTARequestor::SendQueryImageRequest(OperationalDeviceProxy & devicePr
     Controller::OtaSoftwareUpdateProviderCluster cluster;
     cluster.Associate(&deviceProxy, mProviderLocation.Value().endpoint);
 
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::SendQueryImageRequest Exit");
+
     return cluster.InvokeCommand(args, this, OnQueryImageResponse, OnQueryImageFailure);
 }
 
@@ -773,6 +848,8 @@ CHIP_ERROR OTARequestor::ExtractUpdateDescription(const QueryImageResponseDecoda
 
 CHIP_ERROR OTARequestor::StartDownload(OperationalDeviceProxy & deviceProxy)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::StartDownload");
+
     VerifyOrReturnError(mBdxDownloader != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     // TODO: allow caller to provide their own OTADownloader instance and set BDX parameters
@@ -802,6 +879,8 @@ CHIP_ERROR OTARequestor::StartDownload(OperationalDeviceProxy & deviceProxy)
 
 CHIP_ERROR OTARequestor::SendApplyUpdateRequest(OperationalDeviceProxy & deviceProxy)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::SendApplyUpdateRequest");
+
     VerifyOrReturnError(mProviderLocation.HasValue(), CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(GenerateUpdateToken());
 
@@ -817,6 +896,8 @@ CHIP_ERROR OTARequestor::SendApplyUpdateRequest(OperationalDeviceProxy & deviceP
 
 CHIP_ERROR OTARequestor::SendNotifyUpdateAppliedRequest(OperationalDeviceProxy & deviceProxy)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::SendNotifyUpdateAppliedRequest");
+
     VerifyOrReturnError(mProviderLocation.HasValue(), CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(GenerateUpdateToken());
 
@@ -912,6 +993,8 @@ void OTARequestor::LoadCurrentUpdateInfo()
 // Invoked when the device becomes commissioned
 void OTARequestor::OnCommissioningCompleteRequestor(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
 {
+    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnCommissioningCompleteRequestor");
+
     VerifyOrReturn(event->Type == DeviceLayer::DeviceEventType::kCommissioningComplete);
 
     ChipLogProgress(SoftwareUpdate, "Device commissioned, schedule a default provider query");

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -658,6 +658,7 @@ void OTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeRe
     }
     OtaRequestorServerOnStateTransition(mCurrentUpdateState, newState, reason, targetSoftwareVersion);
 
+    // Issue#16151 tracks re-factoring error and state transitioning handling.
     if ((newState == OTAUpdateStateEnum::kIdle) && (mCurrentUpdateState != OTAUpdateStateEnum::kIdle))
     {
         IdleStateReason idleStateReason = MapErrorToIdleStateReason(error);
@@ -665,8 +666,7 @@ void OTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeRe
         // Inform the driver that the OTARequestor has entered the Idle state
         mOtaRequestorDriver->HandleIdleState(idleStateReason);
     }
-    else if (((mCurrentUpdateState == OTAUpdateStateEnum::kIdle) || (mCurrentUpdateState == OTAUpdateStateEnum::kUnknown)) &&
-             (newState != OTAUpdateStateEnum::kIdle))
+    else if ((mCurrentUpdateState == OTAUpdateStateEnum::kIdle) && (newState != OTAUpdateStateEnum::kIdle))
     {
         mOtaRequestorDriver->HandleIdleStateExit();
     }

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -440,8 +440,7 @@ void OTARequestor::CancelImageUpdate()
 
     mOtaRequestorDriver->UpdateCancelled();
 
-    //is: replace with reset()
-    RecordNewUpdateState(OTAUpdateStateEnum::kIdle, OTAChangeReasonEnum::kUnknown);
+    Reset();
 
     ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::CancelImageUpdate Exit");
 }

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -624,8 +624,6 @@ void OTARequestor::OnUpdateProgressChanged(Nullable<uint8_t> percent)
 
 void OTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::RecordNewUpdateState");
-
     // Set server UpdateState attribute
     OtaRequestorServerSetUpdateState(newState);
 
@@ -656,15 +654,10 @@ void OTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeRe
     mOtaRequestorDriver->HandleStateTransition(mCurrentUpdateState, newState, reason, error);
 
     mCurrentUpdateState = newState;
-    
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::RecordNewUpdateState Exit");
 }
 
 void OTARequestor::RecordErrorUpdateState(UpdateFailureState failureState, CHIP_ERROR error, OTAChangeReasonEnum reason)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::RecordErrorUpdateState failureState %d reason %d", 
-            to_underlying(failureState), to_underlying(reason));
-
     // Inform driver of the error
     mOtaRequestorDriver->HandleError(failureState, error);
 
@@ -677,8 +670,6 @@ void OTARequestor::RecordErrorUpdateState(UpdateFailureState failureState, CHIP_
 
     // Whenever an error occurs, always reset to Idle state
     RecordNewUpdateState(OTAUpdateStateEnum::kIdle, reason, error);
-
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::RecordErrorUpdateState Exit");
 }
 
 CHIP_ERROR OTARequestor::GenerateUpdateToken()
@@ -701,8 +692,6 @@ CHIP_ERROR OTARequestor::GenerateUpdateToken()
 
 CHIP_ERROR OTARequestor::SendQueryImageRequest(OperationalDeviceProxy & deviceProxy)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::SendQueryImageRequest");
-
     VerifyOrReturnError(mProviderLocation.HasValue(), CHIP_ERROR_INCORRECT_STATE);
 
     constexpr OTADownloadProtocol kProtocolsSupported[] = { OTADownloadProtocol::kBDXSynchronous };
@@ -740,8 +729,6 @@ CHIP_ERROR OTARequestor::SendQueryImageRequest(OperationalDeviceProxy & devicePr
     Controller::OtaSoftwareUpdateProviderCluster cluster;
     cluster.Associate(&deviceProxy, mProviderLocation.Value().endpoint);
 
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::SendQueryImageRequest Exit");
-
     return cluster.InvokeCommand(args, this, OnQueryImageResponse, OnQueryImageFailure);
 }
 
@@ -773,8 +760,6 @@ CHIP_ERROR OTARequestor::ExtractUpdateDescription(const QueryImageResponseDecoda
 
 CHIP_ERROR OTARequestor::StartDownload(OperationalDeviceProxy & deviceProxy)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::StartDownload");
-
     VerifyOrReturnError(mBdxDownloader != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     // TODO: allow caller to provide their own OTADownloader instance and set BDX parameters
@@ -804,8 +789,6 @@ CHIP_ERROR OTARequestor::StartDownload(OperationalDeviceProxy & deviceProxy)
 
 CHIP_ERROR OTARequestor::SendApplyUpdateRequest(OperationalDeviceProxy & deviceProxy)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::SendApplyUpdateRequest");
-
     VerifyOrReturnError(mProviderLocation.HasValue(), CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(GenerateUpdateToken());
 
@@ -821,8 +804,6 @@ CHIP_ERROR OTARequestor::SendApplyUpdateRequest(OperationalDeviceProxy & deviceP
 
 CHIP_ERROR OTARequestor::SendNotifyUpdateAppliedRequest(OperationalDeviceProxy & deviceProxy)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::SendNotifyUpdateAppliedRequest");
-
     VerifyOrReturnError(mProviderLocation.HasValue(), CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(GenerateUpdateToken());
 
@@ -918,8 +899,6 @@ void OTARequestor::LoadCurrentUpdateInfo()
 // Invoked when the device becomes commissioned
 void OTARequestor::OnCommissioningCompleteRequestor(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnCommissioningCompleteRequestor");
-
     VerifyOrReturn(event->Type == DeviceLayer::DeviceEventType::kCommissioningComplete);
 
     ChipLogProgress(SoftwareUpdate, "Device commissioned, schedule a default provider query");

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -663,12 +663,12 @@ void OTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeRe
         IdleStateReason idleStateReason = MapErrorToIdleStateReason(error);
 
         // Inform the driver that the OTARequestor has entered the Idle state
-        mOtaRequestorDriver->HandleIdleState(idleStateReason); 
+        mOtaRequestorDriver->HandleIdleState(idleStateReason);
     }
-    else if(((mCurrentUpdateState == OTAUpdateStateEnum::kIdle) || (mCurrentUpdateState == OTAUpdateStateEnum::kUnknown)) &&
-            (newState != OTAUpdateStateEnum::kIdle))
+    else if (((mCurrentUpdateState == OTAUpdateStateEnum::kIdle) || (mCurrentUpdateState == OTAUpdateStateEnum::kUnknown)) &&
+             (newState != OTAUpdateStateEnum::kIdle))
     {
-        mOtaRequestorDriver->HandleIdleStateExit(); 
+        mOtaRequestorDriver->HandleIdleStateExit();
     }
 
     mCurrentUpdateState = newState;

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -638,9 +638,6 @@ IdleStateReason OTARequestor::MapErrorToIdleStateReason(CHIP_ERROR error)
 
 void OTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error)
 {
-    ChipLogError(SoftwareUpdate, "//is: RecordNewUpdateState newState %d, reason %d", to_underlying(newState),
-                 to_underlying(reason));
-
     // Set server UpdateState attribute
     OtaRequestorServerSetUpdateState(newState);
 

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -656,7 +656,7 @@ void OTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeRe
     mOtaRequestorDriver->HandleStateTransition(mCurrentUpdateState, newState, reason, error);
 
     mCurrentUpdateState = newState;
-
+    
     ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::RecordNewUpdateState Exit");
 }
 

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -638,6 +638,9 @@ IdleStateReason OTARequestor::MapErrorToIdleStateReason(CHIP_ERROR error)
 
 void OTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error)
 {
+    ChipLogError(SoftwareUpdate, "//is: RecordNewUpdateState newState %d, reason %d", to_underlying(newState),
+                 to_underlying(reason));
+
     // Set server UpdateState attribute
     OtaRequestorServerSetUpdateState(newState);
 

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -104,8 +104,6 @@ OTARequestorInterface * GetRequestorInstance()
 
 void OTARequestor::InitState(intptr_t context)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::InitState");
-
     OTARequestor * requestorCore = reinterpret_cast<OTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
@@ -116,8 +114,6 @@ void OTARequestor::InitState(intptr_t context)
     //   resetting the states appropriately, including the current update state.
     OtaRequestorServerSetUpdateState(requestorCore->mCurrentUpdateState);
     OtaRequestorServerSetUpdateStateProgress(app::DataModel::NullNullable);
-
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::InitState exit");
 }
 
 CHIP_ERROR OTARequestor::Init(Server & server, OTARequestorStorage & storage, OTARequestorDriver & driver,
@@ -142,8 +138,6 @@ CHIP_ERROR OTARequestor::Init(Server & server, OTARequestorStorage & storage, OT
 
 void OTARequestor::OnQueryImageResponse(void * context, const QueryImageResponse::DecodableType & response)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnQueryImageResponse");
-
     LogQueryImageResponse(response);
 
     OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
@@ -218,14 +212,10 @@ void OTARequestor::OnQueryImageResponse(void * context, const QueryImageResponse
         requestorCore->RecordErrorUpdateState(UpdateFailureState::kQuerying, CHIP_ERROR_BAD_REQUEST);
         break;
     }
-
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnQueryImageResponse Exit");
 }
 
 void OTARequestor::OnQueryImageFailure(void * context, CHIP_ERROR error)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnQueryImageFailure");
-    
     OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
@@ -240,14 +230,10 @@ void OTARequestor::OnQueryImageFailure(void * context, CHIP_ERROR error)
     }
 
     requestorCore->RecordErrorUpdateState(UpdateFailureState::kQuerying, error);
-
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnQueryImageFailure Exit");
 }
 
 void OTARequestor::OnApplyUpdateResponse(void * context, const ApplyUpdateResponse::DecodableType & response)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnApplyUpdateResponse");
-
     LogApplyUpdateResponse(response);
 
     OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
@@ -267,39 +253,26 @@ void OTARequestor::OnApplyUpdateResponse(void * context, const ApplyUpdateRespon
         requestorCore->mOtaRequestorDriver->UpdateDiscontinued();
         break;
     }
-
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnApplyUpdateResponse Exit");
 }
 
 void OTARequestor::OnApplyUpdateFailure(void * context, CHIP_ERROR error)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnApplyUpdateFailure");
-
     OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
     ChipLogDetail(SoftwareUpdate, "ApplyUpdate failure response %" CHIP_ERROR_FORMAT, error.Format());
     requestorCore->RecordErrorUpdateState(UpdateFailureState::kApplying, error);
-
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnApplyUpdateFailure Exit");
 }
 
-void OTARequestor::OnNotifyUpdateAppliedResponse(void * context, const app::DataModel::NullObjectType & response) 
-{
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnNotifyUpdateAppliedResponse - Does nothing");
-}
+void OTARequestor::OnNotifyUpdateAppliedResponse(void * context, const app::DataModel::NullObjectType & response) {}
 
 void OTARequestor::OnNotifyUpdateAppliedFailure(void * context, CHIP_ERROR error)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnNotifyUpdateAppliedFailure");
-
     OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
     ChipLogDetail(SoftwareUpdate, "NotifyUpdateApplied failure response %" CHIP_ERROR_FORMAT, error.Format());
     requestorCore->RecordErrorUpdateState(UpdateFailureState::kNotifying, error);
-
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnNotifyUpdateAppliedFailure Exit");
 }
 
 void OTARequestor::Reset()
@@ -322,8 +295,6 @@ EmberAfStatus OTARequestor::HandleAnnounceOTAProvider(app::CommandHandler * comm
                                                       const app::ConcreteCommandPath & commandPath,
                                                       const AnnounceOtaProvider::DecodableType & commandData)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::HandleAnnounceOTAProvider");
-
     auto & announcementReason = commandData.announcementReason;
 
     ChipLogProgress(SoftwareUpdate, "OTA Requestor received AnnounceOTAProvider");
@@ -350,15 +321,11 @@ EmberAfStatus OTARequestor::HandleAnnounceOTAProvider(app::CommandHandler * comm
 
     mOtaRequestorDriver->ProcessAnnounceOTAProviders(providerLocation, announcementReason);
 
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::HandleAnnounceOTAProvider Exit");
-
     return EMBER_ZCL_STATUS_SUCCESS;
 }
 
 void OTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::ConnectToProvider");
-    
     if (mServer == nullptr)
     {
         ChipLogError(SoftwareUpdate, "Server not set");
@@ -396,13 +363,10 @@ void OTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
         RecordErrorUpdateState(UpdateFailureState::kUnknown, CHIP_ERROR_INCORRECT_STATE);
         return;
     }
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::ConnectToProvider Exit");
 }
 
 void OTARequestor::DisconnectFromProvider()
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::DisconnectFromProvider");
-
     if (mServer == nullptr)
     {
         ChipLogError(SoftwareUpdate, "Server not set");
@@ -426,23 +390,17 @@ void OTARequestor::DisconnectFromProvider()
     }
 
     mCASESessionManager->ReleaseSession(fabricInfo->GetPeerIdForNode(mProviderLocation.Value().providerNodeID));
-
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::DisconnectFromProvider Exit");
 }
 
 // Requestor is directed to cancel image update in progress. All the Requestor state is
 // cleared, UpdateState is reset to Idle
 void OTARequestor::CancelImageUpdate()
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::CancelImageUpdate");
-
     mBdxDownloader->EndDownload(CHIP_ERROR_CONNECTION_ABORTED);
 
     mOtaRequestorDriver->UpdateCancelled();
 
     Reset();
-
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::CancelImageUpdate Exit");
 }
 
 CHIP_ERROR OTARequestor::GetUpdateStateProgressAttribute(EndpointId endpointId, app::DataModel::Nullable<uint8_t> & progress)
@@ -461,8 +419,6 @@ CHIP_ERROR OTARequestor::GetUpdateStateAttribute(EndpointId endpointId, OTAUpdat
 // Called whenever FindOrEstablishSession is successful
 void OTARequestor::OnConnected(void * context, OperationalDeviceProxy * deviceProxy)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnConnected");
-
     OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
     VerifyOrDie(deviceProxy != nullptr);
@@ -516,15 +472,11 @@ void OTARequestor::OnConnected(void * context, OperationalDeviceProxy * devicePr
     default:
         break;
     }
-
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnConnected Exit");
 }
 
 // Called whenever FindOrEstablishSession fails
 void OTARequestor::OnConnectionFailure(void * context, PeerId peerId, CHIP_ERROR error)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnConnectionFailure");
-
     OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
@@ -545,29 +497,21 @@ void OTARequestor::OnConnectionFailure(void * context, PeerId peerId, CHIP_ERROR
     default:
         break;
     }
-
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnConnectionFailure Exit");
 }
 
 // Sends the QueryImage command to the Provider currently set in the OTARequestor
 void OTARequestor::TriggerImmediateQueryInternal()
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::TriggerImmediateQueryInternal");
-
     // We are now connecting to a provider for the purpose of sending a QueryImage,
     // treat this as a move to the Querying state
     RecordNewUpdateState(OTAUpdateStateEnum::kQuerying, OTAChangeReasonEnum::kSuccess);
 
     ConnectToProvider(kQueryImage);
-
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::TriggerImmediateQueryInternal Exit");
 }
 
 // Sends the QueryImage command to the next available Provider
 OTARequestorInterface::OTATriggerResult OTARequestor::TriggerImmediateQuery()
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::TriggerImmediateQuery");
-
     ProviderLocationType providerLocation;
     bool listExhausted = false;
     if (mOtaRequestorDriver->GetNextProviderLocation(providerLocation, listExhausted) != true)
@@ -581,30 +525,22 @@ OTARequestorInterface::OTATriggerResult OTARequestor::TriggerImmediateQuery()
     // Go through the driver as it has additional logic to execute
     mOtaRequestorDriver->SendQueryImage();
 
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::TriggerImmediateQuery Exit");
-
     return kTriggerSuccessful;
 }
 
 void OTARequestor::DownloadUpdate()
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::DownloadUpdate");
-
     RecordNewUpdateState(OTAUpdateStateEnum::kDownloading, OTAChangeReasonEnum::kSuccess);
     ConnectToProvider(kDownload);
 }
 
 void OTARequestor::DownloadUpdateDelayedOnUserConsent()
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::DownloadUpdateDelayedOnUserConsent");
-
     RecordNewUpdateState(OTAUpdateStateEnum::kDelayedOnUserConsent, OTAChangeReasonEnum::kSuccess);
 }
 
 void OTARequestor::ApplyUpdate()
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::ApplyUpdate");
-
     RecordNewUpdateState(OTAUpdateStateEnum::kApplying, OTAChangeReasonEnum::kSuccess);
 
     // If image is successfully applied, the device will reboot so persist all relevant data
@@ -615,8 +551,6 @@ void OTARequestor::ApplyUpdate()
 
 void OTARequestor::NotifyUpdateApplied()
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::NotifyUpdateApplied");
-
     // Log the VersionApplied event
     uint16_t productId;
     if (DeviceLayer::ConfigurationMgr().GetProductId(productId) != CHIP_NO_ERROR)
@@ -633,8 +567,6 @@ void OTARequestor::NotifyUpdateApplied()
 
 CHIP_ERROR OTARequestor::ClearDefaultOtaProviderList(FabricIndex fabricIndex)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::ClearDefaultOtaProviderList");
-
     CHIP_ERROR error = mDefaultOtaProviderList.Delete(fabricIndex);
 
     // Ignore the error if no entry for the associated fabric index has been found.
@@ -646,8 +578,6 @@ CHIP_ERROR OTARequestor::ClearDefaultOtaProviderList(FabricIndex fabricIndex)
 
 CHIP_ERROR OTARequestor::AddDefaultOtaProvider(const ProviderLocationType & providerLocation)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::AddDefaultOtaProvider");
-
     // Look for an entry with the same fabric index indicated
     auto iterator = mDefaultOtaProviderList.Begin();
     while (iterator.Next())
@@ -667,18 +597,14 @@ CHIP_ERROR OTARequestor::AddDefaultOtaProvider(const ProviderLocationType & prov
 
 void OTARequestor::OnDownloadStateChanged(OTADownloader::State state, OTAChangeReasonEnum reason)
 {
-    ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnDownloadStateChanged");
-
     VerifyOrDie(mOtaRequestorDriver != nullptr);
 
     switch (state)
     {
     case OTADownloader::State::kComplete:
-        ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnDownloadStateChanged - OTADownloader::State::kComplete");
         mOtaRequestorDriver->UpdateDownloaded();
         break;
     case OTADownloader::State::kIdle:
-        ChipLogDetail(SoftwareUpdate, "//is: OTARequestor::OnDownloadStateChanged - OTADownloader::State::kIdle");
         if (reason != OTAChangeReasonEnum::kSuccess)
         {
             // TODO: Should we call some driver API to give it a chance to reschedule?

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -187,6 +187,11 @@ private:
      * Callback to initialize states and server attributes in the CHIP context
      */
     static void InitState(intptr_t context);
+    
+    /**
+     * Map a CHIP_ERROR to an IdleStateReason enum type
+     */
+    IdleStateReason MapErrorToIdleStateReason(CHIP_ERROR error);
 
     /**
      * Record the new update state by updating the corresponding server attribute and logging a StateTransition event

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -187,7 +187,7 @@ private:
      * Callback to initialize states and server attributes in the CHIP context
      */
     static void InitState(intptr_t context);
-    
+
     /**
      * Map a CHIP_ERROR to an IdleStateReason enum type
      */

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -189,11 +189,6 @@ private:
     static void InitState(intptr_t context);
 
     /**
-     * Map a CHIP_ERROR to an IdleStateReason enum type
-     */
-    IdleStateReason MapErrorToIdleStateReason(CHIP_ERROR error);
-
-    /**
      * Record the new update state by updating the corresponding server attribute and logging a StateTransition event
      */
     void RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error = CHIP_NO_ERROR);

--- a/src/app/clusters/ota-requestor/OTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/OTARequestorDriver.h
@@ -81,7 +81,7 @@ enum class SelectedTimer
 class OTARequestorDriver
 {
 public:
-    using OTAUpdateStateEnum   = chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
+    using OTAUpdateStateEnum   = app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
     using OTAChangeReasonEnum = app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum;
 
     using ProviderLocationType = app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type;

--- a/src/app/clusters/ota-requestor/OTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/OTARequestorDriver.h
@@ -81,7 +81,7 @@ enum class SelectedTimer
 class OTARequestorDriver
 {
 public:
-    using OTAUpdateStateEnum   = app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
+    using OTAUpdateStateEnum  = app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
     using OTAChangeReasonEnum = app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum;
 
     using ProviderLocationType = app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type;

--- a/src/app/clusters/ota-requestor/OTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/OTARequestorDriver.h
@@ -81,8 +81,8 @@ enum class SelectedTimer
 class OTARequestorDriver
 {
 public:
-    using OTAUpdateStateEnum   = chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum; //is:
-    using OTAChangeReasonEnum = app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum; //is:
+    using OTAUpdateStateEnum   = chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
+    using OTAChangeReasonEnum = app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum;
 
     using ProviderLocationType = app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type;
 

--- a/src/app/clusters/ota-requestor/OTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/OTARequestorDriver.h
@@ -97,8 +97,8 @@ public:
     /// Called when an error occurs at any OTA requestor operation
     virtual void HandleError(UpdateFailureState state, CHIP_ERROR error) = 0;
 
-    /// Called when OTA Requestor has a state transition for which the driver may need to take various actions
-    virtual void HandleStateTransition(OTAUpdateStateEnum currentUpdateState, OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error = CHIP_NO_ERROR) = 0;
+    /// Called when OTA Requestor has exitted the Idle state for which the driver may need to take various actions
+    virtual void HandleIdleStateExit() = 0;
 
     // Called when the OTA Requestor has entered the Idle state for which the driver may need to take various actions
     virtual void HandleIdleState(IdleStateReason reason) = 0;

--- a/src/app/clusters/ota-requestor/OTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/OTARequestorDriver.h
@@ -69,11 +69,21 @@ enum class IdleStateReason
     kInvalidSession,
 };
 
+// The current selected OTA Requestor timer to be running
+enum class SelectedTimer
+{
+    kDefaultProviderTimer,
+    kWatchdogTimer,
+};
+
 // Interface class to abstract the OTA-related business logic. Each application
 // must implement this interface. All calls must be non-blocking unless stated otherwise
 class OTARequestorDriver
 {
 public:
+    using OTAUpdateStateEnum   = chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum; //is:
+    using OTAChangeReasonEnum = app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum; //is:
+
     using ProviderLocationType = app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type;
 
     virtual ~OTARequestorDriver() = default;
@@ -86,6 +96,9 @@ public:
 
     /// Called when an error occurs at any OTA requestor operation
     virtual void HandleError(UpdateFailureState state, CHIP_ERROR error) = 0;
+
+    /// Called when OTA Requestor has a state transition for which the driver may need to take various actions
+    virtual void HandleStateTransition(OTAUpdateStateEnum currentUpdateState, OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error = CHIP_NO_ERROR) = 0;
 
     // Called when the OTA Requestor has entered the Idle state for which the driver may need to take various actions
     virtual void HandleIdleState(IdleStateReason reason) = 0;

--- a/src/app/clusters/ota-requestor/OTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/OTARequestorDriver.h
@@ -72,7 +72,7 @@ enum class IdleStateReason
 // The current selected OTA Requestor timer to be running
 enum class SelectedTimer
 {
-    kDefaultProviderTimer,
+    kPeriodicQueryTimer,
     kWatchdogTimer,
 };
 

--- a/src/app/clusters/ota-requestor/OTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/OTARequestorDriver.h
@@ -81,9 +81,6 @@ enum class SelectedTimer
 class OTARequestorDriver
 {
 public:
-    using OTAUpdateStateEnum  = app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
-    using OTAChangeReasonEnum = app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum;
-
     using ProviderLocationType = app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type;
 
     virtual ~OTARequestorDriver() = default;
@@ -97,7 +94,7 @@ public:
     /// Called when an error occurs at any OTA requestor operation
     virtual void HandleError(UpdateFailureState state, CHIP_ERROR error) = 0;
 
-    /// Called when OTA Requestor has exitted the Idle state for which the driver may need to take various actions
+    /// Called when OTA Requestor has exited the Idle state for which the driver may need to take various actions
     virtual void HandleIdleStateExit() = 0;
 
     // Called when the OTA Requestor has entered the Idle state for which the driver may need to take various actions


### PR DESCRIPTION
#### Problem
Currently, there is no failsafe check to ensure the OTA process doesn't get stuck in a bad state.

Fixes: https://github.com/project-chip/connectedhomeip/issues/16462

#### Change overview
Trigger a 6 hour watchdog timer whenever OTA Requestor transitions from idle state to a non-idle state. When the watchdog timer expires and detects OTA process is still stuck in a non-idle state, cancel any pending download, reset it back to idle state and restart the 24 hour query image periodic timer. 

#### Testing
* Verified default query image process.
* Temporarily reduced watchdog timer for testing, and verified watchdog timer catches OTA Requestor in a non-idle state when the timer expires, and resets OTA Requestor for the next periodic query update.