### PR TITLE
WindowCovering: fixes + simplification

### DIFF
--- a/examples/window-app/common/include/WindowApp.h
+++ b/examples/window-app/common/include/WindowApp.h
@@ -149,7 +149,8 @@ public:
 
         static void ScheduleTiltPositionSet(intptr_t arg);
         static void ScheduleLiftPositionSet(intptr_t arg);
-        static void ScheduleOperationalStatusSetWithGlobalUpdate(intptr_t arg);
+        void ScheduleOperationalStatusSetWithGlobalUpdate(OperationalStatus opStatus);
+        static void CallbackOperationalStatusSetWithGlobalUpdate(intptr_t arg);
     };
 
     static WindowApp & Instance();

--- a/examples/window-app/common/include/WindowApp.h
+++ b/examples/window-app/common/include/WindowApp.h
@@ -110,16 +110,16 @@ public:
         void LiftUpdate(bool newTarget);
         void LiftGoToTarget() { LiftUpdate(true); }
         void LiftContinueToTarget() { LiftUpdate(false); }
-        void LiftUp();
-        void LiftDown();
+        void LiftStepToward(OperationalState direction);
         void LiftSchedulePositionSet(chip::Percent100ths position) { SchedulePositionSet(position, false); }
 
         void TiltUpdate(bool newTarget);
         void TiltGoToTarget() { TiltUpdate(true); }
         void TiltContinueToTarget() { TiltUpdate(false); }
-        void TiltUp();
-        void TiltDown();
+        void TiltStepToward(OperationalState direction);
         void TiltSchedulePositionSet(chip::Percent100ths position) { SchedulePositionSet(position, true); }
+
+        void StepToward(OperationalState direction, bool isTilt);
 
         EmberAfWcType CycleType();
 

--- a/examples/window-app/common/include/WindowApp.h
+++ b/examples/window-app/common/include/WindowApp.h
@@ -141,6 +141,7 @@ public:
         struct CoverWorkData
         {
             chip::EndpointId mEndpointId;
+            bool isTilt;
 
             union
             {
@@ -149,8 +150,8 @@ public:
             };
         };
 
-        static void ScheduleTiltPositionSet(intptr_t arg);
-        static void ScheduleLiftPositionSet(intptr_t arg);
+        void SchedulePositionSet(chip::Percent100ths position, bool isTilt);
+        static void CallbackPositionSet(intptr_t arg);
         void ScheduleOperationalStatusSetWithGlobalUpdate(OperationalStatus opStatus);
         static void CallbackOperationalStatusSetWithGlobalUpdate(intptr_t arg);
     };

--- a/examples/window-app/common/include/WindowApp.h
+++ b/examples/window-app/common/include/WindowApp.h
@@ -112,12 +112,14 @@ public:
         void LiftContinueToTarget() { LiftUpdate(false); }
         void LiftUp();
         void LiftDown();
+        void LiftSchedulePositionSet(chip::Percent100ths position) { SchedulePositionSet(position, false); }
 
         void TiltUpdate(bool newTarget);
         void TiltGoToTarget() { TiltUpdate(true); }
         void TiltContinueToTarget() { TiltUpdate(false); }
         void TiltUp();
         void TiltDown();
+        void TiltSchedulePositionSet(chip::Percent100ths position) { SchedulePositionSet(position, true); }
 
         EmberAfWcType CycleType();
 

--- a/examples/window-app/common/src/WindowApp.cpp
+++ b/examples/window-app/common/src/WindowApp.cpp
@@ -537,10 +537,8 @@ void WindowApp::Cover::LiftUpdate(bool newTarget)
     else /* CURRENT reached TARGET or crossed it */
     {
         /* Actuator finalize the movement AND CURRENT Must be equal to TARGET at the end */
-
-        chip::DeviceLayer::PlatformMgr().LockChipStack();
-        Attributes::CurrentPositionLiftPercent100ths::Set(mEndpoint, target);
-        chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+        if (!target.IsNull())
+            LiftSchedulePositionSet(target.Value());
 
         mLiftOpState = OperationalState::Stall;
     }
@@ -643,10 +641,8 @@ void WindowApp::Cover::TiltUpdate(bool newTarget)
     else /* CURRENT reached TARGET or crossed it */
     {
         /* Actuator finalize the movement AND CURRENT Must be equal to TARGET at the end */
-
-        chip::DeviceLayer::PlatformMgr().LockChipStack();
-        Attributes::CurrentPositionTiltPercent100ths::Set(mEndpoint, target);
-        chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+        if (!target.IsNull())
+            TiltSchedulePositionSet(target.Value());
 
         mTiltOpState = OperationalState::Stall;
     }

