### PR TITLE
Fix for ECM pairing open-commissioning-window command failure

### DIFF
--- a/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.h
+++ b/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.h
@@ -40,7 +40,7 @@ public:
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(5); }
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(20); }
 
 private:
     NodeId mNodeId;


### PR DESCRIPTION
#### Problem
pairing open-commissioning-window command fails 
Fixes https://github.com/project-chip/connectedhomeip/issues/14696 

#### Change overview
- changed the following constraint in class OpenCommissioningWindowCommand : public CHIPCommand :
chip::System::Clock::Timeout GetWaitDuration() value is changed from 5 -> 20 
- changing value from 5->15 didnt work as suggested here: https://github.com/project-chip/connectedhomeip/issues/14696#issuecomment-1046520604

#### Testing
* tested multiadmin pairing using chip-tool
