### PR TITLE
[OTA] Make OTARequestor responsible for responding to AnnounceOTAProvider command

### DIFF
--- a/src/app/clusters/ota-requestor/OTARequestor.h
+++ b/src/app/clusters/ota-requestor/OTARequestor.h
@@ -42,7 +42,7 @@ public:
     //////////// OTARequestorInterface Implementation ///////////////
     void Reset(void) override;
 
-    EmberAfStatus HandleAnnounceOTAProvider(
+    void HandleAnnounceOTAProvider(
         app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
         const app::Clusters::OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::DecodableType & commandData) override;
 

--- a/src/app/clusters/ota-requestor/OTARequestorInterface.h
+++ b/src/app/clusters/ota-requestor/OTARequestorInterface.h
@@ -156,8 +156,11 @@ public:
     // Reset any relevant states
     virtual void Reset(void) = 0;
 
-    // Handler for the AnnounceOTAProvider command
-    virtual EmberAfStatus HandleAnnounceOTAProvider(
+    /**
+     * Called to handle an AnnounceOTAProvider command and is responsible for sending the status. The caller is responsible for
+     * validating fields in the command.
+     */
+    virtual void HandleAnnounceOTAProvider(
         chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
         const chip::app::Clusters::OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::DecodableType & commandData) = 0;
 


### PR DESCRIPTION
#### Problem
The responsibility of whether the requestor cluster or the default OTARequestor class is sending the status was not well defined.

Fixes: https://github.com/project-chip/connectedhomeip/issues/15895

#### Change overview
- Make the OTARequestor responsible for sending the status
- Clearly spell this out in the header file

#### Testing
- Verify that chip-tool gets a status when issuing an announce-ota-provider command
