### PR TITLE
Resolve wait on subscriptions for attributes.

### DIFF
--- a/examples/chip-tool-darwin/templates/commands.zapt
+++ b/examples/chip-tool-darwin/templates/commands.zapt
@@ -235,7 +235,9 @@ public:
                                             params:params
                                 subscriptionEstablished: NULL reportHandler:^({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error) {
         NSLog(@"{{asUpperCamelCase parent.name}}.{{asUpperCamelCase name}} response %@", [value description]);
-        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+        if (error || !mWait){
+            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+        }
          }];
 
         return CHIP_NO_ERROR;

--- a/zzz_generated/chip-tool-darwin/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool-darwin/zap-generated/cluster/Commands.h
@@ -230,7 +230,9 @@ public:
                               subscriptionEstablished:NULL
                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                             NSLog(@"AccessControl.Acl response %@", [value description]);
-                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                            if (error || !mWait) {
+                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                            }
                                         }];
 
         return CHIP_NO_ERROR;
@@ -307,7 +309,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"AccessControl.Extension response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -383,7 +387,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"AccessControl.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -459,7 +465,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"AccessControl.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -534,7 +542,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"AccessControl.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -609,7 +619,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"AccessControl.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -809,7 +821,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"AccountLogin.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -885,7 +899,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"AccountLogin.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -960,7 +976,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"AccountLogin.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -1035,7 +1053,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"AccountLogin.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -1251,7 +1271,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"AdministratorCommissioning.WindowStatus response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -1331,7 +1353,9 @@ public:
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"AdministratorCommissioning.AdminFabricIndex response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -1411,7 +1435,9 @@ public:
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"AdministratorCommissioning.AdminVendorId response %@",
                                                           [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -1491,7 +1517,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"AdministratorCommissioning.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -1571,7 +1599,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"AdministratorCommissioning.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -1651,7 +1681,9 @@ public:
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"AdministratorCommissioning.AttributeList response %@",
                                                           [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -1731,7 +1763,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"AdministratorCommissioning.ClusterRevision response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -1833,7 +1867,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"ApplicationBasic.VendorName response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -1912,7 +1948,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"ApplicationBasic.VendorID response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -1991,7 +2029,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ApplicationBasic.ApplicationName response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -2070,7 +2110,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ApplicationBasic.ProductID response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -2152,7 +2194,9 @@ public:
                                            reportHandler:^(CHIPApplicationBasicClusterApplicationBasicApplication * _Nullable value,
                                                NSError * _Nullable error) {
                                                NSLog(@"ApplicationBasic.Application response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -2231,7 +2275,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"ApplicationBasic.Status response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -2311,7 +2357,9 @@ public:
                                                        reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                            NSLog(@"ApplicationBasic.ApplicationVersion response %@",
                                                                [value description]);
-                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           if (error || !mWait) {
+                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           }
                                                        }];
 
         return CHIP_NO_ERROR;
@@ -2391,7 +2439,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"ApplicationBasic.AllowedVendorList response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -2471,7 +2521,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"ApplicationBasic.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -2551,7 +2603,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"ApplicationBasic.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -2630,7 +2684,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"ApplicationBasic.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -2709,7 +2765,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ApplicationBasic.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -2919,7 +2977,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"ApplicationLauncher.CatalogList response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -3034,7 +3094,9 @@ public:
                                                reportHandler:^(CHIPApplicationLauncherClusterApplicationEP * _Nullable value,
                                                    NSError * _Nullable error) {
                                                    NSLog(@"ApplicationLauncher.CurrentApp response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -3114,7 +3176,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"ApplicationLauncher.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -3194,7 +3258,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"ApplicationLauncher.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -3273,7 +3339,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"ApplicationLauncher.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -3353,7 +3421,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"ApplicationLauncher.ClusterRevision response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -3518,7 +3588,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"AudioOutput.OutputList response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -3593,7 +3665,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"AudioOutput.CurrentOutput response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -3669,7 +3743,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"AudioOutput.GeneratedCommandList response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -3745,7 +3821,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"AudioOutput.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -3820,7 +3898,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"AudioOutput.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -3895,7 +3975,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"AudioOutput.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -4061,7 +4143,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"BarrierControl.BarrierMovingState response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -4137,7 +4221,9 @@ public:
                                                         reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"BarrierControl.BarrierSafetyStatus response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -4213,7 +4299,9 @@ public:
                                                         reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"BarrierControl.BarrierCapabilities response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -4288,7 +4376,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"BarrierControl.BarrierPosition response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -4364,7 +4454,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"BarrierControl.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -4440,7 +4532,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"BarrierControl.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -4515,7 +4609,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"BarrierControl.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -4590,7 +4686,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"BarrierControl.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -4704,7 +4802,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"Basic.DataModelRevision response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -4779,7 +4879,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"Basic.VendorName response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -4854,7 +4956,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"Basic.VendorID response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -4929,7 +5033,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"Basic.ProductName response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -5004,7 +5110,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"Basic.ProductID response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -5115,7 +5223,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"Basic.NodeLabel response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -5226,7 +5336,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"Basic.Location response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -5301,7 +5413,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Basic.HardwareVersion response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -5377,7 +5491,9 @@ public:
                                            subscriptionEstablished:NULL
                                                      reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"Basic.HardwareVersionString response %@", [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -5452,7 +5568,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Basic.SoftwareVersion response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -5528,7 +5646,9 @@ public:
                                            subscriptionEstablished:NULL
                                                      reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"Basic.SoftwareVersionString response %@", [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -5603,7 +5723,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"Basic.ManufacturingDate response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -5678,7 +5800,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"Basic.PartNumber response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -5753,7 +5877,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"Basic.ProductURL response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -5828,7 +5954,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"Basic.ProductLabel response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -5903,7 +6031,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"Basic.SerialNumber response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -6012,7 +6142,9 @@ public:
                                               subscriptionEstablished:NULL
                                                         reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"Basic.LocalConfigDisabled response %@", [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -6087,7 +6219,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"Basic.Reachable response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -6162,7 +6296,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"Basic.UniqueID response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -6237,7 +6373,9 @@ public:
                                                subscriptionEstablished:NULL
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"Basic.GeneratedCommandList response %@", [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -6312,7 +6450,9 @@ public:
                                               subscriptionEstablished:NULL
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"Basic.AcceptedCommandList response %@", [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -6387,7 +6527,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"Basic.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -6462,7 +6604,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Basic.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -6601,7 +6745,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"BinaryInputBasic.OutOfService response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -6716,7 +6862,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"BinaryInputBasic.PresentValue response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -6795,7 +6943,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"BinaryInputBasic.StatusFlags response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -6875,7 +7025,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"BinaryInputBasic.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -6955,7 +7107,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"BinaryInputBasic.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -7034,7 +7188,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"BinaryInputBasic.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -7113,7 +7269,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"BinaryInputBasic.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -7206,7 +7364,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"Binding.Binding response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -7282,7 +7442,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Binding.GeneratedCommandList response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -7357,7 +7519,9 @@ public:
                                               subscriptionEstablished:NULL
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"Binding.AcceptedCommandList response %@", [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -7432,7 +7596,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"Binding.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -7507,7 +7673,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Binding.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -7599,7 +7767,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"BooleanState.StateValue response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -7675,7 +7845,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"BooleanState.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -7751,7 +7923,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"BooleanState.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -7826,7 +8000,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"BooleanState.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -7901,7 +8077,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"BooleanState.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -8467,7 +8645,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"BridgedActions.ActionList response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -8542,7 +8722,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"BridgedActions.EndpointList response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -8617,7 +8799,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"BridgedActions.SetupUrl response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -8693,7 +8877,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"BridgedActions.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -8769,7 +8955,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"BridgedActions.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -8844,7 +9032,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"BridgedActions.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -8919,7 +9109,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"BridgedActions.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -9032,7 +9224,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"BridgedDeviceBasic.VendorName response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -9111,7 +9305,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"BridgedDeviceBasic.VendorID response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -9190,7 +9386,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"BridgedDeviceBasic.ProductName response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -9307,7 +9505,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"BridgedDeviceBasic.NodeLabel response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -9387,7 +9587,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"BridgedDeviceBasic.HardwareVersion response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -9467,7 +9669,9 @@ public:
                                                           reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                               NSLog(@"BridgedDeviceBasic.HardwareVersionString response %@",
                                                                   [value description]);
-                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              if (error || !mWait) {
+                                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              }
                                                           }];
 
         return CHIP_NO_ERROR;
@@ -9547,7 +9751,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"BridgedDeviceBasic.SoftwareVersion response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -9627,7 +9833,9 @@ public:
                                                           reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                               NSLog(@"BridgedDeviceBasic.SoftwareVersionString response %@",
                                                                   [value description]);
-                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              if (error || !mWait) {
+                                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              }
                                                           }];
 
         return CHIP_NO_ERROR;
@@ -9707,7 +9915,9 @@ public:
                                                       reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"BridgedDeviceBasic.ManufacturingDate response %@",
                                                               [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -9786,7 +9996,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"BridgedDeviceBasic.PartNumber response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -9865,7 +10077,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"BridgedDeviceBasic.ProductURL response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -9944,7 +10158,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"BridgedDeviceBasic.ProductLabel response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -10023,7 +10239,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"BridgedDeviceBasic.SerialNumber response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -10102,7 +10320,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"BridgedDeviceBasic.Reachable response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -10181,7 +10401,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"BridgedDeviceBasic.UniqueID response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -10261,7 +10483,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"BridgedDeviceBasic.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -10341,7 +10565,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"BridgedDeviceBasic.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -10420,7 +10646,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"BridgedDeviceBasic.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -10500,7 +10728,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"BridgedDeviceBasic.ClusterRevision response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -10703,7 +10933,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"Channel.ChannelList response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -10780,7 +11012,9 @@ public:
                             subscriptionEstablished:NULL
                                       reportHandler:^(CHIPChannelClusterLineupInfo * _Nullable value, NSError * _Nullable error) {
                                           NSLog(@"Channel.Lineup response %@", [value description]);
-                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                          if (error || !mWait) {
+                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                          }
                                       }];
 
         return CHIP_NO_ERROR;
@@ -10857,7 +11091,9 @@ public:
                                                    reportHandler:^(
                                                        CHIPChannelClusterChannelInfo * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"Channel.CurrentChannel response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -10933,7 +11169,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Channel.GeneratedCommandList response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -11008,7 +11246,9 @@ public:
                                               subscriptionEstablished:NULL
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"Channel.AcceptedCommandList response %@", [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -11083,7 +11323,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"Channel.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -11158,7 +11400,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Channel.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -12181,7 +12425,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"ColorControl.CurrentHue response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -12256,7 +12502,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ColorControl.CurrentSaturation response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -12331,7 +12579,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"ColorControl.RemainingTime response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -12406,7 +12656,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"ColorControl.CurrentX response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -12481,7 +12733,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"ColorControl.CurrentY response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -12556,7 +12810,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ColorControl.DriftCompensation response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -12631,7 +12887,9 @@ public:
                                            subscriptionEstablished:NULL
                                                      reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"ColorControl.CompensationText response %@", [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -12706,7 +12964,9 @@ public:
                                            subscriptionEstablished:NULL
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"ColorControl.ColorTemperature response %@", [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -12781,7 +13041,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ColorControl.ColorMode response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -12892,7 +13154,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"ColorControl.ColorControlOptions response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -12967,7 +13231,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ColorControl.NumberOfPrimaries response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -13042,7 +13308,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ColorControl.Primary1X response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -13117,7 +13385,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ColorControl.Primary1Y response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -13192,7 +13462,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ColorControl.Primary1Intensity response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -13267,7 +13539,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ColorControl.Primary2X response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -13342,7 +13616,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ColorControl.Primary2Y response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -13417,7 +13693,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ColorControl.Primary2Intensity response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -13492,7 +13770,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ColorControl.Primary3X response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -13567,7 +13847,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ColorControl.Primary3Y response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -13642,7 +13924,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ColorControl.Primary3Intensity response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -13717,7 +14001,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ColorControl.Primary4X response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -13792,7 +14078,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ColorControl.Primary4Y response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -13867,7 +14155,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ColorControl.Primary4Intensity response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -13942,7 +14232,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ColorControl.Primary5X response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -14017,7 +14309,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ColorControl.Primary5Y response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -14092,7 +14386,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ColorControl.Primary5Intensity response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -14167,7 +14463,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ColorControl.Primary6X response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -14242,7 +14540,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ColorControl.Primary6Y response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -14317,7 +14617,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ColorControl.Primary6Intensity response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -14426,7 +14728,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"ColorControl.WhitePointX response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -14535,7 +14839,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"ColorControl.WhitePointY response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -14644,7 +14950,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"ColorControl.ColorPointRX response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -14753,7 +15061,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"ColorControl.ColorPointRY response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -14864,7 +15174,9 @@ public:
                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"ColorControl.ColorPointRIntensity response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -14973,7 +15285,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"ColorControl.ColorPointGX response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -15082,7 +15396,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"ColorControl.ColorPointGY response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -15193,7 +15509,9 @@ public:
                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"ColorControl.ColorPointGIntensity response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -15302,7 +15620,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"ColorControl.ColorPointBX response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -15411,7 +15731,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"ColorControl.ColorPointBY response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -15522,7 +15844,9 @@ public:
                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"ColorControl.ColorPointBIntensity response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -15598,7 +15922,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"ColorControl.EnhancedCurrentHue response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -15673,7 +15999,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ColorControl.EnhancedColorMode response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -15748,7 +16076,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ColorControl.ColorLoopActive response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -15824,7 +16154,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"ColorControl.ColorLoopDirection response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -15899,7 +16231,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"ColorControl.ColorLoopTime response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -15977,7 +16311,9 @@ public:
                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"ColorControl.ColorLoopStartEnhancedHue response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -16055,7 +16391,9 @@ public:
                                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                               NSLog(@"ColorControl.ColorLoopStoredEnhancedHue response %@",
                                                                   [value description]);
-                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              if (error || !mWait) {
+                                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              }
                                                           }];
 
         return CHIP_NO_ERROR;
@@ -16130,7 +16468,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ColorControl.ColorCapabilities response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -16206,7 +16546,9 @@ public:
                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"ColorControl.ColorTempPhysicalMin response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -16282,7 +16624,9 @@ public:
                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"ColorControl.ColorTempPhysicalMax response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -16362,7 +16706,9 @@ public:
                                                                    NSLog(
                                                                        @"ColorControl.CoupleColorTempToLevelMinMireds response %@",
                                                                        [value description]);
-                                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                   if (error || !mWait) {
+                                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                   }
                                                                }];
 
         return CHIP_NO_ERROR;
@@ -16477,7 +16823,9 @@ public:
                                                                  NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                  NSLog(@"ColorControl.StartUpColorTemperatureMireds response %@",
                                                                      [value description]);
-                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                 if (error || !mWait) {
+                                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                 }
                                                              }];
 
         return CHIP_NO_ERROR;
@@ -16553,7 +16901,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"ColorControl.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -16629,7 +16979,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"ColorControl.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -16704,7 +17056,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"ColorControl.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -16779,7 +17133,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ColorControl.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -16957,7 +17313,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"ContentLauncher.AcceptHeader response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -17071,7 +17429,9 @@ public:
                                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                NSLog(@"ContentLauncher.SupportedStreamingProtocols response %@",
                                                                    [value description]);
-                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               if (error || !mWait) {
+                                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               }
                                                            }];
 
         return CHIP_NO_ERROR;
@@ -17147,7 +17507,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"ContentLauncher.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -17223,7 +17585,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"ContentLauncher.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -17298,7 +17662,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"ContentLauncher.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -17373,7 +17739,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ContentLauncher.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -17467,7 +17835,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"Descriptor.DeviceList response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -17542,7 +17912,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"Descriptor.ServerList response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -17617,7 +17989,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"Descriptor.ClientList response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -17692,7 +18066,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"Descriptor.PartsList response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -17768,7 +18144,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Descriptor.GeneratedCommandList response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -17844,7 +18222,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"Descriptor.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -17919,7 +18299,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"Descriptor.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -17994,7 +18376,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Descriptor.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -18129,7 +18513,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"DiagnosticLogs.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -18205,7 +18591,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"DiagnosticLogs.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -18280,7 +18668,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"DiagnosticLogs.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -19039,7 +19429,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"DoorLock.LockState response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -19114,7 +19506,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"DoorLock.LockType response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -19189,7 +19583,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"DoorLock.ActuatorEnabled response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -19264,7 +19660,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"DoorLock.DoorState response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -19342,7 +19740,9 @@ public:
                                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                NSLog(@"DoorLock.NumberOfTotalUsersSupported response %@",
                                                                    [value description]);
-                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               if (error || !mWait) {
+                                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               }
                                                            }];
 
         return CHIP_NO_ERROR;
