### PR TITLE
[OTA] Make default requestor driver more consistently named

### DIFF
--- a/config/mbed/CMakeLists.txt
+++ b/config/mbed/CMakeLists.txt
@@ -473,8 +473,8 @@ if (CONFIG_CHIP_OTA_REQUESTOR)
     target_sources(${APP_TARGET} PRIVATE
         ${CHIP_ROOT}/examples/platform/mbed/ota/OTARequestorDriverImpl.cpp
         ${CHIP_ROOT}/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+        ${CHIP_ROOT}/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
         ${CHIP_ROOT}/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
-        ${CHIP_ROOT}/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
         ${CHIP_ROOT}/src/app/clusters/ota-requestor/BDXDownloader.cpp
         ${CHIP_ROOT}/src/platform/mbed/OTAImageProcessorImpl.cpp
     )

--- a/examples/all-clusters-app/ameba/chip_main.cmake
+++ b/examples/all-clusters-app/ameba/chip_main.cmake
@@ -118,8 +118,8 @@ list(
     #OTARequestor
     ${chip_dir}/src/app/clusters/ota-requestor/BDXDownloader.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+    ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
-    ${chip_dir}/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/ota-requestor-server.cpp
 )
 endif (matter_enable_ota_requestor)

--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -43,7 +43,7 @@
 #include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <platform/Ameba/AmebaOTAImageProcessor.h>
 #endif
 
@@ -101,7 +101,7 @@ static DeviceCallbacks EchoCallbacks;
 #if CONFIG_ENABLE_OTA_REQUESTOR
 DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
-GenericOTARequestorDriver gRequestorUser;
+DefaultOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 AmebaOTAImageProcessor gImageProcessor;
 #endif

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -39,8 +39,8 @@
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/util/af.h>
 #include <binding-handler.h>
