### PR TITLE
Glob blacklist the interactive chip-tool build when cross-compiling

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -266,6 +266,7 @@ def HostTargets():
                           "clang"], use_libfuzzer=True),
     builder.AppendVariant(name="clang", use_clang=True),
 
+    builder.WhitelistVariantNameForGlob('no-interactive')
     builder.WhitelistVariantNameForGlob('ipv6only')
 
     for target in app_targets:

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -276,7 +276,7 @@ def HostTargets():
             builder.targets.append(target)
 
     for target in builder.AllVariants():
-        if cross_compile and 'arm64' in target.name and '-no-interactive' not in target.name:
+        if cross_compile and 'chip-tool' in target.name and 'arm64' in target.name and '-no-interactive' not in target.name:
             # Interactive builds will not compile by default on arm cross compiles
             # because libreadline is not part of the default sysroot
             yield target.GlobBlacklist('Arm crosscompile does not support libreadline-dev')

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -276,7 +276,7 @@ def HostTargets():
             builder.targets.append(target)
 
     for target in builder.AllVariants():
-        if cross_compile and '-no-interactive' not in target.name:
+        if cross_compile and 'arm64' in target.name and '-no-interactive' not in target.name:
             # Interactive builds will not compile by default on arm cross compiles
             # because libreadline is not part of the default sysroot
             yield target.GlobBlacklist('Arm crosscompile does not support libreadline-dev')

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -826,7 +826,7 @@ west build --cmake-only -d {out}/nrf-nrf52840dk-light -b nrf52840dk_nrf52840 {ro
 # Generating nrf-nrf52840dk-light-rpc
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_ARM_CIPD_INSTALL_DIR";
-west build --cmake-only -d {out}/nrf-nrf52840dk-light-rpc -b nrf52840dk_nrf52840 {root}/examples/lighting-app/nrfconnect -- -DOVERLAY_CONFIG=../../rpc.overlay'
+west build --cmake-only -d {out}/nrf-nrf52840dk-light-rpc -b nrf52840dk_nrf52840 {root}/examples/lighting-app/nrfconnect -- -DOVERLAY_CONFIG=rpc.overlay'
 
 # Generating nrf-nrf52840dk-lock
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
@@ -861,7 +861,7 @@ west build --cmake-only -d {out}/nrf-nrf5340dk-light -b nrf5340dk_nrf5340_cpuapp
 # Generating nrf-nrf5340dk-light-rpc
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_ARM_CIPD_INSTALL_DIR";
-west build --cmake-only -d {out}/nrf-nrf5340dk-light-rpc -b nrf5340dk_nrf5340_cpuapp {root}/examples/lighting-app/nrfconnect -- -DOVERLAY_CONFIG=../../rpc.overlay'
+west build --cmake-only -d {out}/nrf-nrf5340dk-light-rpc -b nrf5340dk_nrf5340_cpuapp {root}/examples/lighting-app/nrfconnect -- -DOVERLAY_CONFIG=rpc.overlay'
 
 # Generating nrf-nrf5340dk-lock
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -826,7 +826,7 @@ west build --cmake-only -d {out}/nrf-nrf52840dk-light -b nrf52840dk_nrf52840 {ro
 # Generating nrf-nrf52840dk-light-rpc
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_ARM_CIPD_INSTALL_DIR";
-west build --cmake-only -d {out}/nrf-nrf52840dk-light-rpc -b nrf52840dk_nrf52840 {root}/examples/lighting-app/nrfconnect -- -DOVERLAY_CONFIG=rpc.overlay'
+west build --cmake-only -d {out}/nrf-nrf52840dk-light-rpc -b nrf52840dk_nrf52840 {root}/examples/lighting-app/nrfconnect -- -DOVERLAY_CONFIG=../../rpc.overlay'
 
 # Generating nrf-nrf52840dk-lock
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
@@ -861,7 +861,7 @@ west build --cmake-only -d {out}/nrf-nrf5340dk-light -b nrf5340dk_nrf5340_cpuapp
 # Generating nrf-nrf5340dk-light-rpc
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_ARM_CIPD_INSTALL_DIR";
-west build --cmake-only -d {out}/nrf-nrf5340dk-light-rpc -b nrf5340dk_nrf5340_cpuapp {root}/examples/lighting-app/nrfconnect -- -DOVERLAY_CONFIG=rpc.overlay'
+west build --cmake-only -d {out}/nrf-nrf5340dk-light-rpc -b nrf5340dk_nrf5340_cpuapp {root}/examples/lighting-app/nrfconnect -- -DOVERLAY_CONFIG=../../rpc.overlay'
 
 # Generating nrf-nrf5340dk-lock
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -11,6 +11,11 @@ bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters-ipv6only'
 
+# Generating linux-arm64-chip-tool-no-interactive
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=config_use_interactive_mode=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-no-interactive'
+
 # Generating linux-arm64-door-lock
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
@@ -92,6 +97,9 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Generating linux-x64-chip-tool-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-chip-tool-ipv6only
 
+# Generating linux-x64-chip-tool-no-interactive
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool --args=config_use_interactive_mode=false {out}/linux-x64-chip-tool-no-interactive
+
 # Generating linux-x64-door-lock
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/door-lock-app/linux {out}/linux-x64-door-lock
 
@@ -145,6 +153,9 @@ ninja -C {out}/linux-arm64-all-clusters
 
 # Building linux-arm64-all-clusters-ipv6only
 ninja -C {out}/linux-arm64-all-clusters-ipv6only
+
+# Building linux-arm64-chip-tool-no-interactive
+ninja -C {out}/linux-arm64-chip-tool-no-interactive
 
 # Building linux-arm64-door-lock
 ninja -C {out}/linux-arm64-door-lock
@@ -202,6 +213,9 @@ ninja -C {out}/linux-x64-chip-tool
 
 # Building linux-x64-chip-tool-ipv6only
 ninja -C {out}/linux-x64-chip-tool-ipv6only
+
+# Building linux-x64-chip-tool-no-interactive
+ninja -C {out}/linux-x64-chip-tool-no-interactive
 
 # Building linux-x64-door-lock
 ninja -C {out}/linux-x64-door-lock

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -7,14 +7,68 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--
 # Generating linux-x64-address-resolve-tool
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root} {out}/linux-x64-address-resolve-tool
 
+# Generating linux-x64-all-clusters
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux {out}/linux-x64-all-clusters
+
+# Generating linux-x64-all-clusters-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-all-clusters-ipv6only
+
 # Generating linux-x64-chip-cert
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--args=chip_crypto="openssl"' {out}/linux-x64-chip-cert
+
+# Generating linux-x64-chip-tool
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool {out}/linux-x64-chip-tool
+
+# Generating linux-x64-chip-tool-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-chip-tool-ipv6only
+
+# Generating linux-x64-door-lock
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/door-lock-app/linux {out}/linux-x64-door-lock
+
+# Generating linux-x64-door-lock-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/door-lock-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-door-lock-ipv6only
+
+# Generating linux-x64-minmdns
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns {out}/linux-x64-minmdns
+
+# Generating linux-x64-minmdns-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-minmdns-ipv6only
+
+# Generating linux-x64-ota-provider
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux --args=chip_config_network_layer_ble=false {out}/linux-x64-ota-provider
+
+# Generating linux-x64-ota-provider-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false' {out}/linux-x64-ota-provider-ipv6only
+
+# Generating linux-x64-ota-requestor
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux --args=chip_config_network_layer_ble=false {out}/linux-x64-ota-requestor
+
+# Generating linux-x64-ota-requestor-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false' {out}/linux-x64-ota-requestor-ipv6only
 
 # Generating linux-x64-rpc-console
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/common/pigweed/rpc_console {out}/linux-x64-rpc-console
 
+# Generating linux-x64-shell
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/standalone {out}/linux-x64-shell
+
+# Generating linux-x64-shell-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/standalone --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-shell-ipv6only
+
 # Generating linux-x64-tests
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root} --args=chip_build_tests=true {out}/linux-x64-tests
+
+# Generating linux-x64-thermostat
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux {out}/linux-x64-thermostat
+
+# Generating linux-x64-thermostat-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-thermostat-ipv6only
+
+# Generating linux-x64-tv-app
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-app/linux {out}/linux-x64-tv-app
+
+# Generating linux-x64-tv-app-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-tv-app-ipv6only
 
 # Building linux-fake-tests
 ninja -C {out}/linux-fake-tests check