@@ -19420,7 +19820,9 @@ public:
                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"DoorLock.NumberOfPINUsersSupported response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -19498,7 +19900,9 @@ public:
                                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                               NSLog(@"DoorLock.NumberOfRFIDUsersSupported response %@",
                                                                   [value description]);
-                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              if (error || !mWait) {
+                                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              }
                                                           }];
 
         return CHIP_NO_ERROR;
@@ -19579,8 +19983,10 @@ public:
                                                                                   @"NumberOfWeekDaySchedulesSupportedPerUser "
                                                                                   @"response %@",
                                                                                 [value description]);
-                                                                            SetCommandExitStatus(
-                                                                                [CHIPError errorToCHIPErrorCode:error]);
+                                                                            if (error || !mWait) {
+                                                                                SetCommandExitStatus(
+                                                                                    [CHIPError errorToCHIPErrorCode:error]);
+                                                                            }
                                                                         }];
 
         return CHIP_NO_ERROR;
@@ -19661,8 +20067,10 @@ public:
                                                                                   @"NumberOfYearDaySchedulesSupportedPerUser "
                                                                                   @"response %@",
                                                                                 [value description]);
-                                                                            SetCommandExitStatus(
-                                                                                [CHIPError errorToCHIPErrorCode:error]);
+                                                                            if (error || !mWait) {
+                                                                                SetCommandExitStatus(
+                                                                                    [CHIPError errorToCHIPErrorCode:error]);
+                                                                            }
                                                                         }];
 
         return CHIP_NO_ERROR;
@@ -19737,7 +20145,9 @@ public:
                                            subscriptionEstablished:NULL
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"DoorLock.MaxPINCodeLength response %@", [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -19812,7 +20222,9 @@ public:
                                            subscriptionEstablished:NULL
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"DoorLock.MinPINCodeLength response %@", [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -19887,7 +20299,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"DoorLock.MaxRFIDCodeLength response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -19962,7 +20376,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"DoorLock.MinRFIDCodeLength response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -20073,7 +20489,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"DoorLock.Language response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -20182,7 +20600,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"DoorLock.AutoRelockTime response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -20291,7 +20711,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"DoorLock.SoundVolume response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -20400,7 +20822,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"DoorLock.OperatingMode response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -20477,7 +20901,9 @@ public:
                                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                 NSLog(@"DoorLock.SupportedOperatingModes response %@",
                                                                     [value description]);
-                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                if (error || !mWait) {
+                                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                }
                                                             }];
 
         return CHIP_NO_ERROR;
@@ -20588,7 +21014,9 @@ public:
                                            subscriptionEstablished:NULL
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"DoorLock.EnableOneTouchLocking response %@", [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -20700,7 +21128,9 @@ public:
                                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                 NSLog(@"DoorLock.EnablePrivacyModeButton response %@",
                                                                     [value description]);
-                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                if (error || !mWait) {
+                                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                }
                                                             }];
 
         return CHIP_NO_ERROR;
