### PR TITLE
Introduce ExchangeAcceptor for unsolicited message handler

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -415,6 +415,16 @@ CHIP_ERROR InteractionModelEngine::OnUnsolicitedReportData(Messaging::ExchangeCo
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR InteractionModelEngine::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader,
+                                                                System::PacketBufferHandle & payload,
+                                                                ExchangeDelegate *& newDelegate)
+{
+    // TODO: Implement OnUnsolicitedMessageReceived, let messaging layer dispatch message to ReadHandler/ReadClient/TimedHandler
+    // directly.
+    newDelegate = this;
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR InteractionModelEngine::OnMessageReceived(Messaging::ExchangeContext * apExchangeContext,
                                                      const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload)
 {

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -416,7 +416,6 @@ CHIP_ERROR InteractionModelEngine::OnUnsolicitedReportData(Messaging::ExchangeCo
 }
 
 CHIP_ERROR InteractionModelEngine::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader,
-                                                                System::PacketBufferHandle & payload,
                                                                 ExchangeDelegate *& newDelegate)
 {
     // TODO: Implement OnUnsolicitedMessageReceived, let messaging layer dispatch message to ReadHandler/ReadClient/TimedHandler

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -69,7 +69,7 @@ namespace app {
  * handlers
  *
  */
-class InteractionModelEngine : public Messaging::ExchangeAcceptor,
+class InteractionModelEngine : public Messaging::UnsolicitedMessageHandler,
                                public Messaging::ExchangeDelegate,
                                public CommandHandler::Callback,
                                public ReadHandler::ManagementCallback
@@ -268,8 +268,7 @@ private:
 
     ReadHandler::ApplicationCallback * GetAppCallback() override { return mpReadHandlerApplicationCallback; }
 
-    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
-                                            ExchangeDelegate *& newDelegate) override;
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override;
 
     /**
      * Called when Interaction Model receives a Command Request message.  Errors processing

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -69,7 +69,8 @@ namespace app {
  * handlers
  *
  */
-class InteractionModelEngine : public Messaging::ExchangeDelegate,
+class InteractionModelEngine : public Messaging::ExchangeAcceptor,
+                               public Messaging::ExchangeDelegate,
                                public CommandHandler::Callback,
                                public ReadHandler::ManagementCallback
 {
@@ -266,6 +267,9 @@ private:
     void OnDone(ReadHandler & apReadObj) override;
 
     ReadHandler::ApplicationCallback * GetAppCallback() override { return mpReadHandlerApplicationCallback; }
+
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
+                                            ExchangeDelegate *& newDelegate) override;
 
     /**
      * Called when Interaction Model receives a Command Request message.  Errors processing

--- a/src/messaging/ExchangeDelegate.h
+++ b/src/messaging/ExchangeDelegate.h
@@ -102,7 +102,8 @@ public:
 
 /**
  * @brief
- *   This class handles unsolicited messages. The implementation can peek the message and creating a new exchange for it or not.
+ *   This class handles unsolicited messages. The implementation can select an exchange
+ *   delegate to use based on the payload header of the incoming message.
  */
 class DLL_EXPORT UnsolicitedMessageHandler
 {
@@ -111,27 +112,33 @@ public:
 
     /**
      * @brief
-     *   This function handles a unsolicited CHIP message.
+     *   This function handles an unsolicited CHIP message.
      *
-     *   If the implmentation returns CHIP_NO_ERROR, the message layer will create a new exchange with newDelegate, associated to
-     * the message, and using the new exchange to handle future messages.
+     *   If the implementation returns CHIP_NO_ERROR, it is expected to set newDelegate
+     *   to the delegate to use for the exchange handling the message.  The message layer
+     *   will handle creating the exchange with this delegate.
      *
-     *   The acceptor peek the message here, and the message payload will be sent to the new exchange regardless.
+     *   If the implementation returns an error, message processing will be aborted for this message.
      *
-     *  @param[in]  payloadHeader A reference to the PayloadHeader object.
-     *  @param[in]  payload       A handle to the PacketBuffer object holding the message payload.
-     *  @param[out] newDelegate   A new exchange delegate being used by the new exchange to handle future messages.
+     *  @param[in]  payloadHeader A reference to the PayloadHeader object for
+                                  the unsolicited message.  The protocol and
+                                  message type of this header match the
+				  UnsolicitedMessageHandler.
+     *  @param[out] newDelegate   A new exchange delegate to be used by the new exchange created to handle the message.
      */
     virtual CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) = 0;
 
     /**
      * @brief
      *   This function is called when OnUnsolicitedMessageReceived successfully returns a new delegate, but the session manager
-     *   fails to assign the delegate to a new exchange, then the delegate should be released to avoid resource leak.
+     *   fails to assign the delegate to a new exchange.  It can be used to free the delegate as needed.
+     *
+     *   Once an exchange is created with the delegate, the OnExchangeClosing notification can be used
+     *   to free the delegate as needed.
      *
      *  @param[in] delegate   The exchange delegate to be released.
      */
-    virtual void ReleaseDelegate(ExchangeDelegate * delegate) {}
+    virtual void ExchangeCreationFailed(ExchangeDelegate * delegate) {}
 };
 
 } // namespace Messaging

