### PR TITLE
Add parsing support of access control tags in matter IDL

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -307,6 +307,7 @@ ctypes
 CurrentHue
 CurrentLevel
 CurrentSaturation
+customAcl
 customizations
 cvfJ
 cxx
@@ -417,8 +418,8 @@ DoorLock
 doru
 DOTBR
 DOVERLAY
-DownloadProtocolEnum
 downcasting
+DownloadProtocolEnum
 Doxygen
 dpkg
 dropdown
@@ -923,8 +924,8 @@ OTAProviderIpAddress
 OTAProviderNodeId
 OTAProviderSerialPort
 OTARequesterImpl
-OTARequestorInterface
 OTARequestorDriver
+OTARequestorInterface
 OTARequestorSerialPort
 OTARequestorStorage
 OtaSoftwareUpdateProvider
@@ -1073,6 +1074,7 @@ RequestorCanConsent
 Requestor's
 Requestors
 responder
+RestrictedEvent
 retargeting
 reusability
 reviwed

--- a/scripts/idl/README.md
+++ b/scripts/idl/README.md
@@ -80,7 +80,7 @@ server cluster AccessControl = 31 {
   }
 
   // events default to 'view' privilege however this can be modified
-  info event access(read: manage) Leave = 2 {
+  info event access(read: manage) RestrictedEvent = 3 {
   }
 
   attribute AccessControlEntry acl[] = 0;    // attributes are read-write by default
@@ -114,7 +114,7 @@ server cluster AccessControl = 31 {
 
   // command invokation default to "operate" privilege, however these
   // can be updated as well
-  command access(invoke: administer) Off(): DefaultSuccess = 3;
+  command access(invoke: administer) Off(): DefaultSuccess = 4;
 }
 
 // A client cluster represents something that is used by an app

--- a/scripts/idl/README.md
+++ b/scripts/idl/README.md
@@ -90,7 +90,7 @@ server cluster AccessControl = 31 {
   //
   // access(read: view, write: operate)
   //
-  // These defaults can be overriden to any of view/operate/manage/administer roles.
+  // These defaults can be overridden to any of view/operate/manage/administer roles.
   attribute access(read: manage, write: administer) int32u customAcl = 3;
 
   // attributes may be read-only as well

--- a/scripts/idl/README.md
+++ b/scripts/idl/README.md
@@ -90,7 +90,7 @@ server cluster AccessControl = 31 {
   //
   // access(read: view, write: operate)
   //
-  // These defaults can be overridden to any of view/operate/manage/administer roles.
+  // These defaults can be modified to any of view/operate/manage/administer roles.
   attribute access(read: manage, write: administer) int32u customAcl = 3;
 
   // attributes may be read-only as well

--- a/scripts/idl/README.md
+++ b/scripts/idl/README.md
@@ -86,7 +86,7 @@ server cluster AccessControl = 31 {
   attribute AccessControlEntry acl[] = 0;    // attributes are read-write by default
   attribute ExtensionEntry extension[] = 1;  // and require a (spec defined) number
 
-  // Access control privileges on attributes defaults to:
+  // Access control privileges on attributes default to:
   //
   // access(read: view, write: operate)
   //

--- a/scripts/idl/README.md
+++ b/scripts/idl/README.md
@@ -112,7 +112,7 @@ server cluster AccessControl = 31 {
   command On(): DefaultSuccess = 2;
   command Off(): DefaultSuccess = 3;
 
-  // command invokation default to "operate" privilege, however these
+  // command invocation default to "operate" privilege, however these
   // can be updated as well
   command access(invoke: administer) Off(): DefaultSuccess = 4;
 }

--- a/scripts/idl/README.md
+++ b/scripts/idl/README.md
@@ -70,17 +70,31 @@ server cluster AccessControl = 31 {
     INT32S errorValue = 2;
   }
 
+  // events can be specified with a type (critical/info) and may contain data
+  critical event StartUp = 0 {
+       INT32U softwareVersion = 0;
+  }
+  
+  // no-data events are supported
+  info event Leave = 2 {
+  }
+
+  // events default to 'view' privilege however this can be modified
+  info event access(read: manage) Leave = 2 {
+  }
 
   attribute AccessControlEntry acl[] = 0;    // attributes are read-write by default
   attribute ExtensionEntry extension[] = 1;  // and require a (spec defined) number
 
-  // attributes may be read-only as well
-  // "global" specifies that this attribute number is generally available and
-  // reused across all clusters.
+  // Access control privileges on attributes defaults to:
+  // 
+  // access(read: view, write: operate)
   //
-  // TODO: it is unclear if this helps codegen or readability  so the "global"
-  //       attribute may be removed in the future.
-  readonly global attribute int16u clusterRevision = 65533;
+  // These defaults can be overriden to any of view/operate/manage/administer roles.
+  attribute access(read: manage, write: administer) int32u customAcl = 3;
+
+  // attributes may be read-only as well
+  readonly attribute int16u clusterRevision = 65533;
 
   // Commands have spec-defined numbers which are used for over-the-wire
   // invocation.
@@ -97,6 +111,10 @@ server cluster AccessControl = 31 {
   // Some commands may take no inputs at all
   command On(): DefaultSuccess = 2;
   command Off(): DefaultSuccess = 3;
+
+  // command invokation default to "operate" privilege, however these
+  // can be updated as well
+  command access(invoke: administer) Off(): DefaultSuccess = 3;
 }
 
 // A client cluster represents something that is used by an app

--- a/scripts/idl/README.md
+++ b/scripts/idl/README.md
@@ -74,7 +74,7 @@ server cluster AccessControl = 31 {
   critical event StartUp = 0 {
        INT32U softwareVersion = 0;
   }
-  
+
   // no-data events are supported
   info event Leave = 2 {
   }
@@ -87,7 +87,7 @@ server cluster AccessControl = 31 {
   attribute ExtensionEntry extension[] = 1;  // and require a (spec defined) number
 
   // Access control privileges on attributes defaults to:
-  // 
+  //
   // access(read: view, write: operate)
   //
   // These defaults can be overriden to any of view/operate/manage/administer roles.

--- a/scripts/idl/README.md
+++ b/scripts/idl/README.md
@@ -113,7 +113,7 @@ server cluster AccessControl = 31 {
   command Off(): DefaultSuccess = 3;
 
   // command invocation default to "operate" privilege, however these
-  // can be updated as well
+  // can be modified as well
   command access(invoke: administer) Off(): DefaultSuccess = 4;
 }
 

--- a/scripts/idl/matter_grammar.lark
+++ b/scripts/idl/matter_grammar.lark
@@ -2,12 +2,6 @@ struct: "struct"i id "{" struct_field* "}"
 enum: "enum"i id ":" type "{" constant_entry* "}"
 bitmap: "bitmap"i id ":" type "{" constant_entry* "}"
 
-event: event_priority "event"i id "=" number "{" struct_field* "}"
-
-?event_priority: "critical"i -> critical_priority
-               | "info"i     -> info_priority
-               | "debug"i    -> debug_priority
-
 ?access_privilege: "view"i       -> view_privilege
                  | "operate"i    -> operate_privilege
                  | "manage"i     -> manage_privilege
@@ -15,6 +9,16 @@ event: event_priority "event"i id "=" number "{" struct_field* "}"
 
 ?attribute_access_type: "read"i  -> read_access
                       | "write"i -> write_access
+
+event_access: "access" "(" ("read" ":" access_privilege)? ")"
+
+event_with_access: "event" event_access? id
+
+event: event_priority event_with_access "=" number "{" struct_field* "}"
+
+?event_priority: "critical"i -> critical_priority
+               | "info"i     -> info_priority
+               | "debug"i    -> debug_priority
 
 attribute_access_entry: attribute_access_type ":" access_privilege
 

--- a/scripts/idl/matter_grammar.lark
+++ b/scripts/idl/matter_grammar.lark
@@ -35,7 +35,13 @@ response_struct: "response"i struct
 
 command_attribute: "timed"i -> timed_command
 command_attributes: command_attribute*
-command: command_attributes "command"i id "(" id? ")" ":" id "=" number ";"
+
+
+command_access: "access" "(" ("invoke" ":" access_privilege)? ")"
+
+command_with_access: "command" command_access? id
+
+command: command_attributes command_with_access "(" id? ")" ":" id "=" number ";"
 
 cluster: cluster_side "cluster"i id "=" number "{" (enum|bitmap|event|attribute|struct|request_struct|response_struct|command)* "}"
 ?cluster_side: "server"i -> server_cluster

--- a/scripts/idl/matter_grammar.lark
+++ b/scripts/idl/matter_grammar.lark
@@ -8,7 +8,21 @@ event: event_priority "event"i id "=" number "{" struct_field* "}"
                | "info"i     -> info_priority
                | "debug"i    -> debug_priority
 
-attribute: attribute_tag* "attribute"i struct_field
+?access_privilege: "view"i       -> view_privilege
+                 | "operate"i    -> operate_privilege
+                 | "manage"i     -> manage_privilege
+                 | "administer"i -> administer_privilege
+
+?attribute_access_type: "read"i  -> read_access
+                      | "write"i -> write_access
+
+attribute_access_entry: attribute_access_type ":" access_privilege
+
+attribute_access: "access" "(" (attribute_access_entry ("," attribute_access_entry)* )? ")"
+
+attribute_with_access: attribute_access? struct_field
+
+attribute: attribute_tag* "attribute"i attribute_with_access
 attribute_tag: "readonly"i -> attr_readonly
              | "nosubscribe"i -> attr_nosubscribe
 

--- a/scripts/idl/matter_idl_parser.py
+++ b/scripts/idl/matter_idl_parser.py
@@ -152,8 +152,23 @@ class MatterIdlTransformer(Transformer):
         return Command(
             attributes=args[0], name=args[1], input_param=param_in, output_param=args[-2], code=args[-1])
 
+    def event_access(self, privilege):
+        return privilege[0]
+
+    def event_with_access(self, args):
+        # Arguments
+        #   - optional access for read
+        #   - event identifier (name)
+        init_args = {
+            "name": args[-1]
+        }
+        if len(args) > 1:
+            init_args["readacl"] = args[0]
+
+        return init_args
+
     def event(self, args):
-        return Event(priority=args[0], name=args[1], code=args[2], fields=args[3:], )
+        return Event(priority=args[0], code=args[2], fields=args[3:], **args[1])
 
     def view_privilege(self, args):
         return AccessPrivilege.VIEW

--- a/scripts/idl/matter_idl_parser.py
+++ b/scripts/idl/matter_idl_parser.py
@@ -142,6 +142,21 @@ class MatterIdlTransformer(Transformer):
     def client_cluster(self, _):
         return ClusterSide.CLIENT
 
+    def command_access(self, privilege):
+        return privilege[0]
+
+    def command_with_access(self, args):
+        # Arguments
+        #   - optional access for invoke
+        #   - event identifier (name)
+        init_args = {
+            "name": args[-1]
+        }
+        if len(args) > 1:
+            init_args["invokeacl"] = args[0]
+
+        return init_args
+
     def command(self, args):
         # A command has 4 arguments if no input or
         # 5 arguments if input parameter is available
@@ -150,7 +165,7 @@ class MatterIdlTransformer(Transformer):
             param_in = args[2]
 
         return Command(
-            attributes=args[0], name=args[1], input_param=param_in, output_param=args[-2], code=args[-1])
+            attributes=args[0], input_param=param_in, output_param=args[-2], code=args[-1], **args[1])
 
     def event_access(self, privilege):
         return privilege[0]

--- a/scripts/idl/matter_idl_parser.py
+++ b/scripts/idl/matter_idl_parser.py
@@ -197,12 +197,11 @@ class MatterIdlTransformer(Transformer):
 
         return (args[-1], acl)
 
-
     def attribute(self, args):
         # Input arguments are:
         #   -  tags (0 or more)
         #   -  attribute_with_access (i.e. pair of definition and acl arguments)
-        tags       = set(args[:-1])
+        tags = set(args[:-1])
         (definition, acl) = args[-1]
 
         # until we support write only (and need a bit of a reshuffle)
@@ -211,7 +210,6 @@ class MatterIdlTransformer(Transformer):
         if AttributeTag.READABLE not in tags:
             tags.add(AttributeTag.READABLE)
             tags.add(AttributeTag.WRITABLE)
-
 
         return Attribute(definition=definition, tags=tags, **acl)
 

--- a/scripts/idl/matter_idl_types.py
+++ b/scripts/idl/matter_idl_types.py
@@ -140,6 +140,7 @@ class Command:
     input_param: Optional[str]
     output_param: str
     attributes: Set[CommandAttribute] = field(default_factory=set)
+    invokeacl: AccessPrivilege = AccessPrivilege.OPERATE
 
     @property
     def is_timed_invoke(self):

--- a/scripts/idl/matter_idl_types.py
+++ b/scripts/idl/matter_idl_types.py
@@ -39,15 +39,18 @@ class EndpointContentType(enum.Enum):
     SERVER_CLUSTER = enum.auto()
     CLIENT_BINDING = enum.auto()
 
+
 class AccessPrivilege(enum.Enum):
     VIEW = enum.auto()
     OPERATE = enum.auto()
     MANAGE = enum.auto()
     ADMINISTER = enum.auto()
 
+
 class AttributeOperation(enum.Enum):
     READ = enum.auto()
     WRITE = enum.auto()
+
 
 @dataclass
 class DataType:

--- a/scripts/idl/matter_idl_types.py
+++ b/scripts/idl/matter_idl_types.py
@@ -39,6 +39,15 @@ class EndpointContentType(enum.Enum):
     SERVER_CLUSTER = enum.auto()
     CLIENT_BINDING = enum.auto()
 
+class AccessPrivilege(enum.Enum):
+    VIEW = enum.auto()
+    OPERATE = enum.auto()
+    MANAGE = enum.auto()
+    ADMINISTER = enum.auto()
+
+class AttributeOperation(enum.Enum):
+    READ = enum.auto()
+    WRITE = enum.auto()
 
 @dataclass
 class DataType:
@@ -69,6 +78,8 @@ class Field:
 class Attribute:
     definition: Field
     tags: Set[AttributeTag] = field(default_factory=set)
+    readacl: AccessPrivilege = AccessPrivilege.VIEW
+    writeacl: AccessPrivilege = AccessPrivilege.OPERATE
 
     @property
     def is_readable(self):

--- a/scripts/idl/matter_idl_types.py
+++ b/scripts/idl/matter_idl_types.py
@@ -110,6 +110,7 @@ class Event:
     name: str
     code: int
     fields: List[Field]
+    readacl: AccessPrivilege = AccessPrivilege.VIEW
 
 
 @dataclass

--- a/scripts/idl/test_matter_idl_parser.py
+++ b/scripts/idl/test_matter_idl_parser.py
@@ -285,6 +285,28 @@ class TestParser(unittest.TestCase):
                     ])])
         self.assertEqual(actual, expected)
 
+    def test_cluster_event_acl(self):
+        actual = parseText("""
+            client cluster EventTester = 0x123 {
+               info event Hello = 1 {}
+               debug event access(read: manage) GoodBye = 2 {}
+               debug event access(read: administer) AdminEvent = 3 {}
+            }
+        """)
+        expected = Idl(clusters=[
+            Cluster(side=ClusterSide.CLIENT,
+                    name="EventTester",
+                    code=0x123,
+                    events=[
+                        Event(priority=EventPriority.INFO, readacl=AccessPrivilege.VIEW,
+                              name="Hello", code=1, fields=[]),
+                        Event(priority=EventPriority.DEBUG, readacl=AccessPrivilege.MANAGE,
+                              name="GoodBye", code=2, fields=[]),
+                        Event(priority=EventPriority.DEBUG, readacl=AccessPrivilege.ADMINISTER,
+                              name="AdminEvent", code=3, fields=[]),
+                    ])])
+        self.assertEqual(actual, expected)
+
     def test_multiple_clusters(self):
         actual = parseText("""
             server cluster A = 1 {}

--- a/scripts/idl/test_matter_idl_parser.py
+++ b/scripts/idl/test_matter_idl_parser.py
@@ -137,6 +137,49 @@ class TestParser(unittest.TestCase):
                     )])
         self.assertEqual(actual, expected)
 
+    def test_attribute_access(self):
+        actual = parseText("""
+            server cluster MyCluster = 1 {
+                attribute                                      int8s attr1 = 1;
+                attribute access()                             int8s attr2 = 2;
+                attribute access(read: manage)                 int8s attr3 = 3;
+                attribute access(write: administer)            int8s attr4 = 4;
+                attribute access(read: operate, write: manage) int8s attr5 = 5;
+            }
+        """)
+
+        expected = Idl(clusters=[
+            Cluster(side=ClusterSide.SERVER,
+                    name="MyCluster",
+                    code=1,
+                    attributes=[
+                        Attribute(tags=set([AttributeTag.READABLE, AttributeTag.WRITABLE]), definition=Field(
+                            data_type=DataType(name="int8s"), code=1, name="attr1"),
+                            readacl = AccessPrivilege.VIEW,
+                            writeacl = AccessPrivilege.OPERATE
+                        ),
+                        Attribute(tags=set([AttributeTag.READABLE, AttributeTag.WRITABLE]), definition=Field(
+                            data_type=DataType(name="int8s"), code=2, name="attr2"),
+                            readacl = AccessPrivilege.VIEW,
+                            writeacl = AccessPrivilege.OPERATE
+                            ),
+                        Attribute(tags=set([AttributeTag.READABLE, AttributeTag.WRITABLE]), definition=Field(
+                            data_type=DataType(name="int8s"), code=3, name="attr3"),
+                            readacl = AccessPrivilege.MANAGE
+                        ),
+                        Attribute(tags=set([AttributeTag.READABLE, AttributeTag.WRITABLE]), definition=Field(
+                            data_type=DataType(name="int8s"), code=4, name="attr4"),
+                            writeacl = AccessPrivilege.ADMINISTER
+                        ),
+                        Attribute(tags=set([AttributeTag.READABLE, AttributeTag.WRITABLE]), definition=Field(
+                            data_type=DataType(name="int8s"), code=5, name="attr5"),
+                            readacl = AccessPrivilege.OPERATE,
+                            writeacl = AccessPrivilege.MANAGE
+                        ),
+                    ]
+                    )])
+        self.assertEqual(actual, expected)
+
     def test_cluster_commands(self):
         actual = parseText("""
             server cluster WithCommands = 1 {

--- a/scripts/idl/test_matter_idl_parser.py
+++ b/scripts/idl/test_matter_idl_parser.py
@@ -155,26 +155,26 @@ class TestParser(unittest.TestCase):
                     attributes=[
                         Attribute(tags=set([AttributeTag.READABLE, AttributeTag.WRITABLE]), definition=Field(
                             data_type=DataType(name="int8s"), code=1, name="attr1"),
-                            readacl = AccessPrivilege.VIEW,
-                            writeacl = AccessPrivilege.OPERATE
+                            readacl=AccessPrivilege.VIEW,
+                            writeacl=AccessPrivilege.OPERATE
                         ),
                         Attribute(tags=set([AttributeTag.READABLE, AttributeTag.WRITABLE]), definition=Field(
                             data_type=DataType(name="int8s"), code=2, name="attr2"),
-                            readacl = AccessPrivilege.VIEW,
-                            writeacl = AccessPrivilege.OPERATE
-                            ),
+                            readacl=AccessPrivilege.VIEW,
+                            writeacl=AccessPrivilege.OPERATE
+                        ),
                         Attribute(tags=set([AttributeTag.READABLE, AttributeTag.WRITABLE]), definition=Field(
                             data_type=DataType(name="int8s"), code=3, name="attr3"),
-                            readacl = AccessPrivilege.MANAGE
+                            readacl=AccessPrivilege.MANAGE
                         ),
                         Attribute(tags=set([AttributeTag.READABLE, AttributeTag.WRITABLE]), definition=Field(
                             data_type=DataType(name="int8s"), code=4, name="attr4"),
-                            writeacl = AccessPrivilege.ADMINISTER
+                            writeacl=AccessPrivilege.ADMINISTER
                         ),
                         Attribute(tags=set([AttributeTag.READABLE, AttributeTag.WRITABLE]), definition=Field(
                             data_type=DataType(name="int8s"), code=5, name="attr5"),
-                            readacl = AccessPrivilege.OPERATE,
-                            writeacl = AccessPrivilege.MANAGE
+                            readacl=AccessPrivilege.OPERATE,
+                            writeacl=AccessPrivilege.MANAGE
                         ),
                     ]
                     )])


### PR DESCRIPTION
#### Problem
Access control tags are part of matter spec and we should have them in IDL (easier to review for correctess once we add codegen to it).

#### Change overview
Support a `access(read: view)` and similar tags for events, attributes and commands.

Added documentation, parsing support and unit tests.

#### Testing
Unit tests added.