### PR TITLE
[Tizen] Add Tizen Studio CLI to docker images

### DIFF
--- a/integrations/docker/images/chip-build-tizen/Dockerfile
+++ b/integrations/docker/images/chip-build-tizen/Dockerfile
@@ -14,37 +14,76 @@ RUN set -x \
     && : # last line
 
 # ------------------------------------------------------------------------------
-# Install toolchain
+# Install dependencies
 RUN set -x \
     && apt-get update \
-    && apt-get install -fy --no-install-recommends obs-build=20180831-3ubuntu1 cpio=2.13+dfsg-2 \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
+    cpio=2.13+dfsg-2 \
+    obs-build=20180831-3ubuntu1 \
+    openjdk-8-jre-headless \
+    zip \
+    # Cleanup
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && : # last line
 
 # ------------------------------------------------------------------------------
 # Install tizen SDK
-ENV TIZEN_HOME /opt/tizen_sdk
-ENV TIZEN_ROOTSTRAP_VERSION 6.0
-ENV TIZEN_ROOTSTRAPS mobile-$TIZEN_ROOTSTRAP_VERSION-rs-device.core_0.0.123_ubuntu-64
-ENV DNS_LIBS libnsd-dns-sd.so*
+ENV TIZEN_SDK_ROOT /opt/tizen-sdk
+ENV TIZEN_VERSION 6.0
 
-WORKDIR $TIZEN_HOME
-
-RUN set -x \
-    && wget --progress=dot:giga http://download.tizen.org/sdk/tizenstudio/official/binary/$TIZEN_ROOTSTRAPS.zip \
-    && unzip $TIZEN_ROOTSTRAPS.zip \
-    && mv data/platforms/tizen-$TIZEN_ROOTSTRAP_VERSION/mobile/rootstraps/mobile-$TIZEN_ROOTSTRAP_VERSION-device.core/usr . \
-    && mv data/platforms/tizen-$TIZEN_ROOTSTRAP_VERSION/mobile/rootstraps/mobile-$TIZEN_ROOTSTRAP_VERSION-device.core/lib . \
-    && rm -rf usr/lib/$DNS_LIBS \
-    && rm -rf data \
-    && rm -rf mobile-$TIZEN_ROOTSTRAP_VERSION-rs-device.* \
-    && rm pkginfo.manifest \
-    && : # last line
+WORKDIR /tmp/workdir
 
 # ------------------------------------------------------------------------------
-# Get tizen packages
+# Get tizen studio CLI
 RUN set -x \
