### PR TITLE
RPC: Fix locks in the RPC services

### DIFF
--- a/examples/common/pigweed/rpc_services/Attributes.h
+++ b/examples/common/pigweed/rpc_services/Attributes.h
@@ -24,6 +24,7 @@
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-id.h>
+#include <platform/PlatformManager.h>
 
 namespace chip {
 namespace rpc {
@@ -35,6 +36,8 @@ public:
     ::pw::Status Write(const chip_rpc_AttributeWrite & request, pw_protobuf_Empty & response)
     {
         const void * data;
+        DeviceLayer::StackLock lock;
+
         switch (request.data.which_data)
         {
         case chip_rpc_AttributeData_data_bool_tag:
@@ -74,6 +77,8 @@ public:
     {
         void * data;
         size_t size = 0;
+        DeviceLayer::StackLock lock;
+
         switch (request.type)
         {
         case chip_rpc_AttributeType_ZCL_BOOLEAN_ATTRIBUTE_TYPE:

--- a/examples/common/pigweed/rpc_services/Descriptor.h
+++ b/examples/common/pigweed/rpc_services/Descriptor.h
@@ -24,6 +24,7 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <platform/PlatformManager.h>
 
 namespace chip {
 namespace rpc {
@@ -35,6 +36,7 @@ public:
 
     virtual void DeviceTypeList(const ::chip_rpc_Endpoint & request, ServerWriter<::chip_rpc_DeviceType> & writer)
     {
+        DeviceLayer::StackLock lock;
         constexpr uint16_t kInvalidEndpointIndex = 0xFFFF;
         uint16_t index                           = emberAfIndexFromEndpoint(request.endpoint);
         if (index == kInvalidEndpointIndex)
@@ -50,16 +52,19 @@ public:
 
     void ServerList(const ::chip_rpc_Endpoint & request, ServerWriter<::chip_rpc_Cluster> & writer)
     {
+        DeviceLayer::StackLock lock;
         ClusterList(request.endpoint, true /*server*/, writer);
     }
 
     void ClientList(const ::chip_rpc_Endpoint & request, ServerWriter<::chip_rpc_Cluster> & writer)
     {
+        DeviceLayer::StackLock lock;
         ClusterList(request.endpoint, false /*server*/, writer);
     }
 
     void PartsList(const ::chip_rpc_Endpoint & request, ServerWriter<::chip_rpc_Endpoint> & writer)
     {
+        DeviceLayer::StackLock lock;
         if (request.endpoint == 0x00)
         {
             for (uint16_t index = 0; index < emberAfEndpointCount(); index++)

--- a/examples/common/pigweed/rpc_services/Lighting.h
+++ b/examples/common/pigweed/rpc_services/Lighting.h
@@ -24,6 +24,7 @@
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-id.h>
+#include <platform/PlatformManager.h>
 
 namespace chip {
 namespace rpc {
@@ -37,6 +38,8 @@ public:
 
     virtual pw::Status Set(const chip_rpc_LightingState & request, pw_protobuf_Empty & response)
     {
+        DeviceLayer::StackLock lock;
+
         uint8_t on = request.on;
         RETURN_STATUS_IF_NOT_OK(
             emberAfWriteServerAttribute(1, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, &on, ZCL_BOOLEAN_ATTRIBUTE_ID));
@@ -65,6 +68,8 @@ public:
 
     virtual pw::Status Get(const pw_protobuf_Empty & request, chip_rpc_LightingState & response)
     {
+        DeviceLayer::StackLock lock;
+
         uint8_t on;
         uint8_t level;
         uint8_t hue;

--- a/examples/common/pigweed/rpc_services/Locking.h
+++ b/examples/common/pigweed/rpc_services/Locking.h
@@ -23,6 +23,7 @@
 #include "pigweed/rpc_services/internal/StatusUtils.h"
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <platform/PlatformManager.h>
 
 namespace chip {
 namespace rpc {
@@ -35,6 +36,7 @@ public:
     virtual pw::Status Set(const chip_rpc_LockingState & request, pw_protobuf_Empty & response)
     {
         bool locked = request.locked;
+        DeviceLayer::StackLock lock;
         RETURN_STATUS_IF_NOT_OK(app::Clusters::OnOff::Attributes::OnOff::Set(kEndpoint, locked));
         return pw::OkStatus();
     }
@@ -42,6 +44,7 @@ public:
     virtual pw::Status Get(const pw_protobuf_Empty & request, chip_rpc_LockingState & response)
     {
         bool locked;
+        DeviceLayer::StackLock lock;
         RETURN_STATUS_IF_NOT_OK(app::Clusters::OnOff::Attributes::OnOff::Get(kEndpoint, &locked));
         response.locked = locked;
         return pw::OkStatus();


### PR DESCRIPTION
#### Problem
RPC services not locking the chip stack when reading and writing attributes, which is causing RPCs to fail assert.

#### Change overview
Add locks to the RPC services.

#### Testing
Using the chip-console on m5stack, verified the RPC services now work.
