### PR TITLE
Make breadcrumb optional in network commissioning cluster commands.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -2075,34 +2075,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -588,34 +588,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/door-lock-app/door-lock-common/door-lock-app.matter
+++ b/examples/door-lock-app/door-lock-common/door-lock-app.matter
@@ -985,34 +985,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -877,34 +877,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -948,34 +948,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -441,34 +441,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/log-source-app/log-source-common/log-source-app.matter
+++ b/examples/log-source-app/log-source-common/log-source-app.matter
@@ -232,34 +232,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
+++ b/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
@@ -305,34 +305,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
+++ b/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
@@ -278,34 +278,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -1134,34 +1134,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -1134,34 +1134,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/pump-app/pump-common/pump-app.matter
+++ b/examples/pump-app/pump-common/pump-app.matter
@@ -688,34 +688,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
@@ -599,34 +599,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
+++ b/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
@@ -439,29 +439,29 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -609,34 +609,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -1146,34 +1146,34 @@ client cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {
@@ -1272,34 +1272,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -1298,34 +1298,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -545,34 +545,34 @@ server cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/src/app/zap-templates/zcl/data-model/chip/commissioning.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/commissioning.xml
@@ -94,7 +94,7 @@ limitations under the License.
         <command source="client" code="0x00" name="ScanNetworks" optional="false" response="ScanNetworksResponse" cli="chip network_commissioning scannetworks">
             <description>TODO</description>
             <arg name="SSID" type="OCTET_STRING"/>
-            <arg name="Breadcrumb" type="INT64U"/>
+            <arg name="Breadcrumb" type="INT64U" optional="true"/>
         </command>
         <command source="server" code="0x01" name="ScanNetworksResponse" optional="false" cli="chip network_commissioning scannetworksresponse">
             <description>TODO</description>
@@ -107,17 +107,17 @@ limitations under the License.
             <description>TODO</description>
             <arg name="SSID" type="OCTET_STRING"/>
             <arg name="Credentials" type="OCTET_STRING"/>
-            <arg name="breadcrumb" type="INT64U"/>
+            <arg name="breadcrumb" type="INT64U" optional="true"/>
         </command>
         <command source="client" code="0x03" name="AddOrUpdateThreadNetwork" optional="true" response="NetworkConfigResponse" cli="chip network_commissioning addorupdatethreadnetwork">
             <description>TODO</description>
             <arg name="OperationalDataset" type="OCTET_STRING"/>
-            <arg name="Breadcrumb" type="INT64U"/>
+            <arg name="Breadcrumb" type="INT64U" optional="true"/>
         </command>
         <command source="client" code="0x04" name="RemoveNetwork" optional="false" response="NetworkConfigResponse" cli="chip network_commissioning removenetwork">
             <description>TODO</description>
             <arg name="NetworkID" type="OCTET_STRING"/>
-            <arg name="Breadcrumb" type="INT64U"/>
+            <arg name="Breadcrumb" type="INT64U" optional="true"/>
         </command>
         <command source="server" code="0x05" name="NetworkConfigResponse" optional="true" cli="chip network_commissioning addwifiresponse">
             <description>TODO</description>
@@ -128,7 +128,7 @@ limitations under the License.
         <command source="client" code="0x06" name="ConnectNetwork" optional="false" response="ConnectNetworkResponse" cli="chip network_commissioning connectnetwork">
             <description>TODO</description>
             <arg name="NetworkID" type="OCTET_STRING"/>
-            <arg name="Breadcrumb" type="INT64U"/>
+            <arg name="Breadcrumb" type="INT64U" optional="true"/>
         </command>
         <command source="server" code="0x07" name="ConnectNetworkResponse" optional="false" cli="chip network_commissioning connectnetworkresponse">
             <description>TODO</description>
@@ -140,7 +140,7 @@ limitations under the License.
             <description>TODO</description>
             <arg name="NetworkID" type="OCTET_STRING"/>
             <arg name="NetworkIndex" type="INT8U"/>
-            <arg name="Breadcrumb" type="INT64U"/>
+            <arg name="Breadcrumb" type="INT64U" optional="true"/>
         </command>
     </cluster>
     <bitmap name="NetworkCommissioningFeature" type="BITMAP32">

--- a/src/app/zap-templates/zcl/data-model/chip/commissioning.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/commissioning.xml
@@ -76,7 +76,7 @@ limitations under the License.
     <cluster>
         <name>Network Commissioning</name>
         <domain>CHIP</domain>
-        <description>TODO</description>
+        <description>Functionality to configure, enable, disable network credentials and access on a Matter device.</description>
         <code>0x0031</code>
         <define>NETWORK_COMMISSIONING_CLUSTER</define>
         <client tick="false" init="false">true</client>
@@ -92,52 +92,52 @@ limitations under the License.
         <attribute side="server" code="0x0007" define="LAST_CONNECT_ERROR_VALUE" type="INT32S" writable="false" optional="false" isNullable="true">LastConnectErrorValue</attribute>
 
         <command source="client" code="0x00" name="ScanNetworks" optional="false" response="ScanNetworksResponse" cli="chip network_commissioning scannetworks">
-            <description>TODO</description>
+            <description>Detemine the set of networks the device sees as available.</description>
             <arg name="SSID" type="OCTET_STRING"/>
             <arg name="Breadcrumb" type="INT64U" optional="true"/>
         </command>
         <command source="server" code="0x01" name="ScanNetworksResponse" optional="false" cli="chip network_commissioning scannetworksresponse">
-            <description>TODO</description>
+            <description>Relay the set of networks the device sees as available back to the client.</description>
             <arg name="NetworkingStatus" type="NetworkCommissioningStatus"/>
             <arg name="DebugText" type="CHAR_STRING"/>
             <arg name="WiFiScanResults" type="WiFiInterfaceScanResult" array="true" optional="true"/>
             <arg name="ThreadScanResults" type="ThreadInterfaceScanResult" array="true" optional="true"/>
         </command>
         <command source="client" code="0x02" name="AddOrUpdateWiFiNetwork" optional="true" response="NetworkConfigResponse" cli="chip network_commissioning addorupdatewifinetwork">
-            <description>TODO</description>
+            <description>Add or update the credentials for a given Wi-Fi network.</description>
             <arg name="SSID" type="OCTET_STRING"/>
             <arg name="Credentials" type="OCTET_STRING"/>
             <arg name="breadcrumb" type="INT64U" optional="true"/>
         </command>
         <command source="client" code="0x03" name="AddOrUpdateThreadNetwork" optional="true" response="NetworkConfigResponse" cli="chip network_commissioning addorupdatethreadnetwork">
-            <description>TODO</description>
+            <description>Add or update the credentials for a given Thread network.</description>
             <arg name="OperationalDataset" type="OCTET_STRING"/>
             <arg name="Breadcrumb" type="INT64U" optional="true"/>
         </command>
         <command source="client" code="0x04" name="RemoveNetwork" optional="false" response="NetworkConfigResponse" cli="chip network_commissioning removenetwork">
-            <description>TODO</description>
+            <description>Remove the definition of a given network (including its credentials).</description>
             <arg name="NetworkID" type="OCTET_STRING"/>
             <arg name="Breadcrumb" type="INT64U" optional="true"/>
         </command>
         <command source="server" code="0x05" name="NetworkConfigResponse" optional="true" cli="chip network_commissioning addwifiresponse">
-            <description>TODO</description>
+            <description>Response command for various commands that add/remove/modify network credentials.</description>
             <arg name="NetworkingStatus" type="NetworkCommissioningStatus"/>
             <arg name="DebugText" type="CHAR_STRING" optional="true" />
             <arg name="NetworkIndex" type="INT8U" optional="true" />
         </command>
         <command source="client" code="0x06" name="ConnectNetwork" optional="false" response="ConnectNetworkResponse" cli="chip network_commissioning connectnetwork">
-            <description>TODO</description>
+            <description>Connect to the specified network, using previously-defined credentials.</description>
             <arg name="NetworkID" type="OCTET_STRING"/>
             <arg name="Breadcrumb" type="INT64U" optional="true"/>
         </command>
         <command source="server" code="0x07" name="ConnectNetworkResponse" optional="false" cli="chip network_commissioning connectnetworkresponse">
-            <description>TODO</description>
+            <description>Command that indicates whether we have succcessfully connected to a network.</description>
             <arg name="NetworkingStatus" type="NetworkCommissioningStatus"/>
             <arg name="DebugText" type="CHAR_STRING"/>
             <arg name="ErrorValue" type="INT32S"/>
         </command>
         <command source="client" code="0x08" name="ReorderNetwork" optional="false" response="NetworkConfigResponse" cli="chip network_commissioning connectnetwork">
-            <description>TODO</description>
+            <description>Modify the order in which networks will be presented in the Networks attribute.</description>
             <arg name="NetworkID" type="OCTET_STRING"/>
             <arg name="NetworkIndex" type="INT8U"/>
             <arg name="Breadcrumb" type="INT64U" optional="true"/>

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1879,7 +1879,7 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         NetworkCommissioning::Commands::AddOrUpdateWiFiNetwork::Type request;
         request.ssid        = params.GetWiFiCredentials().Value().ssid;
         request.credentials = params.GetWiFiCredentials().Value().credentials;
-        request.breadcrumb  = breadcrumb;
+        request.breadcrumb.Emplace(breadcrumb);
         SendCommand<NetworkCommissioningCluster>(proxy, request, OnNetworkConfigResponse, OnBasicFailure, endpoint, timeout);
     }
     break;
