### PR TITLE
Resolve logic in generating the root certificate

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
@@ -79,7 +79,7 @@ private:
     chip::NodeId mNextRequestedNodeId = 1;
     chip::FabricId mNextFabricId = 1;
     bool mNodeIdRequested = false;
-    bool mGenerateRootCert = false;
+    bool mForceRootCertRegeneration = false;
 };
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### Problem
When a NOC provider is passed in the root certificate is not generated. 

#### Change overview
- Add logic to check if the root certificate is present and generate it when not present. 

- Rename  variable.

- Add new variable to check if root cert is present.  

#### Testing
Ran chip-tool-darwin which passes the NOC signer. 