### PR TITLE
[nrfconnect] Fixed using Kconfig.features options

### DIFF
--- a/examples/all-clusters-app/nrfconnect/Kconfig
+++ b/examples/all-clusters-app/nrfconnect/Kconfig
@@ -22,6 +22,6 @@ config STATE_LEDS
 	  Use LEDs to render the current state of the device such as the progress of commissioning of
 	  the device into a network or the factory reset initiation.
 
-rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 rsource "../../../config/nrfconnect/chip-module/Kconfig.features"
+rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/examples/light-switch-app/nrfconnect/Kconfig
+++ b/examples/light-switch-app/nrfconnect/Kconfig
@@ -23,6 +23,6 @@ config STATE_LEDS
 	  the device into a network or the factory reset initiation. Note that setting this option to
 	  'n' does not disable the LED indicating the state of the simulated bolt.
 
-rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 rsource "../../../config/nrfconnect/chip-module/Kconfig.features"
+rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/examples/lighting-app/nrfconnect/Kconfig
+++ b/examples/lighting-app/nrfconnect/Kconfig
@@ -15,6 +15,6 @@
 #
 mainmenu "Matter nRF Connect Lighting Example Application"
 
-rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 rsource "../../../config/nrfconnect/chip-module/Kconfig.features"
+rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/examples/lock-app/nrfconnect/Kconfig
+++ b/examples/lock-app/nrfconnect/Kconfig
@@ -23,6 +23,6 @@ config STATE_LEDS
 	  the device into a network or the factory reset initiation. Note that setting this option to
 	  'n' does not disable the LED indicating the state of the simulated bolt.
 
-rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 rsource "../../../config/nrfconnect/chip-module/Kconfig.features"
+rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/examples/pigweed-app/nrfconnect/Kconfig
+++ b/examples/pigweed-app/nrfconnect/Kconfig
@@ -15,6 +15,6 @@
 #
 mainmenu "Matter nRF Connect Lighting Example Application"
 
-rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 rsource "../../../config/nrfconnect/chip-module/Kconfig.features"
+rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/examples/pump-app/nrfconnect/Kconfig
+++ b/examples/pump-app/nrfconnect/Kconfig
@@ -15,6 +15,6 @@
 #
 mainmenu "Matter nRF Connect Lighting Example Application"
 
-rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 rsource "../../../config/nrfconnect/chip-module/Kconfig.features"
+rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/examples/pump-controller-app/nrfconnect/Kconfig
+++ b/examples/pump-controller-app/nrfconnect/Kconfig
@@ -15,6 +15,6 @@
 #
 mainmenu "Matter nRF Connect Lighting Example Application"
 
-rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 rsource "../../../config/nrfconnect/chip-module/Kconfig.features"
+rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/examples/shell/nrfconnect/Kconfig
+++ b/examples/shell/nrfconnect/Kconfig
@@ -15,6 +15,6 @@
 #
 mainmenu "Matter nRF Connect Lighting Example Application"
 
-rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 rsource "../../../config/nrfconnect/chip-module/Kconfig.features"
+rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"


### PR DESCRIPTION
#### Problem
Kconfig.features is currently sourced after Kconfig.defaults,
so the default values from Kconfig.defaults are used and features
cannot modify it.

#### Change overview
Removed Kconfig.features to be sourced before Kconfig.defaults.

