### PR TITLE
Untangle SetUpCodePairer from CHIPDeviceCommissioner a bit.

### DIFF
--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -50,6 +50,7 @@ static_library("controller") {
       "CommissioningWindowOpener.cpp",
       "CommissioningWindowOpener.h",
       "DeviceDiscoveryDelegate.h",
+      "DevicePairingDelegate.h",
       "EmptyDataModelHandler.cpp",
       "ExampleOperationalCredentialsIssuer.cpp",
       "ExampleOperationalCredentialsIssuer.h",

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -481,7 +481,7 @@ CHIP_ERROR DeviceCommissioner::Shutdown()
     if (device != nullptr && device->IsSessionSetupInProgress())
     {
         ChipLogDetail(Controller, "Setup in progress, stopping setup before shutting down");
-        PairingFailed(CHIP_ERROR_CONNECTION_ABORTED);
+        OnSessionEstablishmentError(CHIP_ERROR_CONNECTION_ABORTED);
     }
     // TODO: If we have a commissioning step in progress, is there a way to cancel that callback?
 
@@ -812,27 +812,7 @@ void DeviceCommissioner::RendezvousCleanup(CHIP_ERROR status)
 
 void DeviceCommissioner::OnSessionEstablishmentError(CHIP_ERROR err)
 {
-    // Need to null out mDeviceInPASEEstablishment before maybe trying to
-    // establish PASE again, so EstablishPASEConnection won't error out.
-    auto * oldDeviceInPASEEstablishment = mDeviceInPASEEstablishment;
-    mDeviceInPASEEstablishment          = nullptr;
-
-    if (mSetUpCodePairer.TryNextRendezvousParameters())
-    {
-        ChipLogProgress(Controller, "Ignoring PASE error; will try commissioning over a different transport");
-        // We don't need oldDeviceInPASEEstablishment anymore.
-        ReleaseCommissioneeDevice(oldDeviceInPASEEstablishment);
-        return;
-    }
-
-    // Reset mDeviceInPASEEstablishment because PairingFailed checks for that to
-    // send the right notifications.
-    mDeviceInPASEEstablishment = oldDeviceInPASEEstablishment;
-    PairingFailed(err);
-}
-
-void DeviceCommissioner::PairingFailed(CHIP_ERROR err)
-{
+    // PASE session establishment failure.
     mSystemState->SystemLayer()->CancelTimer(OnSessionEstablishmentTimeoutCallback, this);
 
     if (mPairingDelegate != nullptr)
@@ -851,7 +831,7 @@ void DeviceCommissioner::OnSessionEstablished()
     // We are in the callback for this pairing. Reset so we can pair another device.
     mDeviceInPASEEstablishment = nullptr;
 
-    VerifyOrReturn(device != nullptr, PairingFailed(CHIP_ERROR_INVALID_DEVICE_DESCRIPTOR));
+    VerifyOrReturn(device != nullptr, OnSessionEstablishmentError(CHIP_ERROR_INVALID_DEVICE_DESCRIPTOR));
 
     PASESession * pairing = &device->GetPairing();
 
@@ -862,21 +842,18 @@ void DeviceCommissioner::OnSessionEstablished()
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "Failed in setting up secure channel: err %s", ErrorStr(err));
-        PairingFailed(err);
+        OnSessionEstablishmentError(err);
         return;
     }
 
     ChipLogDetail(Controller, "Remote device completed SPAKE2+ handshake");
 
+    mPairingDelegate->OnPairingComplete(CHIP_NO_ERROR);
+
     if (mRunCommissioningAfterConnection)
     {
         mRunCommissioningAfterConnection = false;
         mDefaultCommissioner->StartCommissioning(this, device);
-    }
-    else
-    {
-        ChipLogProgress(Controller, "OnPairingComplete");
-        mPairingDelegate->OnPairingComplete(CHIP_NO_ERROR);
     }
 }
 

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -1,0 +1,74 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <lib/core/NodeId.h>
+#include <lib/support/DLLUtil.h>
+#include <stdint.h>
+
+namespace chip {
+namespace Controller {
+
+/**
+ * A delegate that can be notified of progress as a "pairing" (which might mean
+ * "PASE session establishment" or "commissioning") proceeds.
+ */
+class DLL_EXPORT DevicePairingDelegate
+{
+public:
+    virtual ~DevicePairingDelegate() {}
+
+    enum Status : uint8_t
+    {
+        SecurePairingSuccess = 0,
+        SecurePairingFailed,
+    };
+
+    /**
+     * @brief
+     *   Called when the pairing reaches a certain stage.
+     *
+     * @param status Current status of pairing
+     */
+    virtual void OnStatusUpdate(DevicePairingDelegate::Status status) {}
+
+    /**
+     * @brief
+     *   Called when PASE session establishment is complete (with success or error)
+     *
+     * @param error Error cause, if any
+     */
+    virtual void OnPairingComplete(CHIP_ERROR error) {}
+
+    /**
+     * @brief
+     *   Called when the pairing is deleted (with success or error)
+     *
+     * @param error Error cause, if any
+     */
+    virtual void OnPairingDeleted(CHIP_ERROR error) {}
+
+    /**
+     *   Called when the commissioning process is complete (with success or error)
+     */
+    virtual void OnCommissioningComplete(NodeId deviceId, CHIP_ERROR error) {}
+};
+
+} // namespace Controller
+} // namespace chip


### PR DESCRIPTION
Followup to https://github.com/project-chip/connectedhomeip/pull/16802

Instead of making the behavior of CHIPDeviceCommissioner depend on the
state of the SetUpCodePairer, just have the latter register as the
pairing delegate when it cares about PASE establishment, and restore
the logic we used to have in CHIPDeviceCommissioner before PR 16802.

The one logic change in CHIPDeviceCommissioner other than that is a
fix to ensure that we in fact call OnPairingComplete when PASE is
established even if we're going to proceed to auto-commission, so
SetUpCodePairer knows to get out of the way at that point.

#### Problem
See discussion at https://github.com/project-chip/connectedhomeip/pull/16802#discussion_r838992533

#### Change overview
See above.

#### Testing
Ensured that the test steps from #16802 still pass.  CI should test the rest, generally.