### PR TITLE
Add sanity-checking that CI explicitly defines values for all PICS items

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,7 @@ jobs:
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+
             - name: Check broken links
               # On-push disabled until the job can run fully green
               # At that point the step should be enabled.
@@ -67,3 +68,8 @@ jobs:
             - name: Check for disallowed include files
               if: always()
               run: scripts/tools/check_includes.sh
+
+            - name: Ensure all PICS are set for tests (to true or false)
+              if: always()
+              run: |
+                  scripts/tools/check_test_pics.py src/app/tests/suites/certification/ci-pics-values src/app/tests/suites/certification/PICS.yaml

--- a/scripts/tools/check_test_pics.py
+++ b/scripts/tools/check_test_pics.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Check that our test PICS include values for every PICS if we know about.
+
+Takes two filenames as arguments: the CI PICS values file and the PICS
+definition YAML file.
+"""
+
+import yaml
+import sys
+import re
+
+value_regexp = re.compile("=.*")
+
+
+def main():
+    if len(sys.argv) != 3:
+        print('Expecting two arguments: the CI PICS values file and the YAML file defining all PICS values.  Got: %r' %
+              sys.argv[1:])
+        return 1
+
+    value_defs = sys.argv[1]
+    pics_yaml = sys.argv[2]
+
+    with open(value_defs, "r") as stream:
+        defined_values = set(map(lambda item: re.sub(
+            value_regexp, "", item.rstrip()), stream.readlines()))
+
+    with open(pics_yaml, "r") as stream:
+        try:
+            yaml_data = yaml.safe_load(stream)
+        except yaml.YAMLError as e:
+            print(e)
+            return 1
+
+        possible_values = set(map(lambda item: item["id"], yaml_data["PICS"]))
+
+    if defined_values != possible_values:
+        for value in sorted(possible_values - defined_values):
+            print('"%s" does not have a value defined in %s' %
+                  (value, value_defs))
+        for value in sorted(defined_values - possible_values):
+            print('"%s" is not a known PICS item in %s' % (value, pics_yaml))
+        return 1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Otherwise we could have items silently defaulting to false.

Fixes https://github.com/project-chip/connectedhomeip/issues/16735

#### Problem
See #16735 

#### Change overview
Add a lint that checks that we are defining values for CI for all the PICS items.

#### Testing
Tried adding a new PICS item without adding it to the CI file and the lint failed.