### PR TITLE
Clang tidy readability-redundant-*

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -118,7 +118,7 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
     chip::FabricId fabricId = strtoull(name.c_str(), nullptr, 0);
     if (fabricId >= kIdentityOtherFabricId)
     {
-        ReturnLogErrorOnFailure(InitializeCommissioner(name.c_str(), fabricId, trustStore));
+        ReturnLogErrorOnFailure(InitializeCommissioner(name, fabricId, trustStore));
     }
 
     // Initialize Group Data, including IPK
@@ -168,7 +168,7 @@ CHIP_ERROR CHIPCommand::MaybeTearDownStack()
     chip::FabricId fabricId = strtoull(name.c_str(), nullptr, 0);
     if (fabricId >= kIdentityOtherFabricId)
     {
-        ReturnLogErrorOnFailure(ShutdownCommissioner(name.c_str()));
+        ReturnLogErrorOnFailure(ShutdownCommissioner(name));
     }
 
     StopTracing();
@@ -286,7 +286,7 @@ chip::FabricId CHIPCommand::CurrentCommissionerId()
 chip::Controller::DeviceCommissioner & CHIPCommand::CurrentCommissioner()
 {
     auto item = mCommissioners.find(GetIdentity());
-    return *item->second.get();
+    return *item->second;
 }
 
 CHIP_ERROR CHIPCommand::ShutdownCommissioner(std::string key)

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -310,7 +310,7 @@ void Commands::ShowCommand(std::string executable, std::string clusterName, Comm
 {
     fprintf(stderr, "Usage:\n");
 
-    std::string arguments = "";
+    std::string arguments;
     arguments += command->GetName();
 
     size_t argumentsCount = command->GetArgumentsCount();

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -213,7 +213,6 @@ public:
          */
         CHIP_ERROR RemoveTarget(size_t index) { return mDelegate->RemoveTarget(index); }
 
-    
         const Delegate & GetDelegate() const { return *mDelegate; }
 
         Delegate & GetDelegate() { return *mDelegate; }
@@ -267,7 +266,6 @@ public:
 
         CHIP_ERROR Next(Entry & entry) { return mDelegate->Next(entry); }
 
-    
         const Delegate & GetDelegate() const { return *mDelegate; }
 
         Delegate & GetDelegate() { return *mDelegate; }

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -213,7 +213,7 @@ public:
          */
         CHIP_ERROR RemoveTarget(size_t index) { return mDelegate->RemoveTarget(index); }
 
-    public:
+    
         const Delegate & GetDelegate() const { return *mDelegate; }
 
         Delegate & GetDelegate() { return *mDelegate; }
@@ -267,7 +267,7 @@ public:
 
         CHIP_ERROR Next(Entry & entry) { return mDelegate->Next(entry); }
 
-    public:
+    
         const Delegate & GetDelegate() const { return *mDelegate; }
 
         Delegate & GetDelegate() { return *mDelegate; }

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -130,7 +130,6 @@ public:
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-
     CHIP_ERROR Serialize(chip::TLV::TLVWriter & writer) const { return writer.Put(chip::TLV::AnonymousTag(), mNode); }
 
     CHIP_ERROR Deserialize(chip::TLV::TLVReader & reader)
@@ -142,9 +141,7 @@ public:
 private:
     static bool IsValid(NodeId node) { return node != kUndefinedNodeId; }
 
-
     static_assert(sizeof(NodeId) == 8, "Expecting 8 byte node ID");
-
 
     NodeId mNode;
 };
@@ -194,7 +191,6 @@ public:
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-
     CHIP_ERROR Serialize(chip::TLV::TLVWriter & writer) const
     {
         ReturnErrorOnFailure(writer.Put(chip::TLV::AnonymousTag(), mCluster));
@@ -240,7 +236,6 @@ private:
             !((target.flags & Target::kEndpoint) && !IsValidEndpoint(target.endpoint)) &&
             !((target.flags & Target::kDeviceType) && !IsValidDeviceType(target.deviceType));
     }
-
 
     void Decode(Target & target) const
     {
@@ -297,7 +292,6 @@ private:
         }
     }
 
