### PR TITLE
add imx targets to the build_examples tool

### DIFF
--- a/scripts/build/BUILD.gn
+++ b/scripts/build/BUILD.gn
@@ -40,6 +40,7 @@ pw_python_package("build_examples") {
     "builders/esp32.py",
     "builders/gn.py",
     "builders/host.py",
+    "builders/imx.py",
     "builders/infineon.py",
     "builders/k32w.py",
     "builders/mbed.py",

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -31,6 +31,7 @@ from builders.qpg import QpgApp, QpgBoard, QpgBuilder
 from builders.telink import TelinkApp, TelinkBoard, TelinkBuilder
 from builders.tizen import TizenApp, TizenBoard, TizenBuilder
 from builders.bl602 import Bl602App, Bl602Board, Bl602Builder
+from builders.imx import IMXApp, IMXBuilder
 
 
 class Target:
@@ -538,6 +539,21 @@ def Bl602Targets():
     yield target.Extend('light', board=Bl602Board.BL602BOARD, app=Bl602App.LIGHT)
 
 
+def IMXTargets():
+    target = Target('imx', IMXBuilder)
+
+    yield target.Extend('chip-tool', app=IMXApp.CHIP_TOOL)
+    yield target.Extend('lighting-app', app=IMXApp.LIGHT)
+    yield target.Extend('thermostat', app=IMXApp.THERMOSTAT)
+    yield target.Extend('all-clusters-app', app=IMXApp.ALL_CLUSTERS)
+    yield target.Extend('ota-provider-app', app=IMXApp.OTA_PROVIDER)
+    yield target.Extend('chip-tool-release', app=IMXApp.CHIP_TOOL, release=True)
+    yield target.Extend('lighting-app-release', app=IMXApp.LIGHT, release=True)
+    yield target.Extend('thermostat-release', app=IMXApp.THERMOSTAT, release=True)
+    yield target.Extend('all-clusters-app-release', app=IMXApp.ALL_CLUSTERS, release=True)
+    yield target.Extend('ota-provider-app-release', app=IMXApp.OTA_PROVIDER, release=True)
+
+
 ALL = []
 
 target_generators = [
@@ -555,6 +571,7 @@ target_generators = [
     QorvoTargets(),
     TizenTargets(),
     Bl602Targets(),
+    IMXTargets(),
 ]
 
 for generator in target_generators:

--- a/scripts/build/builders/imx.py
+++ b/scripts/build/builders/imx.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from enum import Enum, auto
+
+from .gn import GnBuilder
+
+
+class IMXApp(Enum):
+    CHIP_TOOL = auto()
+    LIGHT = auto()
+    THERMOSTAT = auto()
+    ALL_CLUSTERS = auto()
+    OTA_PROVIDER = auto()
+
+    def ExamplePath(self):
+        if self == IMXApp.CHIP_TOOL:
+            return 'chip-tool'
+        if self == IMXApp.LIGHT:
+            return 'lighting-app/linux'
+        if self == IMXApp.THERMOSTAT:
+            return 'thermostat/linux'
+        if self == IMXApp.ALL_CLUSTERS:
+            return 'all-clusters-app/linux'
+        if self == IMXApp.OTA_PROVIDER:
+            return 'ota-provider-app/linux'
+
+    def OutputNames(self):
+        if self == IMXApp.CHIP_TOOL:
+            yield 'chip-tool'
+            yield 'chip-tool.map'
+        if self == IMXApp.LIGHT:
+            yield 'chip-lighting-app'
+            yield 'chip-lighting-app.map'
+        if self == IMXApp.THERMOSTAT:
+            yield 'thermostat-app'
+            yield 'thermostat-app.map'
+        if self == IMXApp.ALL_CLUSTERS:
+            yield 'chip-all-clusters-app'
+            yield 'chip-all-clusters-app.map'
+        if self == IMXApp.OTA_PROVIDER:
+            yield 'chip-ota-provider-app'
+            yield 'chip-ota-provider-app.map'
+
+
+class IMXBuilder(GnBuilder):
+
+    def __init__(self,
+                 root,
+                 runner,
+                 app: IMXApp,
+                 release: bool = False):
+        super(IMXBuilder, self).__init__(
+            root=os.path.join(root, 'examples', app.ExamplePath()),
+            runner=runner)
+        self.release = release
+        self.app = app
+
+    def GnBuildEnv(self):
+        return {
+            'PKG_CONFIG_PATH': self.SysRootPath('IMX_SDK_ROOT') + '/sysroots/cortexa53-crypto-poky-linux/lib/aarch64-linux-gnu/pkgconfig',
+        }
+
+    def GnBuildArgs(self):
+        args = [
+            'target_os="linux"',
+            'target_cpu="arm64"',
+            'arm_arch="armv8-a"',
+            'import(\"//build_overrides/build.gni\")',
+            'custom_toolchain=\"${build_root}/toolchain/custom\"',
+            'sysroot="%s/sysroots/cortexa53-crypto-poky-linux"' % self.SysRootPath('IMX_SDK_ROOT'),
+            'target_cflags=[ "-DCHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME=\\"mlan0\\"", "-DCHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD=\\"udhcpc -b -i %s \\"" ]',
+            'target_cc="%s/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc"' % self.SysRootPath(
+                'IMX_SDK_ROOT'),
+            'target_cxx="%s/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++"' % self.SysRootPath(
+                'IMX_SDK_ROOT'),
+            'target_ar="%s/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-ar"' % self.SysRootPath(
+                'IMX_SDK_ROOT'),
+        ]
+
+        if self.release:
+            args.append('is_debug=false')
+
+        return args
+
+    def SysRootPath(self, name):
+        if name not in os.environ:
+            raise Exception('Missing environment variable "%s"' % name)
+        return os.environ[name]
+
+    def build_outputs(self):
+        outputs = {}
+
+        for name in self.app.OutputNames():
+            path = os.path.join(self.output_dir, name)
+            if os.path.isdir(path):
+                for root, dirs, files in os.walk(path):
+                    for file in files:
+                        outputs.update({
+                            file: os.path.join(root, file)
+                        })
+            else:
+                outputs.update({
+                    name: os.path.join(self.output_dir, name)
+                })
+
+        return outputs

--- a/scripts/build/test.py
+++ b/scripts/build/test.py
@@ -44,6 +44,7 @@ def build_actual_output(root: str, out: str, args: List[str]) -> List[str]:
         'TELINK_ZEPHYR_SDK_DIR': 'TELINK_ZEPHYR_SDK_DIR',
         'SYSROOT_AARCH64': 'SYSROOT_AARCH64',
         'NXP_K32W061_SDK_ROOT': 'TEST_NXP_K32W061_SDK_ROOT',
+        'IMX_SDK_ROOT': 'IMX_SDK_ROOT',
         'TI_SYSCONFIG_ROOT': 'TEST_TI_SYSCONFIG_ROOT',
     })
 

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -152,6 +152,16 @@ esp32-m5stack-all-clusters-ipv6only
 esp32-m5stack-all-clusters-rpc
 esp32-m5stack-all-clusters-rpc-ipv6only
 esp32-qemu-tests
