### PR TITLE
add space to gn_efr32_example.sh

### DIFF
--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -159,7 +159,7 @@ else
     arm-none-eabi-size -A "$BUILD_DIR"/*.out
 
     # Generate bootloader file
-    if [ "${BUILD_DIR:0:2}" == "./"]; then
+    if [ "${BUILD_DIR:0:2}" == "./" ]; then
         BUILD_DIR_TRIMMED="${BUILD_DIR:2}"
         S37_PATH=$(find "$BUILD_DIR_TRIMMED" -type f -name "*.s37")
         if [ -z "$S37_PATH" ]; then


### PR DESCRIPTION
#### Problem
Fix error in PR #16193 

The error did not break any other feature, but caused the .gbl file to not be generated.