### PR TITLE
Change TODO to NOTE in ProcessGroupCommandDataIB

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -413,7 +413,9 @@ CHIP_ERROR CommandHandler::ProcessGroupCommandDataIB(CommandDataIB::Parser & aCo
             err                                = Access::GetAccessControl().Check(subjectDescriptor, requestPath, requestPrivilege);
             if (err != CHIP_NO_ERROR)
             {
-                // TODO: handle errors that aren't CHIP_ERROR_ACCESS_DENIED, etc.
+                // NOTE: an expected error is CHIP_ERROR_ACCESS_DENIED, but there could be other unexpected errors;
+                // therefore, keep processing subsequent commands, and if any errors continue, those subsequent
+                // commands will likewise fail.
                 continue;
             }
         }


### PR DESCRIPTION
#### Problem
Issue #14541 required double checking that any handling of errors
at this location is adequate.

#### Change overview
There's not much else to do here, so change the TODO to a NOTE.

#### Testing
- N/A