--- a/src/messaging/ExchangeDelegate.h
+++ b/src/messaging/ExchangeDelegate.h
@@ -100,5 +100,31 @@ public:
     virtual ExchangeMessageDispatch & GetMessageDispatch() { return ApplicationExchangeDispatch::Instance(); }
 };
 
+/**
+ * @brief
+ *   This class handles unsolicited messages. The implementation can peek the message and creating a new exchange for it or not.
+ */
+class DLL_EXPORT ExchangeAcceptor
+{
+public:
+    virtual ~ExchangeAcceptor() {}
+
+    /**
+     * @brief
+     *   This function handles a unsolicited CHIP message.
+     *
+     *   If the implmentation returns CHIP_NO_ERROR, the message layer will create a new exchange with newDelegate, associated to
+     * the message, and using the new exchange to handle future messages.
+     *
+     *   The acceptor peek the message here, and the message payload will be sent to the new exchange regardless.
+     *
+     *  @param[in]  payloadHeader A reference to the PayloadHeader object.
+     *  @param[in]  payload       A handle to the PacketBuffer object holding the message payload.
+     *  @param[out] newDelegate   A new exchange delegate being used by the new exchange to handle future messages.
+     */
+    virtual CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
+                                                    ExchangeDelegate *& newDelegate) = 0;
+};
+
 } // namespace Messaging
 } // namespace chip

--- a/src/messaging/ExchangeDelegate.h
+++ b/src/messaging/ExchangeDelegate.h
@@ -102,8 +102,8 @@ public:
 
 /**
  * @brief
- *   This class handles unsolicited messages. The implementation can select an exchange
- *   delegate to use based on the payload header of the incoming message.
+ *   This class handles unsolicited messages. The implementation can select an exchange delegate to use based on the payload header
+ * of the incoming message.
  */
 class DLL_EXPORT UnsolicitedMessageHandler
 {
@@ -114,16 +114,13 @@ public:
      * @brief
      *   This function handles an unsolicited CHIP message.
      *
-     *   If the implementation returns CHIP_NO_ERROR, it is expected to set newDelegate
-     *   to the delegate to use for the exchange handling the message.  The message layer
-     *   will handle creating the exchange with this delegate.
+     *   If the implementation returns CHIP_NO_ERROR, it is expected to set newDelegate to the delegate to use for the exchange
+     *   handling the message.  The message layer will handle creating the exchange with this delegate.
      *
      *   If the implementation returns an error, message processing will be aborted for this message.
      *
-     *  @param[in]  payloadHeader A reference to the PayloadHeader object for
-                                  the unsolicited message.  The protocol and
-                                  message type of this header match the
-				  UnsolicitedMessageHandler.
+     *  @param[in]  payloadHeader A reference to the PayloadHeader object for the unsolicited message.  The protocol and message
+     *                            type of this header match the UnsolicitedMessageHandler.
      *  @param[out] newDelegate   A new exchange delegate to be used by the new exchange created to handle the message.
      */
     virtual CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) = 0;
@@ -133,12 +130,12 @@ public:
      *   This function is called when OnUnsolicitedMessageReceived successfully returns a new delegate, but the session manager
      *   fails to assign the delegate to a new exchange.  It can be used to free the delegate as needed.
      *
-     *   Once an exchange is created with the delegate, the OnExchangeClosing notification can be used
-     *   to free the delegate as needed.
+     *   Once an exchange is created with the delegate, the OnExchangeClosing notification can be used to free the delegate as
+     *   needed.
      *
      *  @param[in] delegate   The exchange delegate to be released.
      */
-    virtual void ExchangeCreationFailed(ExchangeDelegate * delegate) {}
+    virtual void OnExchangeCreationFailed(ExchangeDelegate * delegate) {}
 };
 
 } // namespace Messaging

--- a/src/messaging/ExchangeDelegate.h
+++ b/src/messaging/ExchangeDelegate.h
@@ -104,10 +104,10 @@ public:
  * @brief
  *   This class handles unsolicited messages. The implementation can peek the message and creating a new exchange for it or not.
  */
