### PR TITLE
[nrfconnect] Added support for updating network core using new DFU Target library.

### DIFF
--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-nrf-platform:0.5.58
+            image: connectedhomeip/chip-build-nrf-platform:0.5.64
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/config/nrfconnect/.nrfconnect-recommended-revision
+++ b/config/nrfconnect/.nrfconnect-recommended-revision
@@ -1,1 +1,1 @@
-v1.9.1
+5ea8f7fa91d7315fcc6cd9eb3aa74f9640d0abac

--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.5.58"
+    - name: "connectedhomeip/chip-build-vscode:0.5.64"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -12,7 +12,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.58"
+    - name: "connectedhomeip/chip-build-vscode:0.5.64"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.5.58"
+    - name: "connectedhomeip/chip-build-vscode:0.5.64"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -12,7 +12,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.58"
+    - name: "connectedhomeip/chip-build-vscode:0.5.64"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -28,7 +28,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.58"
+    - name: "connectedhomeip/chip-build-vscode:0.5.64"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -45,7 +45,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.58"
+    - name: "connectedhomeip/chip-build-vscode:0.5.64"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -62,7 +62,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.58"
+    - name: "connectedhomeip/chip-build-vscode:0.5.64"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -79,7 +79,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.58"
+    - name: "connectedhomeip/chip-build-vscode:0.5.64"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.h
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.h
@@ -34,6 +34,13 @@ public:
 
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; };
 
+    struct OTAImage
+    {
+        OTAImageContentHeader::FileInfo * mFileInfo;
+        uint8_t mIndex;
+        uint64_t mCurrentOffset;
+    };
+
     CHIP_ERROR PrepareDownload() override;
     CHIP_ERROR Finalize() override;
     CHIP_ERROR Abort() override;
@@ -50,6 +57,8 @@ private:
     OTAImageHeaderParser mHeaderParser;
     OTAImageContentHeaderParser mContentHeaderParser;
     uint8_t mBuffer[kBufferSize];
+    OTAImageContentHeader mContentHeader;
+    OTAImage mCurrentImage;
 };
 
 class ExtFlashHandler


### PR DESCRIPTION
**Problem**

Old DFU Target API did not allow to perform a firmware update for app core and net core simultaneously.
DFU Target API needs to be updated and utilized in the OTA process for nrfconnect boards.

**Change overview**
- Updated NCS revision to cc0412169 to get new DFU Target revision.
- Utilized new DFU Target API.
- Handled both application and network core image swap for NRF5340.

**Testing**
Tested manually on NRF5340DK
CI tested
