### PR TITLE
Speed up clang-tidy runs: deduplicate clang-tidy file names to check.

### DIFF
--- a/scripts/run-clang-tidy-on-compile-commands.py
+++ b/scripts/run-clang-tidy-on-compile-commands.py
@@ -189,6 +189,7 @@ class ClangTidyRunner:
         self.fixes_file = None
         self.fixes_temporary_file_dir = None
         self.gcc_sysroot = None
+        self.file_names_to_check = set()
 
         if sys.platform == 'darwin':
             # Darwin gcc invocation will auto select a system root, however clang requires an explicit path since
@@ -206,6 +207,11 @@ class ClangTidyRunner:
             if not item.valid:
                 continue
 
+            if item.file in self.file_names_to_check:
+                logging.info('Ignoring additional request for checking %s', item.file)
+                continue
+
+            self.file_names_to_check.add(item.file)
             self.entries.append(item)
 
     def Cleanup(self):


### PR DESCRIPTION
#### Problem
Clang tidy does extra work by running on the same files several times:
  - on linux for example, ../../src/app/util/binding-table.cpp is compiled 3 separate times when running over tests
  - on darwin, every file is compiled at least 2 times, once for gcc_x64 and once for standalone
  - unified builds in general will compile the same file several times (separate output and maybe separate build arguments)

#### Change overview
Process source files only once.

This has the sideffect that only the 'first one' wins and different arguments like defines may not be checked, however for the types of checks and fixes we do, this should be sufficient and gain significant CI and manual run speedup.

#### Testing
CI runs clang-tidy. Can validate how much faster ci tidy will run (expect significant speedup at least on darwin).