-
     static_assert(sizeof(ClusterId) == 4, "Expecting 4 byte cluster ID");
     static_assert(sizeof(EndpointId) == 2, "Expecting 2 byte endpoint ID");
     static_assert(sizeof(DeviceTypeId) == 4, "Expecting 4 byte device type ID");
@@ -346,7 +340,6 @@ private:
     // (mDeviceType >> kEndpointShift) --> extract endpoint from mDeviceType
     static constexpr int kEndpointShift = 16;
 
-
     ClusterId mCluster;
     DeviceTypeId mDeviceType;
 };
@@ -390,7 +383,6 @@ public:
         return nullptr;
     }
 
-
     // Pool support
     static EntryStorage pool[kEntryStoragePoolSize];
 
@@ -418,7 +410,6 @@ public:
         constexpr auto * end = pool + ArraySize(pool);
         return pool <= this && this < end;
     }
-
 
     EntryStorage() = default;
 
@@ -456,7 +447,6 @@ public:
             target.Clear();
         }
     }
-
 
     enum class ConvertDirection
     {
@@ -511,7 +501,6 @@ public:
         }
         index = found ? toIndex : ArraySize(acl);
     }
-
 
     static constexpr uint8_t kTagInUse       = 1;
     static constexpr uint8_t kTagFabricIndex = 2;
@@ -598,7 +587,6 @@ public:
         return reader.ExitContainer(container);
     }
 
-
     static constexpr size_t kMaxSubjects = CHIP_CONFIG_EXAMPLE_ACCESS_CONTROL_MAX_SUBJECTS_PER_ENTRY;
     static constexpr size_t kMaxTargets  = CHIP_CONFIG_EXAMPLE_ACCESS_CONTROL_MAX_TARGETS_PER_ENTRY;
 
@@ -647,7 +635,6 @@ public:
         constexpr auto * end = pool + ArraySize(pool);
         return pool <= &delegate && &delegate < end;
     }
-
 
     void Release() override
     {
@@ -840,7 +827,6 @@ public:
         return CHIP_ERROR_SENTINEL;
     }
 
-
     void Init(Entry & entry, EntryStorage & storage)
     {
         entry.SetDelegate(*this);
@@ -922,7 +908,6 @@ public:
         return pool <= &delegate && &delegate < end;
     }
 
-
     void Release() override { mInUse = false; }
 
     CHIP_ERROR Next(Entry & entry) override
@@ -962,7 +947,6 @@ public:
         }
         return CHIP_ERROR_SENTINEL;
     }
-
 
     void Init(EntryIterator & iterator, const FabricIndex * fabricIndex)
     {
@@ -1244,7 +1228,6 @@ public:
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
-
 
     void SetStorageDelegate(chip::PersistentStorageDelegate * storageDelegate) { mStorageDelegate = storageDelegate; }
 

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -130,7 +130,7 @@ public:
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-public:
+
     CHIP_ERROR Serialize(chip::TLV::TLVWriter & writer) const { return writer.Put(chip::TLV::AnonymousTag(), mNode); }
 
     CHIP_ERROR Deserialize(chip::TLV::TLVReader & reader)
@@ -142,10 +142,10 @@ public:
 private:
     static bool IsValid(NodeId node) { return node != kUndefinedNodeId; }
 
-private:
+
     static_assert(sizeof(NodeId) == 8, "Expecting 8 byte node ID");
 
-private:
+
     NodeId mNode;
 };
 
@@ -194,7 +194,7 @@ public:
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-public:
+
     CHIP_ERROR Serialize(chip::TLV::TLVWriter & writer) const
     {
         ReturnErrorOnFailure(writer.Put(chip::TLV::AnonymousTag(), mCluster));
@@ -241,7 +241,7 @@ private:
             !((target.flags & Target::kDeviceType) && !IsValidDeviceType(target.deviceType));
     }
 
-private:
+
     void Decode(Target & target) const
     {
         auto & flags      = target.flags;
@@ -297,7 +297,7 @@ private:
         }
     }
 
-private:
+
     static_assert(sizeof(ClusterId) == 4, "Expecting 4 byte cluster ID");
     static_assert(sizeof(EndpointId) == 2, "Expecting 2 byte endpoint ID");
     static_assert(sizeof(DeviceTypeId) == 4, "Expecting 4 byte device type ID");
