### PR TITLE
Add chip-tool-darwin tests to run in CI

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -1,0 +1,126 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Darwin Tests
+
+on:
+    push:
+    pull_request:
+    workflow_dispatch:
+
+concurrency:
+    group:
+        ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name ==
+        'pull_request' && github.event.number) || (github.event_name ==
+        'workflow_dispatch' && github.run_number) || github.sha }}
+    cancel-in-progress: true
+
+jobs:
+    test_suites_chip_tool_darwin:
+        name: Test Suites - Darwin
+        timeout-minutes: 120
+
+        strategy:
+            matrix:
+                build_variant: [no-ble-tsan, no-ble-asan]
+                chip_tool: ["", same-event-loop-]
+        env:
+            BUILD_VARIANT: ${{matrix.build_variant}}
+            CHIP_TOOL_VARIANT: ${{matrix.chip_tool}}
+            TSAN_OPTIONS: "halt_on_error=1"
+
+        if: github.actor != 'restyled-io[bot]'
+        runs-on: macos-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  submodules: true
+            - name: Setup Environment
+              # coreutils for stdbuf
+              run: brew install openssl pkg-config coreutils
+            - name:
+                  Try to ensure the directories for core dumping and diagnostic
+                  log collection exist and we can write them.
+              run: |
+                  sudo chown ${USER} /cores || true
+                  mkdir -p ~/Library/Logs/DiagnosticReports || true
+                  mkdir objdir-clone || true
+            - name: Fix pkgconfig link
+              working-directory: /usr/local/lib/pkgconfig
+              run: |
+                  pwd
+                  ls -la /usr/local/Cellar/
+                  ls -la /usr/local/Cellar/openssl@1.1
+                  OPEN_SSL_VERSION=`ls -la /usr/local/Cellar/openssl@1.1 | cat | tail -n1 | awk '{print $NF}'`
+                  ln -s /usr/local/Cellar/openssl@1.1/$OPEN_SSL_VERSION/lib/pkgconfig/* .
+            - name: Bootstrap
+              timeout-minutes: 25
+              run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }} && ${{ !env.ACT }}
+              with:
+                  name:
+                      bootstrap-logs-darwin-${{ matrix.build_variant }}${{ matrix.chip_tool }}
+                  path: |
+                      .environment/gn_out/.ninja_log
+                      .environment/pigweed-venv/*.log
+            - name: Build Apps
+              timeout-minutes: 30
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --target darwin-x64-chip-tool-darwin-${CHIP_TOOL_VARIANT}${BUILD_VARIANT} \
+                        --target darwin-x64-all-clusters-${BUILD_VARIANT} \
+                        build \
+                        --copy-artifacts-to objdir-clone \
+                     "
+            - name: Run Tests
+              timeout-minutes: 45
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                  "./scripts/tests/run_test_suite.py \
+                     --chip-tool ./out/darwin-x64-chip-tool-darwin-${CHIP_TOOL_VARIANT}${BUILD_VARIANT}/chip-tool-darwin \
+                     --target-skip-glob '{TestGroupMessaging,TV_*}' \
+                     run \
+                     --iterations 1 \
+                     --all-clusters-app ./out/darwin-x64-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
+                  "
+            - name: Uploading core files
+              uses: actions/upload-artifact@v2
+              if: ${{ failure() }} && ${{ !env.ACT }}
+              with:
+                  name:
+                      crash-core-darwin-${{ matrix.build_variant }}${{ matrix.chip_tool }}
+                  path: /cores/
+                  # Cores are big; don't hold on to them too long.
+                  retention-days: 5
+            - name: Uploading diagnostic logs
+              uses: actions/upload-artifact@v2
+              if: ${{ failure() }} && ${{ !env.ACT }}
+              with:
+                  name:
+                      crash-log-darwin-${{ matrix.build_variant }}${{ matrix.chip_tool }}
+                  path: ~/Library/Logs/DiagnosticReports/
+            - name: Uploading objdir for debugging
+              uses: actions/upload-artifact@v2
+              if: ${{ failure() }} && ${{ !env.ACT }}
+              with:
+                  name:
+                      crash-objdir-darwin-${{ matrix.build_variant }}${{ matrix.chip_tool }}
+                  path: objdir-clone/
+                  # objdirs are big; don't hold on to them too long.
+                  retention-days: 5

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -233,6 +233,8 @@ def HostTargets():
     for target in targets:
         app_targets.append(target.Extend(
             'all-clusters', app=HostApp.ALL_CLUSTERS))
+        app_targets.append(target.Extend(
+            'chip-tool-darwin', app=HostApp.CHIP_TOOL_DARWIN))
         app_targets.append(target.Extend('chip-tool', app=HostApp.CHIP_TOOL))
         app_targets.append(target.Extend('thermostat', app=HostApp.THERMOSTAT))
         app_targets.append(target.Extend('minmdns', app=HostApp.MIN_MDNS))
@@ -250,7 +252,7 @@ def HostTargets():
     builder.AppendVariant(name="test-group", validator=AcceptNameWithSubstrings(
         ['-all-clusters', '-chip-tool']), test_group=True),
     builder.AppendVariant(name="same-event-loop", validator=AcceptNameWithSubstrings(
-        ['-chip-tool']), separate_event_loop=False),
+        ['-chip-tool', '-chip-tool-darwin']), separate_event_loop=False),
     builder.AppendVariant(name="no-interactive", validator=AcceptNameWithSubstrings(
         ['-chip-tool']), interactive_mode=False),
     builder.AppendVariant(name="ipv6only", enable_ipv4=False),

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -23,6 +23,7 @@ from .gn import GnBuilder
 class HostApp(Enum):
     ALL_CLUSTERS = auto()
     CHIP_TOOL = auto()
+    CHIP_TOOL_DARWIN = auto()
     THERMOSTAT = auto()
     RPC_CONSOLE = auto()
     MIN_MDNS = auto()
@@ -40,6 +41,8 @@ class HostApp(Enum):
             return 'all-clusters-app/linux'
         elif self == HostApp.CHIP_TOOL:
             return 'chip-tool'
+        elif self == HostApp.CHIP_TOOL_DARWIN:
+            return 'chip-tool-darwin'
         elif self == HostApp.THERMOSTAT:
             return 'thermostat/linux'
         elif self == HostApp.RPC_CONSOLE:
@@ -72,6 +75,9 @@ class HostApp(Enum):
         elif self == HostApp.CHIP_TOOL:
             yield 'chip-tool'
             yield 'chip-tool.map'
+        elif self == HostApp.CHIP_TOOL_DARWIN:
+            yield 'chip-tool-darwin'
+            yield 'chip-tool-darwin.map'
         elif self == HostApp.THERMOSTAT:
             yield 'thermostat-app'
             yield 'thermostat-app.map'


### PR DESCRIPTION
#### Problem
- Currently chip-tool-darwin tests are not running in CI allowing for changes to break the tool.
- Fixes #16930 

#### Change overview
- Adds new workflow
- Adds chip-tool-darwin to targets in python files
- Adds chip-tool-darwin to builder

#### Testing
- Ran CI on my fork
