### PR TITLE
trace: Add tracing for prepared secure messages

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -318,6 +318,7 @@ CHIP_ERROR SessionManager::SendPreparedMessage(const SessionHandle & sessionHand
 
     if (mTransportMgr != nullptr)
     {
+        CHIP_TRACE_PREPARED_MESSAGE_SENT(destination, &msgBuf);
         return mTransportMgr->SendMessage(*destination, std::move(msgBuf));
     }
 
@@ -414,6 +415,7 @@ void SessionManager::CancelExpiryTimer()
 
 void SessionManager::OnMessageReceived(const PeerAddress & peerAddress, System::PacketBufferHandle && msg)
 {
+    CHIP_TRACE_PREPARED_MESSAGE_RECEIVED(&peerAddress, &msg);
     PacketHeader packetHeader;
 
     ReturnOnFailure(packetHeader.DecodeAndConsume(msg));

--- a/src/transport/TraceMessage.h
+++ b/src/transport/TraceMessage.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <core/CHIPBuildConfig.h>
+#include <system/SystemPacketBuffer.h>
 #include <transport/Session.h>
 #include <transport/raw/MessageHeader.h>
 #include <transport/raw/PeerAddress.h>
@@ -30,7 +31,7 @@
     do                                                                                                                             \
     {                                                                                                                              \
         const ::chip::trace::TraceSecureMessageSentData _trace_data{ &payloadHeader, &packetHeader, data, dataLen };               \
-        PW_TRACE_INSTANT_DATA("SecureMsg", ::chip::trace::kTraceMessageSentDataFormat,                                             \
+        PW_TRACE_INSTANT_DATA(::chip::trace::kTraceMessageEvent, ::chip::trace::kTraceMessageSentDataFormat,                       \
                               reinterpret_cast<const void *>(&_trace_data), sizeof(_trace_data));                                  \
     } while (0)
 
@@ -39,7 +40,23 @@
     {                                                                                                                              \
         const ::chip::trace::TraceSecureMessageReceivedData _trace_data{ &payloadHeader, &packetHeader, session,                   \
                                                                          &peerAddress,   data,          dataLen };                 \
-        PW_TRACE_INSTANT_DATA("SecureMsg", ::chip::trace::kTraceMessageReceivedDataFormat,                                         \
+        PW_TRACE_INSTANT_DATA(::chip::trace::kTraceMessageEvent, ::chip::trace::kTraceMessageReceivedDataFormat,                   \
+                              reinterpret_cast<const void *>(&_trace_data), sizeof(_trace_data));                                  \
+    } while (0)
+
+#define CHIP_TRACE_PREPARED_MESSAGE_SENT(destination, packetBuffer)                                                                \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        const ::chip::trace::TracePreparedSecureMessageData _trace_data{ destination, packetBuffer };                              \
+        PW_TRACE_INSTANT_DATA(::chip::trace::kTraceMessageEvent, ::chip::trace::kTracePreparedMessageSentDataFormat,               \
+                              reinterpret_cast<const void *>(&_trace_data), sizeof(_trace_data));                                  \
+    } while (0)
+
+#define CHIP_TRACE_PREPARED_MESSAGE_RECEIVED(source, packetBuffer)                                                                 \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        const ::chip::trace::TracePreparedSecureMessageData _trace_data{ source, packetBuffer };                                   \
+        PW_TRACE_INSTANT_DATA(::chip::trace::kTraceMessageEvent, ::chip::trace::kTracePreparedMessageReceivedDataFormat,           \
                               reinterpret_cast<const void *>(&_trace_data), sizeof(_trace_data));                                  \
     } while (0)
 
@@ -54,14 +71,25 @@
     {                                                                                                                              \
     } while (0)
 
+#define CHIP_TRACE_PREPARED_MESSAGE_SENT(destination, packetBuffer)                                                                \
+    do                                                                                                                             \
+    {                                                                                                                              \
+    } while (0)
+
+#define CHIP_TRACE_PREPARED_MESSAGE_RECEIVED(source, packetBuffer)                                                                 \
+    do                                                                                                                             \
+    {                                                                                                                              \
+    } while (0)
 #endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
 
 namespace chip {
 namespace trace {
 
-constexpr const char * kTraceMessageEvent              = "SecureMsg";
-constexpr const char * kTraceMessageSentDataFormat     = "SecMsgSent";
-constexpr const char * kTraceMessageReceivedDataFormat = "SecMsgReceived";
+constexpr const char * kTraceMessageEvent                      = "SecureMsg";
+constexpr const char * kTraceMessageSentDataFormat             = "SecMsgSent";
+constexpr const char * kTraceMessageReceivedDataFormat         = "SecMsgReceived";
+constexpr const char * kTracePreparedMessageSentDataFormat     = "PreparedMsgSent";
+constexpr const char * kTracePreparedMessageReceivedDataFormat = "PreparedMsgReceived";
 
 struct TraceSecureMessageSentData
 {
@@ -79,6 +107,12 @@ struct TraceSecureMessageReceivedData
     const Transport::PeerAddress * peerAddress;
     const uint8_t * packetPayload;
     size_t packetSize;
+};
+
+struct TracePreparedSecureMessageData
+{
+    const Transport::PeerAddress * peerAddress;
+    const System::PacketBufferHandle * packetBuffer;
 };
 
 } // namespace trace


### PR DESCRIPTION

#### Problem
It would be helpful to have the prepared secure messages to validate some CSG tests.

#### Change overview
- Add new traces for the prepared messages for send and receive.
- Add handlers to pack the data into the json, which can either be streamed to the log or a file using the command line arguments.

Note: This is only enabled when CHIP_CONFIG_TRANSPORT_TRACE is enabled, otherwise this is a no-op.

#### Testing
ran chip-tool with logging:
```
chip-tool pairing ble-wifi $node_id $ssid $pass 32423 0 --trace_file trace.log
```
output snippet:
```
[1648041423.353875]	SecureMsg.SecMsgSent
    json	{"msg_counter": 647868007, "source_node_id": 8183665693545772584, "session_id": 0, "msg_flags": 4, "security_flags": 0, "exchange_flags": 1, "exchange_id": 31693, "protocol_id": 0, "protocol_opcode": 32, "is_initiator": true, "is_ack_requested": false, "payload_size": 56, "payload_hex": "15300120af17db5285e0d18f09b7199e0be44821e3ce276196f63fb901a747280f5c0d7f240201240300280435052501881325022c011818"}

[1648041423.353908]	SecureMsg.PreparedMsgSent
    json	{"destination": "BLE", "payload_size": 78, "payload_hex": "0400000067ae9d2628b658e0963892710120cd7b000015300120af17db5285e0d18f09b7199e0be44821e3ce276196f63fb901a747280f5c0d7f240201240300280435052501881325022c011818", "buffer_ptr": 140224441100048}

[1648041424.602071]	SecureMsg.PreparedMsgReceived
    json	{"source": "BLE", "payload_size": 134, "payload_hex": "01000000046df14028b658e0963892710021cd7b000015300120af17db5285e0d18f09b7199e0be44821e3ce276196f63fb901a747280f5c0d7f30022008b40ee8183f8d1a2591d83a9360d0725a915d3832560034c25d65e387deb70324030135042501e8033002105350414b453250204b65792053616c741835052501881325022c011818", "buffer_ptr": 140224441144912}

[1648041424.602313]	SecureMsg.SecMsgReceived
    json	{"peer_address": "BLE", "msg_counter": 1089563908, "dest_node_id": 8183665693545772584, "session_id": 0, "msg_flags": 1, "security_flags": 0, "exchange_flags": 0, "exchange_id": 31693, "protocol_id": 0, "protocol_opcode": 33, "is_initiator": false, "is_ack_requested": false, "payload_size": 112, "payload_hex": "15300120af17db5285e0d18f09b7199e0be44821e3ce276196f63fb901a747280f5c0d7f30022008b40ee8183f8d1a2591d83a9360d0725a915d3832560034c25d65e387deb70324030135042501e8033002105350414b453250204b65792053616c741835052501881325022c011818"}
```