### PR TITLE
Move timeouts from 5 to 10 minutes for linux app builds

### DIFF
--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -67,7 +67,7 @@ jobs:
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
             - name: Build Standalone cert tool
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/build/build_examples.py --no-log-timestamps --target-glob '*-chip-cert' build"
@@ -80,7 +80,7 @@ jobs:
                     out/chip_tool_debug/chip-tool \
                     /tmp/bloat_reports/
             - name: Build example Standalone Shell
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: |
                   scripts/examples/gn_build_example.sh examples/shell/standalone out/shell_debug
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
@@ -88,7 +88,7 @@ jobs:
                     out/shell_debug/chip-shell \
                     /tmp/bloat_reports/
             - name: Build example Standalone All Clusters Server
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: |
                   scripts/examples/gn_build_example.sh examples/all-clusters-app/linux out/all_clusters_debug
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
@@ -96,7 +96,7 @@ jobs:
                     out/all_clusters_debug/chip-all-clusters-app \
                     /tmp/bloat_reports/
             - name: Build example TV app
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: |
                   scripts/examples/gn_build_example.sh examples/tv-app/linux out/tv_app_debug
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
@@ -113,7 +113,7 @@ jobs:
                     out/lighting_app_debug_rpc/chip-lighting-app \
                     /tmp/bloat_reports/
             - name: Build example Standalone Bridge
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: |
                   scripts/examples/gn_build_example.sh examples/bridge-app/linux out/bridge_debug
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
@@ -121,7 +121,7 @@ jobs:
                     out/bridge_debug/chip-bridge-app \
                     /tmp/bloat_reports/
             - name: Build example OTA Provider
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: |
                   scripts/examples/gn_build_example.sh examples/ota-provider-app/linux out/ota_provider_debug
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
@@ -129,7 +129,7 @@ jobs:
                     out/ota_provider_debug/chip-ota-provider-app \
                     /tmp/bloat_reports/
             - name: Build example OTA Requestor
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: |
                   scripts/examples/gn_build_example.sh examples/ota-requestor-app/linux out/ota_requestor_debug
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
@@ -138,7 +138,7 @@ jobs:
                     /tmp/bloat_reports/
 
             - name: Build example Standalone Door Lock App
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \


### PR DESCRIPTION
#### Problem
Seeing timeouts on builds, like https://github.com/project-chip/connectedhomeip/runs/5871924721?check_suite_focus=true

#### Change overview
Change timeouts from 5 to 10 minutes.

#### Testing
CI will validate - nothing to test here. We should get less linux CI failures.