### PR TITLE
Remove duplicate logic to cleanup FailSafeContext

### DIFF
--- a/src/include/platform/FailSafeContext.h
+++ b/src/include/platform/FailSafeContext.h
@@ -46,10 +46,10 @@ public:
 
     /**
      * @brief
-     *   Schedules a call to cleanup the FailSafe Context asynchronously after various cleanup work
+     *   Schedules a work to cleanup the FailSafe Context asynchronously after various cleanup work
      *   has completed.
      */
-    void ScheduleFailSafeCleanup();
+    void ScheduleFailSafeCleanup(FabricIndex fabricIndex, bool addNocCommandInvoked, bool updateNocCommandInvoked);
 
     inline bool IsFailSafeArmed(FabricIndex accessingFabricIndex) const
     {

--- a/src/include/platform/FailSafeContext.h
+++ b/src/include/platform/FailSafeContext.h
@@ -44,6 +44,13 @@ public:
     CHIP_ERROR SetAddNocCommandInvoked(FabricIndex nocFabricIndex);
     CHIP_ERROR SetUpdateNocCommandInvoked(FabricIndex nocFabricIndex);
 
+    /**
+     * @brief
+     *   Schedules a work to cleanup the FailSafe Context asynchronously after various cleanup work
+     *   has completed.
+     */
+    void ScheduleFailSafeCleanup();
+
     inline bool IsFailSafeArmed(FabricIndex accessingFabricIndex) const
     {
         return mFailSafeArmed && MatchesFabricIndex(accessingFabricIndex);
@@ -54,8 +61,6 @@ public:
     inline bool IsFailSafeBusy() const { return mFailSafeBusy; }
 
     inline bool IsFailSafeArmed() const { return mFailSafeArmed; }
-
-    inline void SetFailSafeBusy(bool val) { mFailSafeBusy = val; }
 
     inline bool MatchesFabricIndex(FabricIndex accessingFabricIndex) const
     {

--- a/src/include/platform/FailSafeContext.h
+++ b/src/include/platform/FailSafeContext.h
@@ -46,7 +46,7 @@ public:
 
     /**
      * @brief
-     *   Schedules a work to cleanup the FailSafe Context asynchronously after various cleanup work
+     *   Schedules a call to cleanup the FailSafe Context asynchronously after various cleanup work
      *   has completed.
      */
     void ScheduleFailSafeCleanup();

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -153,9 +153,6 @@ protected:
     virtual CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen)               = 0;
     virtual CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)          = 0;
     virtual void RunConfigUnitTest(void)                                                           = 0;
-
-private:
-    static void HandleFailSafeContextCleanup(intptr_t arg);
 };
 
 } // namespace Internal

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -276,10 +276,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::Init()
         err = PlatformMgr().PostEvent(&event);
         SuccessOrExit(err);
 
-        DeviceControlServer::DeviceControlSvr().GetFailSafeContext().SetFailSafeBusy(true);
-
-        // Ensure HandleFailSafeContextCleanup runs after the timer-expired event has been processed.
-        PlatformMgr().ScheduleWork(HandleFailSafeContextCleanup);
+        DeviceControlServer::DeviceControlSvr().GetFailSafeContext().ScheduleFailSafeCleanup();
     }
 
 exit:
@@ -899,22 +896,6 @@ void GenericConfigurationManagerImpl<ConfigClass>::LogDeviceConfig()
         }
         ChipLogProgress(DeviceLayer, "  Device Type: %" PRIu32 " (0x%" PRIX32 ")", deviceType, deviceType);
     }
-}
-
-template <class ConfigClass>
-void GenericConfigurationManagerImpl<ConfigClass>::HandleFailSafeContextCleanup(intptr_t arg)
-{
-    if (ConfigurationMgr().SetFailSafeArmed(false) != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Failed to set FailSafeArmed config to false");
-    }
-
-    if (FailSafeContext::DeleteFromStorage() != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Failed to delete FailSafeContext from configuration");
-    }
-
-    DeviceControlServer::DeviceControlSvr().GetFailSafeContext().SetFailSafeBusy(false);
 }
 
 } // namespace Internal

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -267,16 +267,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::Init()
         err = FailSafeContext::LoadFromStorage(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
         SuccessOrExit(err);
 
-        ChipDeviceEvent event;
-        event.Type                                                = DeviceEventType::kFailSafeTimerExpired;
-        event.FailSafeTimerExpired.PeerFabricIndex                = fabricIndex;
-        event.FailSafeTimerExpired.AddNocCommandHasBeenInvoked    = addNocCommandInvoked;
-        event.FailSafeTimerExpired.UpdateNocCommandHasBeenInvoked = updateNocCommandInvoked;
-
-        err = PlatformMgr().PostEvent(&event);
-        SuccessOrExit(err);
-
-        DeviceControlServer::DeviceControlSvr().GetFailSafeContext().ScheduleFailSafeCleanup();
+        DeviceControlServer::DeviceControlSvr().GetFailSafeContext().ScheduleFailSafeCleanup(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
     }
 
 exit:

--- a/src/platform/FailSafeContext.cpp
+++ b/src/platform/FailSafeContext.cpp
@@ -76,8 +76,12 @@ void FailSafeContext::FailSafeTimerExpired()
         ChipLogError(DeviceLayer, "Failed to post fail-safe timer expired: %" CHIP_ERROR_FORMAT, status.Format());
     }
 
-    mFailSafeBusy = true;
+    ScheduleFailSafeCleanup();
+}
 
+void FailSafeContext::ScheduleFailSafeCleanup()
+{
+    mFailSafeBusy = true;
     PlatformMgr().ScheduleWork(HandleDisarmFailSafe, reinterpret_cast<intptr_t>(this));
 }
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* We should have the event posting and SetFailSafeBusy all be inside the fail-safe, so that we don't have duplicated logic to do the FailSafeContext cleanup.

* Fixes #16814

#### Change overview
Have the event posting and SetFailSafeBusy all be inside the fail-safe,

#### Testing
How was this tested? (at least one bullet point required)
* No logic change, merging duplicated logic to function ScheduleFailSafeCleanup() 
