### PR TITLE
[Ameba] Support reset-counts command in wifi diagnostics

### DIFF
--- a/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
@@ -354,6 +354,11 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiOverrunCount(uint64_t & overrunCou
     overrunCount = 0;
     return CHIP_NO_ERROR;
 }
+
+CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
+{
+    return CHIP_NO_ERROR;
+}
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
 } // namespace DeviceLayer

--- a/src/platform/Ameba/DiagnosticDataProviderImpl.h
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.h
@@ -62,6 +62,7 @@ public:
     CHIP_ERROR GetWiFiPacketUnicastTxCount(uint32_t & packetUnicastTxCount) override;
     CHIP_ERROR GetWiFiCurrentMaxRate(uint64_t & currentMaxRate) override;
     CHIP_ERROR GetWiFiOverrunCount(uint64_t & overrunCount) override;
+    CHIP_ERROR ResetWiFiNetworkDiagnosticsCounts() override;
 #endif
 };
 


### PR DESCRIPTION
#### Problem
reset-counts command is failing, returning error 0x01, see #16822.

#### Change overview
Add an empty function to fix this issue, will be updated again

#### Testing
Tested with chip-tool
`./chip-tool wifinetworkdiagnostics reset-counts 1 0`
make sure status returned is 0