@@ -1892,7 +1892,7 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         }
         NetworkCommissioning::Commands::AddOrUpdateThreadNetwork::Type request;
         request.operationalDataset = params.GetThreadOperationalDataset().Value();
-        request.breadcrumb         = breadcrumb;
+        request.breadcrumb.Emplace(breadcrumb);
         SendCommand<NetworkCommissioningCluster>(proxy, request, OnNetworkConfigResponse, OnBasicFailure, endpoint, timeout);
     }
     break;
@@ -1904,8 +1904,8 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
             return;
         }
         NetworkCommissioning::Commands::ConnectNetwork::Type request;
-        request.networkID  = params.GetWiFiCredentials().Value().ssid;
-        request.breadcrumb = breadcrumb;
+        request.networkID = params.GetWiFiCredentials().Value().ssid;
+        request.breadcrumb.Emplace(breadcrumb);
         SendCommand<NetworkCommissioningCluster>(proxy, request, OnConnectNetworkResponse, OnBasicFailure, endpoint, timeout);
     }
     break;
@@ -1921,8 +1921,8 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
             return;
         }
         NetworkCommissioning::Commands::ConnectNetwork::Type request;
-        request.networkID  = extendedPanId;
-        request.breadcrumb = breadcrumb;
+        request.networkID = extendedPanId;
+        request.breadcrumb.Emplace(breadcrumb);
         SendCommand<NetworkCommissioningCluster>(proxy, request, OnConnectNetworkResponse, OnBasicFailure, endpoint, timeout);
     }
     break;

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -2465,34 +2465,34 @@ client cluster NetworkCommissioning = 49 {
 
   request struct ScanNetworksRequest {
     OCTET_STRING ssid = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
     OCTET_STRING ssid = 0;
     OCTET_STRING credentials = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
     OCTET_STRING operationalDataset = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
     OCTET_STRING networkID = 0;
-    INT64U breadcrumb = 1;
+    optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
     OCTET_STRING networkID = 0;
     INT8U networkIndex = 1;
-    INT64U breadcrumb = 2;
+    optional INT64U breadcrumb = 2;
   }
 
   response struct ScanNetworksResponse {

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -11337,21 +11337,26 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public void addOrUpdateThreadNetwork(
-        NetworkConfigResponseCallback callback, byte[] operationalDataset, Long breadcrumb) {
+        NetworkConfigResponseCallback callback,
+        byte[] operationalDataset,
+        Optional<Long> breadcrumb) {
       addOrUpdateThreadNetwork(chipClusterPtr, callback, operationalDataset, breadcrumb, null);
     }
 
     public void addOrUpdateThreadNetwork(
         NetworkConfigResponseCallback callback,
         byte[] operationalDataset,
-        Long breadcrumb,
+        Optional<Long> breadcrumb,
         int timedInvokeTimeoutMs) {
       addOrUpdateThreadNetwork(
           chipClusterPtr, callback, operationalDataset, breadcrumb, timedInvokeTimeoutMs);
     }
 
     public void addOrUpdateWiFiNetwork(
-        NetworkConfigResponseCallback callback, byte[] ssid, byte[] credentials, Long breadcrumb) {
+        NetworkConfigResponseCallback callback,
+        byte[] ssid,
+        byte[] credentials,
+        Optional<Long> breadcrumb) {
       addOrUpdateWiFiNetwork(chipClusterPtr, callback, ssid, credentials, breadcrumb, null);
     }
 
@@ -11359,34 +11364,34 @@ public class ChipClusters {
         NetworkConfigResponseCallback callback,
         byte[] ssid,
         byte[] credentials,
-        Long breadcrumb,
+        Optional<Long> breadcrumb,
         int timedInvokeTimeoutMs) {
       addOrUpdateWiFiNetwork(
           chipClusterPtr, callback, ssid, credentials, breadcrumb, timedInvokeTimeoutMs);
     }
 
     public void connectNetwork(
-        ConnectNetworkResponseCallback callback, byte[] networkID, Long breadcrumb) {
+        ConnectNetworkResponseCallback callback, byte[] networkID, Optional<Long> breadcrumb) {
       connectNetwork(chipClusterPtr, callback, networkID, breadcrumb, null);
     }
 
     public void connectNetwork(
         ConnectNetworkResponseCallback callback,
         byte[] networkID,
-        Long breadcrumb,
+        Optional<Long> breadcrumb,
         int timedInvokeTimeoutMs) {
       connectNetwork(chipClusterPtr, callback, networkID, breadcrumb, timedInvokeTimeoutMs);
     }
 
     public void removeNetwork(
-        NetworkConfigResponseCallback callback, byte[] networkID, Long breadcrumb) {
+        NetworkConfigResponseCallback callback, byte[] networkID, Optional<Long> breadcrumb) {
       removeNetwork(chipClusterPtr, callback, networkID, breadcrumb, null);
     }
 
     public void removeNetwork(
         NetworkConfigResponseCallback callback,
         byte[] networkID,
-        Long breadcrumb,
+        Optional<Long> breadcrumb,
         int timedInvokeTimeoutMs) {
       removeNetwork(chipClusterPtr, callback, networkID, breadcrumb, timedInvokeTimeoutMs);
     }
@@ -11395,7 +11400,7 @@ public class ChipClusters {
         NetworkConfigResponseCallback callback,
         byte[] networkID,
         Integer networkIndex,
-        Long breadcrumb) {
+        Optional<Long> breadcrumb) {
       reorderNetwork(chipClusterPtr, callback, networkID, networkIndex, breadcrumb, null);
     }
 
@@ -11403,20 +11408,21 @@ public class ChipClusters {
         NetworkConfigResponseCallback callback,
         byte[] networkID,
         Integer networkIndex,
-        Long breadcrumb,
+        Optional<Long> breadcrumb,
         int timedInvokeTimeoutMs) {
       reorderNetwork(
           chipClusterPtr, callback, networkID, networkIndex, breadcrumb, timedInvokeTimeoutMs);
     }
 
-    public void scanNetworks(ScanNetworksResponseCallback callback, byte[] ssid, Long breadcrumb) {
+    public void scanNetworks(
+        ScanNetworksResponseCallback callback, byte[] ssid, Optional<Long> breadcrumb) {
       scanNetworks(chipClusterPtr, callback, ssid, breadcrumb, null);
     }
 
     public void scanNetworks(
         ScanNetworksResponseCallback callback,
         byte[] ssid,
-        Long breadcrumb,
+        Optional<Long> breadcrumb,
         int timedInvokeTimeoutMs) {
       scanNetworks(chipClusterPtr, callback, ssid, breadcrumb, timedInvokeTimeoutMs);
     }
@@ -11425,7 +11431,7 @@ public class ChipClusters {
         long chipClusterPtr,
         NetworkConfigResponseCallback Callback,
         byte[] operationalDataset,
-        Long breadcrumb,
+        Optional<Long> breadcrumb,
         @Nullable Integer timedInvokeTimeoutMs);
 
     private native void addOrUpdateWiFiNetwork(
@@ -11433,21 +11439,21 @@ public class ChipClusters {
         NetworkConfigResponseCallback Callback,
         byte[] ssid,
         byte[] credentials,
-        Long breadcrumb,
+        Optional<Long> breadcrumb,
         @Nullable Integer timedInvokeTimeoutMs);
 
     private native void connectNetwork(
         long chipClusterPtr,
         ConnectNetworkResponseCallback Callback,
         byte[] networkID,
-        Long breadcrumb,
+        Optional<Long> breadcrumb,
         @Nullable Integer timedInvokeTimeoutMs);
 
     private native void removeNetwork(
         long chipClusterPtr,
         NetworkConfigResponseCallback Callback,
         byte[] networkID,
-        Long breadcrumb,
+        Optional<Long> breadcrumb,
         @Nullable Integer timedInvokeTimeoutMs);
 
     private native void reorderNetwork(
@@ -11455,14 +11461,14 @@ public class ChipClusters {
         NetworkConfigResponseCallback Callback,
         byte[] networkID,
         Integer networkIndex,
-        Long breadcrumb,
+        Optional<Long> breadcrumb,
         @Nullable Integer timedInvokeTimeoutMs);
 
     private native void scanNetworks(
         long chipClusterPtr,
         ScanNetworksResponseCallback Callback,
         byte[] ssid,
-        Long breadcrumb,
+        Optional<Long> breadcrumb,
         @Nullable Integer timedInvokeTimeoutMs);
 
     public interface ConnectNetworkResponseCallback {

--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
@@ -10379,7 +10379,7 @@ public class ClusterInfoMapping {
 
     CommandParameterInfo
         networkCommissioningaddOrUpdateThreadNetworkbreadcrumbCommandParameterInfo =
-            new CommandParameterInfo("breadcrumb", Long.class);
+            new CommandParameterInfo("breadcrumb", Optional.class);
     networkCommissioningaddOrUpdateThreadNetworkCommandParams.put(
         "breadcrumb", networkCommissioningaddOrUpdateThreadNetworkbreadcrumbCommandParameterInfo);
 
@@ -10391,7 +10391,7 @@ public class ClusterInfoMapping {
                       (ChipClusters.NetworkCommissioningCluster.NetworkConfigResponseCallback)
                           callback,
                       (byte[]) commandArguments.get("operationalDataset"),
-                      (Long) commandArguments.get("breadcrumb"));
+                      (Optional<Long>) commandArguments.get("breadcrumb"));
             },
             () -> new DelegatedNetworkConfigResponseCallback(),
             networkCommissioningaddOrUpdateThreadNetworkCommandParams);
@@ -10410,7 +10410,7 @@ public class ClusterInfoMapping {
         "credentials", networkCommissioningaddOrUpdateWiFiNetworkcredentialsCommandParameterInfo);
 
     CommandParameterInfo networkCommissioningaddOrUpdateWiFiNetworkbreadcrumbCommandParameterInfo =
-        new CommandParameterInfo("breadcrumb", Long.class);
+        new CommandParameterInfo("breadcrumb", Optional.class);
     networkCommissioningaddOrUpdateWiFiNetworkCommandParams.put(
         "breadcrumb", networkCommissioningaddOrUpdateWiFiNetworkbreadcrumbCommandParameterInfo);
 
@@ -10423,7 +10423,7 @@ public class ClusterInfoMapping {
                           callback,
                       (byte[]) commandArguments.get("ssid"),
                       (byte[]) commandArguments.get("credentials"),
-                      (Long) commandArguments.get("breadcrumb"));
+                      (Optional<Long>) commandArguments.get("breadcrumb"));
             },
             () -> new DelegatedNetworkConfigResponseCallback(),
             networkCommissioningaddOrUpdateWiFiNetworkCommandParams);
@@ -10437,7 +10437,7 @@ public class ClusterInfoMapping {
         "networkID", networkCommissioningconnectNetworknetworkIDCommandParameterInfo);
 
     CommandParameterInfo networkCommissioningconnectNetworkbreadcrumbCommandParameterInfo =
-        new CommandParameterInfo("breadcrumb", Long.class);
+        new CommandParameterInfo("breadcrumb", Optional.class);
     networkCommissioningconnectNetworkCommandParams.put(
         "breadcrumb", networkCommissioningconnectNetworkbreadcrumbCommandParameterInfo);
 
@@ -10449,7 +10449,7 @@ public class ClusterInfoMapping {
                       (ChipClusters.NetworkCommissioningCluster.ConnectNetworkResponseCallback)
                           callback,
                       (byte[]) commandArguments.get("networkID"),
-                      (Long) commandArguments.get("breadcrumb"));
+                      (Optional<Long>) commandArguments.get("breadcrumb"));
             },
             () -> new DelegatedConnectNetworkResponseCallback(),
             networkCommissioningconnectNetworkCommandParams);