-class DLL_EXPORT ExchangeAcceptor
+class DLL_EXPORT UnsolicitedMessageHandler
 {
 public:
-    virtual ~ExchangeAcceptor() {}
+    virtual ~UnsolicitedMessageHandler() {}
 
     /**
      * @brief
@@ -122,8 +122,16 @@ public:
      *  @param[in]  payload       A handle to the PacketBuffer object holding the message payload.
      *  @param[out] newDelegate   A new exchange delegate being used by the new exchange to handle future messages.
      */
-    virtual CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
-                                                    ExchangeDelegate *& newDelegate) = 0;
+    virtual CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) = 0;
+
+    /**
+     * @brief
+     *   This function is called when OnUnsolicitedMessageReceived successfully returns a new delegate, but the session manager
+     *   fails to assign the delegate to a new exchange, then the delegate should be released to avoid resource leak.
+     *
+     *  @param[in] delegate   The exchange delegate to be released.
+     */
+    virtual void ReleaseDelegate(ExchangeDelegate * delegate) {}
 };
 
 } // namespace Messaging

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -299,7 +299,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
         {
             if (matchingUMH != nullptr && delegate != nullptr)
             {
-                matchingUMH->Handler->ReleaseDelegate(delegate);
+                matchingUMH->Handler->OnExchangeCreationFailed(delegate);
             }
 
             // Using same error message for all errors to reduce code size.

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -109,13 +109,13 @@ public:
      *
      *  @param[in]    protocolId      The protocol identifier of the received message.
      *
-     *  @param[in]    acceptor        A pointer to ExchangeAcceptor.
+     *  @param[in]    handler         A pointer to UnsolicitedMessageHandler.
      *
      *  @retval #CHIP_ERROR_TOO_MANY_UNSOLICITED_MESSAGE_HANDLERS If the unsolicited message handler pool
      *                                                             is full and a new one cannot be allocated.
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR RegisterUnsolicitedMessageHandlerForProtocol(Protocols::Id protocolId, ExchangeAcceptor * acceptor);
+    CHIP_ERROR RegisterUnsolicitedMessageHandlerForProtocol(Protocols::Id protocolId, UnsolicitedMessageHandler * handler);
 
     /**
      *  Register an unsolicited message handler for a given protocol identifier and message type.
@@ -124,22 +124,23 @@ public:
      *
      *  @param[in]    msgType         The message type of the corresponding protocol.
      *
-     *  @param[in]    acceptor        A pointer to ExchangeAcceptor.
+     *  @param[in]    handler         A pointer to UnsolicitedMessageHandler.
      *
      *  @retval #CHIP_ERROR_TOO_MANY_UNSOLICITED_MESSAGE_HANDLERS If the unsolicited message handler pool
      *                                                             is full and a new one cannot be allocated.
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR RegisterUnsolicitedMessageHandlerForType(Protocols::Id protocolId, uint8_t msgType, ExchangeAcceptor * acceptor);
+    CHIP_ERROR RegisterUnsolicitedMessageHandlerForType(Protocols::Id protocolId, uint8_t msgType,
+                                                        UnsolicitedMessageHandler * handler);
 
     /**
      * A strongly-message-typed version of RegisterUnsolicitedMessageHandlerForType.
      */
     template <typename MessageType, typename = std::enable_if_t<std::is_enum<MessageType>::value>>
-    CHIP_ERROR RegisterUnsolicitedMessageHandlerForType(MessageType msgType, ExchangeAcceptor * acceptor)
+    CHIP_ERROR RegisterUnsolicitedMessageHandlerForType(MessageType msgType, UnsolicitedMessageHandler * handler)
     {
         return RegisterUnsolicitedMessageHandlerForType(Protocols::MessageTypeTraits<MessageType>::ProtocolId(),
-                                                        to_underlying(msgType), acceptor);
+                                                        to_underlying(msgType), handler);
     }
 
     /**
@@ -200,25 +201,26 @@ private:
         kState_Initialized    = 1  // Used to indicate that the ExchangeManager is initialized.
     };
 
-    struct UnsolicitedMessageHandler
+    struct UnsolicitedMessageHandlerSlot
     {
-        UnsolicitedMessageHandler() : ProtocolId(Protocols::NotSpecified) {}
+        UnsolicitedMessageHandlerSlot() : ProtocolId(Protocols::NotSpecified) {}
 
-        constexpr void Reset() { Acceptor = nullptr; }
-        constexpr bool IsInUse() const { return Acceptor != nullptr; }
+        constexpr void Reset() { Handler = nullptr; }
+        constexpr bool IsInUse() const { return Handler != nullptr; }
         // Matches() only returns a sensible value if IsInUse() is true.
         constexpr bool Matches(Protocols::Id aProtocolId, int16_t aMessageType) const
         {
             return ProtocolId == aProtocolId && MessageType == aMessageType;
         }
 
-        ExchangeAcceptor * Acceptor;
         Protocols::Id ProtocolId;
         // Message types are normally 8-bit unsigned ints, but we use
         // kAnyMessageType, which is negative, to represent a wildcard handler,
         // so need a type that can store both that and all valid message type
         // values.
         int16_t MessageType;
+
+        UnsolicitedMessageHandler * Handler;
     };
 
     uint16_t mNextExchangeId;
@@ -232,9 +234,9 @@ private:
 
     BitMapObjectPool<ExchangeContext, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS> mContextPool;
 
-    UnsolicitedMessageHandler UMHandlerPool[CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS];
+    UnsolicitedMessageHandlerSlot UMHandlerPool[CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS];
 
-    CHIP_ERROR RegisterUMH(Protocols::Id protocolId, int16_t msgType, ExchangeAcceptor * acceptor);
+    CHIP_ERROR RegisterUMH(Protocols::Id protocolId, int16_t msgType, UnsolicitedMessageHandler * handler);
     CHIP_ERROR UnregisterUMH(Protocols::Id protocolId, int16_t msgType);
 
     void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, const SessionHandle & session,

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -109,13 +109,13 @@ public:
      *
      *  @param[in]    protocolId      The protocol identifier of the received message.
      *
-     *  @param[in]    delegate        A pointer to ExchangeDelegate.
+     *  @param[in]    acceptor        A pointer to ExchangeAcceptor.
      *
      *  @retval #CHIP_ERROR_TOO_MANY_UNSOLICITED_MESSAGE_HANDLERS If the unsolicited message handler pool
      *                                                             is full and a new one cannot be allocated.
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR RegisterUnsolicitedMessageHandlerForProtocol(Protocols::Id protocolId, ExchangeDelegate * delegate);
+    CHIP_ERROR RegisterUnsolicitedMessageHandlerForProtocol(Protocols::Id protocolId, ExchangeAcceptor * acceptor);
 
     /**
      *  Register an unsolicited message handler for a given protocol identifier and message type.
@@ -124,22 +124,22 @@ public:
      *
      *  @param[in]    msgType         The message type of the corresponding protocol.
      *
-     *  @param[in]    delegate        A pointer to ExchangeDelegate.
+     *  @param[in]    acceptor        A pointer to ExchangeAcceptor.
      *
      *  @retval #CHIP_ERROR_TOO_MANY_UNSOLICITED_MESSAGE_HANDLERS If the unsolicited message handler pool
      *                                                             is full and a new one cannot be allocated.
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR RegisterUnsolicitedMessageHandlerForType(Protocols::Id protocolId, uint8_t msgType, ExchangeDelegate * delegate);
+    CHIP_ERROR RegisterUnsolicitedMessageHandlerForType(Protocols::Id protocolId, uint8_t msgType, ExchangeAcceptor * acceptor);
 
     /**
      * A strongly-message-typed version of RegisterUnsolicitedMessageHandlerForType.
      */
     template <typename MessageType, typename = std::enable_if_t<std::is_enum<MessageType>::value>>
