### PR TITLE
[chip-tool] Add --commissioner-fabricid parameter

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -326,6 +326,8 @@ CHIP_ERROR CHIPCommand::InitializeCommissioner(std::string key, chip::FabricId f
 
         ReturnLogErrorOnFailure(ephemeralKey.Initialize());
         chip::NodeId nodeId = mCommissionerNodeId.ValueOr(mCommissionerStorage.GetLocalNodeId());
+        fabricId            = mCommissionerFabricId.ValueOr(fabricId);
+
         ReturnLogErrorOnFailure(mCredIssuerCmds->GenerateControllerNOCChain(
             nodeId, fabricId, mCommissionerStorage.GetCommissionerCATs(), ephemeralKey, rcacSpan, icacSpan, nocSpan));
         commissionerParams.operationalKeypair = &ephemeralKey;

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -62,6 +62,7 @@ public:
         AddArgument("paa-trust-store-path", &mPaaTrustStorePath);
         AddArgument("commissioner-name", &mCommissionerName);
         AddArgument("commissioner-nodeid", 0, UINT64_MAX, &mCommissionerNodeId);
+        AddArgument("commissioner-fabricid", 0, UINT64_MAX, &mCommissionerNodeId);
 #if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
         AddArgument("trace_file", &mTraceFile);
         AddArgument("trace_log", 0, 1, &mTraceLog);
@@ -118,6 +119,7 @@ private:
     static std::map<std::string, std::unique_ptr<ChipDeviceCommissioner>> mCommissioners;
     chip::Optional<char *> mCommissionerName;
     chip::Optional<chip::NodeId> mCommissionerNodeId;
+    chip::Optional<chip::FabricId> mCommissionerFabricId;
     chip::Optional<uint16_t> mBleAdapterId;
     chip::Optional<char *> mPaaTrustStorePath;
 


### PR DESCRIPTION
#### Problem

There is no way to override the fabric id.

#### Change overview
 * Add a `--commissioner-fabricid` optional parameter to cluster commands
