### PR TITLE
Fix CI on master

### DIFF
--- a/docs/guides/repl/Matter - Multi Fabric Commissioning.ipynb
+++ b/docs/guides/repl/Matter - Multi Fabric Commissioning.ipynb
@@ -607,7 +607,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "await devCtrl.SendCommand(2, 0, Clusters.AdministratorCommissioning.Commands.OpenBasicCommissioningWindow(100))"
+    "await devCtrl.SendCommand(2, 0, Clusters.AdministratorCommissioning.Commands.OpenBasicCommissioningWindow(180))"
    ]
   },
   {

--- a/src/app/tests/suites/certification/Test_TC_MF_1_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MF_1_4.yaml
@@ -51,7 +51,7 @@ tests:
       arguments:
           values:
               - name: "CommissioningTimeout"
-                value: 120
+                value: 180
 
     - label:
           "TH_CR1 writes the Basic Information Clusters NodeLabel mandatory

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -249,7 +249,7 @@ class BaseTestHelper:
     async def TestMultiFabric(self, ip: str, setuppin: int, nodeid: int):
         self.logger.info("Opening Commissioning Window")
 
-        await self.devCtrl.SendCommand(nodeid, 0, Clusters.AdministratorCommissioning.Commands.OpenBasicCommissioningWindow(100), timedRequestTimeoutMs=10000)
+        await self.devCtrl.SendCommand(nodeid, 0, Clusters.AdministratorCommissioning.Commands.OpenBasicCommissioningWindow(180), timedRequestTimeoutMs=10000)
 
         self.logger.info("Creating 2nd Fabric Admin")
         self.fabricAdmin2 = chip.FabricAdmin.FabricAdmin(


### PR DESCRIPTION
#### Problem
CI failing on tip due to several merge conflicts (codegen being out of date, tests that use too-short commissioning timeouts being added or re-enabled while we merged a PR that disallows them).

#### Change overview
Regenerate chip-tool tests.  Fix new YAML test to use 180s (spec minimum) instead of 120s for commissioning timeout.  Fix Python tests to use 180s for commissioning timeout, not 100s.

#### Testing
Should pass CI now.