### PR TITLE
Fix false potive when the test does not connect to a device.

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -53,7 +53,7 @@ void TestCommand::OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHI
     auto * command = static_cast<TestCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "Test command context is null"));
 
-    LogErrorOnFailure(command->ContinueOnChipMainThread(CHIP_NO_ERROR));
+    LogErrorOnFailure(command->ContinueOnChipMainThread(error));
 }
 
 void TestCommand::Exit(std::string message)


### PR DESCRIPTION
#### Problem
When a test does not connect to a device, a false positive is logged. See issue https://github.com/CHIP-Specifications/chip-certification-tool/issues/297

#### Change overview
- Return error when error is received.

#### Testing
- Ran Test_TC_WNCV_3_1 without change and no device present.
- Made change and ran test with no device present. Verified test reported failure.
