### PR TITLE
Abort endpoint_config forcefully if storage option is unknown

### DIFF
--- a/src/app/zap-templates/templates/app/endpoint_config.zapt
+++ b/src/app/zap-templates/templates/app/endpoint_config.zapt
@@ -5,7 +5,7 @@
 
 #include <lib/core/CHIPConfig.h>
 
-{{#endpoint_config}}
+{{#endpoint_config allowUnknownStorageOption="false"}}
 
 // Default values for the attributes longer than a pointer,
 // in a form of a binary blob


### PR DESCRIPTION
#### Problem
This was previous solved in a backwards incompatible way in the zap itself, in process
breaking the previous uses of endpoint_config in ZigbeePro stacks.
With this, the default value is to let unknown options be allowed, but
with adding the allowUnknownStorageOption="false" to the helper, you turn on the strictness.

#### Change overview
Earlier, default state was to be strict. The new default state is to NOT be strict, and you have
to explicitely add the option to endpoint_config zap helper in a template to turn on strictness.

#### Testing
Regen causes no changes.