### PR TITLE
[binding] Fix missing callback when notifying a connecting device

### DIFF
--- a/src/app/clusters/bindings/BindingManager.cpp
+++ b/src/app/clusters/bindings/BindingManager.cpp
@@ -188,6 +188,7 @@ void BindingManager::FabricRemoved(CompressedFabricId compressedFabricId, Fabric
 CHIP_ERROR BindingManager::NotifyBoundClusterChanged(EndpointId endpoint, ClusterId cluster, void * context)
 {
     VerifyOrReturnError(mInitParams.mFabricTable != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mBoundDeviceChangedHandler, CHIP_NO_ERROR);
 
     for (auto iter = BindingTable::GetInstance().begin(); iter != BindingTable::GetInstance().end(); ++iter)
     {
@@ -199,7 +200,7 @@ CHIP_ERROR BindingManager::NotifyBoundClusterChanged(EndpointId endpoint, Cluste
                 VerifyOrReturnError(fabricInfo != nullptr, CHIP_ERROR_NOT_FOUND);
                 PeerId peer                         = fabricInfo->GetPeerIdForNode(iter->nodeId);
                 OperationalDeviceProxy * peerDevice = mInitParams.mCASESessionManager->FindExistingSession(peer);
-                if (peerDevice != nullptr && peerDevice->IsConnected() && mBoundDeviceChangedHandler)
+                if (peerDevice != nullptr && peerDevice->IsConnected())
                 {
                     // We already have an active connection
                     mBoundDeviceChangedHandler(*iter, peerDevice, context);
@@ -207,10 +208,7 @@ CHIP_ERROR BindingManager::NotifyBoundClusterChanged(EndpointId endpoint, Cluste
                 else
                 {
                     mPendingNotificationMap.AddPendingNotification(iter.GetIndex(), context);
-                    if (peerDevice == nullptr || !peerDevice->IsConnecting())
-                    {
-                        ReturnErrorOnFailure(EstablishConnection(iter->fabricIndex, iter->nodeId));
-                    }
+                    ReturnErrorOnFailure(EstablishConnection(iter->fabricIndex, iter->nodeId));
                 }
             }
             else if (iter->type == EMBER_MULTICAST_BINDING)


### PR DESCRIPTION
#### Problem

The `OnConnected` callback will not be triggered when binding to a connecting device.

#### Change overview

Call `EstablishConnection` for connecting devices as well. The callback will be enqueued.

#### Testing
How was this tested? (at least one bullet point required)
* CI tests
