### PR TITLE
Make AddAttribute() APIs More Error Prone for Consumers

### DIFF
--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -131,7 +131,7 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
     // If root certificate not found in the storage, generate new root certificate.
     else
     {
-        ReturnErrorOnFailure(rcac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, mIssuerId));
+        ReturnErrorOnFailure(rcac_dn.AddAttribute_MatterRCACId(mIssuerId));
 
         ChipLogProgress(Controller, "Generating RCAC");
         X509CertRequestParams rcac_request = { 0, mNow, mNow + mValidity, rcac_dn, rcac_dn };
@@ -155,7 +155,7 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
     // If intermediate certificate not found in the storage, generate new intermediate certificate.
     else
     {
-        ReturnErrorOnFailure(icac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipICAId, mIntermediateIssuerId));
+        ReturnErrorOnFailure(icac_dn.AddAttribute_MatterICACId(mIntermediateIssuerId));
 
         ChipLogProgress(Controller, "Generating ICAC");
         X509CertRequestParams icac_request = { 0, mNow, mNow + mValidity, icac_dn, rcac_dn };
@@ -167,8 +167,8 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
     }
 
     ChipDN noc_dn;
-    ReturnErrorOnFailure(noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, fabricId));
-    ReturnErrorOnFailure(noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, nodeId));
+    ReturnErrorOnFailure(noc_dn.AddAttribute_MatterFabricId(fabricId));
+    ReturnErrorOnFailure(noc_dn.AddAttribute_MatterNodeId(nodeId));
     ReturnErrorOnFailure(noc_dn.AddCATs(cats));
 
     ChipLogProgress(Controller, "Generating NOC");

--- a/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
+++ b/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
@@ -97,7 +97,7 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
     // If root certificate not found in the storage, generate new root certificate.
     else
     {
-        ReturnErrorOnFailure(rcac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, mIssuerId));
+        ReturnErrorOnFailure(rcac_dn.AddAttribute_MatterRCACId(mIssuerId));
 
         ChipLogProgress(Controller, "Generating RCAC");
         chip::Credentials::X509CertRequestParams rcac_request = { 0, mNow, mNow + mValidity, rcac_dn, rcac_dn };
@@ -111,8 +111,8 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
     icac.reduce_size(0);
 
     ChipDN noc_dn;
-    ReturnErrorOnFailure(noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, fabricId));
-    ReturnErrorOnFailure(noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, nodeId));
+    ReturnErrorOnFailure(noc_dn.AddAttribute_MatterFabricId(fabricId));
+    ReturnErrorOnFailure(noc_dn.AddAttribute_MatterNodeId(nodeId));
     ReturnErrorOnFailure(noc_dn.AddCATs(cats));
 
     ChipLogProgress(Controller, "Generating NOC");

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -582,7 +582,7 @@ CHIP_ERROR ChipDN::AddCATs(const chip::CATValues & cats)
     {
         if (cat != kUndefinedCAT)
         {
-            ReturnErrorOnFailure(AddAttribute(chip::ASN1::kOID_AttributeType_ChipCASEAuthenticatedTag, cat));
+            ReturnErrorOnFailure(AddAttribute_MatterCASEAuthTag(cat));
         }
     }
 