@@ -346,7 +346,7 @@ private:
     // (mDeviceType >> kEndpointShift) --> extract endpoint from mDeviceType
     static constexpr int kEndpointShift = 16;
 
-private:
+
     ClusterId mCluster;
     DeviceTypeId mDeviceType;
 };
@@ -390,7 +390,7 @@ public:
         return nullptr;
     }
 
-public:
+
     // Pool support
     static EntryStorage pool[kEntryStoragePoolSize];
 
@@ -419,7 +419,7 @@ public:
         return pool <= this && this < end;
     }
 
-public:
+
     EntryStorage() = default;
 
     void Init()
@@ -457,7 +457,7 @@ public:
         }
     }
 
-public:
+
     enum class ConvertDirection
     {
         kAbsoluteToRelative,
@@ -512,7 +512,7 @@ public:
         index = found ? toIndex : ArraySize(acl);
     }
 
-public:
+
     static constexpr uint8_t kTagInUse       = 1;
     static constexpr uint8_t kTagFabricIndex = 2;
     static constexpr uint8_t kTagAuthMode    = 3;
@@ -598,7 +598,7 @@ public:
         return reader.ExitContainer(container);
     }
 
-public:
+
     static constexpr size_t kMaxSubjects = CHIP_CONFIG_EXAMPLE_ACCESS_CONTROL_MAX_SUBJECTS_PER_ENTRY;
     static constexpr size_t kMaxTargets  = CHIP_CONFIG_EXAMPLE_ACCESS_CONTROL_MAX_TARGETS_PER_ENTRY;
 
@@ -648,7 +648,7 @@ public:
         return pool <= &delegate && &delegate < end;
     }
 
-public:
+
     void Release() override
     {
         mStorage->Release();
@@ -840,7 +840,7 @@ public:
         return CHIP_ERROR_SENTINEL;
     }
 
-public:
+
     void Init(Entry & entry, EntryStorage & storage)
     {
         entry.SetDelegate(*this);
@@ -922,7 +922,7 @@ public:
         return pool <= &delegate && &delegate < end;
     }
 
-public:
+
     void Release() override { mInUse = false; }
 
     CHIP_ERROR Next(Entry & entry) override
@@ -963,7 +963,7 @@ public:
         return CHIP_ERROR_SENTINEL;
     }
 
-public:
+
     void Init(EntryIterator & iterator, const FabricIndex * fabricIndex)
     {
         iterator.SetDelegate(*this);
@@ -1245,7 +1245,7 @@ public:
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
-public:
+
     void SetStorageDelegate(chip::PersistentStorageDelegate * storageDelegate) { mStorageDelegate = storageDelegate; }
 
 private:

--- a/src/app/AttributeCache.h
+++ b/src/app/AttributeCache.h
@@ -338,7 +338,6 @@ private:
      */
     CHIP_ERROR UpdateCache(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus);
 
-
     //
     // ReadClient::Callback
     //
@@ -359,7 +358,6 @@ private:
     {
         return mCallback.OnDeallocatePaths(std::move(aReadPrepareParams));
     }
-
 
     Callback & mCallback;
     NodeState mCache;

--- a/src/app/AttributeCache.h
+++ b/src/app/AttributeCache.h
@@ -338,7 +338,7 @@ private:
      */
     CHIP_ERROR UpdateCache(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus);
 
-private:
+
     //
     // ReadClient::Callback
     //
@@ -360,7 +360,7 @@ private:
         return mCallback.OnDeallocatePaths(std::move(aReadPrepareParams));
     }
 
-private:
+
     Callback & mCallback;
     NodeState mCache;
     std::set<ConcreteAttributePath> mChangedAttributeSet;

--- a/src/app/BufferedReadCallback.h
+++ b/src/app/BufferedReadCallback.h
@@ -63,7 +63,7 @@ private:
      */
     CHIP_ERROR BufferData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apReader);
 
-private:
+
     //
     // ReadClient::Callback
     //
@@ -84,7 +84,7 @@ private:
         return mCallback.OnDeallocatePaths(std::move(aReadPrepareParams));
     }
 
-private:
+
     /*
      * Given a reader positioned at a list element, allocate a packet buffer, copy the list item where
      * the reader is positioned into that buffer and add it to our buffered list for tracking.

--- a/src/app/BufferedReadCallback.h
+++ b/src/app/BufferedReadCallback.h
@@ -63,7 +63,6 @@ private:
      */
     CHIP_ERROR BufferData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apReader);
 
