### PR TITLE
[nrfconnect] Fix all-clusters-app partition layout

### DIFF
--- a/examples/all-clusters-app/nrfconnect/CMakeLists.txt
+++ b/examples/all-clusters-app/nrfconnect/CMakeLists.txt
@@ -24,7 +24,7 @@ include(${CHIP_ROOT}/config/nrfconnect/app/check-nrfconnect-version.cmake)
 
 set(APPLICATION_CONFIG_DIR "configuration/\${BOARD}")
 
-if(NOT CONF_FILE STREQUAL "prj.conf")
+if(DEFINED CONF_FILE AND NOT CONF_FILE STREQUAL "prj.conf")
     set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static_dfu.yml)
 endif()
 


### PR DESCRIPTION
#### Problem
nRF Connect all-cluster-app doesn't boot.

#### Change overview
Fix setting the static partition layout when the DFU is enabled.

#### Testing
Verified the app boots correctly now.
