### PR TITLE
Issue 12520 - Remove BDX timeout tracking from TransferSession 

### DIFF
--- a/src/app/clusters/ota-requestor/BDXDownloader.cpp
+++ b/src/app/clusters/ota-requestor/BDXDownloader.cpp
@@ -25,7 +25,6 @@
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <protocols/bdx/BdxMessages.h>
-#include <system/SystemClock.h> /* TODO:(#12520) remove */
 #include <system/SystemPacketBuffer.h>
 #include <transport/raw/MessageHeader.h>
 
@@ -83,8 +82,7 @@ bool BDXDownloader::HasTransferTimedOut()
 void BDXDownloader::OnMessageReceived(const chip::PayloadHeader & payloadHeader, chip::System::PacketBufferHandle msg)
 {
     VerifyOrReturn(mState == State::kInProgress, ChipLogError(BDX, "Can't accept messages, no transfer in progress"));
-    CHIP_ERROR err =
-        mBdxTransfer.HandleMessageReceived(payloadHeader, std::move(msg), /* TODO:(#12520) */ chip::System::Clock::Seconds16(0));
+    CHIP_ERROR err = mBdxTransfer.HandleMessageReceived(payloadHeader, std::move(msg));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(BDX, "unable to handle message: %" CHIP_ERROR_FORMAT, err.Format());
@@ -219,7 +217,7 @@ void BDXDownloader::PollTransferSession()
     // allow that?
     do
     {
-        mBdxTransfer.PollOutput(outEvent, /* TODO:(#12520) */ chip::System::Clock::Seconds16(0));
+        mBdxTransfer.PollOutput(outEvent);
         CHIP_ERROR err = HandleBdxEvent(outEvent);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(BDX, "HandleBDXEvent: %" CHIP_ERROR_FORMAT, err.Format()));
     } while (outEvent.EventType != TransferSession::OutputEventType::kNone);

--- a/src/app/clusters/ota-requestor/BDXDownloader.cpp
+++ b/src/app/clusters/ota-requestor/BDXDownloader.cpp
@@ -104,8 +104,7 @@ CHIP_ERROR BDXDownloader::SetBDXParams(const chip::bdx::TransferSession::Transfe
 
     // Must call StartTransfer() here to store the the pointer data contained in bdxInitData in the TransferSession object.
     // Otherwise it could be freed before we can use it.
-    ReturnErrorOnFailure(mBdxTransfer.StartTransfer(chip::bdx::TransferRole::kReceiver, bdxInitData,
-                                                    /* TODO:(#12520) */ chip::System::Clock::Seconds16(30)));
+    ReturnErrorOnFailure(mBdxTransfer.StartTransfer(chip::bdx::TransferRole::kReceiver, bdxInitData));
 
     return CHIP_NO_ERROR;
 }

--- a/src/protocols/bdx/BdxTransferSession.cpp
+++ b/src/protocols/bdx/BdxTransferSession.cpp
@@ -119,7 +119,7 @@ void TransferSession::PollOutput(OutputEvent & event)
     mPendingOutput = OutputEventType::kNone;
 }
 
-CHIP_ERROR TransferSession::StartTransfer(TransferRole role, const TransferInitData & initData, System::Clock::Timeout timeout)
+CHIP_ERROR TransferSession::StartTransfer(TransferRole role, const TransferInitData & initData)
 {
     VerifyOrReturnError(mState == TransferState::kUnitialized, CHIP_ERROR_INCORRECT_STATE);
 
@@ -161,7 +161,7 @@ CHIP_ERROR TransferSession::StartTransfer(TransferRole role, const TransferInitD
 }
 
 CHIP_ERROR TransferSession::WaitForTransfer(TransferRole role, BitFlags<TransferControlFlags> xferControlOpts,
-                                            uint16_t maxBlockSize, System::Clock::Timeout timeout)
+                                            uint16_t maxBlockSize)
 {
     VerifyOrReturnError(mState == TransferState::kUnitialized, CHIP_ERROR_INCORRECT_STATE);
 

--- a/src/protocols/bdx/BdxTransferSession.cpp
+++ b/src/protocols/bdx/BdxTransferSession.cpp
@@ -64,23 +64,9 @@ TransferSession::TransferSession()
     mSuppportedXferOpts.ClearAll();
 }
 
