### PR TITLE
[Inet] Add TCPEndpointImpl for OpenThread

### DIFF
--- a/examples/light-switch-app/efr32/args.gni
+++ b/examples/light-switch-app/efr32/args.gni
@@ -25,4 +25,3 @@ declare_args() {
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"
 chip_enable_openthread = true
-chip_system_config_use_open_thread_udp = true

--- a/examples/lighting-app/efr32/args.gni
+++ b/examples/lighting-app/efr32/args.gni
@@ -25,4 +25,3 @@ declare_args() {
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"
 chip_enable_openthread = true
-chip_system_config_use_open_thread_udp = true

--- a/examples/lock-app/efr32/args.gni
+++ b/examples/lock-app/efr32/args.gni
@@ -23,6 +23,5 @@ declare_args() {
 }
 
 chip_enable_openthread = true
-chip_system_config_use_open_thread_udp = true
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"

--- a/examples/persistent-storage/qpg/args.gni
+++ b/examples/persistent-storage/qpg/args.gni
@@ -18,7 +18,7 @@ import("${chip_root}/examples/platform/qpg/args.gni")
 qpg_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 chip_enable_openthread = false
 chip_openthread_ftd = false
-chip_system_config_use_open_thread_udp = false
+chip_system_config_use_open_thread_inet_endpoints = false
 
 declare_args() {
   # Disable lock tracking, since our FreeRTOS configuration does not set

--- a/examples/window-app/efr32/args.gni
+++ b/examples/window-app/efr32/args.gni
@@ -26,4 +26,3 @@ declare_args() {
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"
 chip_enable_openthread = true
-chip_system_config_use_open_thread_udp = true

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -150,9 +150,9 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
     err = mTransports.Init(UdpListenParameters(DeviceLayer::UDPEndPointManager())
                                .SetAddressType(IPAddressType::kIPv6)
                                .SetListenPort(mSecuredServicePort)
-#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_UDP
+#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
                                .SetNativeParams(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance())
-#endif // CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_UDP
+#endif // CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 
 #if INET_CONFIG_ENABLE_IPV4
                                ,

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -24,7 +24,7 @@ import("${chip_root}/src/lwip/lwip.gni")
 import("${chip_root}/src/platform/device.gni")
 import("inet.gni")
 
-if (chip_system_config_use_open_thread_udp) {
+if (chip_system_config_use_open_thread_inet_endpoints) {
   import("//build_overrides/openthread.gni")
 }
 
@@ -55,13 +55,7 @@ buildconfig_header("inet_buildconfig") {
   }
 
   defines += [ "INET_TCP_END_POINT_IMPL_CONFIG_FILE=<inet/TCPEndPointImpl${chip_system_config_inet}.h>" ]
-  if (chip_system_config_use_open_thread_udp) {
-    defines += [
-      "INET_UDP_END_POINT_IMPL_CONFIG_FILE=<inet/UDPEndPointImpl_OpenThread.h>",
-    ]
-  } else {
-    defines += [ "INET_UDP_END_POINT_IMPL_CONFIG_FILE=<inet/UDPEndPointImpl${chip_system_config_inet}.h>" ]
-  }
+  defines += [ "INET_UDP_END_POINT_IMPL_CONFIG_FILE=<inet/UDPEndPointImpl${chip_system_config_inet}.h>" ]
 }
 
 source_set("inet_config_header") {
@@ -113,7 +107,7 @@ static_library("inet") {
     public_deps += [ "${chip_root}/src/lwip" ]
   }
 
-  if (chip_system_config_use_open_thread_udp) {
+  if (chip_system_config_use_open_thread_inet_endpoints) {
     if (chip_openthread_ftd) {
       public_deps +=
           [ "${chip_root}/third_party/openthread/repo:libopenthread-ftd" ]
@@ -137,20 +131,10 @@ static_library("inet") {
     sources += [
       "UDPEndPoint.cpp",
       "UDPEndPoint.h",
+      "UDPEndPointImpl${chip_system_config_inet}.cpp",
+      "UDPEndPointImpl${chip_system_config_inet}.h",
       "UDPEndPointImpl.h",
     ]
-
-    if (chip_system_config_use_open_thread_udp) {
-      sources += [
-        "UDPEndPointImpl_OpenThread.cpp",
-        "UDPEndPointImpl_OpenThread.h",
-      ]
-    } else {
-      sources += [
-        "UDPEndPointImpl${chip_system_config_inet}.cpp",
-        "UDPEndPointImpl${chip_system_config_inet}.h",
-      ]
-    }
   }
 
   if (chip_with_nlfaultinjection) {

--- a/src/inet/EndPointStateOpenThread.h
+++ b/src/inet/EndPointStateOpenThread.h
@@ -1,0 +1,49 @@
+/*
+ *
+ *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *  Shared state for OpenThread implementations of TCPEndPoint and UDPEndPoint.
+ */
+
+#pragma once
+
+#include <inet/EndPointBasis.h>
+
+#include <inet/IPAddress.h>
+
+namespace chip {
+namespace Inet {
+
+/**
+ * Definitions shared by all OpenThread EndPoint classes.
+ */
+class DLL_EXPORT EndPointStateOpenThread
+{
+protected:
+    EndPointStateOpenThread() : mOpenThreadEndPointType(OpenThreadEndPointType::Unknown) {}
+
+    enum class OpenThreadEndPointType : uint8_t
+    {
+        Unknown = 0,
+        UDP     = 1,
+        TCP     = 2
+    } mOpenThreadEndPointType;
+};
+
+} // namespace Inet
+} // namespace chip

--- a/src/inet/TCPEndPointImplOpenThread.cpp
+++ b/src/inet/TCPEndPointImplOpenThread.cpp
@@ -1,0 +1,96 @@
+/*
+ *
+ *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2018 Google LLC.
+ *    Copyright (c) 2013-2018 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <inet/TCPEndPointImplOpenThread.h>
+
+#include <lib/support/CodeUtils.h>
+#include <lib/support/SafeInt.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+#include <platform/OpenThread/OpenThreadUtils.h>
+
+#include <system/SystemPacketBuffer.h>
+
+namespace chip {
+namespace Inet {
+
+CHIP_ERROR TCPEndPointImplOT::GetPeerInfo(IPAddress * retAddr, uint16_t * retPort) const
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+CHIP_ERROR TCPEndPointImplOT::GetLocalInfo(IPAddress * retAddr, uint16_t * retPort) const
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+CHIP_ERROR TCPEndPointImplOT::GetInterfaceId(InterfaceId * retInterface)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+CHIP_ERROR TCPEndPointImplOT::EnableNoDelay()
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+CHIP_ERROR TCPEndPointImplOT::EnableKeepAlive(uint16_t interval, uint16_t timeoutCount)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+CHIP_ERROR TCPEndPointImplOT::DisableKeepAlive()
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+CHIP_ERROR TCPEndPointImplOT::AckReceive(uint16_t len)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR TCPEndPointImplOT::BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, bool reuseAddr)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+CHIP_ERROR TCPEndPointImplOT::ListenImpl(uint16_t backlog)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+CHIP_ERROR TCPEndPointImplOT::ConnectImpl(const IPAddress & addr, uint16_t port, InterfaceId intfId)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+CHIP_ERROR TCPEndPointImplOT::SendQueuedImpl(bool queueWasEmpty)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+CHIP_ERROR TCPEndPointImplOT::SetUserTimeoutImpl(uint32_t userTimeoutMillis)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+CHIP_ERROR TCPEndPointImplOT::DriveSendingImpl()
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+void TCPEndPointImplOT::HandleConnectCompleteImpl()
+{
+    // Not implemented
+}
+void TCPEndPointImplOT::DoCloseImpl(CHIP_ERROR err, State oldState)
+{
+    // Not implemented
+}
+
+} // namespace Inet
+} // namespace chip

--- a/src/inet/TCPEndPointImplOpenThread.h
+++ b/src/inet/TCPEndPointImplOpenThread.h
@@ -1,0 +1,73 @@
+/*
+ *
+ *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2018 Google LLC
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <inet/EndPointStateOpenThread.h>
+#include <inet/TCPEndPoint.h>
+
+#include <openthread/error.h>
+#include <openthread/icmp6.h>
+#include <openthread/ip6.h>
+#include <openthread/netdata.h>
+#include <openthread/tcp.h>
+#include <openthread/thread.h>
+
+namespace chip {
+namespace Inet {
+
+class TCPEndPointImplOT : public TCPEndPoint, public EndPointStateOpenThread
+{
+public:
+    TCPEndPointImplOT(EndPointManager<TCPEndPoint> & endPointManager) :
+        TCPEndPoint(endPointManager), mBoundIntfId(InterfaceId::Null())
+    {}
+
+    // TCPEndPoint overrides.
+    CHIP_ERROR GetPeerInfo(IPAddress * retAddr, uint16_t * retPort) const override;
+    CHIP_ERROR GetLocalInfo(IPAddress * retAddr, uint16_t * retPort) const override;
+    CHIP_ERROR GetInterfaceId(InterfaceId * retInterface) override;
+    CHIP_ERROR EnableNoDelay() override;
+    CHIP_ERROR EnableKeepAlive(uint16_t interval, uint16_t timeoutCount) override;
+    CHIP_ERROR DisableKeepAlive() override;
+    CHIP_ERROR AckReceive(uint16_t len) override;
+#if INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
+    void TCPUserTimeoutHandler() override;
+#endif // INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
+
+private:
+    // TCPEndPoint overrides.
+    CHIP_ERROR BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, bool reuseAddr) override;
+    CHIP_ERROR ListenImpl(uint16_t backlog) override;
+    CHIP_ERROR ConnectImpl(const IPAddress & addr, uint16_t port, InterfaceId intfId) override;
+    CHIP_ERROR SendQueuedImpl(bool queueWasEmpty) override;
+    CHIP_ERROR SetUserTimeoutImpl(uint32_t userTimeoutMillis) override;
+    CHIP_ERROR DriveSendingImpl() override;
+    void HandleConnectCompleteImpl() override;
+    void DoCloseImpl(CHIP_ERROR err, State oldState) override;
+
+    InterfaceId mBoundIntfId;
+    uint16_t mBoundPort;
+    otInstance * mOTInstance = nullptr;
+};
+
+using TCPEndPointImpl = TCPEndPointImplOT;
+
+} // namespace Inet
+} // namespace chip

--- a/src/inet/UDPEndPointImplOpenThread.cpp
+++ b/src/inet/UDPEndPointImplOpenThread.cpp
@@ -17,7 +17,7 @@
  *    limitations under the License.
  */
 
-#include <inet/UDPEndPointImpl_OpenThread.h>
+#include <inet/UDPEndPointImplOpenThread.h>
 
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>

--- a/src/inet/UDPEndPointImplOpenThread.h
+++ b/src/inet/UDPEndPointImplOpenThread.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <inet/EndPointStateOpenThread.h>
 #include <inet/UDPEndPoint.h>
 
 #include <openthread/error.h>
@@ -31,7 +32,7 @@
 namespace chip {
 namespace Inet {
 
-class UDPEndPointImplOT : public UDPEndPoint
+class UDPEndPointImplOT : public UDPEndPoint, public EndPointStateOpenThread
 {
 public:
     UDPEndPointImplOT(EndPointManager<UDPEndPoint> & endPointManager) :

--- a/src/inet/inet.gni
+++ b/src/inet/inet.gni
@@ -27,7 +27,9 @@ declare_args() {
   chip_inet_config_enable_tcp_endpoint = true
 
   # Inet implementation type.
-  if (chip_system_config_use_lwip) {
+  if (chip_system_config_use_open_thread_inet_endpoints) {
+    chip_system_config_inet = "OpenThread"
+  } else if (chip_system_config_use_lwip) {
     chip_system_config_inet = "LwIP"
   } else {
     chip_system_config_inet = "Sockets"

--- a/src/platform/EFR32/args.gni
+++ b/src/platform/EFR32/args.gni
@@ -32,6 +32,9 @@ lwip_platform = "efr32"
 
 chip_inet_config_enable_ipv4 = false
 
+chip_inet_config_enable_tcp_endpoint = false
+chip_system_config_use_open_thread_inet_endpoints = true
+
 chip_build_tests = false
 
 openthread_core_config_platform_check_file =

--- a/src/platform/EFR32/wifi_args.gni
+++ b/src/platform/EFR32/wifi_args.gni
@@ -34,6 +34,7 @@ chip_device_platform = "efr32"
 chip_enable_openthread = false
 chip_inet_config_enable_ipv4 = true
 chip_inet_config_enable_dns_resolver = false
+chip_inet_config_enable_tcp_endpoint = true
 
 chip_build_tests = false
 chip_config_memory_management = "platform"

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
@@ -233,14 +233,14 @@ void GenericThreadStackManagerImpl_OpenThread_LwIP<ImplClass>::UpdateThreadInter
 
 // Multicast won't work with LWIP on top of OT
 // Duplication of listeners, unecessary timers, buffer duplication, hardfault etc...
-#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_UDP
+#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
             // Refresh Multicast listening
             if (GenericThreadStackManagerImpl_OpenThread<ImplClass>::IsThreadAttachedNoLock())
             {
                 ChipLogDetail(DeviceLayer, "Thread Attached updating Multicast address");
                 Server::GetInstance().RejoinExistingMulticastGroups();
             }
-#endif // CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_UDP
+#endif // CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
         }
 
         ChipLogDetail(DeviceLayer, "LwIP Thread interface addresses %s", isInterfaceUp ? "updated" : "cleared");

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -59,7 +59,7 @@ buildconfig_header("system_buildconfig") {
     "CHIP_WITH_NLFAULTINJECTION=${chip_with_nlfaultinjection}",
     "CHIP_SYSTEM_CONFIG_USE_DISPATCH=${chip_system_config_use_dispatch}",
     "CHIP_SYSTEM_CONFIG_USE_LWIP=${chip_system_config_use_lwip}",
-    "CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_UDP=${chip_system_config_use_open_thread_udp}",
+    "CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT=${chip_system_config_use_open_thread_inet_endpoints}",
     "CHIP_SYSTEM_CONFIG_USE_SOCKETS=${chip_system_config_use_sockets}",
     "CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK=false",
     "CHIP_SYSTEM_CONFIG_POSIX_LOCKING=${chip_system_config_posix_locking}",

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -809,7 +809,7 @@ namespace Inet {
 class UDPEndPointImplLwIP;
 } // namespace Inet
 
-#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_UDP
+#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 // TODO : Temp Implementation issue : 13085
 // Still use LwIP buffer even if using OpenThread UDP implementation
 // since decoupling of LwIP from OpenThread is still in progress
@@ -835,7 +835,7 @@ private:
      */
     static struct pbuf * UnsafeGetLwIPpbuf(const PacketBufferHandle & handle) { return PacketBufferHandle::GetLwIPpbuf(handle); }
     friend class Inet::UDPEndPointImplLwIP;
-#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_UDP
+#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
     // TODO : Temp Implementation issue : 13085
     // Still use LwIP buffer even if using OpenThread UDP implementation
     // since decoupling of LwIP from OpenThread is still in progress

--- a/src/system/system.gni
+++ b/src/system/system.gni
@@ -32,8 +32,8 @@ declare_args() {
   # Enable metrics collection.
   chip_system_config_provide_statistics = true
 
-  # Use OpenThread UDP stack directly
-  chip_system_config_use_open_thread_udp = false
+  # Use OpenThread TCP/UDP stack directly
+  chip_system_config_use_open_thread_inet_endpoints = false
 }
 
 declare_args() {

--- a/src/test_driver/efr32/args.gni
+++ b/src/test_driver/efr32/args.gni
@@ -26,3 +26,7 @@ chip_build_tests = true
 chip_enable_openthread = true
 chip_openthread_ftd = true
 chip_monolithic_tests = true
+
+#Fix me : Test driver should use same config as examples
+# Problem : Linker issue if set to true
+chip_system_config_use_open_thread_inet_endpoints = false

--- a/src/transport/raw/UDP.h
+++ b/src/transport/raw/UDP.h
@@ -34,9 +34,9 @@
 #include <lib/core/CHIPCore.h>
 #include <transport/raw/Base.h>
 
-#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_UDP
+#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 struct otInstance;
-#endif // CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_UDP
+#endif // CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 
 namespace chip {
 namespace Transport {


### PR DESCRIPTION
#### Problem
Current Implementation didn't have a TCP endpoint Implementation for openthread devices only.

#### Change overview
Added TCPEndpoinImplOpenThread as a placeholder for now since not yet implemented.

Renamed `chip_system_config_use_open_thread_udp` to `chip_system_config_use_open_thread`

Users that build with compile option `chip_system_config_use_open_thread` should now disable the TCP implementation until it is implemented (not a loss of feature since wasn't in used). 

Added an option for OpenThread native Inet layer (same as LwIP or Socket implementation)

#### Testing
Local test and Unit Test. No functional changes were made.