-    CHIP_ERROR RegisterUnsolicitedMessageHandlerForType(MessageType msgType, ExchangeDelegate * delegate)
+    CHIP_ERROR RegisterUnsolicitedMessageHandlerForType(MessageType msgType, ExchangeAcceptor * acceptor)
     {
         return RegisterUnsolicitedMessageHandlerForType(Protocols::MessageTypeTraits<MessageType>::ProtocolId(),
-                                                        to_underlying(msgType), delegate);
+                                                        to_underlying(msgType), acceptor);
     }
 
     /**
@@ -204,15 +204,15 @@ private:
     {
         UnsolicitedMessageHandler() : ProtocolId(Protocols::NotSpecified) {}
 
-        constexpr void Reset() { Delegate = nullptr; }
-        constexpr bool IsInUse() const { return Delegate != nullptr; }
+        constexpr void Reset() { Acceptor = nullptr; }
+        constexpr bool IsInUse() const { return Acceptor != nullptr; }
         // Matches() only returns a sensible value if IsInUse() is true.
         constexpr bool Matches(Protocols::Id aProtocolId, int16_t aMessageType) const
         {
             return ProtocolId == aProtocolId && MessageType == aMessageType;
         }
 
-        ExchangeDelegate * Delegate;
+        ExchangeAcceptor * Acceptor;
         Protocols::Id ProtocolId;
         // Message types are normally 8-bit unsigned ints, but we use
         // kAnyMessageType, which is negative, to represent a wildcard handler,
@@ -234,7 +234,7 @@ private:
 
     UnsolicitedMessageHandler UMHandlerPool[CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS];
 
-    CHIP_ERROR RegisterUMH(Protocols::Id protocolId, int16_t msgType, ExchangeDelegate * delegate);
+    CHIP_ERROR RegisterUMH(Protocols::Id protocolId, int16_t msgType, ExchangeAcceptor * acceptor);
     CHIP_ERROR UnregisterUMH(Protocols::Id protocolId, int16_t msgType);
 
     void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, const SessionHandle & session,

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -59,11 +59,10 @@ enum : uint8_t
 
 TestContext sContext;
 
-class MockAppDelegate : public ExchangeAcceptor, public ExchangeDelegate
+class MockAppDelegate : public UnsolicitedMessageHandler, public ExchangeDelegate
 {
 public:
-    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
-                                            ExchangeDelegate *& newDelegate) override
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override
     {
         newDelegate = this;
         return CHIP_NO_ERROR;

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -59,9 +59,16 @@ enum : uint8_t
 
 TestContext sContext;
 
-class MockAppDelegate : public ExchangeDelegate
+class MockAppDelegate : public ExchangeAcceptor, public ExchangeDelegate
 {
 public:
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
+                                            ExchangeDelegate *& newDelegate) override
+    {
+        newDelegate = this;
+        return CHIP_NO_ERROR;
+    }
+
     CHIP_ERROR OnMessageReceived(ExchangeContext * ec, const PayloadHeader & payloadHeader,
                                  System::PacketBufferHandle && buffer) override
     {

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -63,11 +63,10 @@ const char PAYLOAD[] = "Hello!";
 
 auto & gLoopback = sContext.GetLoopback();
 
-class MockAppDelegate : public ExchangeAcceptor, public ExchangeDelegate
+class MockAppDelegate : public UnsolicitedMessageHandler, public ExchangeDelegate
 {
 public:
-    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
-                                            ExchangeDelegate *& newDelegate) override
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override
     {
         // Handle messages by myself
         newDelegate = this;
@@ -147,11 +146,10 @@ public:
     bool mRequireEncryption = false;
 };
 
-class MockSessionEstablishmentDelegate : public ExchangeAcceptor, public ExchangeDelegate
+class MockSessionEstablishmentDelegate : public UnsolicitedMessageHandler, public ExchangeDelegate
 {
 public:
-    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
-                                            ExchangeDelegate *& newDelegate) override
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override
     {
         // Handle messages by myself
         newDelegate = this;

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -63,9 +63,17 @@ const char PAYLOAD[] = "Hello!";
 
 auto & gLoopback = sContext.GetLoopback();
 
-class MockAppDelegate : public ExchangeDelegate
+class MockAppDelegate : public ExchangeAcceptor, public ExchangeDelegate
 {
 public:
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
+                                            ExchangeDelegate *& newDelegate) override
+    {
+        // Handle messages by myself
+        newDelegate = this;
+        return CHIP_NO_ERROR;
+    }
+
     CHIP_ERROR OnMessageReceived(ExchangeContext * ec, const PayloadHeader & payloadHeader,
                                  System::PacketBufferHandle && buffer) override
     {
@@ -139,9 +147,17 @@ public:
     bool mRequireEncryption = false;
 };
 
-class MockSessionEstablishmentDelegate : public ExchangeDelegate
+class MockSessionEstablishmentDelegate : public ExchangeAcceptor, public ExchangeDelegate
 {
 public:
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
+                                            ExchangeDelegate *& newDelegate) override
+    {
+        // Handle messages by myself
+        newDelegate = this;
+        return CHIP_NO_ERROR;
+    }
+
     CHIP_ERROR OnMessageReceived(ExchangeContext * ec, const PayloadHeader & payloadHeader,
                                  System::PacketBufferHandle && buffer) override
     {

--- a/src/protocols/bdx/TransferFacilitator.h
+++ b/src/protocols/bdx/TransferFacilitator.h
@@ -41,13 +41,22 @@ namespace bdx {
  * This class contains a repeating timer which regurlaly polls the TransferSession state machine.
  * A CHIP node may have many TransferFacilitator instances but only one TransferFacilitator should be used for each BDX transfer.
  */
