### PR TITLE
[chip-tool] Add commands to generate/update onboarding payloads

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -61,6 +61,7 @@ static_library("chip-tool-utils") {
     "commands/pairing/OpenCommissioningWindowCommand.h",
     "commands/pairing/PairingCommand.cpp",
     "commands/payload/AdditionalDataParseCommand.cpp",
+    "commands/payload/SetupPayloadGenerateCommand.cpp",
     "commands/payload/SetupPayloadParseCommand.cpp",
     "commands/payload/SetupPayloadVerhoeff.cpp",
     "commands/tests/TestCommand.cpp",

--- a/examples/chip-tool/commands/payload/Commands.h
+++ b/examples/chip-tool/commands/payload/Commands.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "AdditionalDataParseCommand.h"
+#include "SetupPayloadGenerateCommand.h"
 #include "SetupPayloadParseCommand.h"
 #include "SetupPayloadVerhoeff.h"
 
@@ -26,10 +27,12 @@ void registerCommandsPayload(Commands & commands)
 {
     const char * clusterName      = "Payload";
     commands_list clusterCommands = {
-        make_unique<SetupPayloadParseCommand>(),
-        make_unique<AdditionalDataParseCommand>(),
-        make_unique<SetupPayloadVerhoeffVerify>(),
-        make_unique<SetupPayloadVerhoeffGenerate>(),
+        make_unique<SetupPayloadGenerateQRCodeCommand>(),     //
+        make_unique<SetupPayloadGenerateManualCodeCommand>(), //
+        make_unique<SetupPayloadParseCommand>(),              //
+        make_unique<AdditionalDataParseCommand>(),            //
+        make_unique<SetupPayloadVerhoeffVerify>(),            //
+        make_unique<SetupPayloadVerhoeffGenerate>(),          //
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/payload/SetupPayloadGenerateCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadGenerateCommand.cpp
@@ -1,0 +1,107 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "SetupPayloadGenerateCommand.h"
+#include <setup_payload/ManualSetupPayloadGenerator.h>
+#include <setup_payload/ManualSetupPayloadParser.h>
+#include <setup_payload/QRCodeSetupPayloadGenerator.h>
+#include <setup_payload/QRCodeSetupPayloadParser.h>
+#include <setup_payload/SetupPayload.h>
+
+using namespace ::chip;
+
+void SetupPayloadGenerateCommand::ConfigurePayload(SetupPayload & payload)
+{
+    if (mDiscriminator.HasValue())
+    {
+        payload.discriminator = mDiscriminator.Value();
+    }
+
+    if (mSetUpPINCode.HasValue())
+    {
+        payload.setUpPINCode = mSetUpPINCode.Value();
+    }
+
+    if (mVersion.HasValue())
+    {
+        payload.version = mVersion.Value();
+    }
+
+    if (mVendorId.HasValue())
+    {
+        payload.vendorID = mVendorId.Value();
+    }
+
+    if (mProductId.HasValue())
+    {
+        payload.productID = mProductId.Value();
+    }
+
+    if (mCommissioningMode.HasValue())
+    {
+        payload.commissioningFlow = static_cast<CommissioningFlow>(mCommissioningMode.Value());
+    }
+}
+
+CHIP_ERROR SetupPayloadGenerateQRCodeCommand::Run()
+{
+    SetupPayload payload;
+
+    if (mPayload.HasValue())
+    {
+        QRCodeSetupPayloadParser(mPayload.Value()).populatePayload(payload);
+    }
+
+    ConfigurePayload(payload);
+
+    if (mRendezvous.HasValue())
+    {
+        payload.rendezvousInformation.SetRaw(mRendezvous.Value());
+    }
+
+    QRCodeSetupPayloadGenerator generator(payload);
+    generator.SetAllowInvalidPayload(mAllowInvalidPayload.ValueOr(false));
+
+    std::string code;
+    ReturnErrorOnFailure(generator.payloadBase38Representation(code));
+    ChipLogProgress(chipTool, "QR Code: %s", code.c_str());
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR SetupPayloadGenerateManualCodeCommand::Run()
+{
+    SetupPayload payload;
+
+    if (mPayload.HasValue())
+    {
+        ManualSetupPayloadParser(mPayload.Value()).populatePayload(payload);
+    }
+
+    ConfigurePayload(payload);
+
+    ManualSetupPayloadGenerator generator(payload);
+    generator.SetAllowInvalidPayload(mAllowInvalidPayload.ValueOr(false));
+    generator.SetForceShortCode(mForceShortCode.ValueOr(false));
+
+    std::string code;
+    ReturnErrorOnFailure(generator.payloadDecimalStringRepresentation(code));
+    ChipLogProgress(chipTool, "Manual Code: %s", code.c_str());
+
+    return CHIP_NO_ERROR;
+}

--- a/examples/chip-tool/commands/payload/SetupPayloadGenerateCommand.h
+++ b/examples/chip-tool/commands/payload/SetupPayloadGenerateCommand.h
@@ -1,0 +1,76 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "../common/Command.h"
+#include <setup_payload/SetupPayload.h>
+
+class SetupPayloadGenerateCommand : public Command
+{
+public:
+    SetupPayloadGenerateCommand(const char * name) : Command(name)
+    {
+        AddArgument("payload", &mPayload);
+        AddArgument("discriminator", 0, UINT16_MAX, &mDiscriminator);
+        AddArgument("setup-pin-code", 0, UINT32_MAX, &mSetUpPINCode);
+        AddArgument("version", 0, UINT8_MAX, &mVersion);
+        AddArgument("vendor-id", 0, UINT16_MAX, &mVendorId);
+        AddArgument("product-id", 0, UINT16_MAX, &mProductId);
+        AddArgument("commissioning-mode", 0, UINT8_MAX, &mCommissioningMode);
+        AddArgument("allow-invalid-payload", 0, 1, &mAllowInvalidPayload);
+    }
+
+protected:
+    void ConfigurePayload(chip::SetupPayload & payload);
+
+    chip::Optional<uint16_t> mDiscriminator;
+    chip::Optional<uint32_t> mSetUpPINCode;
+    chip::Optional<uint8_t> mVersion;
+    chip::Optional<uint16_t> mVendorId;
+    chip::Optional<uint16_t> mProductId;
+    chip::Optional<char *> mPayload;
+    chip::Optional<uint8_t> mCommissioningMode;
+    chip::Optional<bool> mAllowInvalidPayload;
+};
+
+class SetupPayloadGenerateQRCodeCommand : public SetupPayloadGenerateCommand
+{
+public:
+    SetupPayloadGenerateQRCodeCommand() : SetupPayloadGenerateCommand("generate-qrcode")
+    {
+        AddArgument("rendezvous", 0, UINT8_MAX, &mRendezvous);
+    }
+    CHIP_ERROR Run() override;
+
+private:
+    chip::Optional<uint8_t> mRendezvous;
+};
+
+class SetupPayloadGenerateManualCodeCommand : public SetupPayloadGenerateCommand
+{
+public:
+    SetupPayloadGenerateManualCodeCommand() : SetupPayloadGenerateCommand("generate-manualcode")
+    {
+        AddArgument("force-short-code", 0, 1, &mForceShortCode);
+    }
+    CHIP_ERROR Run() override;
+
+private:
+    chip::Optional<bool> mForceShortCode;
+};

--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -109,13 +109,13 @@ CHIP_ERROR ManualSetupPayloadGenerator::payloadDecimalStringRepresentation(Mutab
     static_assert(kManualSetupChunk2PINCodeLsbitsLength + kManualSetupChunk3PINCodeMsbitsLength == kSetupPINCodeFieldLengthInBits,
                   "PIN code won't fit");
 
-    if (!mPayloadContents.isValidManualCode())
+    if (!mAllowInvalidPayload && !mPayloadContents.isValidManualCode())
     {
         ChipLogError(SetupPayload, "Failed encoding invalid payload");
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    bool useLongCode = (mPayloadContents.commissioningFlow != CommissioningFlow::kStandard);
+    bool useLongCode = (mPayloadContents.commissioningFlow != CommissioningFlow::kStandard) && !mForceShortCode;
 
     // Add two for the check digit and null terminator.
     if ((useLongCode && outBuffer.size() < kManualSetupLongCodeCharLength + 2) ||

--- a/src/setup_payload/ManualSetupPayloadGenerator.h
+++ b/src/setup_payload/ManualSetupPayloadGenerator.h
@@ -70,6 +70,25 @@ public:
     // Populates decimal string representation of the payload into outDecimalString.
     // Wrapper for using std::string.
     CHIP_ERROR payloadDecimalStringRepresentation(std::string & outDecimalString);
+
+    /**
+     * This function disables internal checks about the validity of the generated payload.
+     * It allows using the generator to generate invalid payloads.
+     * Default is false.
+     */
+    void SetAllowInvalidPayload(bool allow) { mAllowInvalidPayload = allow; }
+
+    /**
+     * This function allow forcing the generation of a short code when the commissioning
+     * flow is not standard by ignoring the vendor id and product id informations but with
+     * the VID/PID present flag set.
+     * Default is false.
+     */
+    void SetForceShortCode(bool useShort) { mForceShortCode = useShort; }
+
+private:
+    bool mAllowInvalidPayload = false;
+    bool mForceShortCode      = false;
 };
 
 } // namespace chip

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -213,7 +213,7 @@ CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBase38Representation(std::string 
 {
     size_t tlvDataLengthInBytes = 0;
 
-    VerifyOrReturnError(mPayload.isValidQRCodePayload(), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(mAllowInvalidPayload || mPayload.isValidQRCodePayload(), CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorOnFailure(generateTLVFromOptionalData(mPayload, tlvDataStart, tlvDataStartSize, tlvDataLengthInBytes));
 
     std::vector<uint8_t> bits(kTotalPayloadDataSizeInBytes + tlvDataLengthInBytes);

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.h
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.h
@@ -82,9 +82,18 @@ public:
      */
     CHIP_ERROR payloadBase38Representation(std::string & base38Representation, uint8_t * tlvDataStart, uint32_t tlvDataStartSize);
 
+    /**
+     * This function disable internal checks about the validity of the generated payload.
+     * It allows using the generator to generates invalid payloads.
+     * Defaults is false.
+     */
+    void SetAllowInvalidPayload(bool allow) { mAllowInvalidPayload = allow; }
+
 private:
     CHIP_ERROR generateTLVFromOptionalData(SetupPayload & outPayload, uint8_t * tlvDataStart, uint32_t maxLen,
                                            size_t & tlvDataLengthInBytes);
+
+    bool mAllowInvalidPayload = false;
 };
 
 /**


### PR DESCRIPTION
#### Problem

`chip-tool` is not able to generate onboarding payloads. Furthermore there is no way to generate invalid payloads using the current APIs.

Partially fix #16385

#### Change overview
  * Add a command to `chip-tool` to generate/update a qr code

  * Add a command to `chip-tool` to generate/update a manual code

  *Update the APIs provided by `ManualSetupPayloadGenerator` and `QRCodeSetupPayloadGenerator` to allow for creating invalid payloads. 
 
#### Testing
It was tested locally and it will be used to generate payloads for TC-DD-3.12/13