### PR TITLE
Increase some build timeouts on linux

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -177,7 +177,7 @@ jobs:
                        check \
                     "
             - name: Run Tests with sanitizers
-              timeout-minutes: 30
+              timeout-minutes: 60
               env:
                   LSAN_OPTIONS: detect_leaks=0
               run: |
@@ -194,7 +194,7 @@ jobs:
                         scripts/tests/gn_tests.sh
                     done
             - name: Build using build_examples.py
-              timeout-minutes: 40
+              timeout-minutes: 60
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --no-log-timestamps \


### PR DESCRIPTION
#### Problem
Build with sanitizers times out:

https://github.com/project-chip/connectedhomeip/runs/5967847184?check_suite_focus=true


#### Change overview
Increase timeouts for both this and the build_examples.py just in case

#### Testing
N/A - timeout change only.