### PR TITLE
[YAML] When waiting for an attribute in a test, the name is not gener…

### DIFF
--- a/examples/chip-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_cluster.zapt
@@ -212,7 +212,7 @@ class {{filename}}Suite: public TestCommand
       const chip::EndpointId endpoint = {{#if (chip_tests_config_has "endpoint")}}mEndpoint.HasValue() ? mEndpoint.Value() : {{/if}}{{endpoint}};
       ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: {{cluster}} {{#if isAttribute}}Attribute: {{attribute}}{{else}}Command: {{wait}}{{/if}}] {{label}}", endpoint);
       {{#*inline "waitForTypeName"}}{{#if isAttribute}}Attribute{{else}}Command{{/if}}{{/inline}}
-      {{#*inline "waitForTypeId"}}chip::app::Clusters::{{asUpperCamelCase cluster}}::{{#if isAttribute}}Attributes::{{attribute}}{{else}}Commands::{{wait}}{{/if}}::Id{{/inline}}
+      {{#*inline "waitForTypeId"}}chip::app::Clusters::{{asUpperCamelCase cluster}}::{{#if isAttribute}}Attributes::{{asUpperCamelCase attribute}}{{else}}Commands::{{asUpperCamelCase wait}}{{/if}}::Id{{/inline}}
       ClearAttributeAndCommandPaths();
       m{{>waitForTypeName}}Path = chip::app::Concrete{{>waitForTypeName}}Path(endpoint, chip::app::Clusters::{{asUpperCamelCase cluster}}::Id, {{>waitForTypeId}});
       return CHIP_NO_ERROR;


### PR DESCRIPTION
…ated properly

#### Problem

The name of the attribute from the test is not properly generated.


#### Change overview
 * Use the `asUpperCamelCase` helper

fix #16418
