### PR TITLE
[YAML] Issue an error on pairing timeout

### DIFF
--- a/examples/chip-tool-darwin/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool-darwin/templates/partials/test_cluster.zapt
@@ -107,8 +107,7 @@ class {{filename}}: public TestCommandBridge
           {{else}}
           {{#if (isString type)}}@"{{/if}}{{definedValue}}{{#if (isString type)}}"{{/if}}
           {{~/if~}}
-        {{/chip_tests_item_parameters}}
-        {{additionalArguments}});
+        {{/chip_tests_item_parameters}});
         {{else}}
         CHIPDevice * device = GetConnectedDevice();
         CHIPTest{{asUpperCamelCase cluster}} * cluster = [[CHIPTest{{asUpperCamelCase cluster}} alloc] initWithDevice:device endpoint:{{endpoint}} queue:mCallbackQueue];

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -86,6 +86,12 @@ protected:
     chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
 
+    bool IsUnsupported(const chip::app::StatusIB & status)
+    {
+        return status.mStatus == chip::Protocols::InteractionModel::Status::UnsupportedAttribute ||
+            status.mStatus == chip::Protocols::InteractionModel::Status::UnsupportedCommand;
+    }
+
     void Wait()
     {
         if (mDelayInMs.HasValue())

--- a/examples/chip-tool/templates/tests/helper.js
+++ b/examples/chip-tool/templates/tests/helper.js
@@ -15,7 +15,8 @@
  *    limitations under the License.
  */
 
-const { asLowerCamelCase }  = require('../../../../src/app/zap-templates/templates/app/helper.js');
+const { zapTypeToDecodableClusterObjectType, asUpperCamelCase, asLowerCamelCase }
+= require('../../../../src/app/zap-templates/templates/app/helper.js');
 const { isTestOnlyCluster } = require('../../../../src/app/zap-templates/common/simulated-clusters/SimulatedClusters.js');
 
 function utf8StringLength(str)
@@ -47,8 +48,36 @@ function asPropertyValue(options)
   return name;
 }
 
+async function asDecodableType()
+{
+  // Copy some properties needed by zapTypeToDecodableClusterObjectType
+  let target = { global : this.global, entryType : this.entryType };
+
+  let type;
+  if ('commandObject' in this) {
+    type = this.commandObject.responseName;
+  } else if ('attributeObject' in this) {
+    type              = this.attributeObject.type;
+    target.isArray    = this.attributeObject.isArray;
+    target.isOptional = this.attributeObject.isOptional;
+    target.isNullable = this.attributeObject.isNullable;
+  } else if ('eventObject' in this) {
+    type = this.eventObject.type;
+  } else {
+    throw new Error("Unsupported decodable type");
+  }
+
+  if (isTestOnlyCluster(this.cluster) || 'commandObject' in this) {
+    return `chip::app::Clusters::${asUpperCamelCase(this.cluster)}::Commands::${asUpperCamelCase(type)}::DecodableType`;
+  }
+
+  const options = { 'hash' : { ns : this.cluster } };
+  return await zapTypeToDecodableClusterObjectType.call(target, type, options);
+}
+
 //
 // Module exports
 //
 exports.utf8StringLength = utf8StringLength;
 exports.asPropertyValue  = asPropertyValue;
+exports.asDecodableType  = asDecodableType;

--- a/examples/chip-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_cluster.zapt
@@ -94,7 +94,7 @@ class {{filename}}Suite: public TestCommand
             This check can be removed once the cluster APIs have been converted from Invoke to
             ReadClient/WriteClient/CommandSender
         }}