@@ -10463,7 +10463,7 @@ public class ClusterInfoMapping {
         "networkID", networkCommissioningremoveNetworknetworkIDCommandParameterInfo);
 
     CommandParameterInfo networkCommissioningremoveNetworkbreadcrumbCommandParameterInfo =
-        new CommandParameterInfo("breadcrumb", Long.class);
+        new CommandParameterInfo("breadcrumb", Optional.class);
     networkCommissioningremoveNetworkCommandParams.put(
         "breadcrumb", networkCommissioningremoveNetworkbreadcrumbCommandParameterInfo);
 
@@ -10475,7 +10475,7 @@ public class ClusterInfoMapping {
                       (ChipClusters.NetworkCommissioningCluster.NetworkConfigResponseCallback)
                           callback,
                       (byte[]) commandArguments.get("networkID"),
-                      (Long) commandArguments.get("breadcrumb"));
+                      (Optional<Long>) commandArguments.get("breadcrumb"));
             },
             () -> new DelegatedNetworkConfigResponseCallback(),
             networkCommissioningremoveNetworkCommandParams);
@@ -10494,7 +10494,7 @@ public class ClusterInfoMapping {
         "networkIndex", networkCommissioningreorderNetworknetworkIndexCommandParameterInfo);
 
     CommandParameterInfo networkCommissioningreorderNetworkbreadcrumbCommandParameterInfo =
