### PR TITLE
Bump ESP32 test timeout.

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -81,7 +81,7 @@ jobs:
                      out/esp32-m5stack-all-clusters/chip-all-clusters-app.elf \
                      /tmp/bloat_reports/
             - name: Build example All Clusters App C3
-              timeout-minutes: 10
+              timeout-minutes: 15
               run: scripts/examples/esp_example.sh all-clusters-app sdkconfig_c3devkit.defaults
             - name: Copy aside build products
               run: |


### PR DESCRIPTION
Quite a number of ESP32 test runs time out when doing the "Build
example All Clusters App C3" step.  Bumping timeout for that from 10
to 15 minutes.

#### Problem
Test timeouts.

#### Change overview
Increase the timeout

#### Testing
CI shall tell.