### PR TITLE
Remove node id from outgoing group session

### DIFF
--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -60,9 +60,9 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), mClusterId, mCommandId, mPayload);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, mClusterId, mCommandId, mPayload);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, mClusterId, mCommandId, mPayload);
     }
 
     /////////// CommandSender Callback Interface /////////
@@ -117,8 +117,8 @@ public:
     }
 
     template <class T>
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId,
-                                chip::ClusterId clusterId, chip::CommandId commandId, const T & value)
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::ClusterId clusterId,
+                                chip::CommandId commandId, const T & value)
     {
         chip::app::CommandPathParams commandPath = { 0 /* endpoint */, groupId, clusterId, commandId,
                                                      (chip::app::CommandPathFlags::kGroupIdValid) };
@@ -130,7 +130,7 @@ public:
         VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_NO_MEMORY);
         ReturnErrorOnFailure(commandSender->AddRequestDataNoTimedCheck(commandPath, value, mTimedInteractionTimeoutMs));
 
-        chip::Transport::OutgoingGroupSession session(groupId, fabricIndex, senderNodeId);
+        chip::Transport::OutgoingGroupSession session(groupId, fabricIndex);
         ReturnErrorOnFailure(commandSender->SendGroupCommandRequest(chip::SessionHandle(session)));
         commandSender.release();
 

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -32,7 +32,7 @@ CHIP_ERROR ModelCommand::RunCommand()
         ReturnErrorOnFailure(CurrentCommissioner().GetFabricIndex(&fabricIndex));
         ChipLogProgress(chipTool, "Sending command to group 0x%" PRIx16, GroupIdFromNodeId(mNodeId));
 
-        return SendGroupCommand(GroupIdFromNodeId(mNodeId), fabricIndex, CurrentCommissioner().GetNodeId());
+        return SendGroupCommand(GroupIdFromNodeId(mNodeId), fabricIndex);
     }
 
     ChipLogProgress(chipTool, "Sending command to node 0x%" PRIx64, mNodeId);

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -45,10 +45,7 @@ public:
 
     virtual CHIP_ERROR SendCommand(ChipDevice * device, std::vector<chip::EndpointId> endPointIds) = 0;
 
-    virtual CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId)
-    {
-        return CHIP_ERROR_BAD_REQUEST;
-    };
+    virtual CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) { return CHIP_ERROR_BAD_REQUEST; };
 
     void Shutdown() override
     {

--- a/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
+++ b/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
@@ -63,9 +63,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), mClusterId, mAttributeId, mAttributeValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, mClusterId, mAttributeId, mAttributeValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, mClusterId, mAttributeId, mAttributeValue);
     }
 
     /////////// WriteClient Callback Interface /////////
@@ -115,8 +115,8 @@ public:
     }
 
     template <class T>
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId,
-                                chip::ClusterId clusterId, chip::AttributeId attributeId, const T & value)
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::ClusterId clusterId,
+                                chip::AttributeId attributeId, const T & value)
     {
 
         chip::app::AttributePathParams attributePathParams;
@@ -132,7 +132,7 @@ public:
         VerifyOrReturnError(writeClient != nullptr, CHIP_ERROR_NO_MEMORY);
         ReturnErrorOnFailure(writeClient->EncodeAttribute(attributePathParams, value, mDataVersion));
 
-        chip::Transport::OutgoingGroupSession session(groupId, fabricIndex, senderNodeId);
+        chip::Transport::OutgoingGroupSession session(groupId, fabricIndex);
         ReturnErrorOnFailure(writeClient->SendWriteRequest(chip::SessionHandle(session)));
         writeClient.release();
 

--- a/examples/chip-tool/commands/common/CommandInvoker.h
+++ b/examples/chip-tool/commands/common/CommandInvoker.h
@@ -107,7 +107,7 @@ public:
     }
 
     CHIP_ERROR InvokeGroupCommand(Messaging::ExchangeManager * exchangeManager, FabricIndex fabric, GroupId groupId,
-                                  NodeId sourceNodeId, const RequestType & aRequestData)
+                                  const RequestType & aRequestData)
     {
         app::CommandPathParams commandPath = { 0 /* endpoint */, groupId, RequestType::GetClusterId(), RequestType::GetCommandId(),
                                                (app::CommandPathFlags::kGroupIdValid) };
@@ -117,7 +117,7 @@ public:
 
         ReturnErrorOnFailure(commandSender->AddRequestData(commandPath, aRequestData));
 
-        Transport::OutgoingGroupSession session(groupId, fabric, sourceNodeId);
+        Transport::OutgoingGroupSession session(groupId, fabric);
 
         // this (invoker) and commandSender will be deleted by the onDone call before the return of SendGroupCommandRequest
         // this (invoker) should not be used after the SendGroupCommandRequest call
@@ -230,8 +230,7 @@ CHIP_ERROR InvokeGroupCommand(DeviceProxy * aDevice, void * aContext,
     //
     //  We assume the aDevice already has a Case session which is way we can use he established Secure Session
     ReturnErrorOnFailure(invoker->InvokeGroupCommand(aDevice->GetExchangeManager(),
-                                                     aDevice->GetSecureSession().Value()->GetFabricIndex(), groupId,
-                                                     aDevice->GetDeviceId(), aRequestData));
+                                                     aDevice->GetSecureSession().Value()->GetFabricIndex(), groupId, aRequestData));
 
     //  invoker is already deleted and is not to be used
     invoker.release();

--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -45,11 +45,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), {{asHex parent.code 8}}, {{asHex code 8}}, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 8}}) command ({{asHex code 8}}) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, {{asHex parent.code 8}}, {{asHex code 8}}, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, {{asHex parent.code 8}}, {{asHex code 8}}, mRequest);
     }
 
 private:
@@ -88,9 +88,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), {{asHex parent.code 8}}, {{asHex code 8}}, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, {{asHex parent.code 8}}, {{asHex code 8}}, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, {{asHex parent.code 8}}, {{asHex code 8}}, mValue);
     }
 
 private:

--- a/examples/chip-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_cluster.zapt
@@ -288,7 +288,7 @@ class {{filename}}Suite: public TestCommand
 
         {{#if isWriteAttribute}}
         {{#if isGroupCommand}}
-          ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::{{asUpperCamelCase cluster}}::Attributes::{{asUpperCamelCase attribute}}::TypeInfo>(groupId, {{>device}}->GetSecureSession().Value()->GetFabricIndex(), {{>device}}->GetDeviceId(),{{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument, {{/chip_tests_item_parameters}}this, {{>staticSuccessResponse}}, {{>staticFailureResponse}}
+          ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::{{asUpperCamelCase cluster}}::Attributes::{{asUpperCamelCase attribute}}::TypeInfo>(groupId, {{>device}}->GetSecureSession().Value()->GetFabricIndex(), {{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument, {{/chip_tests_item_parameters}}this, {{>staticSuccessResponse}}, {{>staticFailureResponse}}
             {{~> maybeTimedInteractionTimeout ~}}
             , {{>staticDoneResponse}}
             ));

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -85,25 +85,24 @@ void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTa
 
 void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding)
 {
-    NodeId sourceNodeId = Server::GetInstance().GetFabricTable().FindFabricWithIndex(binding.fabricIndex)->GetNodeId();
     Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
 
     switch (commandId)
     {
     case Clusters::OnOff::Commands::Toggle::Id:
         Clusters::OnOff::Commands::Toggle::Type toggleCommand;
-        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, sourceNodeId, toggleCommand);
+        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, toggleCommand);
         break;
 
     case Clusters::OnOff::Commands::On::Id:
         Clusters::OnOff::Commands::On::Type onCommand;
-        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, sourceNodeId, onCommand);
+        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, onCommand);
 
         break;
 
     case Clusters::OnOff::Commands::Off::Id:
         Clusters::OnOff::Commands::Off::Type offCommand;
-        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, sourceNodeId, offCommand);
+        Controller::InvokeGroupCommandRequest(&exchangeMgr, binding.fabricIndex, binding.groupId, offCommand);
         break;
     }
 }

--- a/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
+++ b/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
@@ -60,10 +60,8 @@ void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindin
         else
         {
 
-            NodeId sourceNodeId = Server::GetInstance().GetFabricTable().FindFabricWithIndex(aBinding.fabricIndex)->GetNodeId();
             Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
-            ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId, sourceNodeId,
-                                                        toggleCommand);
+            ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId, toggleCommand);
         }
         break;
 
@@ -76,10 +74,8 @@ void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindin
         }
         else
         {
-            NodeId sourceNodeId = Server::GetInstance().GetFabricTable().FindFabricWithIndex(aBinding.fabricIndex)->GetNodeId();
             Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
-            ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId, sourceNodeId,
-                                                        onCommand);
+            ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId, onCommand);
         }
         break;
 
@@ -92,10 +88,8 @@ void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindin
         }
         else
         {
-            NodeId sourceNodeId = Server::GetInstance().GetFabricTable().FindFabricWithIndex(aBinding.fabricIndex)->GetNodeId();
             Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
-            ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId, sourceNodeId,
-                                                        onCommand);
+            ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId, onCommand);
         }
         break;
     default:
@@ -134,10 +128,8 @@ void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const Embe
         }
         else
         {
-            NodeId sourceNodeId = Server::GetInstance().GetFabricTable().FindFabricWithIndex(aBinding.fabricIndex)->GetNodeId();
             Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
-            ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId, sourceNodeId,
-                                                        moveToLevelCommand);
+            ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex, aBinding.groupId, moveToLevelCommand);
         }
     }
     break;

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -146,8 +146,8 @@ public:
     }
 
     template <typename AttrType>
-    CHIP_ERROR WriteAttribute(GroupId groupId, FabricIndex fabricIndex, NodeId sourceNodeId, const AttrType & requestData,
-                              void * context, ClusterId clusterId, AttributeId attributeId, WriteResponseSuccessCallback successCb,
+    CHIP_ERROR WriteAttribute(GroupId groupId, FabricIndex fabricIndex, const AttrType & requestData, void * context,
+                              ClusterId clusterId, AttributeId attributeId, WriteResponseSuccessCallback successCb,
                               WriteResponseFailureCallback failureCb, const Optional<uint16_t> & aTimedWriteTimeoutMs,
                               WriteResponseDoneCallback doneCb = nullptr, const Optional<DataVersion> & aDataVersion = NullOptional)
     {
@@ -173,20 +173,19 @@ public:
             }
         };
 
-        Transport::OutgoingGroupSession groupSession(groupId, fabricIndex, sourceNodeId);
+        Transport::OutgoingGroupSession groupSession(groupId, fabricIndex);
         return chip::Controller::WriteAttribute<AttrType>(SessionHandle(groupSession), 0 /*Unused for Group*/, clusterId,
                                                           attributeId, requestData, onSuccessCb, onFailureCb, aTimedWriteTimeoutMs,
                                                           onDoneCb, aDataVersion);
     }
 
     template <typename AttributeInfo>
