### PR TITLE
[EFR32] Fix light-switch-app when build with LCD disabled

### DIFF
--- a/examples/light-switch-app/efr32/src/AppTask.cpp
+++ b/examples/light-switch-app/efr32/src/AppTask.cpp
@@ -22,9 +22,13 @@
 #include "AppEvent.h"
 #include "LEDWidget.h"
 #include "binding-handler.h"
+#include "sl_simple_led_instances.h"
+
+#ifdef DISPLAY_ENABLED
 #include "lcd.h"
 #include "qrcodegen.h"
-#include "sl_simple_led_instances.h"
+#endif // DISPLAY_ENABLED
+
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-id.h>


### PR DESCRIPTION
#### Problem
light-switch-app fails to build for brd4166a (no lcd support) or if built for any board with the build argument `show_qr_code=false`

#### Change overview
If def some include to only enable them if Display is enabled

#### Testing
Build the light-switch-app for brd4166a. The same ifdef already exist for the other efr32 apps.