-
     //
     // ReadClient::Callback
     //
@@ -83,7 +82,6 @@ private:
     {
         return mCallback.OnDeallocatePaths(std::move(aReadPrepareParams));
     }
-
 
     /*
      * Given a reader positioned at a list element, allocate a packet buffer, copy the list item where

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -69,7 +69,6 @@ static void DefaultResubscribePolicy(uint32_t aNumCumulativeRetries, uint32_t & 
                     "Computing Resubscribe policy: attempts %" PRIu32 ", max wait time %" PRIu32 " ms, selected wait time %" PRIu32
                     " ms",
                     aNumCumulativeRetries, maxWaitTimeInMsec, waitTimeInMsec);
-    return;
 }
 
 ReadClient::ReadClient(InteractionModelEngine * apImEngine, Messaging::ExchangeManager * apExchangeMgr, Callback & apCallback,

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -141,11 +141,10 @@ private:
      */
     void Close();
 
-// ExchangeDelegate
+    // ExchangeDelegate
     CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PayloadHeader & aPayloadHeader,
                                  System::PacketBufferHandle && aPayload) override;
     void OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext) override;
-
 
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
     WriteResponseMessage::Builder mWriteResponseBuilder;

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -141,12 +141,12 @@ private:
      */
     void Close();
 
-private: // ExchangeDelegate
+// ExchangeDelegate
     CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PayloadHeader & aPayloadHeader,
                                  System::PacketBufferHandle && aPayload) override;
     void OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext) override;
 
-private:
+
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
     WriteResponseMessage::Builder mWriteResponseBuilder;
     State mState           = State::Uninitialized;

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -598,11 +598,6 @@ uint8_t emberAfGetAddressIndex(void);
 EmberNetworkStatus emberAfNetworkState(void);
 
 /**
- * @brief Get this node's radio channel for the current network.
- */
-uint8_t emberAfGetRadioChannel(void);
-
-/**
  * @brief Returns the current network parameters.
  */
 EmberStatus emberAfGetNetworkParameters(EmberNodeType * nodeType, EmberNetworkParameters * parameters);

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -323,8 +323,7 @@ void IncreaseClusterDataVersion(const ConcreteClusterPath & aConcreteClusterPath
         ChipLogDetail(DataManagement, "Endpoint %" PRIx16 ", Cluster " ChipLogFormatMEI " update version to %" PRIx32,
                       aConcreteClusterPath.mEndpointId, ChipLogValueMEI(aConcreteClusterPath.mClusterId), *(version));
     }