@@ -20809,7 +21239,9 @@ public:
                                               subscriptionEstablished:NULL
                                                         reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"DoorLock.WrongCodeEntryLimit response %@", [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -20885,7 +21317,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"DoorLock.GeneratedCommandList response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -20960,7 +21394,9 @@ public:
                                               subscriptionEstablished:NULL
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"DoorLock.AcceptedCommandList response %@", [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -21035,7 +21471,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"DoorLock.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -21110,7 +21548,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"DoorLock.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -21335,7 +21775,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"ElectricalMeasurement.MeasurementType response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -21415,7 +21857,9 @@ public:
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"ElectricalMeasurement.TotalActivePower response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -21494,7 +21938,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"ElectricalMeasurement.RmsVoltage response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -21574,7 +22020,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"ElectricalMeasurement.RmsVoltageMin response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -21654,7 +22102,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"ElectricalMeasurement.RmsVoltageMax response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -21733,7 +22183,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"ElectricalMeasurement.RmsCurrent response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -21813,7 +22265,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"ElectricalMeasurement.RmsCurrentMin response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -21893,7 +22347,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"ElectricalMeasurement.RmsCurrentMax response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -21972,7 +22428,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"ElectricalMeasurement.ActivePower response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -22052,7 +22510,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ElectricalMeasurement.ActivePowerMin response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -22132,7 +22592,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ElectricalMeasurement.ActivePowerMax response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -22212,7 +22674,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"ElectricalMeasurement.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -22292,7 +22756,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"ElectricalMeasurement.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -22372,7 +22838,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"ElectricalMeasurement.AttributeList response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -22452,7 +22920,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"ElectricalMeasurement.ClusterRevision response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -22587,7 +23057,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"EthernetNetworkDiagnostics.PHYRate response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -22666,7 +23138,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"EthernetNetworkDiagnostics.FullDuplex response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -22746,7 +23220,9 @@ public:
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"EthernetNetworkDiagnostics.PacketRxCount response %@",
                                                           [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -22826,7 +23302,9 @@ public:
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"EthernetNetworkDiagnostics.PacketTxCount response %@",
                                                           [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -22905,7 +23383,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"EthernetNetworkDiagnostics.TxErrCount response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -22985,7 +23465,9 @@ public:
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"EthernetNetworkDiagnostics.CollisionCount response %@",
                                                            [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -23065,7 +23547,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"EthernetNetworkDiagnostics.OverrunCount response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -23145,7 +23629,9 @@ public:
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"EthernetNetworkDiagnostics.CarrierDetect response %@",
                                                           [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -23225,7 +23711,9 @@ public:
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"EthernetNetworkDiagnostics.TimeSinceReset response %@",
                                                            [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -23305,7 +23793,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"EthernetNetworkDiagnostics.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -23385,7 +23875,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"EthernetNetworkDiagnostics.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -23465,7 +23957,9 @@ public:
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"EthernetNetworkDiagnostics.AttributeList response %@",
                                                           [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -23544,7 +24038,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"EthernetNetworkDiagnostics.FeatureMap response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -23624,7 +24120,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"EthernetNetworkDiagnostics.ClusterRevision response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -23750,7 +24248,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"FanControl.FanMode response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -23859,7 +24359,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"FanControl.FanModeSequence response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -23935,7 +24437,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"FanControl.GeneratedCommandList response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -24011,7 +24515,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"FanControl.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -24086,7 +24592,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"FanControl.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -24161,7 +24669,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"FanControl.FeatureMap response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -24236,7 +24746,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"FanControl.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -24327,7 +24839,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"FixedLabel.LabelList response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -24403,7 +24917,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"FixedLabel.GeneratedCommandList response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -24479,7 +24995,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"FixedLabel.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -24554,7 +25072,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"FixedLabel.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -24629,7 +25149,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"FixedLabel.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -24723,7 +25245,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"FlowMeasurement.MeasuredValue response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -24799,7 +25323,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"FlowMeasurement.MinMeasuredValue response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -24875,7 +25401,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"FlowMeasurement.MaxMeasuredValue response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -24950,7 +25478,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"FlowMeasurement.Tolerance response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -25026,7 +25556,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"FlowMeasurement.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -25102,7 +25634,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"FlowMeasurement.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -25177,7 +25711,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"FlowMeasurement.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -25252,7 +25788,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"FlowMeasurement.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -25516,7 +26054,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"GeneralCommissioning.Breadcrumb response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -25600,7 +26140,9 @@ public:
                                                           NSError * _Nullable error) {
                                                           NSLog(@"GeneralCommissioning.BasicCommissioningInfo response %@",
                                                               [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -25680,7 +26222,9 @@ public:
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"GeneralCommissioning.RegulatoryConfig response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -25760,7 +26304,9 @@ public:
                                                        reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                            NSLog(@"GeneralCommissioning.LocationCapability response %@",
                                                                [value description]);
-                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           if (error || !mWait) {
+                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           }
                                                        }];
 
         return CHIP_NO_ERROR;
@@ -25840,7 +26386,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"GeneralCommissioning.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -25920,7 +26468,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"GeneralCommissioning.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -25999,7 +26549,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"GeneralCommissioning.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -26079,7 +26631,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"GeneralCommissioning.ClusterRevision response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -26186,7 +26740,9 @@ public:
                                                       reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"GeneralDiagnostics.NetworkInterfaces response %@",
                                                               [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -26265,7 +26821,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"GeneralDiagnostics.RebootCount response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -26344,7 +26902,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"GeneralDiagnostics.UpTime response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -26424,7 +26984,9 @@ public:
                                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                               NSLog(@"GeneralDiagnostics.TotalOperationalHours response %@",
                                                                   [value description]);
-                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              if (error || !mWait) {
+                                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              }
                                                           }];
 
         return CHIP_NO_ERROR;
@@ -26503,7 +27065,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"GeneralDiagnostics.BootReasons response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -26583,7 +27147,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"GeneralDiagnostics.ActiveHardwareFaults response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -26663,7 +27229,9 @@ public:
                                                       reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"GeneralDiagnostics.ActiveRadioFaults response %@",
                                                               [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -26743,7 +27311,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"GeneralDiagnostics.ActiveNetworkFaults response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -26823,7 +27393,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"GeneralDiagnostics.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -26903,7 +27475,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"GeneralDiagnostics.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -26982,7 +27556,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"GeneralDiagnostics.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -27062,7 +27638,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"GeneralDiagnostics.ClusterRevision response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -27311,7 +27889,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"GroupKeyManagement.GroupKeyMap response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -27392,7 +27972,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"GroupKeyManagement.GroupTable response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -27472,7 +28054,9 @@ public:
                                                        reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                            NSLog(@"GroupKeyManagement.MaxGroupsPerFabric response %@",
                                                                [value description]);
-                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           if (error || !mWait) {
+                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           }
                                                        }];
 
         return CHIP_NO_ERROR;
@@ -27552,7 +28136,9 @@ public:
                                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                               NSLog(@"GroupKeyManagement.MaxGroupKeysPerFabric response %@",
                                                                   [value description]);
-                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              if (error || !mWait) {
+                                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              }
                                                           }];
 
         return CHIP_NO_ERROR;
@@ -27632,7 +28218,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"GroupKeyManagement.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -27712,7 +28300,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"GroupKeyManagement.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -27791,7 +28381,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"GroupKeyManagement.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -27871,7 +28463,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"GroupKeyManagement.ClusterRevision response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -28180,7 +28774,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"Groups.NameSupport response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -28255,7 +28851,9 @@ public:
                                                subscriptionEstablished:NULL
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"Groups.GeneratedCommandList response %@", [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -28330,7 +28928,9 @@ public:
                                               subscriptionEstablished:NULL
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"Groups.AcceptedCommandList response %@", [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -28405,7 +29005,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"Groups.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -28480,7 +29082,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Groups.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -28711,7 +29315,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"Identify.IdentifyTime response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -28786,7 +29392,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"Identify.IdentifyType response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -28862,7 +29470,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Identify.GeneratedCommandList response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -28937,7 +29547,9 @@ public:
                                               subscriptionEstablished:NULL
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"Identify.AcceptedCommandList response %@", [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -29012,7 +29624,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"Identify.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -29087,7 +29701,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Identify.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -29187,7 +29803,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"IlluminanceMeasurement.MeasuredValue response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -29267,7 +29885,9 @@ public:
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"IlluminanceMeasurement.MinMeasuredValue response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -29347,7 +29967,9 @@ public:
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"IlluminanceMeasurement.MaxMeasuredValue response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -29426,7 +30048,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"IlluminanceMeasurement.Tolerance response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -29506,7 +30130,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"IlluminanceMeasurement.LightSensorType response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -29586,7 +30212,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"IlluminanceMeasurement.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -29666,7 +30294,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"IlluminanceMeasurement.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -29746,7 +30376,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"IlluminanceMeasurement.AttributeList response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -29826,7 +30458,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"IlluminanceMeasurement.ClusterRevision response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -29953,7 +30587,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"KeypadInput.GeneratedCommandList response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -30029,7 +30665,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"KeypadInput.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -30104,7 +30742,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"KeypadInput.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -30179,7 +30819,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"KeypadInput.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -30603,7 +31245,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"LevelControl.CurrentLevel response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -30678,7 +31322,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"LevelControl.RemainingTime response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -30753,7 +31399,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"LevelControl.MinLevel response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -30828,7 +31476,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"LevelControl.MaxLevel response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -30903,7 +31553,9 @@ public:
                                            subscriptionEstablished:NULL
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"LevelControl.CurrentFrequency response %@", [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -30978,7 +31630,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"LevelControl.MinFrequency response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -31053,7 +31707,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"LevelControl.MaxFrequency response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -31162,7 +31818,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"LevelControl.Options response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -31273,7 +31931,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"LevelControl.OnOffTransitionTime response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -31382,7 +32042,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"LevelControl.OnLevel response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -31491,7 +32153,9 @@ public:
                                            subscriptionEstablished:NULL
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"LevelControl.OnTransitionTime response %@", [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -31600,7 +32264,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"LevelControl.OffTransitionTime response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -31709,7 +32375,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"LevelControl.DefaultMoveRate response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -31820,7 +32488,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"LevelControl.StartUpCurrentLevel response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -31896,7 +32566,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"LevelControl.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -31972,7 +32644,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"LevelControl.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -32047,7 +32721,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"LevelControl.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -32122,7 +32798,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"LevelControl.FeatureMap response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -32197,7 +32875,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"LevelControl.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -32333,7 +33013,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"LocalizationConfiguration.ActiveLocale response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -32413,7 +33095,9 @@ public:
                                                      reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"LocalizationConfiguration.SupportedLocales response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -32493,7 +33177,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"LocalizationConfiguration.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -32573,7 +33259,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"LocalizationConfiguration.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -32653,7 +33341,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"LocalizationConfiguration.ClusterRevision response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -32774,7 +33464,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"LowPower.GeneratedCommandList response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -32849,7 +33541,9 @@ public:
                                               subscriptionEstablished:NULL
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"LowPower.AcceptedCommandList response %@", [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -32924,7 +33618,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"LowPower.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -32999,7 +33695,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"LowPower.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -33224,7 +33922,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"MediaInput.InputList response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -33299,7 +33999,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"MediaInput.CurrentInput response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -33375,7 +34077,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"MediaInput.GeneratedCommandList response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -33451,7 +34155,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"MediaInput.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -33526,7 +34232,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"MediaInput.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -33601,7 +34309,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"MediaInput.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -34064,7 +34774,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"MediaPlayback.CurrentState response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -34139,7 +34851,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"MediaPlayback.StartTime response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -34214,7 +34928,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"MediaPlayback.Duration response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -34291,7 +35007,9 @@ public:
                                                     reportHandler:^(CHIPMediaPlaybackClusterPlaybackPosition * _Nullable value,
                                                         NSError * _Nullable error) {
                                                         NSLog(@"MediaPlayback.SampledPosition response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -34366,7 +35084,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"MediaPlayback.PlaybackSpeed response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -34441,7 +35161,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"MediaPlayback.SeekRangeEnd response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -34516,7 +35238,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"MediaPlayback.SeekRangeStart response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -34592,7 +35316,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"MediaPlayback.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -34668,7 +35394,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"MediaPlayback.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -34743,7 +35471,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"MediaPlayback.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -34818,7 +35548,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"MediaPlayback.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -34949,7 +35681,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"ModeSelect.Description response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -35024,7 +35758,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ModeSelect.StandardNamespace response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -35099,7 +35835,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"ModeSelect.SupportedModes response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -35174,7 +35912,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"ModeSelect.CurrentMode response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -35283,7 +36023,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"ModeSelect.StartUpMode response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -35392,7 +36134,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"ModeSelect.OnMode response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -35468,7 +36212,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ModeSelect.GeneratedCommandList response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -35544,7 +36290,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"ModeSelect.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -35619,7 +36367,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"ModeSelect.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -35694,7 +36444,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"ModeSelect.FeatureMap response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -35769,7 +36521,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ModeSelect.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -36129,7 +36883,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"NetworkCommissioning.MaxNetworks response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -36208,7 +36964,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"NetworkCommissioning.Networks response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -36288,7 +37046,9 @@ public:
                                                        reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                            NSLog(@"NetworkCommissioning.ScanMaxTimeSeconds response %@",
                                                                [value description]);
-                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           if (error || !mWait) {
+                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           }
                                                        }];
 
         return CHIP_NO_ERROR;
@@ -36368,7 +37128,9 @@ public:
                                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                               NSLog(@"NetworkCommissioning.ConnectMaxTimeSeconds response %@",
                                                                   [value description]);
-                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              if (error || !mWait) {
+                                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              }
                                                           }];
 
         return CHIP_NO_ERROR;
@@ -36485,7 +37247,9 @@ public:
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"NetworkCommissioning.InterfaceEnabled response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -36565,7 +37329,9 @@ public:
                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"NetworkCommissioning.LastNetworkingStatus response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -36644,7 +37410,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSData * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"NetworkCommissioning.LastNetworkID response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -36724,7 +37492,9 @@ public:
                                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                               NSLog(@"NetworkCommissioning.LastConnectErrorValue response %@",
                                                                   [value description]);
-                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              if (error || !mWait) {
+                                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              }
                                                           }];
 
         return CHIP_NO_ERROR;
@@ -36804,7 +37574,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"NetworkCommissioning.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -36884,7 +37656,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"NetworkCommissioning.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -36963,7 +37737,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"NetworkCommissioning.FeatureMap response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -37043,7 +37819,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"NetworkCommissioning.ClusterRevision response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -37278,7 +38056,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"OtaSoftwareUpdateProvider.AttributeList response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -37358,7 +38138,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"OtaSoftwareUpdateProvider.ClusterRevision response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -37513,7 +38295,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"OtaSoftwareUpdateRequestor.DefaultOtaProviders response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -37593,7 +38377,9 @@ public:
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"OtaSoftwareUpdateRequestor.UpdatePossible response %@",
                                                            [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -37673,7 +38459,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"OtaSoftwareUpdateRequestor.UpdateState response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -37753,7 +38541,9 @@ public:
                                                         reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"OtaSoftwareUpdateRequestor.UpdateStateProgress response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -37833,7 +38623,9 @@ public:
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"OtaSoftwareUpdateRequestor.AttributeList response %@",
                                                           [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -37913,7 +38705,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"OtaSoftwareUpdateRequestor.ClusterRevision response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -38019,7 +38813,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"OccupancySensing.Occupancy response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -38099,7 +38895,9 @@ public:
                                                         reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"OccupancySensing.OccupancySensorType response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -38181,7 +38979,9 @@ public:
                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"OccupancySensing.OccupancySensorTypeBitmap response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -38261,7 +39061,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"OccupancySensing.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -38341,7 +39143,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"OccupancySensing.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -38420,7 +39224,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"OccupancySensing.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -38499,7 +39305,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"OccupancySensing.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -38793,7 +39601,9 @@ public:
                                 subscriptionEstablished:NULL
                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                               NSLog(@"OnOff.OnOff response %@", [value description]);
-                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              if (error || !mWait) {
+                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              }
                                           }];
 
         return CHIP_NO_ERROR;
@@ -38868,7 +39678,9 @@ public:
                                              subscriptionEstablished:NULL
                                                        reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                            NSLog(@"OnOff.GlobalSceneControl response %@", [value description]);
-                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           if (error || !mWait) {
+                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           }
                                                        }];
 
         return CHIP_NO_ERROR;
@@ -38977,7 +39789,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"OnOff.OnTime response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -39086,7 +39900,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"OnOff.OffWaitTime response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -39195,7 +40011,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"OnOff.StartUpOnOff response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -39270,7 +40088,9 @@ public:
                                                subscriptionEstablished:NULL
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"OnOff.GeneratedCommandList response %@", [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -39345,7 +40165,9 @@ public:
                                               subscriptionEstablished:NULL
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"OnOff.AcceptedCommandList response %@", [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -39420,7 +40242,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"OnOff.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -39495,7 +40319,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"OnOff.FeatureMap response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -39570,7 +40396,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"OnOff.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -39666,7 +40494,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"OnOffSwitchConfiguration.SwitchType response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -39783,7 +40613,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"OnOffSwitchConfiguration.SwitchActions response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -39863,7 +40695,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"OnOffSwitchConfiguration.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -39943,7 +40777,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"OnOffSwitchConfiguration.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -40023,7 +40859,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"OnOffSwitchConfiguration.AttributeList response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -40103,7 +40941,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"OnOffSwitchConfiguration.ClusterRevision response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -40569,7 +41409,9 @@ public:
                                subscriptionEstablished:NULL
                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                              NSLog(@"OperationalCredentials.NOCs response %@", [value description]);
-                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                             if (error || !mWait) {
+                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                             }
                                          }];
 
         return CHIP_NO_ERROR;
@@ -40650,7 +41492,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"OperationalCredentials.Fabrics response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -40730,7 +41574,9 @@ public:
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"OperationalCredentials.SupportedFabrics response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -40810,7 +41656,9 @@ public:
                                                         reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"OperationalCredentials.CommissionedFabrics response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -40890,7 +41738,9 @@ public:
                                                             reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                                 NSLog(@"OperationalCredentials.TrustedRootCertificates response %@",
                                                                     [value description]);
-                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                if (error || !mWait) {
+                                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                }
                                                             }];
 
         return CHIP_NO_ERROR;
@@ -40970,7 +41820,9 @@ public:
                                                        reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                            NSLog(@"OperationalCredentials.CurrentFabricIndex response %@",
                                                                [value description]);
-                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           if (error || !mWait) {
+                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           }
                                                        }];
 
         return CHIP_NO_ERROR;
