### PR TITLE
Use SupportedLocalesIterator to read ReadSupportedLocales from Device…

### DIFF
--- a/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
+++ b/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
@@ -29,6 +29,7 @@
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/DeviceInfoProvider.h>
 #include <platform/PlatformManager.h>
 
 using namespace chip;
@@ -57,18 +58,32 @@ LocalizationConfigurationAttrAccess gAttrAccess;
 CHIP_ERROR LocalizationConfigurationAttrAccess::ReadSupportedLocales(AttributeValueEncoder & aEncoder)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    DeviceLayer::AttributeList<CharSpan, DeviceLayer::kMaxLanguageTags> supportedLocales;
 
-    if (DeviceLayer::PlatformMgr().GetSupportedLocales(supportedLocales) == CHIP_NO_ERROR)
+    DeviceLayer::DeviceInfoProvider * provider = DeviceLayer::GetDeviceInfoProvider();
+
+    if (provider)
     {
-        err = aEncoder.EncodeList([&supportedLocales](const auto & encoder) -> CHIP_ERROR {
-            for (const Span<const char> & locale : supportedLocales)
-            {
-                ReturnErrorOnFailure(encoder.Encode(locale));
-            }
+        DeviceLayer::DeviceInfoProvider::SupportedLocalesIterator * it = provider->IterateSupportedLocales();
 
-            return CHIP_NO_ERROR;
-        });
+        if (it)
+        {
+            err = aEncoder.EncodeList([&it](const auto & encoder) -> CHIP_ERROR {
+                CharSpan activeLocale;
+
+                while (it->Next(activeLocale))
+                {
+                    ReturnErrorOnFailure(encoder.Encode(activeLocale));
+                }
+
+                return CHIP_NO_ERROR;
+            });
+
+            it->Release();
+        }
+        else
+        {
+            err = aEncoder.EncodeEmptyList();
+        }
     }
     else
     {
@@ -102,17 +117,23 @@ using Status = Protocols::InteractionModel::Status;
 static Protocols::InteractionModel::Status emberAfPluginLocalizationConfigurationOnActiveLocaleChange(EndpointId EndpointId,
                                                                                                       CharSpan newLangtag)
 {
-    DeviceLayer::AttributeList<CharSpan, DeviceLayer::kMaxLanguageTags> supportedLocales;
+    DeviceLayer::DeviceInfoProvider * provider = DeviceLayer::GetDeviceInfoProvider();
+    DeviceLayer::DeviceInfoProvider::SupportedLocalesIterator * it;
 
-    if (DeviceLayer::PlatformMgr().GetSupportedLocales(supportedLocales) == CHIP_NO_ERROR)
+    if (provider && (it = provider->IterateSupportedLocales()))
     {
-        for (const Span<const char> & locale : supportedLocales)
+        CharSpan outLocale;
+
+        while (it->Next(outLocale))
         {
-            if (locale.data_equal(newLangtag))
+            if (outLocale.data_equal(newLangtag))
             {
+                it->Release();
                 return Status::Success;
             }
         }
+
+        it->Release();
     }
 
     return Status::InvalidValue;
@@ -141,32 +162,58 @@ Protocols::InteractionModel::Status MatterLocalizationConfigurationClusterServer
 
 void emberAfLocalizationConfigurationClusterServerInitCallback(EndpointId endpoint)
 {
-    DeviceLayer::AttributeList<CharSpan, DeviceLayer::kMaxLanguageTags> supportedLocales;
-    CharSpan validLocale;
-
-    char outBuffer[Attributes::ActiveLocale::TypeInfo::MaxLength()];
-    MutableCharSpan activeLocale(outBuffer);
+    char outBuf[Attributes::ActiveLocale::TypeInfo::MaxLength()];
+    MutableCharSpan activeLocale(outBuf);
     EmberAfStatus status = ActiveLocale::Get(endpoint, activeLocale);
 
     VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Failed to read ActiveLocale with error: 0x%02x", status));
 
-    // We could have an invalid ActiveLocale value if an OTA update removed support for the value we were using.
-    if (DeviceLayer::PlatformMgr().GetSupportedLocales(supportedLocales) == CHIP_NO_ERROR)
+    DeviceLayer::DeviceInfoProvider * provider = DeviceLayer::GetDeviceInfoProvider();
+
+    VerifyOrReturn(provider != nullptr, ChipLogError(Zcl, "DeviceInfoProvider is not registered"));
+
+    DeviceLayer::DeviceInfoProvider::SupportedLocalesIterator * it = provider->IterateSupportedLocales();
+
+    if (it)
     {
-        for (const Span<const char> & locale : supportedLocales)
+        CHIP_ERROR err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+
+        char tempBuf[Attributes::ActiveLocale::TypeInfo::MaxLength()];
+        MutableCharSpan validLocale(tempBuf);
+        CharSpan outLocale;
+        bool validLocaleCached = false;
+
+        while (it->Next(outLocale))
         {
-            if (locale.data_equal(activeLocale))
+            if (outLocale.data_equal(activeLocale))
             {
-                return;
+                err = CHIP_NO_ERROR;
+                break;
             }
 
-            validLocale = locale;
+            if (!validLocaleCached)
+            {
+                if (CopyCharSpanToMutableCharSpan(outLocale, validLocale) != CHIP_NO_ERROR)
+                {
+                    err = CHIP_ERROR_WRITE_FAILED;
+                    break;
+                }
+                else
+                {
+                    validLocaleCached = true;
+                }
+            }
         }
 
-        // If initial value is not one of the allowed values, pick one valid value and write it.
-        status = ActiveLocale::Set(endpoint, validLocale);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
-                       ChipLogError(Zcl, "Failed to write active locale with error: 0x%02x", status));
+        it->Release();
+
+        if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+        {
+            // If initial value is not one of the allowed values, write the valid value it.
+            status = ActiveLocale::Set(endpoint, validLocale);
+            VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+                           ChipLogError(Zcl, "Failed to write active locale with error: 0x%02x", status));
+        }
     }
 }
 

