### PR TITLE
Force Darwin test chip-all-clusters-app to only advertise on local interface

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -113,7 +113,7 @@ jobs:
               timeout-minutes: 15
               run: |
                   mkdir -p /tmp/darwin/framework-tests
-                  ../../../out/debug/chip-all-clusters-app > >(tee /tmp/darwin/framework-tests/all-cluster-app.log) 2> >(tee /tmp/darwin/framework-tests/all-cluster-app-err.log >&2) &
+                  ../../../out/debug/chip-all-clusters-app --interface-id -1 > >(tee /tmp/darwin/framework-tests/all-cluster-app.log) 2> >(tee /tmp/darwin/framework-tests/all-cluster-app-err.log >&2) &
                   xcodebuild test -target "CHIP" -scheme "CHIP Framework Tests" -sdk macosx OTHER_CFLAGS='${inherited} -Werror -Wno-incomplete-umbrella' > >(tee /tmp/darwin/framework-tests/darwin-tests.log) 2> >(tee /tmp/darwin/framework-tests/darwin-tests-err.log >&2)
               working-directory: src/darwin/Framework
             - name: Uploading log files


### PR DESCRIPTION
Its advertising across all interfaces, and this might be the source of
cross-talk with the Tests jobs and other Darwin jobs.

#### Problem
This might be the cause of the spate of recent Tests job failures, and possibly of some random Darwin failures.

#### Change overview
Force the all-clusters-app instance to only advertise on the local loopback interface.

#### Testing
Will see whether this reduces the incidence of Darwin test failures.