@@ -22,11 +76,65 @@ ninja -C {out}/linux-fake-tests check
 # Building linux-x64-address-resolve-tool
 ninja -C {out}/linux-x64-address-resolve-tool src/lib/address_resolve:address-resolve-tool
 
+# Building linux-x64-all-clusters
+ninja -C {out}/linux-x64-all-clusters
+
+# Building linux-x64-all-clusters-ipv6only
+ninja -C {out}/linux-x64-all-clusters-ipv6only
+
 # Building linux-x64-chip-cert
 ninja -C {out}/linux-x64-chip-cert src/tools/chip-cert
+
+# Building linux-x64-chip-tool
+ninja -C {out}/linux-x64-chip-tool
+
+# Building linux-x64-chip-tool-ipv6only
+ninja -C {out}/linux-x64-chip-tool-ipv6only
+
+# Building linux-x64-door-lock
+ninja -C {out}/linux-x64-door-lock
+
+# Building linux-x64-door-lock-ipv6only
+ninja -C {out}/linux-x64-door-lock-ipv6only
+
+# Building linux-x64-minmdns
+ninja -C {out}/linux-x64-minmdns
+
+# Building linux-x64-minmdns-ipv6only
+ninja -C {out}/linux-x64-minmdns-ipv6only
+
+# Building linux-x64-ota-provider
+ninja -C {out}/linux-x64-ota-provider
+
+# Building linux-x64-ota-provider-ipv6only
+ninja -C {out}/linux-x64-ota-provider-ipv6only
+
+# Building linux-x64-ota-requestor
+ninja -C {out}/linux-x64-ota-requestor
+
+# Building linux-x64-ota-requestor-ipv6only
+ninja -C {out}/linux-x64-ota-requestor-ipv6only
 
 # Building linux-x64-rpc-console
 ninja -C {out}/linux-x64-rpc-console
 
