### PR TITLE
Share more logic between FailSafeCleanup and actual RemoveFabric

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -266,7 +266,7 @@ FabricInfo * RetrieveCurrentFabric(CommandHandler * aCommandHandler)
 
 CHIP_ERROR DeleteFabricFromTable(FabricIndex fabricIndex)
 {
-    ReturnLogErrorOnFailure(Server::GetInstance().GetFabricTable().Delete(fabricIndex));
+    ReturnErrorOnFailure(Server::GetInstance().GetFabricTable().Delete(fabricIndex));
 
     // We need to withdraw the advertisement for the now-removed fabric, so need
     // to restart advertising altogether.


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* We should share more logic with the actual RemoveFabric implementation. For example:
This does not handle withdrawing stale operational advertisements.
This does not close IM transactions for the fabric being removed.
We should probably have a helper method (or two, for the parts that need to happen sync and async during "normal" fabric removal) that takes a fabric index and does whatever cleanup needs to happen and is called from here, and from FabricCleanupExchangeDelegate::OnExchangeClosing and from emberAfOperationalCredentialsClusterRemoveFabricCallback

#### Change overview
Share more logic between FailSafeCleanup and actual RemoveFabric

#### Testing
How was this tested? (at least one bullet point required)
* pair the device to the example lighting server
* remove the fabric device just joined and confirm no regression
