### PR TITLE
Skip calling OnFabricRetrievedFromStorage when the fabric is already loaded

### DIFF
--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -618,15 +618,15 @@ CHIP_ERROR FabricTable::LoadFromStorage(FabricInfo * fabric)
     if (!fabric->IsInitialized())
     {
         ReturnErrorOnFailure(fabric->LoadFromStorage(mStorage));
-    }
 
-    FabricTableDelegate * delegate = mDelegate;
-    while (delegate)
-    {
-        ChipLogProgress(Discovery, "Fabric (%d) loaded from storage. Calling OnFabricRetrievedFromStorage",
-                        fabric->GetFabricIndex());
-        delegate->OnFabricRetrievedFromStorage(fabric);
-        delegate = delegate->mNext;
+        FabricTableDelegate * delegate = mDelegate;
+        while (delegate)
+        {
+            ChipLogProgress(Discovery, "Fabric (%d) loaded from storage. Calling OnFabricRetrievedFromStorage",
+                            fabric->GetFabricIndex());
+            delegate->OnFabricRetrievedFromStorage(fabric);
+            delegate = delegate->mNext;
+        }
     }
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Problem
W/o this change, #16098 always fail with timeout

`OnFabricRetrievedFromStorage` will trigger a subscription report, when handling the report, it will call `FindFabricByIndex`, then trigger another `OnFabricRetrievedFromStorage`, causing a endless loop.

#### Change overview
Skip calling OnFabricRetrievedFromStorage when the fabric is already loaded

#### Testing
Passed unit tests.