-class TransferFacilitator : public Messaging::ExchangeDelegate
+class TransferFacilitator : public Messaging::ExchangeDelegate, public Messaging::UnsolicitedMessageHandler
 {
 public:
     TransferFacilitator() : mExchangeCtx(nullptr), mSystemLayer(nullptr), mPollFreq(kDefaultPollFreq) {}
     ~TransferFacilitator() override = default;
 
 private:
+    //// UnsolicitedMessageHandler Implementation ////
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override
+    {
+        // TODO: Implement a bdx manager, which dispatch bdx messages to bdx transections.
+        // directly.
+        newDelegate = this;
+        return CHIP_NO_ERROR;
+    }
+
     // Inherited from ExchangeContext
     CHIP_ERROR OnMessageReceived(chip::Messaging::ExchangeContext * ec, const chip::PayloadHeader & payloadHeader,
                                  chip::System::PacketBufferHandle && payload) override;

--- a/src/protocols/echo/Echo.h
+++ b/src/protocols/echo/Echo.h
@@ -110,7 +110,7 @@ private:
     void OnResponseTimeout(Messaging::ExchangeContext * ec) override;
 };
 
-class DLL_EXPORT EchoServer : public Messaging::ExchangeAcceptor, public Messaging::ExchangeDelegate
+class DLL_EXPORT EchoServer : public Messaging::UnsolicitedMessageHandler, public Messaging::ExchangeDelegate
 {
 public:
     /**
@@ -147,8 +147,7 @@ private:
     Messaging::ExchangeManager * mExchangeMgr = nullptr;
     EchoFunct OnEchoRequestReceived           = nullptr;
 
-    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
-                                            ExchangeDelegate *& newDelegate) override;
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override;
     CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
                                  System::PacketBufferHandle && payload) override;
     void OnResponseTimeout(Messaging::ExchangeContext * ec) override {}

--- a/src/protocols/echo/Echo.h
+++ b/src/protocols/echo/Echo.h
@@ -110,7 +110,7 @@ private:
     void OnResponseTimeout(Messaging::ExchangeContext * ec) override;
 };
 
-class DLL_EXPORT EchoServer : public Messaging::ExchangeDelegate
+class DLL_EXPORT EchoServer : public Messaging::ExchangeAcceptor, public Messaging::ExchangeDelegate
 {
 public:
     /**
@@ -147,6 +147,8 @@ private:
     Messaging::ExchangeManager * mExchangeMgr = nullptr;
     EchoFunct OnEchoRequestReceived           = nullptr;
 
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
+                                            ExchangeDelegate *& newDelegate) override;
     CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
                                  System::PacketBufferHandle && payload) override;
     void OnResponseTimeout(Messaging::ExchangeContext * ec) override {}

--- a/src/protocols/echo/EchoServer.cpp
+++ b/src/protocols/echo/EchoServer.cpp
@@ -53,8 +53,7 @@ void EchoServer::Shutdown()
     }
 }
 
-CHIP_ERROR EchoServer::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
-                                                    ExchangeDelegate *& newDelegate)
+CHIP_ERROR EchoServer::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate)
 {
     // Handle messages by myself
     newDelegate = this;

--- a/src/protocols/echo/EchoServer.cpp
+++ b/src/protocols/echo/EchoServer.cpp
@@ -53,6 +53,14 @@ void EchoServer::Shutdown()
     }
 }
 
+CHIP_ERROR EchoServer::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
+                                                    ExchangeDelegate *& newDelegate)
+{
+    // Handle messages by myself
+    newDelegate = this;
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR EchoServer::OnMessageReceived(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
                                          System::PacketBufferHandle && payload)
 {

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -81,8 +81,7 @@ CHIP_ERROR CASEServer::InitCASEHandshake(Messaging::ExchangeContext * ec)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CASEServer::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
-                                                    ExchangeDelegate *& newDelegate)
+CHIP_ERROR CASEServer::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate)
 {
     // TODO: assign newDelegate to CASESession, let CASESession handle future messages.
     newDelegate = this;

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -81,6 +81,14 @@ CHIP_ERROR CASEServer::InitCASEHandshake(Messaging::ExchangeContext * ec)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR CASEServer::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
+                                                    ExchangeDelegate *& newDelegate)
+{
+    // TODO: assign newDelegate to CASESession, let CASESession handle future messages.
+    newDelegate = this;
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR CASEServer::OnMessageReceived(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
                                          System::PacketBufferHandle && payload)
 {

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -27,7 +27,7 @@
 
 namespace chip {
 
-class CASEServer : public SessionEstablishmentDelegate, public Messaging::ExchangeDelegate
+class CASEServer : public SessionEstablishmentDelegate, public Messaging::ExchangeAcceptor, public Messaging::ExchangeDelegate
 {
 public:
     CASEServer() {}
@@ -50,6 +50,10 @@ public:
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
     void OnSessionEstablished() override;
+
+    //// ExchangeAcceptor Implementation ////
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
+                                            ExchangeDelegate *& newDelegate) override;
 
     //// ExchangeDelegate Implementation ////
     CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -27,7 +27,9 @@
 
 namespace chip {
 
-class CASEServer : public SessionEstablishmentDelegate, public Messaging::ExchangeAcceptor, public Messaging::ExchangeDelegate
+class CASEServer : public SessionEstablishmentDelegate,
+                   public Messaging::UnsolicitedMessageHandler,
+                   public Messaging::ExchangeDelegate
 {
 public:
     CASEServer() {}
@@ -51,9 +53,8 @@ public:
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
     void OnSessionEstablished() override;
 
-    //// ExchangeAcceptor Implementation ////
-    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
-                                            ExchangeDelegate *& newDelegate) override;
+    //// UnsolicitedMessageHandler Implementation ////
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override;
 
     //// ExchangeDelegate Implementation ////
     CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -53,7 +53,11 @@ namespace chip {
 #define CASE_EPHEMERAL_KEY 0xCA5EECD0
 #endif
 
-class DLL_EXPORT CASESession : public Messaging::ExchangeDelegate, public PairingSession
+// TODO: temporary derive from Messaging::UnsolicitedMessageHandler, actually the CASEServer should be the umh, it will be fixed
+// when implementing concurrent CASE session.
+class DLL_EXPORT CASESession : public Messaging::UnsolicitedMessageHandler,
+                               public Messaging::ExchangeDelegate,
+                               public PairingSession
 {
 public:
     CASESession();
@@ -140,6 +144,13 @@ public:
      * @return CHIP_ERROR The result of session derivation
      */
     CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) override;
