### PR TITLE
Try multiple transports in SetUpCodePairer.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -481,7 +481,7 @@ CHIP_ERROR DeviceCommissioner::Shutdown()
     if (device != nullptr && device->IsSessionSetupInProgress())
     {
         ChipLogDetail(Controller, "Setup in progress, stopping setup before shutting down");
-        OnSessionEstablishmentError(CHIP_ERROR_CONNECTION_ABORTED);
+        PairingFailed(CHIP_ERROR_CONNECTION_ABORTED);
     }
     // TODO: If we have a commissioning step in progress, is there a way to cancel that callback?
 
@@ -812,7 +812,27 @@ void DeviceCommissioner::RendezvousCleanup(CHIP_ERROR status)
 
 void DeviceCommissioner::OnSessionEstablishmentError(CHIP_ERROR err)
 {
-    // PASE session establishment failure.
+    // Need to null out mDeviceInPASEEstablishment before maybe trying to
+    // establish PASE again, so EstablishPASEConnection won't error out.
+    auto * oldDeviceInPASEEstablishment = mDeviceInPASEEstablishment;
+    mDeviceInPASEEstablishment          = nullptr;
+
+    if (mSetUpCodePairer.TryNextRendezvousParameters())
+    {
+        ChipLogProgress(Controller, "Ignoring PASE error; will try commissioning over a different transport");
+        // We don't need oldDeviceInPASEEstablishment anymore.
+        ReleaseCommissioneeDevice(oldDeviceInPASEEstablishment);
+        return;
+    }
+
+    // Reset mDeviceInPASEEstablishment because PairingFailed checks for that to
+    // send the right notifications.
+    mDeviceInPASEEstablishment = oldDeviceInPASEEstablishment;
+    PairingFailed(err);
+}
+
+void DeviceCommissioner::PairingFailed(CHIP_ERROR err)
+{
     mSystemState->SystemLayer()->CancelTimer(OnSessionEstablishmentTimeoutCallback, this);
 
     if (mPairingDelegate != nullptr)
@@ -831,7 +851,7 @@ void DeviceCommissioner::OnSessionEstablished()
     // We are in the callback for this pairing. Reset so we can pair another device.
     mDeviceInPASEEstablishment = nullptr;
 
-    VerifyOrReturn(device != nullptr, OnSessionEstablishmentError(CHIP_ERROR_INVALID_DEVICE_DESCRIPTOR));
+    VerifyOrReturn(device != nullptr, PairingFailed(CHIP_ERROR_INVALID_DEVICE_DESCRIPTOR));
 
     PASESession * pairing = &device->GetPairing();
 
@@ -842,7 +862,7 @@ void DeviceCommissioner::OnSessionEstablished()
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "Failed in setting up secure channel: err %s", ErrorStr(err));
-        OnSessionEstablishmentError(err);
+        PairingFailed(err);
         return;
     }
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -623,6 +623,11 @@ private:
 
     static void OnSessionEstablishmentTimeoutCallback(System::Layer * aLayer, void * aAppState);
 
+    // Helper to call once we decide that pairing has failed.  This might be
+    // called from OnSessionEstablishmentError if we have no other transports to
+    // try, or in various other failure cases.
+    void PairingFailed(CHIP_ERROR err);
+
     /* This function sends a Device Attestation Certificate chain request to the device.
        The function does not hold a reference to the device object.
      */

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -45,15 +45,7 @@ CHIP_ERROR SetUpCodePairer::PairDevice(NodeId remoteId, const char * setUpCode, 
     mRemoteId     = remoteId;
     mSetUpPINCode = payload.setUpPINCode;
 
-    for (auto & waiting : mWaitingForDiscovery)
-    {
-        waiting = false;
-    }
-
-    for (auto & params : mDiscoveredParameters)
-    {
-        params = RendezvousParameters();
-    }
+    ResetDiscoveryState();
 
     return Connect(payload);
 }
@@ -314,6 +306,19 @@ bool SetUpCodePairer::TryNextRendezvousParameters()
     }
 
     return false;
+}
+
+void SetUpCodePairer::ResetDiscoveryState()
+{
+    for (auto & waiting : mWaitingForDiscovery)
+    {
+        waiting = false;
+    }
+
+    for (auto & params : mDiscoveredParameters)
+    {
+        params = RendezvousParameters();
+    }
 }
 
 } // namespace Controller

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -222,6 +222,8 @@ void SetUpCodePairer::OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj)
 {
     ChipLogProgress(Controller, "Discovered device to be commissioned over BLE");
 
+    mWaitingForDiscovery[kBLETransport] = false;
+
     // Probably safe to stop connections over other transports at this point?
     LogErrorOnFailure(StopConnectOverIP());
     LogErrorOnFailure(StopConnectOverSoftAP());
@@ -276,8 +278,6 @@ void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::Discover
     }
 
     ChipLogProgress(Controller, "Discovered device to be commissioned over DNS-SD");
-
-    mWaitingForDiscovery[kIPTransport] = false;
 
     // Don't stop trying to connect over BLE, because we may be dealing with
     // stale DNS-SD records.

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -53,7 +53,7 @@ enum class SetupCodePairerBehaviour : uint8_t
 class DLL_EXPORT SetUpCodePairer
 {
 public:
-    SetUpCodePairer(DeviceCommissioner * commissioner) : mCommissioner(commissioner) {}
+    SetUpCodePairer(DeviceCommissioner * commissioner) : mCommissioner(commissioner) { ResetDiscoveryState(); }
     virtual ~SetUpCodePairer() {}
 
     CHIP_ERROR PairDevice(chip::NodeId remoteId, const char * setUpCode,
@@ -90,6 +90,10 @@ private:
     // Returns whether we have kicked off a new connection attempt.
     bool ConnectToDiscoveredDevice();
 
+    // Reset our mWaitingForDiscovery/mDiscoveredParameters state to indicate no
+    // pending work.
+    void ResetDiscoveryState();
+
     // Not an enum class because we use this for indexing into arrays.
     enum TransportTypes
     {
@@ -118,7 +122,7 @@ private:
 
     // Boolean will be set to true if we currently have an async discovery
     // process happening via the relevant transport.
-    bool mWaitingForDiscovery[kTransportTypeCount];
+    bool mWaitingForDiscovery[kTransportTypeCount] = { false };
 
     // HasPeerAddress() for a given transport type will test true if we have
     // discovered an address for that transport and not tried connecting to it


### PR DESCRIPTION
When a device gets removed from a fabric and then factory reset, we
can get into a situation where it's only listening over BLE but there
are stale DNS-SD records for it.  In that case we should try BLE once
we discover that doing PASE over IP does not work.

Fixes https://github.com/project-chip/connectedhomeip/issues/16728

#### Problem
See above.

#### Change overview
See above.

#### Testing
Followed the steps to reproduce from https://github.com/project-chip/connectedhomeip/issues/16728 and verified that once the IP PASE setup times out we connect to the m5stack over BLE and commission it.