-        new CommandParameterInfo("breadcrumb", Long.class);
+        new CommandParameterInfo("breadcrumb", Optional.class);
     networkCommissioningreorderNetworkCommandParams.put(
         "breadcrumb", networkCommissioningreorderNetworkbreadcrumbCommandParameterInfo);
 
@@ -10507,7 +10507,7 @@ public class ClusterInfoMapping {
                           callback,
                       (byte[]) commandArguments.get("networkID"),
                       (Integer) commandArguments.get("networkIndex"),
-                      (Long) commandArguments.get("breadcrumb"));
+                      (Optional<Long>) commandArguments.get("breadcrumb"));
             },
             () -> new DelegatedNetworkConfigResponseCallback(),
             networkCommissioningreorderNetworkCommandParams);
@@ -10521,7 +10521,7 @@ public class ClusterInfoMapping {
         "ssid", networkCommissioningscanNetworksssidCommandParameterInfo);
 
     CommandParameterInfo networkCommissioningscanNetworksbreadcrumbCommandParameterInfo =
-        new CommandParameterInfo("breadcrumb", Long.class);
+        new CommandParameterInfo("breadcrumb", Optional.class);
     networkCommissioningscanNetworksCommandParams.put(
         "breadcrumb", networkCommissioningscanNetworksbreadcrumbCommandParameterInfo);
 
