### PR TITLE
Stop storing the extended discovery timeout in the dns-sd layer.

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -29,7 +29,6 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/CommissionableDataProvider.h>
 #include <platform/ConfigurationManager.h>
-#include <platform/KeyValueStoreManager.h>
 #include <protocols/secure_channel/PASESession.h>
 #if CHIP_ENABLE_ROTATING_DEVICE_ID && defined(CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID)
 #include <setup_payload/AdditionalDataPayloadGenerator.h>
@@ -87,26 +86,12 @@ bool DnssdServer::HaveOperationalCredentials()
 void DnssdServer::SetExtendedDiscoveryTimeoutSecs(int32_t secs)
 {
     ChipLogDetail(Discovery, "Setting extended discovery timeout to %" PRId32 "s", secs);
-    chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Put(DefaultStorageKeyAllocator::DNSExtendedDiscoveryTimeout(), secs);
+    mExtendedDiscoveryTimeoutSecs = MakeOptional(secs);
 }
 
 int32_t DnssdServer::GetExtendedDiscoveryTimeoutSecs()
 {
-    int32_t secs;
-    CHIP_ERROR err = chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Get(
-        DefaultStorageKeyAllocator::DNSExtendedDiscoveryTimeout(), &secs);
-
-    if (err == CHIP_NO_ERROR)
-    {
-        return secs;
-    }
-
-    if (err != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
-    {
-        ChipLogError(Discovery, "Failed to load extended discovery timeout: %" CHIP_ERROR_FORMAT, err.Format());
-    }
-
-    return CHIP_DEVICE_CONFIG_EXTENDED_DISCOVERY_TIMEOUT_SECS;
+    return mExtendedDiscoveryTimeoutSecs.ValueOr(CHIP_DEVICE_CONFIG_EXTENDED_DISCOVERY_TIMEOUT_SECS);
 }
 
 /// Callback from Extended Discovery Expiration timer

--- a/src/app/server/Dnssd.h
+++ b/src/app/server/Dnssd.h
@@ -168,11 +168,14 @@ private:
     int16_t mDiscoveryTimeoutSecs                 = CHIP_DEVICE_CONFIG_DISCOVERY_TIMEOUT_SECS;
     System::Clock::Timestamp mDiscoveryExpiration = kTimeoutCleared;
 
+    Optional<int32_t> mExtendedDiscoveryTimeoutSecs = NullOptional;
+
     /// return true if expirationMs is valid (not cleared and not in the future)
     bool OnExpiration(System::Clock::Timestamp expiration);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
-    /// get the current extended discovery timeout (from persistent storage)
+    /// Get the current extended discovery timeout (set by
+    /// SetExtendedDiscoveryTimeoutSecs, or the configuration default if not set).
     int32_t GetExtendedDiscoveryTimeoutSecs();
 
     /// schedule next extended discovery expiration

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -112,9 +112,6 @@ public:
     static const char * OTACurrentUpdateState() { return "g/o/us"; }
     static const char * OTATargetVersion() { return "g/o/tv"; }
 
-    // [G]lobal [D]NS-related keys
-    static const char * DNSExtendedDiscoveryTimeout() { return "g/d/edt"; }
-
 private:
     // The ENFORCE_FORMAT args are "off by one" because this is a class method,
     // with an implicit "this" as first arg.


### PR DESCRIPTION
It's set at startup by all the examples that care to set it.  There's
no obvious reason this value should be in SDK-managed persistent storage.  Applications can store it as needed.

#### Problem
Using key-value store directly in dns-sd code, not going through storage delegates.

#### Change overview
Stop storing a value deep in the dns-sd code that applications could just store as they see fit.

#### Testing
Existing tests should cover this.