### PR TITLE
[OTA] Make default requestor more consistently named

### DIFF
--- a/config/mbed/CMakeLists.txt
+++ b/config/mbed/CMakeLists.txt
@@ -472,7 +472,7 @@ if (CONFIG_CHIP_OTA_REQUESTOR)
 
     target_sources(${APP_TARGET} PRIVATE
         ${CHIP_ROOT}/examples/platform/mbed/ota/OTARequestorDriverImpl.cpp
-        ${CHIP_ROOT}/src/app/clusters/ota-requestor/OTARequestor.cpp
+        ${CHIP_ROOT}/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
         ${CHIP_ROOT}/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
         ${CHIP_ROOT}/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
         ${CHIP_ROOT}/src/app/clusters/ota-requestor/BDXDownloader.cpp

--- a/examples/all-clusters-app/ameba/chip_main.cmake
+++ b/examples/all-clusters-app/ameba/chip_main.cmake
@@ -117,7 +117,7 @@ list(
     APPEND ${list_chip_main_sources}
     #OTARequestor
     ${chip_dir}/src/app/clusters/ota-requestor/BDXDownloader.cpp
-    ${chip_dir}/src/app/clusters/ota-requestor/OTARequestor.cpp
+    ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/ota-requestor-server.cpp

--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -42,8 +42,8 @@
 #if CONFIG_ENABLE_OTA_REQUESTOR
 #include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/Ameba/AmebaOTAImageProcessor.h>
 #endif
 
@@ -99,7 +99,7 @@ Identify gIdentify1 = {
 static DeviceCallbacks EchoCallbacks;
 
 #if CONFIG_ENABLE_OTA_REQUESTOR
-OTARequestor gRequestorCore;
+DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -38,9 +38,9 @@
 
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/util/af.h>
 #include <binding-handler.h>
@@ -77,7 +77,7 @@ static DeviceCallbacks EchoCallbacks;
 namespace {
 
 #if CONFIG_ENABLE_OTA_REQUESTOR
-OTARequestor gRequestorCore;
+DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;

--- a/examples/lighting-app/ameba/chip_main.cmake
+++ b/examples/lighting-app/ameba/chip_main.cmake
@@ -15,7 +15,7 @@ list(
     APPEND ${list_chip_main_sources}
     #OTARequestor
     ${chip_dir}/src/app/clusters/ota-requestor/BDXDownloader.cpp
-    ${chip_dir}/src/app/clusters/ota-requestor/OTARequestor.cpp
+    ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/ota-requestor-server.cpp

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -45,8 +45,8 @@
 #if CONFIG_ENABLE_OTA_REQUESTOR
 #include "app/clusters/ota-requestor/DefaultOTARequestorStorage.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/Ameba/AmebaOTAImageProcessor.h>
 #endif
 
@@ -84,7 +84,7 @@ void NetWorkCommissioningInstInit()
 static DeviceCallbacks EchoCallbacks;
 
 #if CONFIG_ENABLE_OTA_REQUESTOR
-OTARequestor gRequestorCore;
+DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;

--- a/examples/lighting-app/esp32/main/main.cpp
+++ b/examples/lighting-app/esp32/main/main.cpp
@@ -28,9 +28,9 @@
 #include "shell_extension/launch.h"
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 #include <app/server/Dnssd.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
@@ -45,7 +45,7 @@ using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 
 #if CONFIG_ENABLE_OTA_REQUESTOR
-OTARequestor gRequestorCore;
+DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;

--- a/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -37,9 +37,9 @@
 #include "OTAImageProcessorImpl.h"
 #include "OtaSupport.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 
 #include "Keyboard.h"
 #include "LED.h"
@@ -85,7 +85,7 @@ using namespace chip;
 AppTask AppTask::sAppTask;
 
 /* OTA related variables */
-static OTARequestor gRequestorCore;
+static DefaultOTARequestor gRequestorCore;
 static DefaultOTARequestorStorage gRequestorStorage;
 static DeviceLayer::GenericOTARequestorDriver gRequestorUser;
 static BDXDownloader gDownloader;
@@ -489,7 +489,7 @@ void AppTask::OTAHandler(AppEvent * aEvent)
         return;
     }
 
-    static_cast<OTARequestor *>(GetRequestorInstance())->TriggerImmediateQuery();
+    static_cast<DefaultOTARequestor *>(GetRequestorInstance())->TriggerImmediateQuery();
 }
 
 void AppTask::BleHandler(AppEvent * aEvent)

--- a/examples/lighting-app/telink/CMakeLists.txt
+++ b/examples/lighting-app/telink/CMakeLists.txt
@@ -106,7 +106,7 @@ target_sources(app PRIVATE
                ${CHIP_ROOT}/src/app/clusters/network-commissioning/network-commissioning.cpp
                ${CHIP_ROOT}/src/app/clusters/ota-requestor/ota-requestor-server.cpp
                ${CHIP_ROOT}/src/app/clusters/ota-requestor/BDXDownloader.cpp
-               ${CHIP_ROOT}/src/app/clusters/ota-requestor/OTARequestor.cpp
+               ${CHIP_ROOT}/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
                ${CHIP_ROOT}/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
                ${CHIP_ROOT}/src/app/clusters/groups-server/groups-server.cpp
                )

--- a/examples/lock-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/lock-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -30,9 +30,9 @@
 #include <platform/CHIPDeviceLayer.h>
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPPlatformMemory.h>
 #include <platform/cc13x2_26x2/OTAImageProcessorImpl.h>
@@ -63,7 +63,7 @@ static Button_Handle sAppRightHandle;
 
 AppTask AppTask::sAppTask;
 
-static OTARequestor sRequestorCore;
+static DefaultOTARequestor sRequestorCore;
 static DefaultOTARequestorStorage sRequestorStorage;
 static GenericOTARequestorDriver sRequestorUser;
 static BDXDownloader sDownloader;

--- a/examples/ota-requestor-app/ameba/chip_main.cmake
+++ b/examples/ota-requestor-app/ameba/chip_main.cmake
@@ -23,7 +23,7 @@ list(
     ${chip_dir}/examples/ota-requestor-app/ameba/main/DeviceCallbacks.cpp
 
     ${chip_dir}/src/app/clusters/ota-requestor/BDXDownloader.cpp
-    ${chip_dir}/src/app/clusters/ota-requestor/OTARequestor.cpp
+    ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/ota-requestor-server.cpp

--- a/examples/ota-requestor-app/ameba/main/chipinterface.cpp
+++ b/examples/ota-requestor-app/ameba/main/chipinterface.cpp
@@ -34,9 +34,9 @@
 #include <support/CHIPMem.h>
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/Ameba/AmebaOTAImageProcessor.h>
 
 void * __dso_handle = 0;
@@ -44,6 +44,7 @@ void * __dso_handle = 0;
 using chip::AmebaOTAImageProcessor;
 using chip::BDXDownloader;
 using chip::ByteSpan;
+using chip::DefaultOTARequestor;
 using chip::EndpointId;
 using chip::FabricIndex;
 using chip::GetRequestorInstance;
@@ -51,7 +52,6 @@ using chip::NodeId;
 using chip::OnDeviceConnected;
 using chip::OnDeviceConnectionFailure;
 using chip::OTADownloader;
-using chip::OTARequestor;
 using chip::PeerId;
 using chip::Server;
 using chip::VendorId;
@@ -85,7 +85,7 @@ void NetWorkCommissioningInstInit()
 
 static DeviceCallbacks EchoCallbacks;
 
-OTARequestor gRequestorCore;
+DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;

--- a/examples/ota-requestor-app/cyw30739/src/main.cpp
+++ b/examples/ota-requestor-app/cyw30739/src/main.cpp
@@ -18,9 +18,9 @@
  */
 #include <ChipShellCollection.h>
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 #include <app/server/Server.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <lib/shell/Engine.h>
@@ -42,7 +42,7 @@ using namespace chip::Shell;
 
 static void InitApp(intptr_t args);
 
-OTARequestor gRequestorCore;
+DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
 DeviceLayer::GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;

--- a/examples/ota-requestor-app/efr32/src/AppTask.cpp
+++ b/examples/ota-requestor-app/efr32/src/AppTask.cpp
@@ -35,9 +35,9 @@
 #include <app/util/attribute-storage.h>
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/EFR32/OTAImageProcessorImpl.h>
 
 #include <assert.h>
@@ -100,7 +100,7 @@ using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
 
 // Global OTA objects
-OTARequestor gRequestorCore;
+DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
 DeviceLayer::GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;

--- a/examples/ota-requestor-app/esp32/main/main.cpp
+++ b/examples/ota-requestor-app/esp32/main/main.cpp
@@ -30,9 +30,9 @@
 #include "nvs_flash.h"
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 #include <app/server/Server.h>
 #include <platform/ESP32/NetworkCommissioningDriver.h>
 
@@ -53,7 +53,7 @@ namespace {
 const char * TAG = "ota-requester-app";
 static DeviceCallbacks EchoCallbacks;
 
-OTARequestor gRequestorCore;
+DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -18,10 +18,10 @@
 
 #include "AppMain.h"
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorUserConsent.h>
 #include <app/clusters/ota-requestor/ExtendedOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/Linux/OTAImageProcessorImpl.h>
 
 using chip::BDXDownloader;
@@ -35,10 +35,10 @@ using chip::OnDeviceConnected;
 using chip::OnDeviceConnectionFailure;
 using chip::OTADownloader;
 using chip::OTAImageProcessorImpl;
-using chip::OTARequestor;
 using chip::PeerId;
 using chip::Server;
 using chip::VendorId;
+using chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
 using chip::Callback::Callback;
 using chip::System::Layer;
 using chip::Transport::PeerAddress;
@@ -54,7 +54,7 @@ public:
     void UpdateDownloaded() override;
 };
 
-OTARequestor gRequestorCore;
+DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
 CustomOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
@@ -229,7 +229,7 @@ int main(int argc, char * argv[])
     ChipLinuxAppMainLoop();
 
     // If the event loop had been stopped due to an update being applied, boot into the new image
-    if (gRequestorCore.GetCurrentUpdateState() == OTARequestor::OTAUpdateStateEnum::kApplying)
+    if (gRequestorCore.GetCurrentUpdateState() == OTAUpdateStateEnum::kApplying)
     {
         if (kMaxFilePathSize <= strlen(kImageExecPath))
         {

--- a/examples/ota-requestor-app/p6/src/AppTask.cpp
+++ b/examples/ota-requestor-app/p6/src/AppTask.cpp
@@ -29,9 +29,9 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 #include <app/server/Dnssd.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
@@ -60,12 +60,12 @@ extern "C" {
 
 using chip::BDXDownloader;
 using chip::CharSpan;
+using chip::DefaultOTARequestor;
 using chip::FabricIndex;
 using chip::GetRequestorInstance;
 using chip::NodeId;
 using chip::OTADownloader;
 using chip::OTAImageProcessorImpl;
-using chip::OTARequestor;
 using chip::System::Layer;
 
 using namespace ::chip;
@@ -93,7 +93,7 @@ StaticQueue_t sAppEventQueueStruct;
 StackType_t appStack[APP_TASK_STACK_SIZE / sizeof(StackType_t)];
 StaticTask_t appTaskStruct;
 
-OTARequestor gRequestorCore;
+DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;
@@ -470,6 +470,6 @@ void OnTriggerUpdateTimerHandler(Layer * systemLayer, void * appState)
 {
     P6_LOG("Triggering immediate OTA update query");
 
-    OTARequestor * req = static_cast<OTARequestor *>(GetRequestorInstance());
+    DefaultOTARequestor * req = static_cast<DefaultOTARequestor *>(GetRequestorInstance());
     req->TriggerImmediateQuery();
 }

--- a/examples/platform/efr32/OTAConfig.cpp
+++ b/examples/platform/efr32/OTAConfig.cpp
@@ -61,7 +61,7 @@ __attribute__((used)) ApplicationProperties_t sl_app_properties = {
 };
 
 // Global OTA objects
-chip::OTARequestor gRequestorCore;
+chip::DefaultOTARequestor gRequestorCore;
 chip::DefaultOTARequestorStorage gRequestorStorage;
 chip::DeviceLayer::GenericOTARequestorDriver gRequestorUser;
 chip::BDXDownloader gDownloader;

--- a/examples/platform/efr32/OTAConfig.h
+++ b/examples/platform/efr32/OTAConfig.h
@@ -19,9 +19,9 @@
 #pragma once
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/EFR32/OTAImageProcessorImpl.h>
 
 class OTAConfig

--- a/examples/platform/mbed/util/include/DFUManager.h
+++ b/examples/platform/mbed/util/include/DFUManager.h
@@ -28,9 +28,9 @@
 
 #ifdef CHIP_OTA_REQUESTOR
 #include <BDXDownloader.h>
+#include <DefaultOTARequestor.h>
 #include <DefaultOTARequestorStorage.h>
 #include <OTAImageProcessorImpl.h>
-#include <OTARequestor.h>
 #include <OTARequestorDriverImpl.h>
 #endif // CHIP_OTA_REQUESTOR
 
@@ -54,7 +54,7 @@ private:
     static DFUManager sDFUMgr;
 
 #ifdef CHIP_OTA_REQUESTOR
-    chip::OTARequestor mRequestorCore;
+    chip::DefaultOTARequestor mRequestorCore;
     chip::DefaultOTARequestorStorage mRequestorStorage;
     chip::DeviceLayer::OTARequestorDriverImpl mRequestorDriver;
     chip::BDXDownloader mDownloader;

--- a/examples/platform/nrfconnect/util/OTAUtil.cpp
+++ b/examples/platform/nrfconnect/util/OTAUtil.cpp
@@ -16,9 +16,9 @@
  */
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 #include <app/server/Server.h>
 #include <platform/nrfconnect/OTAImageProcessorImpl.h>
 
@@ -30,7 +30,7 @@ namespace {
 DefaultOTARequestorStorage sOTARequestorStorage;
 GenericOTARequestorDriver sOTARequestorDriver;
 chip::BDXDownloader sBDXDownloader;
-chip::OTARequestor sOTARequestor;
+chip::DefaultOTARequestor sOTARequestor;
 
 } // namespace
 

--- a/examples/platform/qpg/ota/ota.cpp
+++ b/examples/platform/qpg/ota/ota.cpp
@@ -28,9 +28,9 @@
 #include <platform/CHIPDeviceLayer.h>
 
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/qpg/OTAImageProcessorImpl.h>
 
 using namespace chip;
@@ -40,7 +40,7 @@ using namespace chip::DeviceLayer;
  *                    Static Data Definitions
  *****************************************************************************/
 
-OTARequestor gRequestorCore;
+DefaultOTARequestor gRequestorCore;
 DefaultOTARequestorStorage gRequestorStorage;
 GenericOTARequestorDriver gRequestorUser;
 BDXDownloader gDownloader;

--- a/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -33,9 +33,9 @@
 
 #if defined(CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR)
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/cc13x2_26x2/OTAImageProcessorImpl.h>
 #endif
 #include <app-common/zap-generated/attributes/Accessors.h>
@@ -76,7 +76,7 @@ static Button_Handle sAppRightHandle;
 AppTask AppTask::sAppTask;
 
 #if defined(CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR)
-static OTARequestor sRequestorCore;
+static DefaultOTARequestor sRequestorCore;
 static DefaultOTARequestorStorage sRequestorStorage;
 static GenericOTARequestorDriver sRequestorUser;
 static BDXDownloader sDownloader;

--- a/examples/pump-controller-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/pump-controller-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -31,9 +31,9 @@
 
 #if defined(CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR)
 #include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/clusters/ota-requestor/GenericOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/OTARequestor.h>
 #include <platform/cc13x2_26x2/OTAImageProcessorImpl.h>
 #endif
 #include <app-common/zap-generated/attributes/Accessors.h>
@@ -68,7 +68,7 @@ static Button_Handle sAppRightHandle;
 AppTask AppTask::sAppTask;
 
 #if defined(CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR)
-static OTARequestor sRequestorCore;
+static DefaultOTARequestor sRequestorCore;
 static DefaultOTARequestorStorage sRequestorStorage;
 static GenericOTARequestorDriver sRequestorUser;
 static BDXDownloader sDownloader;

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -132,12 +132,12 @@ template("chip_data_model") {
           "${_app_root}/clusters/${cluster}/${cluster}-server.cpp",
           "${_app_root}/clusters/${cluster}/BDXDownloader.cpp",
           "${_app_root}/clusters/${cluster}/BDXDownloader.h",
+          "${_app_root}/clusters/${cluster}/DefaultOTARequestor.cpp",
           "${_app_root}/clusters/${cluster}/DefaultOTARequestorStorage.cpp",
           "${_app_root}/clusters/${cluster}/DefaultOTARequestorStorage.h",
           "${_app_root}/clusters/${cluster}/DefaultOTARequestorUserConsent.h",
           "${_app_root}/clusters/${cluster}/ExtendedOTARequestorDriver.cpp",
           "${_app_root}/clusters/${cluster}/GenericOTARequestorDriver.cpp",
-          "${_app_root}/clusters/${cluster}/OTARequestor.cpp",
           "${_app_root}/clusters/${cluster}/OTARequestorStorage.h",
         ]
       } else if (cluster == "bindings") {

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -16,7 +16,7 @@
  *    limitations under the License.
  */
 
-/* This file contains the implementation of the OTARequestor class. All the core
+/* This file contains the implementation of the OTARequestorInterface class. All the core
  * OTA Requestor logic is contained in this class.
  */
 
@@ -28,7 +28,7 @@
 #include <zap-generated/CHIPClusters.h>
 
 #include "BDXDownloader.h"
-#include "OTARequestor.h"
+#include "DefaultOTARequestor.h"
 
 namespace chip {
 
@@ -103,9 +103,9 @@ OTARequestorInterface * GetRequestorInstance()
     return globalOTARequestorInstance;
 }
 
-void OTARequestor::InitState(intptr_t context)
+void DefaultOTARequestor::InitState(intptr_t context)
 {
-    OTARequestor * requestorCore = reinterpret_cast<OTARequestor *>(context);
+    DefaultOTARequestor * requestorCore = reinterpret_cast<DefaultOTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
     // This initialization may occur due to the following:
@@ -117,8 +117,8 @@ void OTARequestor::InitState(intptr_t context)
     OtaRequestorServerSetUpdateStateProgress(app::DataModel::NullNullable);
 }
 
-CHIP_ERROR OTARequestor::Init(Server & server, OTARequestorStorage & storage, OTARequestorDriver & driver,
-                              BDXDownloader & downloader)
+CHIP_ERROR DefaultOTARequestor::Init(Server & server, OTARequestorStorage & storage, OTARequestorDriver & driver,
+                                     BDXDownloader & downloader)
 {
     mServer             = &server;
     mCASESessionManager = server.GetCASESessionManager();
@@ -137,11 +137,11 @@ CHIP_ERROR OTARequestor::Init(Server & server, OTARequestorStorage & storage, OT
     return chip::DeviceLayer::PlatformMgrImpl().AddEventHandler(OnCommissioningCompleteRequestor, reinterpret_cast<intptr_t>(this));
 }
 
-void OTARequestor::OnQueryImageResponse(void * context, const QueryImageResponse::DecodableType & response)
+void DefaultOTARequestor::OnQueryImageResponse(void * context, const QueryImageResponse::DecodableType & response)
 {
     LogQueryImageResponse(response);
 
-    OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
+    DefaultOTARequestor * requestorCore = static_cast<DefaultOTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
     switch (response.status)
@@ -215,9 +215,9 @@ void OTARequestor::OnQueryImageResponse(void * context, const QueryImageResponse
     }
 }
 
-void OTARequestor::OnQueryImageFailure(void * context, CHIP_ERROR error)
+void DefaultOTARequestor::OnQueryImageFailure(void * context, CHIP_ERROR error)
 {
-    OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
+    DefaultOTARequestor * requestorCore = static_cast<DefaultOTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
     ChipLogError(SoftwareUpdate, "Received QueryImage failure response: %" CHIP_ERROR_FORMAT, error.Format());
@@ -233,11 +233,11 @@ void OTARequestor::OnQueryImageFailure(void * context, CHIP_ERROR error)
     requestorCore->RecordErrorUpdateState(UpdateFailureState::kQuerying, error);
 }
 
-void OTARequestor::OnApplyUpdateResponse(void * context, const ApplyUpdateResponse::DecodableType & response)
+void DefaultOTARequestor::OnApplyUpdateResponse(void * context, const ApplyUpdateResponse::DecodableType & response)
 {
     LogApplyUpdateResponse(response);
 
-    OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
+    DefaultOTARequestor * requestorCore = static_cast<DefaultOTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
     switch (response.action)
@@ -256,27 +256,27 @@ void OTARequestor::OnApplyUpdateResponse(void * context, const ApplyUpdateRespon
     }
 }
 
-void OTARequestor::OnApplyUpdateFailure(void * context, CHIP_ERROR error)
+void DefaultOTARequestor::OnApplyUpdateFailure(void * context, CHIP_ERROR error)
 {
-    OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
+    DefaultOTARequestor * requestorCore = static_cast<DefaultOTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
     ChipLogDetail(SoftwareUpdate, "ApplyUpdate failure response %" CHIP_ERROR_FORMAT, error.Format());
     requestorCore->RecordErrorUpdateState(UpdateFailureState::kApplying, error);
 }
 
-void OTARequestor::OnNotifyUpdateAppliedResponse(void * context, const app::DataModel::NullObjectType & response) {}
+void DefaultOTARequestor::OnNotifyUpdateAppliedResponse(void * context, const app::DataModel::NullObjectType & response) {}
 
-void OTARequestor::OnNotifyUpdateAppliedFailure(void * context, CHIP_ERROR error)
+void DefaultOTARequestor::OnNotifyUpdateAppliedFailure(void * context, CHIP_ERROR error)
 {
-    OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
+    DefaultOTARequestor * requestorCore = static_cast<DefaultOTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
     ChipLogDetail(SoftwareUpdate, "NotifyUpdateApplied failure response %" CHIP_ERROR_FORMAT, error.Format());
     requestorCore->RecordErrorUpdateState(UpdateFailureState::kNotifying, error);
 }
 
-void OTARequestor::Reset()
+void DefaultOTARequestor::Reset()
 {
     mProviderLocation.ClearValue();
     mUpdateToken.reduce_size(0);
@@ -287,8 +287,8 @@ void OTARequestor::Reset()
     StoreCurrentUpdateInfo();
 }
 
-void OTARequestor::HandleAnnounceOTAProvider(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-                                             const AnnounceOtaProvider::DecodableType & commandData)
+void DefaultOTARequestor::HandleAnnounceOTAProvider(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
+                                                    const AnnounceOtaProvider::DecodableType & commandData)
 {
     VerifyOrReturn(commandObj != nullptr, ChipLogError(SoftwareUpdate, "Invalid commandObj, cannot handle AnnounceOTAProvider"));
 
@@ -315,7 +315,7 @@ void OTARequestor::HandleAnnounceOTAProvider(app::CommandHandler * commandObj, c
     commandObj->AddStatus(commandPath, Status::Success);
 }
 
-void OTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
+void DefaultOTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
 {
     if (mServer == nullptr)
     {
@@ -356,7 +356,7 @@ void OTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
     }
 }
 
-void OTARequestor::DisconnectFromProvider()
+void DefaultOTARequestor::DisconnectFromProvider()
 {
     if (mServer == nullptr)
     {
@@ -385,7 +385,7 @@ void OTARequestor::DisconnectFromProvider()
 
 // Requestor is directed to cancel image update in progress. All the Requestor state is
 // cleared, UpdateState is reset to Idle
-void OTARequestor::CancelImageUpdate()
+void DefaultOTARequestor::CancelImageUpdate()
 {
     mBdxDownloader->EndDownload(CHIP_ERROR_CONNECTION_ABORTED);
 
@@ -394,23 +394,23 @@ void OTARequestor::CancelImageUpdate()
     Reset();
 }
 
-CHIP_ERROR OTARequestor::GetUpdateStateProgressAttribute(EndpointId endpointId, app::DataModel::Nullable<uint8_t> & progress)
+CHIP_ERROR DefaultOTARequestor::GetUpdateStateProgressAttribute(EndpointId endpointId, app::DataModel::Nullable<uint8_t> & progress)
 {
     VerifyOrReturnError(OtaRequestorServerGetUpdateStateProgress(endpointId, progress) == EMBER_ZCL_STATUS_SUCCESS,
                         CHIP_ERROR_BAD_REQUEST);
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OTARequestor::GetUpdateStateAttribute(EndpointId endpointId, OTAUpdateStateEnum & state)
+CHIP_ERROR DefaultOTARequestor::GetUpdateStateAttribute(EndpointId endpointId, OTAUpdateStateEnum & state)
 {
     VerifyOrReturnError(OtaRequestorServerGetUpdateState(endpointId, state) == EMBER_ZCL_STATUS_SUCCESS, CHIP_ERROR_BAD_REQUEST);
     return CHIP_NO_ERROR;
 }
 
 // Called whenever FindOrEstablishSession is successful
-void OTARequestor::OnConnected(void * context, OperationalDeviceProxy * deviceProxy)
+void DefaultOTARequestor::OnConnected(void * context, OperationalDeviceProxy * deviceProxy)
 {
-    OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
+    DefaultOTARequestor * requestorCore = static_cast<DefaultOTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
     VerifyOrDie(deviceProxy != nullptr);
 
@@ -466,9 +466,9 @@ void OTARequestor::OnConnected(void * context, OperationalDeviceProxy * devicePr
 }
 
 // Called whenever FindOrEstablishSession fails
-void OTARequestor::OnConnectionFailure(void * context, PeerId peerId, CHIP_ERROR error)
+void DefaultOTARequestor::OnConnectionFailure(void * context, PeerId peerId, CHIP_ERROR error)
 {
-    OTARequestor * requestorCore = static_cast<OTARequestor *>(context);
+    DefaultOTARequestor * requestorCore = static_cast<DefaultOTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
 
     ChipLogError(SoftwareUpdate, "Failed to connect to node 0x" ChipLogFormatX64 ": %" CHIP_ERROR_FORMAT,
@@ -490,8 +490,7 @@ void OTARequestor::OnConnectionFailure(void * context, PeerId peerId, CHIP_ERROR
     }
 }
 
-// Sends the QueryImage command to the Provider currently set in the OTARequestor
-void OTARequestor::TriggerImmediateQueryInternal()
+void DefaultOTARequestor::TriggerImmediateQueryInternal()
 {
     // We are now connecting to a provider for the purpose of sending a QueryImage,
     // treat this as a move to the Querying state
@@ -500,8 +499,7 @@ void OTARequestor::TriggerImmediateQueryInternal()
     ConnectToProvider(kQueryImage);
 }
 
-// Sends the QueryImage command to the next available Provider
-OTARequestorInterface::OTATriggerResult OTARequestor::TriggerImmediateQuery()
+OTARequestorInterface::OTATriggerResult DefaultOTARequestor::TriggerImmediateQuery()
 {
     ProviderLocationType providerLocation;
     bool listExhausted = false;
@@ -519,18 +517,18 @@ OTARequestorInterface::OTATriggerResult OTARequestor::TriggerImmediateQuery()
     return kTriggerSuccessful;
 }
 
-void OTARequestor::DownloadUpdate()
+void DefaultOTARequestor::DownloadUpdate()
 {
     RecordNewUpdateState(OTAUpdateStateEnum::kDownloading, OTAChangeReasonEnum::kSuccess);
     ConnectToProvider(kDownload);
 }
 
-void OTARequestor::DownloadUpdateDelayedOnUserConsent()
+void DefaultOTARequestor::DownloadUpdateDelayedOnUserConsent()
 {
     RecordNewUpdateState(OTAUpdateStateEnum::kDelayedOnUserConsent, OTAChangeReasonEnum::kSuccess);
 }
 
-void OTARequestor::ApplyUpdate()
+void DefaultOTARequestor::ApplyUpdate()
 {
     RecordNewUpdateState(OTAUpdateStateEnum::kApplying, OTAChangeReasonEnum::kSuccess);
 
@@ -540,7 +538,7 @@ void OTARequestor::ApplyUpdate()
     ConnectToProvider(kApplyUpdate);
 }
 
-void OTARequestor::NotifyUpdateApplied()
+void DefaultOTARequestor::NotifyUpdateApplied()
 {
     // Log the VersionApplied event
     uint16_t productId;
@@ -556,7 +554,7 @@ void OTARequestor::NotifyUpdateApplied()
     ConnectToProvider(kNotifyUpdateApplied);
 }
 
-CHIP_ERROR OTARequestor::ClearDefaultOtaProviderList(FabricIndex fabricIndex)
+CHIP_ERROR DefaultOTARequestor::ClearDefaultOtaProviderList(FabricIndex fabricIndex)
 {
     CHIP_ERROR error = mDefaultOtaProviderList.Delete(fabricIndex);
 
@@ -567,7 +565,7 @@ CHIP_ERROR OTARequestor::ClearDefaultOtaProviderList(FabricIndex fabricIndex)
     return mStorage->StoreDefaultProviders(mDefaultOtaProviderList);
 }
 
-CHIP_ERROR OTARequestor::AddDefaultOtaProvider(const ProviderLocationType & providerLocation)
+CHIP_ERROR DefaultOTARequestor::AddDefaultOtaProvider(const ProviderLocationType & providerLocation)
 {
     // Look for an entry with the same fabric index indicated
     auto iterator = mDefaultOtaProviderList.Begin();
@@ -586,7 +584,7 @@ CHIP_ERROR OTARequestor::AddDefaultOtaProvider(const ProviderLocationType & prov
     return mStorage->StoreDefaultProviders(mDefaultOtaProviderList);
 }
 
-void OTARequestor::OnDownloadStateChanged(OTADownloader::State state, OTAChangeReasonEnum reason)
+void DefaultOTARequestor::OnDownloadStateChanged(OTADownloader::State state, OTAChangeReasonEnum reason)
 {
     VerifyOrDie(mOtaRequestorDriver != nullptr);
 
@@ -608,12 +606,12 @@ void OTARequestor::OnDownloadStateChanged(OTADownloader::State state, OTAChangeR
     }
 }
 
-void OTARequestor::OnUpdateProgressChanged(Nullable<uint8_t> percent)
+void DefaultOTARequestor::OnUpdateProgressChanged(Nullable<uint8_t> percent)
 {
     OtaRequestorServerSetUpdateStateProgress(percent);
 }
 
-IdleStateReason OTARequestor::MapErrorToIdleStateReason(CHIP_ERROR error)
+IdleStateReason DefaultOTARequestor::MapErrorToIdleStateReason(CHIP_ERROR error)
 {
     if (error == CHIP_NO_ERROR)
     {
@@ -627,7 +625,7 @@ IdleStateReason OTARequestor::MapErrorToIdleStateReason(CHIP_ERROR error)
     return IdleStateReason::kUnknown;
 }
 
-void OTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error)
+void DefaultOTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error)
 {
     // Set server UpdateState attribute
     OtaRequestorServerSetUpdateState(newState);
@@ -654,7 +652,7 @@ void OTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeRe
     {
         IdleStateReason idleStateReason = MapErrorToIdleStateReason(error);
 
-        // Inform the driver that the OTARequestor has entered the Idle state
+        // Inform the driver that the core logic has entered the Idle state
         mOtaRequestorDriver->HandleIdleState(idleStateReason);
     }
     else if ((mCurrentUpdateState == OTAUpdateStateEnum::kIdle) && (newState != OTAUpdateStateEnum::kIdle))
@@ -665,7 +663,7 @@ void OTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeRe
     mCurrentUpdateState = newState;
 }
 
-void OTARequestor::RecordErrorUpdateState(UpdateFailureState failureState, CHIP_ERROR error, OTAChangeReasonEnum reason)
+void DefaultOTARequestor::RecordErrorUpdateState(UpdateFailureState failureState, CHIP_ERROR error, OTAChangeReasonEnum reason)
 {
     // Inform driver of the error
     mOtaRequestorDriver->HandleError(failureState, error);
@@ -681,7 +679,7 @@ void OTARequestor::RecordErrorUpdateState(UpdateFailureState failureState, CHIP_
     RecordNewUpdateState(OTAUpdateStateEnum::kIdle, reason, error);
 }
 
-CHIP_ERROR OTARequestor::GenerateUpdateToken()
+CHIP_ERROR DefaultOTARequestor::GenerateUpdateToken()
 {
     if (mUpdateToken.empty())
     {
@@ -699,7 +697,7 @@ CHIP_ERROR OTARequestor::GenerateUpdateToken()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OTARequestor::SendQueryImageRequest(OperationalDeviceProxy & deviceProxy)
+CHIP_ERROR DefaultOTARequestor::SendQueryImageRequest(OperationalDeviceProxy & deviceProxy)
 {
     VerifyOrReturnError(mProviderLocation.HasValue(), CHIP_ERROR_INCORRECT_STATE);
 
@@ -741,8 +739,8 @@ CHIP_ERROR OTARequestor::SendQueryImageRequest(OperationalDeviceProxy & devicePr
     return cluster.InvokeCommand(args, this, OnQueryImageResponse, OnQueryImageFailure);
 }
 
-CHIP_ERROR OTARequestor::ExtractUpdateDescription(const QueryImageResponseDecodableType & response,
-                                                  UpdateDescription & update) const
+CHIP_ERROR DefaultOTARequestor::ExtractUpdateDescription(const QueryImageResponseDecodableType & response,
+                                                         UpdateDescription & update) const
 {
     NodeId nodeId;
     CharSpan fileDesignator;
@@ -767,7 +765,7 @@ CHIP_ERROR OTARequestor::ExtractUpdateDescription(const QueryImageResponseDecoda
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OTARequestor::StartDownload(OperationalDeviceProxy & deviceProxy)
+CHIP_ERROR DefaultOTARequestor::StartDownload(OperationalDeviceProxy & deviceProxy)
 {
     VerifyOrReturnError(mBdxDownloader != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
@@ -796,7 +794,7 @@ CHIP_ERROR OTARequestor::StartDownload(OperationalDeviceProxy & deviceProxy)
     return mBdxDownloader->BeginPrepareDownload();
 }
 
-CHIP_ERROR OTARequestor::SendApplyUpdateRequest(OperationalDeviceProxy & deviceProxy)
+CHIP_ERROR DefaultOTARequestor::SendApplyUpdateRequest(OperationalDeviceProxy & deviceProxy)
 {
     VerifyOrReturnError(mProviderLocation.HasValue(), CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(GenerateUpdateToken());
@@ -811,7 +809,7 @@ CHIP_ERROR OTARequestor::SendApplyUpdateRequest(OperationalDeviceProxy & deviceP
     return cluster.InvokeCommand(args, this, OnApplyUpdateResponse, OnApplyUpdateFailure);
 }
 
-CHIP_ERROR OTARequestor::SendNotifyUpdateAppliedRequest(OperationalDeviceProxy & deviceProxy)
+CHIP_ERROR DefaultOTARequestor::SendNotifyUpdateAppliedRequest(OperationalDeviceProxy & deviceProxy)
 {
     VerifyOrReturnError(mProviderLocation.HasValue(), CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(GenerateUpdateToken());
@@ -830,7 +828,7 @@ CHIP_ERROR OTARequestor::SendNotifyUpdateAppliedRequest(OperationalDeviceProxy &
     return cluster.InvokeCommand(args, this, OnNotifyUpdateAppliedResponse, OnNotifyUpdateAppliedFailure);
 }
 
-void OTARequestor::StoreCurrentUpdateInfo()
+void DefaultOTARequestor::StoreCurrentUpdateInfo()
 {
     // TODO: change OTA requestor storage interface to store both values at once
     CHIP_ERROR error = CHIP_NO_ERROR;
@@ -878,7 +876,7 @@ void OTARequestor::StoreCurrentUpdateInfo()
     }
 }
 
-void OTARequestor::LoadCurrentUpdateInfo()
+void DefaultOTARequestor::LoadCurrentUpdateInfo()
 {
     mStorage->LoadDefaultProviders(mDefaultOtaProviderList);
 
@@ -906,7 +904,7 @@ void OTARequestor::LoadCurrentUpdateInfo()
 }
 
 // Invoked when the device becomes commissioned
-void OTARequestor::OnCommissioningCompleteRequestor(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
+void DefaultOTARequestor::OnCommissioningCompleteRequestor(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
 {
     VerifyOrReturn(event->Type == DeviceLayer::DeviceEventType::kCommissioningComplete);
 
@@ -915,7 +913,7 @@ void OTARequestor::OnCommissioningCompleteRequestor(const DeviceLayer::ChipDevic
     // TODO: Should we also send UpdateApplied here?
 
     // Schedule a query. At the end of this query/update process the Default Provider timer is started
-    OTARequestorDriver * driver = (reinterpret_cast<OTARequestor *>(arg))->mOtaRequestorDriver;
+    OTARequestorDriver * driver = (reinterpret_cast<DefaultOTARequestor *>(arg))->mOtaRequestorDriver;
     driver->OTACommissioningCallback();
 }
 

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.h
@@ -34,10 +34,10 @@
 namespace chip {
 
 // This class implements all of the core logic of the OTA Requestor
-class OTARequestor : public OTARequestorInterface, public BDXDownloader::StateDelegate
+class DefaultOTARequestor : public OTARequestorInterface, public BDXDownloader::StateDelegate
 {
 public:
-    OTARequestor() : mOnConnectedCallback(OnConnected, this), mOnConnectionFailureCallback(OnConnectionFailure, this) {}
+    DefaultOTARequestor() : mOnConnectedCallback(OnConnected, this), mOnConnectionFailureCallback(OnConnectionFailure, this) {}
 
     //////////// OTARequestorInterface Implementation ///////////////
     void Reset(void) override;
@@ -50,7 +50,7 @@ public:
     OTATriggerResult TriggerImmediateQuery() override;
 
     // Internal API meant for use by OTARequestorDriver to send the QueryImage command and start the image update process
-    // with the Provider currently set in the OTARequestor
+    // with the Provider currently set
     void TriggerImmediateQueryInternal() override;
 
     // Initiate download of the new image
@@ -103,7 +103,7 @@ public:
                                 app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason) override;
     void OnUpdateProgressChanged(app::DataModel::Nullable<uint8_t> percent) override;
 
-    //////////// OTARequestor public APIs ///////////////
+    //////////// DefaultOTARequestor public APIs ///////////////
 
     /**
      * Called to perform some initialization. Note that some states that must be initalized in the CHIP context will be deferred to

--- a/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/GenericOTARequestorDriver.cpp
@@ -23,7 +23,7 @@
 //
 // This particular implementation of the OTARequestorDriver makes the following choices:
 // - Only a single timer can be active at any given moment
-// - The periodic query timer is running if and only if there is no update in progress (the OTARequestor
+// - The periodic query timer is running if and only if there is no update in progress (the core logic
 //   UpdateState is kIdle)
 // - AnnounceOTAProviders command is ignored if an update is in progress
 // - The provider location passed in AnnounceOTAProviders is used in a single query (possibly retried) and then discarded
@@ -311,7 +311,7 @@ void GenericOTARequestorDriver::ProcessAnnounceOTAProviders(
         return;
     }
 
-    // Point the OTARequestor to the announced provider
+    // Point to the announced provider
     mRequestor->SetCurrentProviderLocation(providerLocation);
 
     ScheduleDelayedAction(System::Clock::Seconds32(secToStart), StartDelayTimerHandler, this);

--- a/src/app/clusters/ota-requestor/OTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/OTARequestorDriver.h
@@ -130,7 +130,7 @@ public:
                                 app::Clusters::OtaSoftwareUpdateRequestor::OTAAnnouncementReason announcementReason) = 0;
 
     /// Direct the driver to trigger the QueryImage command. The driver may choose to execute some internal
-    /// logic and will then call an OTARequestor API to actually send the command. The purpose of this
+    /// logic and will then call an OTARequestorInterface API to actually send the command. The purpose of this
     /// function is to allow implementation-specific logic (such as possibly cancelling an ongoing update)
     /// to be executed before triggering the image update process
     virtual void SendQueryImage() = 0;

--- a/src/app/clusters/ota-requestor/OTARequestorInterface.h
+++ b/src/app/clusters/ota-requestor/OTARequestorInterface.h
@@ -171,7 +171,7 @@ public:
     virtual OTATriggerResult TriggerImmediateQuery() = 0;
 
     // Internal API meant for use by OTARequestorDriver to send the QueryImage command and start the image update process
-    // with the Provider currently set in the OTARequestor
+    // with the preset provider
     virtual void TriggerImmediateQueryInternal() = 0;
 
     // Download image


### PR DESCRIPTION
#### Problem
All default implementations for various OTA Requestor components are aptly named except for a few.

#### Change overview
Rename the OTARequestor class -> DefaultOTARequestor

#### Testing
- No functional change, tree compiles
- Verified basic happy path flow of OTA download succeeds
