### PR TITLE
[zephyr] Fix re-joining multicast groups

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -255,11 +255,11 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
     // This code is necessary to restart listening to existing groups after a reboot
     // Each manufacturer needs to validate that they can rejoin groups by placing this code at the appropriate location for them
     //
-    // This is disabled for thread device because the same code is already present for thread devices in
+    // Thread LWIP devices using dedicated Inet endpoint implementations are excluded because they call this function from:
     // src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
-#if !CHIP_DEVICE_CONFIG_ENABLE_THREAD
+#if !CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
     RejoinExistingMulticastGroups();
-#endif // !CHIP_DEVICE_CONFIG_ENABLE_THREAD
+#endif // !CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 
     PlatformMgr().HandleServerStarted();
 


### PR DESCRIPTION
#### Problem
`RejoinExistingMulticastGroups()` is never called at boot on Zephyr platforms (and other non-LWIP Thread platforms)

#### Change overview
Fix the condition in `Server::Init` not to exclude socket-based platforms from the call.

#### Testing
Tested on nRF Connect platform.