-    return;
-}
+    }
 
 CHIP_ERROR SendSuccessStatus(AttributeReportIB::Builder & aAttributeReport, AttributeDataIB::Builder & aAttributeDataIBBuilder)
 {

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -323,7 +323,7 @@ void IncreaseClusterDataVersion(const ConcreteClusterPath & aConcreteClusterPath
         ChipLogDetail(DataManagement, "Endpoint %" PRIx16 ", Cluster " ChipLogFormatMEI " update version to %" PRIx32,
                       aConcreteClusterPath.mEndpointId, ChipLogValueMEI(aConcreteClusterPath.mClusterId), *(version));
     }
-    }
+}
 
 CHIP_ERROR SendSuccessStatus(AttributeReportIB::Builder & aAttributeReport, AttributeDataIB::Builder & aAttributeDataIBBuilder)
 {

--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -105,7 +105,7 @@ extern chip::Controller::ScriptDevicePairingDelegate sPairingDelegate;
 class TestCommissioner : public chip::Controller::AutoCommissioner
 {
 public:
-    TestCommissioner()  { Reset(); }
+    TestCommissioner() { Reset(); }
     ~TestCommissioner() {}
     CHIP_ERROR SetCommissioningParameters(const chip::Controller::CommissioningParameters & params) override
     {

--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -105,7 +105,7 @@ extern chip::Controller::ScriptDevicePairingDelegate sPairingDelegate;
 class TestCommissioner : public chip::Controller::AutoCommissioner
 {
 public:
-    TestCommissioner() : AutoCommissioner() { Reset(); }
+    TestCommissioner()  { Reset(); }
     ~TestCommissioner() {}
     CHIP_ERROR SetCommissioningParameters(const chip::Controller::CommissioningParameters & params) override
     {

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -212,7 +212,7 @@ private:
     // of reads in parallel and wait for them all to succeed.
     static void SubscribeThenReadHelper(nlTestSuite * apSuite, TestContext & aCtx, size_t aSubscribeCount, size_t aReadCount);
 
-private:
+
     bool mEmitSubscriptionError      = false;
     int32_t mNumActiveSubscriptions  = 0;
     bool mAlterSubscriptionIntervals = false;

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -212,7 +212,6 @@ private:
     // of reads in parallel and wait for them all to succeed.
     static void SubscribeThenReadHelper(nlTestSuite * apSuite, TestContext & aCtx, size_t aSubscribeCount, size_t aReadCount);
 
-
     bool mEmitSubscriptionError      = false;
     int32_t mNumActiveSubscriptions  = 0;
     bool mAlterSubscriptionIntervals = false;

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -799,7 +799,6 @@ void FabricTable::UpdateNextAvailableFabricIndex()
     }
 
     mNextAvailableFabricIndex.ClearValue();
-    return;
 }
 
 CHIP_ERROR FabricTable::StoreFabricIndexInfo() const

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -384,7 +384,7 @@ struct GroupData : public GroupDataProvider::GroupInfo, PersistentData<kPersiste
     bool first                      = true;
 
     GroupData() : GroupInfo(nullptr){};
-    GroupData(chip::FabricIndex fabric) : GroupInfo(), fabric_index(fabric) {}
+    GroupData(chip::FabricIndex fabric) :  fabric_index(fabric) {}
     GroupData(chip::FabricIndex fabric, chip::GroupId group) : GroupInfo(group, nullptr), fabric_index(fabric) {}
 
     CHIP_ERROR UpdateKey(DefaultStorageKeyAllocator & key) override
@@ -505,7 +505,7 @@ struct KeyMapData : public GroupDataProvider::GroupKey, LinkedData
     chip::GroupId group_id         = kUndefinedGroupId;
     chip::KeysetId keyset_id       = 0;
 
-    KeyMapData() : GroupKey(){};
+    KeyMapData()  {};
     KeyMapData(chip::FabricIndex fabric, uint16_t link_id = 0, chip::GroupId group = kUndefinedGroupId, chip::KeysetId keyset = 0) :
         GroupKey(group, keyset), LinkedData(link_id), fabric_index(fabric)
     {}

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -384,7 +384,7 @@ struct GroupData : public GroupDataProvider::GroupInfo, PersistentData<kPersiste
     bool first                      = true;
 
     GroupData() : GroupInfo(nullptr){};
-    GroupData(chip::FabricIndex fabric) :  fabric_index(fabric) {}
+    GroupData(chip::FabricIndex fabric) : fabric_index(fabric) {}
     GroupData(chip::FabricIndex fabric, chip::GroupId group) : GroupInfo(group, nullptr), fabric_index(fabric) {}
 
     CHIP_ERROR UpdateKey(DefaultStorageKeyAllocator & key) override
@@ -505,7 +505,7 @@ struct KeyMapData : public GroupDataProvider::GroupKey, LinkedData
     chip::GroupId group_id         = kUndefinedGroupId;
     chip::KeysetId keyset_id       = 0;
 
-    KeyMapData()  {};
+    KeyMapData(){};
     KeyMapData(chip::FabricIndex fabric, uint16_t link_id = 0, chip::GroupId group = kUndefinedGroupId, chip::KeysetId keyset = 0) :
         GroupKey(group, keyset), LinkedData(link_id), fabric_index(fabric)
     {}

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
@@ -195,8 +195,6 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::_RunEventLoop()
     // StopEventLoopTask().
     //
     pthread_cond_signal(&mEventQueueStoppedCond);
-
-    return;
 }
 
 template <class ImplClass>

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -125,7 +125,7 @@ public:
     static constexpr uint16_t kMaxStringLength = INET6_ADDRSTRLEN;
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
-public:
+
     IPAddress()                        = default;
     IPAddress(const IPAddress & other) = default;
 

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -125,7 +125,6 @@ public:
     static constexpr uint16_t kMaxStringLength = INET6_ADDRSTRLEN;
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
-
     IPAddress()                        = default;
     IPAddress(const IPAddress & other) = default;
 

--- a/src/inet/InetInterface.h
+++ b/src/inet/InetInterface.h
@@ -91,7 +91,7 @@ public:
     static constexpr size_t kMaxIfNameLength = Z_DEVICE_MAX_NAME_LEN;
 #endif
 
-public:
+
     ~InterfaceId() = default;
 
     constexpr InterfaceId() : mPlatformInterface(kPlatformNull) {}

--- a/src/inet/InetInterface.h
+++ b/src/inet/InetInterface.h
@@ -91,7 +91,6 @@ public:
     static constexpr size_t kMaxIfNameLength = Z_DEVICE_MAX_NAME_LEN;
 #endif
 
-
     ~InterfaceId() = default;
 
     constexpr InterfaceId() : mPlatformInterface(kPlatformNull) {}

--- a/src/lib/dnssd/minimal_mdns/tests/TestMinimalMdnsAllocator.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestMinimalMdnsAllocator.cpp
@@ -36,7 +36,7 @@ constexpr size_t kMaxRecords = 10;
 class TestAllocator : public QueryResponderAllocator<kMaxRecords>
 {
 public:
-    TestAllocator()  
+    TestAllocator()
     {
 #if CHIP_CONFIG_MEMORY_DEBUG_DMALLOC
         // void dmalloc_track(const dmalloc_track_t track_func)

--- a/src/lib/dnssd/minimal_mdns/tests/TestMinimalMdnsAllocator.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestMinimalMdnsAllocator.cpp
@@ -36,7 +36,7 @@ constexpr size_t kMaxRecords = 10;
 class TestAllocator : public QueryResponderAllocator<kMaxRecords>
 {
 public:
-    TestAllocator() : QueryResponderAllocator<kMaxRecords>()
+    TestAllocator()  
     {
 #if CHIP_CONFIG_MEMORY_DEBUG_DMALLOC
         // void dmalloc_track(const dmalloc_track_t track_func)

--- a/src/lib/shell/commands/Config.cpp
+++ b/src/lib/shell/commands/Config.cpp
@@ -211,7 +211,6 @@ void RegisterConfigCommands()
 
     // Register the root `config` command with the top-level shell.
     Engine::Root().RegisterCommands(&sConfigComand, 1);
-    return;
 }
 
 } // namespace Shell

--- a/src/lib/shell/commands/OnboardingCodes.cpp
+++ b/src/lib/shell/commands/OnboardingCodes.cpp
@@ -170,7 +170,6 @@ void RegisterOnboardingCodesCommands()
 
     // Register the root `device` command with the top-level shell.
     Engine::Root().RegisterCommands(&sDeviceComand, 1);
-    return;
 }
 
 } // namespace Shell

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -229,7 +229,7 @@ private:
     // will send that ack at some point.
     void SetPendingPeerAckMessageCounter(uint32_t aPeerAckMessageCounter);
 
-private:
+
     friend class ReliableMessageMgr;
     friend class ExchangeContext;
     friend class ExchangeMessageDispatch;

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -229,7 +229,6 @@ private:
     // will send that ack at some point.
     void SetPendingPeerAckMessageCounter(uint32_t aPeerAckMessageCounter);
 
-
     friend class ReliableMessageMgr;
     friend class ExchangeContext;
     friend class ExchangeMessageDispatch;

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -41,7 +41,7 @@ namespace chip {
 namespace Messaging {
 
 ReliableMessageMgr::RetransTableEntry::RetransTableEntry(ReliableMessageContext * rc) :
-    ec(*rc->GetExchangeContext()),  nextRetransTime(0), sendCount(0)
+    ec(*rc->GetExchangeContext()), nextRetransTime(0), sendCount(0)
 {
     ec->SetMessageNotAcked(true);
 }
@@ -89,9 +89,7 @@ void ReliableMessageMgr::TicklessDebugDumpRetransTable(const char * log)
     });
 }
 #else
-void ReliableMessageMgr::TicklessDebugDumpRetransTable(const char * log)
-{
-    }
+void ReliableMessageMgr::TicklessDebugDumpRetransTable(const char * log) {}
 #endif // RMP_TICKLESS_DEBUG
 
 void ReliableMessageMgr::ExecuteActions()

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -41,7 +41,7 @@ namespace chip {
 namespace Messaging {
 
 ReliableMessageMgr::RetransTableEntry::RetransTableEntry(ReliableMessageContext * rc) :
-    ec(*rc->GetExchangeContext()), retainedBuf(EncryptedPacketBufferHandle()), nextRetransTime(0), sendCount(0)
+    ec(*rc->GetExchangeContext()),  nextRetransTime(0), sendCount(0)
 {
     ec->SetMessageNotAcked(true);
 }
@@ -91,8 +91,7 @@ void ReliableMessageMgr::TicklessDebugDumpRetransTable(const char * log)
 #else
 void ReliableMessageMgr::TicklessDebugDumpRetransTable(const char * log)
 {
-    return;
-}
+    }
 #endif // RMP_TICKLESS_DEBUG
 
 void ReliableMessageMgr::ExecuteActions()

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -69,7 +69,6 @@ public:
                                                        including both successfully and failure send. */
     };
 
-
     ReliableMessageMgr(BitMapObjectPool<ExchangeContext, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS> & contextPool);
     ~ReliableMessageMgr();
 

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -69,7 +69,7 @@ public:
                                                        including both successfully and failure send. */
     };
 
