### PR TITLE
Adjust min number of read paths to match new spec

### DIFF
--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1383,7 +1383,7 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  * @brief Defines the maximum number of path objects, limits the number of attributes being read or subscribed at the same time.
  */
 #ifndef CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
-#define CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS 8
+#define CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS 9
 #endif
 
 /**


### PR DESCRIPTION
#### Problem
The spec wasn't clear on how many read paths are required. Spec PR #5031 proposes 9 - PR is not yet in, but the discussion is around the wording and placement, not the number.

#### Change overview
- changes # default read paths to 9.

#### Testing
tested manually