-        {{~#if (isStrEqual cluster "DiscoveryCommands")~}}
+        {{~#if (isTestOnlyCluster cluster)~}}
         case {{index}}:
             {{>test_step_response}}
             break;
@@ -209,8 +209,7 @@ class {{filename}}Suite: public TestCommand
           {{~else if (isString type)}}"{{definedValue}}"
           {{else}}{{definedValue}}
           {{~/if~}}
-          {{/chip_tests_item_parameters}}
-          {{additionalArguments}});
+          {{/chip_tests_item_parameters}});
     }
     {{else if isWait}}
     CHIP_ERROR {{>testCommand}}()

--- a/examples/chip-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_cluster.zapt
@@ -83,25 +83,31 @@ class {{filename}}Suite: public TestCommand
 
     {{>setupSaveAs}}
 
-    void OnDiscoveryCommandsResults(const DiscoveryCommandResult & value) override
+    void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-      bool isExpectedDnssdResult = false;
-      {{#chip_tests_items}}
-      {{#if (isStrEqual cluster "DiscoveryCommands")}}
-      if ((mTestIndex - 1) == {{index}})
-      {
-          isExpectedDnssdResult = true;
-          {{#chip_tests_item_response_parameters}}
-          {{>maybeCheckExpectedValue}}
-          {{>maybeCheckExpectedConstraints}}
-          {{>maybeSaveAs}}
-          {{/chip_tests_item_response_parameters}}
-      }
-      {{/if}}
-      {{/chip_tests_items}}
+        bool shouldContinue = false;
 
-      VerifyOrReturn(isExpectedDnssdResult, Exit("An unexpected dnssd result has been received"));
-      NextTest();
+        switch (mTestIndex - 1)
+        {
+        {{#chip_tests_items}}
+        {{!
+            This check can be removed once the cluster APIs have been converted from Invoke to
+            ReadClient/WriteClient/CommandSender
+        }}
+        {{~#if (isStrEqual cluster "DiscoveryCommands")~}}
+        case {{index}}:
+            {{>test_step_response}}
+            break;
+        {{/if~}}
+        {{/chip_tests_items}}
+        default:
+            LogErrorOnFailure(ContinueOnChipMainThread(CHIP_ERROR_INVALID_ARGUMENT));
+        }
+
+        if (shouldContinue)
+        {
+            ContinueOnChipMainThread(CHIP_NO_ERROR);
+        }
     }
 
     {{! Helper around zapTypeToDecodableClusterObjectType that lets us set the

--- a/examples/chip-tool/templates/tests/partials/test_step_response.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_step_response.zapt
@@ -1,3 +1,10 @@
+{{~#*inline "maybeCheckClusterError"}}
+{{#if response.clusterError}}
+    VerifyOrReturn(CheckValue("clusterStatus", status.mClusterStatus.HasValue(), true));
+    VerifyOrReturn(CheckValue("clusterStatus", status.mClusterStatus.Value(), {{response.clusterError}}));
+{{/if}}
+{{/inline~}}
+
 {{~#*inline "maybeContinueWithoutWaitingOnDone"}}
     {{~#if isWaitForReport}}shouldContinue = true;{{/if~}}
     {{~#if (isTestOnlyCluster cluster)}}shouldContinue = true;{{/if~}}
@@ -16,6 +23,7 @@
 {{! --- Test Step Response Content --}}
 {{#if response.error}}
     VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), {{response.error}}));
+    {{>maybeCheckClusterError}}
 {{else}}
     {{>maybeReturnOnUnsupported}}
     VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), {{response.error}}));

--- a/examples/chip-tool/templates/tests/partials/test_step_response.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_step_response.zapt
@@ -1,0 +1,34 @@
+{{~#*inline "maybeContinueWithoutWaitingOnDone"}}
+    {{~#if isWaitForReport}}shouldContinue = true;{{/if~}}
+    {{~#if (isTestOnlyCluster cluster)}}shouldContinue = true;{{/if~}}
+{{/inline~}}
+
+{{~#*inline "maybeReturnOnUnsupported"}}
+{{~#if optional}}
+    if (IsUnsupported(status.mStatus))
+    {
+        {{>maybeContinueWithoutWaitingOnDone}}
+        return;
+    }
+{{/if~}}
+{{/inline~}}
+
+{{! --- Test Step Response Content --}}
+{{#if response.error}}
+    VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), {{response.error}}));
+{{else}}
+    {{>maybeReturnOnUnsupported}}
+    VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), {{response.error}}));
+    {{#if hasSpecificResponse}}
+    {
+        {{asDecodableType}} value;
+        VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+        {{#chip_tests_item_response_parameters}}
+            {{>maybeCheckExpectedValue}}
+            {{>maybeCheckExpectedConstraints}}
+            {{>maybeSaveAs}}
+        {{/chip_tests_item_response_parameters}}
+    }
+    {{/if}}
+{{/if}}
+{{>maybeContinueWithoutWaitingOnDone}}

--- a/examples/chip-tool/templates/tests/templates.json
+++ b/examples/chip-tool/templates/tests/templates.json
@@ -22,6 +22,10 @@
             "path": "partials/test_cluster.zapt"
         },
         {
+            "name": "test_step_response",
+            "path": "partials/test_step_response.zapt"
+        },
+        {
             "name": "maybeCheckExpectedValue",
             "path": "partials/checks/maybeCheckExpectedValue.zapt"
         },

--- a/examples/placeholder/templates/templates.json
+++ b/examples/placeholder/templates/templates.json
@@ -22,6 +22,10 @@
             "path": "../../../examples/chip-tool/templates/tests/partials/test_cluster.zapt"
         },
         {
+            "name": "test_step_response",
+            "path": "../../../examples/chip-tool/templates/tests/partials/test_step_response.zapt"
+        },
+        {
             "name": "maybeCheckExpectedValue",
             "path": "../../../examples/chip-tool/templates/tests/partials/checks/maybeCheckExpectedValue.zapt"
         },

--- a/src/app/tests/suites/TestMultiAdmin.yaml
+++ b/src/app/tests/suites/TestMultiAdmin.yaml
@@ -50,6 +50,19 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
+    - label: "Commission from alpha when the commissioning window is not opened"
+      identity: "alpha"
+      cluster: "CommissionerCommands"
+      command: "PairWithQRCode"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeIdForDuplicateCommissioning
+              - name: "payload"
+                value: payload
+      response:
+          error: FAILURE
+
     - label: "Open Commissioning Window from alpha"
       cluster: "AdministratorCommissioning"
       command: "OpenBasicCommissioningWindow"

--- a/src/app/tests/suites/TestMultiAdmin.yaml
+++ b/src/app/tests/suites/TestMultiAdmin.yaml
@@ -63,13 +63,15 @@ tests:
       identity: "alpha"
       cluster: "CommissionerCommands"
       command: "PairWithQRCode"
-      additionalArguments: ", CHIP_ERROR_FABRIC_EXISTS"
       arguments:
           values:
               - name: "nodeId"
                 value: nodeIdForDuplicateCommissioning
               - name: "payload"
                 value: payload
+      response:
+          error: FAILURE
+          clusterError: 0x09 #OperationalCertStatus::kFabricConflict
 
     - label: "Check that we just have the one fabric and did not add a new one"
       identity: "alpha"

--- a/src/app/tests/suites/commands/commissioner/CommissionerCommands.cpp
+++ b/src/app/tests/suites/commands/commissioner/CommissionerCommands.cpp
@@ -20,11 +20,9 @@
 
 constexpr uint16_t kPayloadMaxSize = 64;
 
-CHIP_ERROR CommissionerCommands::PairWithQRCode(chip::NodeId nodeId, const chip::CharSpan payload, CHIP_ERROR expectedStatus)
+CHIP_ERROR CommissionerCommands::PairWithQRCode(chip::NodeId nodeId, const chip::CharSpan payload)
 {
     VerifyOrReturnError(payload.size() > 0 && payload.size() < kPayloadMaxSize, CHIP_ERROR_INVALID_ARGUMENT);
-
-    mExpectedStatus = expectedStatus;
 
     GetCurrentCommissioner().RegisterPairingDelegate(this);
 
@@ -37,8 +35,6 @@ CHIP_ERROR CommissionerCommands::PairWithManualCode(chip::NodeId nodeId, const c
 {
     VerifyOrReturnError(payload.size() > 0 && payload.size() < kPayloadMaxSize, CHIP_ERROR_INVALID_ARGUMENT);
 
-    mExpectedStatus = CHIP_NO_ERROR;
-
     GetCurrentCommissioner().RegisterPairingDelegate(this);
 
     char manualCode[kPayloadMaxSize];
@@ -48,9 +44,40 @@ CHIP_ERROR CommissionerCommands::PairWithManualCode(chip::NodeId nodeId, const c
 
 CHIP_ERROR CommissionerCommands::Unpair(chip::NodeId nodeId)
 {
-    mExpectedStatus = CHIP_NO_ERROR;
-
     return GetCurrentCommissioner().UnpairDevice(nodeId);
+}
+
+chip::app::StatusIB ConvertToStatusIB(CHIP_ERROR err)
+{
+    using chip::app::StatusIB;
+    using namespace chip;
+    using namespace chip::Protocols::InteractionModel;
+    using namespace chip::app::Clusters::OperationalCredentials;
+
+    if (CHIP_ERROR_INVALID_PUBLIC_KEY == err)
+    {
+        return StatusIB(Status::Failure, to_underlying(OperationalCertStatus::kInvalidPublicKey));
+    }
+    else if (CHIP_ERROR_WRONG_NODE_ID == err)
+    {
+        return StatusIB(Status::Failure, to_underlying(OperationalCertStatus::kInvalidNodeOpId));
+    }
+    else if (CHIP_ERROR_UNSUPPORTED_CERT_FORMAT == err)
+    {
+        return StatusIB(Status::Failure, to_underlying(OperationalCertStatus::kInvalidNOC));
+    }
+    else if (CHIP_ERROR_FABRIC_EXISTS == err)
+    {
+        return StatusIB(Status::Failure, to_underlying(OperationalCertStatus::kFabricConflict));
+    }
+    else if (CHIP_ERROR_INVALID_FABRIC_ID == err)
+    {
+        return StatusIB(Status::Failure, to_underlying(OperationalCertStatus::kInvalidFabricIndex));
+    }
+    else
+    {
+        return StatusIB(err);
+    }
 }
 
 void CommissionerCommands::OnStatusUpdate(DevicePairingDelegate::Status status)
@@ -62,6 +89,7 @@ void CommissionerCommands::OnStatusUpdate(DevicePairingDelegate::Status status)
         break;
     case DevicePairingDelegate::Status::SecurePairingFailed:
         ChipLogError(chipTool, "Secure Pairing Failed");
+        OnResponse(ConvertToStatusIB(CHIP_ERROR_INCORRECT_STATE), nullptr);
         break;
     }
 }
@@ -71,52 +99,26 @@ void CommissionerCommands::OnPairingComplete(CHIP_ERROR err)
     if (CHIP_NO_ERROR != err)
     {
         ChipLogError(chipTool, "Pairing Complete Failure: %s", ErrorStr(err));
-        LogErrorOnFailure(ContinueOnChipMainThread(err));
+        OnResponse(ConvertToStatusIB(err), nullptr);
     }
 }
 
 void CommissionerCommands::OnPairingDeleted(CHIP_ERROR err)
 {
-    if (mExpectedStatus != err)
+    if (err != CHIP_NO_ERROR)
     {
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogError(chipTool, "Pairing Delete Failure: %s", ErrorStr(err));
-        }
-        else
-        {
-            ChipLogError(chipTool, "Got success but expected: %s", ErrorStr(mExpectedStatus));
-            err = CHIP_ERROR_INCORRECT_STATE;
-        }
-    }
-    else
-    {
-        // Treat as success.
-        err = CHIP_NO_ERROR;
+        ChipLogError(chipTool, "Pairing Delete Failure: %s", ErrorStr(err));
     }
 
-    LogErrorOnFailure(ContinueOnChipMainThread(err));
+    OnResponse(ConvertToStatusIB(err), nullptr);
 }
 
 void CommissionerCommands::OnCommissioningComplete(chip::NodeId nodeId, CHIP_ERROR err)
 {
-    if (mExpectedStatus != err)
+    if (err != CHIP_NO_ERROR)
     {
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogError(chipTool, "Commissioning Complete Failure: %s", ErrorStr(err));
-        }
-        else
-        {
-            ChipLogError(chipTool, "Got success but expected: %s", ErrorStr(mExpectedStatus));
-            err = CHIP_ERROR_INCORRECT_STATE;
-        }
-    }
-    else
-    {
-        // Treat as success.
-        err = CHIP_NO_ERROR;
+        ChipLogError(chipTool, "Commissioning Complete Failure: %s", ErrorStr(err));
     }
 
-    LogErrorOnFailure(ContinueOnChipMainThread(err));
+    OnResponse(ConvertToStatusIB(err), nullptr);
 }

--- a/src/app/tests/suites/commands/commissioner/CommissionerCommands.h
+++ b/src/app/tests/suites/commands/commissioner/CommissionerCommands.h
@@ -27,10 +27,11 @@ public:
     CommissionerCommands(){};
     ~CommissionerCommands() override{};
 
-    virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err)             = 0;
-    virtual chip::Controller::DeviceCommissioner & GetCurrentCommissioner() = 0;
+    virtual void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) = 0;
+    virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err)                              = 0;
+    virtual chip::Controller::DeviceCommissioner & GetCurrentCommissioner()                  = 0;
 
-    CHIP_ERROR PairWithQRCode(chip::NodeId nodeId, const chip::CharSpan payload, CHIP_ERROR expectedStatus = CHIP_NO_ERROR);
+    CHIP_ERROR PairWithQRCode(chip::NodeId nodeId, const chip::CharSpan payload);
     CHIP_ERROR PairWithManualCode(chip::NodeId nodeId, const chip::CharSpan payload);
     CHIP_ERROR Unpair(chip::NodeId nodeId);
 
@@ -39,7 +40,4 @@ public:
     void OnPairingComplete(CHIP_ERROR error) override;
     void OnPairingDeleted(CHIP_ERROR error) override;
     void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR error) override;
-
-private:
-    CHIP_ERROR mExpectedStatus = CHIP_NO_ERROR;
 };

--- a/src/app/tests/suites/commands/discovery/BUILD.gn
+++ b/src/app/tests/suites/commands/discovery/BUILD.gn
@@ -26,6 +26,7 @@ static_library("discovery") {
   cflags = [ "-Wconversion" ]
 
   public_deps = [
+    "${chip_root}/src/app",
     "${chip_root}/src/lib/address_resolve",
     "${chip_root}/src/lib/support",
   ]

--- a/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
+++ b/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
@@ -159,5 +159,137 @@ void DiscoveryCommands::OnNodeDiscovered(const chip::Dnssd::DiscoveredNodeData &
         data.mrpRetryIntervalActive.SetValue(nodeData.mrpRetryIntervalActive.Value().count());
     }
 
-    OnDiscoveryCommandsResults(data);
+    chip::app::StatusIB status;
+    status.mStatus = chip::Protocols::InteractionModel::Status::Success;
+
+    constexpr uint32_t kMaxDataLen = 4096;
+    uint8_t * buffer               = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(sizeof(uint8_t), kMaxDataLen));
+    if (buffer == nullptr)
+    {
+        ChipLogError(chipTool, "Can not dispatch mdns data: %s", chip::ErrorStr(CHIP_ERROR_NO_MEMORY));
+        return;
+    }
+
+    chip::TLV::TLVWriter writer;
+    writer.Init(buffer, kMaxDataLen);
+    CHIP_ERROR err = data.Encode(writer, chip::TLV::AnonymousTag());
+    if (CHIP_NO_ERROR != err)
+    {
+        ChipLogError(chipTool, "Can not encode mdns data: %s", chip::ErrorStr(err));
+        return;
+    }
+
+    uint32_t dataLen = writer.GetLengthWritten();
+    writer.Finalize();
+
+    chip::TLV::TLVReader reader;
+    reader.Init(buffer, dataLen);
+    reader.Next();
+
+    OnResponse(status, &reader);
+
+    chip::Platform::MemoryFree(buffer);
 }
+
+CHIP_ERROR DiscoveryCommandResult::Encode(chip::TLV::TLVWriter & writer, chip::TLV::Tag tag) const
+{
+    chip::TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, chip::TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(0), hostName));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(1), instanceName));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(2), longDiscriminator));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(3), shortDiscriminator));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(4), vendorId));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(5), productId));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(6), commissioningMode));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(7), deviceType));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(8), deviceName));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(9), rotatingId));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(10), rotatingIdLen));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(11), pairingHint));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(12), pairingInstruction));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(13), supportsTcp));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(14), numIPs));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(15), port));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(16), mrpRetryIntervalIdle));
+    ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, chip::TLV::ContextTag(17), mrpRetryIntervalActive));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DiscoveryCommandResult::Decode(chip::TLV::TLVReader & reader)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::TLV::TLVType outer;
+    VerifyOrReturnError(chip::TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorOnFailure(reader.EnterContainer(outer));
+
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(chip::TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case 0:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, hostName));
+            break;
+        case 1:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, instanceName));
+            break;
+        case 2:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, longDiscriminator));
+            break;
+        case 3:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, shortDiscriminator));
+            break;
+        case 4:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, vendorId));
+            break;
+        case 5:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, productId));
+            break;
+        case 6:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, commissioningMode));
+            break;
+        case 7:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, deviceType));
+            break;
+        case 8:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, deviceName));
+            break;
+        case 9:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, rotatingId));
+            break;
+        case 10:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, rotatingIdLen));
+            break;
+        case 11:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, pairingHint));
+            break;
+        case 12:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, pairingInstruction));
+            break;
+        case 13:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, supportsTcp));
+            break;
+        case 14:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, numIPs));
+            break;
+        case 15:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, port));
+            break;
+        case 16:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, mrpRetryIntervalIdle));
+            break;
+        case 17:
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(reader, mrpRetryIntervalActive));
+            break;
+        default:
+            break;
+        }
+    }
+
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+
+    return CHIP_NO_ERROR;
+};

