### PR TITLE
Allow re-establishing pase sessions

### DIFF
--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -42,6 +42,7 @@ CIRQUE_TESTS=(
     "InteractionModelTest"
     "SplitCommissioningTest"
     "PaseReestablishTest"
+    "PaseFailureTest"
 )
 
 BOLD_GREEN_TEXT="\033[1;32m"

--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -175,12 +175,12 @@ subcommand=$1
 shift
 
 case $subcommand in
-*)
-    cirquetest_"$subcommand" "$@"
-    exitcode=$?
-    if ((exitcode == 127)); then
-        echo "Unknown command: $subcommand" >&2
-    fi
-    exit "$exitcode"
-    ;;
+    *)
+        cirquetest_"$subcommand" "$@"
+        exitcode=$?
+        if ((exitcode == 127)); then
+            echo "Unknown command: $subcommand" >&2
+        fi
+        exit "$exitcode"
+        ;;
 esac

--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -41,6 +41,7 @@ CIRQUE_TESTS=(
     "CommissioningTest"
     "InteractionModelTest"
     "SplitCommissioningTest"
+    "PaseReestablishTest"
 )
 
 BOLD_GREEN_TEXT="\033[1;32m"
@@ -173,12 +174,12 @@ subcommand=$1
 shift
 
 case $subcommand in
-    *)
-        cirquetest_"$subcommand" "$@"
-        exitcode=$?
-        if ((exitcode == 127)); then
-            echo "Unknown command: $subcommand" >&2
-        fi
-        exit "$exitcode"
-        ;;
+*)
+    cirquetest_"$subcommand" "$@"
+    exitcode=$?
+    if ((exitcode == 127)); then
+        echo "Unknown command: $subcommand" >&2
+    fi
+    exit "$exitcode"
+    ;;
 esac

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -96,6 +96,8 @@ private:
 
     CHIP_ERROR OpenCommissioningWindow();
 
+    // Re-adds an unsolicited message handler for PASE without re-starting the commissioning window timer.
+    // Used to allow devices to re-establish pase sessions or re-try after a failure.
     CHIP_ERROR ListenForPASE();
 
     // Helper for Shutdown and Cleanup.  Does not do anything with

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -96,6 +96,8 @@ private:
 
     CHIP_ERROR OpenCommissioningWindow();
 
+    CHIP_ERROR ListenForPASE();
+
     // Helper for Shutdown and Cleanup.  Does not do anything with
     // advertisements, because Shutdown and Cleanup want to handle those
     // differently.

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -664,8 +664,8 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
         if (mPairingDelegate)
         {
             mPairingDelegate->OnPairingComplete(CHIP_NO_ERROR);
-            return CHIP_NO_ERROR;
         }
+        return CHIP_NO_ERROR;
     }
 
     device = mCommissioneeDevicePool.CreateObject();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -874,7 +874,6 @@ void DeviceCommissioner::OnSessionEstablished()
 
     ChipLogDetail(Controller, "Remote device completed SPAKE2+ handshake");
 
