### PR TITLE
Added absolute path for the Default PAA Trust Store

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -913,6 +913,7 @@ outgoingCommands
 OxygenConcentrationMeasurement
 OzoneConcentrationMeasurement
 PAA
+PAAs
 PacketBuffer
 PAI
 PairDevice

--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -105,6 +105,20 @@ devices log when they start up) and try to pair with the first one it discovers.
 In all these cases, the device will be assigned node id `${NODE_ID_TO_ASSIGN}`
 (which must be a decimal number or a 0x-prefixed hex number).
 
+#### Trust Store
+
+Trust store will be automatically created using the default Test Attestation
+PAA. To use a different set of PAAs, pass the path using the optional parameter
+--paa-trust-store-path while running the built executable. Trusted PAAs are
+available at credentials/development/paa-root-certs/.
+
+The command below will select a set of trusted PAAs to be used during
+Attestation Verification. It will also discover devices with long discriminator
+3840 and try to pair with the first one it discovers using the provided setup
+code.
+
+    $ chip-tool pairing onnetwork-long ${NODE_ID_TO_ASSIGN} 20202021 3840 --paa-trust-store-path path/to/PAAs
+
 ### Forget the currently-commissioned device
 
     $ chip-tool pairing unpair

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -75,11 +75,13 @@ CHIP_ERROR CHIPCommand::Run()
     factoryInitParams.listenPort = port;
     ReturnLogErrorOnFailure(DeviceControllerFactory::GetInstance().Init(factoryInitParams));
 
-    const chip::Credentials::AttestationTrustStore * trustStore =
-        GetTestFileAttestationTrustStore(mPaaTrustStorePath.HasValue() ? mPaaTrustStorePath.Value() : ".");
-    if (trustStore == nullptr)
+    const chip::Credentials::AttestationTrustStore * trustStore = mPaaTrustStorePath.HasValue()
+        ? GetTestFileAttestationTrustStore(mPaaTrustStorePath.Value())
+        : chip::Credentials::GetTestAttestationTrustStore();
+    ;
+    if (mPaaTrustStorePath.HasValue() && trustStore == nullptr)
     {
-        ChipLogError(chipTool, "No PAAs found in path: %s", mPaaTrustStorePath.HasValue() ? mPaaTrustStorePath.Value() : ".");
+        ChipLogError(chipTool, "No PAAs found in path: %s", mPaaTrustStorePath.Value());
         ChipLogError(chipTool,
                      "Please specify a valid path containing trusted PAA certificates using [--paa-trust-store-path paa/file/path] "
                      "argument");


### PR DESCRIPTION
#### Problem
* chip-tool is not working without the "--paa-trust-store-path" argument

#### Change overview
* chip-tool will use the Test Attestation Trust Store if "--paa-trust-store-path" is not passed

#### Testing
* Matter Unit Tests
* Tested Commissioning flow (chip-tool vs chip-all-clusters-app)
