### PR TITLE
Allow issuing model commands via PASE

### DIFF
--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -582,22 +582,26 @@ features, read the following guide:
 
 ## Using the Client via PASE
 
-For testing chip-tool can stop after setting up a PASE session. Model commands
-can be issued via PASE as well.
+For testing, chip-tool can stop after setting up a PASE session and model
+commands can be issued via PASE.
+
+Note: You cannot rely on PASE forever: on PASE establishment, a fail-safe timer
+will be set, which will cause eventual reset of state. Also, the commissioning
+window can only be open for 15 minutes at a time.
 
 ```bash
 # Start chip-tool interactively
 ./out/debug/chip-tool interactive start
 
 # Pair PASE only
-pairing qrcode-paseonly 7676777 MT:6FCJ142C00X50648G00
+pairing qrcode-paseonly ${NODE_ID} ${QR_CODE}
 
 # Issue a command via PASE
-onoff toggle 7676777 1 --via-pase 1
+onoff toggle ${NODE_ID} 1 --via-pase 1
 
 # Also uses PASE
-onoff toggle 7676777 1
+onoff toggle ${NODE_ID} 1
 
 # Switch back to CASE (fails if paseonly)
-onoff toggle 7676777 1 --via-pase 1
+onoff toggle ${NODE_ID} 1 --via-pase 0
 ```

--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -583,7 +583,7 @@ features, read the following guide:
 ## Using the Client via PASE
 
 For testing chip-tool can stop after setting up a PASE session. Model commands
