### PR TITLE
NL_TEST_RUNNER: Add runner to build script

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -233,6 +233,8 @@ def HostTargets():
         target_native.Extend('rpc-console', app=HostApp.RPC_CONSOLE))
     app_targets.append(
         target_native.Extend('tv-app', app=HostApp.TV_APP))
+    app_targets.append(
+        target_native.Extend('nl-test-runner', app=HostApp.NL_TEST_RUNNER))
 
     for target in targets:
         app_targets.append(target.Extend(
@@ -271,7 +273,7 @@ def HostTargets():
     builder.WhitelistVariantNameForGlob('ipv6only')
 
     for target in app_targets:
-        if ('-rpc-console' in target.name) or ('-python-bindings' in target.name):
+        if ('-rpc-console' in target.name) or ('-python-bindings' in target.name) or ('nl-test-runner' in target.name):
             # Single-variant builds
             yield target
         else:

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -34,6 +34,7 @@ class HostApp(Enum):
     OTA_PROVIDER = auto()
     OTA_REQUESTOR = auto()
     PYTHON_BINDINGS = auto()
+    NL_TEST_RUNNER = auto()
 
     def ExamplePath(self):
         if self == HostApp.ALL_CLUSTERS:
@@ -58,6 +59,8 @@ class HostApp(Enum):
             return 'ota-requestor-app/linux'
         elif self in [HostApp.ADDRESS_RESOLVE, HostApp.TESTS, HostApp.PYTHON_BINDINGS, HostApp.CERT_TOOL]:
             return '../'
+        elif self == HostApp.NL_TEST_RUNNER:
+            return '../src/test_driver/efr32'
         else:
             raise Exception('Unknown app type: %r' % self)
 
@@ -105,6 +108,8 @@ class HostApp(Enum):
             yield 'chip-ota-requestor-app.map'
         elif self == HostApp.PYTHON_BINDINGS:
             yield 'controller/python'  # Directory containing WHL files
+        elif self == HostApp.NL_TEST_RUNNER:
+            yield 'chip_nl_test_runner_wheels'
         else:
             raise Exception('Unknown app type: %r' % self)
 
@@ -200,6 +205,9 @@ class HostBuilder(GnBuilder):
         if app == HostApp.TESTS:
             self.extra_gn_options.append('chip_build_tests=true')
             self.build_command = 'check'
+
+        if app == HostApp.NL_TEST_RUNNER:
+            self.build_command = 'runner'
 
         if app == HostApp.CERT_TOOL:
             # Certification only built for openssl

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -117,6 +117,9 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Generating linux-x64-minmdns-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-minmdns-ipv6only
 
+# Generating linux-x64-nl-test-runner
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/src/test_driver/efr32 {out}/linux-x64-nl-test-runner
+
 # Generating linux-x64-ota-provider
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux --args=chip_config_network_layer_ble=false {out}/linux-x64-ota-provider
 
@@ -239,6 +242,9 @@ ninja -C {out}/linux-x64-minmdns
 
 # Building linux-x64-minmdns-ipv6only
 ninja -C {out}/linux-x64-minmdns-ipv6only
+
+# Building linux-x64-nl-test-runner
+ninja -C {out}/linux-x64-nl-test-runner runner
 
 # Building linux-x64-ota-provider
 ninja -C {out}/linux-x64-ota-provider

--- a/src/test_driver/efr32/README.md
+++ b/src/test_driver/efr32/README.md
@@ -82,8 +82,16 @@ OR use GN/Ninja directly
 Build the runner using gn:
 
     ```
+    cd <connectedhomeip>/src/test_driver/efr32
     gn gen out/debug
     ninja -C out/debug runner
+    ```
+
+Or build using build script from the root
+
+    ```
+    cd <connectedhomeip>
+    ./scripts/build/build_examples.py --target-glob '*nl-test-runner' build
     ```
 
 The runner will be installed into the venv and python wheels will be packaged in

--- a/src/test_driver/efr32/py/BUILD.gn
+++ b/src/test_driver/efr32/py/BUILD.gn
@@ -20,13 +20,17 @@ import("$dir_pw_build/python_dist.gni")
 import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 
 pw_python_package("nl_test_runner") {
-  generate_setup = {
-    metadata = {
-      name = "nl_test_runner"
-      version = "0.0.1"
-    }
-  }
-  sources = [ "nl_test_runner/nl_test_runner.py" ]
+  setup = [
+    "pyproject.toml",
+    "setup.cfg",
+    "setup.py",
+  ]
+
+  sources = [
+    "nl_test_runner/__init__.py",
+    "nl_test_runner/nl_test_runner.py",
+  ]
+
   python_deps = [
     "$dir_pw_hdlc/py",
     "$dir_pw_protobuf_compiler/py",

--- a/src/test_driver/efr32/py/pyproject.toml
+++ b/src/test_driver/efr32/py/pyproject.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+[build-system]
+requires = ['setuptools', 'wheel']
+build-backend = 'setuptools.build_meta'

--- a/src/test_driver/efr32/py/setup.cfg
+++ b/src/test_driver/efr32/py/setup.cfg
@@ -1,0 +1,24 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+[metadata]
+name = nl_test_runner
+version = 0.0.1
+
+[options]
+packages = find:
+zip_safe = False
+install_requires =
+    pw_hdlc
+    pw_protobuf_compiler
+    pw_rpc

--- a/src/test_driver/efr32/py/setup.py
+++ b/src/test_driver/efr32/py/setup.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import setuptools  # type: ignore
+
+setuptools.setup()  # Package definition in setup.cfg


### PR DESCRIPTION

#### Problem
The nl_test_runner for EFR32 is not currently built by the build script.

#### Change overview

- Add a nl-test-runner target to the build script for host.
- Cleanup python package build to use setup files, which is now the preferred approach.

#### Testing

- Ran `python ./scripts/build/test.py`
- Ran `./scripts/build/build_examples.py --target-glob '*nl-test-runner' build --create-archives out` and verified generated archive
