### PR TITLE
Fix AttributeCache forwarding callback

### DIFF
--- a/src/app/AttributeCache.cpp
+++ b/src/app/AttributeCache.cpp
@@ -115,12 +115,19 @@ void AttributeCache::OnAttributeData(const ConcreteDataAttributePath & aPath, TL
     //
     VerifyOrDie(!aPath.IsListItemOperation());
 
+    // Copy the reader for forwarding
+    TLV::TLVReader dataSnapshot;
+    if (apData)
+    {
+        dataSnapshot.Init(*apData);
+    }
+
     UpdateCache(aPath, apData, aStatus);
 
     //
     // Forward the call through.
     //
-    mCallback.OnAttributeData(aPath, apData, aStatus);
+    mCallback.OnAttributeData(aPath, apData ? &dataSnapshot : nullptr, aStatus);
 }
 
 CHIP_ERROR AttributeCache::Get(const ConcreteAttributePath & path, TLV::TLVReader & reader)


### PR DESCRIPTION
#### Problem
* Fix AttributeCache forwarding OnAttributeData callback with incorrect data

#### Change overview
* Fix forwarded OnAttributeData callback losing data by
  copying the TLV reader before its state changes for cache update.

#### Testing
* This was tested in integration along with #16534.
* Unit test was also updated to validate the callback.