### PR TITLE
[Ameba] Increase kMaxLookupTimeMsDefault to 15000

### DIFF
--- a/src/lib/address_resolve/AddressResolve.h
+++ b/src/lib/address_resolve/AddressResolve.h
@@ -142,7 +142,7 @@ public:
 
 private:
     static constexpr uint32_t kMinLookupTimeMsDefault = 200;
-    static constexpr uint32_t kMaxLookupTimeMsDefault = 10000;
+    static constexpr uint32_t kMaxLookupTimeMsDefault = 15000;
 
     PeerId mPeerId;
     System::Clock::Milliseconds32 mMinLookupTimeMs{ kMinLookupTimeMsDefault };


### PR DESCRIPTION
#### Problem
* Ameba is frequently facing timeout during address resolution step of the ble-wifi commissioning 
* Ameba needs more time to obtain IPv6 address
* Solves #16820

#### Change overview
* Increase `kMaxLookupTimeMsDefault` from 10000 to 15000

#### Testing
* Tested ble-wifi commissioning against chip-tool
