### PR TITLE
Stop using a fixed salt when opening commissioning windows.

### DIFF
--- a/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.cpp
+++ b/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.cpp
@@ -35,7 +35,7 @@ CHIP_ERROR OpenCommissioningWindowCommand::RunCommand()
     {
         SetupPayload ignored;
         return mWindowOpener->OpenCommissioningWindow(mNodeId, System::Clock::Seconds16(mTimeout), mIteration, mDiscriminator,
-                                                      NullOptional, &mOnOpenCommissioningWindowCallback, ignored,
+                                                      NullOptional, NullOptional, &mOnOpenCommissioningWindowCallback, ignored,
                                                       /* readVIDPIDAttributes */ true);
     }
 

--- a/src/controller/CommissioningWindowOpener.cpp
+++ b/src/controller/CommissioningWindowOpener.cpp
@@ -65,7 +65,7 @@ CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindow(NodeId deviceId, S
                         CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(
         !salt.HasValue() ||
-            (salt.Value().size() >= kSpake2p_Max_PBKDF_Salt_Length && salt.Value().size() <= kSpake2p_Max_PBKDF_Salt_Length),
+            (salt.Value().size() >= kSpake2p_Min_PBKDF_Salt_Length && salt.Value().size() <= kSpake2p_Max_PBKDF_Salt_Length),
         CHIP_ERROR_INVALID_ARGUMENT);
 
     mSetupPayload = SetupPayload();

--- a/src/controller/CommissioningWindowOpener.cpp
+++ b/src/controller/CommissioningWindowOpener.cpp
@@ -87,10 +87,8 @@ CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindow(NodeId deviceId, S
     }
     else
     {
-        // What size should we use?
-        constexpr size_t saltLength = (kSpake2p_Min_PBKDF_Salt_Length + kSpake2p_Max_PBKDF_Salt_Length) / 2;
-        ReturnErrorOnFailure(DRBG_get_bytes(mPBKDFSaltBuffer, saltLength));
-        mPBKDFSalt = ByteSpan(mPBKDFSaltBuffer, saltLength);
+        ReturnErrorOnFailure(DRBG_get_bytes(mPBKDFSaltBuffer, sizeof(mPBKDFSaltBuffer)));
+        mPBKDFSalt = ByteSpan(mPBKDFSaltBuffer);
     }
 
     mSetupPayload.version               = 0;

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -624,9 +624,9 @@ JNI_METHOD(jboolean, openPairingWindowWithPIN)
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
 
     chip::SetupPayload setupPayload;
-    err = AutoCommissioningWindowOpener::OpenCommissioningWindow(wrapper->Controller(), chipDevice->GetDeviceId(),
-                                                                 System::Clock::Seconds16(duration), iteration, discriminator,
-                                                                 MakeOptional(static_cast<uint32_t>(setupPinCode)), setupPayload);
+    err = AutoCommissioningWindowOpener::OpenCommissioningWindow(
+        wrapper->Controller(), chipDevice->GetDeviceId(), System::Clock::Seconds16(duration), iteration, discriminator,
+        MakeOptional(static_cast<uint32_t>(setupPinCode)), NullOptional, setupPayload);
 
     if (err != CHIP_NO_ERROR)
     {

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -426,7 +426,8 @@ ChipError::StorageType pychip_DeviceController_OpenCommissioningWindow(chip::Con
     {
         SetupPayload payload;
         return Controller::AutoCommissioningWindowOpener::OpenCommissioningWindow(
-                   devCtrl, nodeid, System::Clock::Seconds16(timeout), iteration, discriminator, NullOptional, payload)
+                   devCtrl, nodeid, System::Clock::Seconds16(timeout), iteration, discriminator, NullOptional, NullOptional,
+                   payload)
             .AsInteger();
     }
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -527,7 +527,8 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
     chip::SetupPayload setupPayload;
     err = chip::Controller::AutoCommissioningWindowOpener::OpenCommissioningWindow(self.cppCommissioner, deviceID,
         chip::System::Clock::Seconds16(static_cast<uint16_t>(duration)), chip::Crypto::kSpake2p_Min_PBKDF_Iterations,
-        static_cast<uint16_t>(discriminator), chip::MakeOptional(static_cast<uint32_t>(setupPIN)), setupPayload);
+        static_cast<uint16_t>(discriminator), chip::MakeOptional(static_cast<uint32_t>(setupPIN)), chip::NullOptional,
+        setupPayload);
 
     if (err != CHIP_NO_ERROR) {
         CHIP_LOG_ERROR("Error(%s): Open Pairing Window failed", chip::ErrorStr(err));


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/10586

#### Problem
We're using a hardcoded salt value, which is not the right thing.

#### Change overview
Add a way for consumers to pass in a salt (if they want to reuse a single onboarding payload for multiple devices) or have it be randomly generated.

#### Testing
Verified that `chip-tool pairing open-commissioning-window` works and I can then commission into a different fabric using the resulting onboarding payload.