### PR TITLE
[ESP32] Use nvs iterator to check if key exists

### DIFF
--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -329,6 +329,7 @@ bool ESP32Config::ConfigValueExists(Key key)
             return true;
         }
     }
+    // if nvs_entry_find() or nvs_entry_next() returns NULL, then no need to release the iterator.
     return false;
 }
 


### PR DESCRIPTION
#### Problem
* Current `ESP32Config::ConfigValueExists()` API takes a brute force approach with all the supported data types to find whether a key is present in NVS or not.

#### Change overview
* Use the nvs_iterator to check if key is present in nvs or not

#### Testing
* Manually tested the results of an old API and new API.