### PR TITLE
GroupKeyManagement server: Added validation against groupKeySetID == 0.

### DIFF
--- a/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
+++ b/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
@@ -203,6 +203,9 @@ private:
             {
                 const auto & value = iter.GetValue();
                 VerifyOrReturnError(fabric_index == value.fabricIndex, CHIP_ERROR_INVALID_FABRIC_ID);
+                // Cannot map to IPK, see `GroupKeyMapStruct` in Group Key Management cluster spec
+                VerifyOrReturnError(value.groupKeySetID != 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
+
                 ReturnErrorOnFailure(provider->SetGroupKeyAt(value.fabricIndex, i++,
                                                              GroupDataProvider::GroupKey(value.groupId, value.groupKeySetID)));
             }
@@ -215,6 +218,8 @@ private:
             VerifyOrReturnError(nullptr != provider, CHIP_ERROR_INTERNAL);
             ReturnErrorOnFailure(aDecoder.Decode(value));
             VerifyOrReturnError(fabric_index == value.fabricIndex, CHIP_ERROR_INVALID_FABRIC_ID);
+            // Cannot map to IPK, see `GroupKeyMapStruct` in Group Key Management cluster spec
+            VerifyOrReturnError(value.groupKeySetID != 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
 
             {
                 auto iter     = provider->IterateGroupKeys(fabric_index);

--- a/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
+++ b/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
@@ -138,6 +138,14 @@ tests:
               - name: "GroupKeySetIDs"
                 value: [0x01a1, 0x01a2]
 
+    - label: "Write Group Keys (invalid)"
+      command: "writeAttribute"
+      attribute: "GroupKeyMap"
+      arguments:
+          value: [{ FabricIndex: 1, GroupId: 0x0102, GroupKeySetID: 0 }]
+      response:
+          error: 0x87
+
     - label: "Write Group Keys"
       command: "writeAttribute"
       attribute: "GroupKeyMap"

--- a/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
+++ b/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
@@ -144,7 +144,7 @@ tests:
       arguments:
           value: [{ FabricIndex: 1, GroupId: 0x0102, GroupKeySetID: 0 }]
       response:
-          error: 0x87
+          error: CONSTRAINT_ERROR
 
     - label: "Write Group Keys"
       command: "writeAttribute"

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -47621,6 +47621,35 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
 }
 - (void)testSendClusterTestGroupKeyManagementCluster_000008_WriteAttribute
 {
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write Group Keys (invalid)"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestGroupKeyManagement * cluster = [[CHIPTestGroupKeyManagement alloc] initWithDevice:device endpoint:0 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id groupKeyMapArgument;
+    {
+        NSMutableArray * temp_0 = [[NSMutableArray alloc] init];
+        temp_0[0] = [[CHIPGroupKeyManagementClusterGroupKeyMapStruct alloc] init];
+        ((CHIPGroupKeyManagementClusterGroupKeyMapStruct *) temp_0[0]).groupId = [NSNumber numberWithUnsignedShort:258U];
+        ((CHIPGroupKeyManagementClusterGroupKeyMapStruct *) temp_0[0]).groupKeySetID = [NSNumber numberWithUnsignedShort:0U];
+        ((CHIPGroupKeyManagementClusterGroupKeyMapStruct *) temp_0[0]).fabricIndex = [NSNumber numberWithUnsignedChar:1];
+
+        groupKeyMapArgument = temp_0;
+    }
+    [cluster writeAttributeGroupKeyMapWithValue:groupKeyMapArgument
+                              completionHandler:^(NSError * _Nullable err) {
+                                  NSLog(@"Write Group Keys (invalid) Error: %@", err);
+
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
+                                  [expectation fulfill];
+                              }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestGroupKeyManagementCluster_000009_WriteAttribute
+{
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write Group Keys"];
 
     CHIPDevice * device = GetConnectedDevice();
@@ -47654,7 +47683,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestGroupKeyManagementCluster_000009_ReadAttribute
+- (void)testSendClusterTestGroupKeyManagementCluster_000010_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read Group Keys"];
 
@@ -47699,7 +47728,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestGroupKeyManagementCluster_000010_ReadAttribute
+- (void)testSendClusterTestGroupKeyManagementCluster_000011_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read GroupTable"];
 
@@ -47742,7 +47771,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestGroupKeyManagementCluster_000011_KeySetRemove
+- (void)testSendClusterTestGroupKeyManagementCluster_000012_KeySetRemove
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"KeySet Remove 1"];
 
@@ -47764,7 +47793,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestGroupKeyManagementCluster_000012_KeySetRead
+- (void)testSendClusterTestGroupKeyManagementCluster_000013_KeySetRead
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"KeySet Read (removed)"];
 
@@ -47786,7 +47815,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestGroupKeyManagementCluster_000013_KeySetRead
+- (void)testSendClusterTestGroupKeyManagementCluster_000014_KeySetRead
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"KeySet Read (not removed)"];
 
@@ -47833,7 +47862,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestGroupKeyManagementCluster_000014_RemoveAllGroups
+- (void)testSendClusterTestGroupKeyManagementCluster_000015_RemoveAllGroups
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Remove All"];
 
@@ -47852,7 +47881,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestGroupKeyManagementCluster_000015_KeySetRemove
+- (void)testSendClusterTestGroupKeyManagementCluster_000016_KeySetRemove
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"KeySet Remove 2"];
 
@@ -47874,7 +47903,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestGroupKeyManagementCluster_000016_KeySetRead
+- (void)testSendClusterTestGroupKeyManagementCluster_000017_KeySetRead
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"KeySet Read (also removed)"];
 

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -47642,7 +47642,7 @@ NSData * _Nonnull readAttributeOctetStringNotDefaultValue;
                               completionHandler:^(NSError * _Nullable err) {
                                   NSLog(@"Write Group Keys (invalid) Error: %@", err);
 
-                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
                                   [expectation fulfill];
                               }];
 