+    && mkdir -p $TIZEN_SDK_ROOT \
+    # Download
+    && wget --progress=dot:giga \
+    http://download.tizen.org/sdk/tizenstudio/official/binary/certificate-encryptor_1.0.7_ubuntu-64.zip \
+    http://download.tizen.org/sdk/tizenstudio/official/binary/certificate-generator_0.1.3_ubuntu-64.zip \
+    http://download.tizen.org/sdk/tizenstudio/official/binary/new-common-cli_2.5.7_ubuntu-64.zip \
+    http://download.tizen.org/sdk/tizenstudio/official/binary/new-native-cli_2.5.7_ubuntu-64.zip \
+    # Install tizen studio CLI
+    && unzip -o '*.zip' \
+    && cp -rf data/* $TIZEN_SDK_ROOT \
+    && echo "TIZEN_SDK_INSTALLED_PATH=$TIZEN_SDK_ROOT" > $TIZEN_SDK_ROOT/sdk.info \
+    && echo "TIZEN_SDK_DATA_PATH=$USER_HOME/tizen-sdk-data" >> $TIZEN_SDK_ROOT/sdk.info \
+    && ln -sf $USER_HOME/.tizen-cli-config $TIZEN_SDK_ROOT/tools/.tizen-cli-config \
+    # Cleanup
+    && rm -rf /tmp/workdir \
+    && : # last line
+
+COPY secret-tool.py $TIZEN_SDK_ROOT/tools/certificate-encryptor/secret-tool
+ENV PATH="$TIZEN_SDK_ROOT/tools/ide/bin:$PATH"
+
+# ------------------------------------------------------------------------------
+# Get toolchain
+RUN set -x \
+    && mkdir -p $TIZEN_SDK_ROOT \
+    # Download
+    && wget --progress=dot:giga \
+    http://download.tizen.org/sdk/tizenstudio/official/binary/cross-arm-gcc-9.2_0.1.9_ubuntu-64.zip \
+    http://download.tizen.org/sdk/tizenstudio/official/binary/sbi-toolchain-gcc-9.2.cpp.app_2.2.16_ubuntu-64.zip \
+    # Install toolchain
+    && unzip -o '*.zip' \
+    && cp -rf data/* $TIZEN_SDK_ROOT \
+    # Cleanup
+    && rm -rf /tmp/workdir \
+    && : # last line
+
+ENV TIZEN_SDK_TOOLCHAIN $TIZEN_SDK_ROOT/tools/arm-linux-gnueabi-gcc-9.2
+ENV PATH="$TIZEN_SDK_TOOLCHAIN/bin:$PATH"
+
+# ------------------------------------------------------------------------------
+# Get tizen sysroot
+ENV TIZEN_SDK_SYSROOT \
+    $TIZEN_SDK_ROOT/platforms/tizen-$TIZEN_VERSION/mobile/rootstraps/mobile-$TIZEN_VERSION-device.core
+RUN set -x \
+    # Base sysroot
+    && wget --progress=dot:giga \
+    http://download.tizen.org/sdk/tizenstudio/official/binary/mobile-$TIZEN_VERSION-core-add-ons_0.0.262_ubuntu-64.zip \
+    http://download.tizen.org/sdk/tizenstudio/official/binary/mobile-$TIZEN_VERSION-rs-device.core_0.0.123_ubuntu-64.zip \
     # Base packages
     && wget -r -nd --no-parent -q -A 'pcre-devel-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/base/latest/repos/standard/packages/armv7l/ \
     && wget -r -nd --no-parent -q -A 'libffi-devel-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/base/latest/repos/standard/packages/armv7l/ \
@@ -67,26 +106,32 @@ RUN set -x \
     && wget -r -nd --no-parent -q -A 'capi-network-nsd-*.armv7l.rpm' http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/armv7l/ \
     && wget -r -nd --no-parent -q -A 'libnsd-dns-sd-*.armv7l.rpm' http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/armv7l/ \
     && wget -r -nd --no-parent -q -A 'capi-network-thread-*.armv7l.rpm' http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/armv7l/ \
-    && unrpm ./*.rpm \
-    && cp usr/lib/pkgconfig/openssl1.1.pc usr/lib/pkgconfig/openssl.pc \
-    && rm usr/lib/libdns_sd.so \
-    && cp usr/lib/libdns_sd.so.878.* usr/lib/libdns_sd.so \
-    && rm ./*.rpm \
-    && : # last line
-
-# ------------------------------------------------------------------------------
-# Get toolchain
-RUN set -x \
-    && wget --progress=dot:giga http://download.tizen.org/sdk/tizenstudio/official/binary/cross-arm-gcc-9.2_0.1.9_ubuntu-64.zip \
-    && unzip cross-arm-gcc-9.2_0.1.9_ubuntu-64.zip \
-    && cp -rf data/tools/arm-linux-gnueabi-gcc-9.2/* . \
-    && rm pkginfo.manifest \
-    && rm changelog \
-    && rm -rf data \
-    && rm cross-arm-gcc-9.2_0.1.9_ubuntu-64.zip \
+    # Install base sysroot
+    && unzip -o '*.zip' \
+    && cp -rf data/* $TIZEN_SDK_ROOT \
+    # Install packages
+    && unrpm *.rpm \
+    && cp -rf lib usr $TIZEN_SDK_SYSROOT \
+    # Fix some symbolic links
+    && ln -sf libcap.so.2 $TIZEN_SDK_SYSROOT/usr/lib/libcap.so \
+    && ln -sf libdns_sd.so.878.70.2 $TIZEN_SDK_SYSROOT/usr/lib/libdns_sd.so \
+    && ln -sf libdns_sd.so.878.70.2 $TIZEN_SDK_SYSROOT/usr/lib/libdns_sd.so.878 \
+    && ln -sf openssl1.1.pc $TIZEN_SDK_SYSROOT/usr/lib/pkgconfig/openssl.pc \
+    # Cleanup
+    && rm -rf /tmp/workdir \
     && : # last line
 
 # ------------------------------------------------------------------------------
 # Switch to the non-root user
 USER $USER_NAME
 WORKDIR $USER_HOME
+
+# ------------------------------------------------------------------------------
+# Setup tizen studio CLI
+RUN set -x \
+    # Generate author certificate
+    && tizen certificate --alias=CHIP --name=CHIP --email=chip@tizen.org --password=chiptizen \
+    # Add new security profile
+    && tizen security-profiles add --active --name=CHIP --author=$HOME/tizen-sdk-data/keystore/author/author.p12 --password=chiptizen \
+    # Cleanup
+    && : # last line

--- a/integrations/docker/images/chip-build-tizen/secret-tool.py
+++ b/integrations/docker/images/chip-build-tizen/secret-tool.py
@@ -1,80 +1,127 @@
 #!/usr/bin/python3
 # Dummy Password Manager for Tizen Studio CLI
+#
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+import argparse
+import fcntl
 import os
 import pickle
 import sys
-from argparse import ArgumentParser
 
 
 class Secrets:
 
     def __init__(self, filename: str):
         self.filename = filename
+        self.dirty = False
         self.secrets = {}
+        self.fp = None
+
+    def __enter__(self):
+        self.fp = open(self.filename, "a+b")
+        fcntl.flock(self.fp.fileno(), fcntl.LOCK_EX)
+        self._load()
+        return self
+
+    def __exit__(self, _type, value, tb):
+        if self.dirty:
+            self._save()
+        fcntl.flock(self.fp.fileno(), fcntl.LOCK_UN)
+        self.fp.close()
 
     @staticmethod
     def _build_key(label: str, **kw):
         return label + ":" + str(tuple(sorted(kw.items())))
 
-    def load(self):
+    def _load(self):
         try:
-            with open(self.filename, "rb") as f:
-                self.secrets = pickle.load(f)
-        except (IOError, ValueError) as e:
+            self.fp.seek(0)
+            self.secrets = pickle.load(self.fp)
+        except EOFError:
+            # Unpickling an empty file is not an error for us
+            pass
+        except ValueError as e:
             print("ERROR: " + str(e), file=sys.stderr)
 
-    def save(self):
+    def _save(self):
         try:
-            with open(self.filename, "wb") as f:
-                pickle.dump(self.secrets, f)
+            self.fp.seek(0)
+            self.fp.truncate()
+            pickle.dump(self.secrets, self.fp)
         except IOError as e:
             print("ERROR: " + str(e), file=sys.stderr)
 
     def clear(self, label: str, **kw):
         key = self._build_key(label, **kw)
         self.secrets.pop(key, None)
+        self.dirty = True
 
     def store(self, label: str, password: str, **kw):
         key = self._build_key(label, **kw)
         self.secrets[key] = password
+        self.dirty = True
 
     def lookup(self, label: str, **kw):
         key = self._build_key(label, **kw)
         return self.secrets.get(key, "")
 
 
-parser = ArgumentParser()
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    description="""
+Dummy Password Manager for Tizen Studio CLI.
+
+This simple password manager circumvents the requirement of having functional
+D-Bus Secrets service (org.freedesktop.secrets) in the Docker container. As a
+storage this manager uses plain-text file with pickled data (~/.secretsdb).
+
+Please, DO NOT store real secrets in it!""")
 subparsers = parser.add_subparsers(dest='command', required=True)
 
-parser_clear = subparsers.add_parser("clear")
-parser_clear.add_argument("-l", "--label", action='store', required=True)
-parser_clear.add_argument("kw", nargs='*')
+parser_clear = subparsers.add_parser(
+    "clear", help="Remove passward associated with given key value pairs")
+parser_clear.add_argument("-l", "--label", action='store', required=True,
+                          help="label for given key value pairs")
+parser_clear.add_argument("kw", nargs='*',
+                          help="key value pairs")
 
-parser_store = subparsers.add_parser("store")
-parser_store.add_argument("-l", "--label", action='store', required=True)
-parser_store.add_argument("-p", "--password", action='store', required=True)
-parser_store.add_argument("kw", nargs='*')
+parser_store = subparsers.add_parser(
+    "store", help="Store passward for given key value pairs")
+parser_store.add_argument("-l", "--label", action='store', required=True,
+                          help="label for given key value pairs")
+parser_store.add_argument("-p", "--password", action='store', required=True,
+                          help="password for given key value pairs")
+parser_store.add_argument("kw", nargs='*',
+                          help="key value pairs")
 
-parser_lookup = subparsers.add_parser("lookup")
-parser_lookup.add_argument("-l", "--label", action='store', required=True)
-parser_lookup.add_argument("kw", nargs='*')
+parser_lookup = subparsers.add_parser(
+    "lookup", help="Retrieve passward associated with given key value pairs")
+parser_lookup.add_argument("-l", "--label", action='store', required=True,
+                           help="label for given key value pairs")
+parser_lookup.add_argument("kw", nargs='*',
+                           help="key value pairs")
 
 args = parser.parse_args()
 kw = dict(zip(args.kw[:: 2], args.kw[1:: 2]))
 
-with open(os.path.expanduser("~/.secretsdb.log"), "a") as f:
-    f.write("%s: %s: %s\n" % (args.command, args.label, kw))
-
-secrets = Secrets(os.path.expanduser("~/.secretsdb"))
-secrets.load()
-
-if args.command == "clear":
-    secrets.clear(args.label, **kw)
-    secrets.save()
-elif args.command == "store":
-    secrets.store(args.label, args.password, **kw)
-    secrets.save()
-elif args.command == "lookup":
-    password = secrets.lookup(args.label, **kw)
-    print(password)
+with Secrets(os.path.expanduser("~/.secretsdb")) as secrets:
+    if args.command == "clear":
+        secrets.clear(args.label, **kw)
+    elif args.command == "store":
+        secrets.store(args.label, args.password, **kw)
+    elif args.command == "lookup":
+        password = secrets.lookup(args.label, **kw)
+        print(password)

--- a/integrations/docker/images/chip-build-tizen/secret-tool.py
+++ b/integrations/docker/images/chip-build-tizen/secret-tool.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python3
+# Dummy Password Manager for Tizen Studio CLI
+
+import os
+import pickle
+import sys
+from argparse import ArgumentParser
+
+
+class Secrets:
+
+    def __init__(self, filename: str):
+        self.filename = filename
+        self.secrets = {}
+
+    @staticmethod
+    def _build_key(label: str, **kw):
+        return label + ":" + str(tuple(sorted(kw.items())))
+
+    def load(self):
+        try:
+            with open(self.filename, "rb") as f:
+                self.secrets = pickle.load(f)
+        except (IOError, ValueError) as e:
+            print("ERROR: " + str(e), file=sys.stderr)
+
+    def save(self):
+        try:
+            with open(self.filename, "wb") as f:
+                pickle.dump(self.secrets, f)
+        except IOError as e:
+            print("ERROR: " + str(e), file=sys.stderr)
+
+    def clear(self, label: str, **kw):
+        key = self._build_key(label, **kw)
+        self.secrets.pop(key, None)
+
+    def store(self, label: str, password: str, **kw):
+        key = self._build_key(label, **kw)
+        self.secrets[key] = password
+
+    def lookup(self, label: str, **kw):
+        key = self._build_key(label, **kw)
+        return self.secrets.get(key, "")
+
+
+parser = ArgumentParser()
+subparsers = parser.add_subparsers(dest='command', required=True)
+
+parser_clear = subparsers.add_parser("clear")
+parser_clear.add_argument("-l", "--label", action='store', required=True)
+parser_clear.add_argument("kw", nargs='*')
+
+parser_store = subparsers.add_parser("store")
+parser_store.add_argument("-l", "--label", action='store', required=True)
+parser_store.add_argument("-p", "--password", action='store', required=True)
+parser_store.add_argument("kw", nargs='*')
+
+parser_lookup = subparsers.add_parser("lookup")
+parser_lookup.add_argument("-l", "--label", action='store', required=True)
+parser_lookup.add_argument("kw", nargs='*')
+
+args = parser.parse_args()
+kw = dict(zip(args.kw[:: 2], args.kw[1:: 2]))
+
+with open(os.path.expanduser("~/.secretsdb.log"), "a") as f:
+    f.write("%s: %s: %s\n" % (args.command, args.label, kw))
+
+secrets = Secrets(os.path.expanduser("~/.secretsdb"))
+secrets.load()
+
+if args.command == "clear":
+    secrets.clear(args.label, **kw)
+    secrets.save()
+elif args.command == "store":
+    secrets.store(args.label, args.password, **kw)
+    secrets.save()
+elif args.command == "lookup":
+    password = secrets.lookup(args.label, **kw)
+    print(password)

--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -35,7 +35,7 @@ COPY --from=p6 /opt/ModusToolbox /opt/ModusToolbox
 COPY --from=telink /opt/telink/zephyrproject /opt/telink/zephyrproject
 COPY --from=telink /opt/telink/zephyr-sdk-0.13.2 /opt/telink/zephyr-sdk-0.13.2
 
-COPY --from=tizen /opt/tizen_sdk /opt/tizen_sdk
+COPY --from=tizen /opt/tizen-sdk /opt/tizen-sdk
 
 COPY --from=crosscompile /opt/ubuntu-21.04-aarch64-sysroot /opt/ubuntu-21.04-aarch64-sysroot
 
@@ -72,7 +72,7 @@ ENV PW_ENVIRONMENT_ROOT=/home/vscode/pigweed/env
 ENV TELINK_ZEPHYR_BASE=/opt/telink/zephyrproject/zephyr
 ENV TELINK_ZEPHYR_SDK_DIR=/opt/telink/zephyr-sdk-0.13.2
 ENV CY_TOOLS_PATHS="/opt/ModusToolbox/tools_2.4"
-ENV TIZEN_HOME /opt/tizen_sdk
+ENV TIZEN_SDK_ROOT /opt/tizen-sdk
 ENV SYSROOT_AARCH64=/opt/ubuntu-21.04-aarch64-sysroot
 ENV AMEBA_PATH=/opt/ameba/ambd_sdk_with_chip_non_NDA
 ENV NXP_K32W061_SDK_ROOT=/opt/sdk/sdks

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.67 Version bump reason: update git version in Doxygen image
+0.5.68 Version bump reason: [Tizen] Add Tizen Studio CLI to Tizen docker image


### PR DESCRIPTION
#### Problem

Currently it's not possible to create proper Tizen application package (*.tpk) with Tizen docker image.

#### Change overview

This commit adds Tizen Studio CLI into the Tizen docker image. Also, it setups app's author certificate for signing the application. With that setup it will be possible to pack Tizen application into the tpk package as follows:

```sh
tizen package -t tpk --sign CHIP -- <TizenAppBuildDir>
```

#### Testing

Created Tizen application package with `connectedhomeip/chip-build-tizen` docker image.