### PR TITLE
Disable CYW30739 OTA requestor logging to fit the flash space.

### DIFF
--- a/examples/ota-requestor-app/cyw30739/args.gni
+++ b/examples/ota-requestor-app/cyw30739/args.gni
@@ -21,6 +21,7 @@ chip_openthread_ftd = true
 
 # Disable progress logging to fit in flash
 chip_progress_logging = false
+chip_error_logging = false
 
 declare_args() {
   chip_enable_ota_requestor = true


### PR DESCRIPTION
#### Problem
Infineon CYW30739 CI was disabled because the OTA requestor app runs out of flash space.

#### Change overview
Disable CYW30739 OTA requestor logging

#### Testing
Check by CI.