-    ChipLogProgress(Controller, "OnPairingComplete");
     mPairingDelegate->OnPairingComplete(CHIP_NO_ERROR);
     if (mRunCommissioningAfterConnection)
     {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -734,6 +734,7 @@ private:
 
     CommissioneeDeviceProxy * FindCommissioneeDevice(const SessionHandle & session);
     CommissioneeDeviceProxy * FindCommissioneeDevice(NodeId id);
+    CommissioneeDeviceProxy * FindCommissioneeDevice(const Transport::PeerAddress & peerAddress);
     void ReleaseCommissioneeDevice(CommissioneeDeviceProxy * device);
 
     template <typename ClusterObjectT, typename RequestObjectT>

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -206,6 +206,7 @@ public:
     NodeId GetDeviceId() const override { return mPeerId.GetNodeId(); }
     PeerId GetPeerId() const { return mPeerId; }
     CHIP_ERROR SetPeerId(ByteSpan rcac, ByteSpan noc) override;
+    Transport::PeerAddress GetPeerAddress() { return mDeviceAddress; }
 
     bool MatchesSession(const SessionHandle & session) const { return mSecureSession.Contains(session); }
 

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -206,7 +206,7 @@ public:
     NodeId GetDeviceId() const override { return mPeerId.GetNodeId(); }
     PeerId GetPeerId() const { return mPeerId; }
     CHIP_ERROR SetPeerId(ByteSpan rcac, ByteSpan noc) override;
-    Transport::PeerAddress GetPeerAddress() { return mDeviceAddress; }
+    const Transport::PeerAddress & GetPeerAddress() const { return mDeviceAddress; }
 
     bool MatchesSession(const SessionHandle & session) const { return mSecureSession.Contains(session); }
 

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -125,6 +125,8 @@ ChipError::StorageType pychip_DeviceController_CloseSession(chip::Controller::De
 ChipError::StorageType pychip_DeviceController_EstablishPASESessionIP(chip::Controller::DeviceCommissioner * devCtrl,
                                                                       const char * peerAddrStr, uint32_t setupPINCode,
                                                                       chip::NodeId nodeid);
+ChipError::StorageType pychip_DeviceController_StopPairing(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid);
+
 ChipError::StorageType pychip_DeviceController_Commission(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid);
 
 ChipError::StorageType
@@ -361,6 +363,12 @@ ChipError::StorageType pychip_DeviceController_EstablishPASESessionIP(chip::Cont
     params.SetPeerAddress(addr).SetDiscriminator(0);
     return devCtrl->EstablishPASEConnection(nodeid, params).AsInteger();
 }
+
+ChipError::StorageType pychip_DeviceController_StopPairing(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid)
+{
+    return devCtrl->StopPairing(nodeid).AsInteger();
+}
+
 ChipError::StorageType pychip_DeviceController_Commission(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid)
 {
     CommissioningParameters params;

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -246,6 +246,13 @@ class ChipDeviceController():
                 self.devCtrl, ipaddr, setupPinCode, nodeid)
         )
 
+    def StopPairing(self, nodeid):
+        self.CheckIsActive()
+        return self._ChipStack.Call(
+            lambda: self._dmLib.pychip_DeviceController_StopPairing(
+                self.devCtrl, nodeid)
+        )
+
     def Commission(self, nodeid):
         self.CheckIsActive()
         self._ChipStack.commissioningCompleteEvent.clear()
@@ -931,3 +938,7 @@ class ChipDeviceController():
             self._dmLib.pychip_DeviceController_OpenCommissioningWindow.restype = c_uint32
             self._dmLib.pychip_TestCommissionerUsed.argtypes = []
             self._dmLib.pychip_TestCommissionerUsed.restype = c_bool
+
+            self._dmLib.pychip_DeviceController_StopPairing.argtypes = [
+                c_void_p, c_uint64]
+            self._dmLib.pychip_DeviceController_StopPairing.restype = c_uint32

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -213,6 +213,15 @@ class BaseTestHelper:
             "Successfully established PASE session with device id: {} addr: {}".format(str(nodeid), ip))
         return True
 
+    def TestStopPairing(self, nodeid: int):
+        self.logger.info(
+            "Removing PASE connection for {}".format(nodeid))
+        if self.devCtrl.StopPairing(nodeid) != 0:
+            self.logger.info("Unable to remove connection")
+            return False
+        self.logger.info("Removed successfully")
+        return True
+
     def TestCommissionOnly(self, nodeid: int):
         self.logger.info(
             "Commissioning device with id {}".format(nodeid))

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -52,6 +52,11 @@ def TestFail(message):
     os._exit(1)
 
 
+def FailIfTrue(cond, message):
+    if cond:
+        TestFail(message)
+
+
 def FailIfNot(cond, message):
     if not cond:
         TestFail(message)
@@ -204,11 +209,14 @@ class BaseTestHelper:
     def TestPaseOnly(self, ip: str, setuppin: int, nodeid: int):
         self.logger.info(
             "Attempting to establish PASE session with device id: {} addr: {}".format(str(nodeid), ip))
