### PR TITLE
Fail A record parsing if IPV4 is disabled in CHIP

### DIFF
--- a/src/lib/dnssd/minimal_mdns/RecordData.cpp
+++ b/src/lib/dnssd/minimal_mdns/RecordData.cpp
@@ -90,6 +90,7 @@ bool SrvRecord::Parse(const BytesRange & data, const BytesRange & packet)
 
 bool ParseARecord(const BytesRange & data, chip::Inet::IPAddress * addr)
 {
+#if INET_CONFIG_ENABLE_IPV4
     if (data.Size() != 4)
     {
         return false;
@@ -101,6 +102,10 @@ bool ParseARecord(const BytesRange & data, chip::Inet::IPAddress * addr)
     addr->Addr[3] = htonl(chip::Encoding::BigEndian::Get32(data.Start()));
 
     return true;
+#else
+    // IPV4 support is disabled: IPAddress should never get IPv4 values.
+    return false;
+#endif
 }
 
 bool ParseAAAARecord(const BytesRange & data, chip::Inet::IPAddress * addr)

--- a/src/lib/dnssd/minimal_mdns/tests/TestRecordData.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestRecordData.cpp
@@ -106,7 +106,6 @@ void SrvWithPtrRecord(nlTestSuite * inSuite, void * inContext)
     }
 }
 
-#if INET_CONFIG_ENABLE_IPV4
 void ARecordParsing(nlTestSuite * inSuite, void * inContext)
 {
     const uint8_t record[] = {
@@ -117,13 +116,17 @@ void ARecordParsing(nlTestSuite * inSuite, void * inContext)
     };
 
     Inet::IPAddress addr;
+
+#if INET_CONFIG_ENABLE_IPV4
     Inet::IPAddress expected;
 
     NL_TEST_ASSERT(inSuite, ParseARecord(BytesRange(record, record + sizeof(record)), &addr));
     NL_TEST_ASSERT(inSuite, Inet::IPAddress::FromString("10.11.12.13", expected));
     NL_TEST_ASSERT(inSuite, addr == expected);
-}
+#else
+    NL_TEST_ASSERT(inSuite, !ParseARecord(BytesRange(record, record + sizeof(record)), &addr));
 #endif // INET_CONFIG_ENABLE_IPV4
+}
 
 void AAAARecordParsing(nlTestSuite * inSuite, void * inContext)
 {

--- a/src/lib/dnssd/minimal_mdns/tests/TestRecordData.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestRecordData.cpp
@@ -243,11 +243,9 @@ void TxtRecord(nlTestSuite * inSuite, void * inContext)
 }
 
 const nlTest sTests[] = {
-    NL_TEST_DEF("SrvRecordSimpleParsing", SrvRecordSimpleParsing), //
-    NL_TEST_DEF("SrvWithPtrRecord", SrvWithPtrRecord),             //
-#if INET_CONFIG_ENABLE_IPV4
+    NL_TEST_DEF("SrvRecordSimpleParsing", SrvRecordSimpleParsing),   //
+    NL_TEST_DEF("SrvWithPtrRecord", SrvWithPtrRecord),               //
     NL_TEST_DEF("ARecordParsing", ARecordParsing),                   //
-#endif                                                               // INET_CONFIG_ENABLE_IPV4
     NL_TEST_DEF("AAAARecordParsing", AAAARecordParsing),             //
     NL_TEST_DEF("PtrRecordSimpleParsing", PtrRecordSimpleParsing),   //
     NL_TEST_DEF("PtrRecordComplexParsing", PtrRecordComplexParsing), //


### PR DESCRIPTION
#### Problem

MinMDNS blindly parses A records even though code relies that IPV4 disabled means no IPV4 addresses anywhere.


#### Change overview
Refuse to parse A records if no IPV4 support.

Fixes #16837

#### Testing
Compile and unit test updated.