+imx-all-clusters-app
+imx-all-clusters-app-release
+imx-chip-tool
+imx-chip-tool-release
+imx-lighting-app
+imx-lighting-app-release
+imx-ota-provider-app
+imx-ota-provider-app-release
+imx-thermostat
+imx-thermostat-release
 infineon-p6-all-clusters
 infineon-p6-light
 infineon-p6-lock

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -716,6 +716,56 @@ bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh;
 export SDKCONFIG_DEFAULTS={out}/esp32-qemu-tests/sdkconfig.defaults
 idf.py -C src/test_driver/esp32 -B {out}/esp32-qemu-tests reconfigure'
 
+# Generating imx-all-clusters-app
+bash -c '
+PKG_CONFIG_PATH="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=target_os="linux" target_cpu="arm64" arm_arch="armv8-a" import("//build_overrides/build.gni") custom_toolchain="${build_root}/toolchain/custom" sysroot="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux" target_cflags=[ "-DCHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME=\"mlan0\"", "-DCHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD=\"udhcpc -b -i %s \"" ] target_cc="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc" target_cxx="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++" target_ar="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-ar"'"'"' {out}/imx-all-clusters-app'
+
+# Generating imx-all-clusters-app-release
+bash -c '
+PKG_CONFIG_PATH="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=target_os="linux" target_cpu="arm64" arm_arch="armv8-a" import("//build_overrides/build.gni") custom_toolchain="${build_root}/toolchain/custom" sysroot="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux" target_cflags=[ "-DCHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME=\"mlan0\"", "-DCHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD=\"udhcpc -b -i %s \"" ] target_cc="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc" target_cxx="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++" target_ar="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-ar" is_debug=false'"'"' {out}/imx-all-clusters-app-release'
+
+# Generating imx-chip-tool
+bash -c '
+PKG_CONFIG_PATH="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=target_os="linux" target_cpu="arm64" arm_arch="armv8-a" import("//build_overrides/build.gni") custom_toolchain="${build_root}/toolchain/custom" sysroot="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux" target_cflags=[ "-DCHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME=\"mlan0\"", "-DCHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD=\"udhcpc -b -i %s \"" ] target_cc="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc" target_cxx="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++" target_ar="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-ar"'"'"' {out}/imx-chip-tool'
+
+# Generating imx-chip-tool-release
+bash -c '
+PKG_CONFIG_PATH="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=target_os="linux" target_cpu="arm64" arm_arch="armv8-a" import("//build_overrides/build.gni") custom_toolchain="${build_root}/toolchain/custom" sysroot="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux" target_cflags=[ "-DCHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME=\"mlan0\"", "-DCHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD=\"udhcpc -b -i %s \"" ] target_cc="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc" target_cxx="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++" target_ar="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-ar" is_debug=false'"'"' {out}/imx-chip-tool-release'
+
+# Generating imx-lighting-app
+bash -c '
+PKG_CONFIG_PATH="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux '"'"'--args=target_os="linux" target_cpu="arm64" arm_arch="armv8-a" import("//build_overrides/build.gni") custom_toolchain="${build_root}/toolchain/custom" sysroot="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux" target_cflags=[ "-DCHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME=\"mlan0\"", "-DCHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD=\"udhcpc -b -i %s \"" ] target_cc="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc" target_cxx="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++" target_ar="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-ar"'"'"' {out}/imx-lighting-app'
+
+# Generating imx-lighting-app-release
+bash -c '
+PKG_CONFIG_PATH="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux '"'"'--args=target_os="linux" target_cpu="arm64" arm_arch="armv8-a" import("//build_overrides/build.gni") custom_toolchain="${build_root}/toolchain/custom" sysroot="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux" target_cflags=[ "-DCHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME=\"mlan0\"", "-DCHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD=\"udhcpc -b -i %s \"" ] target_cc="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc" target_cxx="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++" target_ar="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-ar" is_debug=false'"'"' {out}/imx-lighting-app-release'
+
+# Generating imx-ota-provider-app
+bash -c '
+PKG_CONFIG_PATH="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=target_os="linux" target_cpu="arm64" arm_arch="armv8-a" import("//build_overrides/build.gni") custom_toolchain="${build_root}/toolchain/custom" sysroot="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux" target_cflags=[ "-DCHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME=\"mlan0\"", "-DCHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD=\"udhcpc -b -i %s \"" ] target_cc="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc" target_cxx="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++" target_ar="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-ar"'"'"' {out}/imx-ota-provider-app'
+
+# Generating imx-ota-provider-app-release
+bash -c '
+PKG_CONFIG_PATH="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=target_os="linux" target_cpu="arm64" arm_arch="armv8-a" import("//build_overrides/build.gni") custom_toolchain="${build_root}/toolchain/custom" sysroot="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux" target_cflags=[ "-DCHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME=\"mlan0\"", "-DCHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD=\"udhcpc -b -i %s \"" ] target_cc="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc" target_cxx="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++" target_ar="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-ar" is_debug=false'"'"' {out}/imx-ota-provider-app-release'
+
+# Generating imx-thermostat
+bash -c '
+PKG_CONFIG_PATH="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux '"'"'--args=target_os="linux" target_cpu="arm64" arm_arch="armv8-a" import("//build_overrides/build.gni") custom_toolchain="${build_root}/toolchain/custom" sysroot="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux" target_cflags=[ "-DCHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME=\"mlan0\"", "-DCHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD=\"udhcpc -b -i %s \"" ] target_cc="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc" target_cxx="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++" target_ar="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-ar"'"'"' {out}/imx-thermostat'
+
+# Generating imx-thermostat-release
+bash -c '
+PKG_CONFIG_PATH="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux '"'"'--args=target_os="linux" target_cpu="arm64" arm_arch="armv8-a" import("//build_overrides/build.gni") custom_toolchain="${build_root}/toolchain/custom" sysroot="IMX_SDK_ROOT/sysroots/cortexa53-crypto-poky-linux" target_cflags=[ "-DCHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME=\"mlan0\"", "-DCHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD=\"udhcpc -b -i %s \"" ] target_cc="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc" target_cxx="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++" target_ar="IMX_SDK_ROOT/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux/aarch64-poky-linux-ar" is_debug=false'"'"' {out}/imx-thermostat-release'
+
 # Generating infineon-p6-all-clusters
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/p6 '--args=p6_board="CY8CKIT-062S2-43012"' {out}/infineon-p6-all-clusters
 
