### PR TITLE
Fix wildcard path setDirty merge

### DIFF
--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -645,7 +645,7 @@ bool Engine::MergeOverlappedAttributePath(const AttributePathParams & aAttribute
         {
             // TODO: the wildcard input path may be superset of next paths in globalDirtySet, it is fine at this moment, since
             // when building report, it would use the first path of globalDirtySet to compare against interested paths read clients
-            // wants.
+            // want.
             // It is better to eliminate the duplicate wildcard paths in follow-up
             path->mGeneration  = GetDirtySetGeneration();
             path->mEndpointId  = aAttributePath.mEndpointId;

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -633,7 +633,7 @@ void Engine::Run()
     }
 }
 
-bool Engine::MergeOverlappedAttributePath(AttributePathParams & aAttributePath)
+bool Engine::MergeOverlappedAttributePath(const AttributePathParams & aAttributePath)
 {
     return Loop::Break == mGlobalDirtySet.ForEachActiveObject([&](auto * path) {
         if (path->IsAttributePathSupersetOf(aAttributePath))
@@ -643,7 +643,13 @@ bool Engine::MergeOverlappedAttributePath(AttributePathParams & aAttributePath)
         }
         if (aAttributePath.IsAttributePathSupersetOf(*path))
         {
+            // TODO: the wildcard input path may be superset of next paths in globalDirtySet, it is fine at this moment, since
+            // when building report, it would use the first path of globalDirySet to compare against interested paths read clients
+            // wants.
+            // It is better to eliminate the duplicate wildcard paths in follow-up
             path->mGeneration  = GetDirtySetGeneration();
+            path->mEndpointId  = aAttributePath.mEndpointId;
+            path->mClusterId   = aAttributePath.mClusterId;
             path->mListIndex   = aAttributePath.mListIndex;
             path->mAttributeId = aAttributePath.mAttributeId;
             return Loop::Break;

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -644,7 +644,7 @@ bool Engine::MergeOverlappedAttributePath(const AttributePathParams & aAttribute
         if (aAttributePath.IsAttributePathSupersetOf(*path))
         {
             // TODO: the wildcard input path may be superset of next paths in globalDirtySet, it is fine at this moment, since
-            // when building report, it would use the first path of globalDirySet to compare against interested paths read clients
+            // when building report, it would use the first path of globalDirtySet to compare against interested paths read clients
             // wants.
             // It is better to eliminate the duplicate wildcard paths in follow-up
             path->mGeneration  = GetDirtySetGeneration();

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -186,7 +186,7 @@ private:
      *
      * Return whether one of our paths is now a superset of the provided path.
      */
-    bool MergeOverlappedAttributePath(AttributePathParams & aAttributePath);
+    bool MergeOverlappedAttributePath(const AttributePathParams & aAttributePath);
 
     inline void BumpDirtySetGeneration() { mDirtyGeneration++; }
 

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -122,22 +122,57 @@ void TestReportingEngine::TestMergeOverlappedAttributePath(nlTestSuite * apSuite
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     AttributePathParams * clusterInfo = InteractionModelEngine::GetInstance()->GetReportingEngine().mGlobalDirtySet.CreateObject();
+    clusterInfo->mEndpointId          = 1;
+    clusterInfo->mClusterId           = 1;
     clusterInfo->mAttributeId         = 1;
 
     {
         AttributePathParams testClusterInfo;
+        testClusterInfo.mEndpointId  = 1;
+        testClusterInfo.mClusterId   = 1;
         testClusterInfo.mAttributeId = 3;
         NL_TEST_ASSERT(apSuite,
                        !InteractionModelEngine::GetInstance()->GetReportingEngine().MergeOverlappedAttributePath(testClusterInfo));
     }
     {
         AttributePathParams testClusterInfo;
+        testClusterInfo.mEndpointId  = 1;
+        testClusterInfo.mClusterId   = 1;
         testClusterInfo.mAttributeId = 1;
         testClusterInfo.mListIndex   = 2;
         NL_TEST_ASSERT(apSuite,
                        InteractionModelEngine::GetInstance()->GetReportingEngine().MergeOverlappedAttributePath(testClusterInfo));
     }
 
+    {
+        AttributePathParams testClusterInfo;
+        testClusterInfo.mEndpointId  = 1;
+        testClusterInfo.mClusterId   = 1;
+        testClusterInfo.mAttributeId = kInvalidAttributeId;
+        NL_TEST_ASSERT(apSuite,
+                       InteractionModelEngine::GetInstance()->GetReportingEngine().MergeOverlappedAttributePath(testClusterInfo));
+    }
+
+    {
+        AttributePathParams testClusterInfo;
+        testClusterInfo.mClusterId   = kInvalidClusterId;
+        testClusterInfo.mAttributeId = kInvalidAttributeId;
+        NL_TEST_ASSERT(apSuite,
+                       InteractionModelEngine::GetInstance()->GetReportingEngine().MergeOverlappedAttributePath(testClusterInfo));
+        NL_TEST_ASSERT(apSuite, clusterInfo->mClusterId == kInvalidClusterId && clusterInfo->mAttributeId == kInvalidAttributeId);
+    }
+
+    {
+        AttributePathParams testClusterInfo;
+        testClusterInfo.mEndpointId  = kInvalidEndpointId;
+        testClusterInfo.mClusterId   = kInvalidClusterId;
+        testClusterInfo.mAttributeId = kInvalidAttributeId;
+        NL_TEST_ASSERT(apSuite,
+                       InteractionModelEngine::GetInstance()->GetReportingEngine().MergeOverlappedAttributePath(testClusterInfo));
+        NL_TEST_ASSERT(apSuite,
+                       clusterInfo->mEndpointId == kInvalidEndpointId && clusterInfo->mClusterId == kInvalidClusterId &&
+                           clusterInfo->mAttributeId == kInvalidAttributeId);
+    }
     InteractionModelEngine::GetInstance()->GetReportingEngine().Shutdown();
 }
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fixes #16734 
#### Change overview
update MergeOverlappedAttributePath with wildcard handling and update the existing test to cover the wildcard situations.

#### Testing
Update the testing to cover the wildcard situation.
