### PR TITLE
Fix compile for iOS CHIPTool.

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
@@ -224,6 +224,7 @@ static TemperatureSensorViewController * _Nullable sCurrentController = nil;
                                    minInterval:minIntervalSeconds
                                    maxInterval:maxIntervalSeconds
                                         params:nil
+                                cacheContainer:nil
                                  reportHandler:^(NSArray<CHIPAttributeReport *> * _Nullable reports, NSError * _Nullable error) {
                                      if (error) {
                                          NSLog(@"Status: update reportAttributeMeasuredValue completed with error %@",


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/16679

#### Problem
iOS CHIPTool does not compile.

#### Change overview
Fix compile by adjusting callsite to match the new callee signature.

#### Testing
Compiled locally.