-public:
+
     ReliableMessageMgr(BitMapObjectPool<ExchangeContext, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS> & contextPool);
     ~ReliableMessageMgr();
 

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -103,8 +103,6 @@ void UserDirectedCommissioningServer::SetUDCClientProcessingState(char * instanc
     client->SetUDCClientProcessingState(state);
 
     mUdcClients.MarkUDCClientActive(client);
-
-    return;
 }
 
 void UserDirectedCommissioningServer::OnCommissionableNodeFound(const Dnssd::DiscoveredNodeData & nodeData)

--- a/src/setup_payload/tests/TestManualCode.cpp
+++ b/src/setup_payload/tests/TestManualCode.cpp
@@ -128,7 +128,7 @@ void TestDecimalRepresentation_AllZeros(nlTestSuite * inSuite, void * inContext)
     payload.setUpPINCode  = 0;
     payload.discriminator = 0;
 
-    std::string expectedResult = "";
+    std::string expectedResult;
 
     NL_TEST_ASSERT(inSuite, CheckGenerator(payload, expectedResult));
 }

--- a/src/tools/chip-cert/CertUtils.cpp
+++ b/src/tools/chip-cert/CertUtils.cpp
@@ -356,9 +356,9 @@ bool AddAuthorityKeyId(X509 * cert, X509 * caCert)
     int index = 0;
     std::unique_ptr<AUTHORITY_KEYID, void (*)(AUTHORITY_KEYID *)> akid(AUTHORITY_KEYID_new(), &AUTHORITY_KEYID_free);
 
