### PR TITLE
[IM] Fix potential CI crash and random CI failure

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
     cirque:
         name: Cirque
-        timeout-minutes: 60
+        timeout-minutes: 75
 
         env:
             DOCKER_RUN_VERSION: 0.5.56

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -243,6 +243,7 @@ public:
             readClient->mpImEngine = nullptr;
             auto * tmpClient       = readClient->GetNextClient();
             readClient->SetNextClient(nullptr);
+            readClient->Close(CHIP_NO_ERROR);
             readClient = tmpClient;
         }
 

--- a/src/controller/TypedReadCallback.h
+++ b/src/controller/TypedReadCallback.h
@@ -108,12 +108,20 @@ private:
 
     void OnDeallocatePaths(chip::app::ReadPrepareParams && aReadPrepareParams) override
     {
-        VerifyOrDie(aReadPrepareParams.mAttributePathParamsListSize == 1 &&
-                    aReadPrepareParams.mpAttributePathParamsList != nullptr);
-        chip::Platform::Delete<app::AttributePathParams>(aReadPrepareParams.mpAttributePathParamsList);
+        if (aReadPrepareParams.mAttributePathParamsListSize == 1 && aReadPrepareParams.mpAttributePathParamsList != nullptr)
+        {
+            chip::Platform::Delete<app::AttributePathParams>(aReadPrepareParams.mpAttributePathParamsList);
+        }
 
-        VerifyOrDie(aReadPrepareParams.mDataVersionFilterListSize == 1 && aReadPrepareParams.mpDataVersionFilterList != nullptr);
-        chip::Platform::Delete<app::DataVersionFilter>(aReadPrepareParams.mpDataVersionFilterList);
+        if (aReadPrepareParams.mEventPathParamsListSize == 1 && aReadPrepareParams.mpEventPathParamsList != nullptr)
+        {
+            chip::Platform::Delete<app::EventPathParams>(aReadPrepareParams.mpEventPathParamsList);
+        }
+
+        if (aReadPrepareParams.mDataVersionFilterListSize == 1 && aReadPrepareParams.mpDataVersionFilterList != nullptr)
+        {
+            chip::Platform::Delete<app::DataVersionFilter>(aReadPrepareParams.mpDataVersionFilterList);
+        }
     }
 
     ClusterId mClusterId;

--- a/src/controller/TypedReadCallback.h
+++ b/src/controller/TypedReadCallback.h
@@ -108,15 +108,9 @@ private:
 
     void OnDeallocatePaths(chip::app::ReadPrepareParams && aReadPrepareParams) override
     {
-        if (aReadPrepareParams.mAttributePathParamsListSize == 1 && aReadPrepareParams.mpAttributePathParamsList != nullptr)
-        {
-            chip::Platform::Delete<app::AttributePathParams>(aReadPrepareParams.mpAttributePathParamsList);
-        }
-
-        if (aReadPrepareParams.mEventPathParamsListSize == 1 && aReadPrepareParams.mpEventPathParamsList != nullptr)
-        {
-            chip::Platform::Delete<app::EventPathParams>(aReadPrepareParams.mpEventPathParamsList);
-        }
+        VerifyOrDie(aReadPrepareParams.mAttributePathParamsListSize == 1 &&
+                    aReadPrepareParams.mpAttributePathParamsList != nullptr);
+        chip::Platform::Delete<app::AttributePathParams>(aReadPrepareParams.mpAttributePathParamsList);
 
         if (aReadPrepareParams.mDataVersionFilterListSize == 1 && aReadPrepareParams.mpDataVersionFilterList != nullptr)
         {


### PR DESCRIPTION
#### Problem
TestRead might fail in random (although it has not occurred yet, CI history in https://github.com/project-chip/connectedhomeip/pull/16811 indicated this)

#### Change overview
- `ShutdownActiveReads` should also "close" the read client, then the application can release the object.
- `OnDeallocatePaths` should not use VerifyOrDie(), since we may send subscriptions without a data version filter, attribute path or event path.

#### Testing

CI should pass, also CI history in https://github.com/project-chip/connectedhomeip/pull/16811 verified this.
