### PR TITLE
Fix nrf rpc builds

### DIFF
--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -146,7 +146,7 @@ class NrfConnectBuilder(Builder):
 
             overlays = []
             if self.enable_rpcs:
-                overlays.append("-DOVERLAY_CONFIG=rpc.overlay")
+                overlays.append("-DOVERLAY_CONFIG=../../rpc.overlay")
 
             cmd = '''
 source "$ZEPHYR_BASE/zephyr-env.sh";

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -826,7 +826,7 @@ west build --cmake-only -d {out}/nrf-nrf52840dk-light -b nrf52840dk_nrf52840 {ro
 # Generating nrf-nrf52840dk-light-rpc
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_ARM_CIPD_INSTALL_DIR";
-west build --cmake-only -d {out}/nrf-nrf52840dk-light-rpc -b nrf52840dk_nrf52840 {root}/examples/lighting-app/nrfconnect -- -DOVERLAY_CONFIG=rpc.overlay'
+west build --cmake-only -d {out}/nrf-nrf52840dk-light-rpc -b nrf52840dk_nrf52840 {root}/examples/lighting-app/nrfconnect -- -DOVERLAY_CONFIG=../../rpc.overlay'
 
 # Generating nrf-nrf52840dk-lock
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
@@ -861,7 +861,7 @@ west build --cmake-only -d {out}/nrf-nrf5340dk-light -b nrf5340dk_nrf5340_cpuapp
 # Generating nrf-nrf5340dk-light-rpc
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_ARM_CIPD_INSTALL_DIR";
-west build --cmake-only -d {out}/nrf-nrf5340dk-light-rpc -b nrf5340dk_nrf5340_cpuapp {root}/examples/lighting-app/nrfconnect -- -DOVERLAY_CONFIG=rpc.overlay'
+west build --cmake-only -d {out}/nrf-nrf5340dk-light-rpc -b nrf5340dk_nrf5340_cpuapp {root}/examples/lighting-app/nrfconnect -- -DOVERLAY_CONFIG=../../rpc.overlay'
 
 # Generating nrf-nrf5340dk-lock
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";


### PR DESCRIPTION
#### Problem
NRF overlay path changed in #16991, now builds fail with:

```
2022-04-05 19:35:06 WARNING CMake Error at /opt/NordicSemiconductor/nrfconnect/zephyr/cmake/kconfig.cmake:213 (message):
2022-04-05 19:35:06 WARNING   File not found:
2022-04-05 19:35:06 WARNING   /workspace/examples/lighting-app/nrfconnect/configuration/nrf52840dk_nrf52840/rpc.overlay
2022-04-05 19:35:06 WARNING Call Stack (most recent call first):
2022-04-05 19:35:06 WARNING   /opt/NordicSemiconductor/nrfconnect/zephyr/cmake/app/boilerplate.cmake:544 (include)
2022-04-05 19:35:06 WARNING   /opt/NordicSemiconductor/nrfconnect/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:24 (include)
2022-04-05 19:35:06 WARNING   /opt/NordicSemiconductor/nrfconnect/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:35 (include_boilerplate)
2022-04-05 19:35:06 WARNING   CMakeLists.txt:32 (find_package)
```

#### Change overview
Update path with `../../rpc.overlay`

#### Testing

Ran `./scripts/build/build_examples.py --enable-flashbundle --target-glob '*-nrf52840*light*rpc' build`