### PR TITLE
Access control device type support

### DIFF
--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -32,6 +32,17 @@ class AccessControl
 {
 public:
     /**
+     * Used by access control to determine if a device type resolves to an endpoint.
+     */
+    struct DeviceTypeResolver
+    {
+    public:
+        virtual ~DeviceTypeResolver() = default;
+
+        virtual bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint) = 0;
+    };
+
+    /**
      * Handle to an entry in the access control list.
      *
      * Must be prepared (`AccessControl::PrepareEntry`) or read (`AccessControl::ReadEntry`) before first use.
@@ -376,12 +387,10 @@ public:
     /**
      * Initialize the access control module. Must be called before first use.
      *
-     * @param delegate - The delegate to use for acces control
-     *
      * @return CHIP_NO_ERROR on success, CHIP_ERROR_INCORRECT_STATE if called more than once,
      *         CHIP_ERROR_INVALID_ARGUMENT if delegate is null, or other fatal error.
      */
-    CHIP_ERROR Init(AccessControl::Delegate * delegate);
+    CHIP_ERROR Init(AccessControl::Delegate * delegate, DeviceTypeResolver & deviceTypeResolver);
 
     /**
      * Deinitialize the access control module. Must be called when finished.
@@ -498,6 +507,8 @@ private:
     bool IsValid(const Entry & entry);
 
     Delegate * mDelegate = nullptr;
+
+    DeviceTypeResolver * mDeviceTypeResolver = nullptr;
 };
 
 /**

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -390,6 +390,12 @@ constexpr DeviceTypeId invalidDeviceTypes[] = {
 };
 // clang-format on
 
+class DeviceTypeResolver : public AccessControl::DeviceTypeResolver
+{
+public:
+    bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint) override { return false; }
+} testDeviceTypeResolver;
+
 // For testing, supports one subject and target, allows any value (valid or invalid)
 class TestEntryDelegate : public Entry::Delegate
 {
@@ -1335,12 +1341,11 @@ void TestAclValidateTarget(nlTestSuite * inSuite, void * inContext)
         accessControl.DeleteEntry(1);
     }
 
-    // TODO(#14431): device type target not yet supported (flip != to == when supported)
     for (auto deviceType : validDeviceTypes)
     {
         NL_TEST_ASSERT(inSuite, entry.SetTarget(0, { .flags = Target::kDeviceType, .deviceType = deviceType }) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, accessControl.UpdateEntry(0, entry) != CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, accessControl.CreateEntry(nullptr, entry) != CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, accessControl.UpdateEntry(0, entry) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, accessControl.CreateEntry(nullptr, entry) == CHIP_NO_ERROR);
         accessControl.DeleteEntry(1);
     }
 
@@ -1358,7 +1363,6 @@ void TestAclValidateTarget(nlTestSuite * inSuite, void * inContext)
         }
     }
 
-    // TODO(#14431): device type target not yet supported (flip != to == when supported)
     for (auto cluster : validClusters)
     {
         for (auto deviceType : validDeviceTypes)
@@ -1368,8 +1372,8 @@ void TestAclValidateTarget(nlTestSuite * inSuite, void * inContext)
                 entry.SetTarget(
                     0, { .flags = Target::kCluster | Target::kDeviceType, .cluster = cluster, .deviceType = deviceType }) ==
                     CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, accessControl.UpdateEntry(0, entry) != CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, accessControl.CreateEntry(nullptr, entry) != CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, accessControl.UpdateEntry(0, entry) == CHIP_NO_ERROR);
+            NL_TEST_ASSERT(inSuite, accessControl.CreateEntry(nullptr, entry) == CHIP_NO_ERROR);
             accessControl.DeleteEntry(1);
         }
     }
@@ -2135,7 +2139,7 @@ int Setup(void * inContext)
 {
     AccessControl::Delegate * delegate = Examples::GetAccessControlDelegate(nullptr);
     SetAccessControl(accessControl);
-    VerifyOrDie(GetAccessControl().Init(delegate) == CHIP_NO_ERROR);
+    VerifyOrDie(GetAccessControl().Init(delegate, testDeviceTypeResolver) == CHIP_NO_ERROR);
     return SUCCESS;
 }
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -378,7 +378,7 @@ CHIP_ERROR WriteSingleClusterData(const Access::SubjectDescriptor & aSubjectDesc
 bool IsClusterDataVersionEqual(const ConcreteClusterPath & aConcreteClusterPath, DataVersion aRequiredVersion);
 
 /**
- * TODO: document
+ * Returns true if device type is on endpoint, false otherwise.
  */
 bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint);
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -376,5 +376,11 @@ CHIP_ERROR WriteSingleClusterData(const Access::SubjectDescriptor & aSubjectDesc
  * Check if the given cluster has the given DataVersion.
  */
 bool IsClusterDataVersionEqual(const ConcreteClusterPath & aConcreteClusterPath, DataVersion aRequiredVersion);
+
+/**
+ * TODO: document
+ */
+bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint);
+
 } // namespace app
 } // namespace chip

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -70,6 +70,15 @@ void StopEventLoop(intptr_t arg)
     }
 }
 
