### PR TITLE
[OTA] Handle invalid designator in OTA-P and reset OTA-R state on receiving BDX error

### DIFF
--- a/src/app/clusters/ota-requestor/BDXDownloader.cpp
+++ b/src/app/clusters/ota-requestor/BDXDownloader.cpp
@@ -225,6 +225,14 @@ void BDXDownloader::PollTransferSession()
     } while (outEvent.EventType != TransferSession::OutputEventType::kNone);
 }
 
+void BDXDownloader::CleanupOnError(OTAChangeReasonEnum reason)
+{
+    Reset();
+    mBdxTransfer.Reset();
+    SetState(State::kIdle, reason);
+    mImageProcessor->Abort();
+}
+
 CHIP_ERROR BDXDownloader::HandleBdxEvent(const chip::bdx::TransferSession::OutputEvent & outEvent)
 {
     VerifyOrReturnError(mImageProcessor != nullptr, CHIP_ERROR_INCORRECT_STATE);
@@ -265,20 +273,15 @@ CHIP_ERROR BDXDownloader::HandleBdxEvent(const chip::bdx::TransferSession::Outpu
     }
     case TransferSession::OutputEventType::kStatusReceived:
         ChipLogError(BDX, "BDX StatusReport %x", static_cast<uint16_t>(outEvent.statusData.statusCode));
-        mBdxTransfer.Reset();
-        ReturnErrorOnFailure(mImageProcessor->Abort());
+        CleanupOnError(OTAChangeReasonEnum::kFailure);
         break;
     case TransferSession::OutputEventType::kInternalError:
         ChipLogError(BDX, "TransferSession error");
-        Reset();
-        mBdxTransfer.Reset();
-        ReturnErrorOnFailure(mImageProcessor->Abort());
+        CleanupOnError(OTAChangeReasonEnum::kFailure);
         break;
     case TransferSession::OutputEventType::kTransferTimeout:
         ChipLogError(BDX, "Transfer timed out");
-        Reset();
-        mBdxTransfer.Reset();
-        ReturnErrorOnFailure(mImageProcessor->Abort());
+        CleanupOnError(OTAChangeReasonEnum::kTimeOut);
         break;
     case TransferSession::OutputEventType::kInitReceived:
     case TransferSession::OutputEventType::kAckReceived:

--- a/src/app/clusters/ota-requestor/BDXDownloader.h
+++ b/src/app/clusters/ota-requestor/BDXDownloader.h
@@ -82,6 +82,7 @@ public:
 
 private:
     void PollTransferSession();
+    void CleanupOnError(app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
     CHIP_ERROR HandleBdxEvent(const chip::bdx::TransferSession::OutputEvent & outEvent);
     void SetState(State state, app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
     void Reset();

--- a/src/app/clusters/ota-requestor/BDXDownloader.h
+++ b/src/app/clusters/ota-requestor/BDXDownloader.h
@@ -82,10 +82,9 @@ public:
 
 private:
     void PollTransferSession();
-    void CleanupOnError(app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
     CHIP_ERROR HandleBdxEvent(const chip::bdx::TransferSession::OutputEvent & outEvent);
     void SetState(State state, app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
-    void Reset();
+    void Reset(bool resetBdxTransfer, bool abortImageProcessing, app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
 
     chip::bdx::TransferSession mBdxTransfer;
     MessagingDelegate * mMsgDelegate = nullptr;

--- a/src/app/clusters/ota-requestor/BDXDownloader.h
+++ b/src/app/clusters/ota-requestor/BDXDownloader.h
@@ -84,7 +84,8 @@ private:
     void PollTransferSession();
     CHIP_ERROR HandleBdxEvent(const chip::bdx::TransferSession::OutputEvent & outEvent);
     void SetState(State state, app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
-    void Reset(bool resetBdxTransfer, bool abortImageProcessing, app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
+    void Reset(bool resetBdxTransfer, bool abortImageProcessing,
+               app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
 
     chip::bdx::TransferSession mBdxTransfer;
     MessagingDelegate * mMsgDelegate = nullptr;


### PR DESCRIPTION
#### Problem
- OTA provider do abort the transfer is file designator is invalid. After handling this case, it used to crash.
- OTA requestor do not reset state to Idle if bdx sends a status report

#### Change overview
- [OTA-P] Abort transfer if file designator is invalid
- [OTA-P] Fixed the crash when file designator is invalid
- [OTA-R] Reset ota-requestor state if BDX sends an error

#### Testing
- Tested manually with linux ota-requestor and ota-provider app.
- For testing invalid designator, manually set a byte to an invalid value.