### PR TITLE
Fix nrf-nrf52840dongle-light build

### DIFF
--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -144,21 +144,25 @@ class NrfConnectBuilder(Builder):
 
                     raise Exception('ZEPHYR_BASE validation failed')
 
-            overlays = []
+            flags = []
             if self.enable_rpcs:
-                overlays.append("-DOVERLAY_CONFIG=rpc.overlay")
+                flags.append("-DOVERLAY_CONFIG=rpc.overlay")
+
+            if self.board == NrfBoard.NRF52840DONGLE:
+                flags.append("-DCONF_FILE=prj_no_dfu.conf")
+
+            build_flags = " -- " + " ".join(flags) if len(flags) > 0 else ""
 
             cmd = '''
 source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_ARM_CIPD_INSTALL_DIR";
-west build --cmake-only -d {outdir} -b {board} {sourcedir}{overlayflags}
+west build --cmake-only -d {outdir} -b {board} {sourcedir}{build_flags}
         '''.format(
                 outdir=shlex.quote(self.output_dir),
                 board=self.board.GnArgName(),
                 sourcedir=shlex.quote(os.path.join(
                     self.root, self.app.AppPath(), 'nrfconnect')),
-                overlayflags=" -- " +
-                " ".join(overlays) if len(overlays) > 0 else ""
+                build_flags=build_flags
             ).strip()
             self._Execute(['bash', '-c', cmd],
                           title='Generating ' + self.identifier)

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -851,7 +851,7 @@ west build --cmake-only -d {out}/nrf-nrf52840dk-shell -b nrf52840dk_nrf52840 {ro
 # Generating nrf-nrf52840dongle-light
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_ARM_CIPD_INSTALL_DIR";
-west build --cmake-only -d {out}/nrf-nrf52840dongle-light -b nrf52840dongle_nrf52840 {root}/examples/lighting-app/nrfconnect'
+west build --cmake-only -d {out}/nrf-nrf52840dongle-light -b nrf52840dongle_nrf52840 {root}/examples/lighting-app/nrfconnect -- -DCONF_FILE=prj_no_dfu.conf'
 
 # Generating nrf-nrf5340dk-light
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";


### PR DESCRIPTION
#### Problem
build-examples fails to compile nrf dongle light:

```
2022-04-07 20:13:53 INFO    FAILED: zephyr/drivers/flash/CMakeFiles/drivers__flash.dir/nrf_qspi_nor.c.obj 
2022-04-07 20:13:53 INFO    /pwenv/cipd/packages/arm/bin/arm-none-eabi-gcc -DBUILD_VERSION=b05b8ad63acf -DKERNEL -DNRF52840_XXAA -DUSE_PARTITION_MANAGER=1 -D_FORTIFY_SOURCE=2 -D__PROGRAM_START -D__ZEPHYR_SUPERVISOR__ -D__ZEPHYR__=1 -I/opt/NordicSemiconductor/nrfconnect/zephyr/include -Izephyr/include/generated -I/opt/NordicSemiconductor/nrfconnect/zephyr/soc/arm/nordic_nrf/nrf52 -I/opt/Nord…pt/NordicSemiconductor/nrfconnect/zephyr/lib/libc/minimal/include/errno.h:32,
2022-04-07 20:13:53 INFO                     from /opt/NordicSemiconductor/nrfconnect/zephyr/drivers/flash/nrf_qspi_nor.c:9:
2022-04-07 20:13:53 INFO    /opt/NordicSemiconductor/nrfconnect/zephyr/include/devicetree.h:305:40: error: 'DT_N_INST_0_nordic_qspi_nor_P_sck_frequency' undeclared here (not in a function)
2022-04-07 20:13:53 INFO      305 | #define DT_INST(inst, compat) UTIL_CAT(DT_N_INST, DT_DASH(inst, compat))
```


#### Change overview
It seems after #17174 we need a `-DCONF_FILE=prj_no_dfu.conf` configuration based on how CI is set up.

#### Testing
Compiled successfully locally after the change.