### PR TITLE
[Ameba] Restructure PersistentStorage

### DIFF
--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -151,10 +151,6 @@ static void InitOTARequestor(void)
 
 static void InitServer(intptr_t context)
 {
-#if CONFIG_ENABLE_OTA_REQUESTOR
-    InitOTARequestor();
-#endif
-
     // Init ZCL Data Model and CHIP App Server
     static chip::CommonCaseDeviceServerInitParams initParams;
     initParams.InitializeStaticResourcesBeforeServerInit();
@@ -163,6 +159,10 @@ static void InitServer(intptr_t context)
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
     NetWorkCommissioningInstInit();
+
+#if CONFIG_ENABLE_OTA_REQUESTOR
+    InitOTARequestor();
+#endif
 
     if (RTW_SUCCESS != wifi_is_connected_to_ap())
     {

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -172,10 +172,6 @@ static Identify gIdentify1 = {
 
 static void InitServer(intptr_t context)
 {
-#if CONFIG_ENABLE_OTA_REQUESTOR
-    InitOTARequestor();
-#endif
-
     // Init ZCL Data Model and CHIP App Server
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
@@ -184,6 +180,10 @@ static void InitServer(intptr_t context)
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
     NetWorkCommissioningInstInit();
+
+#if CONFIG_ENABLE_OTA_REQUESTOR
+    InitOTARequestor();
+#endif
 
     if (RTW_SUCCESS != wifi_is_connected_to_ap())
     {

--- a/examples/ota-requestor-app/ameba/main/chipinterface.cpp
+++ b/examples/ota-requestor-app/ameba/main/chipinterface.cpp
@@ -134,8 +134,6 @@ static void InitOTARequestor(void)
 
 static void InitServer(intptr_t context)
 {
-    InitOTARequestor();
-
     // Init ZCL Data Model and CHIP App Server
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
@@ -144,6 +142,8 @@ static void InitServer(intptr_t context)
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
     NetWorkCommissioningInstInit();
+
+    InitOTARequestor();
 }
 
 extern "C" void ChipTest(void)

--- a/src/platform/Ameba/AmebaConfig.cpp
+++ b/src/platform/Ameba/AmebaConfig.cpp
@@ -45,6 +45,18 @@ namespace Internal {
 const char AmebaConfig::kConfigNamespace_ChipFactory[]  = "chip-factory";
 const char AmebaConfig::kConfigNamespace_ChipConfig[]   = "chip-config";
 const char AmebaConfig::kConfigNamespace_ChipCounters[] = "chip-counters";
+const char AmebaConfig::kConfigNamespace_ChipFabric1[]  = "chip-fabric-1";
+const char AmebaConfig::kConfigNamespace_ChipFabric2[]  = "chip-fabric-2";
+const char AmebaConfig::kConfigNamespace_ChipFabric3[]  = "chip-fabric-3";
+const char AmebaConfig::kConfigNamespace_ChipFabric4[]  = "chip-fabric-4";
+const char AmebaConfig::kConfigNamespace_ChipFabric5[]  = "chip-fabric-5";
+const char AmebaConfig::kConfigNamespace_ChipACL[]  = "chip-acl";
+const char AmebaConfig::kConfigNamespace_ChipGroupMsgCounters[]  = "chip-groupmsgcounters";
+const char AmebaConfig::kConfigNamespace_ChipAttributes[]  = "chip-attributes";
+const char AmebaConfig::kConfigNamespace_ChipBindingTable[]  = "chip-bindingtable";
+const char AmebaConfig::kConfigNamespace_ChipOTA[]  = "chip-ota";
+const char AmebaConfig::kConfigNamespace_ChipDNS[]  = "chip-dns";
+const char AmebaConfig::kConfigNamespace_ChipOthers[]  = "chip-others";
 
 // Keys stored in the chip-factory namespace
 const AmebaConfig::Key AmebaConfig::kConfigKey_SerialNum             = { kConfigNamespace_ChipFactory, "serial-num" };
@@ -266,6 +278,19 @@ CHIP_ERROR AmebaConfig::EnsureNamespace(const char * ns)
     if (success != 0)
     {
         ChipLogError(DeviceLayer, "dct_register_module failed\n");
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR AmebaConfig::EnsureNamespace2(const char * ns)
+{
+    int32_t success = -1;
+
+    success = registerPref2(ns);
+    if (success != 0)
+    {
+        ChipLogError(DeviceLayer, "dct_register_module2 failed\n");
     }
 
     return CHIP_NO_ERROR;

--- a/src/platform/Ameba/AmebaConfig.cpp
+++ b/src/platform/Ameba/AmebaConfig.cpp
@@ -42,21 +42,21 @@ namespace Internal {
 // *** CAUTION ***: Changing the names or namespaces of these values will *break* existing devices.
 
 // NVS namespaces used to store device configuration information.
-const char AmebaConfig::kConfigNamespace_ChipFactory[]  = "chip-factory";
-const char AmebaConfig::kConfigNamespace_ChipConfig[]   = "chip-config";
-const char AmebaConfig::kConfigNamespace_ChipCounters[] = "chip-counters";
-const char AmebaConfig::kConfigNamespace_ChipFabric1[]  = "chip-fabric-1";
-const char AmebaConfig::kConfigNamespace_ChipFabric2[]  = "chip-fabric-2";
-const char AmebaConfig::kConfigNamespace_ChipFabric3[]  = "chip-fabric-3";
-const char AmebaConfig::kConfigNamespace_ChipFabric4[]  = "chip-fabric-4";
-const char AmebaConfig::kConfigNamespace_ChipFabric5[]  = "chip-fabric-5";
-const char AmebaConfig::kConfigNamespace_ChipACL[]  = "chip-acl";
-const char AmebaConfig::kConfigNamespace_ChipGroupMsgCounters[]  = "chip-groupmsgcounters";
-const char AmebaConfig::kConfigNamespace_ChipAttributes[]  = "chip-attributes";
-const char AmebaConfig::kConfigNamespace_ChipBindingTable[]  = "chip-bindingtable";
-const char AmebaConfig::kConfigNamespace_ChipOTA[]  = "chip-ota";
-const char AmebaConfig::kConfigNamespace_ChipDNS[]  = "chip-dns";
-const char AmebaConfig::kConfigNamespace_ChipOthers[]  = "chip-others";
+const char AmebaConfig::kConfigNamespace_ChipFactory[]          = "chip-factory";
+const char AmebaConfig::kConfigNamespace_ChipConfig[]           = "chip-config";
+const char AmebaConfig::kConfigNamespace_ChipCounters[]         = "chip-counters";
+const char AmebaConfig::kConfigNamespace_ChipFabric1[]          = "chip-fabric-1";
+const char AmebaConfig::kConfigNamespace_ChipFabric2[]          = "chip-fabric-2";
+const char AmebaConfig::kConfigNamespace_ChipFabric3[]          = "chip-fabric-3";
+const char AmebaConfig::kConfigNamespace_ChipFabric4[]          = "chip-fabric-4";
+const char AmebaConfig::kConfigNamespace_ChipFabric5[]          = "chip-fabric-5";
+const char AmebaConfig::kConfigNamespace_ChipACL[]              = "chip-acl";
+const char AmebaConfig::kConfigNamespace_ChipGroupMsgCounters[] = "chip-groupmsgcounters";
+const char AmebaConfig::kConfigNamespace_ChipAttributes[]       = "chip-attributes";
+const char AmebaConfig::kConfigNamespace_ChipBindingTable[]     = "chip-bindingtable";
+const char AmebaConfig::kConfigNamespace_ChipOTA[]              = "chip-ota";
+const char AmebaConfig::kConfigNamespace_ChipDNS[]              = "chip-dns";
+const char AmebaConfig::kConfigNamespace_ChipOthers[]           = "chip-others";
 
 // Keys stored in the chip-factory namespace
 const AmebaConfig::Key AmebaConfig::kConfigKey_SerialNum             = { kConfigNamespace_ChipFactory, "serial-num" };

--- a/src/platform/Ameba/AmebaConfig.h
+++ b/src/platform/Ameba/AmebaConfig.h
@@ -40,6 +40,18 @@ public:
     static const char kConfigNamespace_ChipFactory[];
     static const char kConfigNamespace_ChipConfig[];
     static const char kConfigNamespace_ChipCounters[];
+    static const char kConfigNamespace_ChipFabric1[];
+    static const char kConfigNamespace_ChipFabric2[];
+    static const char kConfigNamespace_ChipFabric3[];
+    static const char kConfigNamespace_ChipFabric4[];
+    static const char kConfigNamespace_ChipFabric5[];
+    static const char kConfigNamespace_ChipACL[];
+    static const char kConfigNamespace_ChipGroupMsgCounters[];
+    static const char kConfigNamespace_ChipAttributes[];
+    static const char kConfigNamespace_ChipBindingTable[];
+    static const char kConfigNamespace_ChipOTA[];
+    static const char kConfigNamespace_ChipDNS[];
+    static const char kConfigNamespace_ChipOthers[];
 
     // Key definitions for well-known keys.
     static const Key kConfigKey_SerialNum;
@@ -96,6 +108,7 @@ public:
     static bool ConfigValueExists(Key key);
 
     static CHIP_ERROR EnsureNamespace(const char * ns);
+    static CHIP_ERROR EnsureNamespace2(const char * ns);
     static CHIP_ERROR ClearNamespace(const char * ns);
 
     static void RunConfigUnitTest(void);

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -55,6 +55,30 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     SuccessOrExit(err);
     err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipCounters);
     SuccessOrExit(err);
+    err = AmebaConfig::EnsureNamespace2(AmebaConfig::kConfigNamespace_ChipFabric1);
+    SuccessOrExit(err);
+    err = AmebaConfig::EnsureNamespace2(AmebaConfig::kConfigNamespace_ChipFabric2);
+    SuccessOrExit(err);
+    err = AmebaConfig::EnsureNamespace2(AmebaConfig::kConfigNamespace_ChipFabric3);
+    SuccessOrExit(err);
+    err = AmebaConfig::EnsureNamespace2(AmebaConfig::kConfigNamespace_ChipFabric4);
+    SuccessOrExit(err);
+    err = AmebaConfig::EnsureNamespace2(AmebaConfig::kConfigNamespace_ChipFabric5);
+    SuccessOrExit(err);
+    err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipACL);
+    SuccessOrExit(err);
+    err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipGroupMsgCounters);
+    SuccessOrExit(err);
+    err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipAttributes);
+    SuccessOrExit(err);
+    err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipBindingTable);
+    SuccessOrExit(err);
+    err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipOTA);
+    SuccessOrExit(err);
+    err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipDNS);
+    SuccessOrExit(err);
+    err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipOthers);
+    SuccessOrExit(err);
 
     if (AmebaConfig::ConfigValueExists(AmebaConfig::kCounterKey_RebootCount))
     {

--- a/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
@@ -43,13 +43,13 @@ CHIP_ERROR AmebaWiFiDriver::Init(NetworkStatusChangeCallback *)
 
     err = PersistedStorage::KeyValueStoreMgr().Get(kWiFiCredentialsKeyName, mSavedNetwork.credentials,
                                                    sizeof(mSavedNetwork.credentials), &credentialsLen);
-    if (err == CHIP_ERROR_NOT_FOUND)
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         return CHIP_NO_ERROR;
     }
 
     err = PersistedStorage::KeyValueStoreMgr().Get(kWiFiSSIDKeyName, mSavedNetwork.ssid, sizeof(mSavedNetwork.ssid), &ssidLen);
-    if (err == CHIP_ERROR_NOT_FOUND)
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         return CHIP_NO_ERROR;
     }


### PR DESCRIPTION
#### Problem
* Ameba's current implementation of persistent storage is storing key-values in wrong places, causing commissioning issues
* Data stored outside of chip-factory, chip-config and chip-counters are not stored in proper domains
* Wrong error code in AmebaWiFiDriver::Init
* Wrong integer type used in AmebaConfig::ReadConfigValue, causing read value to be wrong
* InitOTARequestor is called after Server::Init, causing runtime hardfault

#### Change overview
* Add more kConfigNamespace to organize key-value data into proper domains
* Fix wrong error code in AmebaWiFiDriver::Init
* Fix integer type in AmebaConfig::ReadConfigValue
* Fix initialization order in chipinterface

#### Testing
* Tested ble-wifi commissioning with chip-tool
