### PR TITLE
Add tracing to efr32 ligthing app.

### DIFF
--- a/config/efr32/lib/pw_rpc/pw_rpc.gni
+++ b/config/efr32/lib/pw_rpc/pw_rpc.gni
@@ -19,6 +19,7 @@ pw_log_BACKEND = "$dir_pw_log_basic"
 pw_assert_BACKEND = "$dir_pw_assert_log"
 pw_sys_io_BACKEND =
     "${chip_root}/examples/platform/efr32/pw_sys_io:pw_sys_io_efr32"
+pw_trace_BACKEND = "$dir_pw_trace_tokenized"
 
 pw_build_LINK_DEPS = [
   "$dir_pw_assert:impl",

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -254,6 +254,7 @@ efr32_executable("lighting_app") {
       "PW_RPC_LIGHTING_SERVICE=1",
       "PW_RPC_OTCLI_SERVICE=1",
       "PW_RPC_THREAD_SERVICE=1",
+      "PW_RPC_TRACING_SERVICE=1",
     ]
 
     sources += [
@@ -266,6 +267,9 @@ efr32_executable("lighting_app") {
     deps += [
       "$dir_pw_hdlc:rpc_channel_output",
       "$dir_pw_stream:sys_io_stream",
+      "$dir_pw_trace",
+      "$dir_pw_trace_tokenized",
+      "$dir_pw_trace_tokenized:trace_rpc_service",
       "${chip_root}/config/efr32/lib/pw_rpc:pw_rpc",
       "${chip_root}/examples/common/pigweed:attributes_service.nanopb_rpc",
       "${chip_root}/examples/common/pigweed:button_service.nanopb_rpc",

--- a/examples/lighting-app/efr32/README.md
+++ b/examples/lighting-app/efr32/README.md
@@ -13,6 +13,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG12.
     -   [Running the Complete Example](#running-the-complete-example)
         -   [Notes](#notes)
     -   [Running RPC console](#running-rpc-console)
+    -   [Device Tracing](#device-tracing)
     -   [Memory settings](#memory-settings)
     -   [OTA Software Update](#ota-software-update)
 
@@ -109,7 +110,7 @@ Silicon Labs platform.
 
           $ gn gen out/debug '--args=efr32_board="BRD4161A" enable_sleepy_device=true chip_openthread_ftd=false'
 
-*   Build the example with pigweed RCP
+*   Build the example with pigweed RPC
 
           $ ./scripts/examples/gn_efr32_example.sh examples/lighting-app/efr32/ out/lighting_app_rpc BRD4161A 'import("//with_pw_rpc.gni")'
 
@@ -301,6 +302,19 @@ via 2002::2
     `rpcs.chip.rpc.Lighting.Get()`
 
     `rpcs.chip.rpc.Lighting.Set(on=True, level=128, color=protos.chip.rpc.LightingColor(hue=5, saturation=5))`
+
+## Device Tracing
+
+Device tracing is available to analyze the device performance. To turn on
+tracing, build with RPC enabled. See
+Build the example with pigweed RPC.
+
+Obtain tracing json file.
+
+```
+    $ ./{PIGWEED_REPO}/pw_trace_tokenized/py/pw_trace_tokenized/get_trace.py -d {PORT} -o {OUTPUT_FILE} \
+    -t {ELF_FILE} {PIGWEED_REPO}/pw_trace_tokenized/pw_trace_protos/trace_rpc.proto
+```
 
 ## Memory settings
 

--- a/examples/lighting-app/efr32/README.md
+++ b/examples/lighting-app/efr32/README.md
@@ -306,8 +306,7 @@ via 2002::2
 ## Device Tracing
 
 Device tracing is available to analyze the device performance. To turn on
-tracing, build with RPC enabled. See
-Build the example with pigweed RPC.
+tracing, build with RPC enabled. See Build the example with pigweed RPC.
 
 Obtain tracing json file.
 

--- a/examples/lighting-app/efr32/with_pw_rpc.gni
+++ b/examples/lighting-app/efr32/with_pw_rpc.gni
@@ -23,5 +23,6 @@ efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
+chip_build_pw_trace_lib = true
 
 cpp_standard = "gnu++17"

--- a/examples/platform/efr32/Rpc.cpp
+++ b/examples/platform/efr32/Rpc.cpp
@@ -55,6 +55,24 @@
 #include "pigweed/rpc_services/Thread.h"
 #endif // defined(PW_RPC_THREAD_SERVICE) && PW_RPC_THREAD_SERVICE
 
+#if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
+#define PW_TRACE_BUFFER_SIZE_BYTES 1024
+#include "pw_trace/trace.h"
+#include "pw_trace_tokenized/trace_rpc_service_nanopb.h"
+
+// Define trace time for pw_trace
+PW_TRACE_TIME_TYPE pw_trace_GetTraceTime()
+{
+    return (PW_TRACE_TIME_TYPE) chip::System::SystemClock().GetMonotonicMicroseconds64().count();
+}
+// Microsecond time source
+size_t pw_trace_GetTraceTimeTicksPerSecond()
+{
+    return 1000000;
+}
+
+#endif // defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
+
 namespace chip {
 namespace rpc {
 
@@ -130,6 +148,10 @@ OtCli ot_cli_service;
 Thread thread;
 #endif // defined(PW_RPC_THREAD_SERVICE) && PW_RPC_THREAD_SERVICE
 
+#if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
+pw::trace::TraceService trace_service;
+#endif // defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
+
 void RegisterServices(pw::rpc::Server & server)
 {
 #if defined(PW_RPC_ATTRIBUTE_SERVICE) && PW_RPC_ATTRIBUTE_SERVICE
@@ -163,6 +185,11 @@ void RegisterServices(pw::rpc::Server & server)
 #if defined(PW_RPC_THREAD_SERVICE) && PW_RPC_THREAD_SERVICE
     server.RegisterService(thread);
 #endif // defined(PW_RPC_THREAD_SERVICE) && PW_RPC_THREAD_SERVICE
+
+#if defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
+    server.RegisterService(trace_service);
+    PW_TRACE_SET_ENABLED(true);
+#endif // defined(PW_RPC_TRACING_SERVICE) && PW_RPC_TRACING_SERVICE
 }
 
 } // namespace


### PR DESCRIPTION
#### Change overview
- Add pigweed trace rpc service to efr Rpc.cpp
- Set pw_trace backend as pw_trace_tokenized
- Add instructions on how to obtain trace file in README

#### Testing
Build and flash with RPC turned on and confirm tracing functionality.
