### PR TITLE
Add define to make autocommissioner optional

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -442,7 +442,9 @@ CHIP_ERROR DeviceCommissioner::Init(CommissionerInitParams params)
     }
     else
     {
+#if CHIP_CONFIG_ENABLE_AUTOCOMMISSIONER
         mDefaultCommissioner = &mAutoCommissioner;
+#endif
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY // make this commissioner discoverable

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -765,7 +765,9 @@ private:
 
     chip::Callback::Callback<OnNOCChainGeneration> mDeviceNOCChainCallback;
     SetUpCodePairer mSetUpCodePairer;
+#if CHIP_CONFIG_ENABLE_AUTOCOMMISSIONER
     AutoCommissioner mAutoCommissioner;
+#endif
     CommissioningDelegate * mDefaultCommissioner =
         nullptr; // Commissioning delegate to call when PairDevice / Commission functions are used
     CommissioningDelegate * mCommissioningDelegate =

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1799,6 +1799,17 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #define CHIP_CONFIG_NETWORK_COMMISSIONING_DEBUG_TEXT_BUFFER_SIZE 64
 #endif // CHIP_CONFIG_NETWORK_COMMISSIONING_DEBUG_TEXT_BUFFER_SIZE
 
+/*
+ * @def CHIP_CONFIG_ENABLE_AUTOCOMMISSIONER
+ *
+ * @brief Enables a default auto-commissioner in the device controller.
+ *        Set this to 0 if you wish to provide your own
+ *        CommissioningDelegate.
+ */
+#ifndef CHIP_CONFIG_ENABLE_AUTOCOMMISSIONER
+#define CHIP_CONFIG_ENABLE_AUTOCOMMISSIONER 1
+#endif // CHIP_CONFIG_ENABLE_AUTOCOMMISSIONER
+
 /**
  * @}
  */


### PR DESCRIPTION
#### Problem
If you provide your own default CommissioningDelegate in the DeviceCommissioner initialization parameters, mAutoCommissioner doesn't get used. Make a build flag to get rid of it. Other 

#### Change overview
- build flag to allow removing auto-commissioner

#### Testing
Manually tested with 
no CommissioningDelegate set in init params - with flag on, everything works, with flag off, commissioning calls fail as expected. 
CommissioningDelegate set in init params (test commissioner in python controller) - ok with flag off.
