### PR TITLE
Update rpc_console docs for building and running

### DIFF
--- a/examples/common/pigweed/rpc_console/README.md
+++ b/examples/common/pigweed/rpc_console/README.md
@@ -43,8 +43,8 @@ To start the console provide the path to the device, for example:
 
     $ chip-console --device /dev/ttyUSB0
 
-Note that `chip-console` is an entry point for chip_rpc.console and could also be run with
-`python -m chip_rpc.console`.
+Note that `chip-console` is an entry point for chip_rpc.console and could also
+be run with `python -m chip_rpc.console`.
 
 An example RPC command:
 

--- a/examples/common/pigweed/rpc_console/README.md
+++ b/examples/common/pigweed/rpc_console/README.md
@@ -18,14 +18,15 @@ files required for CHIP.
     If this is the first time using the checkout the environment must first be
     bootstrapped to install all dependencies.
 
-        $ source ./scripts/bootstrap.sh
+        $ source <project_root>/scripts/bootstrap.sh
 
-    If bootstrap has previously be run simply activate.
+    If bootstrap has previously been run, then simply activate.
 
-        $ source ./scripts/activate.sh
+        $ source <project_root>/scripts/activate.sh
 
     The python console is built and installed in the venv using gn:
 
+        $ cd <project_root>/examples/common/pigweed/rpc_console
         $ gn gen out/debug
         $ ninja -C out/debug
 
@@ -33,6 +34,7 @@ files required for CHIP.
     (chip_rpc_console_wheels), with all the wheels required for the tool. These
     can be used to install the console without needing the sdk. Simply install
     all the wheels in the folder:
+        $ cd <project_root>/examples/common/pigweed/rpc_console/out/debug
         $ pip install chip_rpc_console_wheels/*.whl
 
 ## Running
@@ -41,6 +43,9 @@ To start the console provide the path to the device, for example:
 
     $ chip-console --device /dev/ttyUSB0
 
+Note that `chip-console` is an entry point for chip_rpc.console and could also be run with
+`python -m chip_rpc.console`.
+
 An example RPC command:
 
-    $ rpcs.chip.rpc.DeviceCommon.GetDeviceInfo()
+    $ rpcs.chip.rpc.Device.GetDeviceInfo()


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Clarify location of which files to build and to install.
* Add note that `python -m chip_rpc.console` can be used instead of `chip-console` to imply what the entry point is.

#### Change overview
Clarify process for building and installing `rpc_console` by specifying folder locations for build actions.

#### Testing
How was this tested? (at least one bullet point required)
* I re-ran this process myself to confirm that the updated docs are correct.