@@ -10533,7 +10533,7 @@ public class ClusterInfoMapping {
                       (ChipClusters.NetworkCommissioningCluster.ScanNetworksResponseCallback)
                           callback,
                       (byte[]) commandArguments.get("ssid"),
-                      (Long) commandArguments.get("breadcrumb"));
+                      (Optional<Long>) commandArguments.get("breadcrumb"));
             },
             () -> new DelegatedScanNetworksResponseCallback(),
             networkCommissioningscanNetworksCommandParams);

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -9629,11 +9629,11 @@ class NetworkCommissioning(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="ssid", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="breadcrumb", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="breadcrumb", Tag=1, Type=typing.Optional[uint]),
                     ])
 
             ssid: 'bytes' = b""
-            breadcrumb: 'uint' = 0
+            breadcrumb: 'typing.Optional[uint]' = None
 
         @dataclass
         class ScanNetworksResponse(ClusterCommand):
@@ -9668,12 +9668,12 @@ class NetworkCommissioning(Cluster):
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="ssid", Tag=0, Type=bytes),
                             ClusterObjectFieldDescriptor(Label="credentials", Tag=1, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="breadcrumb", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="breadcrumb", Tag=2, Type=typing.Optional[uint]),
                     ])
 
             ssid: 'bytes' = b""
             credentials: 'bytes' = b""
