### PR TITLE
Fix Tizen platform build with disabled WiFi

### DIFF
--- a/src/platform/Tizen/CHIPDevicePlatformEvent.h
+++ b/src/platform/Tizen/CHIPDevicePlatformEvent.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <platform/CHIPDeviceEvent.h>
+#include <system/SystemPacketBuffer.h>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Tizen/ConnectivityManagerImpl.cpp
+++ b/src/platform/Tizen/ConnectivityManagerImpl.cpp
@@ -52,6 +52,7 @@ CHIP_ERROR ConnectivityManagerImpl::_Init(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     mWiFiStationMode              = kWiFiStationMode_Disabled;
     mWiFiAPMode                   = kWiFiAPMode_Disabled;
     mWiFiAPState                  = kWiFiAPState_NotActive;
@@ -59,7 +60,6 @@ CHIP_ERROR ConnectivityManagerImpl::_Init(void)
     mWiFiStationReconnectInterval = System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_WIFI_STATION_RECONNECT_INTERVAL);
     mWiFiAPIdleTimeout            = System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_WIFI_AP_IDLE_TIMEOUT);
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     WiFiMgr().Init();
 #endif
 
@@ -214,12 +214,12 @@ void ConnectivityManagerImpl::DeactivateWiFiManager(::chip::System::Layer * aLay
 {
     WiFiMgr().Deactivate();
 }
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
 CHIP_ERROR ConnectivityManagerImpl::ProvisionWiFiNetwork(const char * ssid, const char * key)
 {
     return WiFiMgr().Connect(ssid, key);
 }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Tizen/ConnectivityManagerImpl.h
+++ b/src/platform/Tizen/ConnectivityManagerImpl.h
@@ -76,9 +76,9 @@ class ConnectivityManagerImpl final : public ConnectivityManager,
     friend class ConnectivityManager;
 
 public:
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     CHIP_ERROR ProvisionWiFiNetwork(const char * ssid, const char * key);
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     void StartWiFiManagement(void);
     void StopWiFiManagement(void);
 #endif
@@ -124,12 +124,14 @@ private:
 
     // ===== Private members reserved for use by this class only.
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     ConnectivityManager::WiFiStationMode mWiFiStationMode;
     ConnectivityManager::WiFiAPMode mWiFiAPMode;
     WiFiAPState mWiFiAPState;
     System::Clock::Timestamp mLastAPDemandTime;
     System::Clock::Timeout mWiFiStationReconnectInterval;
     System::Clock::Timeout mWiFiAPIdleTimeout;
+#endif
 };
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI

--- a/src/platform/Tizen/DeviceNetworkProvisioningDelegateImpl.cpp
+++ b/src/platform/Tizen/DeviceNetworkProvisioningDelegateImpl.cpp
@@ -29,7 +29,12 @@ CHIP_ERROR DeviceNetworkProvisioningDelegateImpl::_ProvisionWiFiNetwork(const ch
 
     ChipLogProgress(NetworkProvisioning, "TizenNetworkProvisioningDelegate: SSID: %s", ssid);
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     err = ConnectivityMgrImpl().ProvisionWiFiNetwork(ssid, key);
+#else
+    err = CHIP_ERROR_NOT_IMPLEMENTED;
+#endif
+
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network: %s", chip::ErrorStr(err));


### PR DESCRIPTION
#### Problem

Tizen platform could not be built without WiFi support.

#### Change overview

- Fix #ifdefs to account for disabled WiFi support

#### Testing

Build with `./scripts/build/build_examples.py --target tizen-arm-light-no-ble-no-wifi build`
It requires #16701 