@@ -41050,7 +41902,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"OperationalCredentials.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -41130,7 +41984,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"OperationalCredentials.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -41210,7 +42066,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"OperationalCredentials.AttributeList response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -41290,7 +42148,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"OperationalCredentials.ClusterRevision response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -41411,7 +42271,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"PowerSource.Status response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -41486,7 +42348,9 @@ public:
                                 subscriptionEstablished:NULL
                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                               NSLog(@"PowerSource.Order response %@", [value description]);
-                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              if (error || !mWait) {
+                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              }
                                           }];
 
         return CHIP_NO_ERROR;
@@ -41561,7 +42425,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"PowerSource.Description response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -41636,7 +42502,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"PowerSource.BatteryVoltage response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -41713,7 +42581,9 @@ public:
                                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                 NSLog(@"PowerSource.BatteryPercentRemaining response %@",
                                                                     [value description]);
-                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                if (error || !mWait) {
+                                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                }
                                                             }];
 
         return CHIP_NO_ERROR;
@@ -41789,7 +42659,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"PowerSource.BatteryTimeRemaining response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -41865,7 +42737,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"PowerSource.BatteryChargeLevel response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -41941,7 +42815,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"PowerSource.ActiveBatteryFaults response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -42017,7 +42893,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"PowerSource.BatteryChargeState response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -42093,7 +42971,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"PowerSource.GeneratedCommandList response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -42169,7 +43049,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"PowerSource.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -42244,7 +43126,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"PowerSource.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -42319,7 +43203,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"PowerSource.FeatureMap response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -42394,7 +43280,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"PowerSource.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -42489,7 +43377,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"PowerSourceConfiguration.Sources response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -42569,7 +43459,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"PowerSourceConfiguration.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -42649,7 +43541,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"PowerSourceConfiguration.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -42729,7 +43623,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"PowerSourceConfiguration.AttributeList response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -42809,7 +43705,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"PowerSourceConfiguration.ClusterRevision response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -42912,7 +43810,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"PressureMeasurement.MeasuredValue response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -42992,7 +43892,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"PressureMeasurement.MinMeasuredValue response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -43072,7 +43974,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"PressureMeasurement.MaxMeasuredValue response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -43151,7 +44055,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"PressureMeasurement.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -43231,7 +44137,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"PressureMeasurement.ClusterRevision response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -43367,7 +44275,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"PumpConfigurationAndControl.MaxPressure response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -43446,7 +44356,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"PumpConfigurationAndControl.MaxSpeed response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -43525,7 +44437,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"PumpConfigurationAndControl.MaxFlow response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -43605,7 +44519,9 @@ public:
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"PumpConfigurationAndControl.MinConstPressure response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -43685,7 +44601,9 @@ public:
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"PumpConfigurationAndControl.MaxConstPressure response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -43765,7 +44683,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"PumpConfigurationAndControl.MinCompPressure response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -43845,7 +44765,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"PumpConfigurationAndControl.MaxCompPressure response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -43925,7 +44847,9 @@ public:
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"PumpConfigurationAndControl.MinConstSpeed response %@",
                                                           [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -44005,7 +44929,9 @@ public:
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"PumpConfigurationAndControl.MaxConstSpeed response %@",
                                                           [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -44085,7 +45011,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"PumpConfigurationAndControl.MinConstFlow response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -44165,7 +45093,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"PumpConfigurationAndControl.MaxConstFlow response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -44245,7 +45175,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"PumpConfigurationAndControl.MinConstTemp response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -44325,7 +45257,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"PumpConfigurationAndControl.MaxConstTemp response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -44405,7 +45339,9 @@ public:
                                 subscriptionEstablished:NULL
                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                               NSLog(@"PumpConfigurationAndControl.PumpStatus response %@", [value description]);
-                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              if (error || !mWait) {
+                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              }
                                           }];
 
         return CHIP_NO_ERROR;
@@ -44486,7 +45422,9 @@ public:
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"PumpConfigurationAndControl.EffectiveOperationMode response %@",
                                                               [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -44566,7 +45504,9 @@ public:
                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"PumpConfigurationAndControl.EffectiveControlMode response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -44645,7 +45585,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"PumpConfigurationAndControl.Capacity response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -44724,7 +45666,9 @@ public:
                                 subscriptionEstablished:NULL
                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                               NSLog(@"PumpConfigurationAndControl.Speed response %@", [value description]);
-                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              if (error || !mWait) {
+                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              }
                                           }];
 
         return CHIP_NO_ERROR;
@@ -44841,7 +45785,9 @@ public:
                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"PumpConfigurationAndControl.LifetimeRunningHours response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -44920,7 +45866,9 @@ public:
                                 subscriptionEstablished:NULL
                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                               NSLog(@"PumpConfigurationAndControl.Power response %@", [value description]);
-                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              if (error || !mWait) {
+                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              }
                                           }];
 
         return CHIP_NO_ERROR;
