### PR TITLE
ESP32: Add timeout for mdns_query_async_get_results

### DIFF
--- a/src/platform/ESP32/DnssdImpl.cpp
+++ b/src/platform/ESP32/DnssdImpl.cpp
@@ -443,7 +443,7 @@ void MdnsQueryDone(intptr_t context)
     }
     mdns_search_once_t * searchHandle = reinterpret_cast<mdns_search_once_t *>(context);
     GenericContext * ctx              = FindMdnsQuery(searchHandle);
-    if (mdns_query_async_get_results(searchHandle, 0, &(ctx->mResult)))
+    if (mdns_query_async_get_results(searchHandle, kTimeoutMilli, &(ctx->mResult)))
     {
         if (ctx->mContextType == ContextType::Browse)
         {


### PR DESCRIPTION
#### Problem
The browse and resolve can't work on ESP32 because the timeout for `mdns_query_async_get_results` is 0.
Need to add timeout for `mdns_query_async_get_results` in ESP32 platform mdns.

#### Change overview
Add timeout for `mdns_query_async_get_results`

#### Testing
Tested on ESP32 and ESP32C3, browse and resolve works well.