+# Building linux-x64-shell
+ninja -C {out}/linux-x64-shell
+
+# Building linux-x64-shell-ipv6only
+ninja -C {out}/linux-x64-shell-ipv6only
+
 # Building linux-x64-tests
 ninja -C {out}/linux-x64-tests check
+
+# Building linux-x64-thermostat
+ninja -C {out}/linux-x64-thermostat
+
+# Building linux-x64-thermostat-ipv6only
+ninja -C {out}/linux-x64-thermostat-ipv6only
+
+# Building linux-x64-tv-app
+ninja -C {out}/linux-x64-tv-app
+
+# Building linux-x64-tv-app-ipv6only
+ninja -C {out}/linux-x64-tv-app-ipv6only

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -1,6 +1,76 @@
 # Commands will be run in CHIP project root.
 cd "{root}"
 
+# Generating linux-arm64-all-clusters
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters'
+
+# Generating linux-arm64-all-clusters-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters-ipv6only'
+
+# Generating linux-arm64-door-lock
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/door-lock-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-door-lock'
+
+# Generating linux-arm64-door-lock-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/door-lock-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-door-lock-ipv6only'
+
+# Generating linux-arm64-minmdns
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns'
+
+# Generating linux-arm64-minmdns-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns-ipv6only'
+
+# Generating linux-arm64-ota-provider
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-provider'
+
+# Generating linux-arm64-ota-provider-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-provider-ipv6only'
+
+# Generating linux-arm64-ota-requestor
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor'
+
+# Generating linux-arm64-ota-requestor-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor-ipv6only'
+
+# Generating linux-arm64-shell
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/standalone '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-shell'
+
+# Generating linux-arm64-shell-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/standalone '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-shell-ipv6only'
+
+# Generating linux-arm64-thermostat
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-thermostat'
+
+# Generating linux-arm64-thermostat-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-thermostat-ipv6only'
+
 # Generating linux-fake-tests
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--args=chip_build_tests=true custom_toolchain="//build/toolchain/fake:fake_x64_gcc" chip_link_tests=true chip_device_platform="fake"' {out}/linux-fake-tests
 
