### PR TITLE
Added option to override Vendor & Product IDs via cmd-line

### DIFF
--- a/examples/platform/linux/AppMain.h
+++ b/examples/platform/linux/AppMain.h
@@ -20,6 +20,7 @@
 
 #include <controller/CHIPDeviceController.h>
 #include <controller/CommissionerDiscoveryController.h>
+#include <credentials/DeviceAttestationCredsProvider.h>
 #include <lib/core/CHIPError.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/PlatformManager.h>
@@ -28,7 +29,7 @@
 #include "Options.h"
 
 int ChipLinuxAppInit(int argc, char ** argv, chip::ArgParser::OptionSet * customOptions = nullptr);
-void ChipLinuxAppMainLoop();
+void ChipLinuxAppMainLoop(chip::Credentials::DeviceAttestationCredentialsProvider * dacProvider = nullptr);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -26,6 +26,7 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include <lib/core/CHIPVendorIdentifiers.hpp>
+#include <platform/CHIPDeviceConfig.h>
 #include <platform/ConfigurationManager.h>
 #include <platform/Darwin/DiagnosticDataProviderImpl.h>
 #include <platform/Darwin/PosixConfig.h>
@@ -141,6 +142,16 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     // Initialize the generic implementation base class.
     ReturnErrorOnFailure(Internal::GenericConfigurationManagerImpl<PosixConfig>::Init());
 
+    if (!PosixConfig::ConfigValueExists(PosixConfig::kConfigKey_VendorId))
+    {
+        ReturnErrorOnFailure(StoreVendorId(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID));
+    }
+
+    if (!PosixConfig::ConfigValueExists(PosixConfig::kConfigKey_ProductId))
+    {
+        ReturnErrorOnFailure(StoreProductId(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID));
+    }
+
     uint32_t rebootCount;
     if (!PosixConfig::ConfigValueExists(PosixConfig::kCounterKey_RebootCount))
     {
@@ -205,6 +216,26 @@ bool ConfigurationManagerImpl::CanFactoryReset()
 void ConfigurationManagerImpl::InitiateFactoryReset()
 {
     ChipLogError(DeviceLayer, "InitiateFactoryReset not implemented");
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetVendorId(uint16_t & vendorId)
+{
+    return ReadConfigValue(PosixConfig::kConfigKey_VendorId, vendorId);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetProductId(uint16_t & productId)
+{
+    return ReadConfigValue(PosixConfig::kConfigKey_ProductId, productId);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreVendorId(uint16_t vendorId)
+{
+    return WriteConfigValue(PosixConfig::kConfigKey_VendorId, vendorId);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreProductId(uint16_t productId)
+{
+    return WriteConfigValue(PosixConfig::kConfigKey_ProductId, productId);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)
@@ -290,6 +321,11 @@ CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
     return PosixConfig::ReadConfigValue(key, val);
 }
 
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint16_t & val)
+{
+    return PosixConfig::ReadConfigValue(key, val);
+}
+
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
     return PosixConfig::ReadConfigValue(key, val);
@@ -311,6 +347,11 @@ CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, 
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
+{
+    return PosixConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint16_t val)
 {
     return PosixConfig::WriteConfigValue(key, val);
 }

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -38,6 +38,12 @@ static constexpr int kCountryCodeLength = 2;
 class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::PosixConfig>
 {
 public:
+    CHIP_ERROR StoreVendorId(uint16_t vendorId);
+    CHIP_ERROR StoreProductId(uint16_t productId);
+
+    CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
+    CHIP_ERROR GetProductId(uint16_t & productId) override;
+
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
 
@@ -60,6 +66,8 @@ private:
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+    CHIP_ERROR WriteConfigValue(Key key, uint16_t val);
+    CHIP_ERROR ReadConfigValue(Key key, uint16_t & val);
 
     // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
     CHIP_ERROR ReadConfigValue(Key key, bool & val) override;

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -57,6 +57,8 @@ const PosixConfig::Key PosixConfig::kConfigKey_SetupDiscriminator    = { kConfig
 const PosixConfig::Key PosixConfig::kConfigKey_Spake2pIterationCount = { kConfigNamespace_ChipFactory, "iteration-count" };
 const PosixConfig::Key PosixConfig::kConfigKey_Spake2pSalt           = { kConfigNamespace_ChipFactory, "salt" };
 const PosixConfig::Key PosixConfig::kConfigKey_Spake2pVerifier       = { kConfigNamespace_ChipFactory, "verifier" };
+const PosixConfig::Key PosixConfig::kConfigKey_VendorId              = { kConfigNamespace_ChipFactory, "vendor-id" };
+const PosixConfig::Key PosixConfig::kConfigKey_ProductId             = { kConfigNamespace_ChipFactory, "product-id" };
 
 // Keys stored in the Chip-config namespace
 const PosixConfig::Key PosixConfig::kConfigKey_FabricId           = { kConfigNamespace_ChipConfig, "fabric-id" };
@@ -95,6 +97,12 @@ CHIP_ERROR PosixConfig::ReadConfigValue(Key key, bool & val)
     return ReadConfigValueBin(key, reinterpret_cast<uint8_t *>(&val), sizeof(val), outLen);
 }
 
+CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint16_t & val)
+{
+    size_t outLen = 0;
+    return ReadConfigValueBin(key, reinterpret_cast<uint8_t *>(&val), sizeof(val), outLen);
+}
+
 CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint32_t & val)
 {
     size_t outLen = 0;
@@ -123,6 +131,11 @@ CHIP_ERROR PosixConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSiz
 }
 
 CHIP_ERROR PosixConfig::WriteConfigValue(Key key, bool val)
+{
+    return WriteConfigValueBin(key, reinterpret_cast<uint8_t *>(&val), sizeof(val));
+}
+
+CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint16_t val)
 {
     return WriteConfigValueBin(key, reinterpret_cast<uint8_t *>(&val), sizeof(val));
 }

--- a/src/platform/Darwin/PosixConfig.h
+++ b/src/platform/Darwin/PosixConfig.h
@@ -78,6 +78,8 @@ public:
     static const Key kConfigKey_Spake2pSalt;
     static const Key kConfigKey_Spake2pVerifier;
     static const Key kConfigKey_LocationCapability;
+    static const Key kConfigKey_VendorId;
+    static const Key kConfigKey_ProductId;
 
     static const Key kCounterKey_TotalOperationalHours;
     static const Key kCounterKey_RebootCount;
@@ -90,11 +92,13 @@ public:
 
     // Config value accessors.
     static CHIP_ERROR ReadConfigValue(Key key, bool & val);
+    static CHIP_ERROR ReadConfigValue(Key key, uint16_t & val);
     static CHIP_ERROR ReadConfigValue(Key key, uint32_t & val);
     static CHIP_ERROR ReadConfigValue(Key key, uint64_t & val);
     static CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen);
     static CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen);
     static CHIP_ERROR WriteConfigValue(Key key, bool val);
