### PR TITLE
Add instructions to get trace from linux lighting app.

### DIFF
--- a/examples/lighting-app/linux/README.md
+++ b/examples/lighting-app/linux/README.md
@@ -16,6 +16,7 @@ To cross-compile this example on x64 host and run on **NXP i.MX 8M Mini**
     -   [Commandline Arguments](#command-line-args)
     -   [Running the Complete Example on Raspberry Pi 4](#running-complete-example)
     -   [Running RPC console](#running-rpc-console)
+    -   [Device Tracing](#device-tracing)
 
 <hr>
 
@@ -136,3 +137,15 @@ To cross-compile this example on x64 host and run on **NXP i.MX 8M Mini**
     `rpcs.chip.rpc.Lighting.Get()`
 
     `rpcs.chip.rpc.Lighting.Set(on=True, level=128, color=protos.chip.rpc.LightingColor(hue=5, saturation=5))`
+
+## Device Tracing
+
+Device tracing is available to analyze the device performance. To turn on
+tracing, build with RPC enabled. See [Building with RPC enabled](#building).
+
+Obtain tracing json file.
+
+```
+    $ ./{PIGWEED_REPO}/pw_trace_tokenized/py/pw_trace_tokenized/get_trace.py -s localhost:33000 \
+     -o {OUTPUT_FILE} -t {ELF_FILE} {PIGWEED_REPO}/pw_trace_tokenized/pw_trace_protos/trace_rpc.proto
+```

--- a/examples/platform/linux/Rpc.cpp
+++ b/examples/platform/linux/Rpc.cpp
@@ -42,6 +42,7 @@
 #endif // defined(PW_RPC_LOCKING_SERVICE) && PW_RPC_LOCKING_SERVICE
 
 #if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
+#define PW_TRACE_BUFFER_SIZE_BYTES 1024
 #include "pw_trace/trace.h"
 #include "pw_trace_tokenized/trace_rpc_service_nanopb.h"
 
@@ -102,6 +103,7 @@ void RegisterServices(pw::rpc::Server & server)
 
 #if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
     server.RegisterService(trace_service);
+    PW_TRACE_SET_ENABLED(true);
 #endif // defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
 }
 


### PR DESCRIPTION
#### Change overview
* Enable tracing after tracing rpc service is registered.
* Add instructions to get trace file from linux lighting app.

#### Testing
Build linux lighting app and commission it. Grab the trace file as shown below.

```
[{"pid": "", "name": "HandlePBKDFParamRequest", "ts": 0.0, "ph": "B", "tid": "PASESession"},
{"pid": "", "name": "SendPBKDFParamResponse", "ts": 69000.0, "ph": "B", "tid": "PASESession"},
{"pid": "", "name": "SetupSpake2p", "ts": 144000.0, "ph": "B", "tid": "PASESession"},
{"pid": "", "name": "SetupSpake2p", "ts": 262000.0, "ph": "E", "tid": "PASESession"},
{"pid": "", "name": "SendPBKDFParamResponse", "ts": 407000.0, "ph": "E", "tid": "PASESession"},
{"pid": "", "name": "HandlePBKDFParamRequest", "ts": 412000.0, "ph": "E", "tid": "PASESession"},
{"pid": "", "name": "HandleMsg1_and_SendMsg2", "ts": 7845000.0, "ph": "B", "tid": "PASESession"},
{"pid": "", "name": "HandleMsg1_and_SendMsg2", "ts": 8672000.0, "ph": "E", "tid": "PASESession"},
{"pid": "", "name": "HandleMsg3", "ts": 9623000.0, "ph": "B", "tid": "PASESession"},
{"pid": "", "name": "HandleMsg3", "ts": 27921000.0, "ph": "E", "tid": "PASESession"},
...]
```