### PR TITLE
[ESP32] Use absolute paths in example's CMakeLists.txt files

### DIFF
--- a/examples/all-clusters-app/esp32/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/CMakeLists.txt
@@ -18,17 +18,17 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/cmake/idf_flashing.cmake)
 
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
-    "${CMAKE_CURRENT_LIST_DIR}/../../common/QRCode"
+    "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/QRCode"
     "${IDF_PATH}/examples/common_components/led_strip"
 )
 if(${IDF_TARGET} STREQUAL "esp32")
-    list(APPEND EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/m5stack-tft/repo/components/tft"
-                                     "${CMAKE_CURRENT_LIST_DIR}/../../common/m5stack-tft/repo/components/spidriver"
-                                     "${CMAKE_CURRENT_LIST_DIR}/../../common/screen-framework")
+    list(APPEND EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/m5stack-tft/repo/components/tft"
+                                     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/m5stack-tft/repo/components/spidriver"
+                                     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/screen-framework")
 endif()
 
 project(chip-all-clusters-app)

--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -90,17 +90,17 @@ set(SRC_DIRS_LIST
 if (CONFIG_ENABLE_PW_RPC)
 # Append additional directories for RPC build
 set(PRIV_INCLUDE_DIRS_LIST  "${PRIV_INCLUDE_DIRS_LIST}"
-                     "${CMAKE_SOURCE_DIR}/../../platform/esp32/pw_sys_io/public"
-                     "${CMAKE_SOURCE_DIR}/../../common"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
-                     "${CMAKE_SOURCE_DIR}/../../../src/lib/support"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/pw_sys_io/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/lib/support"
                      "${IDF_PATH}/components/freertos/include/freertos"
 )
 set(SRC_DIRS_LIST  "${SRC_DIRS_LIST}"
-                     "${CMAKE_SOURCE_DIR}/../../platform/esp32"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed/esp32"
 )
 endif (CONFIG_ENABLE_PW_RPC)
 
@@ -132,7 +132,7 @@ target_compile_options(${COMPONENT_LIB} PUBLIC
 
 if (CONFIG_ENABLE_PW_RPC)
 
-get_filename_component(CHIP_ROOT ../third_party/connectedhomeip REALPATH)
+get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 
 set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")
 include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)

--- a/examples/bridge-app/esp32/CMakeLists.txt
+++ b/examples/bridge-app/esp32/CMakeLists.txt
@@ -16,11 +16,11 @@
 
 cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/cmake/idf_flashing.cmake)
 
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
-    "${CMAKE_CURRENT_LIST_DIR}/../../common/QRCode"
+    "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/QRCode"
 )
 
 # TODO: add CHIPProjectAppConfig.h to esp32

--- a/examples/common/cmake/idf_flashing.cmake
+++ b/examples/common/cmake/idf_flashing.cmake
@@ -70,7 +70,7 @@ macro(flashing_script)
   add_custom_target(flashing_script
     ALL
     COMMAND ${python}
-            "${project_path}/../../../scripts/flashing/gen_flashing_script.py" ${board_type}
+            "${project_path}/third_party/connectedhomeip/scripts/flashing/gen_flashing_script.py" ${board_type}
             --output "${build_dir}/${flashing_script}"
             --port "$ENV{ESPPORT}"
             --baud 460800

--- a/examples/ipv6only-app/esp32/main/CMakeLists.txt
+++ b/examples/ipv6only-app/esp32/main/CMakeLists.txt
@@ -17,22 +17,21 @@
 idf_component_register(INCLUDE_DIRS
                      "${CMAKE_CURRENT_LIST_DIR}"
                      "${CMAKE_CURRENT_LIST_DIR}/../include"
-                     "${CMAKE_SOURCE_DIR}/../../platform/esp32/pw_sys_io/public"
-                     "${CMAKE_SOURCE_DIR}/../../platform/esp32"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
-                     "${CMAKE_SOURCE_DIR}/../../../src/lib/support"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/pw_sys_io/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/lib/support"
                      "${IDF_PATH}/components/freertos/include/freertos"
 
                       SRC_DIRS
                      "${CMAKE_CURRENT_LIST_DIR}"
-                     "${CMAKE_SOURCE_DIR}/../../platform/esp32"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed/esp32"
                       PRIV_REQUIRES bt chip)
 
-get_filename_component(CHIP_ROOT ../third_party/connectedhomeip REALPATH)
-get_filename_component(IPV6_EXAMPLE_ROOT ../.. REALPATH)
+get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")
 include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)
 include(${PIGWEED_ROOT}/pw_protobuf_compiler/proto.cmake)

