### PR TITLE
[nrfconnect] Fixed obsolete information in docs

### DIFF
--- a/examples/all-clusters-app/nrfconnect/README.md
+++ b/examples/all-clusters-app/nrfconnect/README.md
@@ -363,7 +363,7 @@ To make them persistent, save the configuration options in the `prj.conf` file.
 
 The example uses different configuration files depending on the supported
 features. Configuration files are provided for different build types and they
-are located in the `configuration/build-target` directory.
+are located in the application root directory.
 
 The `prj.conf` file represents a debug build type. Other build types are covered
 by dedicated files with the build type added as a suffix to the prj part, as per

--- a/examples/light-switch-app/nrfconnect/README.md
+++ b/examples/light-switch-app/nrfconnect/README.md
@@ -540,7 +540,7 @@ To make them persistent, save the configuration options in the `prj.conf` file.
 
 The example uses different configuration files depending on the supported
 features. Configuration files are provided for different build types and they
-are located in the `configuration/build-target` directory.
+are located in the application root directory.
 
 The `prj.conf` file represents a debug build type. Other build types are covered
 by dedicated files with the build type added as a suffix to the prj part, as per

--- a/examples/lighting-app/nrfconnect/README.md
+++ b/examples/lighting-app/nrfconnect/README.md
@@ -482,7 +482,7 @@ To make them persistent, save the configuration options in the `prj.conf` file.
 
 The example uses different configuration files depending on the supported
 features. Configuration files are provided for different build types and they
-are located in the `configuration/build-target` directory.
+are located in the application root directory.
 
 The `prj.conf` file represents a debug build type. Other build types are covered
 by dedicated files with the build type added as a suffix to the prj part, as per

--- a/examples/lock-app/nrfconnect/README.md
+++ b/examples/lock-app/nrfconnect/README.md
@@ -469,7 +469,7 @@ To make them persistent, save the configuration options in the `prj.conf` file.
 
 The example uses different configuration files depending on the supported
 features. Configuration files are provided for different build types and they
-are located in the `configuration/build-target` directory.
+are located in the application root directory.
 
 The `prj.conf` file represents a debug build type. Other build types are covered
 by dedicated files with the build type added as a suffix to the prj part, as per

--- a/examples/pump-app/nrfconnect/README.md
+++ b/examples/pump-app/nrfconnect/README.md
@@ -449,7 +449,7 @@ To make them persistent, save the configuration options in the `prj.conf` file.
 
 The example uses different configuration files depending on the supported
 features. Configuration files are provided for different build types and they
-are located in the `configuration/build-target` directory.
+are located in the application root directory.
 
 The `prj.conf` file represents a debug build type. Other build types are covered
 by dedicated files with the build type added as a suffix to the prj part, as per

--- a/examples/pump-controller-app/nrfconnect/README.md
+++ b/examples/pump-controller-app/nrfconnect/README.md
@@ -449,7 +449,7 @@ To make them persistent, save the configuration options in the `prj.conf` file.
 
 The example uses different configuration files depending on the supported
 features. Configuration files are provided for different build types and they
-are located in the `configuration/build-target` directory.
+are located in the application root directory.
 
 The `prj.conf` file represents a debug build type. Other build types are covered
 by dedicated files with the build type added as a suffix to the prj part, as per


### PR DESCRIPTION
#### Problem
Configuration files for nrfconnect were moved and the documentation
points to previous location.

#### Change overview
Updated docs information.

#### Testing
Docs change only, so no testing required.
