### PR TITLE
[Darwin]Fix segmentation fault on writing userLabelList

### DIFF
--- a/src/app/clusters/user-label-server/user-label-server.cpp
+++ b/src/app/clusters/user-label-server/user-label-server.cpp
@@ -95,7 +95,11 @@ CHIP_ERROR UserLabelAttrAccess::ReadLabelList(EndpointId endpoint, AttributeValu
 
 CHIP_ERROR UserLabelAttrAccess::WriteLabelList(const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder)
 {
-    EndpointId endpoint = aPath.mEndpointId;
+    EndpointId endpoint                        = aPath.mEndpointId;
+    DeviceLayer::DeviceInfoProvider * provider = DeviceLayer::GetDeviceInfoProvider();
+
+    VerifyOrReturnError(provider != nullptr, CHIP_ERROR_NOT_IMPLEMENTED);
+
     if (!aPath.IsListItemOperation())
     {
         DeviceLayer::AttributeList<Structs::LabelStruct::Type, DeviceLayer::kMaxUserLabelListLength> labelList;
@@ -111,13 +115,13 @@ CHIP_ERROR UserLabelAttrAccess::WriteLabelList(const ConcreteDataAttributePath &
         }
         ReturnErrorOnFailure(iter.GetStatus());
 
-        return DeviceLayer::GetDeviceInfoProvider()->SetUserLabelList(endpoint, labelList);
+        return provider->SetUserLabelList(endpoint, labelList);
     }
     else if (aPath.mListOp == ConcreteDataAttributePath::ListOperation::AppendItem)
     {
         Structs::LabelStruct::DecodableType entry;
         ReturnErrorOnFailure(aDecoder.Decode(entry));
-        return DeviceLayer::GetDeviceInfoProvider()->AppendUserLabel(endpoint, entry);
+        return provider->AppendUserLabel(endpoint, entry);
     }
     else
     {


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* GetDeviceInfoProvider is currently only installed on Linux platform, we should have null check on it before using it for writing a userLabelList.

#### Change overview
Do null check for GetDeviceInfoProvider in WriteLabelList.


#### Testing
How was this tested? (at least one bullet point required)
* use the yaml test added in https://github.com/project-chip/connectedhomeip/pull/16975. and confirm no crash when writing a userLabelList on Darwin.