### PR TITLE
[nrfconnect] Bump SDK version in Docker

### DIFF
--- a/integrations/docker/images/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/chip-build-nrf-platform/Dockerfile
@@ -2,7 +2,7 @@ ARG VERSION=latest
 FROM connectedhomeip/chip-build:${VERSION} as build
 
 # Compatible Nordic Connect SDK revision.
-ARG NCS_REVISION=v1.9.1
+ARG NCS_REVISION=5ea8f7fa91d7315fcc6cd9eb3aa74f9640d0abac
 
 RUN set -x \
     && apt-get update \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.63 Version bump reason: Add TI sysconfig to chip-build-vscode
+0.5.64 Version bump reason: Update nRF Connect SDK


### PR DESCRIPTION
#### Problem
The new version of NRF SDK contains a new API for performing multi-image DFU for nrf53.

#### Change overview
Updated nRF Connect SDK to 5ea8f7fa9 revision that includes the new DFU API.

#### Testing
Did smoke tests.