### PR TITLE
Added initial implementation of PCC server cluster

### DIFF
--- a/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
+++ b/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
@@ -20,8 +20,11 @@
 #include <app/ConcreteAttributePath.h>
 #include <app/util/af-event.h>
 #include <app/util/attribute-storage.h>
+#include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/ids/Attributes.h>
 
 using namespace chip;
+using namespace chip::app::Clusters::PumpConfigurationAndControl::Attributes;
 
 void emberAfPumpConfigurationAndControlClusterServerInitCallback(EndpointId endpoint)
 {
@@ -33,7 +36,25 @@ void MatterPumpConfigurationAndControlClusterServerAttributeChangedCallback(cons
 {
     emberAfDebugPrintln("PCC Server Cluster Attribute changed [EP:%d, ID:0x%x]", attributePath.mEndpointId,
                         (unsigned int) attributePath.mAttributeId);
-    // TODO
+
+    switch (attributePath.mAttributeId) {
+        case ControlMode::Id:
+        {
+            uint8_t value;
+            ControlMode::Get(attributePath.mEndpointId, &value);
+            EffectiveControlMode::Set(attributePath.mEndpointId, value);
+        }
+        break;
+        case OperationMode::Id:
+        {
+            uint8_t value;
+            OperationMode::Get(attributePath.mEndpointId, &value);
+            EffectiveOperationMode::Set(attributePath.mEndpointId, value);
+        }
+        break;
+        default:
+            emberAfDebugPrintln("PCC Server: unhandled attribute ID");
+    }
 }
 
 void MatterPumpConfigurationAndControlPluginServerInitCallback() {}

--- a/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
+++ b/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
@@ -17,11 +17,11 @@
 
 #include <app/util/af.h>
 
+#include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/ids/Attributes.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/util/af-event.h>
 #include <app/util/attribute-storage.h>
-#include <app-common/zap-generated/attributes/Accessors.h>
-#include <app-common/zap-generated/ids/Attributes.h>
 
 using namespace chip;
 using namespace chip::app::Clusters::PumpConfigurationAndControl::Attributes;
@@ -37,23 +37,22 @@ void MatterPumpConfigurationAndControlClusterServerAttributeChangedCallback(cons
     emberAfDebugPrintln("PCC Server Cluster Attribute changed [EP:%d, ID:0x%x]", attributePath.mEndpointId,
                         (unsigned int) attributePath.mAttributeId);
 
-    switch (attributePath.mAttributeId) {
-        case ControlMode::Id:
-        {
-            uint8_t value;
-            ControlMode::Get(attributePath.mEndpointId, &value);
-            EffectiveControlMode::Set(attributePath.mEndpointId, value);
-        }
-        break;
-        case OperationMode::Id:
-        {
-            uint8_t value;
-            OperationMode::Get(attributePath.mEndpointId, &value);
-            EffectiveOperationMode::Set(attributePath.mEndpointId, value);
-        }
-        break;
-        default:
-            emberAfDebugPrintln("PCC Server: unhandled attribute ID");
+    switch (attributePath.mAttributeId)
+    {
+    case ControlMode::Id: {
+        uint8_t value;
+        ControlMode::Get(attributePath.mEndpointId, &value);
+        EffectiveControlMode::Set(attributePath.mEndpointId, value);
+    }
+    break;
+    case OperationMode::Id: {
+        uint8_t value;
+        OperationMode::Get(attributePath.mEndpointId, &value);
+        EffectiveOperationMode::Set(attributePath.mEndpointId, value);
+    }
+    break;
+    default:
+        emberAfDebugPrintln("PCC Server: unhandled attribute ID");
     }
 }
 


### PR DESCRIPTION
#### Problem
The Pump Configuration and Control server cluster needs implementation

#### Change overview
Added initial implementation which mirrors the OperationMode and ControlMode attributes into the Effective ones

#### Testing
Build the pump-app
Tested that the attribute mirroring worked using chip-tool