### PR TITLE
Resolve default countryCodeSize when not set on commissioner

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1719,6 +1719,7 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
 #endif
         if (status != CHIP_NO_ERROR)
         {
+            actualCountryCodeSize = 2;
             ChipLogError(Controller, "Unable to find country code, defaulting to XX");
         }
         chip::CharSpan countryCode(countryCodeStr, actualCountryCodeSize);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1720,7 +1720,7 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         if (status != CHIP_NO_ERROR)
         {
             actualCountryCodeSize = 2;
-            memset(countryCodeStr, 0x58, actualCountryCodeSize);
+            memset(countryCodeStr, 'X', actualCountryCodeSize);
             ChipLogError(Controller, "Unable to find country code, defaulting to %s", countryCodeStr);
         }
         chip::CharSpan countryCode(countryCodeStr, actualCountryCodeSize);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1720,8 +1720,8 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         if (status != CHIP_NO_ERROR)
         {
             actualCountryCodeSize = 2;
-            memset(countryCodeStr, 58, actualCountryCodeSize);
-            ChipLogError(Controller, "Unable to find country code, defaulting to XX");
+            memset(countryCodeStr, 0x58, actualCountryCodeSize);
+            ChipLogError(Controller, "Unable to find country code, defaulting to %s", countryCodeStr);
         }
         chip::CharSpan countryCode(countryCodeStr, actualCountryCodeSize);
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1720,6 +1720,7 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         if (status != CHIP_NO_ERROR)
         {
             actualCountryCodeSize = 2;
+            memset(countryCodeStr, 58, actualCountryCodeSize);
             ChipLogError(Controller, "Unable to find country code, defaulting to XX");
         }
         chip::CharSpan countryCode(countryCodeStr, actualCountryCodeSize);


### PR DESCRIPTION
#### Problem
* Fixes #16723 

#### Change overview
Update commissioner to correctly set the default country code size.

#### Testing
Linux RPI based CHIP-tool - ble-thread pairinig using out of box configuration on CC13x2x7 device.