### PR TITLE
[M5] Fix device crash when reading fixed label list

### DIFF
--- a/src/app/clusters/fixed-label-server/fixed-label-server.cpp
+++ b/src/app/clusters/fixed-label-server/fixed-label-server.cpp
@@ -55,22 +55,31 @@ CHIP_ERROR FixedLabelAttrAccess::ReadLabelList(EndpointId endpoint, AttributeVal
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    DeviceLayer::DeviceInfoProvider::FixedLabelIterator * it = DeviceLayer::GetDeviceInfoProvider()->IterateFixedLabel(endpoint);
+    DeviceLayer::DeviceInfoProvider * provider = DeviceLayer::GetDeviceInfoProvider();
 
-    if (it)
+    if (provider)
     {
-        err = aEncoder.EncodeList([&it](const auto & encoder) -> CHIP_ERROR {
-            FixedLabel::Structs::LabelStruct::Type fixedlabel;
+        DeviceLayer::DeviceInfoProvider::FixedLabelIterator * it = provider->IterateFixedLabel(endpoint);
 
-            while (it->Next(fixedlabel))
-            {
-                ReturnErrorOnFailure(encoder.Encode(fixedlabel));
-            }
+        if (it)
+        {
+            err = aEncoder.EncodeList([&it](const auto & encoder) -> CHIP_ERROR {
+                FixedLabel::Structs::LabelStruct::Type fixedlabel;
 
-            return CHIP_NO_ERROR;
-        });
+                while (it->Next(fixedlabel))
+                {
+                    ReturnErrorOnFailure(encoder.Encode(fixedlabel));
+                }
 
-        it->Release();
+                return CHIP_NO_ERROR;
+            });
+
+            it->Release();
+        }
+        else
+        {
+            err = aEncoder.EncodeEmptyList();
+        }
     }
     else
     {


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* From the log, the crash occurs at following line
`DeviceLayer::DeviceInfoProvider::FixedLabelIterator * it = DeviceLayer::GetDeviceInfoProvider()->IterateFixedLabel(endpoint);`

Currently, we only implement DeviceInfoProvider on Linux platform, so DeviceLayer::GetDeviceInfoProvider() will be null on other platforms. We should have null check and return empty list if DeviceInfoProvider is not installed

* Fixes #16896 

#### Change overview
Add null check and return empty list if DeviceInfoProvider is not installed

#### Testing
How was this tested? (at least one bullet point required)
* uninstall DeviceInfoProvider on Linux and repo the crash, and confirm the crash go away with this change.
*