### PR TITLE
QPG platform updates wrt OTA

### DIFF
--- a/config/qpg/chip-gn/BUILD.gn
+++ b/config/qpg/chip-gn/BUILD.gn
@@ -35,6 +35,7 @@ qpg_sdk("sdk") {
 static_library("qpg") {
   deps = [
     "//src/app/server",
+    "//src/controller",
     "//src/lib",
   ]
 

--- a/config/qpg/chip-gn/args.gni
+++ b/config/qpg/chip-gn/args.gni
@@ -27,6 +27,7 @@ chip_build_tests = false
 chip_monolithic_tests = false
 chip_inet_config_enable_tcp_endpoint = false
 chip_build_libshell = false
+chip_enable_ota_requestor = true
 qpg_ar = "arm-none-eabi-ar"
 qpg_cc = "arm-none-eabi-gcc"
 qpg_cxx = "arm-none-eabi-g++"

--- a/examples/lighting-app/qpg/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/qpg/src/ZclCallbacks.cpp
@@ -26,6 +26,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/util/af-types.h>
+#include <assert.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace ::chip;

--- a/examples/lock-app/qpg/src/ZclCallbacks.cpp
+++ b/examples/lock-app/qpg/src/ZclCallbacks.cpp
@@ -22,6 +22,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
+#include <assert.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace ::chip;

--- a/third_party/qpg_sdk/qpg_executable.gni
+++ b/third_party/qpg_sdk/qpg_executable.gni
@@ -100,9 +100,21 @@ template("qpg_executable") {
       ota_header_generator = "${qpg_sdk_root}/Tools/ota/generate_ota_img.py"
 
       ota_header_options = [
-        rebase_path(chip_root, root_build_dir),
-        "${out_dir}/${invoker.output_name}.hex",
-        "${out_dir}/${invoker.output_name}.ota",
+        string_join("=",
+                    [
+                      "--chip_root",
+                      rebase_path(chip_root, root_build_dir),
+                    ]),
+        string_join("=",
+                    [
+                      "--in_file",
+                      "${out_dir}/${invoker.output_name}.hex",
+                    ]),
+        string_join("=",
+                    [
+                      "--out_file",
+                      "${out_dir}/${invoker.output_name}.ota",
+                    ]),
       ]
       deps = [ ":$executable_target_name" ]
     }

--- a/third_party/qpg_sdk/qpg_sdk.gni
+++ b/third_party/qpg_sdk/qpg_sdk.gni
@@ -82,8 +82,14 @@ template("qpg_sdk") {
         "${qpg_sdk_root}/${qpg_sdk_lib_dir}/MatterQorvoGlue_${qpg_target_ic}_libbuild/libMatterQorvoGlue_${qpg_target_ic}_libbuild.a",
         "${qpg_sdk_root}/${qpg_sdk_lib_dir}/QorvoStack_${qpg_target_ic}/libQorvoStack_${qpg_target_ic}.a",
         "${qpg_sdk_root}/${qpg_sdk_lib_dir}/mbedtls_alt_${qpg_target_ic}/libmbedtls_alt_${qpg_target_ic}.a",
+        "${qpg_sdk_root}/${qpg_sdk_lib_dir}/Bootloader_${qpg_target_ic}/libBootloader_${qpg_target_ic}.a",
       ]
     }
+
+    ldflags = [
+      "-Wl,-u_binary_bl_userlicense_bin_start",
+      "-Wl,-u_binary_bootloader_bin_start",
+    ]
 
     #MBed TLS built from third_party/mbedtls tree - OT config not used
     defines = [


### PR DESCRIPTION

#### Problem

* Enable the QPG matter applications to use the qpg user mode bootloader
* Generate a complete .ota image in build flow

#### Change overview
qpg: update third_party/qpg_sdk/repo
qpg: Add bootloader library and ldflags to keep it in.
qpg: Update argument usage of generate_ota_img.py
qpg: chip-gn config: add OTA and controller
qpg: examples ZclCallbacks.cpp: add #include <assert.h>

#### Testing
How was this tested? (at least one bullet point required)
* boot up the lighting-app/qpg example