--- a/src/app/tests/suites/commands/discovery/DiscoveryCommands.h
+++ b/src/app/tests/suites/commands/discovery/DiscoveryCommands.h
@@ -18,6 +18,9 @@
 
 #pragma once
 
+#include <app/MessageDef/StatusIB.h>
+#include <app/data-model/Decode.h>
+#include <app/data-model/Encode.h>
 #include <lib/dnssd/ResolverProxy.h>
 #include <lib/support/CodeUtils.h>
 
@@ -41,7 +44,24 @@ struct DiscoveryCommandResult
     uint16_t port;
     chip::Optional<uint32_t> mrpRetryIntervalIdle;
     chip::Optional<uint32_t> mrpRetryIntervalActive;
+
+    CHIP_ERROR Encode(chip::TLV::TLVWriter & writer, chip::TLV::Tag tag) const;
+    CHIP_ERROR Decode(chip::TLV::TLVReader & reader);
 };
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace DiscoveryCommands {
+namespace Commands {
+namespace DiscoveryCommandResponse {
+using DecodableType = DiscoveryCommandResult;
+}
+} // namespace Commands
+} // namespace DiscoveryCommands
+} // namespace Clusters
+} // namespace app
+} // namespace chip
 
 class DiscoveryCommands : public chip::Dnssd::CommissioningResolveDelegate, public chip::Dnssd::OperationalResolveDelegate
 {
@@ -49,7 +69,8 @@ public:
     DiscoveryCommands(){};
     ~DiscoveryCommands() override{};
 
-    virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) = 0;
+    virtual void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) = 0;
+    virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err)                              = 0;
 
     CHIP_ERROR FindCommissionable();
     CHIP_ERROR FindCommissionableByShortDiscriminator(uint64_t value);