-        if self.devCtrl.EstablishPASESessionIP(
-                ip.encode("utf-8"), setuppin, nodeid) is not None:
+        try:
+            self.devCtrl.EstablishPASESessionIP(
+                ip.encode("utf-8"), setuppin, nodeid)
+        except:
             self.logger.info(
                 "Failed to establish PASE session with device id: {} addr: {}".format(str(nodeid), ip))
             return False
+
         self.logger.info(
             "Successfully established PASE session with device id: {} addr: {}".format(str(nodeid), ip))
         return True

--- a/src/controller/python/test/test_scripts/pase_failure_test.py
+++ b/src/controller/python/test/test_scripts/pase_failure_test.py
@@ -80,7 +80,8 @@ def main():
     timeoutTicker = TestTimeout(options.testTimeout)
     timeoutTicker.start()
 
-    test = BaseTestHelper(nodeid=112233, testCommissioner=False, paaTrustStorePath=options.paaPath)
+    test = BaseTestHelper(nodeid=112233, testCommissioner=False,
+                          paaTrustStorePath=options.paaPath)
 
     FailIfNot(test.SetNetworkCommissioningParameters(dataset=TEST_THREAD_NETWORK_DATASET_TLV),
               "Failed to finish network commissioning")

--- a/src/controller/python/test/test_scripts/pase_failure_test.py
+++ b/src/controller/python/test/test_scripts/pase_failure_test.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+#
+#    Copyright (c) 2022 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Commissioning test.
+import os
+import sys
+from optparse import OptionParser
+from base import TestFail, TestTimeout, BaseTestHelper, FailIfNot, FailIfTrue, logger
+from cluster_objects import NODE_ID, ClusterObjectTests
+from network_commissioning import NetworkCommissioningTests
+import asyncio
+
+# The thread network dataset tlv for testing, splited into T-L-V.
+
+TEST_THREAD_NETWORK_DATASET_TLV = "0e080000000000010000" + \
+    "000300000c" + \
+    "35060004001fffe0" + \
+    "0208fedcba9876543210" + \
+    "0708fd00000000001234" + \
+    "0510ffeeddccbbaa99887766554433221100" + \
+    "030e54657374696e674e6574776f726b" + \
+    "0102d252" + \
+    "041081cb3b2efa781cc778397497ff520fa50c0302a0ff"
+# Network id, for the thread network, current a const value, will be changed to XPANID of the thread network.
+TEST_THREAD_NETWORK_ID = "fedcba9876543210"
+TEST_DISCRIMINATOR = 3840
+
+ENDPOINT_ID = 0
+LIGHTING_ENDPOINT_ID = 1
+GROUP_ID = 0
+
+
+def main():
+    optParser = OptionParser()
+    optParser.add_option(
+        "-t",
+        "--timeout",
+        action="store",
+        dest="testTimeout",
+        default=75,
+        type='int',
+        help="The program will return with timeout after specified seconds.",
+        metavar="<timeout-second>",
+    )
+    optParser.add_option(
+        "-a",
+        "--address",
+        action="store",
+        dest="deviceAddress",
+        default='',
+        type='str',
+        help="Address of the device",
+    )
+    optParser.add_option(
+        '--paa-trust-store-path',
+        dest="paaPath",
+        default='',
+        type='str',
+        help="Path that contains valid and trusted PAA Root Certificates."
+    )
+
+    (options, remainingArgs) = optParser.parse_args(sys.argv[1:])
+
+    timeoutTicker = TestTimeout(options.testTimeout)
+    timeoutTicker.start()
+
+    test = BaseTestHelper(nodeid=112233, testCommissioner=False, paaTrustStorePath=options.paaPath)
+
+    FailIfNot(test.SetNetworkCommissioningParameters(dataset=TEST_THREAD_NETWORK_DATASET_TLV),
+              "Failed to finish network commissioning")
+
+    # The device should be closing the commissioning window after 20 failed attempts.
+    for i in range(20):
+        test.logger.info("test attempt {}".format(i))
+        FailIfTrue(test.TestPaseOnly(ip=options.deviceAddress,
+                                     setuppin=0,
+                                     nodeid=1),
+                   "Incorrectly connected PASE to device using incorrect setup code")
+
+    FailIfTrue(test.TestPaseOnly(ip=options.deviceAddress,
+                                 setuppin=20202021,
+                                 nodeid=1),
+               "Incorrectly connected PASE to device after 20 incorrect attempts")
+
+    timeoutTicker.stop()
+
+    logger.info("Test finished")
+
+    # TODO: Python device controller cannot be shutdown clean sometimes and will block on AsyncDNSResolverSockets shutdown.
+    # Call os._exit(0) to force close it.
+    os._exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as ex:
+        logger.exception(ex)
+        TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/pase_reestablish_test.py
+++ b/src/controller/python/test/test_scripts/pase_reestablish_test.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+
+#
+#    Copyright (c) 2022 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Commissioning test.
+import os
+import sys
+from optparse import OptionParser
+from base import TestFail, TestTimeout, BaseTestHelper, FailIfNot, logger
+from cluster_objects import NODE_ID, ClusterObjectTests
+from network_commissioning import NetworkCommissioningTests
+import asyncio
+
+# The thread network dataset tlv for testing, splited into T-L-V.
+
+TEST_THREAD_NETWORK_DATASET_TLV = "0e080000000000010000" + \
+    "000300000c" + \
+    "35060004001fffe0" + \
+    "0208fedcba9876543210" + \
+    "0708fd00000000001234" + \
+    "0510ffeeddccbbaa99887766554433221100" + \
+    "030e54657374696e674e6574776f726b" + \
+    "0102d252" + \
+    "041081cb3b2efa781cc778397497ff520fa50c0302a0ff"
+# Network id, for the thread network, current a const value, will be changed to XPANID of the thread network.
+TEST_THREAD_NETWORK_ID = "fedcba9876543210"
+TEST_DISCRIMINATOR = 3840
+
+ENDPOINT_ID = 0
+LIGHTING_ENDPOINT_ID = 1
+GROUP_ID = 0
+
+
+def main():
+    optParser = OptionParser()
+    optParser.add_option(
+        "-t",
+        "--timeout",
+        action="store",
+        dest="testTimeout",
+        default=75,
+        type='int',
+        help="The program will return with timeout after specified seconds.",
+        metavar="<timeout-second>",
+    )
+    optParser.add_option(
+        "--address1",
+        action="store",
+        dest="deviceAddress1",
+        default='',
+        type='str',
+        help="Address of the first device",
+    )
+    optParser.add_option(
+        "--address2",
+        action="store",
+        dest="deviceAddress2",
+        default='',
+        type='str',
+        help="Address of the second device",
+    )
+    optParser.add_option(
+        '--paa-trust-store-path',
+        dest="paaPath",
+        default='',
+        type='str',
+        help="Path that contains valid and trusted PAA Root Certificates."
+    )
+
+    (options, remainingArgs) = optParser.parse_args(sys.argv[1:])
+
+    timeoutTicker = TestTimeout(options.testTimeout)
+    timeoutTicker.start()
+
+    test = BaseTestHelper(nodeid=112233, testCommissioner=False, paaTrustStorePath=options.paaPath)
+
+    # Test that we can re-establish PASE sessions with devices. Use two to ensure we can find PASE sessions from the pool.
+
+    FailIfNot(test.SetNetworkCommissioningParameters(dataset=TEST_THREAD_NETWORK_DATASET_TLV),
+              "Failed to finish network commissioning")
+
+    logger.info("Testing PASE connection to device 1")
+    FailIfNot(test.TestPaseOnly(ip=options.deviceAddress1,
+                                setuppin=20202021,
+                                nodeid=1),
+              "Failed to establish PASE connection with device 1")
+
+    logger.info("Testing PASE connection to device 2")
+    FailIfNot(test.TestPaseOnly(ip=options.deviceAddress2,
+                                setuppin=20202021,
+                                nodeid=2),
+              "Failed to establish PASE connection with device 2")
+
+    FailIfNot(test.TestPaseOnly(ip=options.deviceAddress1,
+                                setuppin=20202021,
+                                nodeid=1),
+              "Failed to find PASE connection with device 1")
+
+    logger.info("Testing PASE connection to device 2")
+    FailIfNot(test.TestPaseOnly(ip=options.deviceAddress2,
+                                setuppin=20202021,
+                                nodeid=2),
+              "Failed to find PASE connection with device 2")
+
+    FailIfNot(test.TestStopPairing(nodeid=1),
+              "Failed to remove PASE connection with device 1")
+
+    FailIfNot(test.TestStopPairing(nodeid=2),
+              "Failed to remove PASE connection with device 2")
+
+    logger.info("Testing PASE connection to device 1")
+    FailIfNot(test.TestPaseOnly(ip=options.deviceAddress1,
+                                setuppin=20202021,
+                                nodeid=1),
+              "Failed to re-establish PASE connection with device 1")
+
+    logger.info("Testing PASE connection to device 2")
+    FailIfNot(test.TestPaseOnly(ip=options.deviceAddress2,
+                                setuppin=20202021,
+                                nodeid=2),
+              "Failed to re-establish PASE connection with device 2")
+
+    FailIfNot(test.TestCommissionOnly(nodeid=1),
+              "Failed to commission device 1")
+
+    FailIfNot(test.TestCommissionOnly(nodeid=2),
+              "Failed to commission device 2")
+
+    logger.info("Testing on off cluster on device 1")
+    FailIfNot(test.TestOnOffCluster(nodeid=1,
+                                    endpoint=LIGHTING_ENDPOINT_ID,
+                                    group=GROUP_ID), "Failed to test on off cluster on device 1")
+
+    logger.info("Testing on off cluster on device 2")
+    FailIfNot(test.TestOnOffCluster(nodeid=2,
+                                    endpoint=LIGHTING_ENDPOINT_ID,
+                                    group=GROUP_ID), "Failed to test on off cluster on device 2")
+
+    timeoutTicker.stop()
+
+    logger.info("Test finished")
+
+    # TODO: Python device controller cannot be shutdown clean sometimes and will block on AsyncDNSResolverSockets shutdown.
+    # Call os._exit(0) to force close it.
+    os._exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as ex:
+        logger.exception(ex)
+        TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/pase_reestablish_test.py
+++ b/src/controller/python/test/test_scripts/pase_reestablish_test.py
@@ -87,7 +87,8 @@ def main():
     timeoutTicker = TestTimeout(options.testTimeout)
     timeoutTicker.start()
 
