### PR TITLE
[chip-tool] Add config_enable_yaml_tests build option to reduce the i…

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -24,6 +24,7 @@ declare_args() {
   # Use a separate eventloop for CHIP tasks
   config_use_separate_eventloop = true
   config_use_interactive_mode = true
+  config_enable_yaml_tests = true
 }
 
 config("config") {
@@ -36,6 +37,7 @@ config("config") {
   defines = [
     "CONFIG_USE_SEPARATE_EVENTLOOP=${config_use_separate_eventloop}",
     "CONFIG_USE_INTERACTIVE_MODE=${config_use_interactive_mode}",
+    "CONFIG_ENABLE_YAML_TESTS=${config_enable_yaml_tests}",
   ]
 
   cflags = [ "-Wconversion" ]
@@ -72,12 +74,15 @@ static_library("chip-tool-utils") {
     "commands/payload/SetupPayloadGenerateCommand.cpp",
     "commands/payload/SetupPayloadParseCommand.cpp",
     "commands/payload/SetupPayloadVerhoeff.cpp",
-    "commands/tests/TestCommand.cpp",
     "config/PersistentStorage.cpp",
   ]
 
   if (config_use_interactive_mode) {
     sources += [ "commands/interactive/InteractiveCommands.cpp" ]
+  }
+
+  if (config_enable_yaml_tests) {
+    sources += [ "commands/tests/TestCommand.cpp" ]
   }
 
   public_deps = [

--- a/examples/chip-tool/templates/tests/commands.zapt
+++ b/examples/chip-tool/templates/tests/commands.zapt
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#if CONFIG_ENABLE_YAML_TESTS
+
 #include <commands/tests/TestCommand.h>
 #include <commands/common/CommandInvoker.h>
 #include <lib/core/Optional.h>
@@ -37,11 +39,14 @@ public:
 {{>test_cluster tests=(getTests) credsIssuerConfigArg=true needsWaitDuration=true}}
 {{>test_cluster tests=(getManualTests) credsIssuerConfigArg=true needsWaitDuration=true}}
 
+#endif // CONFIG_ENABLE_YAML_TESTS
+
 void registerCommandsTests(Commands & commands, CredentialIssuerCommands * credsIssuerConfig)
 {
     const char * clusterName = "Tests";
 
     commands_list clusterCommands = {
+#if CONFIG_ENABLE_YAML_TESTS
         make_unique<TestList>(),
         make_unique<ManualTestList>(),
       {{#chip_tests (getTests)}}
@@ -50,6 +55,7 @@ void registerCommandsTests(Commands & commands, CredentialIssuerCommands * creds
       {{#chip_tests (getManualTests)}}
         make_unique<{{filename}}Suite>(credsIssuerConfig),
       {{/chip_tests}}
+#endif // CONFIG_ENABLE_YAML_TESTS
     };
 
     commands.Register(clusterName, clusterCommands);


### PR DESCRIPTION
…teration time when working on chip-tool

#### Problem

When iterating over `chip-tool` for development purposes it is sometimes useful to skip building/linking the YAML tests as it takes a while.

#### Change overview
 * Add `config_enable_yaml_tests` to `examples/chip-tool/BUILD.gn`
 