### PR TITLE
Stop using vendor id 0 for controllers in Darwin code.

### DIFF
--- a/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.mm
+++ b/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.mm
@@ -21,6 +21,7 @@
 #import "CHIPToolKeypair.h"
 #import <CHIP/CHIPDeviceController.h>
 #include <core/CHIPBuildConfig.h>
+#include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <lib/support/CodeUtils.h>
 
 const uint16_t kListenPort = 5541;
@@ -43,7 +44,7 @@ CHIP_ERROR CHIPCommandBridge::Run()
 
     [nocSigner createOrLoadKeys:storage];
 
-    if (![mController startup:storage vendorId:0 nocSigner:nocSigner]) {
+    if (![mController startup:storage vendorId:chip::VendorId::TestVendor1 nocSigner:nocSigner]) {
         ChipLogError(chipTool, "Controller startup failure.");
         return CHIP_ERROR_INTERNAL;
     }

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
@@ -18,8 +18,6 @@
 #import <CHIP/CHIP.h>
 #import <Foundation/Foundation.h>
 
-#define kCHIPToolTmpVendorId 0x1771
-
 extern NSString * const kCHIPToolDefaultsDomain;
 extern NSString * const kNetworkSSIDDefaultsKey;
 extern NSString * const kNetworkPasswordDefaultsKey;

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -66,13 +66,15 @@ void CHIPSetNextAvailableDeviceID(uint64_t id)
 
 static CHIPToolPersistentStorageDelegate * storage = nil;
 
+static uint16_t kTestVendorId = 0xFFF1u;
+
 CHIPDeviceController * InitializeCHIP(void)
 {
     static dispatch_once_t onceToken;
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
     dispatch_once(&onceToken, ^{
         storage = [[CHIPToolPersistentStorageDelegate alloc] init];
-        [controller startup:storage vendorId:0 nocSigner:nil];
+        [controller startup:storage vendorId:kTestVendorId nocSigner:nil];
     });
 
     return controller;
@@ -83,7 +85,7 @@ void CHIPRestartController(CHIPDeviceController * controller)
     NSLog(@"Shutting down the stack");
     [controller shutdown];
     NSLog(@"Starting up the stack");
-    [controller startup:storage vendorId:0 nocSigner:nil];
+    [controller startup:storage vendorId:kTestVendorId nocSigner:nil];
 }
 
 uint64_t CHIPGetLastPairedDeviceId(void)

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -40,6 +40,7 @@
 #include <controller/CommissioningWindowOpener.h>
 #include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
+#include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <lib/support/CHIPMem.h>
 #include <platform/PlatformManager.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
@@ -147,6 +148,12 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
        vendorId:(uint16_t)vendorId
       nocSigner:(id<CHIPKeypair>)nocSigner
 {
+    if (vendorId == chip::VendorId::Common) {
+        // Shouldn't be using the "standard" vendor ID for actual devices.
+        CHIP_LOG_ERROR("%d is not a valid vendorId to initialize a device controller with", vendorId);
+        return NO;
+    }
+
     chip::DeviceLayer::PlatformMgrImpl().StartEventLoopTask();
 
     __block BOOL commissionerInitialized = NO;

--- a/src/darwin/Framework/CHIP/templates/tests/CHIPClustersTests.zapt
+++ b/src/darwin/Framework/CHIP/templates/tests/CHIPClustersTests.zapt
@@ -26,6 +26,7 @@ const uint32_t kSetupPINCode = 20202021;
 const uint16_t kRemotePort = 5540;
 const uint16_t kLocalPort = 5541;
 NSString * kAddress = @"::1";
+static uint16_t kTestVendorId = 0xFFF1u;
 
 // This test suite reuses a device object to speed up the test process for CI.
 // The following global variable holds the reference to the device object.
@@ -128,7 +129,7 @@ CHIPDevice * GetConnectedDevice(void)
     [controller setListenPort:kLocalPort];
     [controller setPairingDelegate:pairing queue:callbackQueue];
 
-    BOOL started = [controller startup:nil vendorId:0 nocSigner:nil];
+    BOOL started = [controller startup:nil vendorId:kTestVendorId nocSigner:nil];
     XCTAssertTrue(started);
 
     NSError * error;

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -43,6 +43,7 @@ const uint32_t kSetupPINCode = 20202021;
 const uint16_t kRemotePort = 5540;
 const uint16_t kLocalPort = 5541;
 NSString * kAddress = @"::1";
+static uint16_t kTestVendorId = 0xFFF1u;
 
 // This test suite reuses a device object to speed up the test process for CI.
 // The following global variable holds the reference to the device object.
@@ -145,7 +146,7 @@ CHIPDevice * GetConnectedDevice(void)
     [controller setListenPort:kLocalPort];
     [controller setPairingDelegate:pairing queue:callbackQueue];
 
-    BOOL started = [controller startup:nil vendorId:0 nocSigner:nil];
+    BOOL started = [controller startup:nil vendorId:kTestVendorId nocSigner:nil];
     XCTAssertTrue(started);
 
     NSError * error;

--- a/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
@@ -23,6 +23,8 @@
 // system dependencies
 #import <XCTest/XCTest.h>
 
+static uint16_t kTestVendorId = 0xFFF1u;
+
 @interface CHIPControllerTests : XCTestCase
 
 @end
@@ -32,11 +34,11 @@
 - (void)testControllerLifecycle
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
-    XCTAssertTrue([controller startup:nil vendorId:0 nocSigner:nil]);
+    XCTAssertTrue([controller startup:nil vendorId:kTestVendorId nocSigner:nil]);
     XCTAssertTrue([controller shutdown]);
 
     // now try to restart the controller
-    XCTAssertTrue([controller startup:nil vendorId:0 nocSigner:nil]);
+    XCTAssertTrue([controller startup:nil vendorId:kTestVendorId nocSigner:nil]);
     XCTAssertTrue([controller shutdown]);
 }
 
@@ -44,7 +46,7 @@
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
     for (int i = 0; i < 5; i++) {
-        XCTAssertTrue([controller startup:nil vendorId:0 nocSigner:nil]);
+        XCTAssertTrue([controller startup:nil vendorId:kTestVendorId nocSigner:nil]);
     }
     XCTAssertTrue([controller shutdown]);
 }