@@ -64,7 +85,6 @@ public:
 
     CHIP_ERROR SetupDiscoveryCommands();
     CHIP_ERROR TearDownDiscoveryCommands();
-    virtual void OnDiscoveryCommandsResults(const DiscoveryCommandResult & nodeData){};
 
     /////////// CommissioningDelegate Interface /////////
     void OnNodeDiscovered(const chip::Dnssd::DiscoveredNodeData & nodeData) override;

--- a/src/app/tests/suites/include/ValueChecker.h
+++ b/src/app/tests/suites/include/ValueChecker.h
@@ -32,6 +32,17 @@ public:
 protected:
     virtual void Exit(std::string message) = 0;
 
+    bool CheckDecodeValue(CHIP_ERROR error)
+    {
+        if (CHIP_NO_ERROR != error)
+        {
+            Exit(std::string("Can not decode data: ") + chip::ErrorStr(error));
+            return false;
+        }
+
+        return true;
+    }
+
     bool CheckValueAsString(const char * itemName, chip::ByteSpan current, chip::ByteSpan expected)
     {
         if (!current.data_equal(expected))

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -485,14 +485,20 @@ async function chip_tests(list, options)
     test.tests = await Promise.all(test.tests.map(async function(item) {
       item.global = global;
       if (item.isCommand) {
-        let command        = await assertCommandOrAttributeOrEvent(item);
-        item.commandObject = command;
+        let command               = await assertCommandOrAttributeOrEvent(item);
+        item.commandObject        = command;
+        item.hasSpecificArguments = true;
+        item.hasSpecificResponse  = command.hasSpecificResponse;
       } else if (item.isAttribute) {
-        let attr             = await assertCommandOrAttributeOrEvent(item);
-        item.attributeObject = attr;
+        let attr                  = await assertCommandOrAttributeOrEvent(item);
+        item.attributeObject      = attr;
+        item.hasSpecificArguments = item.isWriteAttribute;
+        item.hasSpecificResponse  = item.isReadAttribute || item.isSubscribeAttribute || item.isWaitForReport;
       } else if (item.isEvent) {
-        let evt          = await assertCommandOrAttributeOrEvent(item);
-        item.eventObject = evt;
+        let evt                   = await assertCommandOrAttributeOrEvent(item);
+        item.eventObject          = evt;
+        item.hasSpecificArguments = false;
+        item.hasSpecificResponse  = true;
       }
       return item;
     }));

--- a/src/app/zap-templates/common/simulated-clusters/clusters/DiscoveryCommands.js
+++ b/src/app/zap-templates/common/simulated-clusters/clusters/DiscoveryCommands.js
@@ -69,48 +69,64 @@ const kDefaultResponse = {
 const FindCommissionable = {
   name : 'FindCommissionable',
   arguments : [],
+  hasSpecificResponse : true,
+  responseName : 'DiscoveryCommandResponse',
   response : kDefaultResponse
 };
 
 const FindCommissionableByShortDiscriminator = {
   name : 'FindCommissionableByShortDiscriminator',
   arguments : [ kNumberValueArgument ],
+  hasSpecificResponse : true,
+  responseName : 'DiscoveryCommandResponse',
   response : kDefaultResponse
 };
 
 const FindCommissionableByLongDiscriminator = {
   name : 'FindCommissionableByLongDiscriminator',
   arguments : [ kNumberValueArgument ],
+  hasSpecificResponse : true,
+  responseName : 'DiscoveryCommandResponse',
   response : kDefaultResponse
 };
 
 const FindCommissionableByCompressedFabricId = {
   name : 'FindOperationalByCompressedFabricId',
   arguments : [ kNumberValueArgument ],
+  hasSpecificResponse : true,
+  responseName : 'DiscoveryCommandResponse',
   response : kDefaultResponse
 };
 
 const FindCommissionableByCommissioningMode = {
   name : 'FindCommissionableByCommissioningMode',
   arguments : [],
+  hasSpecificResponse : true,
+  responseName : 'DiscoveryCommandResponse',
   response : kDefaultResponse
 };
 
 const FindCommissionableByVendorId = {
   name : 'FindCommissionableByVendorId',
   arguments : [ kNumberValueArgument ],
+  hasSpecificResponse : true,
+  responseName : 'DiscoveryCommandResponse',
   response : kDefaultResponse
 };
 
 const FindCommissionableByDeviceType = {
   name : 'FindCommissionableByDeviceType',
   arguments : [ kNumberValueArgument ],
+  hasSpecificResponse : true,
+  responseName : 'DiscoveryCommandResponse',
   response : kDefaultResponse
 };
 
 const FindCommissionableByName = {
   name : 'FindCommissionableByName',
   arguments : [ kStringValueArgument ],
+  hasSpecificResponse : true,
+  responseName : 'DiscoveryCommandResponse',
   response : kDefaultResponse
 };
 
@@ -121,18 +137,24 @@ const FindCommissionableByName = {
 const FindCommissioner = {
   name : 'FindCommissioner',
   arguments : [],
+  hasSpecificResponse : true,
+  responseName : 'DiscoveryCommandResponse',
   response : kDefaultResponse
 };
 
 const FindCommissionerByVendorId = {
   name : 'FindCommissionableByVendorId',
   arguments : [ kNumberValueArgument ],
+  hasSpecificResponse : true,
+  responseName : 'DiscoveryCommandResponse',
   response : kDefaultResponse
 };
 
 const FindCommissionerByDeviceType = {
   name : 'FindCommissionerByDeviceType',
   arguments : [ kNumberValueArgument ],
+  hasSpecificResponse : true,
+  responseName : 'DiscoveryCommandResponse',
   response : kDefaultResponse
 };
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -463,9 +463,11 @@ CHIP_ERROR DeviceCommissioner::Init(CommissionerInitParams params)
     mUdcServer->SetInstanceNameResolver(this);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
+    mSetUpCodePairer.SetSystemLayer(mSystemState->SystemLayer());
 #if CONFIG_NETWORK_LAYER_BLE
     mSetUpCodePairer.SetBleLayer(mSystemState->BleLayer());
 #endif // CONFIG_NETWORK_LAYER_BLE
+
     return CHIP_NO_ERROR;
 }
 

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -64,6 +64,8 @@ public:
     // Called by the DeviceCommissioner to notify that we have discovered a new device.
     void NotifyCommissionableDeviceDiscovered(const chip::Dnssd::DiscoveredNodeData & nodeData);
 
+    void SetSystemLayer(System::Layer * systemLayer) { mSystemLayer = systemLayer; };
+
 #if CONFIG_NETWORK_LAYER_BLE
     void SetBleLayer(Ble::BleLayer * bleLayer) { mBleLayer = bleLayer; };
 #endif // CONFIG_NETWORK_LAYER_BLE
@@ -120,6 +122,8 @@ private:
         kTransportTypeCount,
     };
 
+    static void OnDeviceDiscoveredTimeoutCallback(System::Layer * layer, void * context);
+
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer = nullptr;
     void OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj);
