### PR TITLE
[Server] Ensure that the interface id that is passed as a parameter i…

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -207,6 +207,10 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     SuccessOrExit(err);
 #endif
 
+    app::DnssdServer::Instance().SetSecuredPort(mOperationalServicePort);
+    app::DnssdServer::Instance().SetUnsecuredPort(mUserDirectedCommissioningPort);
+    app::DnssdServer::Instance().SetInterfaceId(mInterfaceId);
+
     if (GetFabricTable().FabricCount() != 0)
     {
         // The device is already commissioned, proactively disable BLE advertisement.
@@ -222,10 +226,6 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
         SuccessOrExit(err = mCommissioningWindowManager.OpenBasicCommissioningWindow());
 #endif
     }
-
-    app::DnssdServer::Instance().SetSecuredPort(mOperationalServicePort);
-    app::DnssdServer::Instance().SetUnsecuredPort(mUserDirectedCommissioningPort);
-    app::DnssdServer::Instance().SetInterfaceId(mInterfaceId);
 
     // TODO @bzbarsky-apple @cecille Move to examples
     // ESP32 and Mbed OS examples have a custom logic for enabling DNS-SD


### PR DESCRIPTION
…s used when auto pairing is enabled

#### Problem

The `--interface-id` option is not used when the application starts because open commissioning window is called before the value is retrieved from the available options.

#### Change overview
 * Move the code to read the value passed as a parameter just before auto-pairing is started.