--- a/zzz_generated/chip-tool-darwin/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool-darwin/zap-generated/test/Commands.h
@@ -54308,7 +54308,7 @@ private:
                                   completionHandler:^(NSError * _Nullable err) {
                                       NSLog(@"Write Group Keys (invalid) Error: %@", err);
 
-                                      VerifyOrReturn(CheckValue("status", err, 135));
+                                      VerifyOrReturn(CheckValue("status", err, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
                                       NextTest();
                                   }];
 

--- a/zzz_generated/chip-tool-darwin/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool-darwin/zap-generated/test/Commands.h
@@ -53982,40 +53982,44 @@ public:
             err = TestKeySetRead_7();
             break;
         case 8:
-            ChipLogProgress(chipTool, " ***** Test Step 8 : Write Group Keys\n");
-            err = TestWriteGroupKeys_8();
+            ChipLogProgress(chipTool, " ***** Test Step 8 : Write Group Keys (invalid)\n");
+            err = TestWriteGroupKeysInvalid_8();
             break;
         case 9:
-            ChipLogProgress(chipTool, " ***** Test Step 9 : Read Group Keys\n");
-            err = TestReadGroupKeys_9();
+            ChipLogProgress(chipTool, " ***** Test Step 9 : Write Group Keys\n");
+            err = TestWriteGroupKeys_9();
             break;
         case 10:
-            ChipLogProgress(chipTool, " ***** Test Step 10 : Read GroupTable\n");
-            err = TestReadGroupTable_10();
+            ChipLogProgress(chipTool, " ***** Test Step 10 : Read Group Keys\n");
+            err = TestReadGroupKeys_10();
             break;
         case 11:
-            ChipLogProgress(chipTool, " ***** Test Step 11 : KeySet Remove 1\n");
-            err = TestKeySetRemove1_11();
+            ChipLogProgress(chipTool, " ***** Test Step 11 : Read GroupTable\n");
+            err = TestReadGroupTable_11();
             break;
         case 12:
-            ChipLogProgress(chipTool, " ***** Test Step 12 : KeySet Read (removed)\n");
-            err = TestKeySetReadRemoved_12();
+            ChipLogProgress(chipTool, " ***** Test Step 12 : KeySet Remove 1\n");
+            err = TestKeySetRemove1_12();
             break;
         case 13:
-            ChipLogProgress(chipTool, " ***** Test Step 13 : KeySet Read (not removed)\n");
-            err = TestKeySetReadNotRemoved_13();
+            ChipLogProgress(chipTool, " ***** Test Step 13 : KeySet Read (removed)\n");
+            err = TestKeySetReadRemoved_13();
             break;
         case 14:
-            ChipLogProgress(chipTool, " ***** Test Step 14 : Remove All\n");
-            err = TestRemoveAll_14();
+            ChipLogProgress(chipTool, " ***** Test Step 14 : KeySet Read (not removed)\n");
+            err = TestKeySetReadNotRemoved_14();
             break;
         case 15:
-            ChipLogProgress(chipTool, " ***** Test Step 15 : KeySet Remove 2\n");
-            err = TestKeySetRemove2_15();
+            ChipLogProgress(chipTool, " ***** Test Step 15 : Remove All\n");
+            err = TestRemoveAll_15();
             break;
         case 16:
-            ChipLogProgress(chipTool, " ***** Test Step 16 : KeySet Read (also removed)\n");
-            err = TestKeySetReadAlsoRemoved_16();
+            ChipLogProgress(chipTool, " ***** Test Step 16 : KeySet Remove 2\n");
+            err = TestKeySetRemove2_16();
+            break;
+        case 17:
+            ChipLogProgress(chipTool, " ***** Test Step 17 : KeySet Read (also removed)\n");
+            err = TestKeySetReadAlsoRemoved_17();
             break;
         }
 
