### PR TITLE
[chip-tool] Add an echo module to chip-tool

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -61,6 +61,7 @@ static_library("chip-tool-utils") {
     "commands/discover/DiscoverCommand.cpp",
     "commands/discover/DiscoverCommissionablesCommand.cpp",
     "commands/discover/DiscoverCommissionersCommand.cpp",
+    "commands/echo/EchoSendCommand.cpp",
 
     # TODO - enable CommissionedListCommand once DNS Cache is implemented
     #    "commands/pairing/CommissionedListCommand.cpp",

--- a/examples/chip-tool/commands/echo/Commands.h
+++ b/examples/chip-tool/commands/echo/Commands.h
@@ -1,0 +1,31 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "EchoSendCommand.h"
+
+void registerCommandsEcho(Commands & commands, CredentialIssuerCommands * credsIssuerConfig)
+{
+    const char * clusterName      = "Echo";
+    commands_list clusterCommands = {
+        make_unique<EchoSendCommand>(credsIssuerConfig),
+    };
+
+    commands.Register(clusterName, clusterCommands);
+}

--- a/examples/chip-tool/commands/echo/EchoSendCommand.cpp
+++ b/examples/chip-tool/commands/echo/EchoSendCommand.cpp
@@ -1,0 +1,156 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "EchoSendCommand.h"
+
+#include <app/InteractionModelEngine.h>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMessageDispatch.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <protocols/Protocols.h>
+#include <transport/SecureMessageCodec.h>
+#include <transport/raw/MessageHeader.h>
+
+using namespace chip;
+using namespace chip::Messaging;
+
+constexpr char kPayload[UINT16_MAX] = "ping";
+
+/////////// CHIPCommand Interface /////////
+CHIP_ERROR EchoSendCommand::RunCommand()
+{
+    ChipLogProgress(chipTool, "Sending echo request to node 0x%" PRIx64, mNodeId);
+    return CurrentCommissioner().GetConnectedDevice(mNodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
+}
+
+void EchoSendCommand::OnDeviceConnectedFn(void * context, OperationalDeviceProxy * device)
+{
+    auto command = static_cast<EchoSendCommand *>(context);
+    LogErrorOnFailure(command->SendMessage(device));
+}
+
+void EchoSendCommand::OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error)
+{
+    auto command = static_cast<EchoSendCommand *>(context);
+    command->SetCommandExitStatus(error);
+}
+
+/////////// ExchangeDelegate Interface /////////
+CHIP_ERROR EchoSendCommand::OnMessageReceived(ExchangeContext * ec, const PayloadHeader & payloadHeader,
+                                              System::PacketBufferHandle && payload)
+{
+    auto payloadLength = payload->DataLength();
+    auto needsAck      = payloadHeader.NeedsAck();
+    ChipLogProgress(chipTool, "Echo Response: \n\t length: %u\n\tneedsAck: %d", payloadLength, needsAck);
+
+    return CHIP_NO_ERROR;
+}
+
+void EchoSendCommand::OnResponseTimeout(ExchangeContext * ec)
+{
+    ChipLogError(chipTool, "Timed out!");
+    SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+}
+
+/////////// SessionMessageDelegate Interface /////////
+void EchoSendCommand::OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
+                                        const SessionHandle & session, const Transport::PeerAddress & source,
+                                        DuplicateMessage isDuplicate, System::PacketBufferHandle && msgBuf)
+{
+    PayloadHeader copy(payloadHeader);
+
+    if (ShouldSkipOutgoingAcks() && payloadHeader.NeedsAck() && payloadHeader.IsAckMsg())
+    {
+        ChipLogProgress(chipTool, "=== Skipping outgoing ack for message counter: %u",
+                        payloadHeader.GetAckMessageCounter().Value());
+        copy.SetNeedsAck(false);
+    }
+
+    if (ShouldSkipIncomingAcks() && payloadHeader.IsAckMsg())
+    {
+        ChipLogProgress(chipTool, "=== Skipping incoming ack for message counter: %u",
+                        payloadHeader.GetAckMessageCounter().Value());
+        copy.SetAckMessageCounter(chip::Optional<uint32_t>::Missing());
+    }
+
+    return mSessionMessageDelegate->OnMessageReceived(packetHeader, copy, session, source, isDuplicate, std::move(msgBuf));
+}
+
+/////////// Internal /////////
+CHIP_ERROR EchoSendCommand::SendMessage(OperationalDeviceProxy * device)
+{
+    auto payload = MessagePacketBuffer::NewWithData(kPayload, mMessageSize);
+    VerifyOrReturnError(!payload.IsNull(), CHIP_ERROR_NO_MEMORY);
+
+    auto exchangeMgr = device->GetExchangeManager();
+    VerifyOrReturnError(nullptr != exchangeMgr, CHIP_ERROR_INCORRECT_STATE);
+
+    auto ec = exchangeMgr->NewContext(device->GetSecureSession().Value(), this);
+    VerifyOrReturnError(nullptr != ec, CHIP_ERROR_NO_MEMORY);
+
+    auto sessionMgr = exchangeMgr->GetSessionManager();
+    VerifyOrReturnError(nullptr != sessionMgr, CHIP_ERROR_INCORRECT_STATE);
+
+    mSessionMessageDelegate = exchangeMgr;
+    sessionMgr->SetMessageDelegate(this);
+
+    CHIP_ERROR err = ec->SendMessage(GetSendMessageType(), std::move(payload), GetSendFlags());
+    if (CHIP_NO_ERROR != err)
+    {
+        ec->Abort();
+    }
+    return err;
+}
+
+SendFlags EchoSendCommand::GetSendFlags() const
+{
+    SendFlags sendFlags = SendMessageFlags::kNone;
+
+    bool needsResponse = NeedsResponse();
+    if (needsResponse)
+    {
+        sendFlags.Set(SendMessageFlags::kExpectResponse);
+    }
+
+    bool needsHack = NeedsAck();
+    if (!needsHack)
+    {
+        sendFlags.Set(SendMessageFlags::kNoAutoRequestAck);
+    }
+
+    return sendFlags;
+}
+
+Protocols::Echo::MsgType EchoSendCommand::GetSendMessageType() const
+{
+    bool needsResponse = NeedsResponse();
+    if (needsResponse)
+    {
+        return Protocols::Echo::MsgType::EchoRequest;
+    }
+
+    return Protocols::Echo::MsgType::EchoRequestWithoutResponse;
+}
+
+bool EchoSendCommand::IsIncomingAck(const PayloadHeader & payloadHeader) const
+{
+    return payloadHeader.GetAckMessageCounter().HasValue() &&
+        (payloadHeader.HasMessageType(Protocols::Echo::MsgType::EchoResponse) ||
+         payloadHeader.HasMessageType(Protocols::SecureChannel::MsgType::StandaloneAck));
+}

