### PR TITLE
Fix management of the commissioning window timeout.

### DIFF
--- a/examples/all-clusters-app/esp32/main/DeviceWithDisplay.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceWithDisplay.cpp
@@ -392,7 +392,7 @@ public:
         {
             chip::Server::GetInstance().GetFabricTable().DeleteAllFabrics();
             chip::Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow(
-                kNoCommissioningTimeout, CommissioningWindowAdvertisement::kDnssdOnly);
+                CommissioningWindowManager::MaxCommissioningTimeout(), CommissioningWindowAdvertisement::kDnssdOnly);
         }
     }
 

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -35,6 +35,7 @@
 #include <platform/ConfigurationManager.h>
 #include <platform/DeviceControlServer.h>
 #include <platform/TestOnlyCommissionableDataProvider.h>
+#include <system/SystemClock.h>
 #include <system/SystemLayer.h>
 #include <transport/raw/PeerAddress.h>
 #include <zap-generated/CHIPClusters.h>
@@ -56,11 +57,11 @@ struct TVExampleDeviceType
     uint16_t id;
 };
 
-constexpr TVExampleDeviceType kKnownDeviceTypes[]    = { { "video-player", 35 }, { "dimmable-light", 257 } };
-constexpr int kKnownDeviceTypesCount                 = sizeof kKnownDeviceTypes / sizeof *kKnownDeviceTypes;
-constexpr uint16_t kOptionDeviceType                 = 't';
-constexpr uint16_t kCommissioningWindowTimeoutInSec  = 3 * 60;
-constexpr uint32_t kCommissionerDiscoveryTimeoutInMs = 5 * 1000;
+constexpr TVExampleDeviceType kKnownDeviceTypes[]              = { { "video-player", 35 }, { "dimmable-light", 257 } };
+constexpr int kKnownDeviceTypesCount                           = sizeof kKnownDeviceTypes / sizeof *kKnownDeviceTypes;
+constexpr uint16_t kOptionDeviceType                           = 't';
+constexpr System::Clock::Seconds16 kCommissioningWindowTimeout = System::Clock::Seconds16(3 * 60);
+constexpr uint32_t kCommissionerDiscoveryTimeoutInMs           = 5 * 1000;
 
 // TODO: Accept these values over CLI
 const char * kContentUrl         = "https://www.test.com/videoid";
@@ -143,7 +144,7 @@ void PrepareForCommissioning(const Dnssd::DiscoveredNodeData * selectedCommissio
     Server::GetInstance().Init();
     Server::GetInstance().GetFabricTable().DeleteAllFabrics();
     ReturnOnFailure(
-        Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow(kCommissioningWindowTimeoutInSec));
+        Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow(kCommissioningWindowTimeout));
 
     // Display onboarding payload
     chip::DeviceLayer::ConfigurationMgr().LogDeviceConfig();

--- a/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
+++ b/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
@@ -24,21 +24,22 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
+#include <app/server/CommissioningWindowManager.h>
 #include <app/server/Server.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CommissionableDataProvider.h>
+#include <protocols/interaction_model/Constants.h>
 #include <setup_payload/SetupPayload.h>
+#include <system/SystemClock.h>
 
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::AdministratorCommissioning;
-
-// Specifications section 5.4.2.3. Announcement Duration
-constexpr uint32_t kMaxCommissionioningTimeoutSeconds = 15 * 60;
+using namespace chip::Protocols;
 
 class AdministratorCommissioningAttrAccess : public AttributeAccessInterface
 {
@@ -91,13 +92,14 @@ bool emberAfAdministratorCommissioningClusterOpenCommissioningWindowCallback(
     app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
     const Commands::OpenCommissioningWindow::DecodableType & commandData)
 {
-    auto & commissioningTimeout = commandData.commissioningTimeout;
-    auto & pakeVerifier         = commandData.PAKEVerifier;
-    auto & discriminator        = commandData.discriminator;
-    auto & iterations           = commandData.iterations;
-    auto & salt                 = commandData.salt;
+    auto commissioningTimeout = System::Clock::Seconds16(commandData.commissioningTimeout);
+    auto & pakeVerifier       = commandData.PAKEVerifier;
+    auto & discriminator      = commandData.discriminator;
+    auto & iterations         = commandData.iterations;
+    auto & salt               = commandData.salt;
 
-    Optional<StatusCode> status = Optional<StatusCode>::Missing();
+    Optional<StatusCode> status           = Optional<StatusCode>::Missing();
+    InteractionModel::Status globalStatus = InteractionModel::Status::Success;
     Spake2pVerifier verifier;
 
     ChipLogProgress(Zcl, "Received command to open commissioning window");
@@ -117,9 +119,11 @@ bool emberAfAdministratorCommissioningClusterOpenCommissioningWindowCallback(
                  status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR));
     VerifyOrExit(salt.size() <= kSpake2p_Max_PBKDF_Salt_Length,
                  status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR));
