### PR TITLE
clang-tidy: make auto-detect of compile_commands.json work

### DIFF
--- a/scripts/run-clang-tidy-on-compile-commands.py
+++ b/scripts/run-clang-tidy-on-compile-commands.py
@@ -389,6 +389,7 @@ def main(
         if not compile_database:
             raise Exception("Could not find `compile_commands.json` in ./out")
         logging.info("Will use %s for compile", compile_database)
+        compile_database = [compile_database]
 
     context.obj = runner = ClangTidyRunner()
 


### PR DESCRIPTION
#### Problem

tidy script was supporting multi-arguments, so having autodetect set 'compile commands' to a string would result in character by character iteration instead of path by path.

```
root@aa7a7b42e599:/workspace# ./scripts/run-clang-tidy-on-compile-commands.py check
2022-04-05 16:00:39 WARNING Compilation database file not provided. Searching for first item in ./out
2022-04-05 16:00:39 INFO    Will use ./out/linux-x64-chip-tool/compile_commands.json for compile
Traceback (most recent call last):
  File "/workspace/./scripts/run-clang-tidy-on-compile-commands.py", line 450, in <module>
    main()
  File "/home/vscode/pigweed/env/pigweed-venv/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/vscode/pigweed/env/pigweed-venv/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/vscode/pigweed/env/pigweed-venv/lib/python3.9/site-packages/click/core.py", line 1268, in invoke
    Command.invoke(self, ctx)
  File "/home/vscode/pigweed/env/pigweed-venv/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/vscode/pigweed/env/pigweed-venv/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/vscode/pigweed/env/pigweed-venv/lib/python3.9/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/workspace/./scripts/run-clang-tidy-on-compile-commands.py", line 400, in main
    runner.AddDatabase(name)
  File "/workspace/./scripts/run-clang-tidy-on-compile-commands.py", line 202, in AddDatabase
    database = json.load(open(compile_commands_json))
IsADirectoryError: [Errno 21] Is a directory: '.'
```


#### Change overview
Change from string to list of strings with 1 element.

#### Testing

```
./scripts/run-clang-tidy-on-compile-commands.py check
```

actually runs.