--- a/examples/chip-tool/commands/echo/EchoSendCommand.h
+++ b/examples/chip-tool/commands/echo/EchoSendCommand.h
@@ -1,0 +1,83 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "../common/CHIPCommand.h"
+
+#include <protocols/echo/Echo.h>
+
+class EchoSendCommand : public CHIPCommand, public chip::SessionMessageDelegate, public chip::Messaging::ExchangeDelegate
+{
+public:
+    EchoSendCommand(CredentialIssuerCommands * credsIssuerConfig) :
+        CHIPCommand("send", credsIssuerConfig), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
+        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
+    {
+        AddArgument("message-size", 0, UINT16_MAX, &mMessageSize);
+        AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
+
+        // Optional arguments
+        AddArgument("suppress-response", 0, 1, &mSuppressResponse);
+        AddArgument("needs-ack", 0, 1, &mNeedsAck);
+        AddArgument("skip-incoming-acks", 0, 1, &mSkipIncomingAcks);
+        AddArgument("skip-outgoing-acks", 0, 1, &mSkipOutgoingAcks);
+    }
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override;
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(30); }
+
+    static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
+    static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
+
+    /////////// SessionMessageDelegate Interface /////////
+    void OnMessageReceived(const chip::PacketHeader & packetHeader, const chip::PayloadHeader & payloadHeader,
+                           const chip::SessionHandle & session, const chip::Transport::PeerAddress & source,
+                           chip::SessionMessageDelegate::DuplicateMessage isDuplicate,
+                           chip::System::PacketBufferHandle && msgBuf) override;
+
+    /////////// ExchangeDelegate Interface /////////
+    CHIP_ERROR OnMessageReceived(chip::Messaging::ExchangeContext * ec, const chip::PayloadHeader & payloadHeader,
+                                 chip::System::PacketBufferHandle && payload) override;
+    void OnResponseTimeout(chip::Messaging::ExchangeContext * ec) override;
+
+private:
+    CHIP_ERROR SendMessage(chip::OperationalDeviceProxy * device);
+    chip::Messaging::SendFlags GetSendFlags() const;
+    chip::Protocols::Echo::MsgType GetSendMessageType() const;
+
+    bool IsIncomingAck(const chip::PayloadHeader & payloadHeader) const;
+
+    chip::NodeId mNodeId;
+    uint16_t mMessageSize;
+    chip::Optional<bool> mSuppressResponse;
+    chip::Optional<bool> mNeedsAck;
+    chip::Optional<bool> mSkipIncomingAcks;
+    chip::Optional<bool> mSkipOutgoingAcks;
+
+    bool NeedsResponse() const { return mSuppressResponse.HasValue() ? !mSuppressResponse.Value() : true; }
+    bool NeedsAck() const { return mNeedsAck.HasValue() ? mNeedsAck.Value() : true; }
+    bool ShouldSkipIncomingAcks() const { return NeedsAck() && (mSkipIncomingAcks.HasValue() ? mSkipIncomingAcks.Value() : false); }
+    bool ShouldSkipOutgoingAcks() const { return NeedsAck() && (mSkipOutgoingAcks.HasValue() ? mSkipOutgoingAcks.Value() : false); }
+
+    chip::SessionMessageDelegate * mSessionMessageDelegate;
+
+    chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;
+    chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
+};

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -20,6 +20,7 @@
 #include "commands/example/ExampleCredentialIssuerCommands.h"
 
 #include "commands/discover/Commands.h"
