### PR TITLE
Update example apps for Infineon P6 Platform

### DIFF
--- a/examples/all-clusters-app/p6/args.gni
+++ b/examples/all-clusters-app/p6/args.gni
@@ -18,9 +18,3 @@ import("${chip_root}/src/platform/P6/args.gni")
 
 p6_target_project =
     get_label_info(":all_clusters_app_sdk_sources", "label_no_toolchain")
-
-declare_args() {
-  # Disable lock tracking, since our FreeRTOS configuration does not set
-  # INCLUDE_xSemaphoreGetMutexHolder
-  chip_stack_lock_tracking = "none"
-}

--- a/examples/all-clusters-app/p6/include/AppTask.h
+++ b/examples/all-clusters-app/p6/include/AppTask.h
@@ -54,7 +54,7 @@ private:
 
     static AppTask sAppTask;
     void DispatchEvent(AppEvent * event);
-    static void OnOffUpdateClusterState(void);
+    static void OnOffUpdateClusterState(intptr_t context);
 };
 
 inline AppTask & GetAppTask(void)

--- a/examples/all-clusters-app/p6/src/AppTask.cpp
+++ b/examples/all-clusters-app/p6/src/AppTask.cpp
@@ -81,6 +81,15 @@ void NetWorkCommissioningInstInit()
     sWiFiNetworkCommissioningInstance.Init();
 }
 
+static void InitServer(intptr_t context)
+{
+    // Init ZCL Data Model
+    chip::Server::GetInstance().Init();
+
+    // Initialize device attestation config
+    SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+}
+
 CHIP_ERROR AppTask::StartAppTask()
 {
     sAppEventQueue = xQueueCreateStatic(APP_EVENT_QUEUE_SIZE, sizeof(AppEvent), sAppEventQueueBuffer, &sAppEventQueueStruct);
@@ -112,11 +121,8 @@ CHIP_ERROR AppTask::Init()
             }
         },
         0);
-    // Init ZCL Data Model
-    chip::Server::GetInstance().Init();
 
-    // Initialize device attestation config
-    SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
 
     // Initialise WSTK buttons PB0 and PB1 (including debounce).
     ButtonHandler::Init();
@@ -166,7 +172,7 @@ void AppTask::LightActionEventHandler(AppEvent * aEvent)
     sLightLED.Invert();
 
     /* Update OnOff Cluster state */
-    sAppTask.OnOffUpdateClusterState();
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(OnOffUpdateClusterState, reinterpret_cast<intptr_t>(nullptr));
 }
 
 void AppTask::ButtonEventHandler(uint8_t btnIdx, uint8_t btnAction)
@@ -232,7 +238,7 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
     }
 }
 
-void AppTask::OnOffUpdateClusterState(void)
+void AppTask::OnOffUpdateClusterState(intptr_t context)
 {
     uint8_t onoff = sLightLED.Get();
 

--- a/examples/lighting-app/p6/args.gni
+++ b/examples/lighting-app/p6/args.gni
@@ -18,9 +18,3 @@ import("${chip_root}/src/platform/P6/args.gni")
 
 p6_target_project =
     get_label_info(":lighting_app_sdk_sources", "label_no_toolchain")
-
-declare_args() {
-  # Disable lock tracking, since our FreeRTOS configuration does not set
-  # INCLUDE_xSemaphoreGetMutexHolder
-  chip_stack_lock_tracking = "none"
-}

--- a/examples/lighting-app/p6/include/AppTask.h
+++ b/examples/lighting-app/p6/include/AppTask.h
@@ -67,7 +67,7 @@ private:
     static void LightActionEventHandler(AppEvent * aEvent);
     static void TimerEventHandler(TimerHandle_t xTimer);
 
-    static void UpdateClusterState(void);
+    static void UpdateClusterState(intptr_t context);
 
     void StartTimer(uint32_t aTimeoutMs);
 

--- a/examples/lighting-app/p6/src/AppTask.cpp
+++ b/examples/lighting-app/p6/src/AppTask.cpp
@@ -85,6 +85,15 @@ void NetWorkCommissioningInstInit()
     sWiFiNetworkCommissioningInstance.Init();
 }
 
