### PR TITLE
Drop messages with a size bigger than CHIP_CONFIG_DEFAULT_UDP_MTU_SIZE

### DIFF
--- a/src/transport/TransportMgrBase.cpp
+++ b/src/transport/TransportMgrBase.cpp
@@ -57,6 +57,14 @@ CHIP_ERROR TransportMgrBase::MulticastGroupJoinLeave(const Transport::PeerAddres
 
 void TransportMgrBase::HandleMessageReceived(const Transport::PeerAddress & peerAddress, System::PacketBufferHandle && msg)
 {
+    if (msg->TotalLength() > CHIP_CONFIG_DEFAULT_UDP_MTU_SIZE)
+    {
+        char addrBuffer[Transport::PeerAddress::kMaxToStringSize];
+        peerAddress.ToString(addrBuffer);
+        ChipLogError(Inet, "message from %s dropped due to message beeing too long (%u bytes).", addrBuffer, msg->TotalLength());
+        return;
+    }
+
     if (msg->HasChainedBuffer())
     {
         // Something in the lower levels messed up.

--- a/src/transport/TransportMgrBase.cpp
+++ b/src/transport/TransportMgrBase.cpp
@@ -59,8 +59,10 @@ void TransportMgrBase::HandleMessageReceived(const Transport::PeerAddress & peer
 {
     if (msg->TotalLength() > CHIP_CONFIG_DEFAULT_UDP_MTU_SIZE)
     {
+#if CHIP_ERROR_LOGGING
         char addrBuffer[Transport::PeerAddress::kMaxToStringSize];
         peerAddress.ToString(addrBuffer);
+#endif // CHIP_ERROR_LOGGING
         ChipLogError(Inet, "Oversize message (%u bytes) from %s dropped.", msg->TotalLength(), addrBuffer);
         return;
     }

--- a/src/transport/TransportMgrBase.cpp
+++ b/src/transport/TransportMgrBase.cpp
@@ -61,7 +61,7 @@ void TransportMgrBase::HandleMessageReceived(const Transport::PeerAddress & peer
     {
         char addrBuffer[Transport::PeerAddress::kMaxToStringSize];
         peerAddress.ToString(addrBuffer);
-        ChipLogError(Inet, "message from %s dropped due to message beeing too long (%u bytes).", addrBuffer, msg->TotalLength());
+        ChipLogError(Inet, "Oversize message (%u bytes) from %s dropped.", msg->TotalLength(), addrBuffer);
         return;
     }
 


### PR DESCRIPTION
#### Problem

The spec says that messages bigger than 1280 bytes should be ignored.
https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/secure_channel/Message_Format.adoc#4-message-size-requirements

I'm not 100% sure this is the right place. It will drop all messages from all transports while currently the seems to says that this restriction only applies to `MRP over UDP, TCP, and BTP over BLE`.
I think that the spec is assuming that all `UDP` messages are over `MRP` and so this is just a wording issue.

#### Change overview
 * Drop messages bigger than `CHIP_CONFIG_DEFAULT_UDP_MTU_SIZE`
 
#### Testing
I tried by manually building packets that are bigger than `CHIP_CONFIG_DEFAULT_UDP_MTU_SIZE`