### PR TITLE
[ci] Checkout only relevant submodules

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,10 +52,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform linux
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
@@ -126,7 +127,6 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
@@ -135,6 +135,8 @@ jobs:
             #   uses: github/codeql-action/init@v1
             #   with:
             #      languages: "cpp"
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform linux
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
@@ -255,10 +257,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform linux
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
@@ -286,7 +289,6 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
@@ -295,6 +297,8 @@ jobs:
             #  uses: github/codeql-action/init@v1
             #  with:
             #     languages: "cpp"
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform darwin
             - name: Setup Environment
               run: brew install openssl pkg-config
             - name: Try to ensure the directory for diagnostic log collection exists

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -53,10 +53,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform linux
 
             - name: Get cirque cache key
               id: cirque-key

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -37,10 +37,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform darwin
             - name: Setup Environment
               run: brew install openssl pkg-config python@3.9
             - name: Fix pkgconfig link

--- a/.github/workflows/examples-ameba.yaml
+++ b/.github/workflows/examples-ameba.yaml
@@ -41,9 +41,10 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform ameba
             - name: Build example Ameba All Clusters App
               run: scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target-glob 'ameba-*' build"

--- a/.github/workflows/examples-cc13x2x7_26x2x7.yaml
+++ b/.github/workflows/examples-cc13x2x7_26x2x7.yaml
@@ -43,10 +43,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform cc13x2_26x2
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}
               env:

--- a/.github/workflows/examples-cyw30739.yaml
+++ b/.github/workflows/examples-cyw30739.yaml
@@ -40,10 +40,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform cyw30739
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -44,10 +44,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform efr32
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -42,10 +42,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform esp32
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}
@@ -127,10 +128,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform esp32
 
             - name: Bootstrap
               timeout-minutes: 10

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -40,10 +40,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform p6
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -43,10 +43,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform k32w0
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -41,10 +41,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform linux
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-linux-imx.yaml
+++ b/.github/workflows/examples-linux-imx.yaml
@@ -39,10 +39,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform linux
 
             - name: Build App
               timeout-minutes: 30

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -44,10 +44,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform linux
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -47,10 +47,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform mbed
 
             - name: Detect changed paths
               uses: dorny/paths-filter@v2

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -44,10 +44,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform nrfconnect
             - name: Detect changed paths
               uses: dorny/paths-filter@v2
               id: changed_paths

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -43,10 +43,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform qpg
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -42,10 +42,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform telink
 
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -44,9 +44,10 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform tizen
             - name: Build example Tizen lighting app
               run: scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target-glob 'tizen-*' build"

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -44,10 +44,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform esp32
             - name: Bootstrap
               timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -44,10 +44,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform android
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,10 +53,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform linux
             - name: Try to ensure the directories for core dumping exist and we
                   can write them.
               run: |
@@ -136,10 +137,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform darwin
             - name: Setup Environment
               # coreutils for stdbuf
               run: brew install openssl pkg-config coreutils
@@ -240,8 +242,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
-              with:
-                  submodules: true
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform linux
             - name:
                   Try to ensure the directories for core dumping exist and we
                   can write them.
@@ -311,8 +313,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
-              with:
-                  submodules: true
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform darwin
             - name: Setup Environment
               # coreutils for stdbuf
               run: brew install openssl pkg-config coreutils

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -48,10 +48,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform linux
             - name: Bootstrap
               timeout-minutes: 10
               run: |

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -41,10 +41,11 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform linux
             - name: Setup ZAP
               timeout-minutes: 10
               run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,6 +26,7 @@
 	path = examples/common/m5stack-tft/repo
 	url = https://github.com/jeremyjh/ESP32_TFT_library.git
 	branch  = master
+	platforms = esp32
 [submodule "pigweed"]
 	path = third_party/pigweed/repo
 	url = https://github.com/google/pigweed.git
@@ -38,14 +39,17 @@
 	path = third_party/ot-br-posix/repo
 	url = https://github.com/openthread/ot-br-posix.git
 	branch  = main
+	platforms = linux
 [submodule "bluez"]
 	path = third_party/bluez/repo
 	url = https://github.com/bluez/bluez.git
 	branch  = master
+	platforms = linux
 [submodule "cirque"]
 	path = third_party/cirque/repo
 	url = https://github.com/openweave/cirque.git
 	branch  = master
+	platforms = linux
 [submodule "nanopb"]
 	path = third_party/nanopb/repo
 	url = https://github.com/nanopb/nanopb.git
