### PR TITLE
Improve code clarity on IsTimeGreaterThanEqual

### DIFF
--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -1351,27 +1351,27 @@ exit:
 
 inline bool IsTimeGreaterThanEqual(const mbedtls_x509_time * const timeA, const mbedtls_x509_time * const timeB)
 {
-    return timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(year) > timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(year) ||
-        (timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(year) == timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(year) &&
-         timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(mon) > timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(mon)) ||
-        (timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(year) == timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(year) &&
-         timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(mon) == timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(mon) &&
-         timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(day) > timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(day)) ||
-        (timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(year) == timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(year) &&
-         timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(mon) == timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(mon) &&
-         timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(day) == timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(day) &&
-         timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(hour) > timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(hour)) ||
-        (timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(year) == timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(year) &&
-         timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(mon) == timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(mon) &&
-         timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(day) == timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(day) &&
-         timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(hour) == timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(hour) &&
-         timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(min) > timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(min)) ||
-        (timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(year) == timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(year) &&
-         timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(mon) == timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(mon) &&
-         timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(day) == timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(day) &&
-         timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(hour) == timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(hour) &&
-         timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(min) == timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(min) &&
-         timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(sec) >= timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(sec));
+
+    // checks if two values are different and if yes, then returns first > second.
+#define RETURN_STRICTLY_GREATER_IF_DIFFERENT(component)                                                                            \
+    {                                                                                                                              \
+        auto valueA = timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(component);                                                              \
+        auto valueB = timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(component);                                                              \
+                                                                                                                                   \
+        if (valueA != valueB)                                                                                                      \
+        {                                                                                                                          \
+            return valueA > valueB;                                                                                                \
+        }                                                                                                                          \
+    }
+
+    RETURN_STRICTLY_GREATER_IF_DIFFERENT(year);
+    RETURN_STRICTLY_GREATER_IF_DIFFERENT(mon);
+    RETURN_STRICTLY_GREATER_IF_DIFFERENT(day);
+    RETURN_STRICTLY_GREATER_IF_DIFFERENT(hour);
+    RETURN_STRICTLY_GREATER_IF_DIFFERENT(min);
+
+    // all above are equal
+    return timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(sec) >= timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(sec);
 }
 
 CHIP_ERROR IsCertificateValidAtIssuance(const ByteSpan & referenceCertificate, const ByteSpan & toBeEvaluatedCertificate)

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -1369,9 +1369,10 @@ inline bool IsTimeGreaterThanEqual(const mbedtls_x509_time * const timeA, const 
     RETURN_STRICTLY_GREATER_IF_DIFFERENT(day);
     RETURN_STRICTLY_GREATER_IF_DIFFERENT(hour);
     RETURN_STRICTLY_GREATER_IF_DIFFERENT(min);
+    RETURN_STRICTLY_GREATER_IF_DIFFERENT(sec);
 
     // all above are equal
-    return timeA->CHIP_CRYPTO_PAL_PRIVATE_X509(sec) >= timeB->CHIP_CRYPTO_PAL_PRIVATE_X509(sec);
+    return true;
 }
 
 CHIP_ERROR IsCertificateValidAtIssuance(const ByteSpan & referenceCertificate, const ByteSpan & toBeEvaluatedCertificate)


### PR DESCRIPTION
#### Problem
Existing code is very hard to validate given the complex boolean
expression.

#### Change overview
Split the logic into clearer steps of comparing year, month,
day, hr, min, sec individually.

The code change should generally be a NOOP except code clarity.

#### Testing
Compilation.
Checked in gotdbolt.org: new code results in more optimized code when using O3 and Os.

Note however that this method is **NOT** currently used since it is referenced in IsCertificateValidAtIssuance where it is commented out, so unit tests or code in general will not be able to validate it.

This is for the future readability in case it does get used.
