### PR TITLE
[chip-tool] Add optional event min argument to read/subscribe events …

### DIFF
--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -289,6 +289,7 @@ protected:
         chip::app::ReadPrepareParams params(device->GetSecureSession().Value());
         params.mpEventPathParamsList        = eventPathParams;
         params.mEventPathParamsListSize     = pathsCount;
+        params.mEventNumber                 = mEventNumber.ValueOr(0);
         params.mpAttributePathParamsList    = nullptr;
         params.mAttributePathParamsListSize = 0;
 
@@ -316,6 +317,8 @@ protected:
     // mFabricFiltered is really only used by the attribute commands, but we end
     // up needing it in our class's shared code.
     chip::Optional<bool> mFabricFiltered;
+
+    chip::Optional<chip::EventNumber> mEventNumber;
 
     CHIP_ERROR mError = CHIP_NO_ERROR;
 };
@@ -448,6 +451,7 @@ public:
     {
         AddArgument("cluster-id", 0, UINT32_MAX, &mClusterIds);
         AddArgument("event-id", 0, UINT32_MAX, &mEventIds);
+        AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
         ReportCommand::AddArguments();
     }
 
@@ -455,6 +459,7 @@ public:
         ReportCommand("read-event-by-id", credsIssuerConfig), mClusterIds(1, clusterId)
     {
         AddArgument("event-id", 0, UINT32_MAX, &mEventIds);
+        AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
         ReportCommand::AddArguments();
     }
 
@@ -464,6 +469,7 @@ public:
         mClusterIds(1, clusterId), mEventIds(1, eventId)
     {
         AddArgument("event-name", eventName);
+        AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
         ReportCommand::AddArguments();
     }
 
@@ -489,6 +495,7 @@ public:
         AddArgument("event-id", 0, UINT32_MAX, &mEventIds);
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
         AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
+        AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
         ReportCommand::AddArguments();
     }
 
@@ -498,6 +505,7 @@ public:
         AddArgument("event-id", 0, UINT32_MAX, &mEventIds);
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
         AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
+        AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
         ReportCommand::AddArguments();
     }
 
@@ -509,6 +517,7 @@ public:
         AddArgument("attr-name", eventName);
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
         AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
+        AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
         ReportCommand::AddArguments();
     }
 


### PR DESCRIPTION
…commands

#### Problem

There is no option to specify the minimum event number in `chip-tool`.

#### Change overview
 * Add an optional argument for it

#### Testing
`./out/debug/standalone/chip-tool basic read-event start-up 0x12344321 0--event-min 65537` (for some reasons the event count starts to 65536 on Mac).