### PR TITLE
[sleepy] Fix #15800 - track idle/active of peer and use dynamic timeout

### DIFF
--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -145,8 +145,8 @@ void ReliableMessageMgr::ExecuteActions()
                       " Send Cnt %d",
                       messageCounter, ChipLogValueExchange(&entry->ec.Get()), entry->sendCount);
         // TODO(#15800): Choose active/idle timeout corresponding to the activity of exchanges of the session.
-        System::Clock::Timestamp backoff =
-            ReliableMessageMgr::GetBackoff(entry->ec->GetSessionHandle()->GetMRPConfig().mActiveRetransTimeout, entry->sendCount);
+        System::Clock::Timestamp baseTimeout = entry->ec->GetSessionHandle()->GetMRPBaseTimeout();
+        System::Clock::Timestamp backoff = ReliableMessageMgr::GetBackoff(baseTimeout, entry->sendCount);
         entry->nextRetransTime = System::SystemClock().GetMonotonicTimestamp() + backoff;
         SendFromRetransTable(entry);
         // For test not using async IO loop, the entry may have been removed after send, do not use entry below
@@ -227,8 +227,9 @@ System::Clock::Timestamp ReliableMessageMgr::GetBackoff(System::Clock::Timestamp
 void ReliableMessageMgr::StartRetransmision(RetransTableEntry * entry)
 {
     // TODO(#15800): Choose active/idle timeout corresponding to the ActiveState of peer in session.
-    System::Clock::Timestamp backoff =
-        ReliableMessageMgr::GetBackoff(entry->ec->GetSessionHandle()->GetMRPConfig().mIdleRetransTimeout, entry->sendCount);
+    //bool isActive = entry->ec->GetSessionHandle()->
+    System::Clock::Timestamp baseTimeout = entry->ec->GetSessionHandle()->GetMRPBaseTimeout();
+    System::Clock::Timestamp backoff = ReliableMessageMgr::GetBackoff(baseTimeout, entry->sendCount);
     entry->nextRetransTime = System::SystemClock().GetMonotonicTimestamp() + backoff;
     StartTimer();
 }

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -144,12 +144,12 @@ void ReliableMessageMgr::ExecuteActions()
                       "Retransmitting MessageCounter:" ChipLogFormatMessageCounter " on exchange " ChipLogFormatExchange
                       " Send Cnt %d",
                       messageCounter, ChipLogValueExchange(&entry->ec.Get()), entry->sendCount);
-        // TODO(#15800): Choose active/idle timeout corresponding to the activity of exchanges of the session.
+
+        // Choose active/idle timeout from PeerActiveMode of session per 4.11.2.1. Retransmissions.
         System::Clock::Timestamp baseTimeout = entry->ec->GetSessionHandle()->GetMRPBaseTimeout();
-        System::Clock::Timestamp backoff = ReliableMessageMgr::GetBackoff(baseTimeout, entry->sendCount);
-        entry->nextRetransTime = System::SystemClock().GetMonotonicTimestamp() + backoff;
+        System::Clock::Timestamp backoff     = ReliableMessageMgr::GetBackoff(baseTimeout, entry->sendCount);
+        entry->nextRetransTime               = System::SystemClock().GetMonotonicTimestamp() + backoff;
         SendFromRetransTable(entry);
-        // For test not using async IO loop, the entry may have been removed after send, do not use entry below
 
         return Loop::Continue;
     });
@@ -226,11 +226,10 @@ System::Clock::Timestamp ReliableMessageMgr::GetBackoff(System::Clock::Timestamp
 
 void ReliableMessageMgr::StartRetransmision(RetransTableEntry * entry)
 {
-    // TODO(#15800): Choose active/idle timeout corresponding to the ActiveState of peer in session.
-    //bool isActive = entry->ec->GetSessionHandle()->
+    // Choose active/idle timeout from PeerActiveMode of session per 4.11.2.1. Retransmissions.
     System::Clock::Timestamp baseTimeout = entry->ec->GetSessionHandle()->GetMRPBaseTimeout();
-    System::Clock::Timestamp backoff = ReliableMessageMgr::GetBackoff(baseTimeout, entry->sendCount);
-    entry->nextRetransTime = System::SystemClock().GetMonotonicTimestamp() + backoff;
+    System::Clock::Timestamp backoff     = ReliableMessageMgr::GetBackoff(baseTimeout, entry->sendCount);
+    entry->nextRetransTime               = System::SystemClock().GetMonotonicTimestamp() + backoff;
     StartTimer();
 }
 

--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -58,6 +58,10 @@ public:
         return cfg;
     }
 