@@ -69,6 +139,48 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 
 # Generating linux-x64-tv-app-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-tv-app-ipv6only
+
+# Building linux-arm64-all-clusters
+ninja -C {out}/linux-arm64-all-clusters
+
+# Building linux-arm64-all-clusters-ipv6only
+ninja -C {out}/linux-arm64-all-clusters-ipv6only
+
+# Building linux-arm64-door-lock
+ninja -C {out}/linux-arm64-door-lock
+
+# Building linux-arm64-door-lock-ipv6only
+ninja -C {out}/linux-arm64-door-lock-ipv6only
+
+# Building linux-arm64-minmdns
+ninja -C {out}/linux-arm64-minmdns
+
+# Building linux-arm64-minmdns-ipv6only
+ninja -C {out}/linux-arm64-minmdns-ipv6only
+
+# Building linux-arm64-ota-provider
+ninja -C {out}/linux-arm64-ota-provider
+
+# Building linux-arm64-ota-provider-ipv6only
+ninja -C {out}/linux-arm64-ota-provider-ipv6only
+
+# Building linux-arm64-ota-requestor
+ninja -C {out}/linux-arm64-ota-requestor
+
+# Building linux-arm64-ota-requestor-ipv6only
+ninja -C {out}/linux-arm64-ota-requestor-ipv6only
+
+# Building linux-arm64-shell
+ninja -C {out}/linux-arm64-shell
+
+# Building linux-arm64-shell-ipv6only
+ninja -C {out}/linux-arm64-shell-ipv6only
+
+# Building linux-arm64-thermostat
+ninja -C {out}/linux-arm64-thermostat
+
+# Building linux-arm64-thermostat-ipv6only
+ninja -C {out}/linux-arm64-thermostat-ipv6only
 
 # Building linux-fake-tests
 ninja -C {out}/linux-fake-tests check

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -1,202 +1,20 @@
 # Commands will be run in CHIP project root.
 cd "{root}"
 
-# Generating linux-arm64-all-clusters
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters'
-
-# Generating linux-arm64-all-clusters-ipv6only
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters-ipv6only'
-
-# Generating linux-arm64-chip-tool
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool'
-
-# Generating linux-arm64-chip-tool-ipv6only
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-ipv6only'
-
-# Generating linux-arm64-door-lock
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/door-lock-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-door-lock'
-
-# Generating linux-arm64-door-lock-ipv6only
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/door-lock-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-door-lock-ipv6only'
-
-# Generating linux-arm64-minmdns
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns'
-
-# Generating linux-arm64-minmdns-ipv6only
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns-ipv6only'
-
-# Generating linux-arm64-ota-provider
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-provider'
-
-# Generating linux-arm64-ota-provider-ipv6only
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-provider-ipv6only'
-
-# Generating linux-arm64-ota-requestor
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor'
-
-# Generating linux-arm64-ota-requestor-ipv6only
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor-ipv6only'
-
-# Generating linux-arm64-shell
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/standalone '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-shell'
-
-# Generating linux-arm64-shell-ipv6only
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/standalone '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-shell-ipv6only'
-
-# Generating linux-arm64-thermostat
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-thermostat'
-
-# Generating linux-arm64-thermostat-ipv6only
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-thermostat-ipv6only'
-
 # Generating linux-fake-tests
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--args=chip_build_tests=true custom_toolchain="//build/toolchain/fake:fake_x64_gcc" chip_link_tests=true chip_device_platform="fake"' {out}/linux-fake-tests
 
 # Generating linux-x64-address-resolve-tool
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root} {out}/linux-x64-address-resolve-tool
 
