### PR TITLE
[general-diagnostics] Use type-safe BootReasonType enum

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -104,26 +104,26 @@ void OnSignalHandler(int signum)
     // The BootReason attribute SHALL indicate the reason for the Node’s most recent boot, the real usecase
     // for this attribute is embedded system. In Linux simulation, we use different signals to tell the current
     // running process to terminate with different reasons.
-    BootReasonType bootReason = BootReasonType::Unspecified;
+    BootReasonType bootReason = BootReasonType::kUnspecified;
     switch (signum)
     {
     case SIGVTALRM:
-        bootReason = BootReasonType::PowerOnReboot;
+        bootReason = BootReasonType::kPowerOnReboot;
         break;
     case SIGALRM:
-        bootReason = BootReasonType::BrownOutReset;
+        bootReason = BootReasonType::kBrownOutReset;
         break;
     case SIGILL:
-        bootReason = BootReasonType::SoftwareWatchdogReset;
+        bootReason = BootReasonType::kSoftwareWatchdogReset;
         break;
     case SIGTRAP:
-        bootReason = BootReasonType::HardwareWatchdogReset;
+        bootReason = BootReasonType::kHardwareWatchdogReset;
         break;
     case SIGIO:
-        bootReason = BootReasonType::SoftwareUpdateCompleted;
+        bootReason = BootReasonType::kSoftwareUpdateCompleted;
         break;
     case SIGINT:
-        bootReason = BootReasonType::SoftwareReset;
+        bootReason = BootReasonType::kSoftwareReset;
         break;
     default:
         IgnoreUnusedVariable(bootReason);

--- a/src/app/clusters/general-diagnostics-server/general-diagnostics-server.cpp
+++ b/src/app/clusters/general-diagnostics-server/general-diagnostics-server.cpp
@@ -36,13 +36,6 @@ using chip::DeviceLayer::ConnectivityMgr;
 using chip::DeviceLayer::DiagnosticDataProvider;
 using chip::DeviceLayer::GetDiagnosticDataProvider;
 
-static_assert(sizeof(chip::DeviceLayer::BootReasonType) == sizeof(EmberAfBootReasonType),
-              "BootReasonType size doesn't match EmberAfBootReasonType size");
-static_assert(static_cast<uint8_t>(chip::DeviceLayer::BootReasonType::Unspecified) == EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED &&
-                  static_cast<uint8_t>(chip::DeviceLayer::BootReasonType::SoftwareReset) ==
-                      EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_RESET,
-              "BootReasonType and EmberAfBootReasonType values does not match.");
-
 namespace {
 
 class GeneralDiagosticsAttrAccess : public AttributeAccessInterface
@@ -71,7 +64,7 @@ CHIP_ERROR GeneralDiagosticsAttrAccess::ReadIfSupported(CHIP_ERROR (DiagnosticDa
     CHIP_ERROR err = (GetDiagnosticDataProvider().*getter)(data);
     if (err == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
     {
-        data = 0;
+        data = {};
     }
     else if (err != CHIP_NO_ERROR)
     {
@@ -195,7 +188,7 @@ class GeneralDiagnosticsDelegate : public DeviceLayer::ConnectivityManagerDelega
     }
 
     // Gets called when the device has been rebooted.
-    void OnDeviceRebooted(chip::DeviceLayer::BootReasonType bootReason) override
+    void OnDeviceRebooted(BootReasonType bootReason) override
     {
         ChipLogDetail(Zcl, "GeneralDiagnosticsDelegate: OnDeviceRebooted");
 
@@ -203,7 +196,7 @@ class GeneralDiagnosticsDelegate : public DeviceLayer::ConnectivityManagerDelega
 
         // GeneralDiagnostics cluster should exist only for endpoint 0.
 
-        Events::BootReason::Type event{ static_cast<EmberAfBootReasonType>(bootReason) };
+        Events::BootReason::Type event{ bootReason };
         EventNumber eventNumber;
 
         CHIP_ERROR err = LogEvent(event, 0, eventNumber);

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -748,7 +748,6 @@ function isWeaklyTypedEnum(label)
     "AttributeWritePermission",
     "BarrierControlBarrierPosition",
     "BarrierControlMovingState",
-    "BootReasonType",
     "ColorControlOptions",
     "ColorLoopAction",
     "ColorLoopDirection",

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <app-common/zap-generated/cluster-objects.h>
+#include <lib/core/ClusterEnums.h>
 #include <platform/CHIPDeviceBuildConfig.h>
 #include <platform/GeneralFaults.h>
 
@@ -41,16 +42,7 @@ constexpr size_t kMaxIPv6AddrSize  = 16;
 constexpr size_t kMaxIPv4AddrCount = 4;
 constexpr size_t kMaxIPv6AddrCount = 8;
 
-enum BootReasonType : uint8_t
-{
-    Unspecified             = 0,
-    PowerOnReboot           = 1,
-    BrownOutReset           = 2,
-    SoftwareWatchdogReset   = 3,
-    HardwareWatchdogReset   = 4,
-    SoftwareUpdateCompleted = 5,
-    SoftwareReset           = 6,
-};
+using BootReasonType = app::Clusters::GeneralDiagnostics::BootReasonType;
 
 struct ThreadMetrics : public app::Clusters::SoftwareDiagnostics::Structs::ThreadMetrics::Type
 {
@@ -168,7 +160,7 @@ public:
     virtual CHIP_ERROR GetRebootCount(uint16_t & rebootCount);
     virtual CHIP_ERROR GetUpTime(uint64_t & upTime);
     virtual CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours);
-    virtual CHIP_ERROR GetBootReason(uint8_t & bootReason);
+    virtual CHIP_ERROR GetBootReason(BootReasonType & bootReason);
     virtual CHIP_ERROR GetActiveHardwareFaults(GeneralFaults<kMaxHardwareFaults> & hardwareFaults);
     virtual CHIP_ERROR GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults);
     virtual CHIP_ERROR GetActiveNetworkFaults(GeneralFaults<kMaxNetworkFaults> & networkFaults);
@@ -296,7 +288,7 @@ inline CHIP_ERROR DiagnosticDataProvider::GetTotalOperationalHours(uint32_t & to
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-inline CHIP_ERROR DiagnosticDataProvider::GetBootReason(uint8_t & bootReason)
+inline CHIP_ERROR DiagnosticDataProvider::GetBootReason(BootReasonType & bootReason)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/include/platform/internal/GenericPlatformManagerImpl.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.ipp
@@ -207,10 +207,10 @@ void GenericPlatformManagerImpl<ImplClass>::_HandleServerStarted()
 
     if (generalDiagnosticsDelegate != nullptr)
     {
-        uint8_t bootReason;
+        BootReasonType bootReason;
 
         if (GetDiagnosticDataProvider().GetBootReason(bootReason) == CHIP_NO_ERROR)
-            generalDiagnosticsDelegate->OnDeviceRebooted(static_cast<BootReasonType>(bootReason));
+            generalDiagnosticsDelegate->OnDeviceRebooted(bootReason);
     }
 }
 

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -80,7 +80,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
     if (!AmebaConfig::ConfigValueExists(AmebaConfig::kCounterKey_BootReason))
     {
-        err = StoreBootReason(BootReasonType::Unspecified);
+        err = StoreBootReason(to_underlying(BootReasonType::kUnspecified));
         SuccessOrExit(err);
     }
 

--- a/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
@@ -103,7 +103,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetTotalOperationalHours(uint32_t & total
     return CHIP_ERROR_INVALID_TIME;
 }
 
-CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(uint8_t & bootReason)
+CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason)
 {
     uint32_t reason = 0;
 
@@ -112,7 +112,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(uint8_t & bootReason)
     if (err == CHIP_NO_ERROR)
     {
         VerifyOrReturnError(reason <= UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
-        bootReason = static_cast<uint8_t>(reason);
+        bootReason = static_cast<BootReasonType>(reason);
     }
 
     return err;

--- a/src/platform/Ameba/DiagnosticDataProviderImpl.h
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.h
@@ -44,7 +44,7 @@ public:
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
     CHIP_ERROR GetUpTime(uint64_t & upTime) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
-    CHIP_ERROR GetBootReason(uint8_t & bootReason) override;
+    CHIP_ERROR GetBootReason(BootReasonType & bootReason) override;
 
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -160,7 +160,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
     if (!PosixConfig::ConfigValueExists(PosixConfig::kCounterKey_BootReason))
     {
-        ReturnErrorOnFailure(StoreBootReason(BootReasonType::Unspecified));
+        ReturnErrorOnFailure(StoreBootReason(to_underlying(BootReasonType::kUnspecified)));
     }
 
     if (!PosixConfig::ConfigValueExists(PosixConfig::kConfigKey_RegulatoryLocation))

--- a/src/platform/EFR32/ConfigurationManagerImpl.cpp
+++ b/src/platform/EFR32/ConfigurationManagerImpl.cpp
@@ -107,57 +107,57 @@ CHIP_ERROR ConfigurationManagerImpl::IncreaseBootCount(void)
 uint32_t ConfigurationManagerImpl::GetBootReason(void)
 {
     // rebootCause is obtained at bootup.
-    uint32_t matterBootCause;
+    BootReasonType matterBootCause;
 #if defined(_SILICON_LABS_32B_SERIES_1)
     if (rebootCause & RMU_RSTCAUSE_PORST || rebootCause & RMU_RSTCAUSE_EXTRST) // PowerOn or External pin reset
     {
-        matterBootCause = BootReasonType::PowerOnReboot;
+        matterBootCause = BootReasonType::kPowerOnReboot;
     }
     else if (rebootCause & RMU_RSTCAUSE_AVDDBOD || rebootCause & RMU_RSTCAUSE_DVDDBOD || rebootCause & RMU_RSTCAUSE_DECBOD)
     {
-        matterBootCause = BootReasonType::BrownOutReset;
+        matterBootCause = BootReasonType::kBrownOutReset;
     }
     else if (rebootCause & RMU_RSTCAUSE_SYSREQRST)
     {
-        matterBootCause = BootReasonType::SoftwareReset;
+        matterBootCause = BootReasonType::kSoftwareReset;
     }
     else if (rebootCause & RMU_RSTCAUSE_WDOGRST)
     {
-        matterBootCause = BootReasonType::SoftwareWatchdogReset;
+        matterBootCause = BootReasonType::kSoftwareWatchdogReset;
     }
     else
     {
-        matterBootCause = BootReasonType::Unspecified;
+        matterBootCause = BootReasonType::kUnspecified;
     }
     // Not tracked HARDWARE_WATCHDOG_RESET && SOFTWARE_UPDATE_COMPLETED
 #elif defined(_SILICON_LABS_32B_SERIES_2)
     if (rebootCause & EMU_RSTCAUSE_POR || rebootCause & EMU_RSTCAUSE_PIN) // PowerOn or External pin reset
     {
-        matterBootCause = BootReasonType::PowerOnReboot;
+        matterBootCause = BootReasonType::kPowerOnReboot;
     }
     else if (rebootCause & EMU_RSTCAUSE_AVDDBOD || rebootCause & EMU_RSTCAUSE_DVDDBOD || rebootCause & EMU_RSTCAUSE_DECBOD ||
              rebootCause & EMU_RSTCAUSE_VREGIN || rebootCause & EMU_RSTCAUSE_IOVDD0BOD || rebootCause & EMU_RSTCAUSE_DVDDLEBOD)
     {
-        matterBootCause = BootReasonType::BrownOutReset;
+        matterBootCause = BootReasonType::kBrownOutReset;
     }
     else if (rebootCause & EMU_RSTCAUSE_SYSREQ)
     {
-        matterBootCause = BootReasonType::SoftwareReset;
+        matterBootCause = BootReasonType::kSoftwareReset;
     }
     else if (rebootCause & EMU_RSTCAUSE_WDOG0 || rebootCause & EMU_RSTCAUSE_WDOG1)
     {
-        matterBootCause = BootReasonType::SoftwareWatchdogReset;
+        matterBootCause = BootReasonType::kSoftwareWatchdogReset;
     }
     else
     {
-        matterBootCause = BootReasonType::Unspecified;
+        matterBootCause = BootReasonType::kUnspecified;
     }
     // Not tracked HARDWARE_WATCHDOG_RESET && SOFTWARE_UPDATE_COMPLETED
 #else
-    matterBootCause = BootReasonType::Unspecified;
+    matterBootCause = BootReasonType::kUnspecified;
 #endif
 
-    return matterBootCause;
+    return to_underlying(matterBootCause);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
@@ -98,7 +98,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetRebootCount(uint16_t & rebootCount)
     return err;
 }
 
-CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(uint8_t & bootReason)
+CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason)
 {
     uint32_t reason = 0;
     CHIP_ERROR err  = ConfigurationMgr().GetBootReason(reason);
@@ -106,7 +106,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(uint8_t & bootReason)
     if (err == CHIP_NO_ERROR)
     {
         VerifyOrReturnError(reason <= UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
-        bootReason = static_cast<uint8_t>(reason);
+        bootReason = static_cast<BootReasonType>(reason);
     }
 
     return err;

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.h
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.h
@@ -43,7 +43,7 @@ public:
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
-    CHIP_ERROR GetBootReason(uint8_t & bootReason) override;
+    CHIP_ERROR GetBootReason(BootReasonType & bootReason) override;
     CHIP_ERROR GetUpTime(uint64_t & upTime) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
     CHIP_ERROR GetActiveHardwareFaults(GeneralFaults<kMaxHardwareFaults> & hardwareFaults) override;

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -165,30 +165,30 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetTotalOperationalHours(uint32_t & total
     return CHIP_ERROR_INVALID_TIME;
 }
 
-CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(uint8_t & bootReason)
+CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason)
 {
-    bootReason = BootReasonType::Unspecified;
+    bootReason = BootReasonType::kUnspecified;
     uint8_t reason;
     reason = static_cast<uint8_t>(esp_reset_reason());
     if (reason == ESP_RST_UNKNOWN)
     {
-        bootReason = BootReasonType::Unspecified;
+        bootReason = BootReasonType::kUnspecified;
     }
     else if (reason == ESP_RST_POWERON)
     {
-        bootReason = BootReasonType::PowerOnReboot;
+        bootReason = BootReasonType::kPowerOnReboot;
     }
     else if (reason == ESP_RST_BROWNOUT)
     {
-        bootReason = BootReasonType::BrownOutReset;
+        bootReason = BootReasonType::kBrownOutReset;
     }
     else if (reason == ESP_RST_SW)
     {
-        bootReason = BootReasonType::SoftwareReset;
+        bootReason = BootReasonType::kSoftwareReset;
     }
     else if (reason == ESP_RST_INT_WDT)
     {
-        bootReason = BootReasonType::SoftwareWatchdogReset;
+        bootReason = BootReasonType::kSoftwareWatchdogReset;
         /* Reboot can be due to hardware or software watchdog*/
     }
     return CHIP_NO_ERROR;

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.h
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.h
@@ -46,7 +46,7 @@ public:
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
     CHIP_ERROR GetUpTime(uint64_t & upTime) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
-    CHIP_ERROR GetBootReason(uint8_t & bootReason) override;
+    CHIP_ERROR GetBootReason(BootReasonType & bootReason) override;
 
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -88,7 +88,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
     if (!PosixConfig::ConfigValueExists(PosixConfig::kCounterKey_BootReason))
     {
-        err = StoreBootReason(BootReasonType::Unspecified);
+        err = StoreBootReason(to_underlying(BootReasonType::kUnspecified));
         SuccessOrExit(err);
     }
 

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -368,7 +368,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetTotalOperationalHours(uint32_t & total
     return CHIP_ERROR_INVALID_TIME;
 }
 
-CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(uint8_t & bootReason)
+CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason)
 {
     uint32_t reason = 0;
 
@@ -377,7 +377,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(uint8_t & bootReason)
     if (err == CHIP_NO_ERROR)
     {
         VerifyOrReturnError(reason <= UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
-        bootReason = static_cast<uint8_t>(reason);
+        bootReason = static_cast<BootReasonType>(reason);
     }
 
     return err;

--- a/src/platform/Linux/DiagnosticDataProviderImpl.h
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.h
@@ -48,7 +48,7 @@ public:
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
     CHIP_ERROR GetUpTime(uint64_t & upTime) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
-    CHIP_ERROR GetBootReason(uint8_t & bootReason) override;
+    CHIP_ERROR GetBootReason(BootReasonType & bootReason) override;
 
     CHIP_ERROR GetActiveHardwareFaults(GeneralFaults<kMaxHardwareFaults> & hardwareFaults) override;
     CHIP_ERROR GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults) override;

--- a/src/platform/P6/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/P6/DiagnosticDataProviderImpl.cpp
@@ -114,28 +114,28 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetTotalOperationalHours(uint32_t & total
     return CHIP_ERROR_INVALID_TIME;
 }
 
-CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(uint8_t & bootReason)
+CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason)
 {
     cyhal_reset_reason_t reset_reason = cyhal_system_get_reset_reason();
     if (reset_reason == CYHAL_SYSTEM_RESET_NONE)
     {
-        bootReason = BootReasonType::PowerOnReboot;
+        bootReason = BootReasonType::kPowerOnReboot;
     }
     else if (reset_reason == CYHAL_SYSTEM_RESET_WDT)
     {
-        bootReason = BootReasonType::SoftwareWatchdogReset;
+        bootReason = BootReasonType::kSoftwareWatchdogReset;
     }
     else if (reset_reason == CYHAL_SYSTEM_RESET_SOFT)
     {
-        bootReason = BootReasonType::SoftwareReset;
+        bootReason = BootReasonType::kSoftwareReset;
     }
     else if (reset_reason == CYHAL_SYSTEM_RESET_HIB_WAKEUP)
     {
-        bootReason = BootReasonType::HardwareWatchdogReset;
+        bootReason = BootReasonType::kHardwareWatchdogReset;
     }
     else
     {
-        bootReason = BootReasonType::Unspecified;
+        bootReason = BootReasonType::kUnspecified;
     }
     return CHIP_NO_ERROR;
 }

--- a/src/platform/P6/DiagnosticDataProviderImpl.h
+++ b/src/platform/P6/DiagnosticDataProviderImpl.h
@@ -71,7 +71,7 @@ public:
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
     CHIP_ERROR GetUpTime(uint64_t & upTime) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
-    CHIP_ERROR GetBootReason(uint8_t & bootReason) override;
+    CHIP_ERROR GetBootReason(BootReasonType & bootReason) override;
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
 

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
@@ -40,14 +40,14 @@ namespace DeviceLayer {
 
 namespace {
 
-uint8_t DetermineBootReason()
+BootReasonType DetermineBootReason()
 {
 #ifdef CONFIG_HWINFO
     uint32_t reason;
 
     if (hwinfo_get_reset_cause(&reason) != 0)
     {
-        return BootReasonType::Unspecified;
+        return BootReasonType::kUnspecified;
     }
 
     // Bits returned by hwinfo_get_reset_cause() are accumulated between subsequent resets, so
@@ -58,17 +58,17 @@ uint8_t DetermineBootReason()
     // If no reset cause is provided, it indicates a power-on-reset.
     if (reason == 0 || reason & (RESET_POR | RESET_PIN))
     {
-        return BootReasonType::PowerOnReboot;
+        return BootReasonType::kPowerOnReboot;
     }
 
     if (reason & RESET_WATCHDOG)
     {
-        return BootReasonType::HardwareWatchdogReset;
+        return BootReasonType::kHardwareWatchdogReset;
     }
 
     if (reason & RESET_BROWNOUT)
     {
-        return BootReasonType::BrownOutReset;
+        return BootReasonType::kBrownOutReset;
     }
 
     if (reason & RESET_SOFTWARE)
@@ -76,14 +76,14 @@ uint8_t DetermineBootReason()
 #ifdef CONFIG_MCUBOOT_IMG_MANAGER
         if (mcuboot_swap_type() == BOOT_SWAP_TYPE_REVERT)
         {
-            return BootReasonType::SoftwareUpdateCompleted;
+            return BootReasonType::kSoftwareUpdateCompleted;
         }
 #endif
-        return BootReasonType::SoftwareReset;
+        return BootReasonType::kSoftwareReset;
     }
 #endif
 
-    return BootReasonType::Unspecified;
+    return BootReasonType::kUnspecified;
 }
 
 } // namespace
@@ -180,7 +180,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetTotalOperationalHours(uint32_t & total
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(uint8_t & bootReason)
+CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason)
 {
 #if CONFIG_HWINFO
     bootReason = mBootReason;

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.h
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.h
@@ -46,14 +46,14 @@ public:
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
     CHIP_ERROR GetUpTime(uint64_t & upTime) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
-    CHIP_ERROR GetBootReason(uint8_t & bootReason) override;
+    CHIP_ERROR GetBootReason(BootReasonType & bootReason) override;
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
 
 private:
     DiagnosticDataProviderImpl();
 
-    const uint8_t mBootReason;
+    const BootReasonType mBootReason;
 };
 
 } // namespace DeviceLayer

--- a/src/platform/fake/DiagnosticDataProviderImpl.h
+++ b/src/platform/fake/DiagnosticDataProviderImpl.h
@@ -48,7 +48,7 @@ public:
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
     CHIP_ERROR GetUpTime(uint64_t & upTime) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
-    CHIP_ERROR GetBootReason(uint8_t & bootReason) override;
+    CHIP_ERROR GetBootReason(BootReasonType & bootReason) override;
 
     CHIP_ERROR GetActiveHardwareFaults(GeneralFaults<kMaxHardwareFaults> & hardwareFaults) override;
     CHIP_ERROR GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults) override;

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
@@ -27,6 +27,7 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include <platform/ConfigurationManager.h>
+#include <platform/DiagnosticDataProvider.h>
 #include <platform/internal/GenericConfigurationManagerImpl.ipp>
 #include <platform/nxp/k32w/k32w0/K32W0Config.h>
 
@@ -75,7 +76,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
     if (!K32WConfig::ConfigValueExists(K32WConfig::kCounterKey_BootReason))
     {
-        err = StoreBootReason(EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED);
+        err = StoreBootReason(to_underlying(BootReasonType::kUnspecified));
         SuccessOrExit(err);
     }
 

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
@@ -119,29 +119,28 @@ CHIP_ERROR ConfigurationManagerImpl::StoreTotalOperationalHours(uint32_t totalOp
 
 CHIP_ERROR ConfigurationManagerImpl::GetBootReason(uint32_t & bootReason)
 {
-    bootReason = EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED;
-    uint8_t reason;
-    reason = POWER_GetResetCause();
+    bootReason     = to_underlying(BootReasonType::kUnspecified);
+    uint8_t reason = POWER_GetResetCause();
 
     if (reason == RESET_UNDEFINED)
     {
-        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED;
+        bootReason = to_underlying(BootReasonType::kUnspecified);
     }
     else if ((reason == RESET_POR) || (reason == RESET_EXT_PIN))
     {
-        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_POWER_ON_REBOOT;
+        bootReason = to_underlying(BootReasonType::kPowerOnReboot);
     }
     else if (reason == RESET_BOR)
     {
-        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_BROWN_OUT_RESET;
+        bootReason = to_underlying(BootReasonType::kBrownOutReset);
     }
     else if (reason == RESET_SW_REQ)
     {
-        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_RESET;
+        bootReason = to_underlying(BootReasonType::kSoftwareReset);
     }
     else if (reason == RESET_WDT)
     {
-        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_WATCHDOG_RESET;
+        bootReason = to_underlying(BootReasonType::kSoftwareWatchdogReset);
         /* Reboot can be due to hardware or software watchdog */
     }
 

--- a/src/platform/nxp/k32w/k32w0/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/DiagnosticDataProviderImpl.cpp
@@ -117,7 +117,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetTotalOperationalHours(uint32_t & total
     return CHIP_ERROR_INVALID_TIME;
 }
 
-CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(uint8_t & bootReason)
+CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason)
 {
     uint32_t reason = 0;
 
@@ -126,7 +126,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(uint8_t & bootReason)
     if (err == CHIP_NO_ERROR)
     {
         VerifyOrReturnError(reason <= UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
-        bootReason = static_cast<uint8_t>(reason);
+        bootReason = static_cast<BootReasonType>(reason);
     }
 
     return err;

--- a/src/platform/nxp/k32w/k32w0/DiagnosticDataProviderImpl.h
+++ b/src/platform/nxp/k32w/k32w0/DiagnosticDataProviderImpl.h
@@ -46,7 +46,7 @@ public:
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
     CHIP_ERROR GetUpTime(uint64_t & upTime) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
-    CHIP_ERROR GetBootReason(uint8_t & bootReason) override;
+    CHIP_ERROR GetBootReason(BootReasonType & bootReason) override;
 };
 
 } // namespace DeviceLayer

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -644,9 +644,6 @@ enum class LogsTransferProtocol : uint8_t
 
 namespace GeneralDiagnostics {
 
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 // Enum for BootReasonType
 enum class BootReasonType : uint8_t
 {
@@ -658,9 +655,6 @@ enum class BootReasonType : uint8_t
     kSoftwareUpdateCompleted = 0x05,
     kSoftwareReset           = 0x06,
 };
-#else // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-using BootReasonType                  = EmberAfBootReasonType;
-#endif
 
 // Need to convert consumers to using the new enum classes, so we
 // don't just have casts all over.

--- a/zzz_generated/app-common/app-common/zap-generated/enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/enums.h
@@ -52,18 +52,6 @@ enum EmberAfBarrierControlMovingState : uint8_t
     EMBER_ZCL_BARRIER_CONTROL_MOVING_STATE_OPENING = 2,
 };
 
-// Enum for BootReasonType
-enum EmberAfBootReasonType : uint8_t
-{
-    EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED               = 0,
-    EMBER_ZCL_BOOT_REASON_TYPE_POWER_ON_REBOOT           = 1,
-    EMBER_ZCL_BOOT_REASON_TYPE_BROWN_OUT_RESET           = 2,
-    EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_WATCHDOG_RESET   = 3,
-    EMBER_ZCL_BOOT_REASON_TYPE_HARDWARE_WATCHDOG_RESET   = 4,
-    EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_UPDATE_COMPLETED = 5,
-    EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_RESET            = 6,
-};
-
 // Enum for ColorControlOptions
 enum EmberAfColorControlOptions : uint8_t
 {


### PR DESCRIPTION
#### Problem
`DiagnosticDataProvider` interface uses raw `uint8_t` to pass boot reasons.

#### Change overview
1. Switch from `EmberAfBootReasonType` to type-safe `BootReasonType` enum class.
2. Use `BootReasonType` in `DiagnosticDataProvider` interface.

#### Testing
CI only.
