### PR TITLE
fix string delete error in channel cluster

### DIFF
--- a/examples/tv-app/android/java/ChannelManager.cpp
+++ b/examples/tv-app/android/java/ChannelManager.cpp
@@ -18,6 +18,7 @@
 #include "ChannelManager.h"
 #include "TvApp-JNI.h"
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <cstdlib>
 #include <jni.h>
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/CHIPJNIError.h>
@@ -82,27 +83,28 @@ CHIP_ERROR ChannelManager::HandleGetChannelList(AttributeValueEncoder & aEncoder
 
             jfieldID getCallSignField = env->GetFieldID(channelClass, "callSign", "Ljava/lang/String;");
             jstring jcallSign         = static_cast<jstring>(env->GetObjectField(channelObject, getCallSignField));
-            if (jcallSign != NULL)
+            JniUtfString callsign(env, jcallSign);
+            if (jcallSign != nullptr)
             {
-                JniUtfString callsign(env, jcallSign);
                 channelInfo.callSign = Optional<CharSpan>(callsign.charSpan());
             }
 
             jfieldID getNameField = env->GetFieldID(channelClass, "name", "Ljava/lang/String;");
             jstring jname         = static_cast<jstring>(env->GetObjectField(channelObject, getNameField));
-            if (jname != NULL)
+            JniUtfString name(env, jname);
+            if (jname != nullptr)
             {
-                JniUtfString name(env, jname);
                 channelInfo.name = Optional<CharSpan>(name.charSpan());
             }
-
+            
             jfieldID getJaffiliateCallSignField = env->GetFieldID(channelClass, "affiliateCallSign", "Ljava/lang/String;");
             jstring jaffiliateCallSign = static_cast<jstring>(env->GetObjectField(channelObject, getJaffiliateCallSignField));
-            if (jaffiliateCallSign != NULL)
+            JniUtfString affiliateCallSign(env, jaffiliateCallSign);
+            if ( jaffiliateCallSign != nullptr )
             {
-                JniUtfString affiliateCallSign(env, jaffiliateCallSign);
                 channelInfo.affiliateCallSign = Optional<CharSpan>(affiliateCallSign.charSpan());
             }
+            
 
             jfieldID majorNumField  = env->GetFieldID(channelClass, "majorNumber", "I");
             jint jmajorNum          = env->GetIntField(channelObject, majorNumField);
@@ -144,25 +146,25 @@ CHIP_ERROR ChannelManager::HandleGetLineup(AttributeValueEncoder & aEncoder)
 
         jfieldID operatorNameFild = env->GetFieldID(channelLineupClazz, "operatorName", "Ljava/lang/String;");
         jstring joperatorName     = static_cast<jstring>(env->GetObjectField(channelLineupObject, operatorNameFild));
-        if (joperatorName != NULL)
+        JniUtfString operatorName(env, joperatorName);
+        if ( joperatorName != nullptr )
         {
-            JniUtfString operatorName(env, joperatorName);
             lineupInfo.operatorName = operatorName.charSpan();
         }
 
         jfieldID lineupNameFild = env->GetFieldID(channelLineupClazz, "lineupName", "Ljava/lang/String;");
         jstring jlineupName     = static_cast<jstring>(env->GetObjectField(channelLineupObject, lineupNameFild));
-        if (jlineupName != NULL)
+        JniUtfString lineupName(env, jlineupName);
+        if (jlineupName != nullptr) 
         {
-            JniUtfString lineupName(env, jlineupName);
             lineupInfo.lineupName = Optional<CharSpan>(lineupName.charSpan());
         }
 
         jfieldID postalCodeFild = env->GetFieldID(channelLineupClazz, "postalCode", "Ljava/lang/String;");
         jstring jpostalCode     = static_cast<jstring>(env->GetObjectField(channelLineupObject, postalCodeFild));
-        if (jpostalCode != NULL)
+        JniUtfString postalCode(env, jpostalCode);
+        if (jpostalCode != nullptr)
         {
-            JniUtfString postalCode(env, jpostalCode);
             lineupInfo.postalCode = Optional<CharSpan>(postalCode.charSpan());
         }
 
@@ -198,28 +200,28 @@ CHIP_ERROR ChannelManager::HandleGetCurrentChannel(AttributeValueEncoder & aEnco
 
         jfieldID getCallSignField = env->GetFieldID(channelClass, "callSign", "Ljava/lang/String;");
         jstring jcallSign         = static_cast<jstring>(env->GetObjectField(channelInfoObject, getCallSignField));
-        if (jcallSign != NULL)
+        JniUtfString callsign(env, jcallSign);
+        if ( jcallSign != nullptr) 
         {
-            JniUtfString callsign(env, jcallSign);
             channelInfo.callSign = Optional<CharSpan>(callsign.charSpan());
         }
 
         jfieldID getNameField = env->GetFieldID(channelClass, "name", "Ljava/lang/String;");
         jstring jname         = static_cast<jstring>(env->GetObjectField(channelInfoObject, getNameField));
-        if (jname != NULL)
+        JniUtfString name(env, jname);
+        if (jname != nullptr)
         {
-            JniUtfString name(env, jname);
             channelInfo.name = Optional<CharSpan>(name.charSpan());
         }
 
         jfieldID getJaffiliateCallSignField = env->GetFieldID(channelClass, "affiliateCallSign", "Ljava/lang/String;");
         jstring jaffiliateCallSign = static_cast<jstring>(env->GetObjectField(channelInfoObject, getJaffiliateCallSignField));
-        if (jaffiliateCallSign != NULL)
+        JniUtfString affiliateCallSign(env, jaffiliateCallSign);
+        if (jaffiliateCallSign != nullptr)
         {
-            JniUtfString affiliateCallSign(env, jaffiliateCallSign);
             channelInfo.affiliateCallSign = Optional<CharSpan>(affiliateCallSign.charSpan());
         }
-
+       
         jfieldID majorNumField  = env->GetFieldID(channelClass, "majorNumber", "I");
         jint jmajorNum          = env->GetIntField(channelInfoObject, majorNumField);
         channelInfo.majorNumber = static_cast<uint16_t>(jmajorNum);

--- a/examples/tv-app/android/java/ChannelManager.cpp
+++ b/examples/tv-app/android/java/ChannelManager.cpp
@@ -96,15 +96,14 @@ CHIP_ERROR ChannelManager::HandleGetChannelList(AttributeValueEncoder & aEncoder
             {
                 channelInfo.name = Optional<CharSpan>(name.charSpan());
             }
-            
+
             jfieldID getJaffiliateCallSignField = env->GetFieldID(channelClass, "affiliateCallSign", "Ljava/lang/String;");
             jstring jaffiliateCallSign = static_cast<jstring>(env->GetObjectField(channelObject, getJaffiliateCallSignField));
             JniUtfString affiliateCallSign(env, jaffiliateCallSign);
-            if ( jaffiliateCallSign != nullptr )
+            if (jaffiliateCallSign != nullptr)
             {
                 channelInfo.affiliateCallSign = Optional<CharSpan>(affiliateCallSign.charSpan());
             }
-            
 
             jfieldID majorNumField  = env->GetFieldID(channelClass, "majorNumber", "I");
             jint jmajorNum          = env->GetIntField(channelObject, majorNumField);
@@ -147,7 +146,7 @@ CHIP_ERROR ChannelManager::HandleGetLineup(AttributeValueEncoder & aEncoder)
         jfieldID operatorNameFild = env->GetFieldID(channelLineupClazz, "operatorName", "Ljava/lang/String;");
         jstring joperatorName     = static_cast<jstring>(env->GetObjectField(channelLineupObject, operatorNameFild));
         JniUtfString operatorName(env, joperatorName);
-        if ( joperatorName != nullptr )
+        if (joperatorName != nullptr)
         {
             lineupInfo.operatorName = operatorName.charSpan();
         }
@@ -155,7 +154,7 @@ CHIP_ERROR ChannelManager::HandleGetLineup(AttributeValueEncoder & aEncoder)
         jfieldID lineupNameFild = env->GetFieldID(channelLineupClazz, "lineupName", "Ljava/lang/String;");
         jstring jlineupName     = static_cast<jstring>(env->GetObjectField(channelLineupObject, lineupNameFild));
         JniUtfString lineupName(env, jlineupName);
-        if (jlineupName != nullptr) 
+        if (jlineupName != nullptr)
         {
             lineupInfo.lineupName = Optional<CharSpan>(lineupName.charSpan());
         }
@@ -201,7 +200,7 @@ CHIP_ERROR ChannelManager::HandleGetCurrentChannel(AttributeValueEncoder & aEnco
         jfieldID getCallSignField = env->GetFieldID(channelClass, "callSign", "Ljava/lang/String;");
         jstring jcallSign         = static_cast<jstring>(env->GetObjectField(channelInfoObject, getCallSignField));
         JniUtfString callsign(env, jcallSign);
-        if ( jcallSign != nullptr) 
+        if (jcallSign != nullptr)
         {
             channelInfo.callSign = Optional<CharSpan>(callsign.charSpan());
         }
@@ -221,7 +220,7 @@ CHIP_ERROR ChannelManager::HandleGetCurrentChannel(AttributeValueEncoder & aEnco
         {
             channelInfo.affiliateCallSign = Optional<CharSpan>(affiliateCallSign.charSpan());
         }
-       
+
         jfieldID majorNumField  = env->GetFieldID(channelClass, "majorNumber", "I");
         jint jmajorNum          = env->GetIntField(channelInfoObject, majorNumField);
         channelInfo.majorNumber = static_cast<uint16_t>(jmajorNum);

--- a/examples/tv-app/android/java/src/com/tcl/chip/tvapp/ChannelInfo.java
+++ b/examples/tv-app/android/java/src/com/tcl/chip/tvapp/ChannelInfo.java
@@ -23,12 +23,12 @@ public class ChannelInfo {
   public static final int kMultipleMatches = 0;
   public static final int kNoMatches = 1;
 
-  private int errorType;
-  private int majorNumber;
-  private int minorNumber;
-  private String name;
-  private String callSign;
-  private String affiliateCallSign;
+  public int errorType;
+  public int majorNumber;
+  public int minorNumber;
+  public String name;
+  public String callSign;
+  public String affiliateCallSign;
 
   public ChannelInfo(
       int majorNumber, int minorNumber, String name, String callSign, String affiliateCallSign) {

--- a/examples/tv-app/android/java/src/com/tcl/chip/tvapp/ChannelManagerStub.java
+++ b/examples/tv-app/android/java/src/com/tcl/chip/tvapp/ChannelManagerStub.java
@@ -31,7 +31,7 @@ public class ChannelManagerStub implements ChannelManager {
   @Override
   public ChannelInfo[] getChannelList() {
     ChannelInfo ChannelInfo1 = new ChannelInfo(1, 11, "HDMI1", "callSign1", "affiliateCallSign1");
-    ChannelInfo ChannelInfo2 = new ChannelInfo(2, 22, "HDMI2", "callSign2", "affiliateCallSign2");
+    ChannelInfo ChannelInfo2 = new ChannelInfo(2, 22, "HDMI2", null, "");
     Log.d(TAG, "getChannelList at " + endpoint);
     return new ChannelInfo[] {ChannelInfo1, ChannelInfo2};
   }


### PR DESCRIPTION
#### Problem
* sometimes channel string will get null 

#### Change overview
* the string is released before call the callback, so let it be released after callback

#### Testing
* chip-tool channel read channel-list