+    static CHIP_ERROR WriteConfigValue(Key key, uint16_t val);
     static CHIP_ERROR WriteConfigValue(Key key, uint32_t val);
     static CHIP_ERROR WriteConfigValue(Key key, uint64_t val);
     static CHIP_ERROR WriteConfigValueStr(Key key, const char * str);

--- a/src/platform/Linux/CHIPLinuxStorage.cpp
+++ b/src/platform/Linux/CHIPLinuxStorage.cpp
@@ -103,6 +103,19 @@ CHIP_ERROR ChipLinuxStorage::ReadValue(const char * key, bool & val)
     return retval;
 }
 
+CHIP_ERROR ChipLinuxStorage::ReadValue(const char * key, uint16_t & val)
+{
+    CHIP_ERROR retval = CHIP_NO_ERROR;
+
+    mLock.lock();
+
+    retval = ChipLinuxStorageIni::GetUInt16Value(key, val);
+
+    mLock.unlock();
+
+    return retval;
+}
+
 CHIP_ERROR ChipLinuxStorage::ReadValue(const char * key, uint32_t & val)
 {
     CHIP_ERROR retval = CHIP_NO_ERROR;
@@ -169,6 +182,15 @@ CHIP_ERROR ChipLinuxStorage::WriteValue(const char * key, bool val)
     }
 
     return retval;
+}
+
+CHIP_ERROR ChipLinuxStorage::WriteValue(const char * key, uint16_t val)
+{
+    char buf[16];
+
+    snprintf(buf, sizeof(buf), "%" PRIu16, val);
+
+    return WriteValueStr(key, buf);
 }
 
 CHIP_ERROR ChipLinuxStorage::WriteValue(const char * key, uint32_t val)