@@ -45039,7 +45987,9 @@ public:
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"PumpConfigurationAndControl.LifetimeEnergyConsumed response %@",
                                                               [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -45156,7 +46106,9 @@ public:
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"PumpConfigurationAndControl.OperationMode response %@",
                                                           [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -45273,7 +46225,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"PumpConfigurationAndControl.ControlMode response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -45352,7 +46306,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"PumpConfigurationAndControl.AlarmMask response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -45432,7 +46388,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"PumpConfigurationAndControl.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -45512,7 +46470,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"PumpConfigurationAndControl.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -45592,7 +46552,9 @@ public:
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"PumpConfigurationAndControl.AttributeList response %@",
                                                           [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -45672,7 +46634,9 @@ public:
                                 subscriptionEstablished:NULL
                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                               NSLog(@"PumpConfigurationAndControl.FeatureMap response %@", [value description]);
-                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              if (error || !mWait) {
+                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              }
                                           }];
 
         return CHIP_NO_ERROR;
@@ -45752,7 +46716,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"PumpConfigurationAndControl.ClusterRevision response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -45851,7 +46817,9 @@ public:
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"RelativeHumidityMeasurement.MeasuredValue response %@",
                                                           [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -45931,7 +46899,9 @@ public:
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"RelativeHumidityMeasurement.MinMeasuredValue response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -46011,7 +46981,9 @@ public:
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"RelativeHumidityMeasurement.MaxMeasuredValue response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -46090,7 +47062,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"RelativeHumidityMeasurement.Tolerance response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -46170,7 +47144,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"RelativeHumidityMeasurement.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -46250,7 +47226,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"RelativeHumidityMeasurement.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -46330,7 +47308,9 @@ public:
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"RelativeHumidityMeasurement.AttributeList response %@",
                                                           [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -46410,7 +47390,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"RelativeHumidityMeasurement.ClusterRevision response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -46789,7 +47771,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"Scenes.SceneCount response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -46864,7 +47848,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"Scenes.CurrentScene response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -46939,7 +47925,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"Scenes.CurrentGroup response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -47014,7 +48002,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"Scenes.SceneValid response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -47089,7 +48079,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"Scenes.NameSupport response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -47164,7 +48156,9 @@ public:
                                                subscriptionEstablished:NULL
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"Scenes.GeneratedCommandList response %@", [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -47239,7 +48233,9 @@ public:
                                               subscriptionEstablished:NULL
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"Scenes.AcceptedCommandList response %@", [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -47314,7 +48310,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"Scenes.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -47389,7 +48387,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Scenes.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -47520,7 +48520,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"SoftwareDiagnostics.ThreadMetrics response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -47600,7 +48602,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"SoftwareDiagnostics.CurrentHeapFree response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -47680,7 +48684,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"SoftwareDiagnostics.CurrentHeapUsed response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -47762,7 +48768,9 @@ public:
                                                         reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"SoftwareDiagnostics.CurrentHeapHighWatermark response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -47842,7 +48850,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"SoftwareDiagnostics.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -47922,7 +48932,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"SoftwareDiagnostics.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -48001,7 +49013,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"SoftwareDiagnostics.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -48080,7 +49094,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"SoftwareDiagnostics.FeatureMap response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -48160,7 +49176,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"SoftwareDiagnostics.ClusterRevision response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -48260,7 +49278,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"Switch.NumberOfPositions response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -48335,7 +49355,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Switch.CurrentPosition response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -48410,7 +49432,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"Switch.MultiPressMax response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -48485,7 +49509,9 @@ public:
                                                subscriptionEstablished:NULL
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"Switch.GeneratedCommandList response %@", [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -48560,7 +49586,9 @@ public:
                                               subscriptionEstablished:NULL
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"Switch.AcceptedCommandList response %@", [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -48635,7 +49663,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"Switch.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -48710,7 +49740,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"Switch.FeatureMap response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -48785,7 +49817,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Switch.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -48917,7 +49951,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"TargetNavigator.TargetList response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -48992,7 +50028,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"TargetNavigator.CurrentTarget response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -49068,7 +50106,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"TargetNavigator.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -49144,7 +50184,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"TargetNavigator.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -49219,7 +50261,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"TargetNavigator.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -49294,7 +50338,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"TargetNavigator.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -49393,7 +50439,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"TemperatureMeasurement.MeasuredValue response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -49473,7 +50521,9 @@ public:
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"TemperatureMeasurement.MinMeasuredValue response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -49553,7 +50603,9 @@ public:
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"TemperatureMeasurement.MaxMeasuredValue response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -49632,7 +50684,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"TemperatureMeasurement.Tolerance response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -49712,7 +50766,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"TemperatureMeasurement.AttributeList response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -49792,7 +50848,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"TemperatureMeasurement.ClusterRevision response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -50632,7 +51690,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"TestCluster.Boolean response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -50741,7 +51801,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"TestCluster.Bitmap8 response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -50850,7 +51912,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"TestCluster.Bitmap16 response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -50959,7 +52023,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"TestCluster.Bitmap32 response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -51068,7 +52134,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"TestCluster.Bitmap64 response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -51177,7 +52245,9 @@ public:
                                 subscriptionEstablished:NULL
                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                               NSLog(@"TestCluster.Int8u response %@", [value description]);
-                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              if (error || !mWait) {
+                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              }
                                           }];
 
         return CHIP_NO_ERROR;
@@ -51286,7 +52356,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"TestCluster.Int16u response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -51395,7 +52467,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"TestCluster.Int24u response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -51504,7 +52578,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"TestCluster.Int32u response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -51613,7 +52689,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"TestCluster.Int40u response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -51722,7 +52800,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"TestCluster.Int48u response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -51831,7 +52911,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"TestCluster.Int56u response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -51940,7 +53022,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"TestCluster.Int64u response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -52049,7 +53133,9 @@ public:
                                 subscriptionEstablished:NULL
                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                               NSLog(@"TestCluster.Int8s response %@", [value description]);
-                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              if (error || !mWait) {
+                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              }
                                           }];
 
         return CHIP_NO_ERROR;
@@ -52158,7 +53244,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"TestCluster.Int16s response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -52267,7 +53355,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"TestCluster.Int24s response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -52376,7 +53466,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"TestCluster.Int32s response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -52485,7 +53577,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"TestCluster.Int40s response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -52594,7 +53688,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"TestCluster.Int48s response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -52703,7 +53799,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"TestCluster.Int56s response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -52812,7 +53910,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"TestCluster.Int64s response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -52921,7 +54021,9 @@ public:
                                 subscriptionEstablished:NULL
                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                               NSLog(@"TestCluster.Enum8 response %@", [value description]);
-                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              if (error || !mWait) {
+                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              }
                                           }];
 
         return CHIP_NO_ERROR;
@@ -53030,7 +54132,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"TestCluster.Enum16 response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -53139,7 +54243,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"TestCluster.FloatSingle response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -53248,7 +54354,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"TestCluster.FloatDouble response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -53357,7 +54465,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSData * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"TestCluster.OctetString response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -53432,7 +54542,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"TestCluster.ListInt8u response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -53507,7 +54619,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"TestCluster.ListOctetString response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -53583,7 +54697,9 @@ public:
                                                           reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                               NSLog(@"TestCluster.ListStructOctetString response %@",
                                                                   [value description]);
-                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              if (error || !mWait) {
+                                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              }
                                                           }];
 
         return CHIP_NO_ERROR;
@@ -53692,7 +54808,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSData * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"TestCluster.LongOctetString response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -53803,7 +54921,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"TestCluster.CharString response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -53914,7 +55034,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.LongCharString response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -54023,7 +55145,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"TestCluster.EpochUs response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -54132,7 +55256,9 @@ public:
                                  subscriptionEstablished:NULL
                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                NSLog(@"TestCluster.EpochS response %@", [value description]);
-                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               if (error || !mWait) {
+                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                               }
                                            }];
 
         return CHIP_NO_ERROR;
@@ -54241,7 +55367,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"TestCluster.VendorId response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -54320,7 +55448,9 @@ public:
                                                                    NSArray * _Nullable value, NSError * _Nullable error) {
                                                                    NSLog(@"TestCluster.ListNullablesAndOptionalsStruct response %@",
                                                                        [value description]);
-                                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                   if (error || !mWait) {
+                                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                   }
                                                                }];
 
         return CHIP_NO_ERROR;
@@ -54429,7 +55559,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"TestCluster.EnumAttr response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -54538,7 +55670,9 @@ public:
                                                reportHandler:^(CHIPTestClusterClusterSimpleStruct * _Nullable value,
                                                    NSError * _Nullable error) {
                                                    NSLog(@"TestCluster.StructAttr response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -54649,7 +55783,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"TestCluster.RangeRestrictedInt8u response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -54760,7 +55896,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"TestCluster.RangeRestrictedInt8s response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -54871,7 +56009,9 @@ public:
                                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                               NSLog(@"TestCluster.RangeRestrictedInt16u response %@",
                                                                   [value description]);
-                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              if (error || !mWait) {
+                                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              }
                                                           }];
 
         return CHIP_NO_ERROR;
@@ -54982,7 +56122,9 @@ public:
                                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                               NSLog(@"TestCluster.RangeRestrictedInt16s response %@",
                                                                   [value description]);
-                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              if (error || !mWait) {
+                                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              }
                                                           }];
 
         return CHIP_NO_ERROR;
@@ -55058,7 +56200,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.ListLongOctetString response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -55135,7 +56279,9 @@ public:
                                            subscriptionEstablished:NULL
                                                      reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"TestCluster.ListFabricScoped response %@", [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -55244,7 +56390,9 @@ public:
                                             subscriptionEstablished:NULL
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"TestCluster.TimedWriteBoolean response %@", [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -55355,7 +56503,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.GeneralErrorBoolean response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -55466,7 +56616,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.ClusterErrorBoolean response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -55575,7 +56727,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"TestCluster.Unsupported response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -55684,7 +56838,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"TestCluster.NullableBoolean response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -55793,7 +56949,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"TestCluster.NullableBitmap8 response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -55902,7 +57060,9 @@ public:
                                            subscriptionEstablished:NULL
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"TestCluster.NullableBitmap16 response %@", [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -56011,7 +57171,9 @@ public:
                                            subscriptionEstablished:NULL
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"TestCluster.NullableBitmap32 response %@", [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -56120,7 +57282,9 @@ public:
                                            subscriptionEstablished:NULL
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"TestCluster.NullableBitmap64 response %@", [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -56229,7 +57393,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"TestCluster.NullableInt8u response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -56338,7 +57504,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableInt16u response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -56447,7 +57615,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableInt24u response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -56556,7 +57726,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableInt32u response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -56665,7 +57837,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableInt40u response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -56774,7 +57948,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableInt48u response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -56883,7 +58059,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableInt56u response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -56992,7 +58170,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableInt64u response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -57101,7 +58281,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"TestCluster.NullableInt8s response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -57210,7 +58392,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableInt16s response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -57319,7 +58503,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableInt24s response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -57428,7 +58614,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableInt32s response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -57537,7 +58725,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableInt40s response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -57646,7 +58836,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableInt48s response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -57755,7 +58947,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableInt56s response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -57864,7 +59058,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableInt64s response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -57973,7 +59169,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"TestCluster.NullableEnum8 response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -58082,7 +59280,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableEnum16 response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -58193,7 +59393,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableFloatSingle response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -58304,7 +59506,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableFloatDouble response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -58415,7 +59619,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSData * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableOctetString response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -58528,7 +59734,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"TestCluster.NullableCharString response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -58637,7 +59845,9 @@ public:
                                            subscriptionEstablished:NULL
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"TestCluster.NullableEnumAttr response %@", [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -58746,7 +59956,9 @@ public:
                                                    reportHandler:^(CHIPTestClusterClusterSimpleStruct * _Nullable value,
                                                        NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.NullableStruct response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -58859,7 +60071,9 @@ public:
                                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                 NSLog(@"TestCluster.NullableRangeRestrictedInt8u response %@",
                                                                     [value description]);
-                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                if (error || !mWait) {
+                                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                }
                                                             }];
 
         return CHIP_NO_ERROR;
@@ -58972,7 +60186,9 @@ public:
                                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                 NSLog(@"TestCluster.NullableRangeRestrictedInt8s response %@",
                                                                     [value description]);
-                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                if (error || !mWait) {
+                                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                }
                                                             }];
 
         return CHIP_NO_ERROR;
@@ -59087,7 +60303,9 @@ public:
                                                                  NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                  NSLog(@"TestCluster.NullableRangeRestrictedInt16u response %@",
                                                                      [value description]);
-                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                 if (error || !mWait) {
+                                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                 }
                                                              }];
 
         return CHIP_NO_ERROR;
@@ -59202,7 +60420,9 @@ public:
                                                                  NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                  NSLog(@"TestCluster.NullableRangeRestrictedInt16s response %@",
                                                                      [value description]);
-                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                 if (error || !mWait) {
+                                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                 }
                                                              }];
 
         return CHIP_NO_ERROR;
