### PR TITLE
Apply most of readability-simplify-boolean-expr from clang-tidy

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -133,7 +133,7 @@ void CHIPCommand::StartTracing()
     {
         chip::trace::SetTraceStream(new chip::trace::TraceStreamFile(mTraceFile.Value()));
     }
-    else if (mTraceLog.HasValue() && mTraceLog.Value() == true)
+    else if (mTraceLog.HasValue() && mTraceLog.Value())
     {
         chip::trace::SetTraceStream(new chip::trace::TraceStreamLog());
     }

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -227,23 +227,23 @@ void Commands::ShowCluster(std::string executable, std::string clusterName, Comm
 
         if (IsGlobalCommand(command->GetName()))
         {
-            if (strcmp(command->GetName(), "read") == 0 && readCommand == false)
+            if (strcmp(command->GetName(), "read") == 0 && !readCommand)
             {
                 readCommand = true;
             }
-            else if (strcmp(command->GetName(), "write") == 0 && writeCommand == false)
+            else if (strcmp(command->GetName(), "write") == 0 && !writeCommand)
             {
                 writeCommand = true;
             }
-            else if (strcmp(command->GetName(), "subscribe") == 0 && subscribeCommand == false)
+            else if (strcmp(command->GetName(), "subscribe") == 0 && !subscribeCommand)
             {
                 subscribeCommand = true;
             }
-            else if (strcmp(command->GetName(), "read-event") == 0 && readEventCommand == false)
+            else if (strcmp(command->GetName(), "read-event") == 0 && !readEventCommand)
             {
                 readEventCommand = true;
             }
-            else if (strcmp(command->GetName(), "subscribe-event") == 0 && subscribeEventCommand == false)
+            else if (strcmp(command->GetName(), "subscribe-event") == 0 && !subscribeEventCommand)
             {
                 subscribeEventCommand = true;
             }

--- a/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
+++ b/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
@@ -98,7 +98,7 @@ CHIP_ERROR DiscoveryCommands::SetupDiscoveryCommands()
 {
     ReturnErrorOnFailure(TearDownDiscoveryCommands());
 
-    if (mReady == false)
+    if (!mReady)
     {
         ReturnErrorOnFailure(mDNSResolver.Init(chip::DeviceLayer::UDPEndPointManager()));
         mReady = true;

--- a/src/lib/asn1/ASN1Reader.cpp
+++ b/src/lib/asn1/ASN1Reader.cpp
@@ -297,7 +297,7 @@ CHIP_ERROR ASN1Reader::DecodeHead()
 
     mHeadLen = static_cast<uint32_t>(p - mElemStart);
 
-    EndOfContents = (Class == kASN1TagClass_Universal && Tag == 0 && Constructed == false && ValueLen == 0);
+    EndOfContents = (Class == kASN1TagClass_Universal && Tag == 0 && !Constructed && ValueLen == 0);
 
     Value = p;
 

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -71,12 +71,8 @@ struct ResolvedNodeData
         // If either retry interval (Idle - CRI, Active - CRA) has a value and that value is greater
         // than the value passed to this function, then the peer device will be treated as if it is
         // a Sleepy End Device (SED)
-        if ((mMrpRetryIntervalIdle.HasValue() && (mMrpRetryIntervalIdle.Value() > defaultMRPConfig->mIdleRetransTimeout)) ||
-            (mMrpRetryIntervalActive.HasValue() && (mMrpRetryIntervalActive.Value() > defaultMRPConfig->mActiveRetransTimeout)))
-        {
-            return true;
-        }
-        return false;
+        return (mMrpRetryIntervalIdle.HasValue() && (mMrpRetryIntervalIdle.Value() > defaultMRPConfig->mIdleRetransTimeout)) ||
+            (mMrpRetryIntervalActive.HasValue() && (mMrpRetryIntervalActive.Value() > defaultMRPConfig->mActiveRetransTimeout));
     }
 
     PeerId mPeerId;
@@ -156,13 +152,8 @@ struct DiscoveredNodeData
         // If either retry interval (Idle - CRI, Active - CRA) has a value and that value is greater
         // than the value passed to this function, then the peer device will be treated as if it is
         // a Sleepy End Device (SED)
-        if ((mrpRetryIntervalIdle.HasValue() && (mrpRetryIntervalIdle.Value() > defaultMRPConfig->mIdleRetransTimeout)) ||
-            (mrpRetryIntervalActive.HasValue() && (mrpRetryIntervalActive.Value() > defaultMRPConfig->mActiveRetransTimeout)))
-
-        {
-            return true;
-        }
-        return false;
+        return (mrpRetryIntervalIdle.HasValue() && (mrpRetryIntervalIdle.Value() > defaultMRPConfig->mIdleRetransTimeout)) ||
+            (mrpRetryIntervalActive.HasValue() && (mrpRetryIntervalActive.Value() > defaultMRPConfig->mActiveRetransTimeout));
     }
 
     void LogDetail() const

--- a/src/platform/Linux/ConnectivityUtils.cpp
+++ b/src/platform/Linux/ConnectivityUtils.cpp
@@ -632,7 +632,7 @@ CHIP_ERROR ConnectivityUtils::GetEthFullDuplex(const char * ifname, bool & fullD
     }
     else
     {
-        fullDuplex = (ecmd.duplex == DUPLEX_FULL) ? true : false;
+        fullDuplex = ecmd.duplex == DUPLEX_FULL;
         err        = CHIP_NO_ERROR;
     }
 


### PR DESCRIPTION
#### Problem
Readability updates using an automated tool.

#### Change overview
Generally ran:

```
./scripts/run-clang-tidy-on-compile-commands.py --compile-database out/linux-x64-chip-tool-clang/compile_commands.json --checks readability-simplify-boolean-expr fix
```

and then restyled. It also changed `src/app/util/attribute-storage.cpp` however that one relied that a constant was 1/0 so readability seemed lost so I reverted that change.

#### Testing
Visual inspection of changes. changes were made by an automated tool.