### PR TITLE
[nrfconnect] Fixed logs configuration.

### DIFF
--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -45,7 +45,7 @@
 #define BUTTON_PUSH_EVENT 1
 #define BUTTON_RELEASE_EVENT 0
 
-LOG_MODULE_DECLARE(app);
+LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 K_MSGQ_DEFINE(sAppEventQueue, sizeof(AppEvent), APP_EVENT_QUEUE_SIZE, alignof(AppEvent));
 
 static LEDWidget sStatusLED;

--- a/examples/all-clusters-app/nrfconnect/main/main.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/main.cpp
@@ -19,7 +19,7 @@
 
 #include <logging/log.h>
 
-LOG_MODULE_REGISTER(app);
+LOG_MODULE_REGISTER(app, CONFIG_MATTER_LOG_LEVEL);
 
 using namespace ::chip;
 

--- a/examples/light-switch-app/nrfconnect/main/AppTask.cpp
+++ b/examples/light-switch-app/nrfconnect/main/AppTask.cpp
@@ -47,7 +47,7 @@ using namespace ::chip::app;
 using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
 
-LOG_MODULE_DECLARE(app);
+LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 namespace {
 constexpr EndpointId kLightSwitchEndpointId    = 1;
 constexpr EndpointId kLightEndpointId          = 1;

--- a/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
+++ b/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
@@ -22,7 +22,7 @@
 #endif
 
 #include <logging/log.h>
-LOG_MODULE_DECLARE(app);
+LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 
 using namespace chip;
 using namespace chip::app;

--- a/examples/light-switch-app/nrfconnect/main/main.cpp
+++ b/examples/light-switch-app/nrfconnect/main/main.cpp
@@ -20,7 +20,7 @@
 
 #include <logging/log.h>
 
-LOG_MODULE_REGISTER(app);
+LOG_MODULE_REGISTER(app, CONFIG_MATTER_LOG_LEVEL);
 
 using namespace ::chip;
 

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -47,7 +47,7 @@
 #include <logging/log.h>
 #include <zephyr.h>
 
-LOG_MODULE_DECLARE(app);
+LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 
 using namespace ::chip;
 using namespace ::chip::app;

--- a/examples/lighting-app/nrfconnect/main/LightingManager.cpp
+++ b/examples/lighting-app/nrfconnect/main/LightingManager.cpp
@@ -26,7 +26,7 @@
 #include <logging/log.h>
 #include <zephyr.h>
 
-LOG_MODULE_DECLARE(app);
+LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 
 LightingManager LightingManager::sLight;
 

--- a/examples/lighting-app/nrfconnect/main/main.cpp
+++ b/examples/lighting-app/nrfconnect/main/main.cpp
@@ -30,7 +30,7 @@
 #include <usb/usb_device.h>
 #endif
 
-LOG_MODULE_REGISTER(app);
+LOG_MODULE_REGISTER(app, CONFIG_MATTER_LOG_LEVEL);
 
 using namespace ::chip;
 

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -57,7 +57,7 @@ using namespace ::chip::DeviceLayer;
 namespace {
 constexpr EndpointId kLockEndpointId = 1;
 
-LOG_MODULE_DECLARE(app);
+LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 K_MSGQ_DEFINE(sAppEventQueue, sizeof(AppEvent), APP_EVENT_QUEUE_SIZE, alignof(AppEvent));
 k_timer sFunctionTimer;
 

--- a/examples/lock-app/nrfconnect/main/BoltLockManager.cpp
+++ b/examples/lock-app/nrfconnect/main/BoltLockManager.cpp
@@ -25,7 +25,7 @@
 #include <logging/log.h>
 #include <zephyr.h>
 
-LOG_MODULE_DECLARE(app);
+LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 
 static k_timer sLockTimer;
 

--- a/examples/lock-app/nrfconnect/main/main.cpp
+++ b/examples/lock-app/nrfconnect/main/main.cpp
@@ -21,7 +21,7 @@
 
 #include <logging/log.h>
 
-LOG_MODULE_REGISTER(app);
+LOG_MODULE_REGISTER(app, CONFIG_MATTER_LOG_LEVEL);
 
 using namespace ::chip;
 

--- a/examples/pigweed-app/nrfconnect/main/main.cpp
+++ b/examples/pigweed-app/nrfconnect/main/main.cpp
@@ -28,7 +28,7 @@
 #include <dk_buttons_and_leds.h>
 #include <logging/log.h>
 
-LOG_MODULE_REGISTER(app);
+LOG_MODULE_REGISTER(app, CONFIG_MATTER_LOG_LEVEL);
 
 namespace {
 LEDWidget sStatusLED;

--- a/examples/platform/nrfconnect/Rpc.cpp
+++ b/examples/platform/nrfconnect/Rpc.cpp
@@ -23,7 +23,7 @@
 
 #include <kernel.h>
 
-LOG_MODULE_DECLARE(app);
+LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 
 #if defined(PW_RPC_ATTRIBUTE_SERVICE) && PW_RPC_ATTRIBUTE_SERVICE
 #include "pigweed/rpc_services/Attributes.h"

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -60,7 +60,7 @@ using namespace ::chip::DeviceLayer;
 
 namespace {
 
-LOG_MODULE_DECLARE(app);
+LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 K_MSGQ_DEFINE(sAppEventQueue, sizeof(AppEvent), APP_EVENT_QUEUE_SIZE, alignof(AppEvent));
 k_timer sFunctionTimer;
 

--- a/examples/pump-app/nrfconnect/main/PumpManager.cpp
+++ b/examples/pump-app/nrfconnect/main/PumpManager.cpp
@@ -25,7 +25,7 @@
 #include <logging/log.h>
 #include <zephyr.h>
 
-LOG_MODULE_DECLARE(app);
+LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 
 static k_timer sStartTimer;
 

--- a/examples/pump-app/nrfconnect/main/main.cpp
+++ b/examples/pump-app/nrfconnect/main/main.cpp
@@ -21,7 +21,7 @@
 
 #include <logging/log.h>
 
-LOG_MODULE_REGISTER(app);
+LOG_MODULE_REGISTER(app, CONFIG_MATTER_LOG_LEVEL);
 
 using namespace ::chip;
 

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -57,7 +57,7 @@ using namespace ::chip::DeviceLayer;
 
 namespace {
 
-LOG_MODULE_DECLARE(app);
+LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 K_MSGQ_DEFINE(sAppEventQueue, sizeof(AppEvent), APP_EVENT_QUEUE_SIZE, alignof(AppEvent));
 k_timer sFunctionTimer;
 

--- a/examples/pump-controller-app/nrfconnect/main/PumpManager.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/PumpManager.cpp
@@ -25,7 +25,7 @@
 #include <logging/log.h>
 #include <zephyr.h>
 
-LOG_MODULE_DECLARE(app);
+LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 
 static k_timer sStartTimer;
 

--- a/examples/pump-controller-app/nrfconnect/main/main.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/main.cpp
@@ -21,7 +21,7 @@
 
 #include <logging/log.h>
 
-LOG_MODULE_REGISTER(app);
+LOG_MODULE_REGISTER(app, CONFIG_MATTER_LOG_LEVEL);
 
 using namespace ::chip;
 

--- a/src/test_driver/nrfconnect/main/runner.cpp
+++ b/src/test_driver/nrfconnect/main/runner.cpp
@@ -26,7 +26,7 @@
 using namespace ::chip;
 using namespace ::chip::DeviceLayer;
 
-LOG_MODULE_REGISTER(runner);
+LOG_MODULE_REGISTER(runner, CONFIG_MATTER_LOG_LEVEL);
 
 void main(void)
 {


### PR DESCRIPTION
#### Problem
Default log level for Zephyr logger modules was changed to warning
and application logs using Zephyr logger directly disappeared.

#### Change overview
Added CONFIG_MATTER_LOG_LEVEL for application log modules.

#### Testing
Tested manually that application logs are visible.