--- a/src/platform/Linux/CHIPLinuxStorage.h
+++ b/src/platform/Linux/CHIPLinuxStorage.h
@@ -70,11 +70,13 @@ public:
 
     CHIP_ERROR Init(const char * configFile);
     CHIP_ERROR ReadValue(const char * key, bool & val);
+    CHIP_ERROR ReadValue(const char * key, uint16_t & val);
     CHIP_ERROR ReadValue(const char * key, uint32_t & val);
     CHIP_ERROR ReadValue(const char * key, uint64_t & val);
     CHIP_ERROR ReadValueStr(const char * key, char * buf, size_t bufSize, size_t & outLen);
     CHIP_ERROR ReadValueBin(const char * key, uint8_t * buf, size_t bufSize, size_t & outLen);
     CHIP_ERROR WriteValue(const char * key, bool val);
+    CHIP_ERROR WriteValue(const char * key, uint16_t val);
     CHIP_ERROR WriteValue(const char * key, uint32_t val);
     CHIP_ERROR WriteValue(const char * key, uint64_t val);
     CHIP_ERROR WriteValueStr(const char * key, const char * val);

--- a/src/platform/Linux/CHIPLinuxStorageIni.cpp
+++ b/src/platform/Linux/CHIPLinuxStorageIni.cpp
@@ -122,6 +122,33 @@ CHIP_ERROR ChipLinuxStorageIni::CommitConfig(const std::string & configFile)
     return retval;
 }
 
+CHIP_ERROR ChipLinuxStorageIni::GetUInt16Value(const char * key, uint16_t & val)
+{
+    CHIP_ERROR retval = CHIP_NO_ERROR;
+    std::map<std::string, std::string> section;
+
+    retval = GetDefaultSection(section);
+
+    if (retval == CHIP_NO_ERROR)
+    {
+        auto it = section.find(key);
+
+        if (it != section.end())
+        {
+            if (!inipp::extract(section[key], val))
+            {
+                retval = CHIP_ERROR_INVALID_ARGUMENT;
+            }
+        }
+        else
+        {
+            retval = CHIP_ERROR_KEY_NOT_FOUND;
+        }
+    }
+
+    return retval;
+}
+
 CHIP_ERROR ChipLinuxStorageIni::GetUIntValue(const char * key, uint32_t & val)
 {
     CHIP_ERROR retval = CHIP_NO_ERROR;

--- a/src/platform/Linux/CHIPLinuxStorageIni.h
+++ b/src/platform/Linux/CHIPLinuxStorageIni.h
@@ -39,6 +39,7 @@ public:
     CHIP_ERROR Init();
     CHIP_ERROR AddConfig(const std::string & configFile);
     CHIP_ERROR CommitConfig(const std::string & configFile);
+    CHIP_ERROR GetUInt16Value(const char * key, uint16_t & val);
     CHIP_ERROR GetUIntValue(const char * key, uint32_t & val);
     CHIP_ERROR GetUInt64Value(const char * key, uint64_t & val);
     CHIP_ERROR GetStringValue(const char * key, char * buf, size_t bufSize, size_t & outLen);

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -31,6 +31,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <netpacket/packet.h>
+#include <platform/CHIPDeviceConfig.h>
 #include <platform/ConfigurationManager.h>
 #include <platform/DiagnosticDataProvider.h>
 #include <platform/Linux/PosixConfig.h>
@@ -63,6 +64,18 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     // Initialize the generic implementation base class.
     err = Internal::GenericConfigurationManagerImpl<PosixConfig>::Init();
     SuccessOrExit(err);
+
+    if (!PosixConfig::ConfigValueExists(PosixConfig::kConfigKey_VendorId))
+    {
+        err = StoreVendorId(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID);
+        SuccessOrExit(err);
+    }
+
+    if (!PosixConfig::ConfigValueExists(PosixConfig::kConfigKey_ProductId))
+    {
+        err = StoreProductId(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID);
+        SuccessOrExit(err);
+    }
 
     if (PosixConfig::ConfigValueExists(PosixConfig::kCounterKey_RebootCount))
     {
@@ -212,6 +225,11 @@ CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
     return PosixConfig::ReadConfigValue(key, val);
 }
 
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint16_t & val)
+{
+    return PosixConfig::ReadConfigValue(key, val);
+}
+
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
     return PosixConfig::ReadConfigValue(key, val);
@@ -233,6 +251,11 @@ CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, 
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
+{
+    return PosixConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint16_t val)
 {
     return PosixConfig::WriteConfigValue(key, val);
 }
