### PR TITLE
chip-tool: use port CHIP_PORT by default instead of a random one at every launch

### DIFF
--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -169,7 +169,7 @@ uint16_t PersistentStorage::GetListenPort()
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // By default chip-tool listens on an ephemeral port.
-    uint16_t chipListenPort = 0;
+    uint16_t chipListenPort = CHIP_PORT;
 
     char value[6];
     uint16_t size = static_cast<uint16_t>(sizeof(value));


### PR DESCRIPTION
#### Problem
chip-tool uses a random port at every launch. This makes correct peer tracking on the same machine impossible.

#### Change overview
Use CHIP_PORT as the default port. Since CHIP_PORT is defined in the config, those who wish to have random port can simply set it to 0. It can also be overridden in the persistent storage.

#### Testing
Tested manually using chip-tool pairing followed by read and write commands.