### PR TITLE
Add an access control delegate implementation for the Darwin framework.

### DIFF
--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		51B22C222740CB1D008D5055 /* CHIPCommandPayloadsObjc.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B22C212740CB1D008D5055 /* CHIPCommandPayloadsObjc.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		51B22C262740CB32008D5055 /* CHIPStructsObjc.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51B22C252740CB32008D5055 /* CHIPStructsObjc.mm */; };
 		51B22C2A2740CB47008D5055 /* CHIPCommandPayloadsObjc.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51B22C292740CB47008D5055 /* CHIPCommandPayloadsObjc.mm */; };
+		51E0310027EA20D20083DC9C /* CHIPControllerAccessControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E030FE27EA20D20083DC9C /* CHIPControllerAccessControl.h */; };
+		51E0310127EA20D20083DC9C /* CHIPControllerAccessControl.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51E030FF27EA20D20083DC9C /* CHIPControllerAccessControl.mm */; };
 		51E24E73274E0DAC007CCF6E /* CHIPErrorTestUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51E24E72274E0DAC007CCF6E /* CHIPErrorTestUtils.mm */; };
 		5A6FEC9027B563D900F25F42 /* CHIPDeviceControllerOverXPC.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A6FEC8F27B563D900F25F42 /* CHIPDeviceControllerOverXPC.m */; };
 		5A6FEC9227B5669C00F25F42 /* CHIPDeviceControllerOverXPC.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A6FEC8D27B5624E00F25F42 /* CHIPDeviceControllerOverXPC.h */; };
@@ -133,6 +135,8 @@
 		51B22C212740CB1D008D5055 /* CHIPCommandPayloadsObjc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CHIPCommandPayloadsObjc.h; path = "zap-generated/CHIPCommandPayloadsObjc.h"; sourceTree = "<group>"; };
 		51B22C252740CB32008D5055 /* CHIPStructsObjc.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = CHIPStructsObjc.mm; path = "zap-generated/CHIPStructsObjc.mm"; sourceTree = "<group>"; };
 		51B22C292740CB47008D5055 /* CHIPCommandPayloadsObjc.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = CHIPCommandPayloadsObjc.mm; path = "zap-generated/CHIPCommandPayloadsObjc.mm"; sourceTree = "<group>"; };
+		51E030FE27EA20D20083DC9C /* CHIPControllerAccessControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPControllerAccessControl.h; sourceTree = "<group>"; };
+		51E030FF27EA20D20083DC9C /* CHIPControllerAccessControl.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPControllerAccessControl.mm; sourceTree = "<group>"; };
 		51E24E72274E0DAC007CCF6E /* CHIPErrorTestUtils.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPErrorTestUtils.mm; sourceTree = "<group>"; };
 		5A6FEC8B27B5609C00F25F42 /* CHIPDeviceOverXPC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPDeviceOverXPC.h; sourceTree = "<group>"; };
 		5A6FEC8D27B5624E00F25F42 /* CHIPDeviceControllerOverXPC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPDeviceControllerOverXPC.h; sourceTree = "<group>"; };
@@ -262,6 +266,8 @@
 				1ED276E126C5812A00547A89 /* CHIPCluster.mm */,
 				2C5EEEF4268A85C400CAE3D3 /* CHIPDeviceConnectionBridge.h */,
 				51431AF827D2973E008A7943 /* CHIPIMDispatch.mm */,
+				51E030FE27EA20D20083DC9C /* CHIPControllerAccessControl.h */,
+				51E030FF27EA20D20083DC9C /* CHIPControllerAccessControl.mm */,
 				2C5EEEF5268A85C400CAE3D3 /* CHIPDeviceConnectionBridge.mm */,
 				1E857311265519DE0050A4D9 /* CHIPApp */,
 				2C1B02792641DB4E00780EF1 /* CHIPOperationalCredentialsDelegate.h */,
@@ -382,6 +388,7 @@
 				5A830D6A27CFCB640053B85D /* CHIPDeviceControllerOverXPC+AttributeCache.h in Headers */,
 				998F286F26D55EC5001846C6 /* CHIPP256KeypairBridge.h in Headers */,
 				2C222ADF255C811800E446B9 /* CHIPDevice_Internal.h in Headers */,
+				51E0310027EA20D20083DC9C /* CHIPControllerAccessControl.h in Headers */,
 				991DC08B247704DC00C13860 /* CHIPLogging.h in Headers */,
 				5A7947E527C0129F00434CF2 /* CHIPDeviceController+XPC.h in Headers */,
 				B2E0D7B4245B0B5C003C5B48 /* CHIPError_Internal.h in Headers */,
@@ -522,6 +529,7 @@
 				991DC0892475F47D00C13860 /* CHIPDeviceController.mm in Sources */,
 				B2E0D7B7245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.mm in Sources */,
 				1EC4CE5D25CC26E900D7304F /* CHIPClustersObjc.mm in Sources */,
+				51E0310127EA20D20083DC9C /* CHIPControllerAccessControl.mm in Sources */,
 				1ED276E226C5812A00547A89 /* CHIPCluster.mm in Sources */,
 				B2E0D7B3245B0B5C003C5B48 /* CHIPError.mm in Sources */,
 				1E85730C265519AE0050A4D9 /* callback-stub.cpp in Sources */,
