### PR TITLE
[Silabs] Fixes for WiFi build

### DIFF
--- a/src/platform/EFR32/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/EFR32/NetworkCommissioningWiFiDriver.cpp
@@ -175,30 +175,34 @@ exit:
     }
 }
 
-uint8_t SlWiFiDriver::ConvertSecuritytype(uint8_t security)
+chip::BitFlags<WiFiSecurity> SlWiFiDriver::ConvertSecuritytype(uint8_t security)
 {
-    uint8_t securityType = EMBER_ZCL_SECURITY_TYPE_UNSPECIFIED;
+    chip::BitFlags<WiFiSecurity> securityType;
     if (security == WFX_SEC_NONE)
     {
-        securityType = EMBER_ZCL_SECURITY_TYPE_NONE;
-    }
-    else if (security == WFX_SEC_WPA3)
-    {
-        securityType = EMBER_ZCL_SECURITY_TYPE_WPA3;
-    }
-    else if (security & WFX_SEC_WPA2)
-    {
-        securityType = EMBER_ZCL_SECURITY_TYPE_WPA2;
-    }
-    else if (security & WFX_SEC_WPA)
-    {
-        securityType = EMBER_ZCL_SECURITY_TYPE_WPA;
+        securityType = WiFiSecurity::kUnencrypted;
     }
     else if (security & WFX_SEC_WEP)
     {
-        securityType = EMBER_ZCL_SECURITY_TYPE_WEP;
+        securityType = WiFiSecurity::kWepPersonal;
     }
-    // wfx_sec_t support more type
+    else if (security & WFX_SEC_WPA)
+    {
+        securityType = WiFiSecurity::kWpaPersonal;
+    }
+    else if (security & WFX_SEC_WPA2)
+    {
+        securityType = WiFiSecurity::kWpa2Personal;
+    }
+    else if (security == WFX_SEC_WPA3)
+    {
+        securityType = WiFiSecurity::kWpa3Personal;
+    }
+    else
+    {
+        // wfx_sec_t support more type
+        securityType = WiFiSecurity::kUnencrypted;
+    }
 
     return securityType;
 }
@@ -235,9 +239,9 @@ void SlWiFiDriver::OnScanWiFiNetworkDone(wfx_wifi_scan_result_t * aScanResult)
     }
     else
     {
-        NetworkCommissioning::WiFiScanResponse scanResponse = { 0 };
+        NetworkCommissioning::WiFiScanResponse scanResponse = {};
 
-        scanResponse.security.SetRaw(GetInstance().ConvertSecuritytype(aScanResult->security));
+        scanResponse.security.Set(GetInstance().ConvertSecuritytype(aScanResult->security));
         scanResponse.channel = aScanResult->chan;
         scanResponse.rssi    = aScanResult->rssi;
         scanResponse.ssidLen = strnlen(aScanResult->ssid, DeviceLayer::Internal::kMaxWiFiSSIDLength);

--- a/src/platform/EFR32/NetworkCommissioningWiFiDriver.h
+++ b/src/platform/EFR32/NetworkCommissioningWiFiDriver.h
@@ -30,39 +30,6 @@ constexpr uint8_t kWiFiScanNetworksTimeOutSeconds   = 10;
 constexpr uint8_t kWiFiConnectNetworkTimeoutSeconds = 20;
 } // namespace
 
-// class SlScanResponseIterator : public Iterator<WiFiScanResponse>
-// {
-// public:
-//     SlScanResponseIterator(const size_t size, const wifi_ap_record_t * scanResults) : mSize(size), mpScanResults(scanResults) {}
-//     size_t Count() override { return mSize; }
-//     bool Next(WiFiScanResponse & item) override
-//     {
-//         if (mIternum >= mSize)
-//         {
-//             return false;
-//         }
-
-//         item.security.SetRaw(mpScanResults[mIternum].authmode);
-//         item.ssidLen =
-//             strnlen(reinterpret_cast<const char *>(mpScanResults[mIternum].ssid),
-//             chip::DeviceLayer::Internal::kMaxWiFiSSIDLength);
-//         item.channel  = mpScanResults[mIternum].primary;
-//         item.wiFiBand = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
-//         item.rssi     = mpScanResults[mIternum].rssi;
-//         memcpy(item.ssid, mpScanResults[mIternum].ssid, item.ssidLen);
-//         memcpy(item.bssid, mpScanResults[mIternum].bssid, 6);
-
-//         mIternum++;
-//         return true;
-//     }
-//     void Release() override {}
-
-// private:
-//     const size_t mSize;
-//     const wifi_ap_record_t * mpScanResults;
-//     size_t mIternum = 0;
-// };
-
 template <typename T>
 class SlScanResponseIterator : public Iterator<T>
 {
@@ -153,7 +120,7 @@ public:
 
     CHIP_ERROR ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, const char * key, uint8_t keyLen);
 
-    uint8_t ConvertSecuritytype(uint8_t security);
+    chip::BitFlags<WiFiSecurity> ConvertSecuritytype(uint8_t security);
 
     void OnConnectWiFiNetwork();
     static SlWiFiDriver & GetInstance()

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -284,6 +284,13 @@ template("efr32_sdk") {
       "-Wno-shadow",
     ]
 
+    if (defined(invoker.use_rs911x)) {
+      if (invoker.use_rs911x == true) {
+        #add compilation flags for rs991x build. This will be addressed directly in wiseconnect sdk in the next version release of that sdk
+        cflags += invoker.rs911x_cflags
+      }
+    }
+
     if (defined(invoker.defines)) {
       defines += invoker.defines
     }


### PR DESCRIPTION
### Problem
Build for the wifi platforms fail. 
An Unsafe/Racy code was caught by `AssertChipStackLockedByCurrentThread`

#### Change overview
Fix compilation errors  for both wifi platforms (wf200 & rs9116)
Fix an `AssertChipStackLockedByCurrentThread` condition in our wifi platform code when starting the DNS server when an IP is acquired.

#### Testing
Build examples for both platforms. Commission and send command with chip-tool 