+    System::Clock::Timestamp GetMRPBaseTimeout() override {
+        return System::Clock::kZero;
+    }
+
     System::Clock::Milliseconds32 GetAckTimeout() const override
     {
         VerifyOrDie(false);
@@ -98,6 +102,10 @@ public:
         static const ReliableMessageProtocolConfig cfg(GetLocalMRPConfig());
         VerifyOrDie(false);
         return cfg;
+    }
+
+    System::Clock::Timestamp GetMRPBaseTimeout() override {
+        return System::Clock::kZero;
     }
 
     System::Clock::Milliseconds32 GetAckTimeout() const override

--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -58,9 +58,7 @@ public:
         return cfg;
     }
 
-    System::Clock::Timestamp GetMRPBaseTimeout() override {
-        return System::Clock::kZero;
-    }
+    System::Clock::Timestamp GetMRPBaseTimeout() override { return System::Clock::kZero; }
 
     System::Clock::Milliseconds32 GetAckTimeout() const override
     {
@@ -104,9 +102,7 @@ public:
         return cfg;
     }
 
-    System::Clock::Timestamp GetMRPBaseTimeout() override {
-        return System::Clock::kZero;
-    }
+    System::Clock::Timestamp GetMRPBaseTimeout() override { return System::Clock::kZero; }
 
     System::Clock::Milliseconds32 GetAckTimeout() const override
     {

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -76,8 +76,7 @@ public:
         mSecureSessionType(secureSessionType),
         mPeerNodeId(peerNodeId), mPeerCATs(peerCATs), mLocalSessionId(localSessionId), mPeerSessionId(peerSessionId),
         mLastActivityTime(System::SystemClock().GetMonotonicTimestamp()),
-        mLastPeerActivityTime(System::SystemClock().GetMonotonicTimestamp()),
-        mMRPConfig(config)
+        mLastPeerActivityTime(System::SystemClock().GetMonotonicTimestamp()), mMRPConfig(config)
     {
         SetFabricIndex(fabric);
     }
@@ -173,16 +172,16 @@ public:
     System::Clock::Timestamp GetLastActivityTime() const { return mLastActivityTime; }
     System::Clock::Timestamp GetLastPeerActivityTime() const { return mLastPeerActivityTime; }
     void MarkActive() { mLastActivityTime = System::SystemClock().GetMonotonicTimestamp(); }
-    void MarkActiveRx() { 
+    void MarkActiveRx()
+    {
         mLastPeerActivityTime = System::SystemClock().GetMonotonicTimestamp();
         MarkActive();
     }
 
-    bool IsPeerActive() {
-        return ((System::SystemClock().GetMonotonicTimestamp() - GetLastPeerActivityTime()) < kMinActiveTime);
-    }
+    bool IsPeerActive() { return ((System::SystemClock().GetMonotonicTimestamp() - GetLastPeerActivityTime()) < kMinActiveTime); }
 
-    System::Clock::Timestamp GetMRPBaseTimeout() override {
+    System::Clock::Timestamp GetMRPBaseTimeout() override
+    {
         return IsPeerActive() ? GetMRPConfig().mActiveRetransTimeout : GetMRPConfig().mIdleRetransTimeout;
     }
 
@@ -198,8 +197,8 @@ private:
     uint16_t mPeerSessionId;
 
     PeerAddress mPeerAddress;
-    System::Clock::Timestamp mLastActivityTime;      ///< Timestamp of last tx or rx
-    System::Clock::Timestamp mLastPeerActivityTime;  ///< Timestamp of last rx
+    System::Clock::Timestamp mLastActivityTime;     ///< Timestamp of last tx or rx
+    System::Clock::Timestamp mLastPeerActivityTime; ///< Timestamp of last rx
     ReliableMessageProtocolConfig mMRPConfig;
     CryptoContext mCryptoContext;
     SessionMessageCounter mSessionMessageCounter;

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -178,10 +178,8 @@ public:
         MarkActive();
     }
 
-    #define MRP_MIN_ACTIVE_TIME System::Clock::Milliseconds64(2000)
-
     bool IsPeerActive() {
-        return ((System::SystemClock().GetMonotonicTimestamp() - GetLastPeerActivityTime()) < MRP_MIN_ACTIVE_TIME);
+        return ((System::SystemClock().GetMonotonicTimestamp() - GetLastPeerActivityTime()) < kMinActiveTime);
     }
 
     System::Clock::Timestamp GetMRPBaseTimeout() override {
@@ -193,8 +191,6 @@ public:
     SessionMessageCounter & GetSessionMessageCounter() { return mSessionMessageCounter; }
 
 private:
-    //static constexpr System::Clock::Timestamp MRP_MIN_ACTIVE_TIME = System::Clock::Milliseconds64(2000);
-
     Type mSecureSessionType;
     NodeId mPeerNodeId;
     CATValues mPeerCATs;

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -178,11 +178,23 @@ public:
         MarkActive();
     }
 
+    #define MRP_MIN_ACTIVE_TIME System::Clock::Milliseconds64(2000)
+
+    bool IsPeerActive() {
+        return ((System::SystemClock().GetMonotonicTimestamp() - GetLastPeerActivityTime()) < MRP_MIN_ACTIVE_TIME);
+    }
+
+    System::Clock::Timestamp GetMRPBaseTimeout() override {
+        return IsPeerActive() ? GetMRPConfig().mActiveRetransTimeout : GetMRPConfig().mIdleRetransTimeout;
+    }
+
     CryptoContext & GetCryptoContext() { return mCryptoContext; }
 
     SessionMessageCounter & GetSessionMessageCounter() { return mSessionMessageCounter; }
 
 private:
+    //static constexpr System::Clock::Timestamp MRP_MIN_ACTIVE_TIME = System::Clock::Milliseconds64(2000);
+
     Type mSecureSessionType;
     NodeId mPeerNodeId;
     CATValues mPeerCATs;
@@ -190,8 +202,8 @@ private:
     uint16_t mPeerSessionId;
 
     PeerAddress mPeerAddress;
-    System::Clock::Timestamp mLastActivityTime;     ///< Timestamp of last tx or rx
-    System::Clock::Timestamp mLastPeerActivityTime;   ///< Timestamp of last rx
+    System::Clock::Timestamp mLastActivityTime;      ///< Timestamp of last tx or rx
+    System::Clock::Timestamp mLastPeerActivityTime;  ///< Timestamp of last rx
     ReliableMessageProtocolConfig mMRPConfig;
     CryptoContext mCryptoContext;
     SessionMessageCounter mSessionMessageCounter;

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -75,7 +75,9 @@ public:
                   FabricIndex fabric, const ReliableMessageProtocolConfig & config) :
         mSecureSessionType(secureSessionType),
         mPeerNodeId(peerNodeId), mPeerCATs(peerCATs), mLocalSessionId(localSessionId), mPeerSessionId(peerSessionId),
-        mLastActivityTime(System::SystemClock().GetMonotonicTimestamp()), mMRPConfig(config)
+        mLastActivityTime(System::SystemClock().GetMonotonicTimestamp()),
+        mLastPeerActivityTime(System::SystemClock().GetMonotonicTimestamp()),
+        mMRPConfig(config)
     {
         SetFabricIndex(fabric);
     }
@@ -169,7 +171,12 @@ public:
     }
 
     System::Clock::Timestamp GetLastActivityTime() const { return mLastActivityTime; }