--- a/examples/lighting-app/esp32/CMakeLists.txt
+++ b/examples/lighting-app/esp32/CMakeLists.txt
@@ -18,11 +18,11 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/cmake/idf_flashing.cmake)
 
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
-    "${CMAKE_CURRENT_LIST_DIR}/../../common/QRCode"
+    "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/QRCode"
     "${IDF_PATH}/examples/common_components/led_strip"
 )
 

--- a/examples/lock-app/esp32/CMakeLists.txt
+++ b/examples/lock-app/esp32/CMakeLists.txt
@@ -18,11 +18,11 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/cmake/idf_flashing.cmake)
 
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
-    "${CMAKE_CURRENT_LIST_DIR}/../../common/QRCode"
+    "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/QRCode"
 )
 
 project(chip-lock-app)

--- a/examples/lock-app/esp32/main/CMakeLists.txt
+++ b/examples/lock-app/esp32/main/CMakeLists.txt
@@ -19,20 +19,20 @@
 if (CONFIG_ENABLE_PW_RPC)
 idf_component_register(INCLUDE_DIRS
                      "${CMAKE_CURRENT_LIST_DIR}"
-                     "${CMAKE_SOURCE_DIR}/../../platform/esp32/pw_sys_io/public"
-                     "${CMAKE_SOURCE_DIR}/../../platform/esp32"
-                     "${CMAKE_SOURCE_DIR}/../../common"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/pw_sys_io/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed/esp32"
                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/lib/support"
                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/zzz_generated/lock-app/"
                      "${CMAKE_CURRENT_LIST_DIR}/include"
                      "${IDF_PATH}/components/freertos/include/freertos"
                       SRC_DIRS
                      "${CMAKE_CURRENT_LIST_DIR}"
-                     "${CMAKE_SOURCE_DIR}/../../platform/esp32"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed/esp32"
                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/zzz_generated/app-common/app-common/zap-generated/attributes"
                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/zzz_generated/app-common/app-common/zap-generated"
                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/zzz_generated/lock-app/zap-generated"
@@ -62,7 +62,7 @@ idf_component_register(INCLUDE_DIRS
                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/power-source-server"
                      PRIV_REQUIRES bt chip QRCode)
 
-get_filename_component(CHIP_ROOT ../third_party/connectedhomeip REALPATH)
+get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 
 set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")
 include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)

--- a/examples/ota-provider-app/esp32/CMakeLists.txt
+++ b/examples/ota-provider-app/esp32/CMakeLists.txt
@@ -19,11 +19,11 @@
 cmake_minimum_required(VERSION 3.5)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/cmake/idf_flashing.cmake)
 
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
-    "${CMAKE_CURRENT_LIST_DIR}/../../common/QRCode"
+    "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/QRCode"
 )
 
 project(chip-ota-provider-app)

--- a/examples/ota-provider-app/esp32/main/CMakeLists.txt
+++ b/examples/ota-provider-app/esp32/main/CMakeLists.txt
@@ -55,7 +55,7 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp"
                       PRIV_REQUIRES chip QRCode bt console spiffs)
 
-spiffs_create_partition_image(img_storage ../spiffs_image FLASH_IN_PROJECT)
+spiffs_create_partition_image(img_storage ${CMAKE_SOURCE_DIR}/spiffs_image FLASH_IN_PROJECT)
 set_property(TARGET ${COMPONENT_LIB} PROPERTY CXX_STANDARD 14)
 target_compile_options(${COMPONENT_LIB} PRIVATE "-DLWIP_IPV6_SCOPES=0" "-DCHIP_HAVE_CONFIG_H")
 target_compile_options(${COMPONENT_LIB} PUBLIC

--- a/examples/ota-requestor-app/esp32/CMakeLists.txt
+++ b/examples/ota-requestor-app/esp32/CMakeLists.txt
@@ -19,11 +19,11 @@
 cmake_minimum_required(VERSION 3.5)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/cmake/idf_flashing.cmake)
 
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
-    "${CMAKE_CURRENT_LIST_DIR}/../../common/QRCode"
+    "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/QRCode"
 )
 
 project(chip-ota-requestor-app)

--- a/examples/persistent-storage/esp32/CMakeLists.txt
+++ b/examples/persistent-storage/esp32/CMakeLists.txt
@@ -17,7 +17,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/cmake/idf_flashing.cmake)
 
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"

--- a/examples/persistent-storage/esp32/main/CMakeLists.txt
+++ b/examples/persistent-storage/esp32/main/CMakeLists.txt
@@ -17,10 +17,10 @@
 
 idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_CURRENT_LIST_DIR}"
-                      "${CMAKE_SOURCE_DIR}/.."
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/persistent-storage"
                       SRC_DIRS
                       "${CMAKE_CURRENT_LIST_DIR}"
-                      "${CMAKE_SOURCE_DIR}/.."
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/persistent-storage"
                       PRIV_REQUIRES chip nvs_flash)
 
 set_property(TARGET ${COMPONENT_LIB} PROPERTY CXX_STANDARD 14)