-    akid.get()->keyid =
+    akid->keyid =
         reinterpret_cast<ASN1_OCTET_STRING *>(X509_get_ext_d2i(caCert, NID_subject_key_identifier, &isCritical, &index));
-    if (akid.get()->keyid == nullptr)
+    if (akid->keyid == nullptr)
     {
         ReportOpenSSLErrorAndExit("X509_get_ext_d2i", res = false);
     }

--- a/src/tools/chip-cert/CertUtils.cpp
+++ b/src/tools/chip-cert/CertUtils.cpp
@@ -356,8 +356,7 @@ bool AddAuthorityKeyId(X509 * cert, X509 * caCert)
     int index = 0;
     std::unique_ptr<AUTHORITY_KEYID, void (*)(AUTHORITY_KEYID *)> akid(AUTHORITY_KEYID_new(), &AUTHORITY_KEYID_free);
 
-    akid->keyid =
-        reinterpret_cast<ASN1_OCTET_STRING *>(X509_get_ext_d2i(caCert, NID_subject_key_identifier, &isCritical, &index));
+    akid->keyid = reinterpret_cast<ASN1_OCTET_STRING *>(X509_get_ext_d2i(caCert, NID_subject_key_identifier, &isCritical, &index));
     if (akid->keyid == nullptr)
     {
         ReportOpenSSLErrorAndExit("X509_get_ext_d2i", res = false);

--- a/src/transport/SessionHolder.cpp
+++ b/src/transport/SessionHolder.cpp
@@ -24,7 +24,7 @@ SessionHolder::~SessionHolder()
     Release();
 }
 