--- a/examples/window-app/common/src/WindowApp.cpp
+++ b/examples/window-app/common/src/WindowApp.cpp
@@ -411,10 +411,8 @@ void WindowApp::Cover::Init(chip::EndpointId endpoint)
 
     Attributes::InstalledOpenLimitLift::Set(endpoint, LIFT_OPEN_LIMIT);
     Attributes::InstalledClosedLimitLift::Set(endpoint, LIFT_CLOSED_LIMIT);
-    LiftPositionSet(endpoint, LiftToPercent100ths(endpoint, LIFT_CLOSED_LIMIT));
     Attributes::InstalledOpenLimitTilt::Set(endpoint, TILT_OPEN_LIMIT);
     Attributes::InstalledClosedLimitTilt::Set(endpoint, TILT_CLOSED_LIMIT);
-    TiltPositionSet(endpoint, TiltToPercent100ths(endpoint, TILT_CLOSED_LIMIT));
 
     // Attribute: Id  0 Type
     TypeSet(endpoint, EMBER_ZCL_WC_TYPE_TILT_BLIND_LIFT_AND_TILT);
@@ -736,7 +734,6 @@ void WindowApp::Cover::OnTiltTimeout(WindowApp::Timer & timer)
 void WindowApp::Cover::ScheduleTiltPositionSet(intptr_t arg)
 {
     WindowApp::Cover::CoverWorkData * data = reinterpret_cast<WindowApp::Cover::CoverWorkData *>(arg);
-    TiltPositionSet(data->mEndpointId, data->percent100ths);
 
     chip::Platform::Delete(data);
 }
@@ -744,7 +741,6 @@ void WindowApp::Cover::ScheduleTiltPositionSet(intptr_t arg)
 void WindowApp::Cover::ScheduleLiftPositionSet(intptr_t arg)
 {
     WindowApp::Cover::CoverWorkData * data = reinterpret_cast<WindowApp::Cover::CoverWorkData *>(arg);
-    LiftPositionSet(data->mEndpointId, data->percent100ths);
 
     chip::Platform::Delete(data);
 }

--- a/examples/window-app/common/src/WindowApp.cpp
+++ b/examples/window-app/common/src/WindowApp.cpp
@@ -401,10 +401,15 @@ void WindowApp::Cover::Init(chip::EndpointId endpoint)
     mLiftTimer = WindowApp::Instance().CreateTimer("Timer:Lift", COVER_LIFT_TILT_TIMEOUT, OnLiftTimeout, this);
     mTiltTimer = WindowApp::Instance().CreateTimer("Timer:Tilt", COVER_LIFT_TILT_TIMEOUT, OnTiltTimeout, this);
 
+    // Preset Lift attributes
     Attributes::InstalledOpenLimitLift::Set(endpoint, LIFT_OPEN_LIMIT);
     Attributes::InstalledClosedLimitLift::Set(endpoint, LIFT_CLOSED_LIMIT);
+
+    // Preset Tilt attributes
     Attributes::InstalledOpenLimitTilt::Set(endpoint, TILT_OPEN_LIMIT);
     Attributes::InstalledClosedLimitTilt::Set(endpoint, TILT_CLOSED_LIMIT);
+
+    // Note: All Current Positions are preset via Zap config and kept accross reboot via NVM: no need to init them
 
     // Attribute: Id  0 Type
     TypeSet(endpoint, EMBER_ZCL_WC_TYPE_TILT_BLIND_LIFT_AND_TILT);

--- a/examples/window-app/common/src/WindowApp.cpp
+++ b/examples/window-app/common/src/WindowApp.cpp
@@ -520,7 +520,6 @@ void WindowApp::Cover::TiltStepToward(OperationalState direction)
     status = Attributes::CurrentPositionTiltPercent100ths::Get(mEndpoint, current);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
-
     if ((status == EMBER_ZCL_STATUS_SUCCESS) && !current.IsNull())
     {
         percent100ths = ComputePercent100thsStep(direction, current.Value(), TILT_DELTA);
@@ -576,7 +575,6 @@ void WindowApp::Cover::TiltUpdate(bool newTarget)
         mTiltTimer->Start();
     }
 }
