### PR TITLE
[Darwin] Keep resolving ips even when the first mdns result has been …

### DIFF
--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -531,9 +531,10 @@ static void OnResolve(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t inter
     GetAddrInfo(sdCtx->context, sdCtx->callback, interfaceId, sdCtx->addressType, sdCtx->name, hostname, ntohs(port), txtLen,
                 txtRecord);
 
-    // TODO: If flags & kDNSServiceFlagsMoreComing should we keep waiting to see
-    // what else we resolve instead of calling Remove() here?
-    MdnsContexts::GetInstance().Remove(sdCtx);
+    if (!(flags & kDNSServiceFlagsMoreComing))
+    {
+        MdnsContexts::GetInstance().Remove(sdCtx);
+    }
 }
 
 static CHIP_ERROR Resolve(void * context, DnssdResolveCallback callback, uint32_t interfaceId,


### PR DESCRIPTION
…received

#### Problem

Darwin code terminates early the mdns ip resolution process. But if there is stall mdns broadcast on the network from some previous interfaces it may result into the correct ip not beeing retrieved.

#### Change overview
 * Keeps trying to resolve ips has long has some mdns results are coming in.

#### Testing
It was tested locally with the help of the `interface-id` on top of a modified version of the `all-clusters-app` that does not map the hostname to the hostname of the computer is it running onto .