### PR TITLE
[build] support custom build config for external platform

### DIFF
--- a/config/esp32/args.gni
+++ b/config/esp32/args.gni
@@ -24,8 +24,6 @@ chip_ble_project_config_include = ""
 mbedtls_target = "//mbedtls:mbedtls"
 lwip_platform = "external"
 
-chip_build_tests = true
-
 #Enabling this causes some error
 #chip_inet_config_enable_tun_endpoint = false
 chip_inet_config_enable_tcp_endpoint = true

--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -91,6 +91,10 @@ if(CONFIG_ENABLE_PW_RPC)
     chip_gn_arg_append("pw_build_LINK_DEPS"                 "[\"\$dir_pw_assert:impl\", \"\$dir_pw_log:impl\"]")
 endif()
 
+if (CONFIG_BUILD_CHIP_TESTS)
+    chip_gn_arg_bool("chip_build_tests"     "true")
+endif()
+
 if (NOT CONFIG_USE_MINIMAL_MDNS)
     chip_gn_arg_append("chip_mdns"                          "\"platform\"")
 endif()
@@ -114,6 +118,11 @@ endif()
 if (CONFIG_ENABLE_ROTATING_DEVICE_ID)
     chip_gn_arg_append("chip_enable_additional_data_advertising"   "true")
     chip_gn_arg_append("chip_enable_rotating_device_id"            "true")
+endif()
+
+if (CONFIG_CHIP_ENABLE_EXTERNAL_PLATFORM)
+    chip_gn_arg_append("chip_device_platform"   "\"external\"")
+    chip_gn_arg_append("chip_platform_target"   "\"${CONFIG_CHIP_EXTERNAL_PLATFORM_TARGET}\"")
 endif()
 
 set(args_gn_input "${CMAKE_CURRENT_BINARY_DIR}/args.gn.in")

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -102,6 +102,12 @@ menu "CHIP Core"
             help
                 Matter spec is based on IPv6 communication only. Enabling this option may save some flash/ram.
 
+        config BUILD_CHIP_TESTS
+            bool "Build CHIP tests"
+            default "y"
+            help
+                Build CHIP test binaries.
+
         # TODO: add log level selection
 
     endmenu # "General Options"
@@ -746,6 +752,20 @@ menu "CHIP Device Layer"
               and ReleaseNotesURL) to the ota_image_tool.py script.
               eg: "-mi 2 -ma 4 -rn https://github.com/espressif/esp-idf/releases/tag/v4.4"
 
+    endmenu
+
+    menu "External Platform"
+        config CHIP_ENABLE_EXTERNAL_PLATFORM
+            bool "Enable external platform layer"
+            default n
+            help
+                Use external platform layer to override the default ESP32 platform in Matter SDK.
+
+        config CHIP_EXTERNAL_PLATFORM_TARGET
+            string "The external platform target"
+            depends on CHIP_ENABLE_EXTERNAL_PLATFORM
+            help
+                The gn target of the external platform.
     endmenu
 
 endmenu

--- a/src/ble/BUILD.gn
+++ b/src/ble/BUILD.gn
@@ -51,6 +51,7 @@ source_set("ble_config_header") {
 
   public_deps = [
     ":ble_buildconfig",
+    "${chip_root}/src/platform:platform_buildconfig",
     "${chip_root}/src/system:system_config_header",
   ]
 }

--- a/src/ble/BleConfig.h
+++ b/src/ble/BleConfig.h
@@ -37,6 +37,7 @@
 
 #if CHIP_HAVE_CONFIG_H
 #include <ble/BleBuildConfig.h>
+#include <platform/CHIPDeviceBuildConfig.h>
 #endif
 
 #include <system/SystemConfig.h>

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -36,7 +36,7 @@ if (chip_device_platform == "linux" && chip_mdns != "none") {
   }
 }
 
-if (chip_device_platform != "none") {
+if (chip_device_platform != "none" && chip_device_platform != "external") {
   declare_args() {
     # Extra header to include in CHIPDeviceConfig.h for project.
     chip_device_project_config_include = ""
@@ -244,7 +244,7 @@ if (chip_device_platform != "none") {
           [ "CHIP_DEVICE_CONFIG_ENABLE_WPA=${chip_device_config_enable_wpa}" ]
     }
   }
-} else {
+} else if (chip_device_platform == "none") {
   buildconfig_header("platform_buildconfig") {
     header = "CHIPDeviceBuildConfig.h"
     header_dir = "platform"
@@ -257,6 +257,10 @@ if (chip_device_platform != "none") {
     if (current_os == "android") {
       defines += [ "EXTERNAL_KEYVALUESTOREMANAGERIMPL_HEADER=\"controller/java/AndroidKeyValueStoreManagerImpl.h\"" ]
     }
+  }
+} else {
+  group("platform_buildconfig") {
+    public_deps = [ "${chip_platform_target}:platform_buildconfig" ]
   }
 }
 

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -115,7 +115,10 @@ source_set("system_config_header") {
     "${chip_root}/src:includes",
   ]
 
-  public_deps = [ ":system_buildconfig" ]
+  public_deps = [
+    ":system_buildconfig",
+    "${chip_root}/src/platform:platform_buildconfig",
+  ]
 
   if (target_cpu != "esp32") {
     if (chip_system_config_use_lwip) {

--- a/src/system/SystemConfig.h
+++ b/src/system/SystemConfig.h
@@ -38,6 +38,7 @@
 
 /* Platform include headers */
 #if CHIP_HAVE_CONFIG_H
+#include <platform/CHIPDeviceBuildConfig.h>
 #include <system/SystemBuildConfig.h>
 #endif
 


### PR DESCRIPTION
#### Problem

The `ChipDeviceBuildConfig.h` is generated by the internal platform `BUILD.gn` for external platforms and cannot be overridden.

#### Change overview

Allow external device layers to generate its own build config.

Add external device layer support for ESP32.

#### Testing

External platforms not included in the PR.
Common build can be verified by the CI.