@@ -59278,7 +60498,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"TestCluster.GeneratedCommandList response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -59354,7 +60576,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"TestCluster.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -59429,7 +60653,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"TestCluster.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -59504,7 +60730,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"TestCluster.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -59819,7 +61047,9 @@ public:
                                            subscriptionEstablished:NULL
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"Thermostat.LocalTemperature response %@", [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -59896,7 +61126,9 @@ public:
                                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                 NSLog(@"Thermostat.AbsMinHeatSetpointLimit response %@",
                                                                     [value description]);
-                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                if (error || !mWait) {
+                                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                }
                                                             }];
 
         return CHIP_NO_ERROR;
@@ -59973,7 +61205,9 @@ public:
                                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                 NSLog(@"Thermostat.AbsMaxHeatSetpointLimit response %@",
                                                                     [value description]);
-                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                if (error || !mWait) {
+                                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                }
                                                             }];
 
         return CHIP_NO_ERROR;
@@ -60050,7 +61284,9 @@ public:
                                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                 NSLog(@"Thermostat.AbsMinCoolSetpointLimit response %@",
                                                                     [value description]);
-                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                if (error || !mWait) {
+                                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                }
                                                             }];
 
         return CHIP_NO_ERROR;
@@ -60127,7 +61363,9 @@ public:
                                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                 NSLog(@"Thermostat.AbsMaxCoolSetpointLimit response %@",
                                                                     [value description]);
-                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                if (error || !mWait) {
+                                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                }
                                                             }];
 
         return CHIP_NO_ERROR;
@@ -60239,7 +61477,9 @@ public:
                                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                 NSLog(@"Thermostat.OccupiedCoolingSetpoint response %@",
                                                                     [value description]);
-                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                if (error || !mWait) {
+                                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                }
                                                             }];
 
         return CHIP_NO_ERROR;
@@ -60351,7 +61591,9 @@ public:
                                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                 NSLog(@"Thermostat.OccupiedHeatingSetpoint response %@",
                                                                     [value description]);
-                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                if (error || !mWait) {
+                                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                }
                                                             }];
 
         return CHIP_NO_ERROR;
@@ -60462,7 +61704,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Thermostat.MinHeatSetpointLimit response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -60573,7 +61817,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Thermostat.MaxHeatSetpointLimit response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -60684,7 +61930,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Thermostat.MinCoolSetpointLimit response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -60795,7 +62043,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Thermostat.MaxCoolSetpointLimit response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -60906,7 +62156,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"Thermostat.MinSetpointDeadBand response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -61019,7 +62271,9 @@ public:
                                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                               NSLog(@"Thermostat.ControlSequenceOfOperation response %@",
                                                                   [value description]);
-                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              if (error || !mWait) {
+                                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              }
                                                           }];
 
         return CHIP_NO_ERROR;
@@ -61128,7 +62382,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"Thermostat.SystemMode response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -61203,7 +62459,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"Thermostat.StartOfWeek response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -61281,7 +62539,9 @@ public:
                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"Thermostat.NumberOfWeeklyTransitions response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -61359,7 +62619,9 @@ public:
                                                         reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"Thermostat.NumberOfDailyTransitions response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -61434,7 +62696,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"Thermostat.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -61509,7 +62773,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"Thermostat.FeatureMap response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -61584,7 +62850,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"Thermostat.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -61718,7 +62986,9 @@ public:
                                                                NSLog(@"ThermostatUserInterfaceConfiguration.TemperatureDisplayMode "
                                                                      @"response %@",
                                                                    [value description]);
-                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               if (error || !mWait) {
+                                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               }
                                                            }];
 
         return CHIP_NO_ERROR;
@@ -61832,7 +63102,9 @@ public:
                                                   reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"ThermostatUserInterfaceConfiguration.KeypadLockout response %@",
                                                           [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -61943,17 +63215,20 @@ public:
         CHIPThermostatUserInterfaceConfiguration * cluster =
             [[CHIPThermostatUserInterfaceConfiguration alloc] initWithDevice:device endpoint:endpointId queue:callbackQueue];
         CHIPSubscribeParams * params = [[CHIPSubscribeParams alloc] init];
-        [cluster subscribeAttributeScheduleProgrammingVisibilityWithMinInterval:[NSNumber numberWithUnsignedInt:mMinInterval]
-                                                                    maxInterval:[NSNumber numberWithUnsignedInt:mMaxInterval]
-                                                                         params:params
-                                                        subscriptionEstablished:NULL
-                                                                  reportHandler:^(
-                                                                      NSNumber * _Nullable value, NSError * _Nullable error) {
-                                                                      NSLog(@"ThermostatUserInterfaceConfiguration."
-                                                                            @"ScheduleProgrammingVisibility response %@",
-                                                                          [value description]);
-                                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
-                                                                  }];
+        [cluster
+            subscribeAttributeScheduleProgrammingVisibilityWithMinInterval:[NSNumber numberWithUnsignedInt:mMinInterval]
+                                                               maxInterval:[NSNumber numberWithUnsignedInt:mMaxInterval]
+                                                                    params:params
+                                                   subscriptionEstablished:NULL
+                                                             reportHandler:^(
+                                                                 NSNumber * _Nullable value, NSError * _Nullable error) {
+                                                                 NSLog(@"ThermostatUserInterfaceConfiguration."
+                                                                       @"ScheduleProgrammingVisibility response %@",
+                                                                     [value description]);
+                                                                 if (error || !mWait) {
+                                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                 }
+                                                             }];
 
         return CHIP_NO_ERROR;
     }
@@ -62031,7 +63306,9 @@ public:
                                                              NSLog(@"ThermostatUserInterfaceConfiguration.GeneratedCommandList "
                                                                    @"response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -62111,7 +63388,9 @@ public:
                                                        NSLog(
                                                            @"ThermostatUserInterfaceConfiguration.AcceptedCommandList response %@",
                                                            [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -62189,7 +63468,9 @@ public:
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"ThermostatUserInterfaceConfiguration.AttributeList response %@",
                                                           [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -62267,7 +63548,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ThermostatUserInterfaceConfiguration.ClusterRevision response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -62457,7 +63740,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"ThreadNetworkDiagnostics.Channel response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -62536,7 +63821,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"ThreadNetworkDiagnostics.RoutingRole response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -62615,7 +63902,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"ThreadNetworkDiagnostics.NetworkName response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -62694,7 +63983,9 @@ public:
                                 subscriptionEstablished:NULL
                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                               NSLog(@"ThreadNetworkDiagnostics.PanId response %@", [value description]);
-                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              if (error || !mWait) {
+                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              }
                                           }];
 
         return CHIP_NO_ERROR;
@@ -62774,7 +64065,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"ThreadNetworkDiagnostics.ExtendedPanId response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -62854,7 +64147,9 @@ public:
                                                     reportHandler:^(NSData * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ThreadNetworkDiagnostics.MeshLocalPrefix response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -62934,7 +64229,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"ThreadNetworkDiagnostics.OverrunCount response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -63014,7 +64311,9 @@ public:
                                                       reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ThreadNetworkDiagnostics.NeighborTableList response %@",
                                                               [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -63094,7 +64393,9 @@ public:
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"ThreadNetworkDiagnostics.RouteTableList response %@",
                                                            [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -63173,7 +64474,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"ThreadNetworkDiagnostics.PartitionId response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -63252,7 +64555,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"ThreadNetworkDiagnostics.Weighting response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -63331,7 +64636,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"ThreadNetworkDiagnostics.DataVersion response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -63411,7 +64718,9 @@ public:
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ThreadNetworkDiagnostics.StableDataVersion response %@",
                                                               [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -63491,7 +64800,9 @@ public:
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"ThreadNetworkDiagnostics.LeaderRouterId response %@",
                                                            [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -63571,7 +64882,9 @@ public:
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ThreadNetworkDiagnostics.DetachedRoleCount response %@",
                                                               [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -63651,7 +64964,9 @@ public:
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"ThreadNetworkDiagnostics.ChildRoleCount response %@",
                                                            [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -63731,7 +65046,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ThreadNetworkDiagnostics.RouterRoleCount response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -63811,7 +65128,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ThreadNetworkDiagnostics.LeaderRoleCount response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -63891,7 +65210,9 @@ public:
                                                        reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                            NSLog(@"ThreadNetworkDiagnostics.AttachAttemptCount response %@",
                                                                [value description]);
-                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           if (error || !mWait) {
+                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           }
                                                        }];
 
         return CHIP_NO_ERROR;
@@ -63971,7 +65292,9 @@ public:
                                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                NSLog(@"ThreadNetworkDiagnostics.PartitionIdChangeCount response %@",
                                                                    [value description]);
-                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               if (error || !mWait) {
+                                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               }
                                                            }];
 
         return CHIP_NO_ERROR;
@@ -64045,18 +65368,20 @@ public:
                                                                                              endpoint:endpointId
                                                                                                 queue:callbackQueue];
         CHIPSubscribeParams * params = [[CHIPSubscribeParams alloc] init];
-        [cluster
-            subscribeAttributeBetterPartitionAttachAttemptCountWithMinInterval:[NSNumber numberWithUnsignedInt:mMinInterval]
-                                                                   maxInterval:[NSNumber numberWithUnsignedInt:mMaxInterval]
-                                                                        params:params
-                                                       subscriptionEstablished:NULL
-                                                                 reportHandler:^(
-                                                                     NSNumber * _Nullable value, NSError * _Nullable error) {
-                                                                     NSLog(@"ThreadNetworkDiagnostics."
-                                                                           @"BetterPartitionAttachAttemptCount response %@",
-                                                                         [value description]);
-                                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
-                                                                 }];
+        [cluster subscribeAttributeBetterPartitionAttachAttemptCountWithMinInterval:[NSNumber numberWithUnsignedInt:mMinInterval]
+                                                                        maxInterval:[NSNumber numberWithUnsignedInt:mMaxInterval]
+                                                                             params:params
+                                                            subscriptionEstablished:NULL
+                                                                      reportHandler:^(
+                                                                          NSNumber * _Nullable value, NSError * _Nullable error) {
+                                                                          NSLog(@"ThreadNetworkDiagnostics."
+                                                                                @"BetterPartitionAttachAttemptCount response %@",
+                                                                              [value description]);
+                                                                          if (error || !mWait) {
+                                                                              SetCommandExitStatus(
+                                                                                  [CHIPError errorToCHIPErrorCode:error]);
+                                                                          }
+                                                                      }];
 
         return CHIP_NO_ERROR;
     }
@@ -64135,7 +65460,9 @@ public:
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ThreadNetworkDiagnostics.ParentChangeCount response %@",
                                                               [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -64215,7 +65542,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"ThreadNetworkDiagnostics.TxTotalCount response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -64295,7 +65624,9 @@ public:
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"ThreadNetworkDiagnostics.TxUnicastCount response %@",
                                                            [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -64375,7 +65706,9 @@ public:
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"ThreadNetworkDiagnostics.TxBroadcastCount response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -64455,7 +65788,9 @@ public:
                                                         reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"ThreadNetworkDiagnostics.TxAckRequestedCount response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -64535,7 +65870,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"ThreadNetworkDiagnostics.TxAckedCount response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -64615,7 +65952,9 @@ public:
                                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                               NSLog(@"ThreadNetworkDiagnostics.TxNoAckRequestedCount response %@",
                                                                   [value description]);
-                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              if (error || !mWait) {
+                                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              }
                                                           }];
 
         return CHIP_NO_ERROR;
@@ -64694,7 +66033,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"ThreadNetworkDiagnostics.TxDataCount response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -64774,7 +66115,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ThreadNetworkDiagnostics.TxDataPollCount response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -64854,7 +66197,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"ThreadNetworkDiagnostics.TxBeaconCount response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -64934,7 +66279,9 @@ public:
                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"ThreadNetworkDiagnostics.TxBeaconRequestCount response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -65014,7 +66361,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"ThreadNetworkDiagnostics.TxOtherCount response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -65094,7 +66443,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"ThreadNetworkDiagnostics.TxRetryCount response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -65177,7 +66528,9 @@ public:
                                                                NSLog(@"ThreadNetworkDiagnostics.TxDirectMaxRetryExpiryCount "
                                                                      @"response %@",
                                                                    [value description]);
-                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               if (error || !mWait) {
+                                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               }
                                                            }];
 
         return CHIP_NO_ERROR;
@@ -65251,17 +66604,20 @@ public:
                                                                                              endpoint:endpointId
                                                                                                 queue:callbackQueue];
         CHIPSubscribeParams * params = [[CHIPSubscribeParams alloc] init];