-can be issues via PASE as well.
+can be issued via PASE as well.
 
 ```bash
 # Start chip-tool interactively

--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -579,3 +579,25 @@ To learn more about the tool, how to build it, use its commands and advanced
 features, read the following guide:
 
 -   [Working with the CHIP Tool](https://github.com/project-chip/connectedhomeip/tree/master/docs/guides/chip_tool_guide.md)
+
+## Using the Client via PASE
+
+For testing chip-tool can stop after setting up a PASE session. Model commands
+can be issues via PASE as well.
+
+```bash
+# Start chip-tool interactively
+./out/debug/chip-tool interactive start
+
+# Pair PASE only
+pairing qrcode-paseonly 7676777 MT:6FCJ142C00X50648G00
+
+# Issue a command via PASE
+onoff toggle 7676777 1 --via-pase 1
+
+# Also uses PASE
+onoff toggle 7676777 1
+
+# Switch back to CASE (fails if paseonly)
+onoff toggle 7676777 1 --via-pase 1
+```

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -38,8 +38,12 @@ CHIP_ERROR ModelCommand::RunCommand()
     if (mViaPase.ValueOr(0) == 1)
     {
         ChipLogProgress(chipTool, "Sending command via PASE to node 0x%" PRIx64, mNodeId);
-        CommissioneeDeviceProxy * device = CurrentCommissioner().FindCommissioneeDevice(mNodeId);
-        return this->SendCommand(device, this->mEndPointId);
+        CommissioneeDeviceProxy * commissioneeDevice = nullptr;
+        CHIP_ERROR err = CurrentCommissioner().GetDeviceBeingCommissioned(mNodeId, &commissioneeDevice);
+        VerifyOrReturnError(CHIP_NO_ERROR == err, err);
+        VerifyOrReturnError(commissioneeDevice != nullptr, CHIP_ERROR_NOT_CONNECTED);
+
+        return this->SendCommand(commissioneeDevice, this->mEndPointId);
     }
     else
     {

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -50,7 +50,7 @@ CHIP_ERROR ModelCommand::RunCommand()
     return CurrentCommissioner().GetConnectedDevice(mNodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
 }
 
-void ModelCommand::OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device)
+void ModelCommand::OnDeviceConnectedFn(void * context, OperationalDeviceProxy * device)
 {
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectedFn: context is null"));

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -35,11 +35,14 @@ CHIP_ERROR ModelCommand::RunCommand()
         return SendGroupCommand(GroupIdFromNodeId(mNodeId), fabricIndex);
     }
 
-    if (mViaPase.ValueOr(0) == 1) {
+    if (mViaPase.ValueOr(0) == 1)
+    {
         ChipLogProgress(chipTool, "Sending command via PASE to node 0x%" PRIx64, mNodeId);
         CommissioneeDeviceProxy * device = CurrentCommissioner().FindCommissioneeDevice(mNodeId);
         return this->SendCommand(device, this->mEndPointId);
-    } else {
+    }
+    else
+    {
         ChipLogProgress(chipTool, "Sending command to node 0x%" PRIx64, mNodeId);
         return CurrentCommissioner().GetConnectedDevice(mNodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
     }

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -45,11 +45,9 @@ CHIP_ERROR ModelCommand::RunCommand()
 
         return this->SendCommand(commissioneeDevice, this->mEndPointId);
     }
-    else
-    {
-        ChipLogProgress(chipTool, "Sending command to node 0x%" PRIx64, mNodeId);
-        return CurrentCommissioner().GetConnectedDevice(mNodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
-    }
+
+    ChipLogProgress(chipTool, "Sending command to node 0x%" PRIx64, mNodeId);
+    return CurrentCommissioner().GetConnectedDevice(mNodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
 }
 
 void ModelCommand::OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device)

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -25,7 +25,7 @@
 class ModelCommand : public CHIPCommand
 {
 public:
-    using ChipDevice = ::chip::OperationalDeviceProxy;
+    using ChipDevice = ::chip::DeviceProxy;
 
     ModelCommand(const char * commandName, CredentialIssuerCommands * credsIssuerConfig) :
         CHIPCommand(commandName, credsIssuerConfig), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
@@ -56,7 +56,7 @@ private:
     chip::NodeId mNodeId;
     std::vector<chip::EndpointId> mEndPointId;
 
-    static void OnDeviceConnectedFn(void * context, ChipDevice * device);
+    static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -66,6 +66,7 @@ public:
         AddArgument("trace_log", 0, 1, &mTraceLog);
 #endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
         AddArgument("ble-adapter", 0, UINT64_MAX, &mBleAdapterId);
+        AddArgument("via-pase", 0, 1, &mViaPase);
     }
 
     /////////// Command Interface /////////
@@ -105,6 +106,9 @@ protected:
     // The default commissioner instance name is "alpha", but it can be overridden by passing
     // --identity "instance name" when running a command.
     ChipDeviceCommissioner & CurrentCommissioner();
+
+protected:
+    chip::Optional<uint16_t> mViaPase;
 
 private:
     CHIP_ERROR MaybeSetUpStack();

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -95,8 +95,7 @@ CHIP_ERROR PairingCommand::PaseWithCode(NodeId remoteId)
     mSetupPINCode  = payload.setUpPINCode;
     mDiscriminator = payload.discriminator;
 
-    RendezvousParameters rendezvousParams =
-        RendezvousParameters().SetSetupPINCode(mSetupPINCode).SetDiscriminator(mDiscriminator);
+    RendezvousParameters rendezvousParams = RendezvousParameters().SetSetupPINCode(mSetupPINCode).SetDiscriminator(mDiscriminator);
     return CurrentCommissioner().EstablishPASEConnection(remoteId, rendezvousParams);
 }
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -96,7 +96,7 @@ CHIP_ERROR PairingCommand::PaseWithCode(NodeId remoteId)
     mDiscriminator = payload.discriminator;
 
     RendezvousParameters rendezvousParams =
-        RendezvousParameters().SetSetupPINCode(mSetupPINCode).SetDiscriminator(mDiscriminator).SetPeerAddress(PeerAddress::BLE());
+        RendezvousParameters().SetSetupPINCode(mSetupPINCode).SetDiscriminator(mDiscriminator);
     return CurrentCommissioner().EstablishPASEConnection(remoteId, rendezvousParams);
 }
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -89,7 +89,17 @@ CommissioningParameters PairingCommand::GetCommissioningParameters()
 
 CHIP_ERROR PairingCommand::PaseWithCode(NodeId remoteId)
 {
-    return CurrentCommissioner().EstablishPASEConnection(remoteId, mOnboardingPayload);
+    chip::SetupPayload payload;
+
+    QRCodeSetupPayloadParser(mOnboardingPayload).populatePayload(payload);
+    mSetupPINCode = payload.setUpPINCode;
+    mDiscriminator = payload.discriminator;
+
+    RendezvousParameters rendezvousParams = RendezvousParameters()
+                                                .SetSetupPINCode(mSetupPINCode)
+                                                .SetDiscriminator(mDiscriminator)
+                                                .SetPeerAddress(PeerAddress::BLE());
+    return CurrentCommissioner().EstablishPASEConnection(remoteId, rendezvousParams);
 }
 
 CHIP_ERROR PairingCommand::PairWithCode(NodeId remoteId)

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -92,13 +92,11 @@ CHIP_ERROR PairingCommand::PaseWithCode(NodeId remoteId)
     chip::SetupPayload payload;
 
     QRCodeSetupPayloadParser(mOnboardingPayload).populatePayload(payload);
-    mSetupPINCode = payload.setUpPINCode;
+    mSetupPINCode  = payload.setUpPINCode;
     mDiscriminator = payload.discriminator;
 
-    RendezvousParameters rendezvousParams = RendezvousParameters()
-                                                .SetSetupPINCode(mSetupPINCode)
-                                                .SetDiscriminator(mDiscriminator)
-                                                .SetPeerAddress(PeerAddress::BLE());
+    RendezvousParameters rendezvousParams =
+        RendezvousParameters().SetSetupPINCode(mSetupPINCode).SetDiscriminator(mDiscriminator).SetPeerAddress(PeerAddress::BLE());
     return CurrentCommissioner().EstablishPASEConnection(remoteId, rendezvousParams);
 }
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -712,7 +712,6 @@ private:
 
     void HandleAttestationResult(CHIP_ERROR err);
 
-public:
     CommissioneeDeviceProxy * FindCommissioneeDevice(const SessionHandle & session);
     CommissioneeDeviceProxy * FindCommissioneeDevice(NodeId id);
     CommissioneeDeviceProxy * FindCommissioneeDevice(const Transport::PeerAddress & peerAddress);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -712,6 +712,7 @@ private:
 
     void HandleAttestationResult(CHIP_ERROR err);
 
+public:
     CommissioneeDeviceProxy * FindCommissioneeDevice(const SessionHandle & session);
     CommissioneeDeviceProxy * FindCommissioneeDevice(NodeId id);
     CommissioneeDeviceProxy * FindCommissioneeDevice(const Transport::PeerAddress & peerAddress);


### PR DESCRIPTION
#### Problem

chip-tool allows to only create a PASE session (e.g. via BLE).

chip-tool does now allow to issue commands via PASE, although the spec allows it and chip-tool auto-commissioner is using it internally.

#### Change overview

* Add an option `--via-pase 1` which allows to send commands via PASE.
* Documentation for PASE only.
* changes protection level of FindCommissioneeDevice (needs to be discussed)

#### Testing

How was this tested? (at least one bullet point required)
* Manually on POSIX against nRF, as described in the README.md