+static void InitServer(intptr_t context)
+{
+    // Init ZCL Data Model
+    chip::Server::GetInstance().Init();
+
+    // Initialize device attestation config
+    SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+}
+
 CHIP_ERROR AppTask::StartAppTask()
 {
     sAppEventQueue = xQueueCreateStatic(APP_EVENT_QUEUE_SIZE, sizeof(AppEvent), sAppEventQueueBuffer, &sAppEventQueueStruct);
@@ -117,11 +126,8 @@ CHIP_ERROR AppTask::Init()
             }
         },
         0);
-    // Init ZCL Data Model
-    chip::Server::GetInstance().Init();
 
-    // Initialize device attestation config
-    SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
 
     // Initialise WSTK buttons PB0 and PB1 (including debounce).
     ButtonHandler::Init();
@@ -153,7 +159,6 @@ CHIP_ERROR AppTask::Init()
     sStatusLED.Init(SYSTEM_STATE_LED);
     sLightLED.Init(LIGHT_LED);
     sLightLED.Set(LightMgr().IsLightOn());
-    UpdateClusterState();
 
     ConfigurationMgr().LogDeviceConfig();
 
@@ -445,7 +450,7 @@ void AppTask::ActionCompleted(LightingManager::Action_t aAction)
 
     if (sAppTask.mSyncClusterToButtonAction)
     {
-        UpdateClusterState();
+        chip::DeviceLayer::PlatformMgr().ScheduleWork(UpdateClusterState, reinterpret_cast<intptr_t>(nullptr));
         sAppTask.mSyncClusterToButtonAction = false;
     }
 }
@@ -504,7 +509,7 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
     }
 }
 
-void AppTask::UpdateClusterState(void)
+void AppTask::UpdateClusterState(intptr_t context)
 {
     uint8_t newValue = LightMgr().IsLightOn();
 

--- a/examples/lock-app/p6/args.gni
+++ b/examples/lock-app/p6/args.gni
@@ -18,9 +18,3 @@ import("${chip_root}/src/platform/P6/args.gni")
 
 p6_target_project =
     get_label_info(":lock_app_sdk_sources", "label_no_toolchain")
-
-declare_args() {
-  # Disable lock tracking, since our FreeRTOS configuration does not set
-  # INCLUDE_xSemaphoreGetMutexHolder
-  chip_stack_lock_tracking = "none"
-}

--- a/examples/lock-app/p6/include/AppTask.h
+++ b/examples/lock-app/p6/include/AppTask.h
@@ -68,6 +68,8 @@ private:
     static void LockActionEventHandler(AppEvent * event);
     static void TimerEventHandler(TimerHandle_t timer);
 
+    static void UpdateCluster(intptr_t context);
+
     void StartTimer(uint32_t aTimeoutMs);
 
     enum class Function

--- a/examples/lock-app/p6/src/AppTask.cpp
+++ b/examples/lock-app/p6/src/AppTask.cpp
@@ -83,6 +83,15 @@ void NetWorkCommissioningInstInit()
     sWiFiNetworkCommissioningInstance.Init();
 }
 
+static void InitServer(intptr_t context)
+{
+    // Init ZCL Data Model
+    chip::Server::GetInstance().Init();
+
+    // Initialize device attestation config
+    SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+}
+
 CHIP_ERROR AppTask::StartAppTask()
 {
     sAppEventQueue = xQueueCreate(APP_EVENT_QUEUE_SIZE, sizeof(AppEvent));
@@ -115,11 +124,8 @@ CHIP_ERROR AppTask::Init()
             }
         },
         0);
-    // Init ZCL Data Model
-    chip::Server::GetInstance().Init();
 
-    // Initialize device attestation config
-    SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
 
     // Initialise WSTK buttons PB0 and PB1 (including debounce).
     ButtonHandler::Init();
@@ -151,7 +157,6 @@ CHIP_ERROR AppTask::Init()
     sStatusLED.Init(SYSTEM_STATE_LED);
     sLockLED.Init(LOCK_STATE_LED);
     sLockLED.Set(!BoltLockMgr().IsUnlocked());