+
+    //// UnsolicitedMessageHandler Implementation ////
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override
+    {
+        newDelegate = this;
+        return CHIP_NO_ERROR;
+    }
 
     //// ExchangeDelegate Implementation ////
     CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,

--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -88,6 +88,15 @@ CHIP_ERROR MessageCounterManager::QueueReceivedMessageAndStartSync(const PacketH
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR MessageCounterManager::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader,
+                                                               System::PacketBufferHandle & payload,
+                                                               ExchangeDelegate *& newDelegate)
+{
+    // MessageCounterManager do not use an extra context to handle messages
+    newDelegate = this;
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR MessageCounterManager::OnMessageReceived(Messaging::ExchangeContext * exchangeContext,
                                                     const PayloadHeader & payloadHeader, System::PacketBufferHandle && msgBuf)
 {

--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -88,9 +88,7 @@ CHIP_ERROR MessageCounterManager::QueueReceivedMessageAndStartSync(const PacketH
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR MessageCounterManager::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader,
-                                                               System::PacketBufferHandle & payload,
-                                                               ExchangeDelegate *& newDelegate)
+CHIP_ERROR MessageCounterManager::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate)
 {
     // MessageCounterManager do not use an extra context to handle messages
     newDelegate = this;

--- a/src/protocols/secure_channel/MessageCounterManager.h
+++ b/src/protocols/secure_channel/MessageCounterManager.h
@@ -31,7 +31,7 @@ namespace secure_channel {
 
 class ExchangeManager;
 
-class MessageCounterManager : public Messaging::ExchangeAcceptor,
+class MessageCounterManager : public Messaging::UnsolicitedMessageHandler,
                               public Messaging::ExchangeDelegate,
                               public Transport::MessageCounterManagerInterface
 {
@@ -107,8 +107,7 @@ private:
     CHIP_ERROR HandleMsgCounterSyncReq(Messaging::ExchangeContext * exchangeContext, System::PacketBufferHandle && msgBuf);
     CHIP_ERROR HandleMsgCounterSyncResp(Messaging::ExchangeContext * exchangeContext, System::PacketBufferHandle && msgBuf);
 
-    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
-                                            ExchangeDelegate *& newDelegate) override;
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override;
     CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * exchangeContext, const PayloadHeader & payloadHeader,
                                  System::PacketBufferHandle && payload) override;
 

--- a/src/protocols/secure_channel/MessageCounterManager.h
+++ b/src/protocols/secure_channel/MessageCounterManager.h
@@ -31,7 +31,9 @@ namespace secure_channel {
 
 class ExchangeManager;
 
-class MessageCounterManager : public Messaging::ExchangeDelegate, public Transport::MessageCounterManagerInterface
+class MessageCounterManager : public Messaging::ExchangeAcceptor,
+                              public Messaging::ExchangeDelegate,
+                              public Transport::MessageCounterManagerInterface
 {
 public:
     static constexpr uint16_t kChallengeSize             = Transport::PeerMessageCounter::kChallengeSize;
@@ -104,6 +106,9 @@ private:
     CHIP_ERROR SendMsgCounterSyncResp(Messaging::ExchangeContext * exchangeContext, FixedByteSpan<kChallengeSize> challenge);
     CHIP_ERROR HandleMsgCounterSyncReq(Messaging::ExchangeContext * exchangeContext, System::PacketBufferHandle && msgBuf);
     CHIP_ERROR HandleMsgCounterSyncResp(Messaging::ExchangeContext * exchangeContext, System::PacketBufferHandle && msgBuf);
+
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
+                                            ExchangeDelegate *& newDelegate) override;
     CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * exchangeContext, const PayloadHeader & payloadHeader,
                                  System::PacketBufferHandle && payload) override;
 

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -820,8 +820,7 @@ CHIP_ERROR PASESession::ValidateReceivedMessage(ExchangeContext * exchange, cons
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR PASESession::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
-                                                     ExchangeDelegate *& newDelegate)
+CHIP_ERROR PASESession::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate)
 {
     // Handle messages by myself
     newDelegate = this;

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -820,6 +820,14 @@ CHIP_ERROR PASESession::ValidateReceivedMessage(ExchangeContext * exchange, cons
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR PASESession::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
+                                                     ExchangeDelegate *& newDelegate)
+{
+    // Handle messages by myself
+    newDelegate = this;
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR PASESession::OnMessageReceived(ExchangeContext * exchange, const PayloadHeader & payloadHeader,
                                           System::PacketBufferHandle && msg)
 {

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -66,7 +66,7 @@ struct PASESessionSerializable
     uint16_t mPeerSessionId;
 };
 
-class DLL_EXPORT PASESession : public Messaging::ExchangeDelegate, public PairingSession
+class DLL_EXPORT PASESession : public Messaging::ExchangeAcceptor, public Messaging::ExchangeDelegate, public PairingSession
 {
 public:
     PASESession();
@@ -78,6 +78,9 @@ public:
     // TODO: The SetPeerNodeId method should not be exposed; PASE sessions
     // should not need to be told their peer node ID
     using PairingSession::SetPeerNodeId;
+
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
+                                            ExchangeDelegate *& newDelegate) override;
 
     /**
      * @brief

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -66,7 +66,9 @@ struct PASESessionSerializable
     uint16_t mPeerSessionId;
 };
 
-class DLL_EXPORT PASESession : public Messaging::ExchangeAcceptor, public Messaging::ExchangeDelegate, public PairingSession
+class DLL_EXPORT PASESession : public Messaging::UnsolicitedMessageHandler,
+                               public Messaging::ExchangeDelegate,
+                               public PairingSession
 {
 public:
     PASESession();
@@ -79,8 +81,7 @@ public:
     // should not need to be told their peer node ID
     using PairingSession::SetPeerNodeId;
 
-    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle & payload,
-                                            ExchangeDelegate *& newDelegate) override;
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override;
 
     /**
      * @brief

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -251,6 +251,8 @@ void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
 void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, CASESession & pairingCommissioner,
                                            TestCASESecurePairingDelegate & delegateCommissioner)
 {
+// Temparory skip this tests. It will be re-enabled after implementing concurrent CASE session
+#if 0
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
     // Test all combinations of invalid parameters
@@ -282,6 +284,7 @@ void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inConte
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 5);
     NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);
     NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
+#endif
 }
 
 void CASE_SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -251,8 +251,6 @@ void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
 void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, CASESession & pairingCommissioner,
                                            TestCASESecurePairingDelegate & delegateCommissioner)
 {
-// Temparory skip this tests. It will be re-enabled after implementing concurrent CASE session
-#if 0
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
     // Test all combinations of invalid parameters
@@ -284,7 +282,6 @@ void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inConte
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 5);
     NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);
     NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
-#endif
 }
 
 void CASE_SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
#### Problem
Path to fix #8342

#### Change overview
The unsolicited message handler should take an exchange acceptor instead of an exchange delegate. Instead of associating the same delegate to all exchanges, the exchange acceptor is able to assign a delegate to each new exchange when an unsolicited message arrives.

There are several usage of unsolicited message handler in CHIP
1. IM: the newly create exchange should associate to ReadHandler/ReadClient when possible. W/o doing this, there is a bug the `OnResponseTimeout` is not handled properly by `InteractionModelEngine`
2. CASE Server: each sigma1 message should create a new exchange, and a new `CASESession` should be created for the new exchange, as its delegate.
3. BDX: We should support concurrent BDX sessions, where every BDX session owns its own exchange.

Due to these usage, the unsolicited message handler should associate to an exchange acceptor instead of an exchange delegate.

#### Testing
Passed unit-tests