### PR TITLE
Fix invalid CAT check routine in generate-cert

### DIFF
--- a/src/tools/chip-cert/Cmd_GenCert.cpp
+++ b/src/tools/chip-cert/Cmd_GenCert.cpp
@@ -268,7 +268,7 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
         break;
 
     case 'a':
-        if (!ParseInt(arg, chip32bitAttr, 16) || chip::IsValidCASEAuthTag(chip32bitAttr))
+        if (!ParseInt(arg, chip32bitAttr, 16) || !chip::IsValidCASEAuthTag(chip32bitAttr))
         {
             PrintArgError("%s: Invalid value specified for the subject CASE Authenticated Tag (CAT) attribute: %s\n", progName,
                           arg);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* After adding CAT option in generate-cert tool, Cert is not generated.

#### Change overview
Change invalid CAT check routine.

#### Testing
How was this tested? (at least one bullet point required)
* Generate cert using chip-cert tool.