-# Generating linux-x64-all-clusters
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux {out}/linux-x64-all-clusters
-
-# Generating linux-x64-all-clusters-ipv6only
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-all-clusters-ipv6only
-
 # Generating linux-x64-chip-cert
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--args=chip_crypto="openssl"' {out}/linux-x64-chip-cert
-
-# Generating linux-x64-chip-tool
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool {out}/linux-x64-chip-tool
-
-# Generating linux-x64-chip-tool-ipv6only
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-chip-tool-ipv6only
-
-# Generating linux-x64-door-lock
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/door-lock-app/linux {out}/linux-x64-door-lock
-
-# Generating linux-x64-door-lock-ipv6only
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/door-lock-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-door-lock-ipv6only
-
-# Generating linux-x64-minmdns
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns {out}/linux-x64-minmdns
-
-# Generating linux-x64-minmdns-ipv6only
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-minmdns-ipv6only
-
-# Generating linux-x64-ota-provider
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux --args=chip_config_network_layer_ble=false {out}/linux-x64-ota-provider
-
-# Generating linux-x64-ota-provider-ipv6only
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false' {out}/linux-x64-ota-provider-ipv6only
-
-# Generating linux-x64-ota-requestor
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux --args=chip_config_network_layer_ble=false {out}/linux-x64-ota-requestor
-
-# Generating linux-x64-ota-requestor-ipv6only
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false' {out}/linux-x64-ota-requestor-ipv6only
 
 # Generating linux-x64-rpc-console
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/common/pigweed/rpc_console {out}/linux-x64-rpc-console
 
-# Generating linux-x64-shell
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/standalone {out}/linux-x64-shell
-
-# Generating linux-x64-shell-ipv6only
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/standalone --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-shell-ipv6only
-
 # Generating linux-x64-tests
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root} --args=chip_build_tests=true {out}/linux-x64-tests
-
-# Generating linux-x64-thermostat
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux {out}/linux-x64-thermostat
-
-# Generating linux-x64-thermostat-ipv6only
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-thermostat-ipv6only
-
-# Generating linux-x64-tv-app
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-app/linux {out}/linux-x64-tv-app
-
-# Generating linux-x64-tv-app-ipv6only
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-tv-app-ipv6only
-
-# Building linux-arm64-all-clusters
-ninja -C {out}/linux-arm64-all-clusters
-
-# Building linux-arm64-all-clusters-ipv6only
-ninja -C {out}/linux-arm64-all-clusters-ipv6only
-
-# Building linux-arm64-chip-tool
-ninja -C {out}/linux-arm64-chip-tool
-
-# Building linux-arm64-chip-tool-ipv6only
-ninja -C {out}/linux-arm64-chip-tool-ipv6only
-
-# Building linux-arm64-door-lock
-ninja -C {out}/linux-arm64-door-lock
-
-# Building linux-arm64-door-lock-ipv6only
-ninja -C {out}/linux-arm64-door-lock-ipv6only
-
-# Building linux-arm64-minmdns
-ninja -C {out}/linux-arm64-minmdns
-
-# Building linux-arm64-minmdns-ipv6only
-ninja -C {out}/linux-arm64-minmdns-ipv6only
-
-# Building linux-arm64-ota-provider
-ninja -C {out}/linux-arm64-ota-provider
-
-# Building linux-arm64-ota-provider-ipv6only
-ninja -C {out}/linux-arm64-ota-provider-ipv6only
-
-# Building linux-arm64-ota-requestor
-ninja -C {out}/linux-arm64-ota-requestor
-
-# Building linux-arm64-ota-requestor-ipv6only
-ninja -C {out}/linux-arm64-ota-requestor-ipv6only
-
-# Building linux-arm64-shell
-ninja -C {out}/linux-arm64-shell
-
-# Building linux-arm64-shell-ipv6only
-ninja -C {out}/linux-arm64-shell-ipv6only
-
-# Building linux-arm64-thermostat
-ninja -C {out}/linux-arm64-thermostat
-
-# Building linux-arm64-thermostat-ipv6only
-ninja -C {out}/linux-arm64-thermostat-ipv6only
 
 # Building linux-fake-tests
 ninja -C {out}/linux-fake-tests check