--- a/examples/pigweed-app/esp32/CMakeLists.txt
+++ b/examples/pigweed-app/esp32/CMakeLists.txt
@@ -18,7 +18,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/cmake/idf_flashing.cmake)
 
 
 set(EXTRA_COMPONENT_DIRS
@@ -57,5 +57,4 @@ list(REMOVE_ITEM _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>)
 list(APPEND _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++17>)
 set_target_properties(pw_build.cpp17 PROPERTIES INTERFACE_COMPILE_OPTIONS "${_target_cxx_flags}")
 
-idf_build_get_property(project_path PROJECT_DIR)
-flashing_script(DEPENDS "${project_path}/echo_test_config.yml" "${project_path}/../mobly_tests/echo_test.py")
+flashing_script(DEPENDS "${CMAKE_CURRENT_LIST_DIR}/echo_test_config.yml" "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/pigweed-app/mobly_tests/echo_test.py")

--- a/examples/pigweed-app/esp32/main/CMakeLists.txt
+++ b/examples/pigweed-app/esp32/main/CMakeLists.txt
@@ -16,21 +16,21 @@
 
 idf_component_register(INCLUDE_DIRS 
                      "${CMAKE_CURRENT_LIST_DIR}"
-                     "${CMAKE_SOURCE_DIR}/../../platform/esp32/pw_sys_io/public"
-                     "${CMAKE_SOURCE_DIR}/../../platform/esp32"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
-                     "${CMAKE_SOURCE_DIR}/../../../src/lib/support"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/pw_sys_io/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/lib/support"
                      "${IDF_PATH}/components/freertos/include/freertos"
                     
                       SRC_DIRS
                      "${CMAKE_CURRENT_LIST_DIR}"
-                     "${CMAKE_SOURCE_DIR}/../../platform/esp32"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed/esp32"
                       PRIV_REQUIRES bt chip)
 
-get_filename_component(CHIP_ROOT ../third_party/connectedhomeip REALPATH)
+get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")
 
 include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)

--- a/examples/shell/esp32/CMakeLists.txt
+++ b/examples/shell/esp32/CMakeLists.txt
@@ -18,7 +18,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/cmake/idf_flashing.cmake)
 
 set(EXTRA_COMPONENT_DIRS
     ${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components

--- a/examples/temperature-measurement-app/esp32/CMakeLists.txt
+++ b/examples/temperature-measurement-app/esp32/CMakeLists.txt
@@ -24,12 +24,12 @@ if(NOT is_debug)
 endif()
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/cmake/idf_flashing.cmake)
 
 
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
-    "${CMAKE_CURRENT_LIST_DIR}/../../common/QRCode"
+    "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/common/QRCode"
 )
 
 project(chip-temperature-measurement-app)

--- a/examples/temperature-measurement-app/esp32/main/CMakeLists.txt
+++ b/examples/temperature-measurement-app/esp32/main/CMakeLists.txt
@@ -57,17 +57,17 @@ set(PRIV_REQUIRES_LIST chip QRCode bt)
 if (CONFIG_ENABLE_PW_RPC)
 # Append additional directories for RPC build
 set(PRIV_INCLUDE_DIRS_LIST  "${PRIV_INCLUDE_DIRS_LIST}"
-                     "${CMAKE_SOURCE_DIR}/../../platform/esp32/pw_sys_io/public"
-                     "${CMAKE_SOURCE_DIR}/../../common"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
-                     "${CMAKE_SOURCE_DIR}/../../../src/lib/support"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/pw_sys_io/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/lib/support"
                      "${IDF_PATH}/components/freertos/include/freertos"
 )
 set(SRC_DIRS_LIST  "${SRC_DIRS_LIST}"
-                     "${CMAKE_SOURCE_DIR}/../../platform/esp32"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
-                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed/esp32"
 )
 endif (CONFIG_ENABLE_PW_RPC)
 
@@ -83,7 +83,7 @@ target_compile_options(${COMPONENT_LIB} PUBLIC
 
 if (CONFIG_ENABLE_PW_RPC)
 
-get_filename_component(CHIP_ROOT ../third_party/connectedhomeip REALPATH)
+get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 
 set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")
 include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)


### PR DESCRIPTION
#### Problem
* Few paths in examples' CMakeLists.txt files uses relative paths. If esp32 application is moved to some other path other than examples/some-app/esp32 then build would fail. 

#### Change overview
* Use absolute path by using `third_party/connectedhomeip` symbolic link.

#### Testing
* Manually built all-clusters-app/esp32 with default configuration
* Manually built all-clusters-app/esp32 by enabling pw rpc, `CONFIG_ENABLE_PW_RPC`
* CI pipeline must be green