### PR TITLE
[EFR32] Fix sleepy device commissioning error

### DIFF
--- a/examples/platform/efr32/project_include/OpenThreadConfig.h
+++ b/examples/platform/efr32/project_include/OpenThreadConfig.h
@@ -64,6 +64,10 @@
 // Support udp multicast by enabling Multicast Listener Registration (MLR)
 #define OPENTHREAD_CONFIG_MLR_ENABLE 1
 
+// Define as 1 to stay awake between fragments while transmitting a large packet,
+// and to stay awake after receiving a packet with frame pending set to true.
+#define OPENTHREAD_CONFIG_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS 1
+
 // Use the SiLabs-supplied default platform configuration for remainder
 // of OpenThread config options.
 //


### PR DESCRIPTION
#### Problem
During the commissioning process, once the device receives the thread network configurations, the device can go to sleep and if it does at the wrong moment it will never join the thread network causing the commission to fail.

#### Change overview
Enable openthread configurations to stop sleepy device radio to sleep in between receiving or sending fragmented packets.
This is a temporary fix until the underlying issue is solved.

#### Testing
Manual tests with EFR32 devices to validate device can join the thread network