--- a/src/include/platform/DeviceInfoProvider.h
+++ b/src/include/platform/DeviceInfoProvider.h
@@ -31,6 +31,7 @@ namespace DeviceLayer {
 static constexpr size_t kMaxUserLabelListLength = 10;
 static constexpr size_t kMaxLabelNameLength     = 16;
 static constexpr size_t kMaxLabelValueLength    = 16;
+static constexpr size_t kMaxActiveLocaleLength  = 35;
 
 class DeviceInfoProvider
 {
@@ -66,8 +67,9 @@ public:
     using FixedLabelType = app::Clusters::FixedLabel::Structs::LabelStruct::Type;
     using UserLabelType  = app::Clusters::UserLabel::Structs::LabelStruct::Type;
 
-    using FixedLabelIterator = Iterator<FixedLabelType>;
-    using UserLabelIterator  = Iterator<UserLabelType>;
+    using FixedLabelIterator       = Iterator<FixedLabelType>;
+    using UserLabelIterator        = Iterator<UserLabelType>;
+    using SupportedLocalesIterator = Iterator<CharSpan>;
 
     DeviceInfoProvider() = default;
 
@@ -90,6 +92,14 @@ public:
      */
     virtual FixedLabelIterator * IterateFixedLabel(EndpointId endpoint) = 0;
     virtual UserLabelIterator * IterateUserLabel(EndpointId endpoint)   = 0;
+
+    /**
+     *  Creates an iterator that may be used to obtain the list of supported locales of the device.
+     *  In order to release the allocated memory, the Release() method must be called after the iteration is finished.
+     *  @retval An instance of EndpointIterator on success
+     *  @retval nullptr if no iterator instances are available.
+     */
+    virtual SupportedLocalesIterator * IterateSupportedLocales() = 0;
 
 protected:
     /**

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -37,7 +37,6 @@ class DiscoveryImplPlatform;
 
 namespace DeviceLayer {
 
-static constexpr size_t kMaxLanguageTags  = 254; // Maximum number of entry type 'ARRAY' supports
 static constexpr size_t kMaxCalendarTypes = 12;
 
 class PlatformManagerImpl;
@@ -193,7 +192,6 @@ public:
     bool IsChipStackLockedByCurrentThread() const;
 #endif
 
-    CHIP_ERROR GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales);
     CHIP_ERROR GetSupportedCalendarTypes(
         AttributeList<app::Clusters::TimeFormatLocalization::CalendarType, kMaxCalendarTypes> & supportedCalendarTypes);
 
@@ -447,11 +445,6 @@ inline void PlatformManager::DispatchEvent(const ChipDeviceEvent * event)
 inline CHIP_ERROR PlatformManager::StartChipTimer(System::Clock::Timeout duration)
 {
     return static_cast<ImplClass *>(this)->_StartChipTimer(duration);
-}
-
-inline CHIP_ERROR PlatformManager::GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales)
-{
-    return static_cast<ImplClass *>(this)->_GetSupportedLocales(supportedLocales);
 }
 
 inline CHIP_ERROR PlatformManager::GetSupportedCalendarTypes(

--- a/src/include/platform/internal/GenericPlatformManagerImpl.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.h
@@ -60,7 +60,6 @@ protected:
     void _ScheduleWork(AsyncWorkFunct workFunct, intptr_t arg);
     void _DispatchEvent(const ChipDeviceEvent * event);
 
-    CHIP_ERROR _GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales);
     CHIP_ERROR _GetSupportedCalendarTypes(
         AttributeList<app::Clusters::TimeFormatLocalization::CalendarType, kMaxCalendarTypes> & supportedCalendarTypes);
 
@@ -78,13 +77,6 @@ private:
 
 // Instruct the compiler to instantiate the template only when explicitly told to do so.
 extern template class GenericPlatformManagerImpl<PlatformManagerImpl>;
-
-template <class ImplClass>
-inline CHIP_ERROR
-GenericPlatformManagerImpl<ImplClass>::_GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
 
 template <class ImplClass>
 inline CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_GetSupportedCalendarTypes(

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -274,4 +274,15 @@ inline CHIP_ERROR CopySpanToMutableSpan(ByteSpan span_to_copy, MutableByteSpan &
     return CHIP_NO_ERROR;
 }
 
+inline CHIP_ERROR CopyCharSpanToMutableCharSpan(CharSpan cspan_to_copy, MutableCharSpan & out_buf)
+{
+    VerifyOrReturnError(IsSpanUsable(cspan_to_copy), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_buf.size() >= cspan_to_copy.size(), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    memcpy(out_buf.data(), cspan_to_copy.data(), cspan_to_copy.size());
+    out_buf.reduce_size(cspan_to_copy.size());
+
+    return CHIP_NO_ERROR;
+}
+
 } // namespace chip

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -137,23 +137,6 @@ CHIP_ERROR PlatformManagerImpl::_PostEvent(const ChipDeviceEvent * event)
 }
 
 CHIP_ERROR
-PlatformManagerImpl::_GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales)
-{
-    // In Darwin simulation, return following hardcoded list of Strings that are valid values for the ActiveLocale.
-    supportedLocales.add(CharSpan::fromCharString("Test"));
-    supportedLocales.add(CharSpan::fromCharString("en-US"));
-    supportedLocales.add(CharSpan::fromCharString("de-DE"));
-    supportedLocales.add(CharSpan::fromCharString("fr-FR"));
-    supportedLocales.add(CharSpan::fromCharString("en-GB"));
-    supportedLocales.add(CharSpan::fromCharString("es-ES"));
-    supportedLocales.add(CharSpan::fromCharString("zh-CN"));
-    supportedLocales.add(CharSpan::fromCharString("it-IT"));
-    supportedLocales.add(CharSpan::fromCharString("ja-JP"));
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR
 PlatformManagerImpl::_GetSupportedCalendarTypes(
     AttributeList<app::Clusters::TimeFormatLocalization::CalendarType, kMaxCalendarTypes> & supportedCalendarTypes)
 {

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -64,7 +64,6 @@ private:
     CHIP_ERROR _StartEventLoopTask();
     CHIP_ERROR _StopEventLoopTask();
 
-    CHIP_ERROR _GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales);
     CHIP_ERROR _GetSupportedCalendarTypes(
         AttributeList<app::Clusters::TimeFormatLocalization::CalendarType, kMaxCalendarTypes> & supportedCalendarTypes);
 

--- a/src/platform/Linux/DeviceInfoProviderImpl.cpp
+++ b/src/platform/Linux/DeviceInfoProviderImpl.cpp
@@ -196,5 +196,76 @@ bool DeviceInfoProviderImpl::UserLabelIteratorImpl::Next(UserLabelType & output)
     }
 }
 
+DeviceInfoProvider::SupportedLocalesIterator * DeviceInfoProviderImpl::IterateSupportedLocales()
+{
+    return new SupportedLocalesIteratorImpl();
+}
+
+size_t DeviceInfoProviderImpl::SupportedLocalesIteratorImpl::Count()
+{
+    // In Linux Simulation, return the size of the hardcoded list of Strings that are valid values for the ActiveLocale.
+    // {("en-US"), ("de-DE"), ("fr-FR"), ("en-GB"), ("es-ES"), ("zh-CN"), ("it-IT"), ("ja-JP")}
+
+    return 8;
+}
+
+bool DeviceInfoProviderImpl::SupportedLocalesIteratorImpl::Next(CharSpan & output)
+{
+    // In Linux simulation, return following hardcoded list of Strings that are valid values for the ActiveLocale.
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    const char * activeLocalePtr = nullptr;
+
+    VerifyOrReturnError(mIndex < 8, false);
+
+    switch (mIndex)
+    {
+    case 0:
+        activeLocalePtr = "en-US";
+        break;
+    case 1:
+        activeLocalePtr = "de-DE";
+        break;
+    case 2:
+        activeLocalePtr = "fr-FR";
+        break;
+    case 3:
+        activeLocalePtr = "en-GB";
+        break;
+    case 4:
+        activeLocalePtr = "es-ES";
+        break;
+    case 5:
+        activeLocalePtr = "zh-CN";
+        break;
+    case 6:
+        activeLocalePtr = "it-IT";
+        break;
+    case 7:
+        activeLocalePtr = "ja-JP";
+        break;
+    default:
+        err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+        break;
+    }
+
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(std::strlen(activeLocalePtr) <= kMaxActiveLocaleLength, false);
+
+        Platform::CopyString(mActiveLocaleBuf, kMaxActiveLocaleLength + 1, activeLocalePtr);
+
+        output = CharSpan::fromCharString(mActiveLocaleBuf);
+
+        mIndex++;
+
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Linux/DeviceInfoProviderImpl.h
+++ b/src/platform/Linux/DeviceInfoProviderImpl.h
@@ -30,6 +30,7 @@ public:
     // Iterators
     FixedLabelIterator * IterateFixedLabel(EndpointId endpoint) override;
     UserLabelIterator * IterateUserLabel(EndpointId endpoint) override;
+    SupportedLocalesIterator * IterateSupportedLocales() override;
 
     static DeviceInfoProviderImpl & GetDefaultInstance();
 
@@ -64,6 +65,19 @@ protected:
         size_t mTotal        = 0;
         char mUserLabelNameBuf[kMaxLabelNameLength + 1];
         char mUserLabelValueBuf[kMaxLabelValueLength + 1];
+    };
+
+    class SupportedLocalesIteratorImpl : public SupportedLocalesIterator
+    {
+    public:
+        SupportedLocalesIteratorImpl() = default;
+        size_t Count() override;
+        bool Next(CharSpan & output) override;
+        void Release() override { delete this; }
+
+    private:
+        size_t mIndex = 0;
+        char mActiveLocaleBuf[kMaxActiveLocaleLength + 1];
     };
 
     CHIP_ERROR SetUserLabelLength(EndpointId endpoint, size_t val) override;

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -243,22 +243,6 @@ CHIP_ERROR PlatformManagerImpl::_Shutdown()
 }
 
 CHIP_ERROR
-PlatformManagerImpl::_GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales)
-{
-    // In Linux simulation, return following hardcoded list of Strings that are valid values for the ActiveLocale.
-    supportedLocales.add(CharSpan::fromCharString("en-US"));
-    supportedLocales.add(CharSpan::fromCharString("de-DE"));
-    supportedLocales.add(CharSpan::fromCharString("fr-FR"));
-    supportedLocales.add(CharSpan::fromCharString("en-GB"));
-    supportedLocales.add(CharSpan::fromCharString("es-ES"));
-    supportedLocales.add(CharSpan::fromCharString("zh-CN"));
-    supportedLocales.add(CharSpan::fromCharString("it-IT"));
-    supportedLocales.add(CharSpan::fromCharString("ja-JP"));
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR
 PlatformManagerImpl::_GetSupportedCalendarTypes(
     AttributeList<app::Clusters::TimeFormatLocalization::CalendarType, kMaxCalendarTypes> & supportedCalendarTypes)
 {

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -65,7 +65,6 @@ private:
 
     CHIP_ERROR _InitChipStack();
     CHIP_ERROR _Shutdown();
-    CHIP_ERROR _GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales);
     CHIP_ERROR _GetSupportedCalendarTypes(
         AttributeList<app::Clusters::TimeFormatLocalization::CalendarType, kMaxCalendarTypes> & supportedCalendarTypes);
 

--- a/src/platform/fake/PlatformManagerImpl.h
+++ b/src/platform/fake/PlatformManagerImpl.h
@@ -100,11 +100,6 @@ private:
 
     CHIP_ERROR _StartChipTimer(System::Clock::Timeout duration) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
-    CHIP_ERROR _GetSupportedLocales(AttributeList<chip::CharSpan, kMaxLanguageTags> & supportedLocales)
-    {
-        return CHIP_ERROR_NOT_IMPLEMENTED;
-    }
-
     CHIP_ERROR _GetSupportedCalendarTypes(
         AttributeList<app::Clusters::TimeFormatLocalization::CalendarType, kMaxCalendarTypes> & supportedCalendarTypes)
     {


### PR DESCRIPTION
…InfoProvider

#### Problem
What is being fixed?  Examples:
* Same as #16861, vendor found it is difficult to implement the ReadSupportedLocales with current API in PlatformMgr.
Currently, API GetSupportedLocales returns a AttributeList with a list of CharSpan which need us pre-allocate a buffer to store those locales loaded from the persistent storage, and we need to keep this buffer after function _GetSupportedLocales returns. But it is hard to know how to release this buffer since different platforms use different mechanism to allocate the memory.

* Need to figure out a way so that vendor do not need to pre-allocate memory to store the supported locales list.

#### Change overview
* Use iteration pattern to get the SupportedLocales list

#### Testing
How was this tested? (at least one bullet point required)
```
yufengw@yufengw-SEi:~/connectedhomeip/out/debug/standalone$ ./chip-tool localizationconfiguration read supported-locales 12344321 0
....
[1648844205.011210][141086:141091] CHIP:DMG: ReportDataMessage =
[1648844205.011239][141086:141091] CHIP:DMG: {
[1648844205.011262][141086:141091] CHIP:DMG: 	AttributeReportIBs =
[1648844205.011301][141086:141091] CHIP:DMG: 	[
[1648844205.011324][141086:141091] CHIP:DMG: 		AttributeReportIB =
[1648844205.011363][141086:141091] CHIP:DMG: 		{
[1648844205.011388][141086:141091] CHIP:DMG: 			AttributeDataIB =
[1648844205.011416][141086:141091] CHIP:DMG: 			{
[1648844205.011446][141086:141091] CHIP:DMG: 				DataVersion = 0x6f2b728,
[1648844205.011473][141086:141091] CHIP:DMG: 				AttributePathIB =
[1648844205.011503][141086:141091] CHIP:DMG: 				{
[1648844205.011533][141086:141091] CHIP:DMG: 					Endpoint = 0x0,
[1648844205.011563][141086:141091] CHIP:DMG: 					Cluster = 0x2b,
[1648844205.011595][141086:141091] CHIP:DMG: 					Attribute = 0x0000_0002,
[1648844205.011622][141086:141091] CHIP:DMG: 				}
[1648844205.011655][141086:141091] CHIP:DMG: 					
[1648844205.011682][141086:141091] CHIP:DMG: 					Data = [
[1648844205.011712][141086:141091] CHIP:DMG: 						
[1648844205.011742][141086:141091] CHIP:DMG: 					],
[1648844205.011768][141086:141091] CHIP:DMG: 			},
[1648844205.011804][141086:141091] CHIP:DMG: 			
[1648844205.011828][141086:141091] CHIP:DMG: 		},
[1648844205.011880][141086:141091] CHIP:DMG: 		
[1648844205.011904][141086:141091] CHIP:DMG: 		AttributeReportIB =
[1648844205.011941][141086:141091] CHIP:DMG: 		{
[1648844205.011965][141086:141091] CHIP:DMG: 			AttributeDataIB =
[1648844205.011992][141086:141091] CHIP:DMG: 			{
[1648844205.012019][141086:141091] CHIP:DMG: 				DataVersion = 0x6f2b728,
[1648844205.012045][141086:141091] CHIP:DMG: 				AttributePathIB =
[1648844205.012072][141086:141091] CHIP:DMG: 				{
[1648844205.012100][141086:141091] CHIP:DMG: 					Endpoint = 0x0,
[1648844205.012129][141086:141091] CHIP:DMG: 					Cluster = 0x2b,
[1648844205.012159][141086:141091] CHIP:DMG: 					Attribute = 0x0000_0002,
[1648844205.012187][141086:141091] CHIP:DMG: 					ListIndex = Null,
[1648844205.012213][141086:141091] CHIP:DMG: 				}
[1648844205.012245][141086:141091] CHIP:DMG: 					
[1648844205.012276][141086:141091] CHIP:DMG: 					Data = "en-US", 
[1648844205.012303][141086:141091] CHIP:DMG: 			},
[1648844205.012337][141086:141091] CHIP:DMG: 			
[1648844205.012360][141086:141091] CHIP:DMG: 		},
[1648844205.012409][141086:141091] CHIP:DMG: 		
[1648844205.012432][141086:141091] CHIP:DMG: 		AttributeReportIB =
[1648844205.012469][141086:141091] CHIP:DMG: 		{
[1648844205.012492][141086:141091] CHIP:DMG: 			AttributeDataIB =
[1648844205.012521][141086:141091] CHIP:DMG: 			{
[1648844205.012549][141086:141091] CHIP:DMG: 				DataVersion = 0x6f2b728,
[1648844205.012578][141086:141091] CHIP:DMG: 				AttributePathIB =
[1648844205.012613][141086:141091] CHIP:DMG: 				{
[1648844205.012637][141086:141091] CHIP:DMG: 					Endpoint = 0x0,
[1648844205.012662][141086:141091] CHIP:DMG: 					Cluster = 0x2b,
[1648844205.012698][141086:141091] CHIP:DMG: 					Attribute = 0x0000_0002,
[1648844205.012723][141086:141091] CHIP:DMG: 					ListIndex = Null,
[1648844205.012750][141086:141091] CHIP:DMG: 				}
[1648844205.012781][141086:141091] CHIP:DMG: 					
[1648844205.012810][141086:141091] CHIP:DMG: 					Data = "de-DE", 
[1648844205.012837][141086:141091] CHIP:DMG: 			},
[1648844205.012866][141086:141091] CHIP:DMG: 			
[1648844205.012889][141086:141091] CHIP:DMG: 		},
[1648844205.012932][141086:141091] CHIP:DMG: 		
[1648844205.012953][141086:141091] CHIP:DMG: 		AttributeReportIB =
[1648844205.012985][141086:141091] CHIP:DMG: 		{
[1648844205.013004][141086:141091] CHIP:DMG: 			AttributeDataIB =
[1648844205.013058][141086:141091] CHIP:DMG: 			{
[1648844205.013094][141086:141091] CHIP:DMG: 				DataVersion = 0x6f2b728,
[1648844205.013129][141086:141091] CHIP:DMG: 				AttributePathIB =
[1648844205.013168][141086:141091] CHIP:DMG: 				{
[1648844205.013203][141086:141091] CHIP:DMG: 					Endpoint = 0x0,
[1648844205.013238][141086:141091] CHIP:DMG: 					Cluster = 0x2b,
[1648844205.013278][141086:141091] CHIP:DMG: 					Attribute = 0x0000_0002,
[1648844205.013315][141086:141091] CHIP:DMG: 					ListIndex = Null,
[1648844205.013352][141086:141091] CHIP:DMG: 				}
[1648844205.013404][141086:141091] CHIP:DMG: 					
[1648844205.013450][141086:141091] CHIP:DMG: 					Data = "fr-FR", 
[1648844205.013493][141086:141091] CHIP:DMG: 			},
[1648844205.013541][141086:141091] CHIP:DMG: 			
[1648844205.013566][141086:141091] CHIP:DMG: 		},
[1648844205.013617][141086:141091] CHIP:DMG: 		
[1648844205.013640][141086:141091] CHIP:DMG: 		AttributeReportIB =
[1648844205.013676][141086:141091] CHIP:DMG: 		{
[1648844205.013699][141086:141091] CHIP:DMG: 			AttributeDataIB =
[1648844205.013726][141086:141091] CHIP:DMG: 			{
[1648844205.013753][141086:141091] CHIP:DMG: 				DataVersion = 0x6f2b728,
[1648844205.013779][141086:141091] CHIP:DMG: 				AttributePathIB =
[1648844205.013807][141086:141091] CHIP:DMG: 				{
[1648844205.013836][141086:141091] CHIP:DMG: 					Endpoint = 0x0,
[1648844205.013865][141086:141091] CHIP:DMG: 					Cluster = 0x2b,
[1648844205.013896][141086:141091] CHIP:DMG: 					Attribute = 0x0000_0002,
[1648844205.013923][141086:141091] CHIP:DMG: 					ListIndex = Null,
[1648844205.013950][141086:141091] CHIP:DMG: 				}
[1648844205.013982][141086:141091] CHIP:DMG: 					
[1648844205.014007][141086:141091] CHIP:DMG: 					Data = "en-GB", 
[1648844205.014034][141086:141091] CHIP:DMG: 			},
[1648844205.014068][141086:141091] CHIP:DMG: 			
[1648844205.014092][141086:141091] CHIP:DMG: 		},
[1648844205.014140][141086:141091] CHIP:DMG: 		
[1648844205.014163][141086:141091] CHIP:DMG: 		AttributeReportIB =
[1648844205.014198][141086:141091] CHIP:DMG: 		{
[1648844205.014221][141086:141091] CHIP:DMG: 			AttributeDataIB =
[1648844205.014247][141086:141091] CHIP:DMG: 			{
[1648844205.014275][141086:141091] CHIP:DMG: 				DataVersion = 0x6f2b728,
[1648844205.014303][141086:141091] CHIP:DMG: 				AttributePathIB =
[1648844205.014331][141086:141091] CHIP:DMG: 				{
[1648844205.014384][141086:141091] CHIP:DMG: 					Endpoint = 0x0,
[1648844205.014409][141086:141091] CHIP:DMG: 					Cluster = 0x2b,
[1648844205.014439][141086:141091] CHIP:DMG: 					Attribute = 0x0000_0002,
[1648844205.014467][141086:141091] CHIP:DMG: 					ListIndex = Null,
[1648844205.014493][141086:141091] CHIP:DMG: 				}
[1648844205.014525][141086:141091] CHIP:DMG: 					
[1648844205.014554][141086:141091] CHIP:DMG: 					Data = "es-ES", 
[1648844205.014580][141086:141091] CHIP:DMG: 			},
[1648844205.014615][141086:141091] CHIP:DMG: 			
[1648844205.014639][141086:141091] CHIP:DMG: 		},
[1648844205.014688][141086:141091] CHIP:DMG: 		
[1648844205.014711][141086:141091] CHIP:DMG: 		AttributeReportIB =
[1648844205.014747][141086:141091] CHIP:DMG: 		{
[1648844205.014771][141086:141091] CHIP:DMG: 			AttributeDataIB =
[1648844205.014798][141086:141091] CHIP:DMG: 			{
[1648844205.014824][141086:141091] CHIP:DMG: 				DataVersion = 0x6f2b728,
[1648844205.014850][141086:141091] CHIP:DMG: 				AttributePathIB =
[1648844205.014878][141086:141091] CHIP:DMG: 				{
[1648844205.014905][141086:141091] CHIP:DMG: 					Endpoint = 0x0,
[1648844205.014935][141086:141091] CHIP:DMG: 					Cluster = 0x2b,
[1648844205.014964][141086:141091] CHIP:DMG: 					Attribute = 0x0000_0002,
[1648844205.014992][141086:141091] CHIP:DMG: 					ListIndex = Null,
[1648844205.015018][141086:141091] CHIP:DMG: 				}
[1648844205.015050][141086:141091] CHIP:DMG: 					
[1648844205.015078][141086:141091] CHIP:DMG: 					Data = "zh-CN", 
[1648844205.015105][141086:141091] CHIP:DMG: 			},
[1648844205.015138][141086:141091] CHIP:DMG: 			
[1648844205.015162][141086:141091] CHIP:DMG: 		},
[1648844205.015208][141086:141091] CHIP:DMG: 		
[1648844205.015230][141086:141091] CHIP:DMG: 		AttributeReportIB =
[1648844205.015266][141086:141091] CHIP:DMG: 		{
[1648844205.015289][141086:141091] CHIP:DMG: 			AttributeDataIB =
[1648844205.015317][141086:141091] CHIP:DMG: 			{
[1648844205.015343][141086:141091] CHIP:DMG: 				DataVersion = 0x6f2b728,
[1648844205.015370][141086:141091] CHIP:DMG: 				AttributePathIB =
[1648844205.015397][141086:141091] CHIP:DMG: 				{
[1648844205.015439][141086:141091] CHIP:DMG: 					Endpoint = 0x0,
[1648844205.015480][141086:141091] CHIP:DMG: 					Cluster = 0x2b,
[1648844205.015519][141086:141091] CHIP:DMG: 					Attribute = 0x0000_0002,
[1648844205.015567][141086:141091] CHIP:DMG: 					ListIndex = Null,
[1648844205.015605][141086:141091] CHIP:DMG: 				}
[1648844205.015653][141086:141091] CHIP:DMG: 					
[1648844205.015704][141086:141091] CHIP:DMG: 					Data = "it-IT", 
[1648844205.015745][141086:141091] CHIP:DMG: 			},
[1648844205.015791][141086:141091] CHIP:DMG: 			
[1648844205.015825][141086:141091] CHIP:DMG: 		},
[1648844205.015889][141086:141091] CHIP:DMG: 		
[1648844205.015920][141086:141091] CHIP:DMG: 		AttributeReportIB =
[1648844205.015969][141086:141091] CHIP:DMG: 		{
[1648844205.016028][141086:141091] CHIP:DMG: 			AttributeDataIB =
[1648844205.016065][141086:141091] CHIP:DMG: 			{
[1648844205.016102][141086:141091] CHIP:DMG: 				DataVersion = 0x6f2b728,
[1648844205.016151][141086:141091] CHIP:DMG: 				AttributePathIB =
[1648844205.016192][141086:141091] CHIP:DMG: 				{
[1648844205.016229][141086:141091] CHIP:DMG: 					Endpoint = 0x0,
[1648844205.016268][141086:141091] CHIP:DMG: 					Cluster = 0x2b,
[1648844205.016309][141086:141091] CHIP:DMG: 					Attribute = 0x0000_0002,
[1648844205.016348][141086:141091] CHIP:DMG: 					ListIndex = Null,
[1648844205.016392][141086:141091] CHIP:DMG: 				}
[1648844205.016436][141086:141091] CHIP:DMG: 					
[1648844205.016477][141086:141091] CHIP:DMG: 					Data = "ja-JP", 
[1648844205.016520][141086:141091] CHIP:DMG: 			},
[1648844205.016569][141086:141091] CHIP:DMG: 			
[1648844205.016604][141086:141091] CHIP:DMG: 		},
[1648844205.016653][141086:141091] CHIP:DMG: 		
[1648844205.016684][141086:141091] CHIP:DMG: 	],
[1648844205.016850][141086:141091] CHIP:DMG: 	
[1648844205.016891][141086:141091] CHIP:DMG: 	SuppressResponse = true, 
[1648844205.016926][141086:141091] CHIP:DMG: 	InteractionModelRevision = 1
[1648844205.016957][141086:141091] CHIP:DMG: }
[1648844205.018506][141086:141091] CHIP:TOO: Endpoint: 0 Cluster: 0x0000_002B Attribute 0x0000_0002 DataVersion: 116569896
[1648844205.018641][141086:141091] CHIP:TOO:   SupportedLocales: 8 entries
[1648844205.018720][141086:141091] CHIP:TOO:     [1]: en-US
[1648844205.018749][141086:141091] CHIP:TOO:     [2]: de-DE
[1648844205.018772][141086:141091] CHIP:TOO:     [3]: fr-FR
[1648844205.018794][141086:141091] CHIP:TOO:     [4]: en-GB
[1648844205.018822][141086:141091] CHIP:TOO:     [5]: es-ES
[1648844205.018848][141086:141091] CHIP:TOO:     [6]: zh-CN
[1648844205.018874][141086:141091] CHIP:TOO:     [7]: it-IT
[1648844205.018900][141086:141091] CHIP:TOO:     [8]: ja-JP
[1648844205.019132][141086:141091] CHIP:EM: Sending Standalone Ack for MessageCounter:15508 on exchange 56360i
```
