### PR TITLE
[Tizen] Update tizen docker image for thread

### DIFF
--- a/integrations/docker/images/chip-build-tizen/Dockerfile
+++ b/integrations/docker/images/chip-build-tizen/Dockerfile
@@ -66,6 +66,7 @@ RUN set -x \
     && wget -r -nd --no-parent -q -A 'libsystemd-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/unified/latest/repos/standard/packages/armv7l/ \
     && wget -r -nd --no-parent -q -A 'capi-network-nsd-*.armv7l.rpm' http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/armv7l/ \
     && wget -r -nd --no-parent -q -A 'libnsd-dns-sd-*.armv7l.rpm' http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/armv7l/ \
+    && wget -r -nd --no-parent -q -A 'capi-network-thread-*.armv7l.rpm' http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/armv7l/ \
     && unrpm ./*.rpm \
     && cp usr/lib/pkgconfig/openssl1.1.pc usr/lib/pkgconfig/openssl.pc \
     && rm usr/lib/libdns_sd.so \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.60 Version bump reason: [Ameba] Fix commissioning and hardfault issue
+0.5.61 Version bump reason: [Tizen] Update Tizen docker image for thread


### PR DESCRIPTION
Update Tizen docker file to download Tizen thread stack.

Signed-off-by: Abhay Agarwal <ay.agarwal@samsung.com>

#### Problem
Tizen platform's thread stack manager requires the tizen thread library.

#### Change overview
Update Tizen docker file to download Tizen thread stack.

#### Testing
Tizen docker image build.