@@ -612,7 +620,7 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
-          "CHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>",
+					"CHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>",
 					"$(inherited)",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -647,7 +655,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					CHIP_HAVE_CONFIG_H,
-          "CHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>",
+					"CHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>",
 					"$(inherited)",
 				);
 				HEADER_SEARCH_PATHS = (
@@ -790,7 +798,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					CHIP_HAVE_CONFIG_H,
-          "CHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>",
+					"CHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>",
 					"$(inherited)",
 				);
 				HEADER_SEARCH_PATHS = (

--- a/src/darwin/Framework/CHIP/BUILD.gn
+++ b/src/darwin/Framework/CHIP/BUILD.gn
@@ -30,6 +30,8 @@ static_library("framework") {
   sources = [
     "CHIP.h",
     "CHIPCluster.mm",
+    "CHIPControllerAccessControl.h",
+    "CHIPControllerAccessControl.mm",
     "CHIPDevice.h",
     "CHIPDevice.mm",
     "CHIPDeviceConnectionBridge.mm",
@@ -42,6 +44,7 @@ static_library("framework") {
     "CHIPError.h",
     "CHIPError.mm",
     "CHIPError_Internal.h",
+    "CHIPIMDispatch.mm",
     "CHIPLogging.h",
     "CHIPManualSetupPayloadParser.h",
     "CHIPManualSetupPayloadParser.mm",

--- a/src/darwin/Framework/CHIP/CHIPControllerAccessControl.h
+++ b/src/darwin/Framework/CHIP/CHIPControllerAccessControl.h
@@ -1,0 +1,36 @@
+/**
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CHIPControllerAccessControl : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
++ (instancetype)alloc NS_UNAVAILABLE;
+
+/**
+ * Initialize the access control module. Must be called on the Matter task
+ * queue.
+ */
++ (void)init;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPControllerAccessControl.mm
+++ b/src/darwin/Framework/CHIP/CHIPControllerAccessControl.mm
@@ -1,0 +1,75 @@
+/**
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "CHIPControllerAccessControl.h"
+
+#include <access/AccessControl.h>
+#include <access/Privilege.h>
+#include <access/RequestPath.h>
+#include <access/SubjectDescriptor.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <lib/core/CHIPError.h>
+
+using namespace chip;
+using namespace chip::Access;
+using namespace chip::app::Clusters;
+
+namespace {
+// TODO: Maybe consider making this configurable?  See also
+// CHIPIMDispatch.mm.
+constexpr EndpointId kSupportedEndpoint = 0;
+
+// TODO: Make the policy more configurable by consumers.
+class AccessControlDelegate : public Access::AccessControl::Delegate {
+    CHIP_ERROR Check(
+        const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath, Privilege requestPrivilege) override
+    {
+        if (requestPath.endpoint != kSupportedEndpoint || requestPath.cluster != OtaSoftwareUpdateProvider::Id) {
+            // We only allow access to OTA software update provider.
+            return CHIP_ERROR_ACCESS_DENIED;
+        }
+
+        if (requestPrivilege != Privilege::kOperate) {
+            // The commands on OtaSoftwareUpdateProvider all require
+            // Operate; we should not be asked for anything else.
+            return CHIP_ERROR_ACCESS_DENIED;
+        }
+
+        if (subjectDescriptor.authMode != AuthMode::kCase && subjectDescriptor.authMode != AuthMode::kPase) {
+            // No idea who is asking; deny for now.
+            return CHIP_ERROR_ACCESS_DENIED;
+        }
+
+        // TODO do we care about the fabric index here?  Probably not.
+
+        return CHIP_NO_ERROR;
+    }
+};
+
+AccessControlDelegate gDelegate;
+} // anonymous namespace
+
+@implementation CHIPControllerAccessControl
+
++ (void)init
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        GetAccessControl().Init(&gDelegate);
+    });
+}
+
+@end

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -17,6 +17,7 @@
 #import "CHIPDeviceController.h"
 
 #import "CHIPCommissioningParameters.h"
+#import "CHIPControllerAccessControl.h"
 #import "CHIPDevicePairingDelegateBridge.h"
 #import "CHIPDevice_Internal.h"
 #import "CHIPError_Internal.h"
@@ -157,6 +158,8 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
             commissionerInitialized = YES;
             return;
         }
+
+        [CHIPControllerAccessControl init];
 
         CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
 

--- a/src/darwin/Framework/CHIP/CHIPIMDispatch.mm
+++ b/src/darwin/Framework/CHIP/CHIPIMDispatch.mm
@@ -52,7 +52,8 @@ using namespace chip::app::Clusters;
 
 namespace {
 
-// TODO: Maybe consider making this configurable?
+// TODO: Maybe consider making this configurable?  See also
+// CHIPControllerAccessControl.mm.
 constexpr EndpointId kSupportedEndpoint = 0;
 
 } // anonymous namespace


### PR DESCRIPTION
#### Problem
Right now, sending a QueryImage command to the Darwin framework (from an OTA Provider client) fails the ACL check, since no ACLs are configured.

#### Change overview
Add an access control delegate that implements the right policy.

#### Testing
Tested that if I have iOS CHIPTool announce itself as an OTA Provider, the ota requestor app can QueryImage on it and get as far as the cluster impl (where it fails due to lack of an OTA delegate so far).