### PR TITLE
[linux] Fix the UserListLength get lost after reboot

### DIFF
--- a/src/platform/Linux/DeviceInfoProviderImpl.cpp
+++ b/src/platform/Linux/DeviceInfoProviderImpl.cpp
@@ -120,7 +120,9 @@ CHIP_ERROR DeviceInfoProviderImpl::SetUserLabelLength(EndpointId endpoint, size_
 {
     DefaultStorageKeyAllocator keyAlloc;
 
-    return mStorage.WriteValue(keyAlloc.UserLabelLengthKey(endpoint), val);
+    ReturnErrorOnFailure(mStorage.WriteValue(keyAlloc.UserLabelLengthKey(endpoint), val));
+
+    return mStorage.Commit();
 }
 
 CHIP_ERROR DeviceInfoProviderImpl::GetUserLabelLength(EndpointId endpoint, size_t & val)


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* UserListLength will be lost after the device get reboot, we need to preserve this value to persistent memory before reboot.


#### Change overview
Commit the value of UserListLength when it get modified.

#### Testing
How was this tested? (at least one bullet point required)
* Write the userList and reboot the device
* Read the userList and confirm all written items are retrieved 
