### PR TITLE
ESP32P: Add CI for ESP32H2

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -172,3 +172,43 @@ jobs:
             - name: Build example OTA Provider App
               run: scripts/examples/esp_example.sh ota-provider-app sdkconfig.defaults
               timeout-minutes: 15
+
+    esp32_h2:
+        name: ESP32_H2
+        timeout-minutes: 40
+
+        runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io[bot]'
+
+        container:
+            image: connectedhomeip/chip-build-esp32:0.5.58
+            volumes:
+                - "/tmp/bloat_reports:/tmp/bloat_reports"
+
+        steps:
+            - uses: Wandalen/wretry.action@v1.0.11
+              name: Checkout
+              with:
+                  action: actions/checkout@v3
+                  with: |
+                      submodules: true
+                      token: ${{ github.token }}
+                  attempt_limit: 3
+                  attempt_delay: 2000
+
+            - name: Bootstrap
+              timeout-minutes: 10
+              run: scripts/build/gn_bootstrap.sh
+
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }} && ${{ !env.ACT }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                      .environment/gn_out/.ninja_log
+                      .environment/pigweed-venv/*.log
+
+            - name: Build example Lighting App
+              timeout-minutes: 20
+              run: scripts/examples/esp_example.sh lighting-app sdkconfig.defaults.esp32h2

--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -103,6 +103,12 @@ if (CONFIG_ENABLE_CHIP_SHELL)
     chip_gn_arg_append("chip_build_libshell"                "true")
 endif()
 
+if (CONFIG_IDF_TARGET_ESP32H2)
+    chip_gn_arg_append("chip_enable_wifi"                   "false")
+else()
+    chip_gn_arg_append("chip_enable_wifi"                   "true")
+endif()
+
 if (CONFIG_OPENTHREAD_ENABLED)
     chip_gn_arg_append("chip_enable_openthread"                 "true")
 endif()

--- a/scripts/examples/esp_example.sh
+++ b/scripts/examples/esp_example.sh
@@ -30,12 +30,26 @@ if [ -z "$app" ]; then
     exit 1
 fi
 
-source "$IDF_PATH/export.sh"
+if [ "$sdkconfig_name" == "sdkconfig.defaults.esp32h2" ]; then
+    pushd .
+    cd "$IDF_PATH"
+    git fetch origin master
+    git checkout 10f3aba770
+    git submodule update --init --recursive
+    ./install.sh
+    . ./export.sh
+    popd
+else
+    source "$IDF_PATH/export.sh"
+fi
+
 source "scripts/activate.sh"
 # shellcheck source=/dev/null
 
 if [ "$sdkconfig_name" == "sdkconfig_c3devkit.defaults" ]; then
     idf_target="esp32c3"
+elif [ "$sdkconfig_name" == "sdkconfig.defaults.esp32h2" ]; then
+    idf_target="esp32h2"
 else
     idf_target="esp32"
 fi
@@ -43,7 +57,13 @@ fi
 rm -f "$root"/sdkconfig
 (
     cd "$root"
-    idf.py -D SDKCONFIG_DEFAULTS="$sdkconfig_name" set-target "$idf_target" build
+    if [ "$idf_target" == "esp32h2" ]; then
+        pip install pyparsing==3.0.7
+        idf.py --preview set-target "$idf_target"
+    else
+        idf.py set-target "$idf_target"
+    fi
+    idf.py -D SDKCONFIG_DEFAULTS="$sdkconfig_name" build
 ) || {
     echo "build $sdkconfig_name failed"
     exit 1

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -55,10 +55,10 @@ declare_args() {
 
   # Enable wifi support.
   chip_enable_wifi =
-      chip_device_platform == "linux" || chip_device_platform == "mbed" ||
-      chip_device_platform == "tizen" || chip_device_platform == "android" ||
-      chip_device_platform == "ameba" || chip_device_platform == "webos" ||
-      chip_device_platform == "bl602"
+      chip_device_platform == "linux" || chip_device_platform == "esp32" ||
+      chip_device_platform == "mbed" || chip_device_platform == "tizen" ||
+      chip_device_platform == "android" || chip_device_platform == "ameba" ||
+      chip_device_platform == "webos" || chip_device_platform == "bl602"
 
   # Enable ble support.
   if (chip_device_platform == "fake") {

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -55,10 +55,10 @@ declare_args() {
 
   # Enable wifi support.
   chip_enable_wifi =
-      chip_device_platform == "linux" || chip_device_platform == "esp32" ||
-      chip_device_platform == "mbed" || chip_device_platform == "tizen" ||
-      chip_device_platform == "android" || chip_device_platform == "ameba" ||
-      chip_device_platform == "webos" || chip_device_platform == "bl602"
+      chip_device_platform == "linux" || chip_device_platform == "mbed" ||
+      chip_device_platform == "tizen" || chip_device_platform == "android" ||
+      chip_device_platform == "ameba" || chip_device_platform == "webos" ||
+      chip_device_platform == "bl602"
 
   # Enable ble support.
   if (chip_device_platform == "fake") {


### PR DESCRIPTION
#### Problem
Add CI for ESP32H2

#### Change overview
* Add CI for ESP32H2
* move `chip_enable_wifi` from `/src/platform/device.gni` to `config/esp32/components/chip/CMakeLists.txt` for esp32 platform

#### Testing
Passed ESP32-H2 CI