@@ -295,6 +318,26 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     // Restart the system.
     ChipLogProgress(DeviceLayer, "System restarting (not implemented)");
     // TODO(#742): restart CHIP exe
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetVendorId(uint16_t & vendorId)
+{
+    return ReadConfigValue(PosixConfig::kConfigKey_VendorId, vendorId);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetProductId(uint16_t & productId)
+{
+    return ReadConfigValue(PosixConfig::kConfigKey_ProductId, productId);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreVendorId(uint16_t vendorId)
+{
+    return WriteConfigValue(PosixConfig::kConfigKey_VendorId, vendorId);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreProductId(uint16_t productId)
+{
+    return WriteConfigValue(PosixConfig::kConfigKey_ProductId, productId);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)

--- a/src/platform/Linux/ConfigurationManagerImpl.h
+++ b/src/platform/Linux/ConfigurationManagerImpl.h
@@ -37,6 +37,11 @@ namespace DeviceLayer {
 class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::PosixConfig>
 {
 public:
+    CHIP_ERROR StoreVendorId(uint16_t vendorId);
+    CHIP_ERROR StoreProductId(uint16_t productId);
+
+    CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
+    CHIP_ERROR GetProductId(uint16_t & productId) override;
     CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;
     CHIP_ERROR StoreRebootCount(uint32_t rebootCount) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
@@ -63,6 +68,8 @@ private:
 #endif
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+    CHIP_ERROR WriteConfigValue(Key key, uint16_t val);
+    CHIP_ERROR ReadConfigValue(Key key, uint16_t & val);
 
     // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
     CHIP_ERROR ReadConfigValue(Key key, bool & val) override;

--- a/src/platform/Linux/PosixConfig.cpp
+++ b/src/platform/Linux/PosixConfig.cpp
@@ -60,6 +60,8 @@ const PosixConfig::Key PosixConfig::kConfigKey_SetupDiscriminator    = { kConfig
 const PosixConfig::Key PosixConfig::kConfigKey_Spake2pIterationCount = { kConfigNamespace_ChipFactory, "iteration-count" };
 const PosixConfig::Key PosixConfig::kConfigKey_Spake2pSalt           = { kConfigNamespace_ChipFactory, "salt" };
 const PosixConfig::Key PosixConfig::kConfigKey_Spake2pVerifier       = { kConfigNamespace_ChipFactory, "verifier" };
+const PosixConfig::Key PosixConfig::kConfigKey_VendorId              = { kConfigNamespace_ChipFactory, "vendor-id" };
+const PosixConfig::Key PosixConfig::kConfigKey_ProductId             = { kConfigNamespace_ChipFactory, "product-id" };
 
 // Keys stored in the Chip-config namespace
 const PosixConfig::Key PosixConfig::kConfigKey_FabricId           = { kConfigNamespace_ChipConfig, "fabric-id" };
@@ -123,6 +125,25 @@ CHIP_ERROR PosixConfig::ReadConfigValue(Key key, bool & val)
     SuccessOrExit(err);
 
     val = (intVal != 0);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint16_t & val)
+{
+    CHIP_ERROR err;
+    ChipLinuxStorage * storage;
+
+    storage = GetStorageForNamespace(key);
+    VerifyOrExit(storage != nullptr, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+
+    err = storage->ReadValue(key.Name, val);
+    if (err == CHIP_ERROR_KEY_NOT_FOUND)
+    {
+        err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    }
+    SuccessOrExit(err);
 
 exit:
     return err;
@@ -246,6 +267,27 @@ CHIP_ERROR PosixConfig::WriteConfigValue(Key key, bool val)
     SuccessOrExit(err);
 
     ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %s", key.Namespace, key.Name, val ? "true" : "false");
+
+exit:
+    return err;
+}
+
+CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint16_t val)
+{
+    CHIP_ERROR err;
+    ChipLinuxStorage * storage;
+
+    storage = GetStorageForNamespace(key);
+    VerifyOrExit(storage != nullptr, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+
+    err = storage->WriteValue(key.Name, val);
+    SuccessOrExit(err);
+
+    // Commit the value to the persistent store.
+    err = storage->Commit();
+    SuccessOrExit(err);
+
+    ChipLogProgress(DeviceLayer, "NVS set: %s/%s = %" PRIu16 " (0x%" PRIX16 ")", key.Namespace, key.Name, val, val);
 
 exit:
     return err;

--- a/src/platform/Linux/PosixConfig.h
+++ b/src/platform/Linux/PosixConfig.h
@@ -80,6 +80,8 @@ public:
     static const Key kConfigKey_Spake2pIterationCount;
     static const Key kConfigKey_Spake2pSalt;
     static const Key kConfigKey_Spake2pVerifier;
+    static const Key kConfigKey_VendorId;
+    static const Key kConfigKey_ProductId;
 
     static const Key kCounterKey_RebootCount;
     static const Key kCounterKey_UpTime;
@@ -92,11 +94,13 @@ public:
 
     // Config value accessors.
     static CHIP_ERROR ReadConfigValue(Key key, bool & val);
+    static CHIP_ERROR ReadConfigValue(Key key, uint16_t & val);
     static CHIP_ERROR ReadConfigValue(Key key, uint32_t & val);
     static CHIP_ERROR ReadConfigValue(Key key, uint64_t & val);
     static CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen);
     static CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen);
     static CHIP_ERROR WriteConfigValue(Key key, bool val);
+    static CHIP_ERROR WriteConfigValue(Key key, uint16_t val);
     static CHIP_ERROR WriteConfigValue(Key key, uint32_t val);
     static CHIP_ERROR WriteConfigValue(Key key, uint64_t val);
     static CHIP_ERROR WriteConfigValueStr(Key key, const char * str);

--- a/src/platform/Tizen/ConfigurationManagerImpl.cpp
+++ b/src/platform/Tizen/ConfigurationManagerImpl.cpp
@@ -28,6 +28,7 @@
 #include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/CHIPDeviceConfig.h>
 #include <platform/ConfigurationManager.h>
 #include <platform/Tizen/PosixConfig.h>
 #include <platform/internal/GenericConfigurationManagerImpl.ipp>
@@ -45,7 +46,47 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
 
 CHIP_ERROR ConfigurationManagerImpl::Init(void)
 {
-    return Internal::GenericConfigurationManagerImpl<PosixConfig>::Init();
+    CHIP_ERROR error;
+
+    error = Internal::GenericConfigurationManagerImpl<PosixConfig>::Init();
+    SuccessOrExit(error);
+
+    if (!PosixConfig::ConfigValueExists(PosixConfig::kConfigKey_VendorId))
+    {
+        error = StoreVendorId(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID);
+        SuccessOrExit(error);
+    }
+
+    if (!PosixConfig::ConfigValueExists(PosixConfig::kConfigKey_ProductId))
+    {
+        error = StoreProductId(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID);
+        SuccessOrExit(error);
+    }
+
+    error = CHIP_NO_ERROR;
+
+exit:
+    return error;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetVendorId(uint16_t & vendorId)
+{
+    return ReadConfigValue(PosixConfig::kConfigKey_VendorId, vendorId);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetProductId(uint16_t & productId)
+{
+    return ReadConfigValue(PosixConfig::kConfigKey_ProductId, productId);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreVendorId(uint16_t vendorId)
+{
+    return WriteConfigValue(PosixConfig::kConfigKey_VendorId, vendorId);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreProductId(uint16_t productId)
+{
+    return WriteConfigValue(PosixConfig::kConfigKey_ProductId, productId);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
@@ -75,6 +116,11 @@ CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
     return PosixConfig::ReadConfigValue(key, val);
 }
 
+CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint16_t & val)
+{
+    return PosixConfig::ReadConfigValue(key, val);
+}
+
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
     return PosixConfig::ReadConfigValue(key, val);
@@ -96,6 +142,11 @@ CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, 
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
+{
+    return PosixConfig::WriteConfigValue(key, val);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint16_t val)
 {
     return PosixConfig::WriteConfigValue(key, val);
 }

--- a/src/platform/Tizen/ConfigurationManagerImpl.h
+++ b/src/platform/Tizen/ConfigurationManagerImpl.h
@@ -37,6 +37,12 @@ namespace DeviceLayer {
 class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::PosixConfig>
 {
 public:
+    CHIP_ERROR StoreVendorId(uint16_t vendorId);
+    CHIP_ERROR StoreProductId(uint16_t productId);
+
+    CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
+    CHIP_ERROR GetProductId(uint16_t & productId) override;
+
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
 
@@ -51,6 +57,8 @@ private:
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+    CHIP_ERROR WriteConfigValue(Key key, uint16_t val);
+    CHIP_ERROR ReadConfigValue(Key key, uint16_t & val);
 
     // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
     CHIP_ERROR ReadConfigValue(Key key, bool & val) override;

--- a/src/platform/Tizen/PosixConfig.cpp
+++ b/src/platform/Tizen/PosixConfig.cpp
@@ -56,6 +56,8 @@ const PosixConfig::Key PosixConfig::kConfigKey_SetupDiscriminator    = { kConfig
 const PosixConfig::Key PosixConfig::kConfigKey_Spake2pIterationCount = { kConfigNamespace_ChipFactory, "iteration-count" };
 const PosixConfig::Key PosixConfig::kConfigKey_Spake2pSalt           = { kConfigNamespace_ChipFactory, "salt" };
 const PosixConfig::Key PosixConfig::kConfigKey_Spake2pVerifier       = { kConfigNamespace_ChipFactory, "verifier" };
+const PosixConfig::Key PosixConfig::kConfigKey_VendorId              = { kConfigNamespace_ChipFactory, "vendor-id" };
+const PosixConfig::Key PosixConfig::kConfigKey_ProductId             = { kConfigNamespace_ChipFactory, "product-id" };
 
 // Keys stored in the Chip-config namespace
 const PosixConfig::Key PosixConfig::kConfigKey_FabricId           = { kConfigNamespace_ChipConfig, "fabric-id" };
@@ -85,6 +87,12 @@ CHIP_ERROR PosixConfig::ReadConfigValue(Key key, bool & val)
     return PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val);
 }
 
+CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint16_t & val)
+
+{
+    return PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val);
+}
+
 CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint32_t & val)
 {
     return PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val);
@@ -108,6 +116,11 @@ CHIP_ERROR PosixConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSiz
 }
 
 CHIP_ERROR PosixConfig::WriteConfigValue(Key key, bool val)
+{
+    return PersistedStorage::KeyValueStoreMgr().Put(key.Name, val);
+}
+
+CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint16_t val)
 {
     return PersistedStorage::KeyValueStoreMgr().Put(key.Name, val);
 }

--- a/src/platform/Tizen/PosixConfig.h
+++ b/src/platform/Tizen/PosixConfig.h
@@ -77,6 +77,8 @@ public:
     static const Key kConfigKey_Spake2pIterationCount;
     static const Key kConfigKey_Spake2pSalt;
     static const Key kConfigKey_Spake2pVerifier;
+    static const Key kConfigKey_VendorId;
+    static const Key kConfigKey_ProductId;
 
     static const char kGroupKeyNamePrefix[];
 
@@ -84,11 +86,13 @@ public:
 
     // Config value accessors.
     static CHIP_ERROR ReadConfigValue(Key key, bool & val);
+    static CHIP_ERROR ReadConfigValue(Key key, uint16_t & val);
     static CHIP_ERROR ReadConfigValue(Key key, uint32_t & val);
     static CHIP_ERROR ReadConfigValue(Key key, uint64_t & val);
     static CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen);
     static CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen);
     static CHIP_ERROR WriteConfigValue(Key key, bool val);
+    static CHIP_ERROR WriteConfigValue(Key key, uint16_t val);
     static CHIP_ERROR WriteConfigValue(Key key, uint32_t val);
     static CHIP_ERROR WriteConfigValue(Key key, uint64_t val);
     static CHIP_ERROR WriteConfigValueStr(Key key, const char * str);


### PR DESCRIPTION
#### Problem
* Example applications (on Linux Platform) do not allow overriding of the default Vendor and Product ID values via cmd-line. Functionality is there but it is currently not working.
* Example applications (on Linux Platform) always override the DAC Provider that was set prior to the blocking ChipLinuxAppMainLoop() method call.
* ChipLinuxAppMainLoop() method always overrides the DAC Provider with the ExampleDACProvider.
#### Change overview
* Extend Linux Configuration Manager implementation to support read and store of uint16_t values
* Added specific Vendor and Product ID methods to store and retrieve value from File system.
* Add optional parameter dacProvider to the ChipLinuxAppMainLoop method.
  * If parameter not provided, defaults to nullptr
  * If parameter is provided, ChipLinuxAppMainLoop sets the desired DAC Provider passed by the user.
#### Testing
* Matter Unit Tests
* Tested Commissioning flow (chip-tool vs chip-all-clusters-app)