@@ -204,65 +22,11 @@ ninja -C {out}/linux-fake-tests check
 # Building linux-x64-address-resolve-tool
 ninja -C {out}/linux-x64-address-resolve-tool src/lib/address_resolve:address-resolve-tool
 
-# Building linux-x64-all-clusters
-ninja -C {out}/linux-x64-all-clusters
-
-# Building linux-x64-all-clusters-ipv6only
-ninja -C {out}/linux-x64-all-clusters-ipv6only
-
 # Building linux-x64-chip-cert
 ninja -C {out}/linux-x64-chip-cert src/tools/chip-cert
-
-# Building linux-x64-chip-tool
-ninja -C {out}/linux-x64-chip-tool
-
-# Building linux-x64-chip-tool-ipv6only
-ninja -C {out}/linux-x64-chip-tool-ipv6only
-
-# Building linux-x64-door-lock
-ninja -C {out}/linux-x64-door-lock
-
-# Building linux-x64-door-lock-ipv6only
-ninja -C {out}/linux-x64-door-lock-ipv6only
-
-# Building linux-x64-minmdns
-ninja -C {out}/linux-x64-minmdns
-
-# Building linux-x64-minmdns-ipv6only
-ninja -C {out}/linux-x64-minmdns-ipv6only
-
-# Building linux-x64-ota-provider
-ninja -C {out}/linux-x64-ota-provider
-
-# Building linux-x64-ota-provider-ipv6only
-ninja -C {out}/linux-x64-ota-provider-ipv6only
-
-# Building linux-x64-ota-requestor
-ninja -C {out}/linux-x64-ota-requestor
-
-# Building linux-x64-ota-requestor-ipv6only
-ninja -C {out}/linux-x64-ota-requestor-ipv6only
 
 # Building linux-x64-rpc-console
 ninja -C {out}/linux-x64-rpc-console
 
-# Building linux-x64-shell
-ninja -C {out}/linux-x64-shell
-
-# Building linux-x64-shell-ipv6only
-ninja -C {out}/linux-x64-shell-ipv6only
-
 # Building linux-x64-tests
 ninja -C {out}/linux-x64-tests check
-
-# Building linux-x64-thermostat
-ninja -C {out}/linux-x64-thermostat
-
-# Building linux-x64-thermostat-ipv6only
-ninja -C {out}/linux-x64-thermostat-ipv6only
-
-# Building linux-x64-tv-app
-ninja -C {out}/linux-x64-tv-app
-
-# Building linux-x64-tv-app-ipv6only
-ninja -C {out}/linux-x64-tv-app-ipv6only


### PR DESCRIPTION
#### Problem
libreadline is not available in the cross compile sysroot, so after #16135 cross-compiles fail with:

```
2022-04-02 13:13:25 INFO    FAILED: obj/commands/interactive/chip-tool-utils.InteractiveCommands.cpp.o 
2022-04-02 13:13:25 INFO    clang++ -MMD -MF obj/commands/interactive/chip-tool-utils.InteractiveCommands.cpp.o.d --target=aarch64-linux-gnu -O0 -g2 -fno-common -ffunction-sections -fdata-sections -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -Wall -Werror -Wextra -Wshadow -Wunreachable-code -Wvla -Wformat -Wformat-nonliteral -Wformat-security -Wimplicit-fallthrough …-tool/third_party/connectedhomeip/third_party/jsoncpp/repo/include -I../../examples/chip-tool/third_party/connectedhomeip/examples/common/tracing -c ../../examples/chip-tool/commands/interactive/InteractiveCommands.cpp -o obj/commands/interactive/chip-tool-utils.InteractiveCommands.cpp.o
2022-04-02 13:13:25 INFO    ../../examples/chip-tool/commands/interactive/InteractiveCommands.cpp:21:10: fatal error: 'readline/history.h' file not found
2022-04-02 13:13:25 INFO    #include <readline/history.h>
```

#### Change overview
Blacklist the interactive build when cross compiling, only the non-interactive builds will be compiled.

#### Testing
Checked that glob takes effect. CI files were updated.