-    test = BaseTestHelper(nodeid=112233, testCommissioner=False, paaTrustStorePath=options.paaPath)
+    test = BaseTestHelper(nodeid=112233, testCommissioner=False,
+                          paaTrustStorePath=options.paaPath)
 
     # Test that we can re-establish PASE sessions with devices. Use two to ensure we can find PASE sessions from the pool.
 

--- a/src/test_driver/linux-cirque/PaseFailureTest.py
+++ b/src/test_driver/linux-cirque/PaseFailureTest.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2021 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+import os
+import pprint
+import time
+import sys
+
+from helper.CHIPTestBase import CHIPVirtualHome
+
+logger = logging.getLogger('MobileDeviceTest')
+logger.setLevel(logging.INFO)
+
+sh = logging.StreamHandler()
+sh.setFormatter(
+    logging.Formatter(
+        '%(asctime)s [%(name)s] %(levelname)s %(message)s'))
+logger.addHandler(sh)
+
+CHIP_PORT = 5540
+
+CIRQUE_URL = "http://localhost:5000"
+CHIP_REPO = os.path.join(os.path.abspath(
+    os.path.dirname(__file__)), "..", "..", "..")
+TEST_EXTPANID = "fedcba9876543210"
+TEST_DISCRIMINATOR = 3840
+MATTER_DEVELOPMENT_PAA_ROOT_CERTS = "credentials/development/paa-root-certs"
+
+DEVICE_CONFIG = {
+    'device0': {
+        'type': 'MobileDevice',
+        'base_image': 'connectedhomeip/chip-cirque-device-base',
+        'capability': ['TrafficControl', 'Mount'],
+        'rcp_mode': True,
+        'docker_network': 'Ipv6',
+        'traffic_control': {'latencyMs': 100},
+        "mount_pairs": [[CHIP_REPO, CHIP_REPO]],
+    },
+    'device1': {
+        'type': 'CHIPEndDevice',
+        'base_image': 'connectedhomeip/chip-cirque-device-base',
+        'capability': ['Thread', 'TrafficControl', 'Mount'],
+        'rcp_mode': True,
+        'docker_network': 'Ipv6',
+        'traffic_control': {'latencyMs': 100},
+        "mount_pairs": [[CHIP_REPO, CHIP_REPO]],
+    }
+}
+
+
+class TestPaseFailure(CHIPVirtualHome):
+    def __init__(self, device_config):
+        super().__init__(CIRQUE_URL, device_config)
+        self.logger = logger
+
+    def setup(self):
+        self.initialize_home()
+
+    def test_routine(self):
+        self.run_controller_test()
+
+    def run_controller_test(self):
+        ethernet_ip = [device['description']['ipv6_addr'] for device in self.non_ap_devices
+                       if device['type'] == 'CHIPEndDevice'][0]
+        server_ids = [device['id'] for device in self.non_ap_devices
+                      if device['type'] == 'CHIPEndDevice']
+        req_ids = [device['id'] for device in self.non_ap_devices
+                   if device['type'] == 'MobileDevice']
+
+        for server in server_ids:
+            self.execute_device_cmd(server, "CHIPCirqueDaemon.py -- run gdb -return-child-result -q -ex \"set pagination off\" -ex run -ex \"bt 25\" --args {} --thread --discriminator {}".format(
+                os.path.join(CHIP_REPO, "out/debug/standalone/chip-all-clusters-app"), TEST_DISCRIMINATOR))
+
+        self.reset_thread_devices(server_ids)
+
+        req_device_id = req_ids[0]
+
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip-0.0-cp37-abi3-linux_x86_64.whl")))
+
+        command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -a {} --paa-trust-store-path {}".format(
+            os.path.join(
+                CHIP_REPO, "src/controller/python/test/test_scripts/pase_failure_test.py"),
+            ethernet_ip, os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS))
+        ret = self.execute_device_cmd(req_device_id, command)
+
+        self.assertEqual(ret['return_code'], '0',
+                         "Test failed: non-zero return code")
+
+
+if __name__ == "__main__":
+    sys.exit(TestPaseFailure(DEVICE_CONFIG).run_test())