@@ -54,6 +58,7 @@
 	path = third_party/qpg_sdk/repo
 	url = https://github.com/Qorvo/qpg-connectedhomeip
 	branch  = master
+	platforms = qpg
 [submodule "zap"]
 	path = third_party/zap/repo
 	url = https://github.com/project-chip/zap.git
@@ -62,103 +67,134 @@
 	path = third_party/freertos/repo
 	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git
 	branch  = V10.3.1-kernel-only
+	platforms = ameba,cc13x2_26x2,bl602,efr32,esp32,k32w0,p6,qpg
 [submodule "efr32_sdk"]
 	path = third_party/efr32_sdk/repo
 	url = https://github.com/SiliconLabs/sdk_support.git
 	branch  = master
+	platforms = efr32
 [submodule "simw-top-mini"]
 	path = third_party/simw-top-mini/repo
 	url = https://github.com/NXP/plug-and-trust.git
 	branch  = int/CHIPSE_Release
+	platforms = k32w0
 [submodule "third_party/openthread/ot-nxp"]
 	path = third_party/openthread/ot-nxp
 	url = https://github.com/openthread/ot-nxp.git
+	platforms = k32w0
 [submodule "third_party/openthread/ot-qorvo"]
 	path = third_party/openthread/ot-qorvo
 	url = https://github.com/openthread/ot-qorvo.git
+	platforms = qpg
 [submodule "third_party/openthread/ot-efr32"]
 	path = third_party/openthread/ot-efr32
 	url = https://github.com/openthread/ot-efr32.git
+	platforms = efr32
 [submodule "third_party/openthread/ot-ifx"]
 	path = third_party/openthread/ot-ifx
 	url = https://github.com/Infineon/ot-ifx-release.git
 	branch = cyw30739
+	platforms = cyw30739
 [submodule "third_party/mbed-os/repo"]
 	path = third_party/mbed-os/repo
 	url = https://github.com/ARMmbed/mbed-os.git
 	branch = master
+	platforms = mbed
 [submodule "third_party/mbed-os-posix-socket/repo"]
 	path = third_party/mbed-os-posix-socket/repo
 	url = https://github.com/ARMmbed/mbed-os-posix-socket.git
 	branch  = main
+	platforms = mbed
 [submodule "mbed-os-cypress-capsense-button"]
 	path = third_party/mbed-os-cypress-capsense-button/repo
 	url = https://github.com/ARMmbed/mbed-os-cypress-capsense-button.git
 	branch = main
+	platforms = mbed
 [submodule "p6/abstraction-rtos"]
 	path = third_party/p6/p6_sdk/libs/abstraction-rtos
 	url = https://github.com/Infineon/abstraction-rtos
+	platforms = p6
 [submodule "p6/bluetooth-freertos"]
 	path = third_party/p6/p6_sdk/libs/bluetooth-freertos
 	url = https://github.com/Infineon/bluetooth-freertos
 	branch  = v2.X
+	platforms = p6
 [submodule "p6/btstack"]
 	path = third_party/p6/p6_sdk/libs/btstack
 	url = https://github.com/Infineon/btstack
+	platforms = p6
 [submodule "p6/clib-support"]
 	path = third_party/p6/p6_sdk/libs/clib-support
 	url = https://github.com/Infineon/clib-support
+	platforms = p6
 [submodule "p6/connectivity-utilities"]
 	path = third_party/p6/p6_sdk/libs/connectivity-utilities
 	url = https://github.com/Infineon/connectivity-utilities
+	platforms = p6
 [submodule "p6/core-lib"]
 	path = third_party/p6/p6_sdk/libs/core-lib
 	url = https://github.com/Infineon/core-lib
+	platforms = p6
 [submodule "p6/core-make"]
 	path = third_party/p6/p6_sdk/libs/core-make
 	url = https://github.com/Infineon/core-make
+	platforms = p6
 [submodule "p6/kv-store"]
 	path = third_party/p6/p6_sdk/libs/kv-store
 	url = https://github.com/Infineon/kv-store
+	platforms = p6
 [submodule "p6/mtb-hal-cat1"]
 	path = third_party/p6/p6_sdk/libs/mtb-hal-cat1
 	url = https://github.com/Infineon/mtb-hal-cat1
+	platforms = p6
 [submodule "p6/mtb-pdl-cat1"]
 	path = third_party/p6/p6_sdk/libs/mtb-pdl-cat1
 	url = https://github.com/Infineon/mtb-pdl-cat1