-    CHIP_ERROR WriteAttribute(GroupId groupId, FabricIndex fabricIndex, NodeId sourceNodeId,
-                              const typename AttributeInfo::Type & requestData, void * context,
-                              WriteResponseSuccessCallback successCb, WriteResponseFailureCallback failureCb,
+    CHIP_ERROR WriteAttribute(GroupId groupId, FabricIndex fabricIndex, const typename AttributeInfo::Type & requestData,
+                              void * context, WriteResponseSuccessCallback successCb, WriteResponseFailureCallback failureCb,
                               WriteResponseDoneCallback doneCb = nullptr, const Optional<DataVersion> & aDataVersion = NullOptional,
                               const Optional<uint16_t> & aTimedWriteTimeoutMs = NullOptional)
     {
-        return WriteAttribute(groupId, fabricIndex, sourceNodeId, requestData, context, AttributeInfo::GetClusterId(),
+        return WriteAttribute(groupId, fabricIndex, requestData, context, AttributeInfo::GetClusterId(),
                               AttributeInfo::GetAttributeId(), successCb, failureCb, aTimedWriteTimeoutMs, doneCb, aDataVersion);
     }
 

--- a/src/controller/InvokeInteraction.h
+++ b/src/controller/InvokeInteraction.h
@@ -103,12 +103,12 @@ InvokeCommandRequest(Messaging::ExchangeManager * aExchangeMgr, const SessionHan
  */
 template <typename RequestObjectT>
 CHIP_ERROR InvokeGroupCommandRequest(Messaging::ExchangeManager * exchangeMgr, chip::FabricIndex fabric, chip::GroupId groupId,
-                                     chip::NodeId sourceNodeId, const RequestObjectT & requestCommandData)
+                                     const RequestObjectT & requestCommandData)
 {
     CHIP_ERROR error                   = CHIP_NO_ERROR;
     app::CommandPathParams commandPath = { groupId, RequestObjectT::GetClusterId(), RequestObjectT::GetCommandId(),
                                            app::CommandPathFlags::kGroupIdValid };
-    Transport::OutgoingGroupSession session(groupId, fabric, sourceNodeId);
+    Transport::OutgoingGroupSession session(groupId, fabric);
 
     auto commandSender = chip::Platform::MakeUnique<app::CommandSender>(nullptr, exchangeMgr);
     VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_NO_MEMORY);

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -109,7 +109,7 @@ CHIP_ERROR MessagingContext::CreateSessionAliceToBob()
 
 CHIP_ERROR MessagingContext::CreateSessionBobToFriends()
 {
-    mSessionBobToFriends.Emplace(GetFriendsGroupId(), mBobFabricIndex, GetBobFabric()->GetNodeId());
+    mSessionBobToFriends.Emplace(GetFriendsGroupId(), mBobFabricIndex);
     return CHIP_NO_ERROR;
 }
 

--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -76,10 +76,7 @@ private:
 class OutgoingGroupSession : public Session
 {
 public:
-    OutgoingGroupSession(GroupId group, FabricIndex fabricIndex, NodeId sourceNodeId) : mGroupId(group), mSourceNodeId(sourceNodeId)
-    {
-        SetFabricIndex(fabricIndex);
-    }
+    OutgoingGroupSession(GroupId group, FabricIndex fabricIndex) : mGroupId(group) { SetFabricIndex(fabricIndex); }
     ~OutgoingGroupSession() override { NotifySessionReleased(); }
 
     Session::SessionType GetSessionType() const override { return Session::SessionType::kGroupOutgoing; }
@@ -111,11 +108,8 @@ public:
 
     GroupId GetGroupId() const { return mGroupId; }
 
-    NodeId GetSourceNodeId() const { return mSourceNodeId; }
-
 private:
     const GroupId mGroupId;
-    const NodeId mSourceNodeId;
 };
 
 } // namespace Transport

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -150,12 +150,15 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         auto * groups     = Credentials::GetGroupDataProvider();
         VerifyOrReturnError(nullptr != groups, CHIP_ERROR_INTERNAL);
 
+        FabricInfo * fabric = mFabricTable->FindFabricWithIndex(groupSession->GetFabricIndex());
+        VerifyOrDie(fabric != nullptr);
+
         packetHeader.SetDestinationGroupId(groupSession->GetGroupId());
         packetHeader.SetMessageCounter(mGroupClientCounter.GetCounter(isControlMsg));
         mGroupClientCounter.IncrementCounter(isControlMsg);
         packetHeader.SetFlags(Header::SecFlagValues::kPrivacyFlag);
         packetHeader.SetSessionType(Header::SessionType::kGroupSession);
-        packetHeader.SetSourceNodeId(groupSession->GetSourceNodeId());
+        packetHeader.SetSourceNodeId(fabric->GetNodeId());
 
         if (!packetHeader.IsValidGroupMsg())
         {
@@ -171,8 +174,7 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
 
         packetHeader.SetSessionId(keyContext->GetKeyHash());
         CryptoContext::NonceStorage nonce;
-        CryptoContext::BuildNonce(nonce, packetHeader.GetSecurityFlags(), packetHeader.GetMessageCounter(),
-                                  groupSession->GetSourceNodeId());
+        CryptoContext::BuildNonce(nonce, packetHeader.GetSecurityFlags(), packetHeader.GetMessageCounter(), fabric->GetNodeId());
         CHIP_ERROR err = SecureMessageCodec::Encrypt(CryptoContext(keyContext), nonce, payloadHeader, packetHeader, message);
         keyContext->Release();
         ReturnErrorOnFailure(err);

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -151,7 +151,7 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         VerifyOrReturnError(nullptr != groups, CHIP_ERROR_INTERNAL);
 
         FabricInfo * fabric = mFabricTable->FindFabricWithIndex(groupSession->GetFabricIndex());
-        VerifyOrDie(fabric != nullptr);
+        VerifyOrReturnError(fabric != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
         packetHeader.SetDestinationGroupId(groupSession->GetGroupId());
         packetHeader.SetMessageCounter(mGroupClientCounter.GetCounter(isControlMsg));

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -241,9 +241,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000010, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000010, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000010, mValue);
     }
 
 private:
@@ -268,9 +268,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000011, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000011, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000011, mValue);
     }
 
 private:
@@ -295,9 +295,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000012, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000012, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000012, mValue);
     }
 
 private:
@@ -322,9 +322,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000013, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000013, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000013, mValue);
     }
 
 private:
@@ -349,9 +349,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000030, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000030, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000030, mValue);
     }
 
 private:
@@ -376,9 +376,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000031, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000031, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000031, mValue);
     }
 
 private:
@@ -403,9 +403,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000032, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000032, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000032, mValue);
     }
 
 private:
@@ -430,9 +430,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000033, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000033, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000033, mValue);
     }
 
 private:
@@ -457,9 +457,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000034, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000034, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000034, mValue);
     }
 
 private:
@@ -484,9 +484,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000035, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000035, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000035, mValue);
     }
 
 private:
@@ -511,9 +511,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000036, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000036, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000036, mValue);
     }
 
 private:
@@ -538,9 +538,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000037, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000037, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000037, mValue);
     }
 
 private:
@@ -565,9 +565,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000038, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000038, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000038, mValue);
     }
 
 private:
@@ -592,9 +592,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000039, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000039, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000039, mValue);
     }
 
 private:
@@ -619,9 +619,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x0000003A, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x0000003A, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x0000003A, mValue);
     }
 
 private:
@@ -646,9 +646,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x0000003B, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x0000003B, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x0000003B, mValue);
     }
 
 private:
@@ -673,9 +673,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x0000003C, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x0000003C, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x0000003C, mValue);
     }
 
 private:
@@ -700,9 +700,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x0000003D, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x0000003D, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x0000003D, mValue);
     }
 
 private:
@@ -727,9 +727,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000050, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000050, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000050, mValue);
     }
 
 private:
@@ -754,9 +754,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000051, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000051, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000051, mValue);
     }
 
 private:
@@ -781,9 +781,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000052, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000052, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000052, mValue);
     }
 
 private:
@@ -808,9 +808,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000053, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000053, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000053, mValue);
     }
 
 private:
@@ -835,9 +835,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000054, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000054, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000054, mValue);
     }
 
 private:
@@ -862,9 +862,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000055, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000055, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000055, mValue);
     }
 
 private:
@@ -889,9 +889,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000056, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000056, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000056, mValue);
     }
 
 private:
@@ -916,9 +916,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000057, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000057, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000057, mValue);
     }
 
 private:
@@ -943,9 +943,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000058, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000058, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000058, mValue);
     }
 
 private:
@@ -970,9 +970,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000059, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000059, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000059, mValue);
     }
 
 private:
@@ -997,9 +997,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x0000005A, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x0000005A, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x0000005A, mValue);
     }
 
 private:
@@ -1024,9 +1024,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x0000005B, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x0000005B, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x0000005B, mValue);
     }
 
 private:
@@ -1051,9 +1051,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x0000005C, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x0000005C, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x0000005C, mValue);
     }
 
 private:
@@ -1078,9 +1078,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x0000005D, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x0000005D, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x0000005D, mValue);
     }
 
 private:
@@ -1105,9 +1105,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000070, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000070, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000070, mValue);
     }
 
 private:
@@ -1132,9 +1132,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000071, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000071, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000071, mValue);
     }
 
 private:
@@ -1159,9 +1159,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000072, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000072, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000072, mValue);
     }
 
 private:
@@ -1186,9 +1186,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000073, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000073, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000073, mValue);
     }
 
 private:
@@ -1213,9 +1213,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000074, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000074, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000074, mValue);
     }
 
 private:
@@ -1240,9 +1240,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000075, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000075, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000075, mValue);
     }
 
 private:
@@ -1267,9 +1267,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000076, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000076, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000076, mValue);
     }
 
 private:
@@ -1294,9 +1294,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000077, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000077, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000077, mValue);
     }
 
 private:
@@ -1321,9 +1321,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000078, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000078, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000078, mValue);
     }
 
 private:
@@ -1348,9 +1348,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x00000079, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x00000079, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x00000079, mValue);
     }
 
 private:
@@ -1375,9 +1375,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x0000007A, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x0000007A, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x0000007A, mValue);
     }
 
 private:
@@ -1402,9 +1402,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x0000007B, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x0000007B, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x0000007B, mValue);
     }
 
 private:
@@ -1429,9 +1429,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x0000007C, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x0000007C, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x0000007C, mValue);
     }
 
 private:
@@ -1456,9 +1456,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000001, 0x0000007D, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000001, 0x0000007D, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000001, 0x0000007D, mValue);
     }
 
 private:
@@ -1507,9 +1507,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000002, 0x00000010, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000002, 0x00000010, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000002, 0x00000010, mValue);
     }
 
 private:
@@ -1534,9 +1534,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000002, 0x00000011, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000002, 0x00000011, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000002, 0x00000011, mValue);
     }
 
 private:
@@ -1561,9 +1561,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000002, 0x00000012, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000002, 0x00000012, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000002, 0x00000012, mValue);
     }
 
 private:
@@ -1588,9 +1588,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000002, 0x00000013, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000002, 0x00000013, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000002, 0x00000013, mValue);
     }
 
 private:
@@ -1615,9 +1615,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000002, 0x00000014, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000002, 0x00000014, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000002, 0x00000014, mValue);
     }
 
 private:
@@ -1663,11 +1663,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000003, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000003) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000003, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000003, 0x00000000, mRequest);
     }
 
 private:
@@ -1692,11 +1692,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000003, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000003) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000003, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000003, 0x00000001, mRequest);
     }
 
 private:
@@ -1723,11 +1723,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000003, 0x00000040, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000003) command (0x00000040) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000003, 0x00000040, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000003, 0x00000040, mRequest);
     }
 
 private:
@@ -1751,9 +1751,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000003, 0x00000000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000003, 0x00000000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000003, 0x00000000, mValue);
     }
 
 private:
@@ -1802,11 +1802,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000004, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000004) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000004, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000004, 0x00000000, mRequest);
     }
 
 private:
@@ -1832,11 +1832,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000004, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000004) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000004, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000004, 0x00000001, mRequest);
     }
 
 private:
@@ -1863,11 +1863,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000004, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000004) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000004, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000004, 0x00000002, mRequest);
     }
 
 private:
@@ -1894,11 +1894,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000004, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000004) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000004, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000004, 0x00000003, mRequest);
     }
 
 private:
@@ -1923,11 +1923,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000004, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000004) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000004, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000004, 0x00000004, mRequest);
     }
 
 private:
@@ -1955,11 +1955,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000004, 0x00000005, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000004) command (0x00000005) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000004, 0x00000005, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000004, 0x00000005, mRequest);
     }
 
 private:
@@ -2021,11 +2021,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000005, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000005) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000005, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000005, 0x00000000, mRequest);
     }
 
 private:
@@ -2054,11 +2054,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000005, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000005) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000005, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000005, 0x00000001, mRequest);
     }
 
 private:
@@ -2085,11 +2085,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000005, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000005) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000005, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000005, 0x00000002, mRequest);
     }
 
 private:
@@ -2115,11 +2115,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000005, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000005) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000005, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000005, 0x00000003, mRequest);
     }
 
 private:
@@ -2146,11 +2146,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000005, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000005) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000005, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000005, 0x00000004, mRequest);
     }
 
 private:
@@ -2178,11 +2178,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000005, 0x00000005, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000005) command (0x00000005) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000005, 0x00000005, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000005, 0x00000005, mRequest);
     }
 
 private:
@@ -2209,11 +2209,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000005, 0x00000006, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000005) command (0x00000006) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000005, 0x00000006, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000005, 0x00000006, mRequest);
     }
 
 private:
@@ -2244,11 +2244,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000005, 0x00000040, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000005) command (0x00000040) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000005, 0x00000040, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000005, 0x00000040, mRequest);
     }
 
 private:
@@ -2277,11 +2277,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000005, 0x00000041, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000005) command (0x00000041) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000005, 0x00000041, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000005, 0x00000041, mRequest);
     }
 
 private:
@@ -2311,11 +2311,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000005, 0x00000042, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000005) command (0x00000042) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000005, 0x00000042, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000005, 0x00000042, mRequest);
     }
 
 private:
@@ -2366,11 +2366,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000006, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000006) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000006, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000006, 0x00000000, mRequest);
     }
 
 private:
@@ -2395,11 +2395,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000006, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000006) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000006, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000006, 0x00000001, mRequest);
     }
 
 private:
@@ -2424,11 +2424,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000006, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000006) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000006, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000006, 0x00000002, mRequest);
     }
 
 private:
@@ -2455,11 +2455,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000006, 0x00000040, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000006) command (0x00000040) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000006, 0x00000040, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000006, 0x00000040, mRequest);
     }
 
 private:
@@ -2485,11 +2485,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000006, 0x00000041, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000006) command (0x00000041) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000006, 0x00000041, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000006, 0x00000041, mRequest);
     }
 
 private:
@@ -2517,11 +2517,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000006, 0x00000042, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000006) command (0x00000042) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000006, 0x00000042, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000006, 0x00000042, mRequest);
     }
 
 private:
@@ -2545,9 +2545,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000006, 0x00004001, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000006, 0x00004001, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000006, 0x00004001, mValue);
     }
 
 private:
@@ -2571,9 +2571,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000006, 0x00004002, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000006, 0x00004002, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000006, 0x00004002, mValue);
     }
 
 private:
@@ -2597,9 +2597,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000006, 0x00004003, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000006, 0x00004003, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000006, 0x00004003, mValue);
     }
 
 private:
@@ -2641,9 +2641,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000007, 0x00000010, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000007, 0x00000010, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000007, 0x00000010, mValue);
     }
 
 private:
@@ -2709,11 +2709,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000008, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000008) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000008, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000008, 0x00000000, mRequest);
     }
 
 private:
@@ -2742,11 +2742,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000008, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000008) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000008, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000008, 0x00000001, mRequest);
     }
 
 private:
@@ -2776,11 +2776,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000008, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000008) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000008, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000008, 0x00000002, mRequest);
     }
 
 private:
@@ -2807,11 +2807,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000008, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000008) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000008, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000008, 0x00000003, mRequest);
     }
 
 private:
@@ -2839,11 +2839,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000008, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000008) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000008, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000008, 0x00000004, mRequest);
     }
 
 private:
@@ -2870,11 +2870,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000008, 0x00000005, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000008) command (0x00000005) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000008, 0x00000005, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000008, 0x00000005, mRequest);
     }
 
 private:
@@ -2902,11 +2902,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000008, 0x00000006, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000008) command (0x00000006) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000008, 0x00000006, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000008, 0x00000006, mRequest);
     }
 
 private:
@@ -2931,11 +2931,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000008, 0x00000007, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000008) command (0x00000007) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000008, 0x00000007, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000008, 0x00000007, mRequest);
     }
 
 private:
@@ -2959,9 +2959,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000008, 0x0000000F, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000008, 0x0000000F, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000008, 0x0000000F, mValue);
     }
 
 private:
@@ -2986,9 +2986,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000008, 0x00000010, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000008, 0x00000010, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000008, 0x00000010, mValue);
     }
 
 private:
@@ -3012,9 +3012,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000008, 0x00000011, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000008, 0x00000011, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000008, 0x00000011, mValue);
     }
 
 private:
@@ -3039,9 +3039,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000008, 0x00000012, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000008, 0x00000012, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000008, 0x00000012, mValue);
     }
 
 private:
@@ -3066,9 +3066,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000008, 0x00000013, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000008, 0x00000013, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000008, 0x00000013, mValue);
     }
 
 private:
@@ -3093,9 +3093,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000008, 0x00000014, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000008, 0x00000014, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000008, 0x00000014, mValue);
     }
 
 private:
@@ -3120,9 +3120,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000008, 0x00004000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000008, 0x00004000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000008, 0x00004000, mValue);
     }
 
 private:
@@ -3169,11 +3169,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000009, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000009) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000009, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000009, 0x00000000, mRequest);
     }
 
 private:
@@ -3198,11 +3198,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000009, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000009) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000009, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000009, 0x00000001, mRequest);
     }
 
 private:
@@ -3227,11 +3227,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000009, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000009) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000009, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000009, 0x00000002, mRequest);
     }
 
 private:
@@ -3256,11 +3256,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000009, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000009) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000009, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000009, 0x00000003, mRequest);
     }
 
 private:
@@ -3309,9 +3309,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000000A, 0x00000000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000000A, 0x00000000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000000A, 0x00000000, mValue);
     }
 
 private:
@@ -3335,9 +3335,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000000A, 0x00000001, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000000A, 0x00000001, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000000A, 0x00000001, mValue);
     }
 
 private:
@@ -3361,9 +3361,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000000A, 0x00000002, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000000A, 0x00000002, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000000A, 0x00000002, mValue);
     }
 
 private:
@@ -3387,9 +3387,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000000A, 0x00000003, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000000A, 0x00000003, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000000A, 0x00000003, mValue);
     }
 
 private:
@@ -3413,9 +3413,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000000A, 0x00000004, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000000A, 0x00000004, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000000A, 0x00000004, mValue);
     }
 
 private:
@@ -3439,9 +3439,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000000A, 0x00000005, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000000A, 0x00000005, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000000A, 0x00000005, mValue);
     }
 
 private:
@@ -3465,9 +3465,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000000A, 0x00000009, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000000A, 0x00000009, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000000A, 0x00000009, mValue);
     }
 
 private:
@@ -3515,9 +3515,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000000F, 0x00000004, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000000F, 0x00000004, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000000F, 0x00000004, mValue);
     }
 
 private:
@@ -3542,9 +3542,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000000F, 0x0000001C, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000000F, 0x0000001C, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000000F, 0x0000001C, mValue);
     }
 
 private:
@@ -3569,9 +3569,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000000F, 0x0000002E, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000000F, 0x0000002E, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000000F, 0x0000002E, mValue);
     }
 
 private:
@@ -3596,9 +3596,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000000F, 0x00000051, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000000F, 0x00000051, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000000F, 0x00000051, mValue);
     }
 
 private:
@@ -3623,9 +3623,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000000F, 0x00000055, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000000F, 0x00000055, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000000F, 0x00000055, mValue);
     }
 
 private:
@@ -3650,9 +3650,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000000F, 0x00000067, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000000F, 0x00000067, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000000F, 0x00000067, mValue);
     }
 
 private:
@@ -3708,11 +3708,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000001A, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000001A) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001A, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000001A, 0x00000000, mRequest);
     }
 
 private:
@@ -3738,11 +3738,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000001A, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000001A) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001A, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000001A, 0x00000001, mRequest);
     }
 
 private:
@@ -3772,11 +3772,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000001A, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000001A) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001A, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000001A, 0x00000002, mRequest);
     }
 
 private:
@@ -3805,11 +3805,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000001A, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000001A) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001A, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000001A, 0x00000003, mRequest);
     }
 
 private:
@@ -3839,11 +3839,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000001A, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000001A) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001A, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000001A, 0x00000004, mRequest);
     }
 
 private:
@@ -3874,11 +3874,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000001A, 0x00000005, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000001A) command (0x00000005) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001A, 0x00000005, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000001A, 0x00000005, mRequest);
     }
 
 private:
@@ -3907,11 +3907,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000001A, 0x00000006, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000001A) command (0x00000006) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001A, 0x00000006, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000001A, 0x00000006, mRequest);
     }
 
 private:
@@ -3938,11 +3938,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000001A, 0x00000007, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000001A) command (0x00000007) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001A, 0x00000007, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000001A, 0x00000007, mRequest);
     }
 
 private:
@@ -3972,11 +3972,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000001A, 0x00000008, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000001A) command (0x00000008) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001A, 0x00000008, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000001A, 0x00000008, mRequest);
     }
 
 private:
@@ -4000,9 +4000,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000001A, 0x00000004, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001A, 0x00000004, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000001A, 0x00000004, mValue);
     }
 
 private:
@@ -4053,11 +4053,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000001B, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000001B) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001B, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000001B, 0x00000000, mRequest);
     }
 
 private:
@@ -4082,11 +4082,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000001B, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000001B) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001B, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000001B, 0x00000001, mRequest);
     }
 
 private:
@@ -4115,11 +4115,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000001B, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000001B) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001B, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000001B, 0x00000002, mRequest);
     }
 
 private:
@@ -4146,11 +4146,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000001B, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000001B) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001B, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000001B, 0x00000003, mRequest);
     }
 
 private:
@@ -4176,11 +4176,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000001B, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000001B) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001B, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000001B, 0x00000004, mRequest);
     }
 
 private:
@@ -4207,11 +4207,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000001B, 0x00000005, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000001B) command (0x00000005) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001B, 0x00000005, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000001B, 0x00000005, mRequest);
     }
 
 private:
@@ -4286,9 +4286,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000001E, 0x00000000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001E, 0x00000000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000001E, 0x00000000, mValue);
     }
 
 private:
@@ -4333,9 +4333,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000001F, 0x00000000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001F, 0x00000000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000001F, 0x00000000, mValue);
     }
 
 private:
@@ -4362,9 +4362,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000001F, 0x00000001, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000001F, 0x00000001, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000001F, 0x00000001, mValue);
     }
 
 private:
@@ -4420,11 +4420,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000020, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000020) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000020, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000020, 0x00000000, mRequest);
     }
 
 private:
@@ -4449,11 +4449,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000020, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000020) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000020, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000020, 0x00000001, mRequest);
     }
 
 private:
@@ -4480,11 +4480,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000020, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000020) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000020, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000020, 0x00000002, mRequest);
     }
 
 private:
@@ -4511,11 +4511,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000020, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000020) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000020, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000020, 0x00000003, mRequest);
     }
 
 private:
@@ -4540,9 +4540,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000020, 0x00000000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000020, 0x00000000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000020, 0x00000000, mValue);
     }
 
 private:
@@ -4567,9 +4567,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000020, 0x00000003, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000020, 0x00000003, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000020, 0x00000003, mValue);
     }
 
 private:
@@ -4628,11 +4628,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000025, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000025) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000025, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000025, 0x00000000, mRequest);
     }
 
 private:
@@ -4661,11 +4661,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000025, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000025) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000025, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000025, 0x00000001, mRequest);
     }
 
 private:
@@ -4692,11 +4692,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000025, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000025) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000025, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000025, 0x00000002, mRequest);
     }
 
 private:
@@ -4725,11 +4725,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000025, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000025) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000025, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000025, 0x00000003, mRequest);
     }
 
 private:
@@ -4756,11 +4756,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000025, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000025) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000025, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000025, 0x00000004, mRequest);
     }
 
 private:
@@ -4787,11 +4787,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000025, 0x00000005, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000025) command (0x00000005) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000025, 0x00000005, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000025, 0x00000005, mRequest);
     }
 
 private:
@@ -4820,11 +4820,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000025, 0x00000006, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000025) command (0x00000006) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000025, 0x00000006, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000025, 0x00000006, mRequest);
     }
 
 private:
@@ -4851,11 +4851,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000025, 0x00000007, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000025) command (0x00000007) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000025, 0x00000007, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000025, 0x00000007, mRequest);
     }
 
 private:
@@ -4882,11 +4882,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000025, 0x00000008, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000025) command (0x00000008) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000025, 0x00000008, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000025, 0x00000008, mRequest);
     }
 
 private:
@@ -4915,11 +4915,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000025, 0x00000009, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000025) command (0x00000009) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000025, 0x00000009, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000025, 0x00000009, mRequest);
     }
 
 private:
@@ -4946,11 +4946,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000025, 0x0000000A, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000025) command (0x0000000A) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000025, 0x0000000A, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000025, 0x0000000A, mRequest);
     }
 
 private:
@@ -4979,11 +4979,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000025, 0x0000000B, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000025) command (0x0000000B) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000025, 0x0000000B, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000025, 0x0000000B, mRequest);
     }
 
 private:
@@ -5047,11 +5047,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000028, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000028) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000028, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000028, 0x00000000, mRequest);
     }
 
 private:
@@ -5075,9 +5075,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000028, 0x00000005, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000028, 0x00000005, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000028, 0x00000005, mValue);
     }
 
 private:
@@ -5101,9 +5101,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000028, 0x00000006, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000028, 0x00000006, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000028, 0x00000006, mValue);
     }
 
 private:
@@ -5128,9 +5128,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000028, 0x00000010, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000028, 0x00000010, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000028, 0x00000010, mValue);
     }
 
 private:
@@ -5182,11 +5182,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000029, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000029) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000029, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000029, 0x00000000, mRequest);
     }
 
 private:
@@ -5216,11 +5216,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000029, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000029) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000029, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000029, 0x00000002, mRequest);
     }
 
 private:
@@ -5248,11 +5248,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000029, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000029) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000029, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000029, 0x00000004, mRequest);
     }
 
 private:
@@ -5306,11 +5306,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000002A, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000002A) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000002A, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000002A, 0x00000000, mRequest);
     }
 
 private:
@@ -5335,9 +5335,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000002A, 0x00000000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000002A, 0x00000000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000002A, 0x00000000, mValue);
     }
 
 private:
@@ -5382,9 +5382,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000002B, 0x00000001, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000002B, 0x00000001, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000002B, 0x00000001, mValue);
     }
 
 private:
@@ -5427,9 +5427,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000002C, 0x00000000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000002C, 0x00000000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000002C, 0x00000000, mValue);
     }
 
 private:
@@ -5454,9 +5454,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000002C, 0x00000001, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000002C, 0x00000001, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000002C, 0x00000001, mValue);
     }
 
 private:
@@ -5497,9 +5497,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000002D, 0x00000000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000002D, 0x00000000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000002D, 0x00000000, mValue);
     }
 
 private:
@@ -5612,11 +5612,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000030, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000030) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000030, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000030, 0x00000000, mRequest);
     }
 
 private:
@@ -5646,11 +5646,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000030, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000030) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000030, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000030, 0x00000002, mRequest);
     }
 
 private:
@@ -5676,11 +5676,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000030, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000030) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000030, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000030, 0x00000004, mRequest);
     }
 
 private:
@@ -5705,9 +5705,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000030, 0x00000000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000030, 0x00000000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000030, 0x00000000, mValue);
     }
 
 private:
@@ -5764,11 +5764,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000031, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000031) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000031, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000031, 0x00000000, mRequest);
     }
 
 private:
@@ -5797,11 +5797,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000031, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000031) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000031, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000031, 0x00000002, mRequest);
     }
 
 private:
@@ -5829,11 +5829,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000031, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000031) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000031, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000031, 0x00000003, mRequest);
     }
 
 private:
@@ -5861,11 +5861,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000031, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000031) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000031, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000031, 0x00000004, mRequest);
     }
 
 private:
@@ -5893,11 +5893,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000031, 0x00000006, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000031) command (0x00000006) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000031, 0x00000006, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000031, 0x00000006, mRequest);
     }
 
 private:
@@ -5926,11 +5926,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000031, 0x00000008, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000031) command (0x00000008) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000031, 0x00000008, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000031, 0x00000008, mRequest);
     }
 
 private:
@@ -5955,9 +5955,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000031, 0x00000004, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000031, 0x00000004, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000031, 0x00000004, mValue);
     }
 
 private:
@@ -6002,11 +6002,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000032, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000032) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000032, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000032, 0x00000000, mRequest);
     }
 
 private:
@@ -6080,11 +6080,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000034, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000034) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000034, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000034, 0x00000000, mRequest);
     }
 
 private:
@@ -6190,11 +6190,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000035, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000035) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000035, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000035, 0x00000000, mRequest);
     }
 
 private:
@@ -6252,11 +6252,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000036, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000036) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000036, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000036, 0x00000000, mRequest);
     }
 
 private:
@@ -6307,11 +6307,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000037, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000037) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000037, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000037, 0x00000000, mRequest);
     }
 
 private:
@@ -6384,9 +6384,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000039, 0x00000005, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000039, 0x00000005, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000039, 0x00000005, mValue);
     }
 
 private:
@@ -6463,11 +6463,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000003C, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000003C) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003C, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000003C, 0x00000000, mRequest);
     }
 
 private:
@@ -6494,11 +6494,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000003C, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000003C) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003C, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000003C, 0x00000001, mRequest);
     }
 
 private:
@@ -6524,11 +6524,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000003C, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000003C) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003C, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000003C, 0x00000002, mRequest);
     }
 
 private:
@@ -6585,11 +6585,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000003E, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000003E) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003E, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000003E, 0x00000000, mRequest);
     }
 
 private:
@@ -6616,11 +6616,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000003E, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000003E) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003E, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000003E, 0x00000002, mRequest);
     }
 
 private:
@@ -6646,11 +6646,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000003E, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000003E) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003E, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000003E, 0x00000004, mRequest);
     }
 
 private:
@@ -6680,11 +6680,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000003E, 0x00000006, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000003E) command (0x00000006) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003E, 0x00000006, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000003E, 0x00000006, mRequest);
     }
 
 private:
@@ -6711,11 +6711,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000003E, 0x00000007, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000003E) command (0x00000007) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003E, 0x00000007, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000003E, 0x00000007, mRequest);
     }
 
 private:
@@ -6742,11 +6742,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000003E, 0x00000009, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000003E) command (0x00000009) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003E, 0x00000009, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000003E, 0x00000009, mRequest);
     }
 
 private:
@@ -6773,11 +6773,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000003E, 0x0000000A, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000003E) command (0x0000000A) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003E, 0x0000000A, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000003E, 0x0000000A, mRequest);
     }
 
 private:
@@ -6804,11 +6804,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000003E, 0x0000000B, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000003E) command (0x0000000B) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003E, 0x0000000B, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000003E, 0x0000000B, mRequest);
     }
 
 private:
@@ -6835,11 +6835,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000003E, 0x0000000C, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000003E) command (0x0000000C) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003E, 0x0000000C, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000003E, 0x0000000C, mRequest);
     }
 
 private:
@@ -6889,11 +6889,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000003F, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000003F) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003F, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000003F, 0x00000000, mRequest);
     }
 
 private:
@@ -6920,11 +6920,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000003F, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000003F) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003F, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000003F, 0x00000001, mRequest);
     }
 
 private:
@@ -6951,11 +6951,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000003F, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000003F) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003F, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000003F, 0x00000003, mRequest);
     }
 
 private:
@@ -6982,11 +6982,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000003F, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000003F) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003F, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000003F, 0x00000004, mRequest);
     }
 
 private:
@@ -7012,9 +7012,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000003F, 0x00000000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000003F, 0x00000000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000003F, 0x00000000, mValue);
     }
 
 private:
@@ -7074,9 +7074,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000041, 0x00000000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000041, 0x00000000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000041, 0x00000000, mValue);
     }
 
 private:
@@ -7187,11 +7187,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000050, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000050) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000050, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000050, 0x00000000, mRequest);
     }
 
 private:
@@ -7215,9 +7215,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000050, 0x00000004, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000050, 0x00000004, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000050, 0x00000004, mValue);
     }
 
 private:
@@ -7241,9 +7241,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000050, 0x00000005, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000050, 0x00000005, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000050, 0x00000005, mValue);
     }
 
 private:
@@ -7287,9 +7287,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000100, 0x00000002, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000100, 0x00000002, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000100, 0x00000002, mValue);
     }
 
 private:
@@ -7314,9 +7314,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000100, 0x00000010, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000100, 0x00000010, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000100, 0x00000010, mValue);
     }
 
 private:
@@ -7340,9 +7340,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000100, 0x00000011, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000100, 0x00000011, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000100, 0x00000011, mValue);
     }
 
 private:
@@ -7464,11 +7464,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000000, mRequest);
     }
 
 private:
@@ -7494,11 +7494,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000001, mRequest);
     }
 
 private:
@@ -7526,11 +7526,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000003, mRequest);
     }
 
 private:
@@ -7556,11 +7556,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000004, mRequest);
     }
 
 private:
@@ -7589,11 +7589,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000005, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000005) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000005, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000005, mRequest);
     }
 
 private:
@@ -7619,11 +7619,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000006, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000006) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000006, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000006, mRequest);
     }
 
 private:
@@ -7649,11 +7649,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000007, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000007) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000007, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000007, mRequest);
     }
 
 private:
@@ -7678,11 +7678,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000008, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000008) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000008, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000008, mRequest);
     }
 
 private:
@@ -7709,11 +7709,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000009, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000009) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000009, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000009, mRequest);
     }
 
 private:
@@ -7739,11 +7739,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x0000000A, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x0000000A) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x0000000A, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x0000000A, mRequest);
     }
 
 private:
@@ -7776,11 +7776,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x0000000B, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x0000000B) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x0000000B, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x0000000B, mRequest);
     }
 
 private:
@@ -7808,11 +7808,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x0000000C, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x0000000C) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x0000000C, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x0000000C, mRequest);
     }
 
 private:
@@ -7840,11 +7840,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x0000000D, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x0000000D) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x0000000D, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x0000000D, mRequest);
     }
 
 private:
@@ -7874,11 +7874,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x0000000E, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x0000000E) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x0000000E, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x0000000E, mRequest);
     }
 
 private:
@@ -7906,11 +7906,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x0000000F, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x0000000F) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x0000000F, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x0000000F, mRequest);
     }
 
 private:
@@ -7938,11 +7938,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000010, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000010) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000010, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000010, mRequest);
     }
 
 private:
@@ -7972,11 +7972,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000011, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000011) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000011, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000011, mRequest);
     }
 
 private:
@@ -8003,11 +8003,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000012, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000012) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000012, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000012, mRequest);
     }
 
 private:
@@ -8034,11 +8034,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000013, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000013) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000013, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000013, mRequest);
     }
 
 private:
@@ -8065,11 +8065,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000014, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000014) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000014, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000014, mRequest);
     }
 
 private:
@@ -8095,11 +8095,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000015, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000015) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000015, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000015, mRequest);
     }
 
 private:
@@ -8128,11 +8128,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000016, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000016) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000016, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000016, mRequest);
     }
 
 private:
@@ -8158,11 +8158,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000017, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000017) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000017, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000017, mRequest);
     }
 
 private:
@@ -8188,11 +8188,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000018, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000018) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000018, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000018, mRequest);
     }
 
 private:
@@ -8218,11 +8218,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000019, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000019) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000019, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000019, mRequest);
     }
 
 private:
@@ -8254,11 +8254,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x0000001A, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x0000001A) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x0000001A, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x0000001A, mRequest);
     }
 
 private:
@@ -8284,11 +8284,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x0000001B, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x0000001B) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x0000001B, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x0000001B, mRequest);
     }
 
 private:
@@ -8314,11 +8314,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x0000001D, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x0000001D) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x0000001D, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x0000001D, mRequest);
     }
 
 private:
@@ -8350,11 +8350,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000022, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000022) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000022, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000022, mRequest);
     }
 
 private:
@@ -8382,11 +8382,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000024, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000024) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000024, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000024, mRequest);
     }
 
 private:
@@ -8414,11 +8414,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000026, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000101) command (0x00000026) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000026, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000026, mRequest);
     }
 
 private:
@@ -8444,9 +8444,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000004, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000004, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000004, mValue);
     }
 
 private:
@@ -8471,9 +8471,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000005, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000005, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000005, mValue);
     }
 
 private:
@@ -8497,9 +8497,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000006, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000006, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000006, mValue);
     }
 
 private:
@@ -8523,9 +8523,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000020, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000020, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000020, mValue);
     }
 
 private:
@@ -8549,9 +8549,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000021, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000021, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000021, mValue);
     }
 
 private:
@@ -8575,9 +8575,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000022, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000022, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000022, mValue);
     }
 
 private:
@@ -8601,9 +8601,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000023, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000023, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000023, mValue);
     }
 
 private:
@@ -8627,9 +8627,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000024, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000024, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000024, mValue);
     }
 
 private:
@@ -8653,9 +8653,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000025, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000025, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000025, mValue);
     }
 
 private:
@@ -8680,9 +8680,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000028, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000028, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000028, mValue);
     }
 
 private:
@@ -8707,9 +8707,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000029, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000029, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000029, mValue);
     }
 
 private:
@@ -8734,9 +8734,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x0000002A, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x0000002A, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x0000002A, mValue);
     }
 
 private:
@@ -8761,9 +8761,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x0000002B, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x0000002B, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x0000002B, mValue);
     }
 
 private:
@@ -8788,9 +8788,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x0000002C, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x0000002C, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x0000002C, mValue);
     }
 
 private:
@@ -8815,9 +8815,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000030, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000030, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000030, mValue);
     }
 
 private:
@@ -8842,9 +8842,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000031, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000031, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000031, mValue);
     }
 
 private:
@@ -8869,9 +8869,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000032, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000032, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000032, mValue);
     }
 
 private:
@@ -8896,9 +8896,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000033, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000033, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000033, mValue);
     }
 
 private:
@@ -8923,9 +8923,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000035, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000035, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000035, mValue);
     }
 
 private:
@@ -8949,9 +8949,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000040, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000040, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000040, mValue);
     }
 
 private:
@@ -8976,9 +8976,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000041, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000041, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000041, mValue);
     }
 
 private:
@@ -9003,9 +9003,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000042, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000042, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000042, mValue);
     }
 
 private:
@@ -9030,9 +9030,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000043, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000043, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000043, mValue);
     }
 
 private:
@@ -9057,9 +9057,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000044, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000044, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000044, mValue);
     }
 
 private:
@@ -9084,9 +9084,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000045, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000045, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000045, mValue);
     }
 
 private:
@@ -9111,9 +9111,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000046, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000046, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000046, mValue);
     }
 
 private:
@@ -9138,9 +9138,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000101, 0x00000047, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000101, 0x00000047, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000101, 0x00000047, mValue);
     }
 
 private:
@@ -9209,11 +9209,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000102, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000102) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000102, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000102, 0x00000000, mRequest);
     }
 
 private:
@@ -9238,11 +9238,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000102, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000102) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000102, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000102, 0x00000001, mRequest);
     }
 
 private:
@@ -9267,11 +9267,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000102, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000102) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000102, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000102, 0x00000002, mRequest);
     }
 
 private:
@@ -9298,11 +9298,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000102, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000102) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000102, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000102, 0x00000004, mRequest);
     }
 
 private:
@@ -9330,11 +9330,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000102, 0x00000005, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000102) command (0x00000005) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000102, 0x00000005, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000102, 0x00000005, mRequest);
     }
 
 private:
@@ -9361,11 +9361,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000102, 0x00000007, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000102) command (0x00000007) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000102, 0x00000007, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000102, 0x00000007, mRequest);
     }
 
 private:
@@ -9393,11 +9393,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000102, 0x00000008, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000102) command (0x00000008) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000102, 0x00000008, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000102, 0x00000008, mRequest);
     }
 
 private:
@@ -9421,9 +9421,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000102, 0x00000017, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000102, 0x00000017, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000102, 0x00000017, mValue);
     }
 
 private:
@@ -9477,11 +9477,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000103, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000103) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000103, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000103, 0x00000000, mRequest);
     }
 
 private:
@@ -9507,11 +9507,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000103, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000103) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000103, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000103, 0x00000001, mRequest);
     }
 
 private:
@@ -9536,9 +9536,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000103, 0x00000004, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000103, 0x00000004, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000103, 0x00000004, mValue);
     }
 
 private:
@@ -9563,9 +9563,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000103, 0x00000005, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000103, 0x00000005, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000103, 0x00000005, mValue);
     }
 
 private:
@@ -9590,9 +9590,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000103, 0x00000006, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000103, 0x00000006, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000103, 0x00000006, mValue);
     }
 
 private:
@@ -9617,9 +9617,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000103, 0x00000007, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000103, 0x00000007, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000103, 0x00000007, mValue);
     }
 
 private:
@@ -9644,9 +9644,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000103, 0x00000008, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000103, 0x00000008, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000103, 0x00000008, mValue);
     }
 
 private:
@@ -9671,9 +9671,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000103, 0x00000009, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000103, 0x00000009, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000103, 0x00000009, mValue);
     }
 
 private:
@@ -9754,9 +9754,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000200, 0x00000015, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000200, 0x00000015, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000200, 0x00000015, mValue);
     }
 
 private:
@@ -9781,9 +9781,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000200, 0x00000017, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000200, 0x00000017, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000200, 0x00000017, mValue);
     }
 
 private:
@@ -9808,9 +9808,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000200, 0x00000020, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000200, 0x00000020, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000200, 0x00000020, mValue);
     }
 
 private:
@@ -9835,9 +9835,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000200, 0x00000021, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000200, 0x00000021, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000200, 0x00000021, mValue);
     }
 
 private:
@@ -9928,11 +9928,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000201) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000000, mRequest);
     }
 
 private:
@@ -9962,11 +9962,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000201) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000001, mRequest);
     }
 
 private:
@@ -9995,11 +9995,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000201) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000002, mRequest);
     }
 
 private:
@@ -10025,11 +10025,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000201) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000003, mRequest);
     }
 
 private:
@@ -10055,11 +10055,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000201) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000004, mRequest);
     }
 
 private:
@@ -10084,9 +10084,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000009, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000009, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000009, mValue);
     }
 
 private:
@@ -10111,9 +10111,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000010, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000010, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000010, mValue);
     }
 
 private:
@@ -10138,9 +10138,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000011, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000011, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000011, mValue);
     }
 
 private:
@@ -10165,9 +10165,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000012, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000012, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000012, mValue);
     }
 
 private:
@@ -10192,9 +10192,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000013, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000013, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000013, mValue);
     }
 
 private:
@@ -10219,9 +10219,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000014, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000014, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000014, mValue);
     }
 
 private:
@@ -10246,9 +10246,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000015, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000015, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000015, mValue);
     }
 
 private:
@@ -10273,9 +10273,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000016, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000016, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000016, mValue);
     }
 
 private:
@@ -10300,9 +10300,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000017, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000017, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000017, mValue);
     }
 
 private:
@@ -10327,9 +10327,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000018, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000018, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000018, mValue);
     }
 
 private:
@@ -10354,9 +10354,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000019, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000019, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000019, mValue);
     }
 
 private:
@@ -10380,9 +10380,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x0000001A, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x0000001A, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x0000001A, mValue);
     }
 
 private:
@@ -10407,9 +10407,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x0000001B, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x0000001B, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x0000001B, mValue);
     }
 
 private:
@@ -10433,9 +10433,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x0000001C, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x0000001C, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x0000001C, mValue);
     }
 
 private:
@@ -10460,9 +10460,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000023, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000023, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000023, mValue);
     }
 
 private:
@@ -10487,9 +10487,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000024, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000024, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000024, mValue);
     }
 
 private:
@@ -10514,9 +10514,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000025, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000025, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000025, mValue);
     }
 
 private:
@@ -10540,9 +10540,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000040, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000040, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000040, mValue);
     }
 
 private:
@@ -10566,9 +10566,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000041, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000041, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000041, mValue);
     }
 
 private:
@@ -10593,9 +10593,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000042, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000042, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000042, mValue);
     }
 
 private:
@@ -10619,9 +10619,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000043, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000043, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000043, mValue);
     }
 
 private:
@@ -10645,9 +10645,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000044, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000044, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000044, mValue);
     }
 
 private:
@@ -10672,9 +10672,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000045, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000045, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000045, mValue);
     }
 
 private:
@@ -10699,9 +10699,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000201, 0x00000047, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000201, 0x00000047, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000201, 0x00000047, mValue);
     }
 
 private:
@@ -10742,9 +10742,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000202, 0x00000000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000202, 0x00000000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000202, 0x00000000, mValue);
     }
 
 private:
@@ -10769,9 +10769,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000202, 0x00000001, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000202, 0x00000001, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000202, 0x00000001, mValue);
     }
 
 private:
@@ -10819,9 +10819,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000203, 0x00000010, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000203, 0x00000010, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000203, 0x00000010, mValue);
     }
 
 private:
@@ -10846,9 +10846,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000203, 0x00000011, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000203, 0x00000011, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000203, 0x00000011, mValue);
     }
 
 private:
@@ -10873,9 +10873,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000203, 0x00000012, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000203, 0x00000012, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000203, 0x00000012, mValue);
     }
 
 private:
@@ -10900,9 +10900,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000203, 0x00000013, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000203, 0x00000013, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000203, 0x00000013, mValue);
     }
 
 private:
@@ -10927,9 +10927,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000203, 0x00000014, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000203, 0x00000014, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000203, 0x00000014, mValue);
     }
 
 private:
@@ -10954,9 +10954,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000203, 0x00000015, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000203, 0x00000015, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000203, 0x00000015, mValue);
     }
 
 private:
@@ -10999,9 +10999,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000204, 0x00000000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000204, 0x00000000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000204, 0x00000000, mValue);
     }
 
 private:
@@ -11026,9 +11026,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000204, 0x00000001, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000204, 0x00000001, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000204, 0x00000001, mValue);
     }
 
 private:
@@ -11053,9 +11053,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000204, 0x00000002, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000204, 0x00000002, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000204, 0x00000002, mValue);
     }
 
 private:
@@ -11171,11 +11171,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000000, mRequest);
     }
 
 private:
@@ -11204,11 +11204,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000001, mRequest);
     }
 
 private:
@@ -11238,11 +11238,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000002, mRequest);
     }
 
 private:
@@ -11272,11 +11272,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000003, mRequest);
     }
 
 private:
@@ -11305,11 +11305,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000004, mRequest);
     }
 
 private:
@@ -11339,11 +11339,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000005, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x00000005) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000005, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000005, mRequest);
     }
 
 private:
@@ -11374,11 +11374,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000006, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x00000006) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000006, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000006, mRequest);
     }
 
 private:
@@ -11408,11 +11408,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000007, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x00000007) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000007, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000007, mRequest);
     }
 
 private:
@@ -11441,11 +11441,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000008, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x00000008) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000008, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000008, mRequest);
     }
 
 private:
@@ -11475,11 +11475,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000009, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x00000009) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000009, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000009, mRequest);
     }
 
 private:
@@ -11509,11 +11509,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x0000000A, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x0000000A) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x0000000A, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x0000000A, mRequest);
     }
 
 private:
@@ -11544,11 +11544,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000040, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x00000040) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000040, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000040, mRequest);
     }
 
 private:
@@ -11578,11 +11578,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000041, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x00000041) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000041, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000041, mRequest);
     }
 
 private:
@@ -11613,11 +11613,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000042, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x00000042) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000042, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000042, mRequest);
     }
 
 private:
@@ -11648,11 +11648,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000043, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x00000043) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000043, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000043, mRequest);
     }
 
 private:
@@ -11684,11 +11684,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000044, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x00000044) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000044, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000044, mRequest);
     }
 
 private:
@@ -11715,11 +11715,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000047, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x00000047) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000047, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000047, mRequest);
     }
 
 private:
@@ -11751,11 +11751,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x0000004B, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x0000004B) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x0000004B, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x0000004B, mRequest);
     }
 
 private:
@@ -11788,11 +11788,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000300, 0x0000004C, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000300) command (0x0000004C) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x0000004C, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x0000004C, mRequest);
     }
 
 private:
@@ -11817,9 +11817,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000300, 0x0000000F, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x0000000F, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x0000000F, mValue);
     }
 
 private:
@@ -11843,9 +11843,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000030, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000030, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000030, mValue);
     }
 
 private:
@@ -11869,9 +11869,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000031, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000031, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000031, mValue);
     }
 
 private:
@@ -11895,9 +11895,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000032, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000032, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000032, mValue);
     }
 
 private:
@@ -11921,9 +11921,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000033, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000033, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000033, mValue);
     }
 
 private:
@@ -11948,9 +11948,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000034, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000034, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000034, mValue);
     }
 
 private:
@@ -11974,9 +11974,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000036, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000036, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000036, mValue);
     }
 
 private:
@@ -12000,9 +12000,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000037, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000037, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000037, mValue);
     }
 
 private:
@@ -12027,9 +12027,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00000038, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00000038, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00000038, mValue);
     }
 
 private:
@@ -12053,9 +12053,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000300, 0x0000003A, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x0000003A, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x0000003A, mValue);
     }
 
 private:
@@ -12079,9 +12079,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000300, 0x0000003B, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x0000003B, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x0000003B, mValue);
     }
 
 private:
@@ -12106,9 +12106,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000300, 0x0000003C, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x0000003C, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x0000003C, mValue);
     }
 
 private:
@@ -12133,9 +12133,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000300, 0x00004010, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000300, 0x00004010, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000300, 0x00004010, mValue);
     }
 
 private:
@@ -12190,9 +12190,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000301, 0x00000010, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000301, 0x00000010, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000301, 0x00000010, mValue);
     }
 
 private:
@@ -12216,9 +12216,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000301, 0x00000011, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000301, 0x00000011, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000301, 0x00000011, mValue);
     }
 
 private:
@@ -12243,9 +12243,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000301, 0x00000012, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000301, 0x00000012, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000301, 0x00000012, mValue);
     }
 
 private:
@@ -12270,9 +12270,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000301, 0x00000013, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000301, 0x00000013, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000301, 0x00000013, mValue);
     }
 
 private:
@@ -12297,9 +12297,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000301, 0x00000014, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000301, 0x00000014, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000301, 0x00000014, mValue);
     }
 
 private:
@@ -12324,9 +12324,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000301, 0x00000015, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000301, 0x00000015, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000301, 0x00000015, mValue);
     }
 
 private:
@@ -12350,9 +12350,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000301, 0x00000030, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000301, 0x00000030, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000301, 0x00000030, mValue);
     }
 
 private:
@@ -12377,9 +12377,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000301, 0x00000031, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000301, 0x00000031, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000301, 0x00000031, mValue);
     }
 
 private:
@@ -12404,9 +12404,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000301, 0x00000032, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000301, 0x00000032, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000301, 0x00000032, mValue);
     }
 
 private:
@@ -12431,9 +12431,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000301, 0x00000033, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000301, 0x00000033, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000301, 0x00000033, mValue);
     }
 
 private:
@@ -12458,9 +12458,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000301, 0x00000034, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000301, 0x00000034, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000301, 0x00000034, mValue);
     }
 
 private:
@@ -12485,9 +12485,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000301, 0x00000035, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000301, 0x00000035, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000301, 0x00000035, mValue);
     }
 
 private:
@@ -12640,9 +12640,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000406, 0x00000010, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000406, 0x00000010, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000406, 0x00000010, mValue);
     }
 
 private:
@@ -12667,9 +12667,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000406, 0x00000011, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000406, 0x00000011, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000406, 0x00000011, mValue);
     }
 
 private:
@@ -12694,9 +12694,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000406, 0x00000012, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000406, 0x00000012, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000406, 0x00000012, mValue);
     }
 
 private:
@@ -12721,9 +12721,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000406, 0x00000020, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000406, 0x00000020, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000406, 0x00000020, mValue);
     }
 
 private:
@@ -12748,9 +12748,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000406, 0x00000021, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000406, 0x00000021, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000406, 0x00000021, mValue);
     }
 
 private:
@@ -12775,9 +12775,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000406, 0x00000022, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000406, 0x00000022, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000406, 0x00000022, mValue);
     }
 
 private:
@@ -12802,9 +12802,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000406, 0x00000030, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000406, 0x00000030, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000406, 0x00000030, mValue);
     }
 
 private:
@@ -12829,9 +12829,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000406, 0x00000031, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000406, 0x00000031, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000406, 0x00000031, mValue);
     }
 
 private:
@@ -12856,9 +12856,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000406, 0x00000032, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000406, 0x00000032, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000406, 0x00000032, mValue);
     }
 
 private:
@@ -13481,11 +13481,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000500, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000500) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000500, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000500, 0x00000000, mRequest);
     }
 
 private:
@@ -13511,11 +13511,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000500, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000500) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000500, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000500, 0x00000001, mRequest);
     }
 
 private:
@@ -13542,11 +13542,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000500, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000500) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000500, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000500, 0x00000002, mRequest);
     }
 
 private:
@@ -13570,9 +13570,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000500, 0x00000010, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000500, 0x00000010, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000500, 0x00000010, mValue);
     }
 
 private:
@@ -13597,9 +13597,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000500, 0x00000013, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000500, 0x00000013, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000500, 0x00000013, mValue);
     }
 
 private:
@@ -13652,11 +13652,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000501, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000501) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000501, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000501, 0x00000000, mRequest);
     }
 
 private:
@@ -13685,11 +13685,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000501, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000501) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000501, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000501, 0x00000001, mRequest);
     }
 
 private:
@@ -13715,11 +13715,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000501, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000501) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000501, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000501, 0x00000002, mRequest);
     }
 
 private:
@@ -13744,11 +13744,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000501, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000501) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000501, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000501, 0x00000003, mRequest);
     }
 
 private:
@@ -13773,11 +13773,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000501, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000501) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000501, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000501, 0x00000004, mRequest);
     }
 
 private:
@@ -13802,11 +13802,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000501, 0x00000005, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000501) command (0x00000005) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000501, 0x00000005, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000501, 0x00000005, mRequest);
     }
 
 private:
@@ -13833,11 +13833,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000501, 0x00000006, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000501) command (0x00000006) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000501, 0x00000006, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000501, 0x00000006, mRequest);
     }
 
 private:
@@ -13862,11 +13862,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000501, 0x00000007, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000501) command (0x00000007) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000501, 0x00000007, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000501, 0x00000007, mRequest);
     }
 
 private:
@@ -13892,11 +13892,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000501, 0x00000008, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000501) command (0x00000008) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000501, 0x00000008, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000501, 0x00000008, mRequest);
     }
 
 private:
@@ -13925,11 +13925,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000501, 0x00000009, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000501) command (0x00000009) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000501, 0x00000009, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000501, 0x00000009, mRequest);
     }
 
 private:
@@ -13976,11 +13976,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000502, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000502) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000502, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000502, 0x00000000, mRequest);
     }
 
 private:
@@ -14006,11 +14006,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000502, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000502) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000502, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000502, 0x00000001, mRequest);
     }
 
 private:
@@ -14034,9 +14034,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000502, 0x00000000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000502, 0x00000000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000502, 0x00000000, mValue);
     }
 
 private:
@@ -14099,11 +14099,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000504, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000504) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000504, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000504, 0x00000000, mRequest);
     }
 
 private:
@@ -14131,11 +14131,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000504, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000504) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000504, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000504, 0x00000002, mRequest);
     }
 
 private:
@@ -14161,11 +14161,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000504, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000504) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000504, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000504, 0x00000003, mRequest);
     }
 
 private:
@@ -14211,11 +14211,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000505, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000505) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000505, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000505, 0x00000000, mRequest);
     }
 
 private:
@@ -14273,11 +14273,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000506, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000506) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000506, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000506, 0x00000000, mRequest);
     }
 
 private:
@@ -14302,11 +14302,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000506, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000506) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000506, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000506, 0x00000001, mRequest);
     }
 
 private:
@@ -14331,11 +14331,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000506, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000506) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000506, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000506, 0x00000002, mRequest);
     }
 
 private:
@@ -14360,11 +14360,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000506, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000506) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000506, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000506, 0x00000003, mRequest);
     }
 
 private:
@@ -14389,11 +14389,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000506, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000506) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000506, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000506, 0x00000004, mRequest);
     }
 
 private:
@@ -14418,11 +14418,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000506, 0x00000005, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000506) command (0x00000005) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000506, 0x00000005, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000506, 0x00000005, mRequest);
     }
 
 private:
@@ -14447,11 +14447,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000506, 0x00000006, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000506) command (0x00000006) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000506, 0x00000006, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000506, 0x00000006, mRequest);
     }
 
 private:
@@ -14476,11 +14476,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000506, 0x00000007, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000506) command (0x00000007) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000506, 0x00000007, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000506, 0x00000007, mRequest);
     }
 
 private:
@@ -14506,11 +14506,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000506, 0x00000008, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000506) command (0x00000008) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000506, 0x00000008, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000506, 0x00000008, mRequest);
     }
 
 private:
@@ -14536,11 +14536,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000506, 0x00000009, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000506) command (0x00000009) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000506, 0x00000009, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000506, 0x00000009, mRequest);
     }
 
 private:
@@ -14566,11 +14566,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000506, 0x0000000B, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000506) command (0x0000000B) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000506, 0x0000000B, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000506, 0x0000000B, mRequest);
     }
 
 private:
@@ -14617,11 +14617,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000507, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000507) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000507, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000507, 0x00000000, mRequest);
     }
 
 private:
@@ -14646,11 +14646,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000507, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000507) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000507, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000507, 0x00000001, mRequest);
     }
 
 private:
@@ -14675,11 +14675,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000507, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000507) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000507, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000507, 0x00000002, mRequest);
     }
 
 private:
@@ -14706,11 +14706,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000507, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000507) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000507, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000507, 0x00000003, mRequest);
     }
 
 private:
@@ -14751,11 +14751,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000508, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000508) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000508, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000508, 0x00000000, mRequest);
     }
 
 private:
@@ -14797,11 +14797,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000509, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000509) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000509, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000509, 0x00000000, mRequest);
     }
 
 private:
@@ -14849,11 +14849,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050A, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050A) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050A, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050A, 0x00000000, mRequest);
     }
 
 private:
@@ -14883,11 +14883,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050A, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050A) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050A, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050A, 0x00000001, mRequest);
     }
 
 private:
@@ -14914,9 +14914,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050A, 0x00000001, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050A, 0x00000001, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050A, 0x00000001, mValue);
     }
 
 private:
@@ -14961,11 +14961,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050B, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050B) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050B, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050B, 0x00000000, mRequest);
     }
 
 private:
@@ -14992,11 +14992,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050B, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050B) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050B, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050B, 0x00000001, mRequest);
     }
 
 private:
@@ -15044,11 +15044,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050C, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050C) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050C, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050C, 0x00000000, mRequest);
     }
 
 private:
@@ -15076,11 +15076,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050C, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050C) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050C, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050C, 0x00000001, mRequest);
     }
 
 private:
@@ -15108,11 +15108,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050C, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050C) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050C, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050C, 0x00000002, mRequest);
     }
 
 private:
@@ -15138,9 +15138,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050C, 0x00000001, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050C, 0x00000001, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050C, 0x00000001, mValue);
     }
 
 private:
@@ -15209,11 +15209,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050E, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050E) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050E, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050E, 0x00000000, mRequest);
     }
 
 private:
@@ -15240,11 +15240,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050E, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050E) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050E, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050E, 0x00000002, mRequest);
     }
 
 private:
@@ -15269,11 +15269,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050E, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050E) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050E, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050E, 0x00000003, mRequest);
     }
 
 private:
@@ -15418,11 +15418,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000000, mRequest);
     }
 
 private:
@@ -15447,11 +15447,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000001, mRequest);
     }
 
 private:
@@ -15476,11 +15476,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000002, mRequest);
     }
 
 private:
@@ -15506,11 +15506,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000003, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000003) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000003, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000003, mRequest);
     }
 
 private:
@@ -15538,11 +15538,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000004, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000004) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000004, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000004, mRequest);
     }
 
 private:
@@ -15569,11 +15569,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000005, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000005) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000005, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000005, mRequest);
     }
 
 private:
@@ -15606,11 +15606,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000006, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000006) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000006, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000006, mRequest);
     }
 
 private:
@@ -15643,11 +15643,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000007, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000007) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000007, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000007, mRequest);
     }
 
 private:
@@ -15675,11 +15675,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000008, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000008) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000008, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000008, mRequest);
     }
 
 private:
@@ -15707,11 +15707,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000009, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000009) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000009, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000009, mRequest);
     }
 
 private:
@@ -15740,11 +15740,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000000A, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x0000000A) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000000A, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000000A, mRequest);
     }
 
 private:
@@ -15772,11 +15772,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000000B, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x0000000B) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000000B, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000000B, mRequest);
     }
 
 private:
@@ -15804,11 +15804,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000000C, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x0000000C) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000000C, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000000C, mRequest);
     }
 
 private:
@@ -15837,11 +15837,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000000D, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x0000000D) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000000D, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000000D, mRequest);
     }
 
 private:
@@ -15870,11 +15870,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000000E, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x0000000E) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000000E, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000000E, mRequest);
     }
 
 private:
@@ -15901,11 +15901,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000000F, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x0000000F) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000000F, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000000F, mRequest);
     }
 
 private:
@@ -15946,11 +15946,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000010, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000010) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000010, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000010, mRequest);
     }
 
 private:
@@ -15991,11 +15991,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000011, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000011) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000011, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000011, mRequest);
     }
 
 private:
@@ -16022,11 +16022,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000012, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000012) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000012, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000012, mRequest);
     }
 
 private:
@@ -16053,11 +16053,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000013, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000013) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000013, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000013, mRequest);
     }
 
 private:
@@ -16086,11 +16086,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000014, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000014) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000014, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000014, mRequest);
     }
 
 private:
@@ -16117,11 +16117,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000015, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000015) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000015, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000015, mRequest);
     }
 
 private:
@@ -16145,9 +16145,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000000, mValue);
     }
 
 private:
@@ -16171,9 +16171,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000001, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000001, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000001, mValue);
     }
 
 private:
@@ -16197,9 +16197,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000002, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000002, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000002, mValue);
     }
 
 private:
@@ -16223,9 +16223,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000003, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000003, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000003, mValue);
     }
 
 private:
@@ -16249,9 +16249,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000004, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000004, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000004, mValue);
     }
 
 private:
@@ -16275,9 +16275,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000005, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000005, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000005, mValue);
     }
 
 private:
@@ -16301,9 +16301,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000006, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000006, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000006, mValue);
     }
 
 private:
@@ -16327,9 +16327,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000007, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000007, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000007, mValue);
     }
 
 private:
@@ -16353,9 +16353,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000008, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000008, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000008, mValue);
     }
 
 private:
@@ -16379,9 +16379,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000009, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000009, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000009, mValue);
     }
 
 private:
@@ -16405,9 +16405,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000000A, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000000A, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000000A, mValue);
     }
 
 private:
@@ -16431,9 +16431,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000000B, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000000B, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000000B, mValue);
     }
 
 private:
@@ -16457,9 +16457,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000000C, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000000C, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000000C, mValue);
     }
 
 private:
@@ -16483,9 +16483,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000000D, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000000D, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000000D, mValue);
     }
 
 private:
@@ -16509,9 +16509,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000000E, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000000E, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000000E, mValue);
     }
 
 private:
@@ -16535,9 +16535,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000000F, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000000F, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000000F, mValue);
     }
 
 private:
@@ -16561,9 +16561,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000010, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000010, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000010, mValue);
     }
 
 private:
@@ -16587,9 +16587,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000011, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000011, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000011, mValue);
     }
 
 private:
@@ -16613,9 +16613,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000012, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000012, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000012, mValue);
     }
 
 private:
@@ -16639,9 +16639,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000013, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000013, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000013, mValue);
     }
 
 private:
@@ -16665,9 +16665,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000014, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000014, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000014, mValue);
     }
 
 private:
@@ -16691,9 +16691,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000015, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000015, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000015, mValue);
     }
 
 private:
@@ -16717,9 +16717,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000016, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000016, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000016, mValue);
     }
 
 private:
@@ -16743,9 +16743,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000017, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000017, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000017, mValue);
     }
 
 private:
@@ -16769,9 +16769,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000018, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000018, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000018, mValue);
     }
 
 private:
@@ -16795,9 +16795,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000019, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000019, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000019, mValue);
     }
 
 private:
@@ -16822,9 +16822,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000001A, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000001A, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000001A, mValue);
     }
 
 private:
@@ -16850,9 +16850,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000001B, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000001B, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000001B, mValue);
     }
 
 private:
@@ -16878,9 +16878,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000001C, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000001C, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000001C, mValue);
     }
 
 private:
@@ -16907,9 +16907,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000001D, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000001D, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000001D, mValue);
     }
 
 private:
@@ -16933,9 +16933,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000001E, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000001E, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000001E, mValue);
     }
 
 private:
@@ -16960,9 +16960,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000001F, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000001F, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000001F, mValue);
     }
 
 private:
@@ -16986,9 +16986,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000020, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000020, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000020, mValue);
     }
 
 private:
@@ -17012,9 +17012,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000021, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000021, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000021, mValue);
     }
 
 private:
@@ -17038,9 +17038,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000022, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000022, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000022, mValue);
     }
 
 private:
@@ -17065,9 +17065,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000023, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000023, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000023, mValue);
     }
 
 private:
@@ -17094,9 +17094,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000024, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000024, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000024, mValue);
     }
 
 private:
@@ -17121,9 +17121,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000025, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000025, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000025, mValue);
     }
 
 private:
@@ -17149,9 +17149,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000026, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000026, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000026, mValue);
     }
 
 private:
@@ -17176,9 +17176,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000027, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000027, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000027, mValue);
     }
 
 private:
@@ -17203,9 +17203,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000028, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000028, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000028, mValue);
     }
 
 private:
@@ -17230,9 +17230,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000029, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000029, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000029, mValue);
     }
 
 private:
@@ -17257,9 +17257,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000002A, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000002A, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000002A, mValue);
     }
 
 private:
@@ -17285,9 +17285,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000002B, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000002B, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000002B, mValue);
     }
 
 private:
@@ -17314,9 +17314,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000030, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000030, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000030, mValue);
     }
 
 private:
@@ -17341,9 +17341,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000031, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000031, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000031, mValue);
     }
 
 private:
@@ -17368,9 +17368,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00000032, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00000032, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00000032, mValue);
     }
 
 private:
@@ -17394,9 +17394,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x000000FF, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x000000FF, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x000000FF, mValue);
     }
 
 private:
@@ -17421,9 +17421,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008000, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008000, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008000, mValue);
     }
 
 private:
@@ -17448,9 +17448,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008001, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008001, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008001, mValue);
     }
 
 private:
@@ -17475,9 +17475,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008002, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008002, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008002, mValue);
     }
 
 private:
@@ -17502,9 +17502,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008003, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008003, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008003, mValue);
     }
 
 private:
@@ -17529,9 +17529,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008004, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008004, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008004, mValue);
     }
 
 private:
@@ -17555,9 +17555,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008005, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008005, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008005, mValue);
     }
 
 private:
@@ -17582,9 +17582,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008006, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008006, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008006, mValue);
     }
 
 private:
@@ -17609,9 +17609,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008007, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008007, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008007, mValue);
     }
 
 private:
@@ -17636,9 +17636,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008008, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008008, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008008, mValue);
     }
 
 private:
@@ -17663,9 +17663,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008009, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008009, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008009, mValue);
     }
 
 private:
@@ -17690,9 +17690,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000800A, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000800A, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000800A, mValue);
     }
 
 private:
@@ -17717,9 +17717,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000800B, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000800B, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000800B, mValue);
     }
 
 private:
@@ -17744,9 +17744,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000800C, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000800C, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000800C, mValue);
     }
 
 private:
@@ -17770,9 +17770,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000800D, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000800D, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000800D, mValue);
     }
 
 private:
@@ -17797,9 +17797,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000800E, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000800E, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000800E, mValue);
     }
 
 private:
@@ -17824,9 +17824,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000800F, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000800F, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000800F, mValue);
     }
 
 private:
@@ -17851,9 +17851,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008010, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008010, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008010, mValue);
     }
 
 private:
@@ -17878,9 +17878,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008011, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008011, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008011, mValue);
     }
 
 private:
@@ -17905,9 +17905,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008012, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008012, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008012, mValue);
     }
 
 private:
@@ -17932,9 +17932,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008013, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008013, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008013, mValue);
     }
 
 private:
@@ -17959,9 +17959,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008014, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008014, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008014, mValue);
     }
 
 private:
@@ -17985,9 +17985,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008015, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008015, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008015, mValue);
     }
 
 private:
@@ -18012,9 +18012,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008016, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008016, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008016, mValue);
     }
 
 private:
@@ -18039,9 +18039,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008017, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008017, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008017, mValue);
     }
 
 private:
@@ -18066,9 +18066,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008018, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008018, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008018, mValue);
     }
 
 private:
@@ -18093,9 +18093,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008019, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008019, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008019, mValue);
     }
 
 private:
@@ -18120,9 +18120,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x0000801E, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x0000801E, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x0000801E, mValue);
     }
 
 private:
@@ -18147,9 +18147,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008024, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008024, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008024, mValue);
     }
 
 private:
@@ -18174,9 +18174,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008025, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008025, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008025, mValue);
     }
 
 private:
@@ -18202,9 +18202,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008026, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008026, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008026, mValue);
     }
 
 private:
@@ -18229,9 +18229,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008027, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008027, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008027, mValue);
     }
 
 private:
@@ -18256,9 +18256,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008028, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008028, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008028, mValue);
     }
 
 private:
@@ -18283,9 +18283,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x0000050F, 0x00008029, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x0000050F, 0x00008029, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x0000050F, 0x00008029, mValue);
     }
 
 private:
@@ -18328,11 +18328,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000703, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000703) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000703, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000703, 0x00000000, mRequest);
     }
 
 private:
@@ -18362,11 +18362,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000703, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000703) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000703, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000703, 0x00000001, mRequest);
     }
 
 private:
@@ -18393,11 +18393,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000703, 0x00000002, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000703) command (0x00000002) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000703, 0x00000002, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000703, 0x00000002, mRequest);
     }
 
 private:
@@ -18476,9 +18476,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000B01, 0x00000005, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000B01, 0x00000005, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000B01, 0x00000005, mValue);
     }
 
 private:
@@ -18519,11 +18519,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000B02, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000B02) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000B02, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000B02, 0x00000000, mRequest);
     }
 
 private:
@@ -18568,11 +18568,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000B03, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000B03) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000B03, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000B03, 0x00000000, mRequest);
     }
 
 private:
@@ -18598,11 +18598,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000B03, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000B03) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000B03, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000B03, 0x00000001, mRequest);
     }
 
 private:
@@ -18773,11 +18773,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000B04, 0x00000000, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000B04) command (0x00000000) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000B04, 0x00000000, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000B04, 0x00000000, mRequest);
     }
 
 private:
@@ -18806,11 +18806,11 @@ public:
         return ClusterCommand::SendCommand(device, endpointIds.at(0), 0x00000B04, 0x00000001, mRequest);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
         ChipLogProgress(chipTool, "Sending cluster (0x00000B04) command (0x00000001) on Group %" PRIu16, groupId);
 
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000B04, 0x00000001, mRequest);
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0x00000B04, 0x00000001, mRequest);
     }
 
 private:
@@ -18835,9 +18835,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000B04, 0x00000511, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000B04, 0x00000511, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000B04, 0x00000511, mValue);
     }
 
 private:
@@ -18862,9 +18862,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000B04, 0x00000513, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000B04, 0x00000513, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000B04, 0x00000513, mValue);
     }
 
 private:
@@ -18889,9 +18889,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000B04, 0x00000514, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000B04, 0x00000514, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000B04, 0x00000514, mValue);
     }
 
 private:
@@ -18916,9 +18916,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000B04, 0x00000515, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000B04, 0x00000515, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000B04, 0x00000515, mValue);
     }
 
 private:
@@ -18943,9 +18943,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000B04, 0x00000516, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000B04, 0x00000516, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000B04, 0x00000516, mValue);
     }
 
 private:
@@ -18970,9 +18970,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000B04, 0x00000517, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000B04, 0x00000517, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000B04, 0x00000517, mValue);
     }
 
 private:
@@ -18997,9 +18997,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000B04, 0x00000700, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000B04, 0x00000700, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000B04, 0x00000700, mValue);
     }
 
 private:
@@ -19024,9 +19024,9 @@ public:
         return WriteAttribute::SendCommand(device, endpointIds.at(0), 0x00000B04, 0x00000800, mValue);
     }
 
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::NodeId senderNodeId) override
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, senderNodeId, 0x00000B04, 0x00000800, mValue);
+        return WriteAttribute::SendGroupCommand(groupId, fabricIndex, 0x00000B04, 0x00000800, mValue);
     }
 
 private:


### PR DESCRIPTION
#### Problem
node id is not needed for outgoing group session, because we can get it from fabric.

#### Change overview
Remove node id from outgoing group session

#### Testing
Passed unit tests.