### PR TITLE
Add IPK option to CHIP framework and chip-tool-darwin.

### DIFF
--- a/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.mm
+++ b/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.mm
@@ -30,6 +30,7 @@ static CHIPToolPersistentStorageDelegate * storage = nil;
 CHIP_ERROR CHIPCommandBridge::Run()
 {
     ChipLogProgress(chipTool, "Running Command");
+    NSData * ipk;
     CHIPToolKeypair * nocSigner = [[CHIPToolKeypair alloc] init];
     storage = [[CHIPToolPersistentStorageDelegate alloc] init];
 
@@ -42,9 +43,11 @@ CHIP_ERROR CHIPCommandBridge::Run()
     [mController setListenPort:kListenPort];
     [mController setKeyValueStoreManagerPath:"/tmp/chip_kvs_darwin"];
 
-    [nocSigner createOrLoadKeys:storage];
+    ReturnLogErrorOnFailure([nocSigner createOrLoadKeys:storage]);
 
-    if (![mController startup:storage vendorId:chip::VendorId::TestVendor1 nocSigner:nocSigner]) {
+    ipk = [nocSigner getIPK];
+
+    if (![mController startup:storage vendorId:chip::VendorId::TestVendor1 nocSigner:nocSigner ipk:ipk]) {
         ChipLogError(chipTool, "Controller startup failure.");
         return CHIP_ERROR_INTERNAL;
     }

--- a/examples/chip-tool-darwin/commands/common/CHIPToolKeypair.h
+++ b/examples/chip-tool-darwin/commands/common/CHIPToolKeypair.h
@@ -10,5 +10,6 @@
 - (CHIP_ERROR)Serialize:(chip::Crypto::P256SerializedKeypair &)output;
 - (CHIP_ERROR)Deserialize:(chip::Crypto::P256SerializedKeypair &)input;
 - (CHIP_ERROR)createOrLoadKeys:(CHIPToolPersistentStorageDelegate *)storage;
+- (NSData *)getIPK;
 
 @end

--- a/examples/chip-tool-darwin/commands/common/CHIPToolKeypair.mm
+++ b/examples/chip-tool-darwin/commands/common/CHIPToolKeypair.mm
@@ -14,6 +14,7 @@
 
 static NSString * const kCHIPToolKeychainLabel = @"Chip Tool Keypair";
 static NSString * const kOperationalCredentialsIssuerKeypairStorage = @"ChipToolOpCredsCAKey";
+static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
 
 std::string StringToBase64(const std::string & value)
 {
@@ -43,6 +44,7 @@ std::string Base64ToString(const std::string & b64Value)
 @interface CHIPToolKeypair ()
 @property (nonatomic) chip::Crypto::P256Keypair mKeyPair;
 @property (nonatomic) chip::Crypto::P256Keypair mIssuer;
+@property (nonatomic) NSData * ipk;
 @property (atomic) uint32_t mNow;
 @end
 
@@ -95,6 +97,11 @@ std::string Base64ToString(const std::string & b64Value)
     return _mKeyPair.Serialize(output);
 }
 
+- (NSData *)getIPK
+{
+    return _ipk;
+}
+
 - (CHIP_ERROR)createOrLoadKeys:(CHIPToolPersistentStorageDelegate *)storage
 {
     chip::ASN1::ASN1UniversalTime effectiveTime;
@@ -126,7 +133,23 @@ std::string Base64ToString(const std::string & b64Value)
     } else {
         ReturnErrorOnFailure([self Deserialize:serializedKey]);
     }
-    return err;
+
+    NSData * ipk;
+    value = [storage CHIPGetKeyValue:kOperationalCredentialsIPK];
+    err = [self decodeNSStringToNSData:value serializedKey:&ipk];
+    if (err != CHIP_NO_ERROR) {
+        uint8_t tempIPK[chip::Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES];
+
+        ReturnLogErrorOnFailure(chip::Crypto::DRBG_get_bytes(tempIPK, sizeof(tempIPK)));
+
+        _ipk = [NSData dataWithBytes:tempIPK length:sizeof(tempIPK)];
+        NSString * valueString = [_ipk base64EncodedStringWithOptions:0];
+        [storage CHIPSetKeyValue:kOperationalCredentialsIPK value:valueString];
+    } else {
+        _ipk = ipk;
+    }
+
+    return CHIP_NO_ERROR;
 }
 
 - (CHIP_ERROR)decodeNSStringWithValue:(NSString *)value serializedKey:(chip::Crypto::P256SerializedKeypair &)serializedKey
@@ -146,4 +169,13 @@ std::string Base64ToString(const std::string & b64Value)
     return CHIP_NO_ERROR;
 }
 