@@ -133,6 +137,7 @@ private:
     Dnssd::DiscoveryFilter currentFilter;
 
     DeviceCommissioner * mCommissioner = nullptr;
+    System::Layer * mSystemLayer       = nullptr;
     chip::NodeId mRemoteId;
     uint32_t mSetUpPINCode                   = 0;
     SetupCodePairerBehaviour mConnectionType = SetupCodePairerBehaviour::kCommission;

--- a/src/darwin/Framework/CHIP/templates/tests/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/tests/partials/test_cluster.zapt
@@ -24,7 +24,7 @@ ResponseHandler {{> subscribeDataCallback}} = nil;
 
 {{#if (isTestOnlyCluster cluster)}}
     dispatch_queue_t queue = dispatch_get_main_queue();
-    {{command}}(expectation, queue{{#chip_tests_item_parameters}}, {{#if (isString type)}}@"{{/if}}{{> defined_value}}{{#if (isString type)}}"{{/if}}{{/chip_tests_item_parameters}}{{additionalArguments}});
+    {{command}}(expectation, queue{{#chip_tests_item_parameters}}, {{#if (isString type)}}@"{{/if}}{{> defined_value}}{{#if (isString type)}}"{{/if}}{{/chip_tests_item_parameters}});
 {{else}}
     CHIPDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1814,5 +1814,17 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif // CHIP_CONFIG_ERROR_FORMAT_AS_STRING
 
 /**
+ *  @def CHIP_CONFIG_SETUP_CODE_PAIRER_DISCOVERY_TIMEOUT_SECS
+ *
+ *  @brief
+ *    This is the default timeout for the discovery of devices by
+ *    the setup code pairer.
+ *
+ */
+#ifndef CHIP_CONFIG_SETUP_CODE_PAIRER_DISCOVERY_TIMEOUT_SECS
+#define CHIP_CONFIG_SETUP_CODE_PAIRER_DISCOVERY_TIMEOUT_SECS 30
+#endif // CHIP_CONFIG_SETUP_CODE_PAIRER_DISCOVERY_TIMEOUT_SECS
+
+/**
  * @}
  */

--- a/zzz_generated/placeholder/app1/zap-generated/test/Commands.h
+++ b/zzz_generated/placeholder/app1/zap-generated/test/Commands.h
@@ -161,12 +161,28 @@ private:
     chip::Optional<chip::EndpointId> mEndpoint;
     chip::Optional<uint16_t> mTimeout;
 
-    void OnDiscoveryCommandsResults(const DiscoveryCommandResult & value) override
+    void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-        bool isExpectedDnssdResult = false;
+        bool shouldContinue = false;
 
-        VerifyOrReturn(isExpectedDnssdResult, Exit("An unexpected dnssd result has been received"));
-        NextTest();
+        switch (mTestIndex - 1)
+        {
+        case 0:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 1:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        default:
+            LogErrorOnFailure(ContinueOnChipMainThread(CHIP_ERROR_INVALID_ARGUMENT));
+        }
+
+        if (shouldContinue)
+        {
+            ContinueOnChipMainThread(CHIP_NO_ERROR);
+        }
     }
 
     //
@@ -494,12 +510,24 @@ private:
     chip::Optional<chip::EndpointId> mEndpoint;
     chip::Optional<uint16_t> mTimeout;
 
-    void OnDiscoveryCommandsResults(const DiscoveryCommandResult & value) override
+    void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-        bool isExpectedDnssdResult = false;
+        bool shouldContinue = false;
 
-        VerifyOrReturn(isExpectedDnssdResult, Exit("An unexpected dnssd result has been received"));
-        NextTest();
+        switch (mTestIndex - 1)
+        {
+        case 0:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        default:
+            LogErrorOnFailure(ContinueOnChipMainThread(CHIP_ERROR_INVALID_ARGUMENT));
+        }
+
+        if (shouldContinue)
+        {
+            ContinueOnChipMainThread(CHIP_NO_ERROR);
+        }
     }
 
     //
@@ -678,12 +706,24 @@ private:
     chip::Optional<chip::EndpointId> mEndpoint;
     chip::Optional<uint16_t> mTimeout;
 
-    void OnDiscoveryCommandsResults(const DiscoveryCommandResult & value) override
+    void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-        bool isExpectedDnssdResult = false;
+        bool shouldContinue = false;
 
-        VerifyOrReturn(isExpectedDnssdResult, Exit("An unexpected dnssd result has been received"));
-        NextTest();
+        switch (mTestIndex - 1)
+        {
+        case 9:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        default:
+            LogErrorOnFailure(ContinueOnChipMainThread(CHIP_ERROR_INVALID_ARGUMENT));
+        }
+
+        if (shouldContinue)
+        {
+            ContinueOnChipMainThread(CHIP_NO_ERROR);
+        }
     }
 
     //

--- a/zzz_generated/placeholder/app2/zap-generated/test/Commands.h
+++ b/zzz_generated/placeholder/app2/zap-generated/test/Commands.h
@@ -161,12 +161,28 @@ private:
     chip::Optional<chip::EndpointId> mEndpoint;
     chip::Optional<uint16_t> mTimeout;
 
-    void OnDiscoveryCommandsResults(const DiscoveryCommandResult & value) override
+    void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-        bool isExpectedDnssdResult = false;
+        bool shouldContinue = false;
 
-        VerifyOrReturn(isExpectedDnssdResult, Exit("An unexpected dnssd result has been received"));
-        NextTest();
+        switch (mTestIndex - 1)
+        {
+        case 0:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 1:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        default:
+            LogErrorOnFailure(ContinueOnChipMainThread(CHIP_ERROR_INVALID_ARGUMENT));
+        }
+
+        if (shouldContinue)
+        {
+            ContinueOnChipMainThread(CHIP_NO_ERROR);
+        }
     }
 
     //
@@ -494,12 +510,24 @@ private:
     chip::Optional<chip::EndpointId> mEndpoint;
     chip::Optional<uint16_t> mTimeout;
 
-    void OnDiscoveryCommandsResults(const DiscoveryCommandResult & value) override
+    void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-        bool isExpectedDnssdResult = false;
+        bool shouldContinue = false;
 
-        VerifyOrReturn(isExpectedDnssdResult, Exit("An unexpected dnssd result has been received"));
-        NextTest();
+        switch (mTestIndex - 1)
+        {
+        case 0:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        default:
+            LogErrorOnFailure(ContinueOnChipMainThread(CHIP_ERROR_INVALID_ARGUMENT));
+        }
+
+        if (shouldContinue)
+        {
+            ContinueOnChipMainThread(CHIP_NO_ERROR);
+        }
     }
 
     //
@@ -678,12 +706,24 @@ private:
     chip::Optional<chip::EndpointId> mEndpoint;
     chip::Optional<uint16_t> mTimeout;
 
-    void OnDiscoveryCommandsResults(const DiscoveryCommandResult & value) override
+    void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
-        bool isExpectedDnssdResult = false;
+        bool shouldContinue = false;
 
-        VerifyOrReturn(isExpectedDnssdResult, Exit("An unexpected dnssd result has been received"));
-        NextTest();
+        switch (mTestIndex - 1)
+        {
+        case 9:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        default:
+            LogErrorOnFailure(ContinueOnChipMainThread(CHIP_ERROR_INVALID_ARGUMENT));
+        }
+
+        if (shouldContinue)
+        {
+            ContinueOnChipMainThread(CHIP_NO_ERROR);
+        }
     }
 
     //


### PR DESCRIPTION
#### Problem

When a YAML test is trying to pair to a device but can not find any advertisement it just wait until the whole test times out.
This PR update the YAML format to have a common path for "simulated" clusters such as "discovery" and "commissioner" since the "commissioner" simulated cluster is what is used to pair with devices.
Then it also add a timer to `SetUpCodePairer` to cancel everything after a given timeout - where the value of the timeout is the one use for other pairing methods into `CHIPDeviceController`.

Also there are a few more changes to the `zapt` templates than what is needed since this was some code I have to migrate the YAML c++ backend from `Invoke` to `ReadClient/WriteClient/CommandSender`

fix #16017

#### Change overview
 * Update `src/app/tests/suites/commands/discovery` to use a decodable type when it returns a value instead of a custom struct.

 * Update `src/app/tests/suites/commands/commissioner` to use the same `OnResponse` path into YAML generated code.

 * Add a timer to `SetUpCodePairer`

 * Add a test to check if not finding any device triggers an error as expected   

#### Testing
A test has been added to `TestMultiAdmin.yaml`