### PR TITLE
Do not update fabric index during SetUpdateNocCommandInvoked

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -712,7 +712,7 @@ bool emberAfOperationalCredentialsClusterUpdateNOCCallback(app::CommandHandler *
     VerifyOrExit(fabric != nullptr, nocResponse = ConvertToNOCResponseStatus(CHIP_ERROR_INVALID_FABRIC_ID));
 
     // Flag on the fail-safe context that the UpdateNOC command was invoked.
-    err = failSafeContext.SetUpdateNocCommandInvoked(fabricIndex);
+    err = failSafeContext.SetUpdateNocCommandInvoked();
     VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
 
     err = fabric->SetNOCCert(NOCValue);

--- a/src/include/platform/FailSafeContext.h
+++ b/src/include/platform/FailSafeContext.h
@@ -42,7 +42,7 @@ public:
     CHIP_ERROR ArmFailSafe(FabricIndex accessingFabricIndex, System::Clock::Timeout expiryLength);
     CHIP_ERROR DisarmFailSafe();
     CHIP_ERROR SetAddNocCommandInvoked(FabricIndex nocFabricIndex);
-    CHIP_ERROR SetUpdateNocCommandInvoked(FabricIndex nocFabricIndex);
+    CHIP_ERROR SetUpdateNocCommandInvoked();
 
     inline bool IsFailSafeArmed(FabricIndex accessingFabricIndex) const
     {

--- a/src/platform/FailSafeContext.cpp
+++ b/src/platform/FailSafeContext.cpp
@@ -117,10 +117,9 @@ CHIP_ERROR FailSafeContext::SetAddNocCommandInvoked(FabricIndex nocFabricIndex)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR FailSafeContext::SetUpdateNocCommandInvoked(FabricIndex nocFabricIndex)
+CHIP_ERROR FailSafeContext::SetUpdateNocCommandInvoked()
 {
     mUpdateNocCommandHasBeenInvoked = true;
-    mFabricIndex                    = nocFabricIndex;
 
     ReturnErrorOnFailure(CommitToStorage());
 

--- a/src/platform/tests/TestFailSafeContext.cpp
+++ b/src/platform/tests/TestFailSafeContext.cpp
@@ -88,11 +88,10 @@ static void TestFailSafeContext_NocCommandInvoked(nlTestSuite * inSuite, void * 
     NL_TEST_ASSERT(inSuite, failSafeContext.AddNocCommandHasBeenInvoked() == true);
     NL_TEST_ASSERT(inSuite, failSafeContext.GetFabricIndex() == kTestAccessingFabricIndex2);
 
-    err = failSafeContext.SetUpdateNocCommandInvoked(kTestAccessingFabricIndex1);
+    err = failSafeContext.SetUpdateNocCommandInvoked();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, failSafeContext.NocCommandHasBeenInvoked() == true);
     NL_TEST_ASSERT(inSuite, failSafeContext.UpdateNocCommandHasBeenInvoked() == true);
-    NL_TEST_ASSERT(inSuite, failSafeContext.GetFabricIndex() == kTestAccessingFabricIndex1);
 
     err = failSafeContext.DisarmFailSafe();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -112,7 +111,7 @@ static void TestFailSafeContext_CommitToStorage(nlTestSuite * inSuite, void * in
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, failSafeContext.AddNocCommandHasBeenInvoked() == true);
 
-    err = failSafeContext.SetUpdateNocCommandInvoked(kTestAccessingFabricIndex1);
+    err = failSafeContext.SetUpdateNocCommandInvoked();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, failSafeContext.UpdateNocCommandHasBeenInvoked() == true);
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
*  We do not update the fabric index in the UpdateNOC case,SetUpdateNocCommandInvoked should not take a fabric index
* Fixes #16582

#### Change overview
Do not update fabric index during SetUpdateNocCommandInvoked

#### Testing
How was this tested? (at least one bullet point required)
* On Server Side:
sudo rm -rf /tmp/chip_*
./chip-all-clusters-app

* On Client Side:
./chip-tool pairing onnetwork 12344321 20202021

* Confirm the pairing succeed