+- (CHIP_ERROR)decodeNSStringToNSData:(NSString *)value serializedKey:(NSData **)decodedData
+{
+    if (value == nil) {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    *decodedData = [[NSData alloc] initWithBase64EncodedString:value options:0];
+    return CHIP_NO_ERROR;
+}
 @end

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -113,6 +113,19 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
       nocSigner:(nullable id<CHIPKeypair>)nocSigner;
 
 /**
+ * Start the CHIP Stack. Repeated calls to startup without calls to shutdown in between are NO-OPs. Use the isRunning property to
+ * check if the stack needs to be started up.
+ *
+ * @param[in] storageDelegate The delegate for persistent storage
+ * @param[in] vendorId The vendor ID of the commissioner application
+ * @param[in] nocSigner The CHIPKeypair that is used to generate and sign Node Operational Credentials
+ * @param[in] ipk The IPK  to use for Operational Credentials.
+ */
+- (BOOL)startup:(_Nullable id<CHIPPersistentStorageDelegate>)storageDelegate
+       vendorId:(uint16_t)vendorId
+      nocSigner:(id<CHIPKeypair>)nocSigner
+            ipk:(NSData * _Nullable)ipk;
+/**
  * Shutdown the CHIP Stack. Repeated calls to shutdown without calls to startup in between are NO-OPs.
  */
 - (BOOL)shutdown;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -183,6 +183,13 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
        vendorId:(uint16_t)vendorId
       nocSigner:(id<CHIPKeypair>)nocSigner
 {
+    return [self startup:storageDelegate vendorId:vendorId nocSigner:nocSigner ipk:nil];
+}
+- (BOOL)startup:(_Nullable id<CHIPPersistentStorageDelegate>)storageDelegate
+       vendorId:(uint16_t)vendorId
+      nocSigner:(id<CHIPKeypair>)nocSigner
+            ipk:(NSData * _Nullable)ipk
+{
     if (vendorId == chip::VendorId::Common) {
         // Shouldn't be using the "standard" vendor ID for actual devices.
         CHIP_LOG_ERROR("%d is not a valid vendorId to initialize a device controller with", vendorId);
@@ -214,7 +221,7 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
             _keypairBridge.Init(nocSigner);
             nativeBridge.reset(new chip::Crypto::CHIPP256KeypairNativeBridge(_keypairBridge));
         }
-        errorCode = _operationalCredentialsDelegate->init(_persistentStorageDelegateBridge, std::move(nativeBridge), nil);
+        errorCode = _operationalCredentialsDelegate->init(_persistentStorageDelegateBridge, std::move(nativeBridge), ipk);
         if ([self checkForStartError:(CHIP_NO_ERROR == errorCode) logMsg:kErrorOperationalCredentialsInit]) {
             return;
         }


### PR DESCRIPTION
#### Problem
- chip-tool-darwin cannot use Keychain and new changes were added that forces users of CHIP.framework to use Keychain. 
- Fixes #16910 

#### Change overview
This PR adds ability to pass in IPK from the controller startup so that it skips attempting to use Keychain. It also adds the IPK generation and pass from chip-tool-darwin. 

#### Testing
- Paired chip-all-clusters successfully and no longer saw the controller startup error.
- Validated that the IPK is persistent.