### PR TITLE
[Group] Remove AssociateWithGroup

### DIFF
--- a/examples/chip-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_cluster.zapt
@@ -276,11 +276,9 @@ class {{filename}}Suite: public TestCommand
         {{> maybeWait }}
         {{else}}
         chip::Controller::{{asUpperCamelCase cluster}}ClusterTest cluster;
-        {{#if isGroupCommand}}
-        cluster.AssociateWithGroup({{>device}}, groupId);
-        {{else}}
+        {{#unless isGroupCommand}}
         cluster.Associate({{>device}}, endpoint);
-        {{/if}}
+        {{/unless}}
 
         {{#if (chip_tests_item_has_list)}} ListFreer listFreer;{{/if}}
         {{#chip_tests_item_parameters}}
@@ -289,11 +287,19 @@ class {{filename}}Suite: public TestCommand
         {{/chip_tests_item_parameters}}
 
         {{#if isWriteAttribute}}
+        {{#if isGroupCommand}}
+          ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::{{asUpperCamelCase cluster}}::Attributes::{{asUpperCamelCase attribute}}::TypeInfo>(groupId, {{>device}}->GetSecureSession().Value()->GetFabricIndex(), {{>device}}->GetDeviceId(),{{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument, {{/chip_tests_item_parameters}}this, {{>staticSuccessResponse}}, {{>staticFailureResponse}}
+            {{~> maybeTimedInteractionTimeout ~}}
+            {{~#if isGroupCommand}}, {{>staticDoneResponse}}{{/if~}}
+            ));
+          {{> maybeWait }}
+        {{else}}
           ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::{{asUpperCamelCase cluster}}::Attributes::{{asUpperCamelCase attribute}}::TypeInfo>({{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument, {{/chip_tests_item_parameters}}this, {{>staticSuccessResponse}}, {{>staticFailureResponse}}
             {{~> maybeTimedInteractionTimeout ~}}
             {{~#if isGroupCommand}}, {{>staticDoneResponse}}{{/if~}}
             ));
           {{> maybeWait }}
+        {{/if}}
         {{else if isReadEvent}}
           ReturnErrorOnFailure(cluster.ReadEvent<{{zapTypeToDecodableClusterObjectType event ns=cluster isArgument=true}}>(this, {{>staticSuccessResponse}}, {{>staticFailureResponse}}));
         {{else if isSubscribeEvent}}

--- a/examples/chip-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_cluster.zapt
@@ -290,13 +290,12 @@ class {{filename}}Suite: public TestCommand
         {{#if isGroupCommand}}
           ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::{{asUpperCamelCase cluster}}::Attributes::{{asUpperCamelCase attribute}}::TypeInfo>(groupId, {{>device}}->GetSecureSession().Value()->GetFabricIndex(), {{>device}}->GetDeviceId(),{{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument, {{/chip_tests_item_parameters}}this, {{>staticSuccessResponse}}, {{>staticFailureResponse}}
             {{~> maybeTimedInteractionTimeout ~}}
-            {{~#if isGroupCommand}}, {{>staticDoneResponse}}{{/if~}}
+            , {{>staticDoneResponse}}
             ));
           {{> maybeWait }}
         {{else}}
           ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::{{asUpperCamelCase cluster}}::Attributes::{{asUpperCamelCase attribute}}::TypeInfo>({{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument, {{/chip_tests_item_parameters}}this, {{>staticSuccessResponse}}, {{>staticFailureResponse}}
             {{~> maybeTimedInteractionTimeout ~}}
-            {{~#if isGroupCommand}}, {{>staticDoneResponse}}{{/if~}}
             ));
           {{> maybeWait }}
         {{/if}}

--- a/src/controller/CHIPCluster.cpp
+++ b/src/controller/CHIPCluster.cpp
@@ -42,15 +42,6 @@ CHIP_ERROR ClusterBase::Associate(DeviceProxy * device, EndpointId endpoint)
     return err;
 }
 
-CHIP_ERROR ClusterBase::AssociateWithGroup(DeviceProxy * device, GroupId groupId)
-{
-    // TODO Update this function to work in all possible conditions Issue #11850
-    mDevice   = device;
-    mEndpoint = 0; // Set to 0 for now.
-    mGroupId.SetValue(groupId);
-    return CHIP_NO_ERROR;
-}
-
 void ClusterBase::Dissociate()
 {
     mDevice = nullptr;

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -56,7 +56,6 @@ public:
     virtual ~ClusterBase() {}
 
     CHIP_ERROR Associate(DeviceProxy * device, EndpointId endpoint);
-    CHIP_ERROR AssociateWithGroup(DeviceProxy * device, GroupId groupId);
 
     void Dissociate();
     // Temporary function to set command timeout before we move over to InvokeCommand
@@ -141,19 +140,54 @@ public:
             }
         };
 
-        if (mGroupId.HasValue())
-        {
-            VerifyOrReturnError(mDevice->GetSecureSession().HasValue(), CHIP_ERROR_INCORRECT_STATE);
-            Transport::OutgoingGroupSession groupSession(mGroupId.Value(), mDevice->GetSecureSession().Value()->GetFabricIndex(),
-                                                         mDevice->GetDeviceId());
-            return chip::Controller::WriteAttribute<AttrType>(SessionHandle(groupSession), mEndpoint, clusterId, attributeId,
-                                                              requestData, onSuccessCb, onFailureCb, aTimedWriteTimeoutMs, onDoneCb,
-                                                              aDataVersion);
-        }
-
         return chip::Controller::WriteAttribute<AttrType>(mDevice->GetSecureSession().Value(), mEndpoint, clusterId, attributeId,
                                                           requestData, onSuccessCb, onFailureCb, aTimedWriteTimeoutMs, onDoneCb,
                                                           aDataVersion);
+    }
+
+    template <typename AttrType>
+    CHIP_ERROR WriteAttribute(GroupId groupId, FabricIndex fabricIndex, NodeId sourceNodeId, const AttrType & requestData,
+                              void * context, ClusterId clusterId, AttributeId attributeId, WriteResponseSuccessCallback successCb,
+                              WriteResponseFailureCallback failureCb, const Optional<uint16_t> & aTimedWriteTimeoutMs,
+                              WriteResponseDoneCallback doneCb = nullptr, const Optional<DataVersion> & aDataVersion = NullOptional)
+    {
+
+        auto onSuccessCb = [context, successCb](const app::ConcreteAttributePath & aPath) {
+            if (successCb != nullptr)
+            {
+                successCb(context);
+            }
+        };
+
+        auto onFailureCb = [context, failureCb](const app::ConcreteAttributePath * aPath, CHIP_ERROR aError) {
+            if (failureCb != nullptr)
+            {
+                failureCb(context, aError);
+            }
+        };
+
+        auto onDoneCb = [context, doneCb](app::WriteClient * pWriteClient) {
+            if (doneCb != nullptr)
+            {
+                doneCb(context);
+            }
+        };
+
+        Transport::OutgoingGroupSession groupSession(groupId, fabricIndex, sourceNodeId);
+        return chip::Controller::WriteAttribute<AttrType>(SessionHandle(groupSession), 0 /*Unused for Group*/, clusterId,
+                                                          attributeId, requestData, onSuccessCb, onFailureCb, aTimedWriteTimeoutMs,
+                                                          onDoneCb, aDataVersion);
+    }
+
+    template <typename AttributeInfo>
+    CHIP_ERROR WriteAttribute(GroupId groupId, FabricIndex fabricIndex, NodeId sourceNodeId,
+                              const typename AttributeInfo::Type & requestData, void * context,
+                              WriteResponseSuccessCallback successCb, WriteResponseFailureCallback failureCb,
+                              WriteResponseDoneCallback doneCb = nullptr, const Optional<DataVersion> & aDataVersion = NullOptional,
+                              const Optional<uint16_t> & aTimedWriteTimeoutMs = NullOptional)
+    {
+        return WriteAttribute(groupId, fabricIndex, sourceNodeId, requestData, context, AttributeInfo::GetClusterId(),
+                              AttributeInfo::GetAttributeId(), successCb, failureCb, aTimedWriteTimeoutMs, doneCb, aDataVersion);
     }
 
     template <typename AttributeInfo>
@@ -345,7 +379,6 @@ protected:
     const ClusterId mClusterId;
     DeviceProxy * mDevice;
     EndpointId mEndpoint;
-    Optional<GroupId> mGroupId;
     Optional<System::Clock::Timeout> mTimeout;
 };
 


### PR DESCRIPTION
#### Problem
Fix #11850

#### Change overview
Remove the `AssociateWithGroup` method since it didn't make sense to tie a `DeviceProxy` object with a group command. The api can now support a WriteAttribute command without any `DeviceProxy` object involved.

However, for the yaml test part of it, the necessary data is still retrieved from the DeviceProxy for convenience reasons only since this is limited to test code.

#### Testing
Yaml test.