-
 
 void WindowApp::Cover::StepToward(OperationalState direction, bool isTilt)
 {
@@ -643,9 +641,9 @@ void WindowApp::Cover::SchedulePositionSet(chip::Percent100ths position, bool is
     CoverWorkData * data = chip::Platform::New<CoverWorkData>();
     VerifyOrReturn(data != nullptr, emberAfWindowCoveringClusterPrint("Cover::SchedulePositionSet - Out of Memory for WorkData"));
 
-    data->mEndpointId = mEndpoint;
+    data->mEndpointId   = mEndpoint;
     data->percent100ths = position;
-    data->isTilt = isTilt;
+    data->isTilt        = isTilt;
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(CallbackPositionSet, reinterpret_cast<intptr_t>(data));
 }

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -442,7 +442,7 @@ Percent100ths ComputePercent100thsStep(OperationalState direction, Percent100ths
     case OperationalState::MovingDownOrClose:
         if (percent100ths < (WC_PERCENT100THS_MAX_CLOSED - delta))
         {
-            percent100ths += delta;
+            percent100ths = static_cast<Percent100ths> (percent100ths + delta);
         }
         else
         {
@@ -452,7 +452,7 @@ Percent100ths ComputePercent100thsStep(OperationalState direction, Percent100ths
     case OperationalState::MovingUpOrOpen:
         if (percent100ths > (WC_PERCENT100THS_MIN_OPEN + delta))
         {
-            percent100ths -= delta;
+            percent100ths = static_cast<Percent100ths> (percent100ths - delta);
         }
         else
         {

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -464,7 +464,7 @@ Percent100ths ComputePercent100thsStep(OperationalState direction, Percent100ths
     case OperationalState::MovingDownOrClose:
         if (percent100ths < (WC_PERCENT100THS_MAX_CLOSED - delta))
         {
-            percent100ths = static_cast<Percent100ths> (percent100ths + delta);
+            percent100ths = static_cast<Percent100ths>(percent100ths + delta);
         }
         else
         {
@@ -474,7 +474,7 @@ Percent100ths ComputePercent100thsStep(OperationalState direction, Percent100ths
     case OperationalState::MovingUpOrOpen:
         if (percent100ths > (WC_PERCENT100THS_MIN_OPEN + delta))
         {
-            percent100ths = static_cast<Percent100ths> (percent100ths - delta);
+            percent100ths = static_cast<Percent100ths>(percent100ths - delta);
         }
         else
         {

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -381,7 +381,7 @@ void LiftPositionSet(chip::EndpointId endpoint, NPercent100ths percent100ths)
     else
     {
         percent.SetNonNull(static_cast<uint8_t>(percent100ths.Value() / 100));
-        rawpos.SetNonNull(Percent100thsToTilt(endpoint, percent100ths.Value()));
+        rawpos.SetNonNull(Percent100thsToLift(endpoint, percent100ths.Value()));
         emberAfWindowCoveringClusterPrint("Lift[%u] Position Set: %u", endpoint, percent100ths.Value());
     }
     Attributes::CurrentPositionLift::Set(endpoint, rawpos);

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -367,15 +367,26 @@ uint16_t Percent100thsToLift(chip::EndpointId endpoint, uint16_t percent100ths)
     return Percent100thsToValue(limits, percent100ths);
 }
 
-void LiftPositionSet(chip::EndpointId endpoint, uint16_t percent100ths)
+void LiftPositionSet(chip::EndpointId endpoint, NPercent100ths percent100ths)
 {
-    uint8_t percent = static_cast<uint8_t>(percent100ths / 100);
-    uint16_t lift   = Percent100thsToLift(endpoint, percent100ths);
+    NPercent percent;
+    NAbsolute rawpos;
 
-    Attributes::CurrentPositionLift::Set(endpoint, lift);
+    if (percent100ths.IsNull())
+    {
+        percent.SetNull();
+        rawpos.SetNull();
+        emberAfWindowCoveringClusterPrint("Lift[%u] Position Set to Null", endpoint);
+    }
+    else
+    {
+        percent.SetNonNull(static_cast<uint8_t>(percent100ths.Value() / 100));
+        rawpos.SetNonNull(Percent100thsToTilt(endpoint, percent100ths.Value()));
+        emberAfWindowCoveringClusterPrint("Lift[%u] Position Set: %u", endpoint, percent100ths.Value());
+    }
+    Attributes::CurrentPositionLift::Set(endpoint, rawpos);
     Attributes::CurrentPositionLiftPercentage::Set(endpoint, percent);
     Attributes::CurrentPositionLiftPercent100ths::Set(endpoint, percent100ths);
-    emberAfWindowCoveringClusterPrint("Lift Position Set: %u%%", percent);
 }
 
 uint16_t TiltToPercent100ths(chip::EndpointId endpoint, uint16_t tilt)
@@ -402,15 +413,26 @@ uint16_t Percent100thsToTilt(chip::EndpointId endpoint, uint16_t percent100ths)
     return Percent100thsToValue(limits, percent100ths);
 }
 
-void TiltPositionSet(chip::EndpointId endpoint, uint16_t percent100ths)
+void TiltPositionSet(chip::EndpointId endpoint, NPercent100ths percent100ths)
 {
-    uint8_t percent = static_cast<uint8_t>(percent100ths / 100);
-    uint16_t tilt   = Percent100thsToTilt(endpoint, percent100ths);
+    NPercent percent;
+    NAbsolute rawpos;
 
-    Attributes::CurrentPositionTilt::Set(endpoint, tilt);
+    if (percent100ths.IsNull())
+    {
+        percent.SetNull();
+        rawpos.SetNull();
+        emberAfWindowCoveringClusterPrint("Tilt[%u] Position Set to Null", endpoint);
+    }
+    else
+    {
+        percent.SetNonNull(static_cast<uint8_t>(percent100ths.Value() / 100));
+        rawpos.SetNonNull(Percent100thsToTilt(endpoint, percent100ths.Value()));
+        emberAfWindowCoveringClusterPrint("Tilt[%u] Position Set: %u", endpoint, percent100ths.Value());
+    }
+    Attributes::CurrentPositionTilt::Set(endpoint, rawpos);
     Attributes::CurrentPositionTiltPercentage::Set(endpoint, percent);
     Attributes::CurrentPositionTiltPercent100ths::Set(endpoint, percent100ths);
-    emberAfWindowCoveringClusterPrint("Tilt Position Set: %u%%", percent);
 }
 
 OperationalState ComputeOperationalState(uint16_t target, uint16_t current)
@@ -482,7 +504,7 @@ void emberAfPluginWindowCoveringFinalizeFakeMotionEventHandler(EndpointId endpoi
         Attributes::TargetPositionLiftPercent100ths::Get(endpoint, position);
         if (!position.IsNull())
         {
-            LiftPositionSet(endpoint, position.Value());
+            LiftPositionSet(endpoint, position);
         }
     }
 
@@ -492,7 +514,7 @@ void emberAfPluginWindowCoveringFinalizeFakeMotionEventHandler(EndpointId endpoi
         Attributes::TargetPositionTiltPercent100ths::Get(endpoint, position);
         if (!position.IsNull())
         {
-            TiltPositionSet(endpoint, position.Value());
+            TiltPositionSet(endpoint, position);
         }
     }
 }

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -433,6 +433,43 @@ OperationalState ComputeOperationalState(NPercent100ths target, NPercent100ths c
     return OperationalState::Stall;
 }
 
+Percent100ths ComputePercent100thsStep(OperationalState direction, Percent100ths previous, Percent100ths delta)
+{
+    Percent100ths percent100ths = previous;
+
+    switch (direction)
+    {
+    case OperationalState::MovingDownOrClose:
+        if (percent100ths < (WC_PERCENT100THS_MAX_CLOSED - delta))
+        {
+            percent100ths += delta;
+        }
+        else
+        {
+            percent100ths = WC_PERCENT100THS_MAX_CLOSED;
+        }
+        break;
+    case OperationalState::MovingUpOrOpen:
+        if (percent100ths > (WC_PERCENT100THS_MIN_OPEN + delta))
+        {
+            percent100ths -= delta;
+        }
+        else
+        {
+            percent100ths = WC_PERCENT100THS_MIN_OPEN;
+        }
+        break;
+    default:
+        // nothing to do we keep previous value, simple passthrought
+        break;
+    }
+
+    if (percent100ths > WC_PERCENT100THS_MAX_CLOSED)
+        return WC_PERCENT100THS_MAX_CLOSED;
+
+    return percent100ths;
+}
+
 void emberAfPluginWindowCoveringFinalizeFakeMotionEventHandler(EndpointId endpoint)
 {
     NPercent100ths position;

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -720,13 +720,12 @@ bool emberAfWindowCoveringClusterGoToLiftPercentageCallback(app::CommandHandler 
 
     EndpointId endpoint = commandPath.mEndpointId;
 
-    emberAfWindowCoveringClusterPrint("GoToLiftPercentage Percentage command received");
+    emberAfWindowCoveringClusterPrint("GoToLiftPercentage %u%% %u command received", liftPercentageValue, liftPercent100thsValue);
     if (HasFeaturePaLift(endpoint))
     {
         if (IsPercent100thsValid(liftPercent100thsValue))
         {
-            Attributes::TargetPositionLiftPercent100ths::Set(
-                endpoint, static_cast<uint16_t>(liftPercentageValue > 100 ? liftPercent100thsValue : liftPercentageValue * 100));
+            Attributes::TargetPositionLiftPercent100ths::Set(endpoint, liftPercent100thsValue);
             emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
         }
         else
@@ -779,13 +778,12 @@ bool emberAfWindowCoveringClusterGoToTiltPercentageCallback(app::CommandHandler 
 
     EndpointId endpoint = commandPath.mEndpointId;
 
-    emberAfWindowCoveringClusterPrint("GoToTiltPercentage command received");
+    emberAfWindowCoveringClusterPrint("GoToTiltPercentage %u%% %u command received", tiltPercentageValue, tiltPercent100thsValue);
     if (HasFeaturePaTilt(endpoint))
     {
         if (IsPercent100thsValid(tiltPercent100thsValue))
         {
-            Attributes::TargetPositionTiltPercent100ths::Set(
-                endpoint, static_cast<uint16_t>(tiltPercentageValue > 100 ? tiltPercent100thsValue : tiltPercentageValue * 100));
+            Attributes::TargetPositionTiltPercent100ths::Set(endpoint, tiltPercent100thsValue);
             emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
         }
         else

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -24,9 +24,9 @@
 
 #include <app/data-model/Nullable.h>
 
-#define WC_PERCENT100THS_MIN_OPEN   0
+#define WC_PERCENT100THS_MIN_OPEN 0
 #define WC_PERCENT100THS_MAX_CLOSED 10000
-#define WC_PERCENT100THS_MIDDLE     5000
+#define WC_PERCENT100THS_MIDDLE 5000
 
 namespace chip {
 namespace app {

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -144,11 +144,11 @@ bool IsPercent100thsValid(NPercent100ths npercent100ths);
 
 uint16_t LiftToPercent100ths(chip::EndpointId endpoint, uint16_t lift);
 uint16_t Percent100thsToLift(chip::EndpointId endpoint, uint16_t percent100ths);
-void LiftPositionSet(chip::EndpointId endpoint, uint16_t percent100ths);
+void LiftPositionSet(chip::EndpointId endpoint, NPercent100ths position);
 
 uint16_t TiltToPercent100ths(chip::EndpointId endpoint, uint16_t tilt);
 uint16_t Percent100thsToTilt(chip::EndpointId endpoint, uint16_t percent100ths);
-void TiltPositionSet(chip::EndpointId endpoint, uint16_t percent100ths);
+void TiltPositionSet(chip::EndpointId endpoint, NPercent100ths position);
 
 } // namespace WindowCovering
 } // namespace Clusters

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -24,8 +24,9 @@
 
 #include <app/data-model/Nullable.h>
 
-#define WC_PERCENT100THS_MIN_OPEN 0
+#define WC_PERCENT100THS_MIN_OPEN   0
 #define WC_PERCENT100THS_MAX_CLOSED 10000
+#define WC_PERCENT100THS_MIDDLE     5000
 
 namespace chip {
 namespace app {
@@ -125,6 +126,7 @@ const OperationalStatus OperationalStatusGet(chip::EndpointId endpoint);
 
 OperationalState ComputeOperationalState(uint16_t target, uint16_t current);
 OperationalState ComputeOperationalState(NPercent100ths target, NPercent100ths current);
+Percent100ths ComputePercent100thsStep(OperationalState direction, Percent100ths previous, Percent100ths delta);
 
 void EndProductTypeSet(chip::EndpointId endpoint, EmberAfWcEndProductType type);
 EmberAfWcEndProductType EndProductTypeGet(chip::EndpointId endpoint);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fix #16817
* Fix #16626
* Fix #16396
* Fix #16167
* Fix #16007
* All those are related to Current -> not equals target
* or GoTos not using the right parameter

#### Change overview
We do 3 fixes
- EFR32 remove overwriting of current positions val at preset
- EFR32 fix Current == Target at the end of motion
- ALL: GoTos are fixed with the right input param

Otherwise there are some factorization to simplify the code a bit
for the EFR32 Demo

#### Testing
How was this tested? (at least one bullet point required)
* Tested on EFR32 window-app demo
* Passing the current CI-TestCases associated with All-cluster-app
* Sadly for the moment WNCV test cannot catch issue on EFR32 

