### PR TITLE
Ensure that the OTA commissioning callback timer is started with the correct function-pointer and object data

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -191,7 +191,7 @@ bool OTAProviderExample::ParseOTAHeader(const char * otaFilePath, OTAImageHeader
     }
 
     otaFile.read(reinterpret_cast<char *>(otaFileContent), kOtaHeaderMaxSize);
-    if (!otaFile.good())
+    if (otaFile.bad())
     {
         ChipLogError(SoftwareUpdate, "Error reading OTA image file: %s", otaFilePath);
         return false;

--- a/scripts/tests/ota_test.sh
+++ b/scripts/tests/ota_test.sh
@@ -18,6 +18,8 @@ CHIP_TOOL_FOLDER="out"
 killall -e "$OTA_PROVIDER_APP" "$OTA_REQUESTOR_APP"
 rm -f "$FIRMWARE_OTA" "$FIRMWARE_BIN" "$OTA_DOWNLOAD_PATH"
 
+set -e
+
 scripts/examples/gn_build_example.sh examples/chip-tool "$CHIP_TOOL_FOLDER"
 scripts/examples/gn_build_example.sh examples/ota-requestor-app/linux "$OTA_REQUESTOR_FOLDER" chip_config_network_layer_ble=false
 scripts/examples/gn_build_example.sh examples/ota-provider-app/linux "$OTA_PROVIDER_FOLDER" chip_config_network_layer_ble=false
@@ -26,7 +28,7 @@ echo "Test" >"$FIRMWARE_BIN"
 
 rm /tmp/chip_*
 
-./src/app/ota_image_tool.py create -v 0xDEAD -p 0xBEEF -vn 1 -vs "1.0" -da sha256 "$FIRMWARE_BIN" "$FIRMWARE_OTA"
+./src/app/ota_image_tool.py create -v 0xDEAD -p 0xBEEF -vn 10 -vs "10.0" -da sha256 "$FIRMWARE_BIN" "$FIRMWARE_OTA"
 
 if [ ! -f "$FIRMWARE_OTA" ]; then
     exit 1

--- a/src/app/clusters/ota-requestor/BDXDownloader.cpp
+++ b/src/app/clusters/ota-requestor/BDXDownloader.cpp
@@ -118,6 +118,9 @@ CHIP_ERROR BDXDownloader::BeginPrepareDownload()
     VerifyOrReturnError(mImageProcessor != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     mPrevBlockCounter = 0;
+
+    // Note that due to the nature of this timer function, the actual time taken to detect a stalled BDX connection might be
+    // anywhere in the range of [mTimeout, 2*mTimeout)
     DeviceLayer::SystemLayer().StartTimer(mTimeout, TransferTimeoutCheckHandler, this);
 
     ReturnErrorOnFailure(mImageProcessor->PrepareDownload());

--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
@@ -275,9 +275,7 @@ void GenericOTARequestorDriver::CancelDelayedAction(System::TimerCompleteCallbac
 void GenericOTARequestorDriver::OTACommissioningCallback()
 {
     // Schedule a query. At the end of this query/update process the Default Provider timer is started
-    ScheduleDelayedAction(
-        System::Clock::Seconds32(kDelayQueryUponCommissioningSec),
-        [](System::Layer *, void * context) { static_cast<OTARequestorDriver *>(context)->SendQueryImage(); }, this);
+    ScheduleDelayedAction(System::Clock::Seconds32(kDelayQueryUponCommissioningSec), StartDelayTimerHandler, this);
 }
 
 void GenericOTARequestorDriver::ProcessAnnounceOTAProviders(


### PR DESCRIPTION
#### Problem
Fixes #16323 
The issue was that the OTA-timer in the "commissioning-done-callback" was never properly stopped (when a new QueryImage request is made). This causes the Requestor to not wait atleast "BDXTimeout" seconds before attempting another request.


#### Change overview
Fix the OTA-start timer (in the commissioning-done-callback) is started with the correct callback/object data to ensure that it gets stopped correctly when a new QueryImage call is made.

#### Testing
- Verified that the requestor waits atleast "BDX-timeout" seconds before attempting a new QueryImage.
- Ensured the ota-Test script still works.