@@ -1695,6 +1745,36 @@ rm -f src/test_driver/esp32/sdkconfig
 bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh; 
 export SDKCONFIG_DEFAULTS={out}/esp32-qemu-tests/sdkconfig.defaults
 idf.py -C src/test_driver/esp32 -B {out}/esp32-qemu-tests build'
+
+# Building imx-all-clusters-app
+ninja -C {out}/imx-all-clusters-app
+
+# Building imx-all-clusters-app-release
+ninja -C {out}/imx-all-clusters-app-release
+
+# Building imx-chip-tool
+ninja -C {out}/imx-chip-tool
+
+# Building imx-chip-tool-release
+ninja -C {out}/imx-chip-tool-release
+
+# Building imx-lighting-app
+ninja -C {out}/imx-lighting-app
+
+# Building imx-lighting-app-release
+ninja -C {out}/imx-lighting-app-release
+
+# Building imx-ota-provider-app
+ninja -C {out}/imx-ota-provider-app
+
+# Building imx-ota-provider-app-release
+ninja -C {out}/imx-ota-provider-app-release
+
+# Building imx-thermostat
+ninja -C {out}/imx-thermostat
+
+# Building imx-thermostat-release
+ninja -C {out}/imx-thermostat-release
 
 # Building infineon-p6-all-clusters
 ninja -C {out}/infineon-p6-all-clusters

