### PR TITLE
ESP32: Enable minimal mdns by default

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -85,7 +85,7 @@ menu "CHIP Core"
 
         config USE_MINIMAL_MDNS
             bool "Use the minimal mDNS implementation shipped in the CHIP library"
-            default n
+            default y
             help
                 The CHIP library is shipped with a minimal mDNS implementation,
                 enable this config to use it rather than the mDNS library in IDF.


### PR DESCRIPTION
#### Problem
There are some issues on platform mDNS of ESP32 #17027 

#### Change overview
Using minimal mDNS by default

#### Testing
Tested on ESP32, multi fabric works on it.
