### PR TITLE
Whitelist no-interactive-ipv6only instead of just no-interactive.

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -266,7 +266,7 @@ def HostTargets():
                           "clang"], use_libfuzzer=True),
     builder.AppendVariant(name="clang", use_clang=True),
 
-    builder.WhitelistVariantNameForGlob('no-interactive')
+    builder.WhitelistVariantNameForGlob('no-interactive-ipv6only')
     builder.WhitelistVariantNameForGlob('ipv6only')
 
     for target in app_targets:

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -11,10 +11,10 @@ bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters-ipv6only'
 
-# Generating linux-arm64-chip-tool-no-interactive
+# Generating linux-arm64-chip-tool-no-interactive-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=config_use_interactive_mode=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-no-interactive'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_inet_config_enable_ipv4=false config_use_interactive_mode=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-no-interactive-ipv6only'
 
 # Generating linux-arm64-door-lock
 bash -c '
@@ -97,8 +97,8 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Generating linux-x64-chip-tool-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-chip-tool-ipv6only
 
-# Generating linux-x64-chip-tool-no-interactive
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool --args=config_use_interactive_mode=false {out}/linux-x64-chip-tool-no-interactive
+# Generating linux-x64-chip-tool-no-interactive-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=chip_inet_config_enable_ipv4=false config_use_interactive_mode=false' {out}/linux-x64-chip-tool-no-interactive-ipv6only
 
 # Generating linux-x64-door-lock
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/door-lock-app/linux {out}/linux-x64-door-lock
@@ -154,8 +154,8 @@ ninja -C {out}/linux-arm64-all-clusters
 # Building linux-arm64-all-clusters-ipv6only
 ninja -C {out}/linux-arm64-all-clusters-ipv6only
 
-# Building linux-arm64-chip-tool-no-interactive
-ninja -C {out}/linux-arm64-chip-tool-no-interactive
+# Building linux-arm64-chip-tool-no-interactive-ipv6only
+ninja -C {out}/linux-arm64-chip-tool-no-interactive-ipv6only
 
 # Building linux-arm64-door-lock
 ninja -C {out}/linux-arm64-door-lock
@@ -214,8 +214,8 @@ ninja -C {out}/linux-x64-chip-tool
 # Building linux-x64-chip-tool-ipv6only
 ninja -C {out}/linux-x64-chip-tool-ipv6only
 
-# Building linux-x64-chip-tool-no-interactive
-ninja -C {out}/linux-x64-chip-tool-no-interactive
+# Building linux-x64-chip-tool-no-interactive-ipv6only
+ninja -C {out}/linux-x64-chip-tool-no-interactive-ipv6only
 
 # Building linux-x64-door-lock
 ninja -C {out}/linux-x64-door-lock


### PR DESCRIPTION
#### Problem
whitelisting is not additive, so whitelisting no-interactive did not pick the ipv6 variant

#### Change overview
Explicitly say 'want no-interactive ipv6' variant whitelisted.

#### Testing
Checked targets output from build_examples.py