+    System::Clock::Timestamp GetLastPeerActivityTime() const { return mLastPeerActivityTime; }
     void MarkActive() { mLastActivityTime = System::SystemClock().GetMonotonicTimestamp(); }
+    void MarkActiveRx() { 
+        mLastPeerActivityTime = System::SystemClock().GetMonotonicTimestamp();
+        MarkActive();
+    }
 
     CryptoContext & GetCryptoContext() { return mCryptoContext; }
 
@@ -183,7 +190,8 @@ private:
     uint16_t mPeerSessionId;
 
     PeerAddress mPeerAddress;
-    System::Clock::Timestamp mLastActivityTime;
+    System::Clock::Timestamp mLastActivityTime;     ///< Timestamp of last tx or rx
+    System::Clock::Timestamp mLastPeerActivityTime;   ///< Timestamp of last rx
     ReliableMessageProtocolConfig mMRPConfig;
     CryptoContext mCryptoContext;
     SessionMessageCounter mSessionMessageCounter;

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -32,7 +32,7 @@ class UnauthenticatedSession;
 class IncomingGroupSession;
 class OutgoingGroupSession;
 
-constexpr System::Clock::Milliseconds32 kMinActiveTime = System::Clock::Milliseconds32(2000);
+constexpr System::Clock::Milliseconds32 kMinActiveTime = System::Clock::Milliseconds32(4000);
 
 class Session
 {
@@ -73,7 +73,7 @@ public:
     virtual Access::SubjectDescriptor GetSubjectDescriptor() const     = 0;
     virtual bool RequireMRP() const                                    = 0;
     virtual const ReliableMessageProtocolConfig & GetMRPConfig() const = 0;
-    virtual System::Clock::Timestamp GetMRPBaseTimeout()    = 0;
+    virtual System::Clock::Timestamp GetMRPBaseTimeout()               = 0;
     virtual System::Clock::Milliseconds32 GetAckTimeout() const        = 0;
 
     FabricIndex GetFabricIndex() const { return mFabricIndex; }

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -32,6 +32,8 @@ class UnauthenticatedSession;
 class IncomingGroupSession;
 class OutgoingGroupSession;
 
+constexpr System::Clock::Milliseconds32 kMinActiveTime = System::Clock::Milliseconds32(2000);
+
 class Session
 {
 public:

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -71,6 +71,7 @@ public:
     virtual Access::SubjectDescriptor GetSubjectDescriptor() const     = 0;
     virtual bool RequireMRP() const                                    = 0;
     virtual const ReliableMessageProtocolConfig & GetMRPConfig() const = 0;
+    virtual System::Clock::Timestamp GetMRPBaseTimeout()    = 0;
     virtual System::Clock::Milliseconds32 GetAckTimeout() const        = 0;
 
     FabricIndex GetFabricIndex() const { return mFabricIndex; }

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -544,7 +544,7 @@ void SessionManager::UnauthenticatedMessageDispatch(const PacketHeader & packetH
     unsecuredSession->SetPeerAddress(peerAddress);
     SessionMessageDelegate::DuplicateMessage isDuplicate = SessionMessageDelegate::DuplicateMessage::No;
 
-    unsecuredSession->MarkActive();
+    unsecuredSession->MarkActiveRx();
 
     PayloadHeader payloadHeader;
     ReturnOnFailure(payloadHeader.DecodeAndConsume(msg));
@@ -628,7 +628,7 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & packetHea
         return;
     }
 
-    secureSession->MarkActive();
+    secureSession->MarkActiveRx();
 
     if (isDuplicate == SessionMessageDelegate::DuplicateMessage::Yes && !payloadHeader.NeedsAck())
     {

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -119,10 +119,8 @@ public:
     const PeerAddress & GetPeerAddress() const { return mPeerAddress; }
     void SetPeerAddress(const PeerAddress & peerAddress) { mPeerAddress = peerAddress; }
 
-    #define MRP_MIN_ACTIVE_TIME System::Clock::Milliseconds64(2000)
-
     bool IsPeerActive() {
-        return ((System::SystemClock().GetMonotonicTimestamp() - GetLastPeerActivityTime()) < MRP_MIN_ACTIVE_TIME);
+        return ((System::SystemClock().GetMonotonicTimestamp() - GetLastPeerActivityTime()) < kMinActiveTime);
     }
 
     System::Clock::Timestamp GetMRPBaseTimeout() override {
@@ -136,8 +134,6 @@ public:
     PeerMessageCounter & GetPeerMessageCounter() { return mPeerMessageCounter; }
 
 private:
-    ///static constexpr System::Clock::Timestamp MRP_MIN_ACTIVE_TIME = System::Clock::Milliseconds64(2000);
-
     const NodeId mEphemeralInitiatorNodeId;
     const SessionRole mSessionRole;
     PeerAddress mPeerAddress;

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -54,7 +54,9 @@ public:
 
     UnauthenticatedSession(SessionRole sessionRole, NodeId ephemeralInitiatorNodeID, const ReliableMessageProtocolConfig & config) :
         mEphemeralInitiatorNodeId(ephemeralInitiatorNodeID), mSessionRole(sessionRole),
-        mLastActivityTime(System::SystemClock().GetMonotonicTimestamp()), mMRPConfig(config)
+        mLastActivityTime(System::SystemClock().GetMonotonicTimestamp()), 
+        mLastPeerActivityTime(System::SystemClock().GetMonotonicTimestamp()), 
+        mMRPConfig(config)
     {}
     ~UnauthenticatedSession() override { NotifySessionReleased(); }
 
@@ -65,6 +67,10 @@ public:
 
     System::Clock::Timestamp GetLastActivityTime() const { return mLastActivityTime; }
     void MarkActive() { mLastActivityTime = System::SystemClock().GetMonotonicTimestamp(); }
+    void MarkActiveRx() { 
+        mLastPeerActivityTime = System::SystemClock().GetMonotonicTimestamp();
+        MarkActive();
+    }
 
     Session::SessionType GetSessionType() const override { return Session::SessionType::kUnauthenticated; }
 #if CHIP_PROGRESS_LOGGING
@@ -122,7 +128,8 @@ private:
     const NodeId mEphemeralInitiatorNodeId;
     const SessionRole mSessionRole;
     PeerAddress mPeerAddress;
-    System::Clock::Timestamp mLastActivityTime;
+    System::Clock::Timestamp mLastActivityTime;     ///< Timestamp of last tx or rx
+    System::Clock::Timestamp mLastPeerActivityTime; ///< Timestamp of last rx
     ReliableMessageProtocolConfig mMRPConfig;
     PeerMessageCounter mPeerMessageCounter;
 };

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -54,8 +54,8 @@ public:
 
     UnauthenticatedSession(SessionRole sessionRole, NodeId ephemeralInitiatorNodeID, const ReliableMessageProtocolConfig & config) :
         mEphemeralInitiatorNodeId(ephemeralInitiatorNodeID), mSessionRole(sessionRole),
-        mLastActivityTime(System::SystemClock().GetMonotonicTimestamp()), 
-        mLastPeerActivityTime(System::SystemClock().GetMonotonicTimestamp()), 
+        mLastActivityTime(System::SystemClock().GetMonotonicTimestamp()),
+        mLastPeerActivityTime(System::Clock::kZero), // Start at zero to default to IDLE state
         mMRPConfig(config)
     {}
     ~UnauthenticatedSession() override { NotifySessionReleased(); }
@@ -68,7 +68,8 @@ public:
     System::Clock::Timestamp GetLastActivityTime() const { return mLastActivityTime; }
     System::Clock::Timestamp GetLastPeerActivityTime() const { return mLastPeerActivityTime; }
     void MarkActive() { mLastActivityTime = System::SystemClock().GetMonotonicTimestamp(); }
-    void MarkActiveRx() { 
+    void MarkActiveRx()
+    {
         mLastPeerActivityTime = System::SystemClock().GetMonotonicTimestamp();
         MarkActive();
     }
@@ -119,11 +120,10 @@ public:
     const PeerAddress & GetPeerAddress() const { return mPeerAddress; }
     void SetPeerAddress(const PeerAddress & peerAddress) { mPeerAddress = peerAddress; }
 
-    bool IsPeerActive() {
-        return ((System::SystemClock().GetMonotonicTimestamp() - GetLastPeerActivityTime()) < kMinActiveTime);
-    }
+    bool IsPeerActive() { return ((System::SystemClock().GetMonotonicTimestamp() - GetLastPeerActivityTime()) < kMinActiveTime); }
 
-    System::Clock::Timestamp GetMRPBaseTimeout() override {
+    System::Clock::Timestamp GetMRPBaseTimeout() override
+    {
         return IsPeerActive() ? GetMRPConfig().mActiveRetransTimeout : GetMRPConfig().mIdleRetransTimeout;
     }
 


### PR DESCRIPTION
#### Purpose
Fix #15800
Initial state tracking added, but need to switch backoff base based on the peer state.

#### Change overview
Add tracking of idle/active state of a remote peer. Switch idle/active intervals based on Active state of peer.
Based on spec edit: https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/5013

#### Testing
* All CI passes