### PR TITLE
Log clearer errors when we get an unexpected failure response in YAML tests.

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -62,9 +62,9 @@ void TestCommand::Exit(std::string message)
     SetCommandExitStatus(CHIP_ERROR_INTERNAL);
 }
 
-void TestCommand::ThrowFailureResponse()
+void TestCommand::ThrowFailureResponse(CHIP_ERROR error)
 {
-    Exit("Expecting success response but got a failure response");
+    Exit(std::string("Expecting success response but got a failure response: ") + chip::ErrorStr(error));
 }
 
 void TestCommand::ThrowSuccessResponse()

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -80,7 +80,7 @@ protected:
     chip::Controller::DeviceCommissioner & GetCurrentCommissioner() override { return CurrentCommissioner(); };
 
     void Exit(std::string message) override;
-    void ThrowFailureResponse();
+    void ThrowFailureResponse(CHIP_ERROR error);
     void ThrowSuccessResponse();
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;

--- a/examples/chip-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_cluster.zapt
@@ -341,7 +341,7 @@ class {{filename}}Suite: public TestCommand
           {{#unless async}}NextTest();{{/unless}}
           {{/if}}
         {{else}}
-          {{#if optional}}(status.mStatus == chip::Protocols::InteractionModel::Status::UnsupportedAttribute) ? NextTest() : {{/if}}ThrowFailureResponse();
+          {{#if optional}}(status.mStatus == chip::Protocols::InteractionModel::Status::UnsupportedAttribute) ? NextTest() : {{/if}}ThrowFailureResponse(error);
         {{/if}}
     }
 


### PR DESCRIPTION
In particular, log the actual error we got.

#### Problem
Uninformative error message like:
```
***** Test Failure: Expecting success response but got a failure response
```

#### Change overview
More informative error message like:
```
***** Test Failure: Expecting success response but got a failure response: ../../../examples/chip-tool/third_party/connectedhomeip/src/lib/core/CHIPTLVReader.cpp:239: CHIP Error 0x00000026: Wrong TLV type
```

#### Testing
Tried removing the error expectations from some YAML tests and got nicer error logging.
