### PR TITLE
Use nicer status logging in a few more places.

### DIFF
--- a/src/app/StatusResponse.cpp
+++ b/src/app/StatusResponse.cpp
@@ -55,7 +55,8 @@ CHIP_ERROR StatusResponse::ProcessStatusResponse(System::PacketBufferHandle && a
 #endif
     StatusIB status;
     ReturnErrorOnFailure(response.GetStatus(status.mStatus));
-    ChipLogProgress(InteractionModel, "Received status response, status is %u", to_underlying(status.mStatus));
+    ChipLogProgress(InteractionModel, "Received status response, status is " ChipLogFormatIMStatus,
+                    ChipLogValueIMStatus(status.mStatus));
     ReturnErrorOnFailure(response.ExitContainer());
 
     if (status.mStatus == Protocols::InteractionModel::Status::Success)

--- a/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
+++ b/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
@@ -145,7 +145,8 @@ exit:
     {
         if (globalStatus != InteractionModel::Status::Success)
         {
-            ChipLogError(Zcl, "Failed to open commissioning window. Global status %d", to_underlying(globalStatus));
+            ChipLogError(Zcl, "Failed to open commissioning window. Global status " ChipLogFormatIMStatus,
+                         ChipLogValueIMStatus(globalStatus));
         }
         commandObj->AddStatus(commandPath, globalStatus);
     }
@@ -191,7 +192,8 @@ exit:
     {
         if (globalStatus != InteractionModel::Status::Success)
         {
-            ChipLogError(Zcl, "Failed to open commissioning window. Global status %d", to_underlying(globalStatus));
+            ChipLogError(Zcl, "Failed to open commissioning window. Global status " ChipLogFormatIMStatus,
+                         ChipLogValueIMStatus(globalStatus));
         }
         commandObj->AddStatus(commandPath, globalStatus);
     }


### PR DESCRIPTION
#### Problem
Status being logged as a number.

#### Change overview
Log as a number plus human-readable string on platforms that enable it.

#### Testing
Tried opening a commissioning window with a bad commissioning timeout and got nicer logging.