@@ -615,31 +615,31 @@ CHIP_ERROR ChipDN::GetCertType(uint8_t & certType) const
 
     for (uint8_t i = 0; i < rdnCount; i++)
     {
-        if (rdn[i].mAttrOID == kOID_AttributeType_ChipRootId)
+        if (rdn[i].mAttrOID == kOID_AttributeType_MatterRCACId)
         {
             VerifyOrExit(lCertType == kCertType_NotSpecified, err = CHIP_ERROR_WRONG_CERT_DN);
 
             lCertType = kCertType_Root;
         }
-        else if (rdn[i].mAttrOID == kOID_AttributeType_ChipICAId)
+        else if (rdn[i].mAttrOID == kOID_AttributeType_MatterICACId)
         {
             VerifyOrExit(lCertType == kCertType_NotSpecified, err = CHIP_ERROR_WRONG_CERT_DN);
 
             lCertType = kCertType_ICA;
         }
-        else if (rdn[i].mAttrOID == kOID_AttributeType_ChipNodeId)
+        else if (rdn[i].mAttrOID == kOID_AttributeType_MatterNodeId)
         {
             VerifyOrExit(lCertType == kCertType_NotSpecified, err = CHIP_ERROR_WRONG_CERT_DN);
             VerifyOrReturnError(IsOperationalNodeId(rdn[i].mChipVal), CHIP_ERROR_WRONG_CERT_DN);
             lCertType = kCertType_Node;
         }
-        else if (rdn[i].mAttrOID == kOID_AttributeType_ChipFirmwareSigningId)
+        else if (rdn[i].mAttrOID == kOID_AttributeType_MatterFirmwareSigningId)
         {
             VerifyOrExit(lCertType == kCertType_NotSpecified, err = CHIP_ERROR_WRONG_CERT_DN);
 
             lCertType = kCertType_FirmwareSigning;
         }
-        else if (rdn[i].mAttrOID == kOID_AttributeType_ChipFabricId)
+        else if (rdn[i].mAttrOID == kOID_AttributeType_MatterFabricId)
         {
             // Only one fabricId attribute is allowed per DN.
             VerifyOrExit(!fabricIdPresent, err = CHIP_ERROR_WRONG_CERT_DN);
@@ -669,10 +669,10 @@ CHIP_ERROR ChipDN::GetCertChipId(uint64_t & chipId) const
     {
         switch (rdn[i].mAttrOID)
         {
-        case kOID_AttributeType_ChipRootId:
-        case kOID_AttributeType_ChipICAId:
-        case kOID_AttributeType_ChipNodeId:
-        case kOID_AttributeType_ChipFirmwareSigningId:
+        case kOID_AttributeType_MatterRCACId:
+        case kOID_AttributeType_MatterICACId:
+        case kOID_AttributeType_MatterNodeId:
+        case kOID_AttributeType_MatterFirmwareSigningId:
             VerifyOrReturnError(chipId == 0, CHIP_ERROR_WRONG_CERT_DN);
 
             chipId = rdn[i].mChipVal;
@@ -695,7 +695,7 @@ CHIP_ERROR ChipDN::GetCertFabricId(uint64_t & fabricId) const
     {
         switch (rdn[i].mAttrOID)
         {
-        case kOID_AttributeType_ChipFabricId:
+        case kOID_AttributeType_MatterFabricId:
             // Ensure only one FabricID RDN present, since start value is kUndefinedFabricId, which is reserved and never seen.
             VerifyOrReturnError(fabricId == kUndefinedFabricId, CHIP_ERROR_WRONG_CERT_DN);
             VerifyOrReturnError(IsValidFabricId(rdn[i].mChipVal), CHIP_ERROR_WRONG_CERT_DN);
@@ -782,11 +782,11 @@ CHIP_ERROR ChipDN::DecodeFromTLV(TLVReader & reader)
             uint64_t chipAttr;
             VerifyOrReturnError(attrIsPrintableString == false, CHIP_ERROR_INVALID_TLV_TAG);
             ReturnErrorOnFailure(reader.Get(chipAttr));
-            if (attrOID == chip::ASN1::kOID_AttributeType_ChipNodeId)
+            if (attrOID == chip::ASN1::kOID_AttributeType_MatterNodeId)
             {
                 VerifyOrReturnError(IsOperationalNodeId(attrOID), CHIP_ERROR_INVALID_ARGUMENT);
             }
-            else if (attrOID == chip::ASN1::kOID_AttributeType_ChipFabricId)
+            else if (attrOID == chip::ASN1::kOID_AttributeType_MatterFabricId)
             {
                 VerifyOrReturnError(IsValidFabricId(attrOID), CHIP_ERROR_INVALID_ARGUMENT);
             }
@@ -798,7 +798,7 @@ CHIP_ERROR ChipDN::DecodeFromTLV(TLVReader & reader)
             uint32_t chipAttr;
             VerifyOrReturnError(attrIsPrintableString == false, CHIP_ERROR_INVALID_TLV_TAG);
             ReturnErrorOnFailure(reader.Get(chipAttr));
-            if (attrOID == chip::ASN1::kOID_AttributeType_ChipCASEAuthenticatedTag)
+            if (attrOID == chip::ASN1::kOID_AttributeType_MatterCASEAuthTag)
             {
                 VerifyOrReturnError(IsValidCASEAuthTag(chipAttr), CHIP_ERROR_INVALID_ARGUMENT);
             }
@@ -937,11 +937,11 @@ CHIP_ERROR ChipDN::DecodeFromASN1(ASN1Reader & reader)
                                                                            chipAttr) == sizeof(uint64_t),
                                             ASN1_ERROR_INVALID_ENCODING);
 
-                        if (attrOID == chip::ASN1::kOID_AttributeType_ChipNodeId)
+                        if (attrOID == chip::ASN1::kOID_AttributeType_MatterNodeId)
                         {
                             VerifyOrReturnError(IsOperationalNodeId(chipAttr), CHIP_ERROR_WRONG_CERT_DN);
                         }
-                        else if (attrOID == chip::ASN1::kOID_AttributeType_ChipFabricId)
+                        else if (attrOID == chip::ASN1::kOID_AttributeType_MatterFabricId)
                         {
                             VerifyOrReturnError(IsValidFabricId(chipAttr), CHIP_ERROR_WRONG_CERT_DN);
                         }
@@ -1135,12 +1135,12 @@ CHIP_ERROR ExtractNodeIdFabricIdFromOpCert(const ChipCertificateData & opcert, N
     for (uint8_t i = 0; i < subjectDN.RDNCount(); ++i)
     {
         const auto & rdn = subjectDN.rdn[i];
-        if (rdn.mAttrOID == ASN1::kOID_AttributeType_ChipNodeId)
+        if (rdn.mAttrOID == ASN1::kOID_AttributeType_MatterNodeId)
         {
             nodeId      = rdn.mChipVal;
             foundNodeId = true;
         }
-        else if (rdn.mAttrOID == ASN1::kOID_AttributeType_ChipFabricId)
+        else if (rdn.mAttrOID == ASN1::kOID_AttributeType_MatterFabricId)
         {
             fabricId      = rdn.mChipVal;
             foundFabricId = true;
@@ -1182,7 +1182,7 @@ CHIP_ERROR ExtractFabricIdFromCert(const ChipCertificateData & cert, FabricId * 
     for (uint8_t i = 0; i < subjectDN.RDNCount(); ++i)
     {
         const auto & rdn = subjectDN.rdn[i];
-        if (rdn.mAttrOID == ASN1::kOID_AttributeType_ChipFabricId)
+        if (rdn.mAttrOID == ASN1::kOID_AttributeType_MatterFabricId)
         {
             *fabricId = rdn.mChipVal;
             return CHIP_NO_ERROR;
@@ -1216,7 +1216,7 @@ CHIP_ERROR ExtractCATsFromOpCert(const ChipCertificateData & opcert, CATValues &
     for (uint8_t i = 0; i < subjectDN.RDNCount(); ++i)
     {
         const auto & rdn = subjectDN.rdn[i];
-        if (rdn.mAttrOID == ASN1::kOID_AttributeType_ChipCASEAuthenticatedTag)
+        if (rdn.mAttrOID == ASN1::kOID_AttributeType_MatterCASEAuthTag)
         {
             // This error should never happen in practice because valid NOC cannot have more
             // than kMaxSubjectCATAttributeCount CATs in its subject. The check that it is

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -251,6 +251,86 @@ public:
      **/
     CHIP_ERROR AddAttribute(chip::ASN1::OID oid, CharSpan val, bool isPrintableString);
 
+    inline CHIP_ERROR AddAttribute_CommonName(CharSpan val, bool isPrintableString)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_CommonName, val, isPrintableString);
+    }
+    inline CHIP_ERROR AddAttribute_Surname(CharSpan val, bool isPrintableString)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_Surname, val, isPrintableString);
+    }
+    inline CHIP_ERROR AddAttribute_SerialNumber(CharSpan val, bool isPrintableString)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_SerialNumber, val, isPrintableString);
+    }
+    inline CHIP_ERROR AddAttribute_CountryName(CharSpan val, bool isPrintableString)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_CountryName, val, isPrintableString);
+    }
+    inline CHIP_ERROR AddAttribute_LocalityName(CharSpan val, bool isPrintableString)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_LocalityName, val, isPrintableString);
+    }
+    inline CHIP_ERROR AddAttribute_StateOrProvinceName(CharSpan val, bool isPrintableString)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_StateOrProvinceName, val, isPrintableString);
+    }
+    inline CHIP_ERROR AddAttribute_OrganizationName(CharSpan val, bool isPrintableString)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_OrganizationName, val, isPrintableString);
+    }
+    inline CHIP_ERROR AddAttribute_OrganizationalUnitName(CharSpan val, bool isPrintableString)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_OrganizationalUnitName, val, isPrintableString);
+    }
+    inline CHIP_ERROR AddAttribute_Title(CharSpan val, bool isPrintableString)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_Title, val, isPrintableString);
+    }
+    inline CHIP_ERROR AddAttribute_Name(CharSpan val, bool isPrintableString)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_Name, val, isPrintableString);
+    }
+    inline CHIP_ERROR AddAttribute_GivenName(CharSpan val, bool isPrintableString)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_GivenName, val, isPrintableString);
+    }
+    inline CHIP_ERROR AddAttribute_Initials(CharSpan val, bool isPrintableString)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_Initials, val, isPrintableString);
+    }
+    inline CHIP_ERROR AddAttribute_GenerationQualifier(CharSpan val, bool isPrintableString)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_GenerationQualifier, val, isPrintableString);
+    }
+    inline CHIP_ERROR AddAttribute_DNQualifier(CharSpan val, bool isPrintableString)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_DNQualifier, val, isPrintableString);
+    }
+    inline CHIP_ERROR AddAttribute_Pseudonym(CharSpan val, bool isPrintableString)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_Pseudonym, val, isPrintableString);
+    }
+    inline CHIP_ERROR AddAttribute_DomainComponent(CharSpan val, bool isPrintableString)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_DomainComponent, val, isPrintableString);
+    }
+    inline CHIP_ERROR AddAttribute_MatterNodeId(uint64_t val) { return AddAttribute(ASN1::kOID_AttributeType_MatterNodeId, val); }
+    inline CHIP_ERROR AddAttribute_MatterFirmwareSigningId(uint64_t val)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_MatterFirmwareSigningId, val);
+    }
+    inline CHIP_ERROR AddAttribute_MatterICACId(uint64_t val) { return AddAttribute(ASN1::kOID_AttributeType_MatterICACId, val); }
+    inline CHIP_ERROR AddAttribute_MatterRCACId(uint64_t val) { return AddAttribute(ASN1::kOID_AttributeType_MatterRCACId, val); }
+    inline CHIP_ERROR AddAttribute_MatterFabricId(uint64_t val)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_MatterFabricId, val);
+    }
+    inline CHIP_ERROR AddAttribute_MatterCASEAuthTag(CASEAuthTag val)
+    {
+        return AddAttribute(ASN1::kOID_AttributeType_MatterCASEAuthTag, val);
+    }
+
     /**
      * @brief Determine type of a CHIP certificate.
      *        This method performs an assessment of a certificate's type based on the structure
@@ -729,9 +809,9 @@ CHIP_ERROR ChipEpochToASN1Time(uint32_t epochTime, chip::ASN1::ASN1UniversalTime
  **/
 inline bool IsChip64bitDNAttr(chip::ASN1::OID oid)
 {
-    return (oid == chip::ASN1::kOID_AttributeType_ChipNodeId || oid == chip::ASN1::kOID_AttributeType_ChipFirmwareSigningId ||
-            oid == chip::ASN1::kOID_AttributeType_ChipICAId || oid == chip::ASN1::kOID_AttributeType_ChipRootId ||
-            oid == chip::ASN1::kOID_AttributeType_ChipFabricId);
+    return (oid == chip::ASN1::kOID_AttributeType_MatterNodeId || oid == chip::ASN1::kOID_AttributeType_MatterFirmwareSigningId ||
+            oid == chip::ASN1::kOID_AttributeType_MatterICACId || oid == chip::ASN1::kOID_AttributeType_MatterRCACId ||
+            oid == chip::ASN1::kOID_AttributeType_MatterFabricId);
 }
 
 /**
@@ -739,7 +819,7 @@ inline bool IsChip64bitDNAttr(chip::ASN1::OID oid)
  **/
 inline bool IsChip32bitDNAttr(chip::ASN1::OID oid)
 {
-    return (oid == chip::ASN1::kOID_AttributeType_ChipCASEAuthenticatedTag);
+    return (oid == chip::ASN1::kOID_AttributeType_MatterCASEAuthTag);
 }
 
 /**

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -326,8 +326,8 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChainAfterValidation(N
         }
     }
     if (!haveRootCert) {
-        ReturnErrorOnFailure(rcac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipRootId, mIssuerId));
-        ReturnErrorOnFailure(rcac_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, fabricId));
+        ReturnErrorOnFailure(rcac_dn.AddAttribute_MatterRCACId(mIssuerId));
+        ReturnErrorOnFailure(rcac_dn.AddAttribute_MatterFabricId(fabricId));
 
         NSLog(@"Generating RCAC");
         X509CertRequestParams rcac_request = { 0, validityStart, validityEnd, rcac_dn, rcac_dn };
@@ -343,8 +343,8 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChainAfterValidation(N
     icac.reduce_size(0);
 
     ChipDN noc_dn;
-    ReturnErrorOnFailure(noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipFabricId, fabricId));
-    ReturnErrorOnFailure(noc_dn.AddAttribute(chip::ASN1::kOID_AttributeType_ChipNodeId, nodeId));
+    ReturnErrorOnFailure(noc_dn.AddAttribute_MatterFabricId(fabricId));
+    ReturnErrorOnFailure(noc_dn.AddAttribute_MatterNodeId(nodeId));
     ReturnErrorOnFailure(noc_dn.AddCATs(cats));
 
     X509CertRequestParams noc_request = { 1, validityStart, validityEnd, noc_dn, rcac_dn };

--- a/src/lib/asn1/gen_asn1oid.py
+++ b/src/lib/asn1/gen_asn1oid.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-#    Copyright (c) 2020 Project CHIP Authors
+#    Copyright (c) 2020-2022 Project CHIP Authors
 #    Copyright (c) 2019 Google LLC.
 #    Copyright (c) 2013-2017 Nest Labs, Inc.
 #    All rights reserved.
@@ -22,8 +22,8 @@
 #
 #    @file
 #      This file implements a Python script to generate a C/C++ header
-#      for individual ASN1 Object IDs (OIDs) that are used in CHIP
-#      TLV encodings (notably the CHIP Certificate object).
+#      for individual ASN1 Object IDs (OIDs) that are used in Matter
+#      TLV encodings (notably the Matter Certificate object).
 #
 
 from __future__ import absolute_import
@@ -40,7 +40,7 @@ def identity(n):
 ansi_X9_62 = identity
 certicom = identity
 characteristicTwo = identity
-chip = identity
+matter = identity
 curve = identity
 curves = identity
 digest_algorithm = identity
@@ -83,7 +83,7 @@ oids = [
 
     # !!! WARNING !!!
     #
-    # The enumerated values associated with individual object IDs are used in CHIP TLV encodings (notably the CHIP Certificate object).
+    # The enumerated values associated with individual object IDs are used in Matter TLV encodings (notably the Matter Certificate object).
     # Because of this, the Enum Values assigned to object IDs in this table MUST NOT BE CHANGED once in use.
 
 
@@ -134,18 +134,18 @@ oids = [
      [joint_iso_ccitt(2), ds(5), 4, 65]),
     ("AttributeType",  "DomainComponent",         16,
      [itu_t(0), 9, 2342, 19200300, 100, 1, 25]),
-    ("AttributeType",  "ChipNodeId",              17,      [iso(1), organization(
-        3), dod(6), internet(1), private(4), enterprise(1), zigbee(37244), chip(1), 1]),
-    ("AttributeType",  "ChipFirmwareSigningId",   18,      [iso(1), organization(
-        3), dod(6), internet(1), private(4), enterprise(1), zigbee(37244), chip(1), 2]),
-    ("AttributeType",  "ChipICAId",               19,      [iso(1), organization(
-        3), dod(6), internet(1), private(4), enterprise(1), zigbee(37244), chip(1), 3]),
-    ("AttributeType",  "ChipRootId",              20,      [iso(1), organization(
-        3), dod(6), internet(1), private(4), enterprise(1), zigbee(37244), chip(1), 4]),
-    ("AttributeType",  "ChipFabricId",            21,      [iso(1), organization(
-        3), dod(6), internet(1), private(4), enterprise(1), zigbee(37244), chip(1), 5]),
-    ("AttributeType",  "ChipCASEAuthenticatedTag", 22,      [iso(1), organization(
-        3), dod(6), internet(1), private(4), enterprise(1), zigbee(37244), chip(1), 6]),
+    ("AttributeType",  "MatterNodeId",              17,      [iso(1), organization(
+        3), dod(6), internet(1), private(4), enterprise(1), zigbee(37244), matter(1), 1]),
+    ("AttributeType",  "MatterFirmwareSigningId",   18,      [iso(1), organization(
+        3), dod(6), internet(1), private(4), enterprise(1), zigbee(37244), matter(1), 2]),
+    ("AttributeType",  "MatterICACId",              19,      [iso(1), organization(
+        3), dod(6), internet(1), private(4), enterprise(1), zigbee(37244), matter(1), 3]),
+    ("AttributeType",  "MatterRCACId",              20,      [iso(1), organization(
+        3), dod(6), internet(1), private(4), enterprise(1), zigbee(37244), matter(1), 4]),
+    ("AttributeType",  "MatterFabricId",            21,      [iso(1), organization(
+        3), dod(6), internet(1), private(4), enterprise(1), zigbee(37244), matter(1), 5]),
+    ("AttributeType",  "MatterCASEAuthTag",         22,      [iso(1), organization(
+        3), dod(6), internet(1), private(4), enterprise(1), zigbee(37244), matter(1), 6]),
 
     # Elliptic Curves
     ("EllipticCurve",  "prime256v1",              1,       [
@@ -199,7 +199,7 @@ def encodeOID(oid):
 
 TEMPLATE = '''/*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2022 Project CHIP Authors
  *    Copyright (c) 2019 Google LLC.
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.

--- a/src/lib/asn1/tests/TestASN1.cpp
+++ b/src/lib/asn1/tests/TestASN1.cpp
@@ -313,7 +313,7 @@ static void TestASN1_ObjectID(nlTestSuite * inSuite, void * inContext)
 
     ASN1_START_SEQUENCE
     {
-        ASN1_ENCODE_OBJECT_ID(kOID_AttributeType_ChipNodeId);
+        ASN1_ENCODE_OBJECT_ID(kOID_AttributeType_MatterNodeId);
         ASN1_ENCODE_OBJECT_ID(kOID_SigAlgo_ECDSAWithSHA256);
         ASN1_ENCODE_OBJECT_ID(kOID_EllipticCurve_prime256v1);
         ASN1_ENCODE_OBJECT_ID(kOID_Extension_AuthorityKeyIdentifier);

--- a/src/tools/chip-cert/CertUtils.cpp
+++ b/src/tools/chip-cert/CertUtils.cpp
@@ -48,22 +48,22 @@ bool ToolChipDN::SetCertSubjectDN(X509 * cert) const
         case kOID_AttributeType_CommonName:
             attrNID = NID_commonName;
             break;
-        case kOID_AttributeType_ChipNodeId:
+        case kOID_AttributeType_MatterNodeId:
             attrNID = gNIDChipNodeId;
             break;
-        case kOID_AttributeType_ChipFirmwareSigningId:
+        case kOID_AttributeType_MatterFirmwareSigningId:
             attrNID = gNIDChipFirmwareSigningId;
             break;
-        case kOID_AttributeType_ChipICAId:
+        case kOID_AttributeType_MatterICACId:
             attrNID = gNIDChipICAId;
             break;
-        case kOID_AttributeType_ChipRootId:
+        case kOID_AttributeType_MatterRCACId:
             attrNID = gNIDChipRootId;
             break;
-        case kOID_AttributeType_ChipFabricId:
+        case kOID_AttributeType_MatterFabricId:
             attrNID = gNIDChipFabricId;
             break;
-        case kOID_AttributeType_ChipCASEAuthenticatedTag:
+        case kOID_AttributeType_MatterCASEAuthTag:
             attrNID = gNIDChipCASEAuthenticatedTag;
             break;
         default:

--- a/src/tools/chip-cert/Cmd_GenCert.cpp
+++ b/src/tools/chip-cert/Cmd_GenCert.cpp
@@ -195,7 +195,6 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint64_t chip64bitAttr;
     uint32_t chip32bitAttr;
-    OID attrOID;
 
     switch (id)
     {
@@ -243,23 +242,22 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
                 PrintArgError("%s: Invalid value specified for chip node-id attribute: %s\n", progName, arg);
                 return false;
             }
-            attrOID = kOID_AttributeType_ChipNodeId;
+            err = gSubjectDN.AddAttribute_MatterNodeId(chip64bitAttr);
             break;
         case kCertType_FirmwareSigning:
-            attrOID = kOID_AttributeType_ChipFirmwareSigningId;
+            err = gSubjectDN.AddAttribute_MatterFirmwareSigningId(chip64bitAttr);
             break;
         case kCertType_ICA:
-            attrOID = kOID_AttributeType_ChipICAId;
+            err = gSubjectDN.AddAttribute_MatterICACId(chip64bitAttr);
             break;
         case kCertType_Root:
-            attrOID = kOID_AttributeType_ChipRootId;
+            err = gSubjectDN.AddAttribute_MatterRCACId(chip64bitAttr);
             break;
         default:
             PrintArgError("%s: Certificate type argument should be specified prior to subject attribute: %s\n", progName, arg);
             return false;
         }
 
-        err = gSubjectDN.AddAttribute(attrOID, chip64bitAttr);
         if (err != CHIP_NO_ERROR)
         {
             fprintf(stderr, "Failed to add subject DN attribute: %s\n", chip::ErrorStr(err));
@@ -274,9 +272,8 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
                           arg);
             return false;
         }
-        attrOID = kOID_AttributeType_ChipCASEAuthenticatedTag;
 
-        err = gSubjectDN.AddAttribute(attrOID, chip32bitAttr);
+        err = gSubjectDN.AddAttribute_MatterCASEAuthTag(chip32bitAttr);
         if (err != CHIP_NO_ERROR)
         {
             fprintf(stderr, "Failed to add subject DN attribute: %s\n", chip::ErrorStr(err));
@@ -298,7 +295,7 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
             return false;
         }
 
-        err = gSubjectDN.AddAttribute(kOID_AttributeType_ChipFabricId, chip64bitAttr);
+        err = gSubjectDN.AddAttribute_MatterFabricId(chip64bitAttr);
         if (err != CHIP_NO_ERROR)
         {
             fprintf(stderr, "Failed to add Fabric Id attribute to the subject DN: %s\n", chip::ErrorStr(err));
@@ -307,7 +304,7 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
         break;
 
     case 'c':
-        err = gSubjectDN.AddAttribute(kOID_AttributeType_CommonName, chip::CharSpan::fromCharString(arg), false);
+        err = gSubjectDN.AddAttribute_CommonName(chip::CharSpan::fromCharString(arg), false);
         if (err != CHIP_NO_ERROR)
         {
             fprintf(stderr, "Failed to add Common Name attribute to the subject DN: %s\n", chip::ErrorStr(err));


### PR DESCRIPTION
#### Problem
Need a use friendly interface to set Certificate DN Attributes. 

ticket: #14314

#### Change overview
 * Added separate AddAttribute_***() method for each attribute type.
 * some minor updates to the Matter attribute names

#### Testing
Existing tests