-        [cluster subscribeAttributeTxIndirectMaxRetryExpiryCountWithMinInterval:[NSNumber numberWithUnsignedInt:mMinInterval]
-                                                                    maxInterval:[NSNumber numberWithUnsignedInt:mMaxInterval]
-                                                                         params:params
-                                                        subscriptionEstablished:NULL
-                                                                  reportHandler:^(
-                                                                      NSNumber * _Nullable value, NSError * _Nullable error) {
-                                                                      NSLog(@"ThreadNetworkDiagnostics."
-                                                                            @"TxIndirectMaxRetryExpiryCount response %@",
-                                                                          [value description]);
-                                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
-                                                                  }];
+        [cluster
+            subscribeAttributeTxIndirectMaxRetryExpiryCountWithMinInterval:[NSNumber numberWithUnsignedInt:mMinInterval]
+                                                               maxInterval:[NSNumber numberWithUnsignedInt:mMaxInterval]
+                                                                    params:params
+                                                   subscriptionEstablished:NULL
+                                                             reportHandler:^(
+                                                                 NSNumber * _Nullable value, NSError * _Nullable error) {
+                                                                 NSLog(@"ThreadNetworkDiagnostics.TxIndirectMaxRetryExpiryCount "
+                                                                       @"response %@",
+                                                                     [value description]);
+                                                                 if (error || !mWait) {
+                                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                 }
+                                                             }];
 
         return CHIP_NO_ERROR;
     }
@@ -65340,7 +66696,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"ThreadNetworkDiagnostics.TxErrCcaCount response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -65420,7 +66778,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ThreadNetworkDiagnostics.TxErrAbortCount response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -65500,7 +66860,9 @@ public:
                                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                               NSLog(@"ThreadNetworkDiagnostics.TxErrBusyChannelCount response %@",
                                                                   [value description]);
-                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              if (error || !mWait) {
+                                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                              }
                                                           }];
 
         return CHIP_NO_ERROR;
@@ -65580,7 +66942,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"ThreadNetworkDiagnostics.RxTotalCount response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -65660,7 +67024,9 @@ public:
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"ThreadNetworkDiagnostics.RxUnicastCount response %@",
                                                            [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -65740,7 +67106,9 @@ public:
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"ThreadNetworkDiagnostics.RxBroadcastCount response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -65819,7 +67187,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"ThreadNetworkDiagnostics.RxDataCount response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -65899,7 +67269,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ThreadNetworkDiagnostics.RxDataPollCount response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -65979,7 +67351,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"ThreadNetworkDiagnostics.RxBeaconCount response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -66059,7 +67433,9 @@ public:
                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"ThreadNetworkDiagnostics.RxBeaconRequestCount response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -66139,7 +67515,9 @@ public:
                                   subscriptionEstablished:NULL
                                             reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                 NSLog(@"ThreadNetworkDiagnostics.RxOtherCount response %@", [value description]);
-                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                if (error || !mWait) {
+                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                }
                                             }];
 
         return CHIP_NO_ERROR;
@@ -66219,7 +67597,9 @@ public:
                                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                NSLog(@"ThreadNetworkDiagnostics.RxAddressFilteredCount response %@",
                                                                    [value description]);
-                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               if (error || !mWait) {
+                                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               }
                                                            }];
 
         return CHIP_NO_ERROR;
@@ -66301,7 +67681,9 @@ public:
                                                        reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                            NSLog(@"ThreadNetworkDiagnostics.RxDestAddrFilteredCount response %@",
                                                                [value description]);
-                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           if (error || !mWait) {
+                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           }
                                                        }];
 
         return CHIP_NO_ERROR;
@@ -66381,7 +67763,9 @@ public:
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ThreadNetworkDiagnostics.RxDuplicatedCount response %@",
                                                               [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -66461,7 +67845,9 @@ public:
                                                       reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                           NSLog(@"ThreadNetworkDiagnostics.RxErrNoFrameCount response %@",
                                                               [value description]);
-                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          if (error || !mWait) {
+                                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                          }
                                                       }];
 
         return CHIP_NO_ERROR;
@@ -66544,7 +67930,9 @@ public:
                                                              NSLog(
                                                                  @"ThreadNetworkDiagnostics.RxErrUnknownNeighborCount response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -66626,7 +68014,9 @@ public:
                                                         reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"ThreadNetworkDiagnostics.RxErrInvalidSrcAddrCount response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -66706,7 +68096,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"ThreadNetworkDiagnostics.RxErrSecCount response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -66786,7 +68178,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"ThreadNetworkDiagnostics.RxErrFcsCount response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -66866,7 +68260,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ThreadNetworkDiagnostics.RxErrOtherCount response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -66946,7 +68342,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ThreadNetworkDiagnostics.ActiveTimestamp response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -67026,7 +68424,9 @@ public:
                                                      reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                          NSLog(@"ThreadNetworkDiagnostics.PendingTimestamp response %@",
                                                              [value description]);
-                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         if (error || !mWait) {
+                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                         }
                                                      }];
 
         return CHIP_NO_ERROR;
@@ -67105,7 +68505,9 @@ public:
                                 subscriptionEstablished:NULL
                                           reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                               NSLog(@"ThreadNetworkDiagnostics.Delay response %@", [value description]);
-                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              if (error || !mWait) {
+                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              }
                                           }];
 
         return CHIP_NO_ERROR;
@@ -67185,7 +68587,9 @@ public:
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"ThreadNetworkDiagnostics.SecurityPolicy response %@",
                                                            [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -67264,7 +68668,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSData * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"ThreadNetworkDiagnostics.ChannelMask response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -67347,7 +68753,9 @@ public:
                                                                 NSLog(@"ThreadNetworkDiagnostics.OperationalDatasetComponents "
                                                                       @"response %@",
                                                                     [value description]);
-                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                if (error || !mWait) {
+                                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                }
                                                             }];
 
         return CHIP_NO_ERROR;
@@ -67428,7 +68836,9 @@ public:
                                                        reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                            NSLog(@"ThreadNetworkDiagnostics.ActiveNetworkFaultsList response %@",
                                                                [value description]);
-                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           if (error || !mWait) {
+                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           }
                                                        }];
 
         return CHIP_NO_ERROR;
@@ -67508,7 +68918,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"ThreadNetworkDiagnostics.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -67588,7 +69000,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"ThreadNetworkDiagnostics.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -67668,7 +69082,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"ThreadNetworkDiagnostics.AttributeList response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -67747,7 +69163,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"ThreadNetworkDiagnostics.FeatureMap response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -67827,7 +69245,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"ThreadNetworkDiagnostics.ClusterRevision response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -67960,7 +69380,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"TimeFormatLocalization.HourFormat response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -68077,7 +69499,9 @@ public:
                                                        reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                            NSLog(@"TimeFormatLocalization.ActiveCalendarType response %@",
                                                                [value description]);
-                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           if (error || !mWait) {
+                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                           }
                                                        }];
 
         return CHIP_NO_ERROR;
@@ -68157,7 +69581,9 @@ public:
                                                            reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                                NSLog(@"TimeFormatLocalization.SupportedCalendarTypes response %@",
                                                                    [value description]);
-                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               if (error || !mWait) {
+                                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               }
                                                            }];
 
         return CHIP_NO_ERROR;
@@ -68237,7 +69663,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"TimeFormatLocalization.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -68317,7 +69745,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"TimeFormatLocalization.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -68397,7 +69827,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"TimeFormatLocalization.ClusterRevision response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -68528,7 +69960,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"UnitLocalization.TemperatureUnit response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -68607,7 +70041,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"UnitLocalization.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -68686,7 +70122,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"UnitLocalization.FeatureMap response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -68765,7 +70203,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"UnitLocalization.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -68856,7 +70296,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"UserLabel.LabelList response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -68932,7 +70374,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"UserLabel.GeneratedCommandList response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -69008,7 +70452,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"UserLabel.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -69083,7 +70529,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"UserLabel.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -69174,7 +70622,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSString * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"WakeOnLan.MACAddress response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -69250,7 +70700,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"WakeOnLan.GeneratedCommandList response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -69326,7 +70778,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"WakeOnLan.AcceptedCommandList response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -69401,7 +70855,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"WakeOnLan.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -69476,7 +70932,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"WakeOnLan.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -69618,7 +71076,9 @@ public:
                                 subscriptionEstablished:NULL
                                           reportHandler:^(NSData * _Nullable value, NSError * _Nullable error) {
                                               NSLog(@"WiFiNetworkDiagnostics.Bssid response %@", [value description]);
-                                              SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              if (error || !mWait) {
+                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                              }
                                           }];
 
         return CHIP_NO_ERROR;
@@ -69697,7 +71157,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"WiFiNetworkDiagnostics.SecurityType response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -69776,7 +71238,9 @@ public:
                                       subscriptionEstablished:NULL
                                                 reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                     NSLog(@"WiFiNetworkDiagnostics.WiFiVersion response %@", [value description]);
-                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    if (error || !mWait) {
+                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                    }
                                                 }];
 
         return CHIP_NO_ERROR;
@@ -69856,7 +71320,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"WiFiNetworkDiagnostics.ChannelNumber response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -69935,7 +71401,9 @@ public:
                                subscriptionEstablished:NULL
                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                              NSLog(@"WiFiNetworkDiagnostics.Rssi response %@", [value description]);
-                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                             if (error || !mWait) {
+                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                             }
                                          }];
 
         return CHIP_NO_ERROR;
@@ -70015,7 +71483,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"WiFiNetworkDiagnostics.BeaconLostCount response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -70095,7 +71565,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"WiFiNetworkDiagnostics.BeaconRxCount response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -70175,7 +71647,9 @@ public:
                                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                NSLog(@"WiFiNetworkDiagnostics.PacketMulticastRxCount response %@",
                                                                    [value description]);
