### PR TITLE
Add RemoveFabric to AccessControl

### DIFF
--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -188,6 +188,22 @@ CHIP_ERROR AccessControl::Finish()
     return retval;
 }
 
+CHIP_ERROR AccessControl::RemoveFabric(FabricIndex fabricIndex)
+{
+    ChipLogProgress(DataManagement, "AccessControl: removing fabric %u", fabricIndex);
+
+    CHIP_ERROR err;
+    do
+    {
+        err = DeleteEntry(0, &fabricIndex);
+    } while (err == CHIP_NO_ERROR);
+
+    // Sentinel error is OK, just means there was no such entry.
+    ReturnErrorCodeIf(err != CHIP_ERROR_SENTINEL, err);
+
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR AccessControl::Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath,
                                 Privilege requestPrivilege)
 {

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -468,6 +468,8 @@ public:
         return mDelegate->DeleteEntry(index, fabricIndex);
     }
 
+    CHIP_ERROR RemoveFabric(FabricIndex fabricIndex);
+
     /**
      * Iterates over entries in the access control list.
      *

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -221,6 +221,7 @@ private:
             {
                 groupDataProvider->RemoveFabric(fabricIndex);
             }
+            Access::GetAccessControl().RemoveFabric(fabricIndex);
         };
         void OnFabricRetrievedFromStorage(FabricInfo * fabricInfo) override { (void) fabricInfo; }
 


### PR DESCRIPTION
#### Problem

Access control needs to support removing a fabric, and full factory reset.
Issue #13876

#### Change overview
Add AccessControl::RemoveFabric.

Call it from ServerFabricDelegate::OnFabricDeletedFromStorage.

Use the "public" API to delete entries for a fabric.

#### Testing

- Tested on Linux using chip-all-clusters-app and chip-tool
- Commissioned app on 3 fabrics
- With 3, 2, and 2 distinct ACLs
- Removed second (middle) fabric
- Verified remaining 5 ACLs (for first and last fabric) correct
- Even after restarting app