+class DeviceTypeResolver : public chip::Access::AccessControl::DeviceTypeResolver
+{
+public:
+    bool IsDeviceTypeOnEndpoint(chip::DeviceTypeId deviceType, chip::EndpointId endpoint) override
+    {
+        return chip::app::IsDeviceTypeOnEndpoint(deviceType, endpoint);
+    }
+} sDeviceTypeResolver;
+
 } // namespace
 
 namespace chip {
@@ -142,7 +151,7 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
     accessDelegate = Access::Examples::GetAccessControlDelegate(&mDeviceStorage);
     VerifyOrExit(accessDelegate != nullptr, ChipLogError(AppServer, "Invalid access delegate found."));
 
-    err = mAccessControl.Init(accessDelegate);
+    err = mAccessControl.Init(accessDelegate, sDeviceTypeResolver);
     SuccessOrExit(err);
     Access::SetAccessControl(mAccessControl);
 

--- a/src/app/tests/AppTestContext.cpp
+++ b/src/app/tests/AppTestContext.cpp
@@ -24,6 +24,12 @@
 
 namespace {
 
+class TestDeviceTypeResolver : public chip::Access::AccessControl::DeviceTypeResolver
+{
+public:
+    bool IsDeviceTypeOnEndpoint(chip::DeviceTypeId deviceType, chip::EndpointId endpoint) override { return false; }
+} gDeviceTypeResolver;
+
 chip::Access::AccessControl gPermissiveAccessControl;
 
 } // namespace
@@ -37,7 +43,8 @@ CHIP_ERROR AppContext::Init()
     ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->Init(&GetExchangeManager()));
 
     Access::SetAccessControl(gPermissiveAccessControl);
-    ReturnErrorOnFailure(Access::GetAccessControl().Init(chip::Access::Examples::GetPermissiveAccessControlDelegate()));
+    ReturnErrorOnFailure(
+        Access::GetAccessControl().Init(chip::Access::Examples::GetPermissiveAccessControlDelegate(), gDeviceTypeResolver));
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -270,6 +270,11 @@ bool IsClusterDataVersionEqual(const ConcreteClusterPath & aConcreteClusterPath,
     }
 }
 
+bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint)
+{
+    return false;
+}
+
 class TestReadInteraction
 {
 public:

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -672,6 +672,12 @@ bool IsClusterDataVersionEqual(const ConcreteClusterPath & aConcreteClusterPath,
 {
     return true;
 }
+
+bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint)
+{
+    return false;
+}
+
 } // namespace app
 } // namespace chip
 

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -134,6 +134,12 @@ bool IsClusterDataVersionEqual(const ConcreteClusterPath & aConcreteClusterPath,
 {
     return true;
 }
+
+bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint)
+{
+    return false;
+}
+
 } // namespace app
 } // namespace chip
 

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -970,6 +970,12 @@ bool IsClusterDataVersionEqual(const ConcreteClusterPath & aConcreteClusterPath,
     return (*(version)) == aRequiredVersion;
 }
 
+bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint)
+{
+    uint16_t index = emberAfIndexFromEndpoint(endpoint);
+    return index != 0xFFFF && emberAfDeviceIdFromIndex(index) == deviceType;
+}
+
 } // namespace app
 } // namespace chip
 

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -151,6 +151,11 @@ bool IsClusterDataVersionEqual(const ConcreteClusterPath & aConcreteClusterPath,
         return false;
     }
 }
+
+bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint)
+{
+    return false;
+}
 } // namespace app
 } // namespace chip
 

--- a/src/darwin/Framework/CHIP/CHIPControllerAccessControl.mm
+++ b/src/darwin/Framework/CHIP/CHIPControllerAccessControl.mm
@@ -21,6 +21,7 @@
 #include <access/RequestPath.h>
 #include <access/SubjectDescriptor.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <app/InteractionModelEngine.h>
 #include <lib/core/CHIPError.h>
 
 using namespace chip;
@@ -34,10 +35,9 @@ constexpr EndpointId kSupportedEndpoint = 0;
 
 class DeviceTypeResolver : public Access::AccessControl::DeviceTypeResolver {
 public:
-    bool IsDeviceTypeOnEndpoint(chip::DeviceTypeId deviceType, chip::EndpointId endpoint) override
+    bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint) override
     {
-        // We only allow access to the OTA software update provider.
-        return false;
+        return app::IsDeviceTypeOnEndpoint(deviceType, endpoint);
     }
 } gDeviceTypeResolver;
 

--- a/src/darwin/Framework/CHIP/CHIPControllerAccessControl.mm
+++ b/src/darwin/Framework/CHIP/CHIPControllerAccessControl.mm
@@ -32,6 +32,15 @@ namespace {
 // CHIPIMDispatch.mm.
 constexpr EndpointId kSupportedEndpoint = 0;
 
+class DeviceTypeResolver : public Access::AccessControl::DeviceTypeResolver {
+public:
+    bool IsDeviceTypeOnEndpoint(chip::DeviceTypeId deviceType, chip::EndpointId endpoint) override
+    {
+        // We only allow access to the OTA software update provider.
+        return false;
+    }
+} gDeviceTypeResolver;
+
 // TODO: Make the policy more configurable by consumers.
 class AccessControlDelegate : public Access::AccessControl::Delegate {
     CHIP_ERROR Check(
@@ -68,7 +77,7 @@ AccessControlDelegate gDelegate;
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        GetAccessControl().Init(&gDelegate);
+        GetAccessControl().Init(&gDelegate, gDeviceTypeResolver);
     });
 }
 

--- a/src/darwin/Framework/CHIP/CHIPIMDispatch.mm
+++ b/src/darwin/Framework/CHIP/CHIPIMDispatch.mm
@@ -153,6 +153,8 @@ namespace app {
         return false;
     }
 
+    bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint) { return false; }
+
     CHIP_ERROR WriteSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, const ConcreteDataAttributePath & aPath,
         TLV::TLVReader & aReader, WriteHandler * aWriteHandler)
     {


### PR DESCRIPTION
#### Problem
Fixes #14431

#### Change overview
Add device type resolver which can be registered with access control
for looking up device types on endpoints. Provide real and test
implementations.

#### Testing
* Unit tests updated.
* Build and run chip-all-clusters-app using chip-tool on Linux
* Install ACLs for device types 0x16 (root) and 0x100 (on/off light device)
* Check that device type targets work as expected
