### PR TITLE
chip-tool: use correct interface when specified

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -62,10 +62,10 @@ CHIP_ERROR PairingCommand::RunInternal(NodeId remoteId)
         err = PairWithMdns(remoteId);
         break;
     case PairingMode::SoftAP:
-        err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort));
+        err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort, mRemoteAddr.interfaceId));
         break;
     case PairingMode::Ethernet:
-        err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort));
+        err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort, mRemoteAddr.interfaceId));
         break;
     }
 


### PR DESCRIPTION
#### Problem
chip-tool fails on Darwin when using commands that require an ipv6 address. The interface is required to make it work. chip-tool parses the interface passed on command line but ignores it.

#### Change overview
Use correct interface when specified. When unspecified, the behavior is unchanged.

#### Testing
Tested manually using pairing ethernet command.