--- a/src/test_driver/linux-cirque/PaseReestablishTest.py
+++ b/src/test_driver/linux-cirque/PaseReestablishTest.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2022 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+import os
+import pprint
+import time
+import sys
+
+from helper.CHIPTestBase import CHIPVirtualHome
+
+logger = logging.getLogger('MobileDeviceTest')
+logger.setLevel(logging.INFO)
+
+sh = logging.StreamHandler()
+sh.setFormatter(
+    logging.Formatter(
+        '%(asctime)s [%(name)s] %(levelname)s %(message)s'))
+logger.addHandler(sh)
+
+CHIP_PORT = 5540
+
+CIRQUE_URL = "http://localhost:5000"
+CHIP_REPO = os.path.join(os.path.abspath(
+    os.path.dirname(__file__)), "..", "..", "..")
+TEST_EXTPANID = "fedcba9876543210"
+TEST_DISCRIMINATOR = 3840
+MATTER_DEVELOPMENT_PAA_ROOT_CERTS = "credentials/development/paa-root-certs"
+
+DEVICE_CONFIG = {
+    'device0': {
+        'type': 'MobileDevice',
+        'base_image': 'connectedhomeip/chip-cirque-device-base',
+        'capability': ['TrafficControl', 'Mount'],
+        'rcp_mode': True,
+        'docker_network': 'Ipv6',
+        'traffic_control': {'latencyMs': 100},
+        "mount_pairs": [[CHIP_REPO, CHIP_REPO]],
+    },
+    'device1': {
+        'type': 'CHIPEndDevice',
+        'base_image': 'connectedhomeip/chip-cirque-device-base',
+        'capability': ['Thread', 'TrafficControl', 'Mount'],
+        'rcp_mode': True,
+        'docker_network': 'Ipv6',
+        'traffic_control': {'latencyMs': 100},
+        "mount_pairs": [[CHIP_REPO, CHIP_REPO]],
+    },
+    'device2': {
+        'type': 'CHIPEndDevice',
+        'base_image': 'connectedhomeip/chip-cirque-device-base',
+        'capability': ['Thread', 'TrafficControl', 'Mount'],
+        'rcp_mode': True,
+        'docker_network': 'Ipv6',
+        'traffic_control': {'latencyMs': 100},
+        "mount_pairs": [[CHIP_REPO, CHIP_REPO]],
+    }
+}
+
+
+class TestCommissioningErrors(CHIPVirtualHome):
+    def __init__(self, device_config):
+        super().__init__(CIRQUE_URL, device_config)
+        self.logger = logger
+
+    def setup(self):
+        self.initialize_home()
+
+    def test_routine(self):
+        self.run_controller_test()
+
+    def run_controller_test(self):
+        ethernet_ips = [device['description']['ipv6_addr'] for device in self.non_ap_devices
+                        if device['type'] == 'CHIPEndDevice']
+        server_ids = [device['id'] for device in self.non_ap_devices
+                      if device['type'] == 'CHIPEndDevice']
+        req_ids = [device['id'] for device in self.non_ap_devices
+                   if device['type'] == 'MobileDevice']
+
+        for server in server_ids:
+            self.execute_device_cmd(server, "CHIPCirqueDaemon.py -- run gdb -return-child-result -q -ex \"set pagination off\" -ex run -ex \"bt 25\" --args {} --thread --discriminator {}".format(
+                os.path.join(CHIP_REPO, "out/debug/standalone/chip-all-clusters-app"), TEST_DISCRIMINATOR))
+
+        self.reset_thread_devices(server_ids)
+
+        req_device_id = req_ids[0]
+
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip-0.0-cp37-abi3-linux_x86_64.whl")))
+
+        command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 --address1 {} --address2 {} --paa-trust-store-path {}".format(
+            os.path.join(
+                CHIP_REPO, "src/controller/python/test/test_scripts/pase_reestablish_test.py"),
+            ethernet_ips[0], ethernet_ips[1], os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS))
+        ret = self.execute_device_cmd(req_device_id, command)
+
+        self.assertEqual(ret['return_code'], '0',
+                         "Test failed: non-zero return code")
+
+
+if __name__ == "__main__":
+    sys.exit(TestCommissioningErrors(DEVICE_CONFIG).run_test())


### PR DESCRIPTION
#### Problem
The spec indicates that the commissioner should re-establish the pase session if commissioning fails in most cases. This is not possible currently because the PASE connection handler is removed when the initial connection is established. This changes the code  to continue accepting PASE connections even after one has been  established.
    
A second commissioner will be able to establish a PASE connection,  but will not be able to arm the failsafe to start commissioning. The first commissioner can re-establish and will be able to re-arm the failsafe because the fabric will match.
    
The StopAdvertising call still happens after commissioning complete,  which is the real point when the commissioning window closes.

#### Change overview
- keeps the commissioning window open until commissioning complete call happens
- Adds code to the commissioner to not re-establish pase if a connection is already open
- adds tests

#### Testing
New cirque tests.