-SessionHolder::SessionHolder(const SessionHolder & that)
+SessionHolder::SessionHolder(const SessionHolder & that) : IntrusiveListNodeBase()
 {
     mSession = that.mSession;
     if (mSession.HasValue())
@@ -33,7 +33,7 @@ SessionHolder::SessionHolder(const SessionHolder & that)
     }
 }
 
-SessionHolder::SessionHolder(SessionHolder && that)
+SessionHolder::SessionHolder(SessionHolder && that) : IntrusiveListNodeBase()
 {
     mSession = that.mSession;
     if (mSession.HasValue())

--- a/src/transport/SessionHolder.cpp
+++ b/src/transport/SessionHolder.cpp
@@ -24,7 +24,7 @@ SessionHolder::~SessionHolder()
     Release();
 }
 
-SessionHolder::SessionHolder(const SessionHolder & that) : IntrusiveListNodeBase()
+SessionHolder::SessionHolder(const SessionHolder & that)  
 {
     mSession = that.mSession;
     if (mSession.HasValue())
@@ -33,7 +33,7 @@ SessionHolder::SessionHolder(const SessionHolder & that) : IntrusiveListNodeBase
     }
 }
 
-SessionHolder::SessionHolder(SessionHolder && that) : IntrusiveListNodeBase()
+SessionHolder::SessionHolder(SessionHolder && that)  
 {
     mSession = that.mSession;
     if (mSession.HasValue())

--- a/src/transport/SessionHolder.cpp
+++ b/src/transport/SessionHolder.cpp
@@ -24,7 +24,7 @@ SessionHolder::~SessionHolder()
     Release();
 }
 
-SessionHolder::SessionHolder(const SessionHolder & that)  
+SessionHolder::SessionHolder(const SessionHolder & that)
 {
     mSession = that.mSession;
     if (mSession.HasValue())
@@ -33,7 +33,7 @@ SessionHolder::SessionHolder(const SessionHolder & that)
     }
 }
 
-SessionHolder::SessionHolder(SessionHolder && that)  
+SessionHolder::SessionHolder(SessionHolder && that)
 {
     mSession = that.mSession;
     if (mSession.HasValue())

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -238,7 +238,7 @@ struct TestData
     // `sizes[]` is a zero-terminated sequence of packet buffer sizes.
     // If total length supplied is not large enough for at least the PacketHeader and length field,
     // the last buffer will be made larger.
-    TestData() : mHandle(), mPayload(nullptr), mTotalLength(0), mMessageLength(0), mMessageOffset(0) {}
+    TestData() :  mPayload(nullptr), mTotalLength(0), mMessageLength(0), mMessageOffset(0) {}
     ~TestData() { Free(); }
     bool Init(const uint16_t sizes[]);
     void Free();

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -238,7 +238,7 @@ struct TestData
     // `sizes[]` is a zero-terminated sequence of packet buffer sizes.
     // If total length supplied is not large enough for at least the PacketHeader and length field,
     // the last buffer will be made larger.
-    TestData() :  mPayload(nullptr), mTotalLength(0), mMessageLength(0), mMessageOffset(0) {}
+    TestData() : mPayload(nullptr), mTotalLength(0), mMessageLength(0), mMessageOffset(0) {}
     ~TestData() { Free(); }
     bool Init(const uint16_t sizes[]);
     void Free();


### PR DESCRIPTION
#### Problem
Redundant code hurts readability/maintenance, clang-tidy can fix things up.

#### Change overview
enabled `readability-redundant-*` in .clang-tidy then ran

```
./scripts/run-clang-tidy-on-compile-commands.py --compile-database out/linux-x64-tests/compile_commands.json fix
```

Removed an extra comment from a duplicated af.h declaration and reverted changes in zzz_generated/controller-clusters/zap-generated/tests/CHIPClustersTest.h since I did not want to update zap templates just yet.

Reverted the .clang-tidy change, only kept fixes for review. Will change clang-tidy once we fix CHIPClustersTest.h as well

#### Testing
Code should still compile, changes were made by an automated tool.
