### PR TITLE
Add a way for CommandHandlerInterface to provide a list of accepted/generated command ids.

### DIFF
--- a/src/app/CommandHandlerInterface.h
+++ b/src/app/CommandHandlerInterface.h
@@ -19,9 +19,12 @@
 #pragma once
 
 #include <app/CommandHandler.h>
+#include <app/ConcreteClusterPath.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Decode.h>
 #include <app/data-model/List.h> // So we can encode lists
+#include <lib/core/DataModelTypes.h>
+#include <lib/support/Iterators.h>
 
 namespace chip {
 namespace app {
@@ -97,6 +100,56 @@ public:
      *                            This is not necessary if the HandleCommand() method below is invoked.
      */
     virtual void InvokeCommand(HandlerContext & handlerContext) = 0;
+
+    typedef Loop (*CommandIdCallback)(CommandId id, void * context);
+
+    /**
+     * Function that may be implemented to enumerate accepted (client-to-server)
+     * commands for the given cluster.
+     *
+     * If this function returns CHIP_ERROR_NOT_IMPLEMENTED, the list of accepted
+     * commands will come from the endpoint metadata for the cluster.
+     *
+     * If this function returns any other error, that will be treated as an
+     * error condition by the caller, and handling will depend on the caller.
+     *
+     * Otherwise the list of accepted commands will be the list of values passed
+     * to the provided callback.
+     *
+     * The implementation _must_ pass the provided context to the callback.
+     *
+     * If the callback returns Loop::Break, there must be no more calls to it.
+     * This is used by callbacks that just look for a particular value in the
+     * list.
+     */
+    virtual CHIP_ERROR EnumerateAcceptedCommands(const ConcreteClusterPath & cluster, CommandIdCallback callback, void * context)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+
+    /**
+     * Function that may be implemented to enumerate generated (response)
+     * commands for the given cluster.
+     *
+     * If this function returns CHIP_ERROR_NOT_IMPLEMENTED, the list of
+     * generated commands will come from the endpoint metadata for the cluster.
+     *
+     * If this function returns any other error, that will be treated as an
+     * error condition by the caller, and handling will depend on the caller.
+     *
+     * Otherwise the list of generated commands will be the list of values
+     * passed to the provided callback.
+     *
+     * The implementation _must_ pass the provided context to the callback.
+     *
+     * If the callback returns Loop::Break, there must be no more calls to it.
+     * This is used by callbacks that just look for a particular value in the
+     * list.
+     */
+    virtual CHIP_ERROR EnumerateGeneratedCommands(const ConcreteClusterPath & cluster, CommandIdCallback callback, void * context)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
 
     /**
      * Mechanism for keeping track of a chain of CommandHandlerInterface.

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -198,7 +198,7 @@ uint16_t emberAfGetDynamicIndexFromEndpoint(EndpointId id)
     return 0xFFFF;
 }
 
-EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, EndpointId id, EmberAfEndpointType * ep, uint16_t deviceId,
+EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, EndpointId id, const EmberAfEndpointType * ep, uint16_t deviceId,
                                         uint8_t deviceVersion, const Span<DataVersion> & dataVersionStorage)
 {
     auto realIndex = index + FIXED_ENDPOINT_COUNT;

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -248,7 +248,7 @@ uint16_t emberAfGetDeviceIdForEndpoint(chip::EndpointId endpoint);
 //
 // The memory backing dataVersionStorage needs to stay alive until this dynamic
 // endpoint is cleared.
-EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, chip::EndpointId id, EmberAfEndpointType * ep, uint16_t deviceId,
+EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, chip::EndpointId id, const EmberAfEndpointType * ep, uint16_t deviceId,
                                         uint8_t deviceVersion, const chip::Span<chip::DataVersion> & dataVersionStorage);
 chip::EndpointId emberAfClearDynamicEndpoint(uint16_t index);
 uint16_t emberAfGetDynamicIndexFromEndpoint(chip::EndpointId id);

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <access/AccessControl.h>
+#include <app/CommandHandlerInterface.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/GlobalAttributes.h>
 #include <app/InteractionModelEngine.h>
@@ -237,7 +238,39 @@ Protocols::InteractionModel::Status ServerClusterCommandExists(const ConcreteCom
         return Status::UnsupportedCluster;
     }
 
-    for (const CommandId * cmd = cluster->acceptedCommandList; cmd != nullptr; cmd++)
+    auto * commandHandler =
+        InteractionModelEngine::GetInstance()->FindCommandHandler(aCommandPath.mEndpointId, aCommandPath.mClusterId);
+    if (commandHandler)
+    {
+        struct Context
+        {
+            bool commandExists;
+            CommandId targetCommand;
+        } context{ false, aCommandPath.mCommandId };
+        CHIP_ERROR err = commandHandler->EnumerateAcceptedCommands(
+            aCommandPath,
+            [](CommandId command, void * context) -> Loop {
+                auto * ctx = static_cast<Context *>(context);
+                if (ctx->targetCommand == command)
+                {
+                    ctx->commandExists = true;
+                    return Loop::Break;
+                }
+                return Loop::Continue;
+            },
+            &context);
+        if (err != CHIP_ERROR_NOT_IMPLEMENTED)
+        {
+            if (err == CHIP_NO_ERROR)
+            {
+                return context.commandExists ? Status::Success : Status::UnsupportedCommand;
+            }
+
+            return Status::Failure;
+        }
+    }
+
+    for (const CommandId * cmd = cluster->acceptedCommandList; cmd != nullptr && *cmd != kInvalidCommandId; cmd++)
     {
         if (*cmd == aCommandPath.mCommandId)
         {
@@ -315,6 +348,13 @@ public:
     GlobalAttributeReader(const EmberAfCluster * aCluster) : MandatoryGlobalAttributeReader(aCluster) {}
 
     CHIP_ERROR Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder) override;
+
+private:
+    typedef CHIP_ERROR (CommandHandlerInterface::*CommandListEnumerator)(const ConcreteClusterPath & cluster,
+                                                                         CommandHandlerInterface::CommandIdCallback callback,
+                                                                         void * context);
+    static CHIP_ERROR EncodeCommandList(const ConcreteClusterPath & aClusterPath, AttributeValueEncoder & aEncoder,
+                                        CommandListEnumerator aEnumerator, const CommandId * aClusterCommandList);
 };
 
 CHIP_ERROR GlobalAttributeReader::Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder)
@@ -357,24 +397,55 @@ CHIP_ERROR GlobalAttributeReader::Read(const ConcreteReadAttributePath & aPath, 
             return CHIP_NO_ERROR;
         });
     case AcceptedCommandList::Id:
-        return aEncoder.EncodeList([this](const auto & encoder) {
-            for (const CommandId * cmd = mCluster->acceptedCommandList; cmd != nullptr && *cmd != kInvalidCommandId; cmd++)
-            {
-                ReturnErrorOnFailure(encoder.Encode(*cmd));
-            }
-            return CHIP_NO_ERROR;
-        });
+        return EncodeCommandList(aPath, aEncoder, &CommandHandlerInterface::EnumerateAcceptedCommands,
+                                 mCluster->acceptedCommandList);
     case GeneratedCommandList::Id:
-        return aEncoder.EncodeList([this](const auto & encoder) {
-            for (const CommandId * cmd = mCluster->generatedCommandList; cmd != nullptr && *cmd != kInvalidCommandId; cmd++)
-            {
-                ReturnErrorOnFailure(encoder.Encode(*cmd));
-            }
-            return CHIP_NO_ERROR;
-        });
+        return EncodeCommandList(aPath, aEncoder, &CommandHandlerInterface::EnumerateGeneratedCommands,
+                                 mCluster->generatedCommandList);
     default:
         return CHIP_NO_ERROR;
     }
+}
+
+CHIP_ERROR GlobalAttributeReader::EncodeCommandList(const ConcreteClusterPath & aClusterPath, AttributeValueEncoder & aEncoder,
+                                                    GlobalAttributeReader::CommandListEnumerator aEnumerator,
+                                                    const CommandId * aClusterCommandList)
+{
+    return aEncoder.EncodeList([&](const auto & encoder) {
+        auto * commandHandler =
+            InteractionModelEngine::GetInstance()->FindCommandHandler(aClusterPath.mEndpointId, aClusterPath.mClusterId);
+        if (commandHandler)
+        {
+            struct Context
+            {
+                decltype(encoder) & commandIdEncoder;
+                CHIP_ERROR err;
+            } context{ encoder, CHIP_NO_ERROR };
+            CHIP_ERROR err = (commandHandler->*aEnumerator)(
+                aClusterPath,
+                [](CommandId command, void * context) -> Loop {
+                    auto * ctx = static_cast<Context *>(context);
+                    ctx->err   = ctx->commandIdEncoder.Encode(command);
+                    if (ctx->err != CHIP_NO_ERROR)
+                    {
+                        return Loop::Break;
+                    }
+                    return Loop::Continue;
+                },
+                &context);
+            if (err != CHIP_ERROR_NOT_IMPLEMENTED)
+            {
+                return context.err;
+            }
+            // Else fall through to the list in aClusterCommandList.
+        }
+
+        for (const CommandId * cmd = aClusterCommandList; cmd != nullptr && *cmd != kInvalidCommandId; cmd++)
+        {
+            ReturnErrorOnFailure(encoder.Encode(*cmd));
+        }
+        return CHIP_NO_ERROR;
+    });
 }
 
 // Helper function for trying to read an attribute value via an

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -250,8 +250,8 @@ Protocols::InteractionModel::Status ServerClusterCommandExists(const ConcreteCom
 
         CHIP_ERROR err = commandHandler->EnumerateAcceptedCommands(
             aCommandPath,
-            [](CommandId command, void * context) -> Loop {
-                auto * ctx = static_cast<Context *>(context);
+            [](CommandId command, void * closure) -> Loop {
+                auto * ctx = static_cast<Context *>(closure);
                 if (ctx->targetCommand == command)
                 {
                     ctx->commandExists = true;
@@ -436,8 +436,8 @@ CHIP_ERROR GlobalAttributeReader::EncodeCommandList(const ConcreteClusterPath & 
             } context{ encoder, CHIP_NO_ERROR };
             CHIP_ERROR err = (commandHandler->*aEnumerator)(
                 aClusterPath,
-                [](CommandId command, void * context) -> Loop {
-                    auto * ctx = static_cast<Context *>(context);
+                [](CommandId command, void * closure) -> Loop {
+                    auto * ctx = static_cast<Context *>(closure);
                     ctx->err   = ctx->commandIdEncoder.Encode(command);
                     if (ctx->err != CHIP_NO_ERROR)
                     {

--- a/src/controller/tests/TestServerCommandDispatch.cpp
+++ b/src/controller/tests/TestServerCommandDispatch.cpp
@@ -32,6 +32,7 @@
 #include <app/tests/AppTestContext.h>
 #include <app/util/attribute-storage.h>
 #include <controller/InvokeInteraction.h>
+#include <controller/ReadInteraction.h>
 #include <lib/support/ErrorStr.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -41,6 +42,7 @@
 using TestContext = chip::Test::AppContext;
 
 using namespace chip;
+using namespace chip::app;
 using namespace chip::app::Clusters;
 
 namespace {
@@ -67,8 +69,15 @@ public:
 
     ~TestClusterCommandHandler() { chip::app::InteractionModelEngine::GetInstance()->UnregisterCommandHandler(this); }
 
+    void OverrideAcceptedCommands() { mOverrideAcceptedCommands = true; }
+    void ClaimNoCommands() { mClaimNoCommands = true; }
+
 private:
     void InvokeCommand(chip::app::CommandHandlerInterface::HandlerContext & handlerContext) final;
+    CHIP_ERROR EnumerateAcceptedCommands(const ConcreteClusterPath & cluster, CommandIdCallback callback, void * context) final;
+
+    bool mOverrideAcceptedCommands = false;
+    bool mClaimNoCommands          = false;
 };
 
 void TestClusterCommandHandler::InvokeCommand(chip::app::CommandHandlerInterface::HandlerContext & handlerContext)
@@ -100,6 +109,24 @@ void TestClusterCommandHandler::InvokeCommand(chip::app::CommandHandlerInterface
         });
 }
 
+CHIP_ERROR TestClusterCommandHandler::EnumerateAcceptedCommands(const ConcreteClusterPath & cluster,
+                                                                CommandHandlerInterface::CommandIdCallback callback, void * context)
+{
+    if (!mOverrideAcceptedCommands)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+
+    if (mClaimNoCommands)
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    // We just have one command id.
+    callback(TestCluster::Commands::TestSimpleArgumentRequest::Id, context);
+    return CHIP_NO_ERROR;
+}
+
 } // namespace
 
 namespace {
@@ -110,8 +137,15 @@ public:
     TestCommandInteraction() {}
     static void TestNoHandler(nlTestSuite * apSuite, void * apContext);
     static void TestDataResponse(nlTestSuite * apSuite, void * apContext);
+    static void TestDataResponseNoCommand1(nlTestSuite * apSuite, void * apContext);
+    static void TestDataResponseNoCommand2(nlTestSuite * apSuite, void * apContext);
+    static void TestDataResponseNoCommand3(nlTestSuite * apSuite, void * apContext);
+    static void TestDataResponseHandlerOverride1(nlTestSuite * apSuite, void * apContext);
+    static void TestDataResponseHandlerOverride2(nlTestSuite * apSuite, void * apContext);
 
 private:
+    static void TestDataResponseHelper(nlTestSuite * apSuite, void * apContext, const EmberAfEndpointType * aEndpoint,
+                                       bool aExpectSuccess);
 };
 
 // We want to send a TestSimpleArgumentRequest::Type, but get a
@@ -177,23 +211,40 @@ DECLARE_DYNAMIC_ATTRIBUTE(chip::app::Clusters::Descriptor::Attributes::DeviceLis
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(testClusterAttrs)
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
 
-constexpr CommandId testClusterCommands[] = {
+constexpr CommandId testClusterCommands1[] = {
     TestCluster::Commands::TestSimpleArgumentRequest::Id,
     kInvalidCommandId,
 };
-DECLARE_DYNAMIC_CLUSTER_LIST_BEGIN(testEndpointClusters)
-DECLARE_DYNAMIC_CLUSTER(chip::app::Clusters::TestCluster::Id, testClusterAttrs, testClusterCommands, nullptr),
+DECLARE_DYNAMIC_CLUSTER_LIST_BEGIN(testEndpointClusters1)
+DECLARE_DYNAMIC_CLUSTER(chip::app::Clusters::TestCluster::Id, testClusterAttrs, testClusterCommands1, nullptr),
     DECLARE_DYNAMIC_CLUSTER(chip::app::Clusters::Descriptor::Id, descriptorAttrs, nullptr, nullptr),
     DECLARE_DYNAMIC_CLUSTER_LIST_END;
 
-DECLARE_DYNAMIC_ENDPOINT(testEndpoint, testEndpointClusters);
+DECLARE_DYNAMIC_ENDPOINT(testEndpoint1, testEndpointClusters1);
 
-void TestCommandInteraction::TestDataResponse(nlTestSuite * apSuite, void * apContext)
+constexpr CommandId testClusterCommands2[] = {
+    kInvalidCommandId,
+};
+DECLARE_DYNAMIC_CLUSTER_LIST_BEGIN(testEndpointClusters2)
+DECLARE_DYNAMIC_CLUSTER(chip::app::Clusters::TestCluster::Id, testClusterAttrs, testClusterCommands2, nullptr),
+    DECLARE_DYNAMIC_CLUSTER(chip::app::Clusters::Descriptor::Id, descriptorAttrs, nullptr, nullptr),
+    DECLARE_DYNAMIC_CLUSTER_LIST_END;
+
+DECLARE_DYNAMIC_ENDPOINT(testEndpoint2, testEndpointClusters2);
+
+DECLARE_DYNAMIC_CLUSTER_LIST_BEGIN(testEndpointClusters3)
+DECLARE_DYNAMIC_CLUSTER(chip::app::Clusters::TestCluster::Id, testClusterAttrs, nullptr, nullptr),
+    DECLARE_DYNAMIC_CLUSTER(chip::app::Clusters::Descriptor::Id, descriptorAttrs, nullptr, nullptr),
+    DECLARE_DYNAMIC_CLUSTER_LIST_END;
+
+DECLARE_DYNAMIC_ENDPOINT(testEndpoint3, testEndpointClusters3);
+
+void TestCommandInteraction::TestDataResponseHelper(nlTestSuite * apSuite, void * apContext, const EmberAfEndpointType * aEndpoint,
+                                                    bool aExpectSuccess)
 {
     TestContext & ctx = *static_cast<TestContext *>(apContext);
     FakeRequest request;
     auto sessionHandle = ctx.GetSessionBobToAlice();
-    TestClusterCommandHandler commandHandler;
 
     bool onSuccessWasCalled = false;
     bool onFailureWasCalled = false;
@@ -202,10 +253,13 @@ void TestCommandInteraction::TestDataResponse(nlTestSuite * apSuite, void * apCo
 
     //
     // Register descriptors for this endpoint since they are needed
-    // at command validation time to ensure the command actually exists on that endpoint.
+    // at command validation time to ensure the command actually exists on that
+    // endpoint.
     //
-    DataVersion dataVersionStorage[ArraySize(testEndpointClusters)];
-    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpoint, 0, 0, Span<DataVersion>(dataVersionStorage));
+    // All our endpoints have the same number of clusters, so just pick one.
+    //
+    DataVersion dataVersionStorage[ArraySize(testEndpointClusters1)];
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, aEndpoint, 0, 0, Span<DataVersion>(dataVersionStorage));
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -241,10 +295,91 @@ void TestCommandInteraction::TestDataResponse(nlTestSuite * apSuite, void * apCo
 
     ctx.DrainAndServiceIO();
 
+    NL_TEST_ASSERT(apSuite, onSuccessWasCalled == aExpectSuccess && onFailureWasCalled != aExpectSuccess);
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+
+    onSuccessWasCalled = false;
+    onFailureWasCalled = false;
+
+    auto readSuccessCb = [apSuite, &onSuccessWasCalled, aExpectSuccess](const ConcreteDataAttributePath &,
+                                                                        const DataModel::DecodableList<CommandId> & commandList) {
+        auto count = 0;
+        auto iter  = commandList.begin();
+        while (iter.Next())
+        {
+            // We only expect 0 or 1 command ids here.
+            NL_TEST_ASSERT(apSuite, count == 0);
+            NL_TEST_ASSERT(apSuite, iter.GetValue() == TestCluster::Commands::TestSimpleArgumentRequest::Id);
+            ++count;
+        }
+        NL_TEST_ASSERT(apSuite, iter.GetStatus() == CHIP_NO_ERROR);
+        if (aExpectSuccess)
+        {
+            NL_TEST_ASSERT(apSuite, count == 1);
+        }
+        else
+        {
+            NL_TEST_ASSERT(apSuite, count == 0);
+        }
+        onSuccessWasCalled = true;
+    };
+    auto readFailureCb = [&onFailureWasCalled](const ConcreteDataAttributePath *, CHIP_ERROR aError) { onFailureWasCalled = true; };
+
+    chip::Controller::ReadAttribute<TestCluster::Attributes::AcceptedCommandList::TypeInfo>(
+        &ctx.GetExchangeManager(), sessionHandle, kTestEndpointId, readSuccessCb, readFailureCb);
+
+    ctx.DrainAndServiceIO();
+
     NL_TEST_ASSERT(apSuite, onSuccessWasCalled && !onFailureWasCalled);
     NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
 
     emberAfClearDynamicEndpoint(0);
+}
+
+void TestCommandInteraction::TestDataResponse(nlTestSuite * apSuite, void * apContext)
+{
+    TestClusterCommandHandler commandHandler;
+    TestDataResponseHelper(apSuite, apContext, &testEndpoint1, true);
+}
+
+void TestCommandInteraction::TestDataResponseNoCommand1(nlTestSuite * apSuite, void * apContext)
+{
+    // Check what happens if we don't claim our command id is supported, by
+    // overriding the acceptedCommandList with an empty list.
+    TestClusterCommandHandler commandHandler;
+    commandHandler.OverrideAcceptedCommands();
+    commandHandler.ClaimNoCommands();
+    TestDataResponseHelper(apSuite, apContext, &testEndpoint1, false);
+}
+
+void TestCommandInteraction::TestDataResponseNoCommand2(nlTestSuite * apSuite, void * apContext)
+{
+    // Check what happens if we don't claim our command id is supported, by
+    // having an acceptedCommandList that ends immediately.
+    TestClusterCommandHandler commandHandler;
+    TestDataResponseHelper(apSuite, apContext, &testEndpoint2, false);
+}
+
+void TestCommandInteraction::TestDataResponseNoCommand3(nlTestSuite * apSuite, void * apContext)
+{
+    // Check what happens if we don't claim our command id is supported, by
+    // having an acceptedCommandList that is null.
+    TestClusterCommandHandler commandHandler;
+    TestDataResponseHelper(apSuite, apContext, &testEndpoint3, false);
+}
+
+void TestCommandInteraction::TestDataResponseHandlerOverride1(nlTestSuite * apSuite, void * apContext)
+{
+    TestClusterCommandHandler commandHandler;
+    commandHandler.OverrideAcceptedCommands();
+    TestDataResponseHelper(apSuite, apContext, &testEndpoint2, true);
+}
+
+void TestCommandInteraction::TestDataResponseHandlerOverride2(nlTestSuite * apSuite, void * apContext)
+{
+    TestClusterCommandHandler commandHandler;
+    commandHandler.OverrideAcceptedCommands();
+    TestDataResponseHelper(apSuite, apContext, &testEndpoint3, true);
 }
 
 // clang-format off
@@ -252,6 +387,11 @@ const nlTest sTests[] =
 {
     NL_TEST_DEF("TestNoHandler", TestCommandInteraction::TestNoHandler),
     NL_TEST_DEF("TestDataResponse", TestCommandInteraction::TestDataResponse),
+    NL_TEST_DEF("TestDataResponseNoCommand1", TestCommandInteraction::TestDataResponseNoCommand1),
+    NL_TEST_DEF("TestDataResponseNoCommand2", TestCommandInteraction::TestDataResponseNoCommand2),
+    NL_TEST_DEF("TestDataResponseNoCommand3", TestCommandInteraction::TestDataResponseNoCommand3),
+    NL_TEST_DEF("TestDataResponseHandlerOverride1", TestCommandInteraction::TestDataResponseHandlerOverride1),
+    NL_TEST_DEF("TestDataResponseHandlerOverride2", TestCommandInteraction::TestDataResponseHandlerOverride2),
     NL_TEST_SENTINEL()
 };
 


### PR DESCRIPTION
#### Problem
Sometimes clusters (e.g. network commissioning) need to decide at runtime what set of commands is actually supported on them.

#### Change overview
Add a way to enumerate the set of supported commands on a CommandHandlerInterface.

Since the CommandHandlerInterface might want to make the decision dynamically, use a callback function for the enumeration instead of just having it return a `CommandId *`.

The other option was explicit iterator objects, but those would need to be allocated and freed and so on, and that seemed more complicated.

#### Testing
Unit tests added that exercise at least AcceptedCommandList handling.  GeneratedCommandList uses the same code, so it should be working as well...