+	platforms = p6
 [submodule "p6/psoc6cm0p"]
 	path = third_party/p6/p6_sdk/libs/psoc6cm0p
 	url = https://github.com/Infineon/psoc6cm0p
+	platforms = p6
 [submodule "p6/whd-bsp-integration"]
 	path = third_party/p6/p6_sdk/libs/whd-bsp-integration
 	url = https://github.com/Infineon/whd-bsp-integration
+	platforms = p6
 [submodule "p6/wifi-connection-manager"]
 	path = third_party/p6/p6_sdk/libs/wifi-connection-manager
 	url = https://github.com/Infineon/wifi-connection-manager
+	platforms = p6
 [submodule "p6/wifi-host-driver"]
 	path = third_party/p6/p6_sdk/libs/wifi-host-driver
 	url = https://github.com/Infineon/wifi-host-driver
+	platforms = p6
 [submodule "p6/wifi-mw-core"]
 	path = third_party/p6/p6_sdk/libs/wifi-mw-core
 	url = https://github.com/Infineon/wifi-mw-core
+	platforms = p6
 [submodule "p6/TARGET_CY8CKIT-062S2-43012"]
 	path = third_party/p6/p6_sdk/libs/TARGET_CY8CKIT-062S2-43012
 	url = https://github.com/Infineon/TARGET_CY8CKIT-062S2-43012
+	platforms = p6
 [submodule "p6/freertos"]
 	path = third_party/p6/p6_sdk/libs/freertos
 	url = https://github.com/Infineon/freertos
+	platforms = p6
 [submodule "p6/retarget-io"]
 	path = third_party/p6/p6_sdk/libs/retarget-io
 	url = https://github.com/Infineon/retarget-io
+	platforms = p6
 [submodule "p6/mbedtls"]
 	path = third_party/p6/p6_sdk/libs/mbedtls
 	url = https://github.com/ARMmbed/mbedtls
+	platforms = p6
 [submodule "p6/secure-sockets"]
 	path = third_party/p6/p6_sdk/libs/secure-sockets
 	url = https://github.com/Infineon/secure-sockets
+	platforms = p6
 [submodule "p6/recipe-make-cat1a"]
 	path = third_party/p6/p6_sdk/libs/recipe-make-cat1a
 	url = https://github.com/Infineon/recipe-make-cat1a
+	platforms = p6
 [submodule "third_party/pybind11/repo"]
 	path = third_party/pybind11/repo
 	url = https://github.com/pybind/pybind11
@@ -166,44 +202,56 @@
 [submodule "p6/lwip"]
 	path = third_party/p6/p6_sdk/libs/lwip
 	url = https://github.com/lwip-tcpip/lwip.git
+	platforms = p6
 [submodule "third_party/jsoncpp/repo"]
 	path = third_party/jsoncpp/repo
 	url = https://github.com/open-source-parsers/jsoncpp.git
 [submodule "cyw30739_sdk/30739A0"]
 	path = third_party/cyw30739_sdk/repos/30739A0
 	url = https://github.com/Infineon/30739A0.git
+	platforms = cyw30739
 [submodule "cyw30739_sdk/include"]
 	path = third_party/cyw30739_sdk/repos/btsdk-include
 	url = https://github.com/Infineon/btsdk-include.git
+	platforms = cyw30739
 [submodule "cyw30739_sdk/target"]
 	path = third_party/cyw30739_sdk/repos/CYW930739M2EVB-01
 	url = https://github.com/Infineon/TARGET_CYW930739M2EVB-01.git
+	platforms = cyw30739
 [submodule "cyw30739_sdk/tools"]
 	path = third_party/cyw30739_sdk/repos/btsdk-tools
 	url = https://github.com/Infineon/btsdk-tools.git
+	platforms = cyw30739
 [submodule "third_party/p6/p6_sdk/libs/anycloud-ota"]
 	path = third_party/p6/p6_sdk/libs/anycloud-ota
 	url = https://github.com/Infineon/anycloud-ota
+	platforms = p6
 [submodule "third_party/mbed-mcu-boot/repo"]
 	path = third_party/mbed-mcu-boot/repo
 	url = https://github.com/ATmobica/mcuboot.git
+	platforms = mbed
 [submodule "perfetto"]
 	path = third_party/perfetto/repo
 	url = https://github.com/google/perfetto
 [submodule "p6/serial-flash"]
 	path = third_party/p6/p6_sdk/libs/serial-flash
 	url = https://github.com/Infineon/serial-flash