-    VerifyOrExit(commissioningTimeout <= kMaxCommissionioningTimeoutSeconds,
-                 status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR));
-    VerifyOrExit(discriminator <= kMaxDiscriminatorValue, status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR));
+    VerifyOrExit(commissioningTimeout <= CommissioningWindowManager::MaxCommissioningTimeout(),
+                 globalStatus = InteractionModel::Status::InvalidCommand);
+    VerifyOrExit(commissioningTimeout >= CommissioningWindowManager::MinCommissioningTimeout(),
+                 globalStatus = InteractionModel::Status::InvalidCommand);
+    VerifyOrExit(discriminator <= kMaxDiscriminatorValue, globalStatus = InteractionModel::Status::InvalidCommand);
 
     VerifyOrExit(verifier.Deserialize(pakeVerifier) == CHIP_NO_ERROR,
                  status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR));
@@ -134,12 +138,16 @@ bool emberAfAdministratorCommissioningClusterOpenCommissioningWindowCallback(
 exit:
     if (status.HasValue())
     {
-        ChipLogError(Zcl, "Failed to open commissioning window. Status %d", status.Value());
+        ChipLogError(Zcl, "Failed to open commissioning window. Cluster status %d", status.Value());
         commandObj->AddClusterSpecificFailure(commandPath, status.Value());
     }
     else
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        if (globalStatus != InteractionModel::Status::Success)
+        {
+            ChipLogError(Zcl, "Failed to open commissioning window. Global status %d", to_underlying(globalStatus));
+        }
+        commandObj->AddStatus(commandPath, globalStatus);
     }
     return true;
 }
@@ -148,9 +156,10 @@ bool emberAfAdministratorCommissioningClusterOpenBasicCommissioningWindowCallbac
     app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
     const Commands::OpenBasicCommissioningWindow::DecodableType & commandData)
 {
-    auto & commissioningTimeout = commandData.commissioningTimeout;
+    auto commissioningTimeout = System::Clock::Seconds16(commandData.commissioningTimeout);
 
-    Optional<StatusCode> status = Optional<StatusCode>::Missing();
+    Optional<StatusCode> status           = Optional<StatusCode>::Missing();
+    InteractionModel::Status globalStatus = InteractionModel::Status::Success;
     ChipLogProgress(Zcl, "Received command to open basic commissioning window");
 
     FabricIndex fabricIndex = commandObj->GetAccessingFabricIndex();
@@ -160,8 +169,10 @@ bool emberAfAdministratorCommissioningClusterOpenBasicCommissioningWindowCallbac
     VerifyOrExit(Server::GetInstance().GetCommissioningWindowManager().CommissioningWindowStatus() ==
                      CommissioningWindowStatus::kWindowNotOpen,
                  status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_BUSY));
-    VerifyOrExit(commissioningTimeout <= kMaxCommissionioningTimeoutSeconds,
-                 status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR));
+    VerifyOrExit(commissioningTimeout <= CommissioningWindowManager::MaxCommissioningTimeout(),
+                 globalStatus = InteractionModel::Status::InvalidCommand);
+    VerifyOrExit(commissioningTimeout >= CommissioningWindowManager::MinCommissioningTimeout(),
+                 globalStatus = InteractionModel::Status::InvalidCommand);
     VerifyOrExit(Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow(
                      commissioningTimeout, CommissioningWindowAdvertisement::kDnssdOnly) == CHIP_NO_ERROR,
                  status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR));
