### PR TITLE
[OTA] Validate various error ImageURI cases

### DIFF
--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -152,7 +152,29 @@ void DefaultOTARequestor::OnQueryImageResponse(void * context, const QueryImageR
 
         if (err != CHIP_NO_ERROR)
         {
+            ChipLogError(SoftwareUpdate, "QueryImageResponse contains invalid fields: %" CHIP_ERROR_FORMAT, err.Format());
             requestorCore->RecordErrorUpdateState(UpdateFailureState::kQuerying, err);
+            return;
+        }
+
+        // This should never happen since receiving a response implies that a CASE session had previously been established with a
+        // valid provider
+        if (!requestorCore->mProviderLocation.HasValue())
+        {
+            ChipLogError(SoftwareUpdate, "No provider location set");
+            requestorCore->RecordErrorUpdateState(UpdateFailureState::kQuerying, CHIP_ERROR_INCORRECT_STATE);
+            return;
+        }
+
+        // The Operational Node ID in the host field SHALL match the NodeID of the OTA Provider responding with the
+        // QueryImageResponse
+        if (update.nodeId != requestorCore->mProviderLocation.Value().providerNodeID)
+        {
+            ChipLogError(SoftwareUpdate,
+                         "The ImageURI provider node 0x" ChipLogFormatX64
+                         " does not match the QueryImageResponse provider node 0x" ChipLogFormatX64,
+                         ChipLogValueX64(update.nodeId), ChipLogValueX64(requestorCore->mProviderLocation.Value().providerNodeID));
+            requestorCore->RecordErrorUpdateState(UpdateFailureState::kQuerying, CHIP_ERROR_WRONG_NODE_ID);
             return;
         }
 


### PR DESCRIPTION
#### Problem
There are some validations missing relating to the ImageURI field in the QueryImageResponse received.

#### Change overview
- Be a bit more verbose if an error is encountered during ImageURI parsing
- For v1, the provider node ID in the ImageURI field must match the the provider sending the QueryImageResponse so make sure this case is caught

#### Testing
- Verified that various invalid ImageURI values results are caught and reported
- Verified that when an invalid ImageURI is caught, the state transitions back to idle and is ready for the next query