-void TransferSession::PollOutput(OutputEvent & event, System::Clock::Timestamp curTime)
+void TransferSession::PollOutput(OutputEvent & event)
 {
     event = OutputEvent(OutputEventType::kNone);
-
-    if (mShouldInitTimeoutStart)
-    {
-        mTimeoutStartTime       = curTime;
-        mShouldInitTimeoutStart = false;
-    }
-
-    if (mAwaitingResponse && ((curTime - mTimeoutStartTime) >= mTimeout))
-    {
-        event             = OutputEvent(OutputEventType::kTransferTimeout);
-        mState            = TransferState::kErrorState;
-        mAwaitingResponse = false;
-        return;
-    }
 
     switch (mPendingOutput)
     {
@@ -94,8 +80,7 @@ void TransferSession::PollOutput(OutputEvent & event, System::Clock::Timestamp c
         event = OutputEvent::StatusReportEvent(OutputEventType::kStatusReceived, mStatusReportData);
         break;
     case OutputEventType::kMsgToSend:
-        event             = OutputEvent::MsgToSendEvent(mMsgTypeData, std::move(mPendingMsgHandle));
-        mTimeoutStartTime = curTime;
+        event = OutputEvent::MsgToSendEvent(mMsgTypeData, std::move(mPendingMsgHandle));
         break;
     case OutputEventType::kInitReceived:
         event = OutputEvent::TransferInitEvent(mTransferRequestData, std::move(mPendingMsgHandle));
@@ -138,8 +123,7 @@ CHIP_ERROR TransferSession::StartTransfer(TransferRole role, const TransferInitD
 {
     VerifyOrReturnError(mState == TransferState::kUnitialized, CHIP_ERROR_INCORRECT_STATE);
 
-    mRole    = role;
-    mTimeout = timeout;
+    mRole = role;
 
     // Set transfer parameters. They may be overridden later by an Accept message
     mSuppportedXferOpts    = initData.TransferCtlFlags;
@@ -183,7 +167,6 @@ CHIP_ERROR TransferSession::WaitForTransfer(TransferRole role, BitFlags<Transfer
 
     // Used to determine compatibility with any future TransferInit parameters
     mRole                  = role;
-    mTimeout               = timeout;
     mSuppportedXferOpts    = xferControlOpts;
     mMaxSupportedBlockSize = maxBlockSize;
 
@@ -422,22 +405,16 @@ void TransferSession::Reset()
     mLastQueryNum      = 0;
     mNextQueryNum      = 0;
 
-    mTimeout                = System::Clock::kZero;
-    mTimeoutStartTime       = System::Clock::kZero;
-    mShouldInitTimeoutStart = true;
-    mAwaitingResponse       = false;
+    mAwaitingResponse = false;
 }
 
-CHIP_ERROR TransferSession::HandleMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle msg,
-                                                  System::Clock::Timestamp curTime)
+CHIP_ERROR TransferSession::HandleMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle msg)
 {
     VerifyOrReturnError(!msg.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
 
     if (payloadHeader.HasProtocol(Protocols::BDX::Id))
     {
         ReturnErrorOnFailure(HandleBdxMessage(payloadHeader, std::move(msg)));
-
-        mTimeoutStartTime = curTime;
     }
     else if (payloadHeader.HasMessageType(Protocols::SecureChannel::MsgType::StatusReport))
     {

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -160,9 +160,8 @@ public:
      *   See OutputEventType for all possible output event types.
      *
      * @param event     Reference to an OutputEvent struct that will be filled out with any pending output data
-     * @param curTime   Current time
      */
-    void PollOutput(OutputEvent & event, System::Clock::Timestamp curTime);
+    void PollOutput(OutputEvent & event);
 
     /**
      * @brief
@@ -285,13 +284,11 @@ public:
      * @param payloadHeader A PayloadHeader containing the Protocol type and Message Type
      * @param msg           A PacketBufferHandle pointing to the message buffer to process. May be BDX or StatusReport protocol.
      *                      Buffer is expected to start at data (not header).
-     * @param curTime       Current time
      *
      * @return CHIP_ERROR Indicates any problems in decoding the message, or if the message is not of the BDX or StatusReport
      *                    protocols.
      */
-    CHIP_ERROR HandleMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle msg,
-                                     System::Clock::Timestamp curTime);
+    CHIP_ERROR HandleMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle msg);
 
     TransferControlFlags GetControlMode() const { return mControlMode; }
     uint64_t GetStartOffset() const { return mStartOffset; }
@@ -382,10 +379,7 @@ private:
     uint32_t mLastQueryNum = 0;
     uint32_t mNextQueryNum = 0;
 
-    System::Clock::Timeout mTimeout            = System::Clock::kZero;
-    System::Clock::Timestamp mTimeoutStartTime = System::Clock::kZero;
-    bool mShouldInitTimeoutStart               = true;
-    bool mAwaitingResponse                     = false;
+    bool mAwaitingResponse = false;
 };
 
 } // namespace bdx

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -172,13 +172,11 @@ public:
      * @param role      Inidcates whether this object will be sending or receiving data
      * @param initData  Data for initializing this object and for populating a TransferInit message
      *                  The role parameter will determine whether to populate a ReceiveInit or SendInit
-     * @param timeout   The amount of time to wait for a response before considering the transfer failed
-     * @param curTime   The current time since epoch. Needed to set a start time for the transfer timeout.
      *
      * @return CHIP_ERROR Result of initialization and preparation of a TransferInit message. May also indicate if the
      *                    TransferSession object is unable to handle this request.
      */
-    CHIP_ERROR StartTransfer(TransferRole role, const TransferInitData & initData, System::Clock::Timeout timeout);
+    CHIP_ERROR StartTransfer(TransferRole role, const TransferInitData & initData);
 
     /**
      * @brief
@@ -189,13 +187,11 @@ public:
      * @param role            Inidcates whether this object will be sending or receiving data
      * @param xferControlOpts Indicates all supported control modes. Used to respond to a TransferInit message
      * @param maxBlockSize    The max Block size that this object supports.
-     * @param timeout         The amount of time to wait for a response before considering the transfer failed
      *
      * @return CHIP_ERROR Result of initialization. May also indicate if the TransferSession object is unable to handle this
      *                    request.
      */
-    CHIP_ERROR WaitForTransfer(TransferRole role, BitFlags<TransferControlFlags> xferControlOpts, uint16_t maxBlockSize,
-                               System::Clock::Timeout timeout);
+    CHIP_ERROR WaitForTransfer(TransferRole role, BitFlags<TransferControlFlags> xferControlOpts, uint16_t maxBlockSize);
 
     /**
      * @brief

--- a/src/protocols/bdx/TransferFacilitator.cpp
+++ b/src/protocols/bdx/TransferFacilitator.cpp
@@ -94,7 +94,7 @@ CHIP_ERROR Responder::PrepareForTransfer(System::Layer * layer, TransferRole rol
     mPollFreq    = pollFreq;
     mSystemLayer = layer;
 
-    ReturnErrorOnFailure(mTransfer.WaitForTransfer(role, xferControlOpts, maxBlockSize, timeout));
+    ReturnErrorOnFailure(mTransfer.WaitForTransfer(role, xferControlOpts, maxBlockSize));
 
     mSystemLayer->StartTimer(mPollFreq, PollTimerHandler, this);
     return CHIP_NO_ERROR;
@@ -108,7 +108,7 @@ CHIP_ERROR Initiator::InitiateTransfer(System::Layer * layer, TransferRole role,
     mPollFreq    = pollFreq;
     mSystemLayer = layer;
 
-    ReturnErrorOnFailure(mTransfer.StartTransfer(role, initData, timeout));
+    ReturnErrorOnFailure(mTransfer.StartTransfer(role, initData));
 
     mSystemLayer->StartTimer(mPollFreq, PollTimerHandler, this);
     return CHIP_NO_ERROR;

--- a/src/protocols/bdx/TransferFacilitator.cpp
+++ b/src/protocols/bdx/TransferFacilitator.cpp
@@ -42,8 +42,7 @@ CHIP_ERROR TransferFacilitator::OnMessageReceived(chip::Messaging::ExchangeConte
 
     ChipLogDetail(BDX, "%s: message " ChipLogFormatMessageType " protocol " ChipLogFormatProtocolId, __FUNCTION__,
                   payloadHeader.GetMessageType(), ChipLogValueProtocolId(payloadHeader.GetProtocolID()));
-    CHIP_ERROR err =
-        mTransfer.HandleMessageReceived(payloadHeader, std::move(payload), System::SystemClock().GetMonotonicTimestamp());
+    CHIP_ERROR err = mTransfer.HandleMessageReceived(payloadHeader, std::move(payload));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(BDX, "failed to handle message: %s", ErrorStr(err));
@@ -74,7 +73,7 @@ void TransferFacilitator::PollTimerHandler(chip::System::Layer * systemLayer, vo
 void TransferFacilitator::PollForOutput()
 {
     TransferSession::OutputEvent outEvent;
-    mTransfer.PollOutput(outEvent, System::SystemClock().GetMonotonicTimestamp());
+    mTransfer.PollOutput(outEvent);
     HandleTransferSessionOutput(outEvent);
 
     VerifyOrReturn(mSystemLayer != nullptr, ChipLogError(BDX, "%s mSystemLayer is null", __FUNCTION__));


### PR DESCRIPTION
#### Problem

Timeout tracking is unnecessary in BDX transfer session because OTA Query Image timeout has already been implemented at the BDX downloader layer via https://github.com/project-chip/connectedhomeip/pull/15768.

Fixes: https://github.com/project-chip/connectedhomeip/issues/12520

#### Change overview
Remove un-used BDX timeout tracking from TransferSession.

#### Testing
- Verified Query Image succeeds.

- Verify BDX timeout is caught if OTA-P is killed during Query Image transfer. 

Example:

```
out/apps/ota-provider/chip-ota-provider-app -f ~/Downloads/test2.ota   

out/apps/ota-requestor/chip-ota-requestor-app --discriminator 30 --secured-device-port 5560 --KVS /tmp/chip_kvs_requestor

out/apps/chip-tool/chip-tool otasoftwareupdaterequestor announce-ota-provider 0x00000000ABCD 0 0 0 0x0000001234567890 0

out/apps/chip-tool/chip-tool otasoftwareupdaterequestor subscribe-event download-error 5 10 1 0x1234567890 0
```

Control-C to kill OTA-P app. Then verify OTA-R logs after ~5 minutes:

```
[1648515793846] [50344:1212061] CHIP: [BDX] BDX transfer timeout*
[1648515793846] [50344:1212061] CHIP: [BDX] aborting due to timeout
[1648515793846] [50344:1212061] CHIP: [EVL] LogEvent event number: 0x00000000000D0003 priority: 1, endpoint id: 0x0 cluster id: 0x0000_002A event id: 0x2 Sys timestamp: 0x000000001638B06E
[1648515793846] [50344:1212061] CHIP: [DMG] Endpoint 0, Cluster 0x0000_002A update version to 31392a45
[1648515793846] [50344:1212061] CHIP: [EVL] LogEvent event number: 0x00000000000D0004 priority: 1, endpoint id: 0x0 cluster id: 0x0000_002A event id: 0x0 Sys timestamp: 0x000000001638B06E
[1648515793846] [50344:1212061] CHIP: [SWU] Unknown idle state reason so set the periodic timer for a next attempt
[1648515793846] [50344:1212061] CHIP: [SWU] Stopping the watchdog timer
[1648515793846] [50344:1212061] CHIP: [SWU] Starting the periodic query timer, timeout: 86400 seconds
```

