### PR TITLE
Bump linux RunTests time limit to 30 min from 15

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,7 +73,7 @@ jobs:
               timeout-minutes: 20
               run: scripts/run_in_build_env.sh "ninja -C ./out"
             - name: Run Tests
-              timeout-minutes: 15
+              timeout-minutes: 30
               run: scripts/tests/gn_tests.sh
             # TODO Log Upload https://github.com/project-chip/connectedhomeip/issues/2227
             # TODO https://github.com/project-chip/connectedhomeip/issues/1512


### PR DESCRIPTION
#### Problem
https://github.com/project-chip/connectedhomeip/runs/5885803407?check_suite_focus=true timed out

#### Change overview
Change timeout from 15 to 30 minutes.

#### Testing
CI will run things again.