--- a/scripts/build/testdata/glob_star_targets_except_host.txt
+++ b/scripts/build/testdata/glob_star_targets_except_host.txt
@@ -46,6 +46,16 @@ esp32-m5stack-all-clusters-ipv6only
 esp32-m5stack-all-clusters-rpc
 esp32-m5stack-all-clusters-rpc-ipv6only
 esp32-qemu-tests
+imx-all-clusters-app
+imx-all-clusters-app-release
+imx-chip-tool
+imx-chip-tool-release
+imx-lighting-app
+imx-lighting-app-release
+imx-ota-provider-app
+imx-ota-provider-app-release
+imx-thermostat
+imx-thermostat-release
 infineon-p6-all-clusters
 infineon-p6-light
 infineon-p6-lock


### PR DESCRIPTION
add below ten imx targets:

  * imx-chip-tool
  * imx-chip-tool-release
  * imx-lighting-app
  * imx-lighting-app-release
  * imx-thermostat
  * imx-thermostat-release
  * imx-all-clusters-app
  * imx-all-clusters-app-release
  * imx-ota-provider-app
  * imx-ota-provider-app-release


imx specific args are passed to the build system through shell env and gn
args. To directly build the targets with the build_example.py tool, follow
below demostration steps:

  * cd <connectedhomeip_root_directory>
  * source scripts/activate.sh
  *  export IMX_SDK_ROOT=<path_to_imx_yocto_sdk_root_directory>
  * ./scripts/build/build_examples.py  --target imx-chip-tool build
  * ./scripts/build/build_examples.py  --target imx-chip-tool-release build
  * ./scripts/build/build_examples.py  --target imx-lighting-app  build
  * ./scripts/build/build_examples.py  --target imx-lighting-app-release  build