@@ -54032,7 +54036,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 17;
+    const uint16_t mTestCount = 18;
 
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
@@ -54282,7 +54286,36 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestWriteGroupKeys_8()
+    CHIP_ERROR TestWriteGroupKeysInvalid_8()
+    {
+        CHIPDevice * device = GetConnectedDevice();
+        CHIPTestGroupKeyManagement * cluster = [[CHIPTestGroupKeyManagement alloc] initWithDevice:device
+                                                                                         endpoint:0
+                                                                                            queue:mCallbackQueue];
+        VerifyOrReturnError(cluster != nil, CHIP_ERROR_INCORRECT_STATE);
+
+        id groupKeyMapArgument;
+        {
+            NSMutableArray * temp_0 = [[NSMutableArray alloc] init];
+            temp_0[0] = [[CHIPGroupKeyManagementClusterGroupKeyMapStruct alloc] init];
+            ((CHIPGroupKeyManagementClusterGroupKeyMapStruct *) temp_0[0]).groupId = [NSNumber numberWithUnsignedShort:258U];
+            ((CHIPGroupKeyManagementClusterGroupKeyMapStruct *) temp_0[0]).groupKeySetID = [NSNumber numberWithUnsignedShort:0U];
+            ((CHIPGroupKeyManagementClusterGroupKeyMapStruct *) temp_0[0]).fabricIndex = [NSNumber numberWithUnsignedChar:1];
+
+            groupKeyMapArgument = temp_0;
+        }
+        [cluster writeAttributeGroupKeyMapWithValue:groupKeyMapArgument
+                                  completionHandler:^(NSError * _Nullable err) {
+                                      NSLog(@"Write Group Keys (invalid) Error: %@", err);
+
+                                      VerifyOrReturn(CheckValue("status", err, 135));
+                                      NextTest();
+                                  }];
+
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR TestWriteGroupKeys_9()
     {
         CHIPDevice * device = GetConnectedDevice();
         CHIPTestGroupKeyManagement * cluster = [[CHIPTestGroupKeyManagement alloc] initWithDevice:device
@@ -54317,7 +54350,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestReadGroupKeys_9()
+    CHIP_ERROR TestReadGroupKeys_10()
     {
         CHIPDevice * device = GetConnectedDevice();
         CHIPTestGroupKeyManagement * cluster = [[CHIPTestGroupKeyManagement alloc] initWithDevice:device
@@ -54357,7 +54390,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestReadGroupTable_10()
+    CHIP_ERROR TestReadGroupTable_11()
     {
         CHIPDevice * device = GetConnectedDevice();
         CHIPTestGroupKeyManagement * cluster = [[CHIPTestGroupKeyManagement alloc] initWithDevice:device
@@ -54398,7 +54431,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestKeySetRemove1_11()
+    CHIP_ERROR TestKeySetRemove1_12()
     {
         CHIPDevice * device = GetConnectedDevice();
         CHIPTestGroupKeyManagement * cluster = [[CHIPTestGroupKeyManagement alloc] initWithDevice:device
@@ -54420,7 +54453,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestKeySetReadRemoved_12()
+    CHIP_ERROR TestKeySetReadRemoved_13()
     {
         CHIPDevice * device = GetConnectedDevice();
         CHIPTestGroupKeyManagement * cluster = [[CHIPTestGroupKeyManagement alloc] initWithDevice:device
@@ -54442,7 +54475,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestKeySetReadNotRemoved_13()
+    CHIP_ERROR TestKeySetReadNotRemoved_14()
     {
         CHIPDevice * device = GetConnectedDevice();
         CHIPTestGroupKeyManagement * cluster = [[CHIPTestGroupKeyManagement alloc] initWithDevice:device
@@ -54492,7 +54525,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestRemoveAll_14()
+    CHIP_ERROR TestRemoveAll_15()
     {
         CHIPDevice * device = GetConnectedDevice();
         CHIPTestGroups * cluster = [[CHIPTestGroups alloc] initWithDevice:device endpoint:1 queue:mCallbackQueue];
@@ -54509,7 +54542,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestKeySetRemove2_15()
+    CHIP_ERROR TestKeySetRemove2_16()
     {
         CHIPDevice * device = GetConnectedDevice();
         CHIPTestGroupKeyManagement * cluster = [[CHIPTestGroupKeyManagement alloc] initWithDevice:device
@@ -54531,7 +54564,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestKeySetReadAlsoRemoved_16()
+    CHIP_ERROR TestKeySetReadAlsoRemoved_17()
     {
         CHIPDevice * device = GetConnectedDevice();
         CHIPTestGroupKeyManagement * cluster = [[CHIPTestGroupKeyManagement alloc] initWithDevice:device


### PR DESCRIPTION
#### Problem
* Fixes [#16621](https://github.com/project-chip/connectedhomeip/issues/16621)

#### Change overview
Added missing validation on WriteGroupKeyMap

#### Testing
* Project built successfully
* Group, and GroupKeyManagement tests ran successfully