### PR TITLE
[EFR32] Change Matter NVM3 reserved keys range

### DIFF
--- a/src/platform/EFR32/EFR32Config.cpp
+++ b/src/platform/EFR32/EFR32Config.cpp
@@ -500,8 +500,10 @@ exit:;
 
 bool EFR32Config::ValidConfigKey(Key key)
 {
-    // Returns true if the key is in the valid Matter Config nvm3 key range.
-    if ((key >= kMinConfigKey_MatterFactory) && (key <= kMaxConfigKey_MatterKvs))
+    // Returns true if the key is in the Matter nvm3 reserved key range.
+    // Additional check validates that the user consciously defined the expected key range
+    if ((key >= kMatterNvm3KeyLoLimit) && (key <= kMatterNvm3KeyHiLimit) && (key >= kMinConfigKey_MatterFactory) &&
+        (key <= kMaxConfigKey_MatterKvs))
     {
         return true;
     }

--- a/src/platform/EFR32/EFR32Config.h
+++ b/src/platform/EFR32/EFR32Config.h
@@ -56,14 +56,16 @@ namespace Internal {
 // Silabs NVM3 objects use a 20-bit number,
 // NVM3 Key 19:16 Stack region
 // NVM3 Key 15:0 Available NVM3 keys 0x0000 -> 0xFFFF.
+// Matter stack reserved region ranges from 0x087200 to 0x087FFF
 // e.g. key = 0x087201
 // '08' = Matter nvm3 region
 // '72' = the sub region group base offset (Factory, Config, Counter or KVS)
 // '01' = the id offset inside the group.
-constexpr uint32_t kMatterNvm3KeyDomain = 0x080000U;
+constexpr uint32_t kMatterNvm3KeyDomain  = 0x080000U;
+constexpr uint32_t kMatterNvm3KeyLoLimit = 0x087200U; // Do not modify without Silabs GSDK team approval
+constexpr uint32_t kMatterNvm3KeyHiLimit = 0x087FFFU; // Do not modify without Silabs GSDK team approval
 constexpr inline uint32_t EFR32ConfigKey(uint8_t keyBaseOffset, uint8_t id)
 {
-    // Matter stack reserved region ranges from 0x087200 to 0x087FFF
     return kMatterNvm3KeyDomain | static_cast<uint32_t>(keyBaseOffset) << 8 | id;
 }
 

--- a/src/platform/EFR32/EFR32Config.h
+++ b/src/platform/EFR32/EFR32Config.h
@@ -56,13 +56,14 @@ namespace Internal {
 // Silabs NVM3 objects use a 20-bit number,
 // NVM3 Key 19:16 Stack region
 // NVM3 Key 15:0 Available NVM3 keys 0x0000 -> 0xFFFF.
-// e.g. key = 0x0AA201
-// '0A' = Matter nvm3 region
-// 'A2' = the nv group base offest (Factory, Config or Counter)
+// e.g. key = 0x087201
+// '08' = Matter nvm3 region
+// '72' = the sub region group base offset (Factory, Config, Counter or KVS)
 // '01' = the id offset inside the group.
-constexpr uint32_t kMatterNvm3KeyDomain = 0x0A0000U;
+constexpr uint32_t kMatterNvm3KeyDomain = 0x080000U;
 constexpr inline uint32_t EFR32ConfigKey(uint8_t keyBaseOffset, uint8_t id)
 {
+    // Matter stack reserved region ranges from 0x087200 to 0x087FFF
     return kMatterNvm3KeyDomain | static_cast<uint32_t>(keyBaseOffset) << 8 | id;
 }
 
@@ -74,14 +75,15 @@ public:
     using Key = uint32_t;
 
     // NVM3 key base offsets used by the CHIP Device Layer.
+    // ** Key base can range from 0x72 to 0x7F **
     // Persistent config values set at manufacturing time. Retained during factory reset.
-    static constexpr uint8_t kMatterFactory_KeyBase = 0xA2;
+    static constexpr uint8_t kMatterFactory_KeyBase = 0x72;
     // Persistent config values set at runtime. Cleared during factory reset.
-    static constexpr uint8_t kMatterConfig_KeyBase = 0xA3;
+    static constexpr uint8_t kMatterConfig_KeyBase = 0x73;
     // Persistent counter values set at runtime. Retained during factory reset.
-    static constexpr uint8_t kMatterCounter_KeyBase = 0xA4;
+    static constexpr uint8_t kMatterCounter_KeyBase = 0x74;
     // Persistent config values set at runtime. Cleared during factory reset.
-    static constexpr uint8_t kMatterKvs_KeyBase = 0xA5;
+    static constexpr uint8_t kMatterKvs_KeyBase = 0x75;
 
     // Key definitions for well-known configuration values.
     // Factory config keys


### PR DESCRIPTION
#### Problem
After a discussion with the Silabs GSDK team, it was determined that we should reserve a different nvm3 key range for Matter. 

#### Change overview
Change Matter nvm3 region 0xA to 0x8 and define sub-region.
This reserved region now ranges from 0x087200 to 0x087FFF  (3583 possible keys)
This new key section becomes the official EFR32 matter stack nvm3 reserved section

**PSA: Since there is no migration mechanism currently. This won't be retro-compatible with prior commissioned devices. Erasing the device flash is also recommended prior to flashing the new app to delete any older matter keys that will now be unknown** 

#### Testing
Commission EFR32 device reboot and test communication are still working
