### PR TITLE
Exclude some redundant things from Darwin build CI.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -321,14 +321,21 @@ jobs:
                   scripts/run_in_build_env.sh "ninja -C ./out/$BUILD_TYPE"
             - name: Setup Build, Run Build and Run Tests
               timeout-minutes: 120
-              # Just go ahead and do the "all" build; on Darwin that's fairly
-              # fast.  If this ever becomes slow, we can think about ways to do
-              # the examples-linux-standalone.yaml tests on darwin without too
-              # much code duplication.
               run: |
-                  for BUILD_TYPE  in clang python_lib; do
+                  for BUILD_TYPE in default python_lib; do
                       case $BUILD_TYPE in
-                          "clang") GN_ARGS='is_clang=true target_os="all" is_asan=true pw_command_launcher="`pwd`/../scripts/helpers/clang-tidy-launcher.py"';;
+                          # We want to build various standalone example apps
+                          # (similar to what examples-linux-standalone.yaml
+                          # does), so use target_os="all" to get those picked
+                          # up as part of the "unified" build.  But then to
+                          # save CI resources we want to exclude a few
+                          # redundant things:
+                          #
+                          # * the mbedtls build, since we don't really plan to
+                          #   use that on Darwin.
+                          # * the "host clang" build, which uses the pigweed
+                          #   clang.
+                          "default") GN_ARGS='target_os="all" is_asan=true enable_host_clang_build=false enable_host_gcc_mbedtls_build=false pw_command_launcher="`pwd`/../scripts/helpers/clang-tidy-launcher.py"';;
                           "python_lib") GN_ARGS='enable_rtti=true enable_pylib=true';;
                       esac
                       scripts/build/gn_gen.sh --args="$GN_ARGS"


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/16464

#### Problem
See #16464.

#### Change overview
Don't build libCHIP three times as part of the darwin build.

#### Testing
Verified that the updated command still builds tests with ASAN and builds various "standalone" things.