### PR TITLE
Pairing: move SessionManager from argument to member field

### DIFF
--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -243,7 +243,7 @@ CHIP_ERROR EstablishSecureSession(streamer_t * stream, const Transport::PeerAddr
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     Optional<Transport::PeerAddress> peerAddr;
-    SecurePairingUsingTestSecret * testSecurePairingSecret = chip::Platform::New<SecurePairingUsingTestSecret>();
+    SecurePairingUsingTestSecret * testSecurePairingSecret = chip::Platform::New<SecurePairingUsingTestSecret>(&gSessionManager);
     VerifyOrExit(testSecurePairingSecret != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     peerAddr = Optional<Transport::PeerAddress>::Value(peerAddress);

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -175,7 +175,7 @@ CHIP_ERROR EstablishSecureSession(streamer_t * stream, Transport::PeerAddress & 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     Optional<Transport::PeerAddress> peerAddr;
-    SecurePairingUsingTestSecret * testSecurePairingSecret = chip::Platform::New<SecurePairingUsingTestSecret>();
+    SecurePairingUsingTestSecret * testSecurePairingSecret = chip::Platform::New<SecurePairingUsingTestSecret>(&gSessionManager);
     VerifyOrExit(testSecurePairingSecret != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     peerAddr = Optional<Transport::PeerAddress>::Value(peerAddress);

--- a/src/app/CASEClient.cpp
+++ b/src/app/CASEClient.cpp
@@ -19,7 +19,10 @@
 
 namespace chip {
 
-CASEClient::CASEClient(const CASEClientInitParams & params) : mInitParams(params) {}
+CASEClient::CASEClient(const CASEClientInitParams & params) : mInitParams(params)
+{
+    mCASESession.Init(params.sessionManager);
+}
 
 void CASEClient::SetMRPIntervals(const ReliableMessageProtocolConfig & mrpConfig)
 {
@@ -45,9 +48,8 @@ CHIP_ERROR CASEClient::EstablishSession(PeerId peer, const Transport::PeerAddres
     VerifyOrReturnError(exchange != nullptr, CHIP_ERROR_INTERNAL);
 
     mCASESession.SetGroupDataProvider(mInitParams.groupDataProvider);
-    ReturnErrorOnFailure(mCASESession.EstablishSession(*mInitParams.sessionManager, peerAddress, mInitParams.fabricInfo,
-                                                       peer.GetNodeId(), exchange, mInitParams.sessionResumptionStorage, this,
-                                                       mInitParams.mrpLocalConfig));
+    ReturnErrorOnFailure(mCASESession.EstablishSession(peerAddress, mInitParams.fabricInfo, peer.GetNodeId(), exchange,
+                                                       mInitParams.sessionResumptionStorage, this, mInitParams.mrpLocalConfig));
     mConnectionSuccessCallback = onConnection;
     mConnectionFailureCallback = onFailure;
     mConectionContext          = context;

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -40,15 +40,7 @@ class CommissioningWindowManager : public SessionEstablishmentDelegate, public a
 public:
     CommissioningWindowManager() {}
 
-    CHIP_ERROR Init(Server * server)
-    {
-        if (server == nullptr)
-        {
-            return CHIP_ERROR_INVALID_ARGUMENT;
-        }
-        mServer = server;
-        return CHIP_NO_ERROR;
-    }
+    CHIP_ERROR Init(Server * server);
 
     static constexpr System::Clock::Seconds16 MaxCommissioningTimeout()
     {

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -431,9 +431,9 @@ CHIP_ERROR EstablishSecureSession()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    chip::SecurePairingUsingTestSecret * testSecurePairingSecret = chip::Platform::New<chip::SecurePairingUsingTestSecret>();
+    chip::SecurePairingUsingTestSecret * testSecurePairingSecret =
+        chip::Platform::New<chip::SecurePairingUsingTestSecret>(&gSessionManager);
     VerifyOrExit(testSecurePairingSecret != nullptr, err = CHIP_ERROR_NO_MEMORY);
-    testSecurePairingSecret->Init(gSessionManager);
 
     // Attempt to connect to the peer.
     err = gSessionManager.NewPairing(gSession,

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -145,7 +145,6 @@ bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint)
 
 namespace {
 chip::TransportMgr<chip::Transport::UDP> gTransportManager;
-chip::SecurePairingUsingTestSecret gTestPairing;
 LivenessEventGenerator gLivenessGenerator;
 
 uint8_t gDebugEventBuffer[2048];
@@ -172,6 +171,7 @@ int main(int argc, char * argv[])
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
     const chip::FabricIndex gFabricIndex = 0;
+    chip::SecurePairingUsingTestSecret gTestPairing(&gSessionManager);
 
     InitializeChip();
 
@@ -197,7 +197,6 @@ int main(int argc, char * argv[])
 
     InitializeEventLogging(&gExchangeManager);
 
-    gTestPairing.Init(gSessionManager);
     err = gSessionManager.NewPairing(gSession, peer, chip::kTestControllerNodeId, &gTestPairing,
                                      chip::CryptoContext::SessionRole::kResponder, gFabricIndex);
     SuccessOrExit(err);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -732,7 +732,7 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
     exchangeCtxt = mSystemState->ExchangeMgr()->NewContext(session.Value(), &device->GetPairing());
     VerifyOrExit(exchangeCtxt != nullptr, err = CHIP_ERROR_INTERNAL);
 
-    err = device->GetPairing().Pair(*mSystemState->SessionMgr(), params.GetPeerAddress(), params.GetSetupPINCode(),
+    err = device->GetPairing().Pair(params.GetPeerAddress(), params.GetSetupPINCode(),
                                     Optional<ReliableMessageProtocolConfig>::Value(GetLocalMRPConfig()), exchangeCtxt, this);
     SuccessOrExit(err);
 

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -121,6 +121,7 @@ public:
 #if CONFIG_NETWORK_LAYER_BLE
         mBleLayer = params.bleLayer;
 #endif
+        mPairing.Init(mSessionManager);
     }
 
     /**

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -95,23 +95,17 @@ CHIP_ERROR MessagingContext::ShutdownAndRestoreExisting(MessagingContext & exist
 
 CHIP_ERROR MessagingContext::CreateSessionBobToAlice()
 {
-    if (!mPairingBobToAlice.GetSecureSessionHandle().HasValue())
-    {
-        mPairingBobToAlice.Init(mSessionManager);
-    }
+    SecurePairingUsingTestSecret pairingBobToAlice(&GetSecureSessionManager(), kAliceKeyId, kBobKeyId);
     return mSessionManager.NewPairing(mSessionBobToAlice, Optional<Transport::PeerAddress>::Value(mAliceAddress),
-                                      GetAliceFabric()->GetNodeId(), &mPairingBobToAlice, CryptoContext::SessionRole::kInitiator,
+                                      GetAliceFabric()->GetNodeId(), &pairingBobToAlice, CryptoContext::SessionRole::kInitiator,
                                       mBobFabricIndex);
 }
 
 CHIP_ERROR MessagingContext::CreateSessionAliceToBob()
 {
-    if (!mPairingAliceToBob.GetSecureSessionHandle().HasValue())
-    {
-        mPairingAliceToBob.Init(mSessionManager);
-    }
+    SecurePairingUsingTestSecret pairingAliceToBob(&GetSecureSessionManager(), kBobKeyId, kAliceKeyId);
     return mSessionManager.NewPairing(mSessionAliceToBob, Optional<Transport::PeerAddress>::Value(mBobAddress),
-                                      GetBobFabric()->GetNodeId(), &mPairingAliceToBob, CryptoContext::SessionRole::kResponder,
+                                      GetBobFabric()->GetNodeId(), &pairingAliceToBob, CryptoContext::SessionRole::kResponder,
                                       mAliceFabricIndex);
 }
 

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -71,9 +71,7 @@ class MessagingContext : public PlatformMemoryUser
 public:
     MessagingContext() :
         mInitialized(false), mAliceAddress(Transport::PeerAddress::UDP(GetAddress(), CHIP_PORT + 1)),
-        mBobAddress(Transport::PeerAddress::UDP(GetAddress(), CHIP_PORT)),
-        mPairingAliceToBob(kBobKeyId, kAliceKeyId, GetSecureSessionManager()),
-        mPairingBobToAlice(kAliceKeyId, kBobKeyId, GetSecureSessionManager())
+        mBobAddress(Transport::PeerAddress::UDP(GetAddress(), CHIP_PORT))
     {}
     ~MessagingContext() { VerifyOrDie(mInitialized == false); }
 
@@ -152,8 +150,6 @@ private:
     GroupId mFriendsGroupId       = 0x0101;
     Transport::PeerAddress mAliceAddress;
     Transport::PeerAddress mBobAddress;
-    SecurePairingUsingTestSecret mPairingAliceToBob;
-    SecurePairingUsingTestSecret mPairingBobToAlice;
     SessionHolder mSessionAliceToBob;
     SessionHolder mSessionBobToAlice;
     Optional<Transport::OutgoingGroupSession> mSessionBobToFriends;

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -153,9 +153,9 @@ CHIP_ERROR EstablishSecureSession()
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     chip::Optional<chip::Transport::PeerAddress> peerAddr;
-    chip::SecurePairingUsingTestSecret * testSecurePairingSecret = chip::Platform::New<chip::SecurePairingUsingTestSecret>();
+    chip::SecurePairingUsingTestSecret * testSecurePairingSecret =
+        chip::Platform::New<chip::SecurePairingUsingTestSecret>(&gSessionManager);
     VerifyOrExit(testSecurePairingSecret != nullptr, err = CHIP_ERROR_NO_MEMORY);
-    testSecurePairingSecret->Init(gSessionManager);
 
     if (gUseTCP)
     {

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -44,7 +44,6 @@ namespace {
 chip::Protocols::Echo::EchoServer gEchoServer;
 chip::TransportMgr<chip::Transport::UDP> gUDPManager;
 chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>> gTCPManager;
-chip::SecurePairingUsingTestSecret gTestPairing;
 chip::SessionHolder gSession;
 
 // Callback handler when a CHIP EchoRequest is received.
@@ -58,6 +57,7 @@ void HandleEchoRequestReceived(chip::Messaging::ExchangeContext * ec, chip::Syst
 int main(int argc, char * argv[])
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::SecurePairingUsingTestSecret testPairing(&gSessionManager);
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
     bool useTCP      = false;
     bool disableEcho = false;
@@ -123,8 +123,7 @@ int main(int argc, char * argv[])
         SuccessOrExit(err);
     }
 
-    gTestPairing.Init(gSessionManager);
-    err = gSessionManager.NewPairing(gSession, peer, chip::kTestControllerNodeId, &gTestPairing,
+    err = gSessionManager.NewPairing(gSession, peer, chip::kTestControllerNodeId, &testPairing,
                                      chip::CryptoContext::SessionRole::kResponder, gFabricIndex);
     SuccessOrExit(err);
 

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -52,6 +52,8 @@ CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager 
     mExchangeManager          = exchangeManager;
     mGroupDataProvider        = responderGroupDataProvider;
 
+    mPairingSession.Init(mSessionManager);
+
     Cleanup();
     return CHIP_NO_ERROR;
 }
@@ -78,9 +80,8 @@ CHIP_ERROR CASEServer::InitCASEHandshake(Messaging::ExchangeContext * ec)
 
     // Setup CASE state machine using the credentials for the current fabric.
     GetSession().SetGroupDataProvider(mGroupDataProvider);
-    ReturnErrorOnFailure(
-        GetSession().ListenForSessionEstablishment(*mSessionManager, mFabrics, mSessionResumptionStorage, this,
-                                                   Optional<ReliableMessageProtocolConfig>::Value(GetLocalMRPConfig())));
+    ReturnErrorOnFailure(GetSession().ListenForSessionEstablishment(
+        mFabrics, mSessionResumptionStorage, this, Optional<ReliableMessageProtocolConfig>::Value(GetLocalMRPConfig())));
 
     // Hand over the exchange context to the CASE session.
     ec->SetDelegate(&GetSession());

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -139,7 +139,7 @@ void CASESession::DiscardExchange()
     }
 }
 
-CHIP_ERROR CASESession::Init(SessionManager & sessionManager, SessionEstablishmentDelegate * delegate)
+CHIP_ERROR CASESession::InitCASE(SessionEstablishmentDelegate * delegate)
 {
     VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(mGroupDataProvider != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -149,7 +149,7 @@ CHIP_ERROR CASESession::Init(SessionManager & sessionManager, SessionEstablishme
     ReturnErrorOnFailure(mCommissioningHash.Begin());
 
     mDelegate = delegate;
-    ReturnErrorOnFailure(AllocateSecureSession(sessionManager));
+    ReturnErrorOnFailure(AllocateSecureSession());
 
     mValidContext.Reset();
     mValidContext.mRequiredKeyUsages.Set(KeyUsageFlags::kDigitalSignature);
@@ -159,13 +159,12 @@ CHIP_ERROR CASESession::Init(SessionManager & sessionManager, SessionEstablishme
 }
 
 CHIP_ERROR
-CASESession::ListenForSessionEstablishment(SessionManager & sessionManager, FabricTable * fabrics,
-                                           SessionResumptionStorage * sessionResumptionStorage,
+CASESession::ListenForSessionEstablishment(FabricTable * fabrics, SessionResumptionStorage * sessionResumptionStorage,
                                            SessionEstablishmentDelegate * delegate,
                                            Optional<ReliableMessageProtocolConfig> mrpConfig)
 {
     VerifyOrReturnError(fabrics != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    ReturnErrorOnFailure(Init(sessionManager, delegate));
+    ReturnErrorOnFailure(InitCASE(delegate));
 
     mFabricsTable             = fabrics;
     mSessionResumptionStorage = sessionResumptionStorage;
@@ -178,9 +177,8 @@ CASESession::ListenForSessionEstablishment(SessionManager & sessionManager, Fabr
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CASESession::EstablishSession(SessionManager & sessionManager, const Transport::PeerAddress peerAddress,
-                                         FabricInfo * fabric, NodeId peerNodeId, ExchangeContext * exchangeCtxt,
-                                         SessionResumptionStorage * sessionResumptionStorage,
+CHIP_ERROR CASESession::EstablishSession(const Transport::PeerAddress peerAddress, FabricInfo * fabric, NodeId peerNodeId,
+                                         ExchangeContext * exchangeCtxt, SessionResumptionStorage * sessionResumptionStorage,
                                          SessionEstablishmentDelegate * delegate, Optional<ReliableMessageProtocolConfig> mrpConfig)
 {
     MATTER_TRACE_EVENT_SCOPE("EstablishSession", "CASESession");
@@ -196,7 +194,7 @@ CHIP_ERROR CASESession::EstablishSession(SessionManager & sessionManager, const 
     ReturnErrorCodeIf(exchangeCtxt == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorCodeIf(fabric == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    err = Init(sessionManager, delegate);
+    err = InitCASE(delegate);
 
     // We are setting the exchange context specifically before checking for error.
     // This is to make sure the exchange will get closed if Init() returned an error.

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -57,31 +57,25 @@ class DLL_EXPORT CASESession : public Messaging::ExchangeDelegate, public Pairin
 {
 public:
     CASESession();
-    CASESession(CASESession &&)      = default;
-    CASESession(const CASESession &) = default;
-
     ~CASESession() override;
 
     /**
      * @brief
      *   Initialize using configured fabrics and wait for session establishment requests.
      *
-     * @param sessionManager                session manager from which to allocate a secure session object
      * @param fabrics                       Table of fabrics that are currently configured on the device
      * @param delegate                      Callback object
      *
      * @return CHIP_ERROR     The result of initialization
      */
     CHIP_ERROR ListenForSessionEstablishment(
-        SessionManager & sessionManager, FabricTable * fabrics, SessionResumptionStorage * sessionResumptionStorage,
-        SessionEstablishmentDelegate * delegate,
+        FabricTable * fabrics, SessionResumptionStorage * sessionResumptionStorage, SessionEstablishmentDelegate * delegate,
         Optional<ReliableMessageProtocolConfig> mrpConfig = Optional<ReliableMessageProtocolConfig>::Missing());
 
     /**
      * @brief
      *   Create and send session establishment request using device's operational credentials.
      *
-     * @param sessionManager                session manager from which to allocate a secure session object
      * @param peerAddress                   Address of peer with which to establish a session.
      * @param fabric                        The fabric that should be used for connecting with the peer
      * @param peerNodeId                    Node id of the peer node
@@ -91,9 +85,9 @@ public:
      * @return CHIP_ERROR      The result of initialization
      */
     CHIP_ERROR
-    EstablishSession(SessionManager & sessionManager, const Transport::PeerAddress peerAddress, FabricInfo * fabric,
-                     NodeId peerNodeId, Messaging::ExchangeContext * exchangeCtxt,
-                     SessionResumptionStorage * sessionResumptionStorage, SessionEstablishmentDelegate * delegate,
+    EstablishSession(const Transport::PeerAddress peerAddress, FabricInfo * fabric, NodeId peerNodeId,
+                     Messaging::ExchangeContext * exchangeCtxt, SessionResumptionStorage * sessionResumptionStorage,
+                     SessionEstablishmentDelegate * delegate,
                      Optional<ReliableMessageProtocolConfig> mrpConfig = Optional<ReliableMessageProtocolConfig>::Missing());
 
     /**
@@ -165,7 +159,7 @@ private:
         kSentSigma2Resume = 5,
     };
 
-    CHIP_ERROR Init(SessionManager & sessionManager, SessionEstablishmentDelegate * delegate);
+    CHIP_ERROR InitCASE(SessionEstablishmentDelegate * delegate);
 
     // On success, sets mIpk to the correct value for outgoing Sigma1 based on internal state
     CHIP_ERROR RecoverInitiatorIpk();

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -121,35 +121,35 @@ void SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext)
     TestSecurePairingDelegate delegate;
     PASESession pairing;
     SessionManager sessionManager;
+    pairing.Init(&sessionManager);
 
     NL_TEST_ASSERT(inSuite, pairing.GetSecureSessionType() == SecureSession::Type::kPASE);
 
     gLoopback.Reset();
 
     NL_TEST_ASSERT(inSuite,
-                   pairing.WaitForPairing(sessionManager, sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount,
-                                          ByteSpan(nullptr, 0), Optional<ReliableMessageProtocolConfig>::Missing(),
+                   pairing.WaitForPairing(sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount, ByteSpan(nullptr, 0),
+                                          Optional<ReliableMessageProtocolConfig>::Missing(),
                                           &delegate) == CHIP_ERROR_INVALID_ARGUMENT);
     ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite,
-                   pairing.WaitForPairing(sessionManager, sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount,
+                   pairing.WaitForPairing(sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount,
                                           ByteSpan(reinterpret_cast<const uint8_t *>("saltSalt"), 8),
                                           Optional<ReliableMessageProtocolConfig>::Missing(),
                                           nullptr) == CHIP_ERROR_INVALID_ARGUMENT);
     ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite,
-                   pairing.WaitForPairing(sessionManager, sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount,
+                   pairing.WaitForPairing(sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount,
                                           ByteSpan(reinterpret_cast<const uint8_t *>("saltSalt"), 8),
                                           Optional<ReliableMessageProtocolConfig>::Missing(),
                                           &delegate) == CHIP_ERROR_INVALID_ARGUMENT);
     ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite,
-                   pairing.WaitForPairing(sessionManager, sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount,
-                                          ByteSpan(sTestSpake2p01_Salt), Optional<ReliableMessageProtocolConfig>::Missing(),
-                                          &delegate) == CHIP_NO_ERROR);
+                   pairing.WaitForPairing(sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount, ByteSpan(sTestSpake2p01_Salt),
+                                          Optional<ReliableMessageProtocolConfig>::Missing(), &delegate) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 }
 
@@ -161,18 +161,19 @@ void SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     TestSecurePairingDelegate delegate;
     PASESession pairing;
     SessionManager sessionManager;
+    pairing.Init(&sessionManager);
 
     gLoopback.Reset();
 
     ExchangeContext * context = ctx.NewUnauthenticatedExchangeToBob(&pairing);
 
     NL_TEST_ASSERT(inSuite,
-                   pairing.Pair(sessionManager, Transport::PeerAddress(Transport::Type::kBle), sTestSpake2p01_PinCode,
+                   pairing.Pair(Transport::PeerAddress(Transport::Type::kBle), sTestSpake2p01_PinCode,
                                 Optional<ReliableMessageProtocolConfig>::Missing(), nullptr, nullptr) != CHIP_NO_ERROR);
 
     gLoopback.Reset();
     NL_TEST_ASSERT(inSuite,
-                   pairing.Pair(sessionManager, Transport::PeerAddress(Transport::Type::kBle), sTestSpake2p01_PinCode,
+                   pairing.Pair(Transport::PeerAddress(Transport::Type::kBle), sTestSpake2p01_PinCode,
                                 Optional<ReliableMessageProtocolConfig>::Missing(), context, &delegate) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
@@ -188,9 +189,10 @@ void SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     gLoopback.mMessageSendError = CHIP_ERROR_BAD_REQUEST;
 
     PASESession pairing1;
+    pairing1.Init(&sessionManager);
     ExchangeContext * context1 = ctx.NewUnauthenticatedExchangeToBob(&pairing1);
     NL_TEST_ASSERT(inSuite,
-                   pairing1.Pair(sessionManager, Transport::PeerAddress(Transport::Type::kBle), sTestSpake2p01_PinCode,
+                   pairing1.Pair(Transport::PeerAddress(Transport::Type::kBle), sTestSpake2p01_PinCode,
                                  Optional<ReliableMessageProtocolConfig>::Missing(), context1,
                                  &delegate) == CHIP_ERROR_BAD_REQUEST);
     ctx.DrainAndServiceIO();
@@ -206,8 +208,11 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, P
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
     TestSecurePairingDelegate delegateAccessory;
-    PASESession pairingAccessory;
     SessionManager sessionManager;
+    pairingCommissioner.Init(&sessionManager);
+
+    PASESession pairingAccessory;
+    pairingAccessory.Init(&sessionManager);
 
     gLoopback.mSentMessageCount = 0;
 
@@ -231,13 +236,13 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, P
                        Protocols::SecureChannel::MsgType::PBKDFParamRequest, &pairingAccessory) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   pairingAccessory.WaitForPairing(sessionManager, sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount,
+                   pairingAccessory.WaitForPairing(sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount,
                                                    ByteSpan(sTestSpake2p01_Salt), mrpAccessoryConfig,
                                                    &delegateAccessory) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner.Pair(sessionManager, Transport::PeerAddress(Transport::Type::kBle), sTestSpake2p01_PinCode,
+                   pairingCommissioner.Pair(Transport::PeerAddress(Transport::Type::kBle), sTestSpake2p01_PinCode,
                                             mrpCommissionerConfig, contextCommissioner, &delegateCommissioner) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
@@ -331,14 +336,15 @@ void SecurePairingHandshakeWithPacketLossTest(nlTestSuite * inSuite, void * inCo
 void SecurePairingFailedHandshake(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+    SessionManager sessionManager;
 
     TestSecurePairingDelegate delegateCommissioner;
     PASESession pairingCommissioner;
+    pairingCommissioner.Init(&sessionManager);
 
     TestSecurePairingDelegate delegateAccessory;
     PASESession pairingAccessory;
-
-    SessionManager sessionManager;
+    pairingAccessory.Init(&sessionManager);
 
     gLoopback.Reset();
     gLoopback.mSentMessageCount = 0;
@@ -359,14 +365,14 @@ void SecurePairingFailedHandshake(nlTestSuite * inSuite, void * inContext)
                    ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(
                        Protocols::SecureChannel::MsgType::PBKDFParamRequest, &pairingAccessory) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite,
-                   pairingAccessory.WaitForPairing(
-                       sessionManager, sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount, ByteSpan(sTestSpake2p01_Salt),
-                       Optional<ReliableMessageProtocolConfig>::Missing(), &delegateAccessory) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(
+        inSuite,
+        pairingAccessory.WaitForPairing(sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount, ByteSpan(sTestSpake2p01_Salt),
+                                        Optional<ReliableMessageProtocolConfig>::Missing(), &delegateAccessory) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner.Pair(sessionManager, Transport::PeerAddress(Transport::Type::kBle), 4321,
+                   pairingCommissioner.Pair(Transport::PeerAddress(Transport::Type::kBle), 4321,
                                             Optional<ReliableMessageProtocolConfig>::Missing(), contextCommissioner,
                                             &delegateCommissioner) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();

--- a/src/transport/PairingSession.cpp
+++ b/src/transport/PairingSession.cpp
@@ -23,17 +23,17 @@
 
 namespace chip {
 
-CHIP_ERROR PairingSession::AllocateSecureSession(SessionManager & sessionManager, uint16_t sessionId)
+CHIP_ERROR PairingSession::AllocateSecureSession(uint16_t sessionId)
 {
-    auto handle = sessionManager.AllocateSession(sessionId);
+    auto handle = mSessionManager->AllocateSession(sessionId);
     VerifyOrReturnError(handle.HasValue(), CHIP_ERROR_NO_MEMORY);
     mSecureSessionHolder.Grab(handle.Value());
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR PairingSession::AllocateSecureSession(SessionManager & sessionManager)
+CHIP_ERROR PairingSession::AllocateSecureSession()
 {
-    auto handle = sessionManager.AllocateSession();
+    auto handle = mSessionManager->AllocateSession();
     VerifyOrReturnError(handle.HasValue(), CHIP_ERROR_NO_MEMORY);
     mSecureSessionHolder.Grab(handle.Value());
     return CHIP_NO_ERROR;

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -41,6 +41,8 @@ public:
     PairingSession(Transport::SecureSession::Type secureSessionType) : mSecureSessionType(secureSessionType) {}
     virtual ~PairingSession() {}
 
+    void Init(SessionManager * sessionManager) { mSessionManager = sessionManager; }
+
     Transport::SecureSession::Type GetSecureSessionType() const { return mSecureSessionType; }
 
     // TODO: the session should know which peer we are trying to connect to at start
@@ -108,7 +110,7 @@ protected:
      * @param sessionManager session manager from which to allocate a secure session object
      * @return CHIP_ERROR The outcome of the allocation attempt
      */
-    CHIP_ERROR AllocateSecureSession(SessionManager & sessionManager);
+    CHIP_ERROR AllocateSecureSession();
 
     /**
      * Allocate a secure session object from the passed session manager with the
@@ -121,7 +123,7 @@ protected:
      * @param sessionId caller-requested session ID
      * @return CHIP_ERROR The outcome of the allocation attempt
      */
-    CHIP_ERROR AllocateSecureSession(SessionManager & sessionManager, uint16_t sessionId);
+    CHIP_ERROR AllocateSecureSession(uint16_t sessionId);
 
     void SetPeerNodeId(NodeId peerNodeId) { mPeerNodeId = peerNodeId; }
     void SetPeerSessionId(uint16_t id) { mPeerSessionId.SetValue(id); }
@@ -199,6 +201,9 @@ protected:
         mPeerSessionId.ClearValue();
         mSecureSessionHolder.Release();
     }
+
+protected:
+    SessionManager * mSessionManager;
 
 private:
     const Transport::SecureSession::Type mSecureSessionType;

--- a/src/transport/tests/TestSessionManager.cpp
+++ b/src/transport/tests/TestSessionManager.cpp
@@ -168,12 +168,12 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.AddNewFabric(bobFabric, &bobFabricIndex));
 
     SessionHolder aliceToBobSession;
-    SecurePairingUsingTestSecret aliceToBobPairing(1, 2, sessionManager);
+    SecurePairingUsingTestSecret aliceToBobPairing(&sessionManager, 1, 2);
     err = sessionManager.NewPairing(aliceToBobSession, peer, fabricTable.FindFabricWithIndex(bobFabricIndex)->GetNodeId(),
                                     &aliceToBobPairing, CryptoContext::SessionRole::kInitiator, aliceFabricIndex);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecurePairingUsingTestSecret bobToAlicePairing(2, 1, sessionManager);
+    SecurePairingUsingTestSecret bobToAlicePairing(&sessionManager, 2, 1);
     SessionHolder bobToAliceSession;
     err = sessionManager.NewPairing(bobToAliceSession, peer, fabricTable.FindFabricWithIndex(aliceFabricIndex)->GetNodeId(),
                                     &bobToAlicePairing, CryptoContext::SessionRole::kResponder, bobFabricIndex);
@@ -283,12 +283,12 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.AddNewFabric(bobFabric, &bobFabricIndex));
 
     SessionHolder aliceToBobSession;
-    SecurePairingUsingTestSecret aliceToBobPairing(1, 2, sessionManager);
+    SecurePairingUsingTestSecret aliceToBobPairing(&sessionManager, 1, 2);
     err = sessionManager.NewPairing(aliceToBobSession, peer, fabricTable.FindFabricWithIndex(bobFabricIndex)->GetNodeId(),
                                     &aliceToBobPairing, CryptoContext::SessionRole::kInitiator, aliceFabricIndex);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecurePairingUsingTestSecret bobToAlicePairing(2, 1, sessionManager);
+    SecurePairingUsingTestSecret bobToAlicePairing(&sessionManager, 2, 1);
     SessionHolder bobToAliceSession;
     err = sessionManager.NewPairing(bobToAliceSession, peer, fabricTable.FindFabricWithIndex(aliceFabricIndex)->GetNodeId(),
                                     &bobToAlicePairing, CryptoContext::SessionRole::kResponder, bobFabricIndex);
@@ -384,12 +384,12 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.AddNewFabric(bobFabric, &bobFabricIndex));
 
     SessionHolder aliceToBobSession;
-    SecurePairingUsingTestSecret aliceToBobPairing(1, 2, sessionManager);
+    SecurePairingUsingTestSecret aliceToBobPairing(&sessionManager, 1, 2);
     err = sessionManager.NewPairing(aliceToBobSession, peer, fabricTable.FindFabricWithIndex(bobFabricIndex)->GetNodeId(),
                                     &aliceToBobPairing, CryptoContext::SessionRole::kInitiator, aliceFabricIndex);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecurePairingUsingTestSecret bobToAlicePairing(2, 1, sessionManager);
+    SecurePairingUsingTestSecret bobToAlicePairing(&sessionManager, 2, 1);
     SessionHolder bobToAliceSession;
     err = sessionManager.NewPairing(bobToAliceSession, peer, fabricTable.FindFabricWithIndex(aliceFabricIndex)->GetNodeId(),
                                     &bobToAlicePairing, CryptoContext::SessionRole::kResponder, bobFabricIndex);
@@ -498,35 +498,35 @@ void StaleConnectionDropTest(nlTestSuite * inSuite, void * inContext)
 
     // First pairing
     callback.mOldConnectionDropped = false;
-    SecurePairingUsingTestSecret pairing1(1, 1, sessionManager);
+    SecurePairingUsingTestSecret pairing1(&sessionManager, 1, 1);
     err = sessionManager.NewPairing(session1, peer, kSourceNodeId, &pairing1, CryptoContext::SessionRole::kInitiator, 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, !callback.mOldConnectionDropped);
 
     // New pairing with different peer node ID and different local key ID (same peer key ID)
     callback.mOldConnectionDropped = false;
-    SecurePairingUsingTestSecret pairing2(1, 2, sessionManager);
+    SecurePairingUsingTestSecret pairing2(&sessionManager, 1, 2);
     err = sessionManager.NewPairing(session2, peer, kSourceNodeId, &pairing2, CryptoContext::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, !callback.mOldConnectionDropped);
 
     // New pairing with undefined node ID and different local key ID (same peer key ID)
     callback.mOldConnectionDropped = false;
-    SecurePairingUsingTestSecret pairing3(1, 3, sessionManager);
+    SecurePairingUsingTestSecret pairing3(&sessionManager, 1, 3);
     err = sessionManager.NewPairing(session3, peer, kUndefinedNodeId, &pairing3, CryptoContext::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, !callback.mOldConnectionDropped);
 
     // New pairing with same local key ID, and a given node ID
     callback.mOldConnectionDropped = false;
-    SecurePairingUsingTestSecret pairing4(1, 2, sessionManager);
+    SecurePairingUsingTestSecret pairing4(&sessionManager, 1, 2);
     err = sessionManager.NewPairing(session4, peer, kSourceNodeId, &pairing4, CryptoContext::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, callback.mOldConnectionDropped);
 
     // New pairing with same local key ID, and undefined node ID
     callback.mOldConnectionDropped = false;
-    SecurePairingUsingTestSecret pairing5(1, 1, sessionManager);
+    SecurePairingUsingTestSecret pairing5(&sessionManager, 1, 1);
     err = sessionManager.NewPairing(session5, peer, kUndefinedNodeId, &pairing5, CryptoContext::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, callback.mOldConnectionDropped);
@@ -590,12 +590,12 @@ void SendPacketWithOldCounterTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.AddNewFabric(bobFabric, &bobFabricIndex));
 
     SessionHolder aliceToBobSession;
-    SecurePairingUsingTestSecret aliceToBobPairing(1, 2, sessionManager);
+    SecurePairingUsingTestSecret aliceToBobPairing(&sessionManager, 1, 2);
     err = sessionManager.NewPairing(aliceToBobSession, peer, fabricTable.FindFabricWithIndex(bobFabricIndex)->GetNodeId(),
                                     &aliceToBobPairing, CryptoContext::SessionRole::kInitiator, aliceFabricIndex);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecurePairingUsingTestSecret bobToAlicePairing(2, 1, sessionManager);
+    SecurePairingUsingTestSecret bobToAlicePairing(&sessionManager, 2, 1);
     SessionHolder bobToAliceSession;
     err = sessionManager.NewPairing(bobToAliceSession, peer, fabricTable.FindFabricWithIndex(aliceFabricIndex)->GetNodeId(),
                                     &bobToAlicePairing, CryptoContext::SessionRole::kResponder, bobFabricIndex);
@@ -704,12 +704,12 @@ void SendPacketWithTooOldCounterTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.AddNewFabric(bobFabric, &bobFabricIndex));
 
     SessionHolder aliceToBobSession;
-    SecurePairingUsingTestSecret aliceToBobPairing(1, 2, sessionManager);
+    SecurePairingUsingTestSecret aliceToBobPairing(&sessionManager, 1, 2);
     err = sessionManager.NewPairing(aliceToBobSession, peer, fabricTable.FindFabricWithIndex(bobFabricIndex)->GetNodeId(),
                                     &aliceToBobPairing, CryptoContext::SessionRole::kInitiator, aliceFabricIndex);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecurePairingUsingTestSecret bobToAlicePairing(2, 1, sessionManager);
+    SecurePairingUsingTestSecret bobToAlicePairing(&sessionManager, 2, 1);
     SessionHolder bobToAliceSession;
     err = sessionManager.NewPairing(bobToAliceSession, peer, fabricTable.FindFabricWithIndex(aliceFabricIndex)->GetNodeId(),
                                     &bobToAlicePairing, CryptoContext::SessionRole::kResponder, bobFabricIndex);


### PR DESCRIPTION
#### Problem
SessionManager is passed for almost all pairing sessin APIs.

There is another problem about calling `SessionManager::NewPairing`, the pairing class is not able to call `NewPairing` directly because it doesn't have a pointer to `SessionManager`, so it calls `SessionEstablishmentDelegate::OnSessionEstablished`, then the session is created in the callback.

With this change we can call `NewPairing` inside pairing session class. It will make the pairing procedure more straightforward and readable.

#### Change overview
Add `Init` function to receive a SessionManager, and remove SessionManager argument for all other APIs.

#### Testing
Passed unit-tests