@@ -79,7 +79,7 @@ namespace {
 #if CONFIG_ENABLE_OTA_REQUESTOR
 DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
-GenericOTARequestorDriver gRequestorUser;
+DefaultOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
 #endif

--- a/examples/lighting-app/ameba/chip_main.cmake
+++ b/examples/lighting-app/ameba/chip_main.cmake
@@ -16,8 +16,8 @@ list(
     #OTARequestor
     ${chip_dir}/src/app/clusters/ota-requestor/BDXDownloader.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+    ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
-    ${chip_dir}/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/ota-requestor-server.cpp
 )
 endif (matter_enable_ota_requestor)

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -46,7 +46,7 @@
 #include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <platform/Ameba/AmebaOTAImageProcessor.h>
 #endif
 
@@ -86,7 +86,7 @@ static DeviceCallbacks EchoCallbacks;
 #if CONFIG_ENABLE_OTA_REQUESTOR
 DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
-GenericOTARequestorDriver gRequestorUser;
+DefaultOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 AmebaOTAImageProcessor gImageProcessor;
 #endif

--- a/examples/lighting-app/esp32/main/main.cpp
+++ b/examples/lighting-app/esp32/main/main.cpp
@@ -29,8 +29,8 @@
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/server/Dnssd.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
@@ -47,7 +47,7 @@ using namespace ::chip::DeviceLayer;
 #if CONFIG_ENABLE_OTA_REQUESTOR
 DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
-GenericOTARequestorDriver gRequestorUser;
+DefaultOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
 #endif

--- a/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -38,8 +38,8 @@
 #include "OtaSupport.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 
 #include "Keyboard.h"
 #include "LED.h"
@@ -87,7 +87,7 @@ AppTask AppTask::sAppTask;
 /* OTA related variables */
 static DefaultOTARequestor gRequestorCore;
 static DefaultOTARequestorStorage gRequestorStorage;
-static DeviceLayer::GenericOTARequestorDriver gRequestorUser;
+static DeviceLayer::DefaultOTARequestorDriver gRequestorUser;
 static BDXDownloader gDownloader;
 static OTAImageProcessorImpl gImageProcessor;
 

--- a/examples/lighting-app/telink/CMakeLists.txt
+++ b/examples/lighting-app/telink/CMakeLists.txt
@@ -107,6 +107,6 @@ target_sources(app PRIVATE
                ${CHIP_ROOT}/src/app/clusters/ota-requestor/ota-requestor-server.cpp
                ${CHIP_ROOT}/src/app/clusters/ota-requestor/BDXDownloader.cpp
                ${CHIP_ROOT}/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
-               ${CHIP_ROOT}/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
+               ${CHIP_ROOT}/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
                ${CHIP_ROOT}/src/app/clusters/groups-server/groups-server.cpp
                )

--- a/examples/lock-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/lock-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -31,8 +31,8 @@
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPPlatformMemory.h>
 #include <platform/cc13x2_26x2/OTAImageProcessorImpl.h>
@@ -65,7 +65,7 @@ AppTask AppTask::sAppTask;
 
 static DefaultOTARequestor sRequestorCore;
 static DefaultOTARequestorStorage sRequestorStorage;
-static GenericOTARequestorDriver sRequestorUser;
+static DefaultOTARequestorDriver sRequestorUser;
 static BDXDownloader sDownloader;
 static OTAImageProcessorImpl sImageProcessor;
 

--- a/examples/ota-requestor-app/ameba/chip_main.cmake
+++ b/examples/ota-requestor-app/ameba/chip_main.cmake
@@ -24,8 +24,8 @@ list(
 
     ${chip_dir}/src/app/clusters/ota-requestor/BDXDownloader.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+    ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
-    ${chip_dir}/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/ota-requestor-server.cpp
 )
 

--- a/examples/ota-requestor-app/ameba/main/chipinterface.cpp
+++ b/examples/ota-requestor-app/ameba/main/chipinterface.cpp
@@ -35,8 +35,8 @@
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <platform/Ameba/AmebaOTAImageProcessor.h>
 
 void * __dso_handle = 0;
@@ -87,7 +87,7 @@ static DeviceCallbacks EchoCallbacks;
 
 DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
-GenericOTARequestorDriver gRequestorUser;
+DefaultOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 AmebaOTAImageProcessor gImageProcessor;
 

--- a/examples/ota-requestor-app/cyw30739/src/main.cpp
+++ b/examples/ota-requestor-app/cyw30739/src/main.cpp
@@ -19,8 +19,8 @@
 #include <ChipShellCollection.h>
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/server/Server.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <lib/shell/Engine.h>
@@ -44,7 +44,7 @@ static void InitApp(intptr_t args);
 
 DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
-DeviceLayer::GenericOTARequestorDriver gRequestorUser;
+DeviceLayer::DefaultOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
 

--- a/examples/ota-requestor-app/efr32/src/AppTask.cpp
+++ b/examples/ota-requestor-app/efr32/src/AppTask.cpp
@@ -36,8 +36,8 @@
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <platform/EFR32/OTAImageProcessorImpl.h>
 
 #include <assert.h>
@@ -102,7 +102,7 @@ using namespace ::chip::DeviceLayer;
 // Global OTA objects
 DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
-DeviceLayer::GenericOTARequestorDriver gRequestorUser;
+DeviceLayer::DefaultOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
 

--- a/examples/ota-requestor-app/esp32/main/main.cpp
+++ b/examples/ota-requestor-app/esp32/main/main.cpp
@@ -31,8 +31,8 @@
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/server/Server.h>
 #include <platform/ESP32/NetworkCommissioningDriver.h>
 
@@ -55,7 +55,7 @@ static DeviceCallbacks EchoCallbacks;
 
 DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
-GenericOTARequestorDriver gRequestorUser;
+DefaultOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
 

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -126,7 +126,7 @@ void CustomOTARequestorDriver::UpdateDownloaded()
     if (gAutoApplyImage)
     {
         // Let the default driver take further action to apply the image
-        GenericOTARequestorDriver::UpdateDownloaded();
+        DefaultOTARequestorDriver::UpdateDownloaded();
     }
     else
     {

--- a/examples/ota-requestor-app/p6/src/AppTask.cpp
+++ b/examples/ota-requestor-app/p6/src/AppTask.cpp
@@ -30,8 +30,8 @@
 #include <app-common/zap-generated/cluster-id.h>
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/server/Dnssd.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
@@ -95,7 +95,7 @@ StaticTask_t appTaskStruct;
 
 DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
-GenericOTARequestorDriver gRequestorUser;
+DefaultOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
 

--- a/examples/platform/efr32/OTAConfig.cpp
+++ b/examples/platform/efr32/OTAConfig.cpp
@@ -63,7 +63,7 @@ __attribute__((used)) ApplicationProperties_t sl_app_properties = {
 // Global OTA objects
 chip::DefaultOTARequestor gRequestorCore;
 chip::DefaultOTARequestorStorage gRequestorStorage;
-chip::DeviceLayer::GenericOTARequestorDriver gRequestorUser;
+chip::DeviceLayer::DefaultOTARequestorDriver gRequestorUser;
 chip::BDXDownloader gDownloader;
 chip::OTAImageProcessorImpl gImageProcessor;
 

--- a/examples/platform/efr32/OTAConfig.h
+++ b/examples/platform/efr32/OTAConfig.h
@@ -20,8 +20,8 @@
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <platform/EFR32/OTAImageProcessorImpl.h>
 
 class OTAConfig

--- a/examples/platform/mbed/ota/OTARequestorDriverImpl.h
+++ b/examples/platform/mbed/ota/OTARequestorDriverImpl.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestorDriver.h>
 #include <app/clusters/ota-requestor/OTARequestorInterface.h>
 #include <lib/core/CHIPCallback.h>
@@ -38,10 +38,10 @@ namespace DeviceLayer {
 typedef bool (*OnOtaUpdateAvailable)(void * context, const UpdateDescription &);
 typedef bool (*OnOtaUpdateApply)(void * context);
 
-class OTARequestorDriverImpl : public GenericOTARequestorDriver
+class OTARequestorDriverImpl : public DefaultOTARequestorDriver
 {
 
-    friend class GenericOTARequestorDriver;
+    friend class DefaultOTARequestorDriver;
 
 public:
     void Init(OTARequestorInterface * requestor, OTAImageProcessorInterface * processor,

--- a/examples/platform/nrfconnect/util/OTAUtil.cpp
+++ b/examples/platform/nrfconnect/util/OTAUtil.cpp
@@ -17,8 +17,8 @@
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <app/server/Server.h>
 #include <platform/nrfconnect/OTAImageProcessorImpl.h>
 
@@ -28,7 +28,7 @@ using namespace chip::DeviceLayer;
 namespace {
 
 DefaultOTARequestorStorage sOTARequestorStorage;
-GenericOTARequestorDriver sOTARequestorDriver;
+DefaultOTARequestorDriver sOTARequestorDriver;
 chip::BDXDownloader sBDXDownloader;
 chip::DefaultOTARequestor sOTARequestor;
 

--- a/examples/platform/qpg/ota/ota.cpp
+++ b/examples/platform/qpg/ota/ota.cpp
@@ -29,8 +29,8 @@
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <platform/qpg/OTAImageProcessorImpl.h>
 
 using namespace chip;
@@ -42,7 +42,7 @@ using namespace chip::DeviceLayer;
 
 DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
-GenericOTARequestorDriver gRequestorUser;
+DefaultOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
 OTAImageProcessorImpl gImageProcessor;
 

--- a/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -34,8 +34,8 @@
 #if defined(CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR)
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <platform/cc13x2_26x2/OTAImageProcessorImpl.h>
 #endif
 #include <app-common/zap-generated/attributes/Accessors.h>
@@ -78,7 +78,7 @@ AppTask AppTask::sAppTask;
 #if defined(CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR)
 static DefaultOTARequestor sRequestorCore;
 static DefaultOTARequestorStorage sRequestorStorage;
-static GenericOTARequestorDriver sRequestorUser;
+static DefaultOTARequestorDriver sRequestorUser;
 static BDXDownloader sDownloader;
 static OTAImageProcessorImpl sImageProcessor;
 

--- a/examples/pump-controller-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/pump-controller-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -32,8 +32,8 @@
 #if defined(CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR)
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
-#include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
 #include <platform/cc13x2_26x2/OTAImageProcessorImpl.h>
 #endif
 #include <app-common/zap-generated/attributes/Accessors.h>
@@ -70,7 +70,7 @@ AppTask AppTask::sAppTask;
 #if defined(CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR)
 static DefaultOTARequestor sRequestorCore;
 static DefaultOTARequestorStorage sRequestorStorage;
-static GenericOTARequestorDriver sRequestorUser;
+static DefaultOTARequestorDriver sRequestorUser;
 static BDXDownloader sDownloader;
 static OTAImageProcessorImpl sImageProcessor;
 

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -133,11 +133,11 @@ template("chip_data_model") {
           "${_app_root}/clusters/${cluster}/BDXDownloader.cpp",
           "${_app_root}/clusters/${cluster}/BDXDownloader.h",
           "${_app_root}/clusters/${cluster}/DefaultOTARequestor.cpp",
+          "${_app_root}/clusters/${cluster}/DefaultOTARequestorDriver.cpp",
           "${_app_root}/clusters/${cluster}/DefaultOTARequestorStorage.cpp",
           "${_app_root}/clusters/${cluster}/DefaultOTARequestorStorage.h",
           "${_app_root}/clusters/${cluster}/DefaultOTARequestorUserConsent.h",
           "${_app_root}/clusters/${cluster}/ExtendedOTARequestorDriver.cpp",
-          "${_app_root}/clusters/${cluster}/GenericOTARequestorDriver.cpp",
           "${_app_root}/clusters/${cluster}/OTARequestorStorage.h",
         ]
       } else if (cluster == "bindings") {

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
@@ -29,7 +29,7 @@ class OTAImageProcessorInterface;
 
 namespace DeviceLayer {
 
-class GenericOTARequestorDriver : public OTARequestorDriver
+class DefaultOTARequestorDriver : public OTARequestorDriver
 {
 public:
     /**

--- a/src/app/clusters/ota-requestor/ExtendedOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/ExtendedOTARequestorDriver.cpp
@@ -58,7 +58,7 @@ void ExtendedOTARequestorDriver::UpdateAvailable(const UpdateDescription & updat
         return;
     }
 
-    GenericOTARequestorDriver::UpdateAvailable(update, delay);
+    DefaultOTARequestorDriver::UpdateAvailable(update, delay);
 }
 
 void ExtendedOTARequestorDriver::PollUserConsentState()

--- a/src/app/clusters/ota-requestor/ExtendedOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/ExtendedOTARequestorDriver.h
@@ -18,16 +18,16 @@
 #include <app/clusters/ota-requestor/OTARequestorUserConsentDelegate.h>
 #include <platform/CHIPDeviceLayer.h>
 
-#include "GenericOTARequestorDriver.h"
+#include "DefaultOTARequestorDriver.h"
 
 namespace chip {
 namespace DeviceLayer {
 
 /**
- * This extends the GenericOTARequestorDriver and provides optional
+ * This extends the DefaultOTARequestorDriver and provides optional
  * features. For now, it adds support for the handling user consent.
  */
-class ExtendedOTARequestorDriver : public GenericOTARequestorDriver
+class ExtendedOTARequestorDriver : public DefaultOTARequestorDriver
 {
 public:
     bool CanConsent() override;

--- a/src/app/clusters/ota-requestor/OTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/OTARequestorDriver.h
@@ -85,7 +85,7 @@ public:
 
     virtual ~OTARequestorDriver() = default;
 
-    /// Return if the device provides UI for asking a user for consent before downloading a software image
+    /// Return true if the device has the ability to ask the user for consent before downloading a software image
     virtual bool CanConsent() = 0;
 
     /// Return maximum supported download block size
@@ -124,8 +124,8 @@ public:
     /// Inform the driver that the device commissioning has completed
     virtual void OTACommissioningCallback() = 0;
 
-    virtual void
     /// Driver portion of the logic for processing the AnnounceOTAProviders command
+    virtual void
     ProcessAnnounceOTAProviders(const ProviderLocationType & providerLocation,
                                 app::Clusters::OtaSoftwareUpdateRequestor::OTAAnnouncementReason announcementReason) = 0;
 
@@ -138,7 +138,7 @@ public:
     // Driver picks the OTA Provider that should be used for the next query and update. The Provider is picked according to
     // the driver's internal logic such as, for example, traversing the default providers list.
     // Returns true if there is a Provider available for the next query, returns false otherwise.
-    // [in] listExhausted - set to TRUE if the list of providers has been traversed until the end and has looped
+    // @param[out] listExhausted - set to TRUE if the list of providers has been traversed until the end and has looped
     // back to the beginning.
     virtual bool GetNextProviderLocation(ProviderLocationType & providerLocation, bool & listExhausted) = 0;
 };


### PR DESCRIPTION
#### Problem
All default implementations for various OTA Requestor components are aptly named except for a few.

#### Change overview
Rename the GenericOTARequestorDriver -> DefaultOTARequestorDriver

#### Testing
- No functional change, tree compiles
- Verified basic happy path flow of OTA download succeeds
