### PR TITLE
[OTA] Shutdown server and stop event loop directly from OTA Image Processor

### DIFF
--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -286,11 +286,6 @@ void OTARequestor::Reset()
     StoreCurrentUpdateInfo();
 }
 
-void OTARequestor::Shutdown(void)
-{
-    mServer->DispatchShutDownAndStopEventLoop();
-}
-
 EmberAfStatus OTARequestor::HandleAnnounceOTAProvider(app::CommandHandler * commandObj,
                                                       const app::ConcreteCommandPath & commandPath,
                                                       const AnnounceOtaProvider::DecodableType & commandData)

--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -41,7 +41,6 @@ public:
 
     //////////// OTARequestorInterface Implementation ///////////////
     void Reset(void) override;
-    void Shutdown(void) override;
 
     EmberAfStatus HandleAnnounceOTAProvider(
         app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,

--- a/src/app/clusters/ota-requestor/OTARequestorInterface.h
+++ b/src/app/clusters/ota-requestor/OTARequestorInterface.h
@@ -156,9 +156,6 @@ public:
     // Reset any relevant states
     virtual void Reset(void) = 0;
 
-    // Perform any clean up necessary
-    virtual void Shutdown(void) = 0;
-
     // Handler for the AnnounceOTAProvider command
     virtual EmberAfStatus HandleAnnounceOTAProvider(
         chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,


### PR DESCRIPTION
#### Problem
Instead of using OTARequestorInterface as a way to access `mServer->DispatchShutDownAndStopEventLoop()`, just directly call the necessary platform APIs to shtudown

Fixes: https://github.com/project-chip/connectedhomeip/issues/16697

#### Change overview
- Remove `OTARequestorInterface::Shutdown`
- Directly schedule calls to `DeviceLayer::PlatformMgr().HandleServerShuttingDown()` and `DeviceLayer::PlatformMgr().StopEventLoopTask()`

#### Testing
- Verified after successful transfer of image, the server is shutdown and even loop stopped and new image is booted on Darwin