### PR TITLE
Allow access to SystemState pointer from DeviceControllerFactory

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -138,6 +138,17 @@ public:
     //
     void ReleaseSystemState() { mSystemState->Release(); }
 
+    //
+    // Retrieve a read-only pointer to the system state object that contains pointers to key stack
+    // singletons. If the pointer is null, it indicates that the DeviceControllerFactory has yet to
+    // be initialized properly, or has already been shut-down.
+    //
+    // This pointer ceases to be valid after a call to Shutdown has been made, or if all active
+    // DeviceController instances have gone to 0. Consequently, care has to be taken to correctly
+    // sequence the shutting down of active controllers with any entity that interacts with objects
+    // present in the system state object. If de-coupling is desired, RetainSystemState and
+    // ReleaseSystemState can be used to avoid this.
+    //
     const DeviceControllerSystemState * GetSystemState() const { return mSystemState; }
 
     class ControllerFabricDelegate final : public FabricTableDelegate

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -138,7 +138,7 @@ public:
     //
     void ReleaseSystemState() { mSystemState->Release(); }
 
-    const DeviceControllerSystemState * GetSystemState() { return mSystemState; }
+    const DeviceControllerSystemState * GetSystemState() const { return mSystemState; }
 
     class ControllerFabricDelegate final : public FabricTableDelegate
     {

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -138,6 +138,8 @@ public:
     //
     void ReleaseSystemState() { mSystemState->Release(); }
 
+    const DeviceControllerSystemState * GetSystemState() { return mSystemState; }
+
     class ControllerFabricDelegate final : public FabricTableDelegate
     {
     public:


### PR DESCRIPTION
#### Problem
When using `DeviceControllerFactory`, callers have no way of accessing the `DeviceControllerSystemState` pointer. Applications may need access if, for example, they want to register an UnsolicitedMessageHandler for some Protocol like BDX through the `ExchangeManager` instance.

#### Change overview
Add a method to `DeviceControllerFactory` to get a pointer to the `DeviceControllerSystemState` member.

#### Testing
N/A