+#include "commands/echo/Commands.h"
 #include "commands/group/Commands.h"
 #include "commands/interactive/Commands.h"
 #include "commands/pairing/Commands.h"
@@ -36,6 +37,7 @@ int main(int argc, char * argv[])
     ExampleCredentialIssuerCommands credIssuerCommands;
     Commands commands;
     registerCommandsDiscover(commands, &credIssuerCommands);
+    registerCommandsEcho(commands, &credIssuerCommands);
     registerCommandsInteractive(commands, &credIssuerCommands);
     registerCommandsPayload(commands);
     registerCommandsPairing(commands, &credIssuerCommands);

--- a/src/protocols/echo/Echo.h
+++ b/src/protocols/echo/Echo.h
@@ -43,8 +43,9 @@ namespace Echo {
  */
 enum class MsgType : uint8_t
 {
-    EchoRequest  = 0x01,
-    EchoResponse = 0x02
+    EchoRequest                = 0x01,
+    EchoResponse               = 0x02,
+    EchoRequestWithoutResponse = 0x03
 };
 
 using EchoFunct = void (*)(Messaging::ExchangeContext * ec, System::PacketBufferHandle && payload);


### PR DESCRIPTION
#### Problem

`chip-tool` can not send messages using the `echo` protocol.

The test plan bits at `3.1. Matter Reliable Message Protocol (MRP) Test Cases` makes uses of the `echo` protocol in order to validate some MRP behavior.

Trying to get something to work has already found 2 issues: 
 * https://github.com/project-chip/connectedhomeip/commit/b58b7be833a97488bae5ebd5a559ba53a5b597ce
 * https://github.com/project-chip/connectedhomeip/pull/16934

While I think the test plan is wrong by stating that the `Echo` protocol is necessary for testing this feature, and instead we should just use a message that reads an attribute or send a command, it may be helpful in the meantime to have something that just allow to drop `incoming` or `outgoing` acks over the "echo" protocol.
But I think we should update the test plan wording so it will be clear that any protocol could be used...


#### Change overview
 * Add an `echo` module to `chip-tool` that basically acts as a client for the "Echo" protocols
 * Modify the "echo" protocol to not always requires an explicit response - considering a "ack" is enough.


#### Testing
I tested it manually against a local "all_clusters_app" built with `chip_app_use_echo=true`