-                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               if (error || !mWait) {
+                                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               }
                                                            }];
 
         return CHIP_NO_ERROR;
@@ -70255,7 +71729,9 @@ public:
                                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                NSLog(@"WiFiNetworkDiagnostics.PacketMulticastTxCount response %@",
                                                                    [value description]);
-                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               if (error || !mWait) {
+                                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               }
                                                            }];
 
         return CHIP_NO_ERROR;
@@ -70335,7 +71811,9 @@ public:
                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"WiFiNetworkDiagnostics.PacketUnicastRxCount response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -70415,7 +71893,9 @@ public:
                                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"WiFiNetworkDiagnostics.PacketUnicastTxCount response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -70495,7 +71975,9 @@ public:
                                     subscriptionEstablished:NULL
                                               reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                   NSLog(@"WiFiNetworkDiagnostics.CurrentMaxRate response %@", [value description]);
-                                                  SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  if (error || !mWait) {
+                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                  }
                                               }];
 
         return CHIP_NO_ERROR;
@@ -70574,7 +72056,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"WiFiNetworkDiagnostics.OverrunCount response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -70654,7 +72138,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"WiFiNetworkDiagnostics.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -70734,7 +72220,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"WiFiNetworkDiagnostics.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -70814,7 +72302,9 @@ public:
                                    subscriptionEstablished:NULL
                                              reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                  NSLog(@"WiFiNetworkDiagnostics.AttributeList response %@", [value description]);
-                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 if (error || !mWait) {
+                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                 }
                                              }];
 
         return CHIP_NO_ERROR;
@@ -70893,7 +72383,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"WiFiNetworkDiagnostics.FeatureMap response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -70973,7 +72465,9 @@ public:
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"WiFiNetworkDiagnostics.ClusterRevision response %@",
                                                             [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;
@@ -71321,7 +72815,9 @@ public:
                                subscriptionEstablished:NULL
                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                              NSLog(@"WindowCovering.Type response %@", [value description]);
-                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                             if (error || !mWait) {
+                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                             }
                                          }];
 
         return CHIP_NO_ERROR;
@@ -71397,7 +72893,9 @@ public:
                                                         reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"WindowCovering.CurrentPositionLift response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -71473,7 +72971,9 @@ public:
                                                         reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"WindowCovering.CurrentPositionTilt response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -71548,7 +73048,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"WindowCovering.ConfigStatus response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -71627,7 +73129,9 @@ public:
                                                                  NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                  NSLog(@"WindowCovering.CurrentPositionLiftPercentage response %@",
                                                                      [value description]);
-                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                 if (error || !mWait) {
+                                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                 }
                                                              }];
 
         return CHIP_NO_ERROR;
@@ -71706,7 +73210,9 @@ public:
                                                                  NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                  NSLog(@"WindowCovering.CurrentPositionTiltPercentage response %@",
                                                                      [value description]);
-                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                 if (error || !mWait) {
+                                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                 }
                                                              }];
 
         return CHIP_NO_ERROR;
@@ -71782,7 +73288,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"WindowCovering.OperationalStatus response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -71862,7 +73370,9 @@ public:
                                                                    NSLog(@"WindowCovering.TargetPositionLiftPercent100ths response "
                                                                          @"%@",
                                                                        [value description]);
-                                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                   if (error || !mWait) {
+                                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                   }
                                                                }];
 
         return CHIP_NO_ERROR;
@@ -71942,7 +73452,9 @@ public:
                                                                    NSLog(@"WindowCovering.TargetPositionTiltPercent100ths response "
                                                                          @"%@",
                                                                        [value description]);
-                                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                   if (error || !mWait) {
+                                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                                   }
                                                                }];
 
         return CHIP_NO_ERROR;
@@ -72017,7 +73529,9 @@ public:
                                          subscriptionEstablished:NULL
                                                    reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                        NSLog(@"WindowCovering.EndProductType response %@", [value description]);
-                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       if (error || !mWait) {
+                                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                       }
                                                    }];
 
         return CHIP_NO_ERROR;
@@ -72087,18 +73601,20 @@ public:
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
         CHIPWindowCovering * cluster = [[CHIPWindowCovering alloc] initWithDevice:device endpoint:endpointId queue:callbackQueue];
         CHIPSubscribeParams * params = [[CHIPSubscribeParams alloc] init];
-        [cluster
-            subscribeAttributeCurrentPositionLiftPercent100thsWithMinInterval:[NSNumber numberWithUnsignedInt:mMinInterval]
-                                                                  maxInterval:[NSNumber numberWithUnsignedInt:mMaxInterval]
-                                                                       params:params
-                                                      subscriptionEstablished:NULL
-                                                                reportHandler:^(
-                                                                    NSNumber * _Nullable value, NSError * _Nullable error) {
-                                                                    NSLog(@"WindowCovering.CurrentPositionLiftPercent100ths "
-                                                                          @"response %@",
-                                                                        [value description]);
-                                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
-                                                                }];
+        [cluster subscribeAttributeCurrentPositionLiftPercent100thsWithMinInterval:[NSNumber numberWithUnsignedInt:mMinInterval]
+                                                                       maxInterval:[NSNumber numberWithUnsignedInt:mMaxInterval]
+                                                                            params:params
+                                                           subscriptionEstablished:NULL
+                                                                     reportHandler:^(
+                                                                         NSNumber * _Nullable value, NSError * _Nullable error) {
+                                                                         NSLog(@"WindowCovering.CurrentPositionLiftPercent100ths "
+                                                                               @"response %@",
+                                                                             [value description]);
+                                                                         if (error || !mWait) {
+                                                                             SetCommandExitStatus(
+                                                                                 [CHIPError errorToCHIPErrorCode:error]);
+                                                                         }
+                                                                     }];
 
         return CHIP_NO_ERROR;
     }
@@ -72167,18 +73683,20 @@ public:
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
         CHIPWindowCovering * cluster = [[CHIPWindowCovering alloc] initWithDevice:device endpoint:endpointId queue:callbackQueue];
         CHIPSubscribeParams * params = [[CHIPSubscribeParams alloc] init];
-        [cluster
-            subscribeAttributeCurrentPositionTiltPercent100thsWithMinInterval:[NSNumber numberWithUnsignedInt:mMinInterval]
-                                                                  maxInterval:[NSNumber numberWithUnsignedInt:mMaxInterval]
-                                                                       params:params
-                                                      subscriptionEstablished:NULL
-                                                                reportHandler:^(
-                                                                    NSNumber * _Nullable value, NSError * _Nullable error) {
-                                                                    NSLog(@"WindowCovering.CurrentPositionTiltPercent100ths "
-                                                                          @"response %@",
-                                                                        [value description]);
-                                                                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
-                                                                }];
+        [cluster subscribeAttributeCurrentPositionTiltPercent100thsWithMinInterval:[NSNumber numberWithUnsignedInt:mMinInterval]
+                                                                       maxInterval:[NSNumber numberWithUnsignedInt:mMaxInterval]
+                                                                            params:params
+                                                           subscriptionEstablished:NULL
+                                                                     reportHandler:^(
+                                                                         NSNumber * _Nullable value, NSError * _Nullable error) {
+                                                                         NSLog(@"WindowCovering.CurrentPositionTiltPercent100ths "
+                                                                               @"response %@",
+                                                                             [value description]);
+                                                                         if (error || !mWait) {
+                                                                             SetCommandExitStatus(
+                                                                                 [CHIPError errorToCHIPErrorCode:error]);
+                                                                         }
+                                                                     }];
 
         return CHIP_NO_ERROR;
     }
@@ -72253,7 +73771,9 @@ public:
                                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                NSLog(@"WindowCovering.InstalledOpenLimitLift response %@",
                                                                    [value description]);
-                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               if (error || !mWait) {
+                                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               }
                                                            }];
 
         return CHIP_NO_ERROR;
@@ -72331,7 +73851,9 @@ public:
                                                         reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"WindowCovering.InstalledClosedLimitLift response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -72407,7 +73929,9 @@ public:
                                                            reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                                NSLog(@"WindowCovering.InstalledOpenLimitTilt response %@",
                                                                    [value description]);
-                                                               SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               if (error || !mWait) {
+                                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                               }
                                                            }];
 
         return CHIP_NO_ERROR;
@@ -72485,7 +74009,9 @@ public:
                                                         reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"WindowCovering.InstalledClosedLimitTilt response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -72594,7 +74120,9 @@ public:
                                subscriptionEstablished:NULL
                                          reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                              NSLog(@"WindowCovering.Mode response %@", [value description]);
-                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                             if (error || !mWait) {
+                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                             }
                                          }];
 
         return CHIP_NO_ERROR;
@@ -72669,7 +74197,9 @@ public:
                                        subscriptionEstablished:NULL
                                                  reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                      NSLog(@"WindowCovering.SafetyStatus response %@", [value description]);
-                                                     SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     if (error || !mWait) {
+                                                         SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                     }
                                                  }];
 
         return CHIP_NO_ERROR;
@@ -72745,7 +74275,9 @@ public:
                                                          reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                              NSLog(@"WindowCovering.GeneratedCommandList response %@",
                                                                  [value description]);
-                                                             SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             if (error || !mWait) {
+                                                                 SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                             }
                                                          }];
 
         return CHIP_NO_ERROR;
@@ -72821,7 +74353,9 @@ public:
                                                         reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                             NSLog(@"WindowCovering.AcceptedCommandList response %@",
                                                                 [value description]);
-                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            if (error || !mWait) {
+                                                                SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                            }
                                                         }];
 
         return CHIP_NO_ERROR;
@@ -72896,7 +74430,9 @@ public:
                                         subscriptionEstablished:NULL
                                                   reportHandler:^(NSArray * _Nullable value, NSError * _Nullable error) {
                                                       NSLog(@"WindowCovering.AttributeList response %@", [value description]);
-                                                      SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      if (error || !mWait) {
+                                                          SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                      }
                                                   }];
 
         return CHIP_NO_ERROR;
@@ -72971,7 +74507,9 @@ public:
                                      subscriptionEstablished:NULL
                                                reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                    NSLog(@"WindowCovering.FeatureMap response %@", [value description]);
-                                                   SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   if (error || !mWait) {
+                                                       SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                   }
                                                }];
 
         return CHIP_NO_ERROR;
@@ -73046,7 +74584,9 @@ public:
                                           subscriptionEstablished:NULL
                                                     reportHandler:^(NSNumber * _Nullable value, NSError * _Nullable error) {
                                                         NSLog(@"WindowCovering.ClusterRevision response %@", [value description]);
-                                                        SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        if (error || !mWait) {
+                                                            SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                                        }
                                                     }];
 
         return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem
Currently, the subscription calls exits chip-tool-darwin when a single event is received. See issue below:
- https://github.com/project-chip/connectedhomeip/issues/16585

#### Change overview
- Allow chip-tool-darwin to wait for subscription notifications if wait is passed it, until user cancels. 

#### Testing
- Generated and compiled code.

- Start the all clusters app.

- Started the subscription from chip-tool-darwin with wait

- Made accessory send notifications.

- Validated chip-tool-darwin received multiple notifications.   

- Validated the wait == 0  does not wait.
 