+	platforms = p6
 [submodule "third_party/telink_sdk/repo"]
 	path = third_party/telink_sdk/repo
 	url = https://github.com/rikorsev/telink_b91_ble_sdk
+	platforms = telink
 [submodule "ti_simplelink_sdk"]
 	path = third_party/ti_simplelink_sdk/repo_cc13xx_cc26xx
 	url = https://github.com/TexasInstruments/cc13xx_cc26xx_sdk.git
 	branch = main
+	platforms = cc13x2_26x2
 [submodule "third_party/efr32_sdk/wiseconnect-wifi-bt-sdk"]
 	path = third_party/efr32_sdk/wiseconnect-wifi-bt-sdk
 	url = https://github.com/SiliconLabs/wiseconnect-wifi-bt-sdk
+	platforms = efr32
 [submodule "third_party/bouffalolab/bl602"]
 	path = third_party/bouffalolab/bl602_sdk/repo
 	url = https://github.com/bouffalolab/bl_iot_sdk_matter.git
 	branch = bl602_release
+	platforms = bl602

--- a/scripts/checkout_submodules.py
+++ b/scripts/checkout_submodules.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+from collections import namedtuple
+import configparser
+import subprocess
+import os
+import sys
+
+CHIP_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+ALL_PLATFORMS = [
+    'ameba',
+    'android',
+    'bl602',
+    'cc13x2_26x2',
+    'cyw30739',
+    'darwin',
+    'efr32',
+    'esp32',
+    'k32w0',
+    'linux',
+    'mbed',
+    'nrfconnect',
+    'p6',
+    'qpg',
+    'telink',
+    'tizen',
+    'webos',
+]
+
+Module = namedtuple('Module', 'name path platforms')
+
+
+def load_module_info() -> list:
+    config = configparser.ConfigParser()
+    config.read(os.path.join(CHIP_ROOT, '.gitmodules'))
+
+    def make_module_info(name, module):
+        platforms = module.get('platforms', '').split(',')
+        platforms = set(filter(None, platforms))
+        return Module(name=name, path=module['path'], platforms=platforms)
+
+    return [make_module_info(name, module) for name, module in config.items() if name != 'DEFAULT']
+
+
+def module_matches_platforms(module: Module, platforms: set) -> bool:
+    # If no platforms have been selected, or the module is not associated with any specific
+    # platforms, treat it as a match.
+    if not platforms or not module.platforms:
+        return True
+    return bool(platforms & module.platforms)
+
+
+def checkout_modules(modules: list, shallow: bool) -> None:
+    names = [module.name.removeprefix('submodule "').removesuffix('"') for module in modules]
+    names = ', '.join(names)
+    sys.stderr.write(f'Checking out: {names}\n')
+
+    cmd = ['git', '-C', CHIP_ROOT, 'submodule', 'update', '--init']
+    cmd += ['--depth', '1'] if shallow else []
+    cmd += [module.path for module in modules]
+
+    subprocess.check_call(cmd)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Checkout or update relevant git submodules')
+    parser.add_argument('--shallow', action='store_true', help='Fetch submodules without history')
+    parser.add_argument('--platform', nargs='+', choices=ALL_PLATFORMS, default=[],
+                        help='Process submodules for specific platforms only')
+    args = parser.parse_args()
+
+    modules = load_module_info()
+    selected_platforms = set(args.platform)
+    selected_modules = [m for m in modules if module_matches_platforms(m, selected_platforms)]
+
+    checkout_modules(selected_modules, args.shallow)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/checkout_submodules.py
+++ b/scripts/checkout_submodules.py
@@ -68,7 +68,7 @@ def module_matches_platforms(module: Module, platforms: set) -> bool:
 
 
 def checkout_modules(modules: list, shallow: bool) -> None:
-    names = [module.name.removeprefix('submodule "').removesuffix('"') for module in modules]
+    names = [module.name.replace('submodule "', '').replace('"', '') for module in modules]
     names = ', '.join(names)
     sys.stderr.write(f'Checking out: {names}\n')
 


### PR DESCRIPTION
#### Problem
More and more platforms are added and our CI jobs always fetch all the submodules instead of only relevant ones. Recently it takes about 5 minutes to checkout the submodules.

#### Change overview
1. Associate submodules to platforms for which they're needed.
2. Add a script that is able to checkout submodules for specific platforms only.
3. Use the script in CI workflows.

#### Testing
CI tested.