@@ -173,12 +184,16 @@ bool emberAfAdministratorCommissioningClusterOpenBasicCommissioningWindowCallbac
 exit:
     if (status.HasValue())
     {
-        ChipLogError(Zcl, "Failed to open commissioning window. Status %d", status.Value());
+        ChipLogError(Zcl, "Failed to open commissioning window. Cluster status %d", status.Value());
         commandObj->AddClusterSpecificFailure(commandPath, status.Value());
     }
     else
     {
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
+        if (globalStatus != InteractionModel::Status::Success)
+        {
+            ChipLogError(Zcl, "Failed to open commissioning window. Global status %d", to_underlying(globalStatus));
+        }
+        commandObj->AddStatus(commandPath, globalStatus);
     }
     return true;
 }

--- a/src/app/tests/TestCommissionManager.cpp
+++ b/src/app/tests/TestCommissionManager.cpp
@@ -32,7 +32,6 @@
 
 using chip::CommissioningWindowAdvertisement;
 using chip::CommissioningWindowManager;
-using chip::kNoCommissioningTimeout;
 using chip::Server;
 
 // Mock function for linking
@@ -85,8 +84,8 @@ void CheckCommissioningWindowManagerBasicWindowOpenCloseTask(intptr_t context)
 {
     nlTestSuite * suite                        = reinterpret_cast<nlTestSuite *>(context);
     CommissioningWindowManager & commissionMgr = Server::GetInstance().GetCommissioningWindowManager();
-    CHIP_ERROR err =
-        commissionMgr.OpenBasicCommissioningWindow(kNoCommissioningTimeout, CommissioningWindowAdvertisement::kDnssdOnly);
+    CHIP_ERROR err = commissionMgr.OpenBasicCommissioningWindow(CommissioningWindowManager::MaxCommissioningTimeout(),
+                                                                CommissioningWindowAdvertisement::kDnssdOnly);
     NL_TEST_ASSERT(suite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(suite,
                    commissionMgr.CommissioningWindowStatus() ==
@@ -118,9 +117,10 @@ void CheckCommissioningWindowManagerWindowTimeoutTask(intptr_t context)
 {
     nlTestSuite * suite                        = reinterpret_cast<nlTestSuite *>(context);
     CommissioningWindowManager & commissionMgr = Server::GetInstance().GetCommissioningWindowManager();
-    constexpr uint16_t kTimeoutSeconds         = 1;
+    constexpr auto kTimeoutSeconds             = chip::System::Clock::Seconds16(1);
     constexpr uint16_t kTimeoutMs              = 1000;
     constexpr unsigned kSleepPadding           = 100;
+    commissionMgr.OverrideMinCommissioningTimeout(kTimeoutSeconds);
     CHIP_ERROR err = commissionMgr.OpenBasicCommissioningWindow(kTimeoutSeconds, CommissioningWindowAdvertisement::kDnssdOnly);
     NL_TEST_ASSERT(suite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(suite,
@@ -138,6 +138,48 @@ void CheckCommissioningWindowManagerWindowTimeout(nlTestSuite * suite, void *)
     sleep(kTestTaskWaitSeconds);
 }
 
+void SimulateFailedSessionEstablishmentTask(chip::System::Layer *, void * context)
+{
+    nlTestSuite * suite                        = static_cast<nlTestSuite *>(context);
+    CommissioningWindowManager & commissionMgr = Server::GetInstance().GetCommissioningWindowManager();
+    NL_TEST_ASSERT(suite,
+                   commissionMgr.CommissioningWindowStatus() !=
+                       chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatus::kWindowNotOpen);
+    commissionMgr.OnSessionEstablishmentStarted();
+    commissionMgr.OnSessionEstablishmentError(CHIP_ERROR_INTERNAL);
+    NL_TEST_ASSERT(suite,
+                   commissionMgr.CommissioningWindowStatus() !=
+                       chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatus::kWindowNotOpen);
+}
+
+void CheckCommissioningWindowManagerWindowTimeoutWithSessionEstablishmentErrorsTask(intptr_t context)
+{
+    nlTestSuite * suite                        = reinterpret_cast<nlTestSuite *>(context);
+    CommissioningWindowManager & commissionMgr = Server::GetInstance().GetCommissioningWindowManager();
+    constexpr auto kTimeoutSeconds             = chip::System::Clock::Seconds16(1);
+    constexpr uint16_t kTimeoutMs              = 1000;
+    constexpr unsigned kSleepPadding           = 100;
+    CHIP_ERROR err = commissionMgr.OpenBasicCommissioningWindow(kTimeoutSeconds, CommissioningWindowAdvertisement::kDnssdOnly);
+    NL_TEST_ASSERT(suite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(suite,
+                   commissionMgr.CommissioningWindowStatus() ==
+                       chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatus::kBasicWindowOpen);
+    NL_TEST_ASSERT(suite, !chip::DeviceLayer::ConnectivityMgr().IsBLEAdvertisingEnabled());
+    chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(kTimeoutMs + kSleepPadding),
+                                                CheckCommissioningWindowManagerWindowClosedTask, suite);
+    // Simulate a session establishment error during that window, such that the
+    // delay for the error plust hte window size exceeds our "timeout + padding" above.
+    chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(kTimeoutMs / 4 * 3),
+                                                SimulateFailedSessionEstablishmentTask, suite);
+}
+
+void CheckCommissioningWindowManagerWindowTimeoutWithSessionEstablishmentErrors(nlTestSuite * suite, void *)
+{
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(CheckCommissioningWindowManagerWindowTimeoutWithSessionEstablishmentErrorsTask,
+                                                  reinterpret_cast<intptr_t>(suite));
+    sleep(kTestTaskWaitSeconds);
+}
+
 void CheckCommissioningWindowManagerEnhancedWindowTask(intptr_t context)
 {
     nlTestSuite * suite                        = reinterpret_cast<nlTestSuite *>(context);
@@ -151,7 +193,8 @@ void CheckCommissioningWindowManagerEnhancedWindowTask(intptr_t context)
     uint8_t salt[chip::kSpake2p_Min_PBKDF_Salt_Length];
     chip::ByteSpan saltData(salt);
 
-    err = commissionMgr.OpenEnhancedCommissioningWindow(kNoCommissioningTimeout, newDiscriminator, verifier, kIterations, saltData);
+    err = commissionMgr.OpenEnhancedCommissioningWindow(CommissioningWindowManager::MaxCommissioningTimeout(), newDiscriminator,
+                                                        verifier, kIterations, saltData);
     NL_TEST_ASSERT(suite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(suite,
                    commissionMgr.CommissioningWindowStatus() ==
@@ -179,7 +222,10 @@ void TearDownTask(intptr_t context)
 const nlTest sTests[] = {
     NL_TEST_DEF("CheckCommissioningWindowManagerEnhancedWindow", CheckCommissioningWindowManagerEnhancedWindow),
     NL_TEST_DEF("CheckCommissioningWindowManagerBasicWindowOpenClose", CheckCommissioningWindowManagerBasicWindowOpenClose),
-    NL_TEST_DEF("CheckCommissioningWindowManagerWindowTimeout", CheckCommissioningWindowManagerWindowTimeout), NL_TEST_SENTINEL()
+    NL_TEST_DEF("CheckCommissioningWindowManagerWindowTimeout", CheckCommissioningWindowManagerWindowTimeout),
+    NL_TEST_DEF("CheckCommissioningWindowManagerWindowTimeoutWithSessionEstablishmentErrors",
+                CheckCommissioningWindowManagerWindowTimeoutWithSessionEstablishmentErrors),
+    NL_TEST_SENTINEL(),
 };
 
 } // namespace

--- a/src/app/tests/suites/TestClusterMultiFabric.yaml
+++ b/src/app/tests/suites/TestClusterMultiFabric.yaml
@@ -41,7 +41,7 @@ tests:
       arguments:
           values:
               - name: "CommissioningTimeout"
-                value: 120
+                value: 180
 
     - label: "Commission from beta"
       identity: "beta"

--- a/src/app/tests/suites/TestDiscovery.yaml
+++ b/src/app/tests/suites/TestDiscovery.yaml
@@ -47,7 +47,7 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
-    - label: "Open Commissioning Window"
+    - label: "Open Commissioning Window with too-short timeout"
       cluster: "AdministratorCommissioning"
       command: "OpenBasicCommissioningWindow"
       timedInteractionTimeoutMs: 10000
@@ -55,6 +55,28 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 120
+      response:
+          error: INVALID_COMMAND
+
+    - label: "Open Commissioning Window with too-long timeout"
+      cluster: "AdministratorCommissioning"
+      command: "OpenBasicCommissioningWindow"
+      timedInteractionTimeoutMs: 10000
+      arguments:
+          values:
+              - name: "CommissioningTimeout"
+                value: 1000
+      response:
+          error: INVALID_COMMAND
+
+    - label: "Open Commissioning Window"
+      cluster: "AdministratorCommissioning"
+      command: "OpenBasicCommissioningWindow"
+      timedInteractionTimeoutMs: 10000
+      arguments:
+          values:
+              - name: "CommissioningTimeout"
+                value: 180
 
     - label: "Check Instance Name"
       cluster: "DiscoveryCommands"
@@ -291,7 +313,7 @@ tests:
       arguments:
           values:
               - name: "CommissioningTimeout"
-                value: 120
+                value: 180
 
     - label: "Check Instance Name"
       cluster: "DiscoveryCommands"

--- a/src/app/tests/suites/TestMultiAdmin.yaml
+++ b/src/app/tests/suites/TestMultiAdmin.yaml
@@ -57,7 +57,7 @@ tests:
       arguments:
           values:
               - name: "CommissioningTimeout"
-                value: 120
+                value: 180
 
     - label: "Commission from alpha again"
       identity: "alpha"
@@ -92,7 +92,7 @@ tests:
       arguments:
           values:
               - name: "CommissioningTimeout"
-                value: 120
+                value: 180
 
     - label: "Commission from beta"
       identity: "beta"
@@ -122,7 +122,7 @@ tests:
       arguments:
           values:
               - name: "CommissioningTimeout"
-                value: 120
+                value: 180
 
     - label: "Commission from gamma"
       identity: "gamma"

--- a/src/app/tests/suites/certification/Test_TC_MF_1_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MF_1_3.yaml
@@ -44,7 +44,7 @@ tests:
               - name: "nodeId"
                 value: 1
 
-    - label: "Open Commissioning Window"
+    - label: "Open Commissioning Window with too-short timeout"
       cluster: "AdministratorCommissioning"
       command: "OpenCommissioningWindow"
       timedInteractionTimeoutMs: 10000
@@ -52,6 +52,44 @@ tests:
           values:
               - name: "CommissioningTimeout"
                 value: 120
+              - name: "PAKEVerifier"
+                value: "\x06\xc7\x56\xdf\xfc\xd7\x22\x65\x34\x52\xa1\x2d\xcd\x94\x5d\x8c\x54\xda\x2b\x0f\x3c\xbd\x1b\x4d\xc3\xf1\xad\xb2\x23\xae\xb2\x6b\x04\x7c\xd2\x4c\x96\x86\x6f\x97\x9b\x1d\x83\xec\x50\xe2\xb4\xae\x30\xcd\xf2\xfd\xb3\x2b\xd8\xa2\x11\xb8\x37\xdc\x94\xed\xcd\x56\xf4\xd1\x43\x77\x19\x10\x76\xbf\xc5\x9d\x99\xb7\xdd\x30\x53\xef\xd6\xf0\x2c\x44\x34\xf2\xbd\xd2\x7a\xa4\xf9\xce\xa7\x0d\x73\x8e\x4c"
+              - name: "discriminator"
+                value: 3840
+              - name: "iterations"
+                value: 1000
+              - name: "salt"
+                value: "SPAKE2P Key Salt"
+      response:
+          error: INVALID_COMMAND
+
+    - label: "Open Commissioning Window with too-long timeout"
+      cluster: "AdministratorCommissioning"
+      command: "OpenCommissioningWindow"
+      timedInteractionTimeoutMs: 10000
+      arguments:
+          values:
+              - name: "CommissioningTimeout"
+                value: 1000
+              - name: "PAKEVerifier"
+                value: "\x06\xc7\x56\xdf\xfc\xd7\x22\x65\x34\x52\xa1\x2d\xcd\x94\x5d\x8c\x54\xda\x2b\x0f\x3c\xbd\x1b\x4d\xc3\xf1\xad\xb2\x23\xae\xb2\x6b\x04\x7c\xd2\x4c\x96\x86\x6f\x97\x9b\x1d\x83\xec\x50\xe2\xb4\xae\x30\xcd\xf2\xfd\xb3\x2b\xd8\xa2\x11\xb8\x37\xdc\x94\xed\xcd\x56\xf4\xd1\x43\x77\x19\x10\x76\xbf\xc5\x9d\x99\xb7\xdd\x30\x53\xef\xd6\xf0\x2c\x44\x34\xf2\xbd\xd2\x7a\xa4\xf9\xce\xa7\x0d\x73\x8e\x4c"
+              - name: "discriminator"
+                value: 3840
+              - name: "iterations"
+                value: 1000
+              - name: "salt"
+                value: "SPAKE2P Key Salt"
+      response:
+          error: INVALID_COMMAND
+
+    - label: "Open Commissioning Window"
+      cluster: "AdministratorCommissioning"
+      command: "OpenCommissioningWindow"
+      timedInteractionTimeoutMs: 10000
+      arguments:
+          values:
+              - name: "CommissioningTimeout"
+                value: 180
               - name: "PAKEVerifier"
                 value: "\x06\xc7\x56\xdf\xfc\xd7\x22\x65\x34\x52\xa1\x2d\xcd\x94\x5d\x8c\x54\xda\x2b\x0f\x3c\xbd\x1b\x4d\xc3\xf1\xad\xb2\x23\xae\xb2\x6b\x04\x7c\xd2\x4c\x96\x86\x6f\x97\x9b\x1d\x83\xec\x50\xe2\xb4\xae\x30\xcd\xf2\xfd\xb3\x2b\xd8\xa2\x11\xb8\x37\xdc\x94\xed\xcd\x56\xf4\xd1\x43\x77\x19\x10\x76\xbf\xc5\x9d\x99\xb7\xdd\x30\x53\xef\xd6\xf0\x2c\x44\x34\xf2\xbd\xd2\x7a\xa4\xf9\xce\xa7\x0d\x73\x8e\x4c"
               - name: "discriminator"

--- a/src/app/tests/suites/certification/Test_TC_SC_4_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_4_2.yaml
@@ -60,7 +60,7 @@ tests:
       arguments:
           values:
               - name: "CommissioningTimeout"
-                value: 120
+                value: 180
 
     - label: "Check Instance Name"
       cluster: "DiscoveryCommands"
@@ -271,7 +271,7 @@ tests:
       arguments:
           values:
               - name: "CommissioningTimeout"
-                value: 120
+                value: 180
 
     - label: "Check Instance Name"
       disabled: true


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/16689

Fixes https://github.com/project-chip/connectedhomeip/issues/16548 
(the fact that most of our example apps by default started a
commissioning window with no timeout at all).

Fixes non-spec-compliant status codes and the lack of a check for the
3 minute minimum on a commissioning timeout window in the
Administrator Commissioning cluster.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Added unit tests (for #16689) and YAML tests (for the incorrect status codes and no enforcement of 3-minute minimum) that fail without this PR and pass with it.  CI should verify that commissioning generally still works.