### PR TITLE
Make UserPrompt with an expected value compile in chip-tool-darwin and Darwin tests.

### DIFF
--- a/examples/chip-tool-darwin/commands/tests/TestCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/tests/TestCommandBridge.h
@@ -78,7 +78,7 @@ public:
         });
     }
 
-    void UserPrompt(NSString * _Nonnull message) { NextTest(); }
+    void UserPrompt(NSString * _Nonnull message, NSString * _Nullable expectedValue = nil) { NextTest(); }
 
     void WaitForCommissionee(chip::NodeId nodeId)
     {

--- a/examples/chip-tool-darwin/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool-darwin/templates/partials/test_cluster.zapt
@@ -101,6 +101,7 @@ class {{filename}}: public TestCommandBridge
         {{#if (isTestOnlyCluster cluster)}}
         {{command}}(
         {{#chip_tests_item_parameters}}
+        {{~#not_first}}, {{/not_first~}}
         {{#*inline "defaultValue"}}{{asTypedLiteral (chip_tests_config_get_default_value definedValue) (chip_tests_config_get_type definedValue)}}{{/inline}}
           {{~#if (chip_tests_config_has definedValue)~}}
               m{{asUpperCamelCase definedValue}}.HasValue() ? m{{asUpperCamelCase definedValue}}.Value() : {{>defaultValue}}

--- a/src/darwin/Framework/CHIP/templates/tests/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/tests/partials/test_cluster.zapt
@@ -24,7 +24,12 @@ ResponseHandler {{> subscribeDataCallback}} = nil;
 
 {{#if (isTestOnlyCluster cluster)}}
     dispatch_queue_t queue = dispatch_get_main_queue();
-    {{command}}(expectation, queue{{#chip_tests_item_parameters}}, {{#if (isString type)}}@"{{/if}}{{> defined_value}}{{#if (isString type)}}"{{/if}}{{/chip_tests_item_parameters}});
+    {{#if (isStrEqual command "UserPrompt")}}
+      {{! We only support the first arg, and our impl is a no-op anyway. }}
+      {{command}}(expectation, queue{{#chip_tests_item_parameters}}{{#first}}, {{#if (isString type)}}@"{{/if}}{{> defined_value}}{{#if (isString type)}}"{{/if}}{{/first}}{{/chip_tests_item_parameters}});
+    {{else}}
+      {{command}}(expectation, queue{{#chip_tests_item_parameters}}, {{#if (isString type)}}@"{{/if}}{{> defined_value}}{{#if (isString type)}}"{{/if}}{{/chip_tests_item_parameters}});
+    {{/if}}
 {{else}}
     CHIPDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();


### PR DESCRIPTION
In the Darwin tests, we can't use a default argument (because this is
C, not C++), so just ignore the expected value in the template.

Fixes https://github.com/project-chip/connectedhomeip/issues/17089

#### Problem
See above.

#### Change overview
See above.

#### Testing
Added an expected value to a UserPrompt in an existing YAML test and made sure that there was no codegen change in the Darwin codegen and that chip-tool-darwin compiled (with the expected codegen change).