-    UpdateClusterState();
 
     ConfigurationMgr().LogDeviceConfig();
 
@@ -490,7 +495,7 @@ void AppTask::DispatchEvent(AppEvent * event)
     }
 }
 
-void AppTask::UpdateClusterState(void)
+void AppTask::UpdateCluster(intptr_t context)
 {
     uint8_t newValue = !BoltLockMgr().IsUnlocked();
 
@@ -502,6 +507,12 @@ void AppTask::UpdateClusterState(void)
         P6_LOG("ERR: updating on/off %x", status);
     }
 }
+
+void AppTask::UpdateClusterState(void)
+{
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(UpdateCluster, reinterpret_cast<intptr_t>(nullptr));
+}
+
 void vApplicationStackOverflowHook(TaskHandle_t pxTask, char * pcTaskName)
 {
     (void) pxTask;

--- a/examples/ota-requestor-app/p6/README.md
+++ b/examples/ota-requestor-app/p6/README.md
@@ -54,11 +54,11 @@ will then join the network.
 
 *   Build the P6 OTA Requestor application from the chip root dir:
 
-          $ ./examples/ota-requestor-app/examples/ota_base_build.sh
+          $ ./examples/ota-requestor-app/p6/ota_base_build.sh
 
 *   Build the P6 OTA Update application from the chip root dir:
 
-          $ ./examples/ota-requestor-app/examples/ota_update_build.sh
+          $ ./examples/ota-requestor-app/p6/ota_update_build.sh
 
 *   On a RPi4: Build the Linux OTA Provider application from the chip root dir:
 

--- a/examples/ota-requestor-app/p6/args.gni
+++ b/examples/ota-requestor-app/p6/args.gni
@@ -18,10 +18,6 @@ import("${chip_root}/src/platform/P6/args.gni")
 
 declare_args() {
   chip_enable_ota_requestor = true
-
-  # Disable lock tracking, since our FreeRTOS configuration does not set
-  # INCLUDE_xSemaphoreGetMutexHolder
-  chip_stack_lock_tracking = "none"
 }
 
 p6_target_project =

--- a/examples/ota-requestor-app/p6/src/AppTask.cpp
+++ b/examples/ota-requestor-app/p6/src/AppTask.cpp
@@ -112,6 +112,15 @@ void NetWorkCommissioningInstInit()
     sWiFiNetworkCommissioningInstance.Init();
 }
 
+static void InitServer(intptr_t context)
+{
+    // Init ZCL Data Model
+    chip::Server::GetInstance().Init();
+
+    // Initialize device attestation config
+    SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+}
+
 CHIP_ERROR AppTask::StartAppTask()
 {
     sAppEventQueue = xQueueCreateStatic(APP_EVENT_QUEUE_SIZE, sizeof(AppEvent), sAppEventQueueBuffer, &sAppEventQueueStruct);
@@ -151,11 +160,8 @@ CHIP_ERROR AppTask::Init()
             }
         },
         0);
-    // Init ZCL Data Model
-    chip::Server::GetInstance().Init();
 
-    // Initialize device attestation config
-    SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
 
     // Initialise WSTK buttons PB0 and PB1 (including debounce).
     ButtonHandler::Init();

--- a/third_party/p6/p6_sdk/configs/FreeRTOSConfig.h
+++ b/third_party/p6/p6_sdk/configs/FreeRTOSConfig.h
@@ -155,6 +155,7 @@ to exclude the API function. */
 #define INCLUDE_vTaskDelay 1
 #define INCLUDE_xTaskIsTaskFinished 1
 #define INCLUDE_xTimerPendFunctionCall 1
+#define INCLUDE_xSemaphoreGetMutexHolder 1
 
 /* Normal assert() semantics without relying on the provision of an assert.h
 header file. */


### PR DESCRIPTION
#### Problem
Infineon P6 Platform examples has chip_stack_lock_tracking disabled

#### Change overview
- Update all P6 example apps with changes to support chip_stack_lock_tracking
>  Added Schedule work for Server init which tries to write/read attributes which has to be done on CHIP task only
- Update README.md for OTA Requestor


#### Testing
Manually tested all apps with chip-tool 