@@ -52,7 +54,7 @@
 - (void)testControllerMultipleShutdown
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
-    XCTAssertTrue([controller startup:nil vendorId:0 nocSigner:nil]);
+    XCTAssertTrue([controller startup:nil vendorId:kTestVendorId nocSigner:nil]);
     for (int i = 0; i < 5; i++) {
         XCTAssertTrue([controller shutdown]);
     }

--- a/src/darwin/Framework/CHIPTests/CHIPDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPDeviceTests.m
@@ -45,6 +45,7 @@ static const uint32_t kSetupPINCode = 20202021;
 static const uint16_t kRemotePort = 5540;
 static const uint16_t kLocalPort = 5541;
 static NSString * kAddress = @"::1";
+static uint16_t kTestVendorId = 0xFFF1u;
 
 // This test suite reuses a device object to speed up the test process for CI.
 // The following global variable holds the reference to the device object.
@@ -144,7 +145,7 @@ static CHIPDevice * GetConnectedDevice(void)
     [controller setListenPort:kLocalPort];
     [controller setPairingDelegate:pairing queue:callbackQueue];
 
-    BOOL started = [controller startup:nil vendorId:0 nocSigner:nil];
+    BOOL started = [controller startup:nil vendorId:kTestVendorId nocSigner:nil];
     XCTAssertTrue(started);
 
     NSError * error;

--- a/src/darwin/Framework/CHIPTests/CHIPXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPXPCListenerSampleTests.m
@@ -34,6 +34,8 @@
 // Set the following to 1 in order to run individual test case manually.
 #define MANUAL_INDIVIDUAL_TEST 0
 
+static uint16_t kTestVendorId = 0xFFF1u;
+
 //
 // Sample XPC Listener implementation that directly communicates with local CHIPDevice instance
 //
@@ -512,7 +514,7 @@ static CHIPDevice * GetConnectedDevice(void)
     [controller setListenPort:kLocalPort];
     [controller setPairingDelegate:pairing queue:callbackQueue];
 
-    BOOL started = [controller startup:nil vendorId:0 nocSigner:nil];
+    BOOL started = [controller startup:nil vendorId:kTestVendorId nocSigner:nil];
     XCTAssertTrue(started);
 
     NSError * error;

--- a/src/lib/core/CHIPVendorIdentifiers.hpp
+++ b/src/lib/core/CHIPVendorIdentifiers.hpp
@@ -42,6 +42,7 @@ namespace chip {
 enum VendorId : uint16_t
 {
     Common       = 0x0000u,
+    Apple        = 0x1349u,
     Google       = 0x6006u,
     TestVendor1  = 0xFFF1u,
     TestVendor2  = 0xFFF2u,


### PR DESCRIPTION
Controllers should use the vendor id of their vendor, or one of the
test vendor ids.  Using the "Matter standard" vendor Id there makes no
sense.

#### Problem
Using vendor id 0 for controllers.

#### Change overview
Stop doing that.

#### Testing
CI should cover this.