### PR TITLE
RPC: Use non-blocking serial for console

### DIFF
--- a/examples/common/pigweed/rpc_console/py/chip_rpc/console.py
+++ b/examples/common/pigweed/rpc_console/py/chip_rpc/console.py
@@ -325,7 +325,7 @@ def console(device: str, baudrate: int,
     serial_impl = SerialWithLogging
 
     if socket_addr is None:
-        serial_device = serial_impl(device, baudrate, timeout=1)
+        serial_device = serial_impl(device, baudrate, timeout=0)
         def read(): return serial_device.read(8192)
         write = serial_device.write
     else:


### PR DESCRIPTION
#### Problem
Currently serial is opened using a timeout of 1 second, this limits the throughput to 1 RPC per second, and makes scripts using RPCs slow. 

Pigweed has now switched to use non-blocking: https://pigweed-review.googlesource.com/c/pigweed/pigweed/+/89940

#### Change overview
Switch our console to open the serial in non-blocking.

#### Testing
Verified basic console functionality with m5stack.

Tested running 500 RPC reads in a loop, this is over 100 times faster after this change.
