### PR TITLE
[net-comm] Check if failsafe is armed

### DIFF
--- a/src/controller/python/test/test_scripts/network_commissioning.py
+++ b/src/controller/python/test/test_scripts/network_commissioning.py
@@ -119,6 +119,12 @@ class NetworkCommissioningTests:
         if res.networkingStatus != Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatus.kSuccess:
             raise AssertionError(f"Unexpected result: {res.networkingStatus}")
 
+        # Arm the failsafe before making network config changes
+        logger.info(f"Arming the failsafe")
+        req = Clusters.GeneralCommissioning.Commands.ArmFailSafe(expiryLengthSeconds=900)
+        res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req)
+        logger.info(f"Received response: {res}")
+
         # Remove existing network
         logger.info(f"Check network list")
         res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)], returnClusterObject=True)
@@ -165,6 +171,12 @@ class NetworkCommissioningTests:
         if res.networkingStatus != Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatus.kSuccess:
             raise AssertionError(f"Unexpected result: {res.networkingStatus}")
         logger.info(f"Device connected to a network.")
+
+        # Disarm the failsafe
+        logger.info(f"Disarming the failsafe")
+        req = Clusters.GeneralCommissioning.Commands.CommissioningComplete()
+        res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req)
+        logger.info(f"Received response: {res}")
 
         # Note: On Linux, when connecting to a connected network, it will return immediately, however, it will try a reconnect. This will make the below attribute read return false negative values.
         await asyncio.sleep(5)
@@ -220,6 +232,12 @@ class NetworkCommissioningTests:
         if res.networkingStatus != Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatus.kSuccess:
             raise AssertionError(f"Unexpected result: {res.networkingStatus}")
 
+        # Arm the failsafe before making network config changes
+        logger.info(f"Arming the failsafe")
+        req = Clusters.GeneralCommissioning.Commands.ArmFailSafe(expiryLengthSeconds=900)
+        res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req)
+        logger.info(f"Received response: {res}")
+
         # Remove existing network
         logger.info(f"Check network list")
         res = await self._devCtrl.ReadAttribute(nodeid=self._nodeid, attributes=[(endpointId, Clusters.NetworkCommissioning.Attributes.Networks)], returnClusterObject=True)
@@ -266,6 +284,12 @@ class NetworkCommissioningTests:
         if res.networkingStatus != Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatus.kSuccess:
             raise AssertionError(f"Unexpected result: {res.networkingStatus}")
         logger.info(f"Device connected to a network.")
+
+        # Disarm the failsafe
+        logger.info(f"Disarming the failsafe")
+        req = Clusters.GeneralCommissioning.Commands.CommissioningComplete()
+        res = await self._devCtrl.SendCommand(nodeid=self._nodeid, endpoint=endpointId, payload=req)
+        logger.info(f"Received response: {res}")
 
         # Verify Last* attributes
         logger.info(f"Read Last* attributes")


### PR DESCRIPTION
#### Problem
NetworkCommissioning commands: AddOrUpdateXXX, RemoveNetwork or ConnectNetwork should only be called with the failsafe armed and return UNSUPPORTED_ACCESS error, otherwise.

#### Change overview
Add the missing check.
Fixes  #16437

#### Testing
Verified using nRF Connect Lock app that the commands only work when the failsafe is armed.
