### PR TITLE
Pass the country code via commissioning parameters.

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -71,6 +71,21 @@ CHIP_ERROR AutoCommissioner::SetCommissioningParameters(const CommissioningParam
         mParams.SetWiFiCredentials(
             WiFiCredentials(ByteSpan(mSsid, creds.ssid.size()), ByteSpan(mCredentials, creds.credentials.size())));
     }
+
+    if (params.GetCountryCode().HasValue())
+    {
+        auto & code = params.GetCountryCode().Value();
+        MutableCharSpan copiedCode(mCountryCode);
+        if (CopyCharSpanToMutableCharSpan(code, copiedCode) == CHIP_NO_ERROR)
+        {
+            mParams.SetCountryCode(copiedCode);
+        }
+        else
+        {
+            ChipLogError(Controller, "Country code is too large: %u", static_cast<unsigned>(code.size()));
+        }
+    }
+
     // If the AttestationNonce is passed in, using that else using a random one..
     if (params.GetAttestationNonce().HasValue())
     {

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -66,6 +66,7 @@ private:
     uint8_t mSsid[CommissioningParameters::kMaxSsidLen];
     uint8_t mCredentials[CommissioningParameters::kMaxCredentialsLen];
     uint8_t mThreadOperationalDataset[CommissioningParameters::kMaxThreadDatasetLen];
+    char mCountryCode[CommissioningParameters::kMaxCountryCodeLen];
 
     bool mNeedsNetworkSetup = false;
     ReadCommissioningInfo mDeviceCommissioningInfo;

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -83,6 +83,7 @@ public:
     static constexpr size_t kMaxThreadDatasetLen = 254;
     static constexpr size_t kMaxSsidLen          = 32;
     static constexpr size_t kMaxCredentialsLen   = 64;
+    static constexpr size_t kMaxCountryCodeLen   = 2;
 
     // Value to use when setting the commissioning failsafe timer on the node being commissioned.
     // If the failsafe timer value is passed in as part of the commissioning parameters, that value will be used. If not supplied,
@@ -101,6 +102,9 @@ public:
     {
         return mDeviceRegulatoryLocation;
     }
+
+    // The country code to be used for the node, if set.
+    Optional<CharSpan> GetCountryCode() const { return mCountryCode; }
 
     // Nonce sent to the node to use during the CSR request.
     // When using the AutoCommissioner, this value will be ignored in favour of the value supplied by the
@@ -222,6 +226,14 @@ public:
         return *this;
     }
 
+    // The lifetime of the buffer countryCode is pointing to should exceed the
+    // lifetime of CommissioningParameters object.
+    CommissioningParameters & SetCountryCode(CharSpan countryCode)
+    {
+        mCountryCode.SetValue(countryCode);
+        return *this;
+    }
+
     // The lifetime of the buffer csrNonce is pointing to, should exceed the lifetime of CommissioningParameters object.
     CommissioningParameters & SetCSRNonce(ByteSpan csrNonce)
     {
@@ -339,6 +351,7 @@ private:
     Optional<ByteSpan> mCSRNonce;
     Optional<ByteSpan> mAttestationNonce;
     Optional<WiFiCredentials> mWiFiCreds;
+    Optional<CharSpan> mCountryCode;
     Optional<ByteSpan> mThreadOperationalDataset;
     Optional<NOCChainGenerationParameters> mNOCChainGenerationParameters;
     Optional<ByteSpan> mRootCert;


### PR DESCRIPTION
We shouldn't assume the configuration manager exists on the
commissioner, or stores anything useful, so switch to passing in the
country code via commissioning parameters instead of reading it from
the configuration manager.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Not sure how to test this so far....