### PR TITLE
Removed redundant Store call in addNOC callback

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -628,9 +628,6 @@ bool emberAfOperationalCredentialsClusterAddNOCCallback(app::CommandHandler * co
     err = Server::GetInstance().GetFabricTable().AddNewFabric(gFabricBeingCommissioned, &fabricIndex);
     VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
 
-    err = Server::GetInstance().GetFabricTable().Store(fabricIndex);
-    VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
-
     // The Fabric Index associated with the armed fail-safe context SHALL be updated to match the Fabric
     // Index just allocated.
     err = failSafeContext.SetAddNocCommandInvoked(fabricIndex);

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -388,6 +388,7 @@ public:
      * can release the memory associated with input parameter after the call is complete.
      *
      * If the call is successful, the assigned fabric index is returned as output parameter.
+     * The fabric information will also be persisted to storage.
      */
     CHIP_ERROR AddNewFabric(FabricInfo & fabric, FabricIndex * assignedIndex);
 


### PR DESCRIPTION
#### Problem
Fixes #16131 
In the AddNOC callback, the same fabric information was being persisted twice, once upon creation in AddNewFabric() and then in a Store() call right after. This PR removes the redundant store call. Also verified that the other AddNewFabric() calls do not have a redundant Store() after.

#### Change overview
Remove redundant Store call

#### Testing
- Verified that the new fabric is not stored twice to the KVS, during commissioning. 
- Sanity-check: Ran OTA test to ensure commissioning and OTA transfer is unaffected