-            breadcrumb: 'uint' = 0
+            breadcrumb: 'typing.Optional[uint]' = None
 
         @dataclass
         class AddOrUpdateThreadNetwork(ClusterCommand):
@@ -9686,11 +9686,11 @@ class NetworkCommissioning(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="operationalDataset", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="breadcrumb", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="breadcrumb", Tag=1, Type=typing.Optional[uint]),
                     ])
 
             operationalDataset: 'bytes' = b""
-            breadcrumb: 'uint' = 0
+            breadcrumb: 'typing.Optional[uint]' = None
 
         @dataclass
         class RemoveNetwork(ClusterCommand):
@@ -9703,11 +9703,11 @@ class NetworkCommissioning(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="networkID", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="breadcrumb", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="breadcrumb", Tag=1, Type=typing.Optional[uint]),
                     ])
 
             networkID: 'bytes' = b""
-            breadcrumb: 'uint' = 0
+            breadcrumb: 'typing.Optional[uint]' = None
 
         @dataclass
         class NetworkConfigResponse(ClusterCommand):
@@ -9739,11 +9739,11 @@ class NetworkCommissioning(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="networkID", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="breadcrumb", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="breadcrumb", Tag=1, Type=typing.Optional[uint]),
                     ])
 
             networkID: 'bytes' = b""
