### PR TITLE
Pass network ID to device layer.

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -411,8 +411,8 @@ void Instance::OnResult(Status commissioningError, CharSpan errorText, int32_t i
 
     if (commissioningError == Status::kSuccess)
     {
-        // TODO: Pass the actual network id to device control server.
-        DeviceLayer::DeviceControlServer::DeviceControlSvr().ConnectNetworkForOperational(ByteSpan());
+        DeviceLayer::DeviceControlServer::DeviceControlSvr().ConnectNetworkForOperational(
+            ByteSpan(mLastNetworkID, mLastNetworkIDLen));
     }
 }
 


### PR DESCRIPTION
#### Problem
Previously, we didn't store the network ID. We have this info now, we should pass it along. Device layer doesn't
do anything with it currently.
Fixes: #13926

#### Change overview
- pass network ID to device layer ConnectNetworkForOperational function

#### Testing
M5 commissioning
