### PR TITLE
[chip-tool] Add repeat-count and repeat-duration-ms optional paramete…

### DIFF
--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <app/CommandSender.h>
+#include <lib/support/UnitTestUtils.h>
 
 #include "DataModelLogger.h"
 #include "ModelCommand.h"
@@ -33,6 +34,8 @@ public:
         AddArgument("payload", &mPayload);
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
         AddArgument("suppressResponse", 0, 1, &mSuppressResponse);
+        AddArgument("repeat-count", 1, UINT16_MAX, &mRepeatCount);
+        AddArgument("repeat-delay-ms", 0, UINT16_MAX, &mRepeatDelayInMs);
         ModelCommand::AddArguments();
     }
 
@@ -43,6 +46,8 @@ public:
         AddArgument("payload", &mPayload);
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
         AddArgument("suppressResponse", 0, 1, &mSuppressResponse);
+        AddArgument("repeat-count", 1, UINT16_MAX, &mRepeatCount);
+        AddArgument("repeat-delay-ms", 0, UINT16_MAX, &mRepeatDelayInMs);
         ModelCommand::AddArguments();
     }
 
@@ -51,6 +56,8 @@ public:
     {
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
         AddArgument("suppressResponse", 0, 1, &mSuppressResponse);
+        AddArgument("repeat-count", 1, UINT16_MAX, &mRepeatCount);
+        AddArgument("repeat-delay-ms", 0, UINT16_MAX, &mRepeatDelayInMs);
     }
 
     ~ClusterCommand() {}
@@ -97,22 +104,48 @@ public:
 
     virtual void OnDone(chip::app::CommandSender * client) override
     {
-        mCommandSender.reset();
-        SetCommandExitStatus(mError);
+        mCommandSender.front().reset();
+        mCommandSender.erase(mCommandSender.begin());
+
+        // If the command is repeated N times, wait for all the responses to comes in
+        // before exiting.
+        bool shouldStop = true;
+        if (mRepeatCount.HasValue())
+        {
+            mRepeatCount.SetValue(static_cast<uint16_t>(mRepeatCount.Value() - 1));
+            shouldStop = mRepeatCount.Value() == 0;
+        }
+
+        if (shouldStop)
+        {
+            SetCommandExitStatus(mError);
+        }
     }
 
     template <class T>
     CHIP_ERROR SendCommand(ChipDevice * device, chip::EndpointId endpointId, chip::ClusterId clusterId, chip::CommandId commandId,
                            const T & value)
     {
-        chip::app::CommandPathParams commandPath = { endpointId, 0 /* groupId */, clusterId, commandId,
-                                                     (chip::app::CommandPathFlags::kEndpointIdValid) };
-        mCommandSender =
-            std::make_unique<chip::app::CommandSender>(this, device->GetExchangeManager(), mTimedInteractionTimeoutMs.HasValue());
-        VerifyOrReturnError(mCommandSender != nullptr, CHIP_ERROR_NO_MEMORY);
-        ReturnErrorOnFailure(mCommandSender->AddRequestDataNoTimedCheck(commandPath, value, mTimedInteractionTimeoutMs,
-                                                                        mSuppressResponse.ValueOr(false)));
-        ReturnErrorOnFailure(mCommandSender->SendCommandRequest(device->GetSecureSession().Value()));
+        uint16_t repeatCount = mRepeatCount.ValueOr(1);
+        while (repeatCount--)
+        {
+            chip::app::CommandPathParams commandPath = { endpointId, 0 /* groupId */, clusterId, commandId,
+                                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+
+            auto commandSender = std::make_unique<chip::app::CommandSender>(this, device->GetExchangeManager(),
+                                                                            mTimedInteractionTimeoutMs.HasValue());
+            VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_NO_MEMORY);
+            ReturnErrorOnFailure(commandSender->AddRequestDataNoTimedCheck(commandPath, value, mTimedInteractionTimeoutMs,
+                                                                           mSuppressResponse.ValueOr(false)));
+
+            ReturnErrorOnFailure(commandSender->SendCommandRequest(device->GetSecureSession().Value()));
+            mCommandSender.push_back(std::move(commandSender));
+
+            if (mRepeatDelayInMs.HasValue())
+            {
+                chip::test_utils::SleepMillis(mRepeatDelayInMs.Value());
+            }
+        }
         return CHIP_NO_ERROR;
     }
 
@@ -142,8 +175,10 @@ private:
     chip::CommandId mCommandId;
     chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
     chip::Optional<bool> mSuppressResponse;
+    chip::Optional<uint16_t> mRepeatCount;
+    chip::Optional<uint16_t> mRepeatDelayInMs;
 
     CHIP_ERROR mError = CHIP_NO_ERROR;
     CustomArgument mPayload;
-    std::unique_ptr<chip::app::CommandSender> mCommandSender;
+    std::vector<std::unique_ptr<chip::app::CommandSender>> mCommandSender;
 };


### PR DESCRIPTION
…rs for cluster commands

#### Problem

Some test cases requires to repeat a command after some delay.

Fix #16091 

#### Change overview
 * Add `repeat-count` and `repeat-delay-ms` optional parameters to cluster commands

#### Testing
It was tried using `./out/debug/standalone/chip-tool onoff toggle 0x12344321 1 --repeat-count 4 --repeat-delay-ms 200`