-            breadcrumb: 'uint' = 0
+            breadcrumb: 'typing.Optional[uint]' = None
 
         @dataclass
         class ConnectNetworkResponse(ClusterCommand):
@@ -9776,12 +9776,12 @@ class NetworkCommissioning(Cluster):
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="networkID", Tag=0, Type=bytes),
                             ClusterObjectFieldDescriptor(Label="networkIndex", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="breadcrumb", Tag=2, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="breadcrumb", Tag=2, Type=typing.Optional[uint]),
                     ])
 
             networkID: 'bytes' = b""
             networkIndex: 'uint' = 0
-            breadcrumb: 'uint' = 0
+            breadcrumb: 'typing.Optional[uint]' = None
 
 
     class Attributes:

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -27476,7 +27476,10 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     NetworkCommissioning::Commands::AddOrUpdateThreadNetwork::Type request;
     request.operationalDataset = [self asByteSpan:params.operationalDataset];
-    request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
+    if (params.breadcrumb != nil) {
+        auto & definedValue_0 = request.breadcrumb.Emplace();
+        definedValue_0 = params.breadcrumb.unsignedLongLongValue;
+    }
 
     new CHIPNetworkCommissioningClusterNetworkConfigResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -27494,7 +27497,10 @@ using namespace chip::app::Clusters;
     NetworkCommissioning::Commands::AddOrUpdateWiFiNetwork::Type request;
     request.ssid = [self asByteSpan:params.ssid];
     request.credentials = [self asByteSpan:params.credentials];
-    request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
+    if (params.breadcrumb != nil) {
+        auto & definedValue_0 = request.breadcrumb.Emplace();
+        definedValue_0 = params.breadcrumb.unsignedLongLongValue;
+    }
 
     new CHIPNetworkCommissioningClusterNetworkConfigResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -27511,7 +27517,10 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     NetworkCommissioning::Commands::ConnectNetwork::Type request;
     request.networkID = [self asByteSpan:params.networkID];
-    request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
+    if (params.breadcrumb != nil) {
+        auto & definedValue_0 = request.breadcrumb.Emplace();
+        definedValue_0 = params.breadcrumb.unsignedLongLongValue;
+    }
 
     new CHIPNetworkCommissioningClusterConnectNetworkResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -27528,7 +27537,10 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     NetworkCommissioning::Commands::RemoveNetwork::Type request;
     request.networkID = [self asByteSpan:params.networkID];
-    request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
+    if (params.breadcrumb != nil) {
+        auto & definedValue_0 = request.breadcrumb.Emplace();
+        definedValue_0 = params.breadcrumb.unsignedLongLongValue;
+    }
 
     new CHIPNetworkCommissioningClusterNetworkConfigResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -27546,7 +27558,10 @@ using namespace chip::app::Clusters;
     NetworkCommissioning::Commands::ReorderNetwork::Type request;
     request.networkID = [self asByteSpan:params.networkID];
     request.networkIndex = params.networkIndex.unsignedCharValue;
-    request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
+    if (params.breadcrumb != nil) {
+        auto & definedValue_0 = request.breadcrumb.Emplace();
+        definedValue_0 = params.breadcrumb.unsignedLongLongValue;
+    }
 
     new CHIPNetworkCommissioningClusterNetworkConfigResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -27563,7 +27578,10 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     NetworkCommissioning::Commands::ScanNetworks::Type request;
     request.ssid = [self asByteSpan:params.ssid];
-    request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
+    if (params.breadcrumb != nil) {
+        auto & definedValue_0 = request.breadcrumb.Emplace();
+        definedValue_0 = params.breadcrumb.unsignedLongLongValue;
+    }
 
     new CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge(
         self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
@@ -647,7 +647,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPNetworkCommissioningClusterScanNetworksParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull ssid;
-@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (strong, nonatomic) NSNumber * _Nullable breadcrumb;
 - (instancetype)init;
 @end
 
@@ -662,19 +662,19 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CHIPNetworkCommissioningClusterAddOrUpdateWiFiNetworkParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull ssid;
 @property (strong, nonatomic) NSData * _Nonnull credentials;
-@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (strong, nonatomic) NSNumber * _Nullable breadcrumb;
 - (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterAddOrUpdateThreadNetworkParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull operationalDataset;
-@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (strong, nonatomic) NSNumber * _Nullable breadcrumb;
 - (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterRemoveNetworkParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull networkID;
-@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (strong, nonatomic) NSNumber * _Nullable breadcrumb;
 - (instancetype)init;
 @end
 
@@ -687,7 +687,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPNetworkCommissioningClusterConnectNetworkParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull networkID;
-@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (strong, nonatomic) NSNumber * _Nullable breadcrumb;
 - (instancetype)init;
 @end
 
@@ -701,7 +701,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CHIPNetworkCommissioningClusterReorderNetworkParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull networkID;
 @property (strong, nonatomic) NSNumber * _Nonnull networkIndex;
-@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (strong, nonatomic) NSNumber * _Nullable breadcrumb;
 - (instancetype)init;
 @end
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
@@ -1361,7 +1361,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _ssid = [NSData data];
 
-        _breadcrumb = @(0);
+        _breadcrumb = nil;
     }
     return self;
 }
@@ -1393,7 +1393,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _credentials = [NSData data];
 
-        _breadcrumb = @(0);
+        _breadcrumb = nil;
     }
     return self;
 }
