### PR TITLE
Check error code on TestMultiFabric

### DIFF
--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -76,9 +76,10 @@ def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: 
                                    nodeid=device_nodeid),
               "Failed to finish key exchange")
 
-    asyncio.run(test.TestMultiFabric(ip=address,
+    ok = asyncio.run(test.TestMultiFabric(ip=address,
                                      setuppin=20202021,
                                      nodeid=1))
+    FailIfNot(ok, "Failed to commission multi-fabric")
     #
     # The server will crash if we are aborting / closing it too fast.
     # Issue: #15987

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -77,8 +77,8 @@ def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: 
               "Failed to finish key exchange")
 
     ok = asyncio.run(test.TestMultiFabric(ip=address,
-                                     setuppin=20202021,
-                                     nodeid=1))
+                                          setuppin=20202021,
+                                          nodeid=1))
     FailIfNot(ok, "Failed to commission multi-fabric")
     #
     # The server will crash if we are aborting / closing it too fast.


### PR DESCRIPTION
#### Problem
If the MultiFabric test fails, the error code is hard to parse because we get an exception later in the test suite. Since this is required to pass for later tests to pass, we should check the error code and fail early here if the MultiFabric tests fail.

#### Change overview
- check error code on TestMultiFabric in mobile-device-test

#### Testing
- tested on a device that failed multi-fabric commissioning and saw proper error
