### PR TITLE
Quick fix for CYW30739 building error caused by removed config.

### DIFF
--- a/src/platform/CYW30739/KeyValueStoreManagerImpl.h
+++ b/src/platform/CYW30739/KeyValueStoreManagerImpl.h
@@ -47,8 +47,8 @@ public:
 private:
     static constexpr uint8_t mMaxEntryCount = 1 + /* For the global message counter */
         1 +                                       /* For the admin key count */
-        CHIP_CONFIG_MAX_FABRICS + 1 +             /* For the session key count */
-        CHIP_CONFIG_MAX_SESSION_KEYS;
+        CHIP_CONFIG_MAX_FABRICS + 1               /* For the session key count */
+        ;
 
     struct KeyEntry
     {


### PR DESCRIPTION
#### Problem
Missing the config CHIP_CONFIG_MAX_SESSION_KEYS which was removed by https://github.com/project-chip/connectedhomeip/pull/17119
CI didn't catch it because CYW30739 was disabled when the PR was merged.

#### Change overview
Remove the reference of CHIP_CONFIG_MAX_SESSION_KEYS.

#### Testing
CI should be able to verify it.