@@ -1406,7 +1406,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _operationalDataset = [NSData data];
 
-        _breadcrumb = @(0);
+        _breadcrumb = nil;
     }
     return self;
 }
@@ -1419,7 +1419,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _networkID = [NSData data];
 
-        _breadcrumb = @(0);
+        _breadcrumb = nil;
     }
     return self;
 }
@@ -1447,7 +1447,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _networkID = [NSData data];
 
-        _breadcrumb = @(0);
+        _breadcrumb = nil;
     }
     return self;
 }
@@ -1477,7 +1477,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         _networkIndex = @(0);
 
-        _breadcrumb = @(0);
+        _breadcrumb = nil;
     }
     return self;
 }

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -10835,7 +10835,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan ssid;
-    uint64_t breadcrumb = static_cast<uint64_t>(0);
+    Optional<uint64_t> breadcrumb;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -10851,7 +10851,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan ssid;
-    uint64_t breadcrumb = static_cast<uint64_t>(0);
+    Optional<uint64_t> breadcrumb;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ScanNetworks
@@ -10913,7 +10913,7 @@ public:
 
     chip::ByteSpan ssid;
     chip::ByteSpan credentials;
-    uint64_t breadcrumb = static_cast<uint64_t>(0);
+    Optional<uint64_t> breadcrumb;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -10930,7 +10930,7 @@ public:
 
     chip::ByteSpan ssid;
     chip::ByteSpan credentials;
-    uint64_t breadcrumb = static_cast<uint64_t>(0);
+    Optional<uint64_t> breadcrumb;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace AddOrUpdateWiFiNetwork
@@ -10949,7 +10949,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan operationalDataset;
-    uint64_t breadcrumb = static_cast<uint64_t>(0);
+    Optional<uint64_t> breadcrumb;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -10965,7 +10965,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan operationalDataset;
-    uint64_t breadcrumb = static_cast<uint64_t>(0);
+    Optional<uint64_t> breadcrumb;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace AddOrUpdateThreadNetwork
@@ -10984,7 +10984,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan networkID;
-    uint64_t breadcrumb = static_cast<uint64_t>(0);
+    Optional<uint64_t> breadcrumb;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -11000,7 +11000,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan networkID;
-    uint64_t breadcrumb = static_cast<uint64_t>(0);
+    Optional<uint64_t> breadcrumb;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RemoveNetwork
@@ -11057,7 +11057,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan networkID;
-    uint64_t breadcrumb = static_cast<uint64_t>(0);
+    Optional<uint64_t> breadcrumb;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -11073,7 +11073,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan networkID;
-    uint64_t breadcrumb = static_cast<uint64_t>(0);
+    Optional<uint64_t> breadcrumb;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ConnectNetwork
@@ -11132,7 +11132,7 @@ public:
 
     chip::ByteSpan networkID;
     uint8_t networkIndex = static_cast<uint8_t>(0);
-    uint64_t breadcrumb  = static_cast<uint64_t>(0);
+    Optional<uint64_t> breadcrumb;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -11149,7 +11149,7 @@ public:
 
     chip::ByteSpan networkID;
     uint8_t networkIndex = static_cast<uint8_t>(0);
-    uint64_t breadcrumb  = static_cast<uint64_t>(0);
+    Optional<uint64_t> breadcrumb;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ReorderNetwork


### PR DESCRIPTION
It's optional in the spec.

#### Problem
Spec not correctly implemented for network commissioning cluster commands.

#### Change overview
Fix the cluster XML to match the spec.

#### Testing
No behavior changes due to https://github.com/project-chip/connectedhomeip/issues/17002, but tested that tree compiles.