### PR TITLE
Fix a typo in src/app/server/Server.cpp that prevents the echo handle…

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -205,7 +205,7 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
 #endif // CHIP_CONFIG_ENABLE_SERVER_IM_EVENT
 
 #if defined(CHIP_APP_USE_ECHO)
-    err = InitEchoHandler(&gExchangeMgr);
+    err = InitEchoHandler(&mExchangeMgr);
     SuccessOrExit(err);
 #endif
 


### PR DESCRIPTION
…r server to starts

#### Problem

Building the server with `chip_app_use_echo=true` fails because of a typo.

#### Change overview
 * Replace `gExchangeMgr` by `mExchangeMgr`

#### Testing
I have tested it by building it with the fix and doing echo requests.
