### PR TITLE
Remove unused `FindDestinationIDCandidate` API

### DIFF
--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -392,9 +392,6 @@ public:
     FabricInfo * FindFabricWithIndex(FabricIndex fabricIndex);
     FabricInfo * FindFabricWithCompressedId(CompressedFabricId fabricId);
 
-    FabricIndex FindDestinationIDCandidate(const ByteSpan & destinationId, const ByteSpan & initiatorRandom,
-                                           const ByteSpan * ipkList, size_t ipkListEntries);
-
     CHIP_ERROR Init(PersistentStorageDelegate * storage);
     CHIP_ERROR AddFabricDelegate(FabricTableDelegate * delegate);
 


### PR DESCRIPTION
#### Problem
- `FabricTable::FindDestinationIDCandidate` is declared, but used nowhere
  since the IPK refactor of #16737, and not implemented either. It is
  100% dead code.

#### Change overview
- Remove stale `FindDestinationIDCandidate` API

#### Testing
- No functional change, removes dead code
- Unit tests and integration tests still pass