### PR TITLE
[thread] Restore OpenThread config on failsafe timeout

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -625,6 +625,7 @@ void Instance::OnFailSafeTimerExpired()
 
     ChipLogDetail(Zcl, "Failsafe timeout, tell platform driver to revert network credentials.");
     mpWirelessDriver->RevertConfiguration();
+    mAsyncCommandHandle.Release();
 }
 
 bool NullNetworkDriver::GetEnabled()

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -108,7 +108,8 @@ public:
     CHIP_ERROR JoinerStart();
     CHIP_ERROR SetThreadProvision(ByteSpan aDataset);
     CHIP_ERROR SetThreadEnabled(bool val);
-    CHIP_ERROR AttachToThreadNetwork(ByteSpan netInfo, NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * callback);
+    CHIP_ERROR AttachToThreadNetwork(const Thread::OperationalDataset & dataset,
+                                     NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * callback);
     CHIP_ERROR StartThreadScan(NetworkCommissioning::ThreadDriver::ScanCallback * callback);
     void OnThreadAttachFinished(void);
 
@@ -357,10 +358,10 @@ inline CHIP_ERROR ThreadStackManager::SetThreadProvision(ByteSpan netInfo)
 }
 
 inline CHIP_ERROR
-ThreadStackManager::AttachToThreadNetwork(ByteSpan netInfo,
+ThreadStackManager::AttachToThreadNetwork(const Thread::OperationalDataset & dataset,
                                           NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * callback)
 {
-    return static_cast<ImplClass *>(this)->_AttachToThreadNetwork(netInfo, callback);
+    return static_cast<ImplClass *>(this)->_AttachToThreadNetwork(dataset, callback);
 }
 
 inline void ThreadStackManager::OnThreadAttachFinished(void)

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -243,14 +243,11 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::Init()
     char uniqueId[kMaxUniqueIDLength + 1];
 
     // Generate Unique ID only if it is not present in the storage.
-    if (GetUniqueId(uniqueId, sizeof(uniqueId)) == CHIP_NO_ERROR)
-        return CHIP_NO_ERROR;
-
-    err = GenerateUniqueId(uniqueId, sizeof(uniqueId));
-    ReturnErrorOnFailure(err);
-
-    err = StoreUniqueId(uniqueId, strlen(uniqueId));
-    ReturnErrorOnFailure(err);
+    if (GetUniqueId(uniqueId, sizeof(uniqueId)) != CHIP_NO_ERROR)
+    {
+        ReturnErrorOnFailure(GenerateUniqueId(uniqueId, sizeof(uniqueId)));
+        ReturnErrorOnFailure(StoreUniqueId(uniqueId, strlen(uniqueId)));
+    }
 
     bool failSafeArmed;
 

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -50,7 +50,8 @@ public:
     const char * FabricOpKey(FabricIndex fabric) { return Format("f/%x/o", fabric); }
 
     // FailSafeContext
-    const char * FailSafeContextKey() { return Format("g/fsc"); }
+    const char * FailSafeContextKey() { return Format("g/fs/c"); }
+    static const char * FailSafeNetworkConfig() { return "g/fs/n"; }
 
     // Session resumption
     const char * FabricSession(FabricIndex fabric, NodeId nodeId)

--- a/src/lib/support/ThreadOperationalDataset.h
+++ b/src/lib/support/ThreadOperationalDataset.h
@@ -270,6 +270,11 @@ public:
     bool IsCommissioned(void) const;
 
     /**
+     * This method checks if the dataset is empty.
+     */
+    bool IsEmpty() const { return mLength == 0; }
+
+    /**
      * This method checks whether @p aData is formatted as ThreadTLVs.
      *
      * @note This method doesn't verify ThreadTLV values are valid.

--- a/src/platform/Linux/NetworkCommissioningThreadDriver.cpp
+++ b/src/platform/Linux/NetworkCommissioningThreadDriver.cpp
@@ -145,7 +145,7 @@ void LinuxThreadDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * cal
     VerifyOrExit((networkId.size() == kSizeExtendedPanId && memcmp(networkId.data(), extpanid, kSizeExtendedPanId) == 0),
                  status = Status::kNetworkNotFound);
 
-    VerifyOrExit(DeviceLayer::ThreadStackMgrImpl().AttachToThreadNetwork(mStagingNetwork.AsByteSpan(), callback) == CHIP_NO_ERROR,
+    VerifyOrExit(DeviceLayer::ThreadStackMgrImpl().AttachToThreadNetwork(mStagingNetwork, callback) == CHIP_NO_ERROR,
                  status = Status::kUnknownError);
 
 exit:

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -696,15 +696,20 @@ CHIP_ERROR ThreadStackManagerImpl::_WriteThreadNetworkDiagnosticAttributeToTlv(A
 }
 
 CHIP_ERROR
-ThreadStackManagerImpl::_AttachToThreadNetwork(ByteSpan netInfo,
+ThreadStackManagerImpl::_AttachToThreadNetwork(const Thread::OperationalDataset & dataset,
                                                NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * callback)
 {
-    // There is another ongoing connect request, reject the new one.
-    VerifyOrReturnError(mpConnectCallback == nullptr, CHIP_ERROR_INCORRECT_STATE);
+    // Reset the previously set callback since it will never be called in case incorrect dataset was supplied.
+    mpConnectCallback = nullptr;
     ReturnErrorOnFailure(DeviceLayer::ThreadStackMgr().SetThreadEnabled(false));
-    ReturnErrorOnFailure(DeviceLayer::ThreadStackMgr().SetThreadProvision(netInfo));
-    ReturnErrorOnFailure(DeviceLayer::ThreadStackMgr().SetThreadEnabled(true));
-    mpConnectCallback = callback;
+    ReturnErrorOnFailure(DeviceLayer::ThreadStackMgr().SetThreadProvision(dataset.AsByteSpan()));
+
+    if (dataset.IsCommissioned())
+    {
+        ReturnErrorOnFailure(DeviceLayer::ThreadStackMgr().SetThreadEnabled(true));
+        mpConnectCallback = callback;
+    }
+
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -71,7 +71,8 @@ public:
 
     bool _IsThreadAttached() const;
 
-    CHIP_ERROR _AttachToThreadNetwork(ByteSpan netInfo, NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * callback);
+    CHIP_ERROR _AttachToThreadNetwork(const Thread::OperationalDataset & dataset,
+                                      NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * callback);
 
     CHIP_ERROR _SetThreadEnabled(bool val);
 

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -16,8 +16,10 @@
  */
 
 #include <lib/support/CodeUtils.h>
+#include <lib/support/DefaultStorageKeyAllocator.h>
 #include <lib/support/SafeInt.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <platform/KeyValueStoreManager.h>
 #include <platform/NetworkCommissioning.h>
 #include <platform/OpenThread/GenericNetworkCommissioningThreadDriver.h>
 #include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h>
@@ -27,13 +29,20 @@
 
 using namespace chip;
 using namespace chip::Thread;
+using namespace chip::DeviceLayer::PersistedStorage;
 
 namespace chip {
 namespace DeviceLayer {
 namespace NetworkCommissioning {
-// NOTE: For ThreadDriver, we use two network configs, one is mSavedNetwork, and another is mStagingNetwork, during init, it will
-// load the network config from thread persistent info, and loads it into both mSavedNetwork and mStagingNetwork. When updating the
-// networks, all changes are made on the staging network. When validated we can commit it and save it to the persistent info
+
+// NOTE: For GenericThreadDriver, we assume that the network configuration is persisted by
+// the OpenThread stack after ConnectNetwork command is called, and before that, all the changes
+// are made to a local copy of the dataset stored in mStagingNetwork.
+// Also, in order to support the fail-safe mechanism, the configuration is backed up in a temporary
+// KVS slot upon any changes and restored when the fail-safe timeout is triggered or the device
+// reboots without completing all the changes.
+
+constexpr uint8_t kEmptyDataset[1] = {};
 
 CHIP_ERROR GenericThreadDriver::Init(Internal::BaseDriver::NetworkStatusChangeCallback * statusChangeCallback)
 {
@@ -41,8 +50,6 @@ CHIP_ERROR GenericThreadDriver::Init(Internal::BaseDriver::NetworkStatusChangeCa
 
     VerifyOrReturnError(ThreadStackMgrImpl().IsThreadAttached(), CHIP_NO_ERROR);
     VerifyOrReturnError(ThreadStackMgrImpl().GetThreadProvision(mStagingNetwork) == CHIP_NO_ERROR, CHIP_NO_ERROR);
-
-    mSavedNetwork.Init(mStagingNetwork.AsByteSpan());
 
     return CHIP_NO_ERROR;
 }
@@ -55,17 +62,35 @@ CHIP_ERROR GenericThreadDriver::Shutdown()
 
 CHIP_ERROR GenericThreadDriver::CommitConfiguration()
 {
-    // Note: on AttachToThreadNetwork OpenThread will persist the networks on its own,
-    // we don't have much to do for saving the networks (see Init() above,
-    // we just load the saved dataset from ot instance.)
-    mSavedNetwork = mStagingNetwork;
-    return CHIP_NO_ERROR;
+    // OpenThread persists the network configuration on AttachToThreadNetwork, so simply remove
+    // the backup, so that it cannot be restored. If no backup could be found, it means that the
+    // configuration has not been modified since the fail-safe was armed, so return with no error.
+
+    CHIP_ERROR error = KeyValueStoreMgr().Delete(DefaultStorageKeyAllocator::FailSafeNetworkConfig());
+
+    return error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND ? CHIP_NO_ERROR : error;
 }
 
 CHIP_ERROR GenericThreadDriver::RevertConfiguration()
 {
-    mStagingNetwork = mSavedNetwork;
-    return CHIP_NO_ERROR;
+    uint8_t datasetBytes[Thread::kSizeOperationalDataset];
+    size_t datasetLength;
+
+    CHIP_ERROR error = KeyValueStoreMgr().Get(DefaultStorageKeyAllocator::FailSafeNetworkConfig(), datasetBytes,
+                                              sizeof(datasetBytes), &datasetLength);
+
+    // If no backup could be found, it means that the network configuration has not been modified
+    // since the fail-safe was armed, so return with no error.
+    ReturnErrorCodeIf(error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND, CHIP_NO_ERROR);
+    ReturnErrorOnFailure(error);
+
+    KeyValueStoreMgr().Delete(DefaultStorageKeyAllocator::FailSafeNetworkConfig());
+
+    // Not all KVS implementations support zero-length values, so handle a special value representing an empty dataset.
+    ByteSpan dataset(datasetBytes, datasetLength);
+    ReturnErrorOnFailure(mStagingNetwork.Init(dataset.data_equal(ByteSpan(kEmptyDataset)) ? ByteSpan{} : dataset));
+
+    return DeviceLayer::ThreadStackMgrImpl().AttachToThreadNetwork(mStagingNetwork, /* callback */ nullptr);
 }
 
 Status GenericThreadDriver::AddOrUpdateNetwork(ByteSpan operationalDataset, MutableCharSpan & outDebugText,
@@ -84,6 +109,7 @@ Status GenericThreadDriver::AddOrUpdateNetwork(ByteSpan operationalDataset, Muta
     // Staging network not commissioned yet (active) or we are updating the dataset with same Extended Pan ID.
     VerifyOrReturnError(!mStagingNetwork.IsCommissioned() || MatchesNetworkId(mStagingNetwork, newExtpanid) == Status::kSuccess,
                         Status::kBoundsExceeded);
+    VerifyOrReturnError(BackupConfiguration() == CHIP_NO_ERROR, Status::kUnknownError);
 
     mStagingNetwork = newDataset;
     return Status::kSuccess;
@@ -97,6 +123,8 @@ Status GenericThreadDriver::RemoveNetwork(ByteSpan networkId, MutableCharSpan & 
     NetworkCommissioning::Status status = MatchesNetworkId(mStagingNetwork, networkId);
 
     VerifyOrReturnError(status == Status::kSuccess, status);
+    VerifyOrReturnError(BackupConfiguration() == CHIP_NO_ERROR, Status::kUnknownError);
+
     mStagingNetwork.Clear();
 
     return Status::kSuccess;
@@ -118,8 +146,13 @@ void GenericThreadDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * c
 {
     NetworkCommissioning::Status status = MatchesNetworkId(mStagingNetwork, networkId);
 
+    if (status == Status::kSuccess && BackupConfiguration() != CHIP_NO_ERROR)
+    {
+        status = Status::kUnknownError;
+    }
+
     if (status == Status::kSuccess &&
-        DeviceLayer::ThreadStackMgrImpl().AttachToThreadNetwork(mStagingNetwork.AsByteSpan(), callback) != CHIP_NO_ERROR)
+        DeviceLayer::ThreadStackMgrImpl().AttachToThreadNetwork(mStagingNetwork, callback) != CHIP_NO_ERROR)
     {
         status = Status::kUnknownError;
     }
@@ -160,6 +193,22 @@ Status GenericThreadDriver::MatchesNetworkId(const Thread::OperationalDataset & 
     }
 
     return networkId.data_equal(extpanid) ? Status::kSuccess : Status::kNetworkIDNotFound;
+}
+
+CHIP_ERROR GenericThreadDriver::BackupConfiguration()
+{
+    uint8_t dummy;
+
+    // If configuration is already backed up, return with no error
+    if (KeyValueStoreMgr().Get(DefaultStorageKeyAllocator::FailSafeNetworkConfig(), &dummy, 0) == CHIP_ERROR_BUFFER_TOO_SMALL)
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    // Not all KVS implementations support zero-length values, so use a special value in such a case.
+    ByteSpan dataset = mStagingNetwork.IsEmpty() ? ByteSpan(kEmptyDataset) : mStagingNetwork.AsByteSpan();
+
+    return KeyValueStoreMgr().Put(DefaultStorageKeyAllocator::FailSafeNetworkConfig(), dataset.data(), dataset.size());
 }
 
 size_t GenericThreadDriver::ThreadNetworkIterator::Count()

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -87,8 +87,6 @@ CHIP_ERROR GenericThreadDriver::RevertConfiguration()
     ReturnErrorCodeIf(error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND, CHIP_NO_ERROR);
     ReturnErrorOnFailure(error);
 
-    KeyValueStoreMgr().Delete(DefaultStorageKeyAllocator::FailSafeNetworkConfig());
-
     // Not all KVS implementations support zero-length values, so handle a special value representing an empty dataset.
     ByteSpan dataset(datasetBytes, datasetLength);
 
@@ -98,8 +96,9 @@ CHIP_ERROR GenericThreadDriver::RevertConfiguration()
     }
 
     ReturnErrorOnFailure(mStagingNetwork.Init(dataset));
+    ReturnErrorOnFailure(DeviceLayer::ThreadStackMgrImpl().AttachToThreadNetwork(mStagingNetwork, /* callback */ nullptr));
 
-    return DeviceLayer::ThreadStackMgrImpl().AttachToThreadNetwork(mStagingNetwork, /* callback */ nullptr);
+    return KeyValueStoreMgr().Delete(DefaultStorageKeyAllocator::FailSafeNetworkConfig());
 }
 
 Status GenericThreadDriver::AddOrUpdateNetwork(ByteSpan operationalDataset, MutableCharSpan & outDebugText,

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
@@ -105,9 +105,9 @@ public:
 
 private:
     Status MatchesNetworkId(const Thread::OperationalDataset & dataset, const ByteSpan & networkId) const;
+    CHIP_ERROR BackupConfiguration();
 
     ThreadNetworkIterator mThreadIterator      = ThreadNetworkIterator(this);
-    Thread::OperationalDataset mSavedNetwork   = {};
     Thread::OperationalDataset mStagingNetwork = {};
     Optional<Status> mScanStatus;
 };

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -89,7 +89,8 @@ protected:
     bool _IsThreadAttached(void);
     CHIP_ERROR _GetThreadProvision(Thread::OperationalDataset & dataset);
     CHIP_ERROR _SetThreadProvision(ByteSpan netInfo);
-    CHIP_ERROR _AttachToThreadNetwork(ByteSpan netInfo, NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * callback);
+    CHIP_ERROR _AttachToThreadNetwork(const Thread::OperationalDataset & dataset,
+                                      NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * callback);
     void _OnThreadAttachFinished(void);
     void _ErasePersistentInfo(void);
     ConnectivityManager::ThreadDeviceType _GetThreadDeviceType(void);


### PR DESCRIPTION
#### Problem
GenericThreadDriver doesn't properly back up the network configuration and restore it when the failsafe expires.

#### Change overview
1. Back up OpenThread operational dataset on the first time the network configuration is changed after arming the failsafe.
2. Restore the backup when the failsafe times out.
3. Delete the backup when CommissioningComplete command is called.
4. Fix `GenericConfigurationManager` initialization to properly detect when a device reboots with an armed failsafe.
5. Don't enable thread when trying to set empty/insufficient operational dataset.

#### Testing
Tested the following scenarios using nRF Connect Lock App:
1. Verified that when commissioning the device using an invalid dataset, the device automatically resets the Thread configuration and returns to the BLE advertising when the failsafe expires.
2. Same as above, but using a correct dataset, but an invalid routing table that prevents CASE over IP.
3. Verified that when the device reboots before `CommissioningComplete` command, the configuration is reset right after the boot.
4. Verified that when the commissioned device is trying to switch to an invalid dataset, it restores the last good configuration on the failsafe expiry.
