### PR TITLE
[OTA] Reset instead of cancel when auto-apply is off

### DIFF
--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -122,8 +122,8 @@ void CustomOTARequestorDriver::UpdateDownloaded()
     }
     else
     {
-        // Cancelling will put the state back to idle
-        gRequestorCore.CancelImageUpdate();
+        // Reset to put the state back to idle to allow the next OTA update to occur
+        gRequestorCore.Reset();
     }
 }
 


### PR DESCRIPTION
#### Problem
By the time `UpdateDownloaded` is called, the download has already completed and there is no need to cancel the download

#### Change overview
- Call `Reset` to ensure sure the state is transitioned to idle

#### Testing
- Verified that without the `--autoApplyImage`, after image download, the current update state is idle and another query image can be initated
