### PR TITLE
Do not report CHIP_NO_ERROR as if it was an error

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -109,8 +109,16 @@ const CommissioningParameters & AutoCommissioner::GetCommissioningParameters() c
 CommissioningStage AutoCommissioner::GetNextCommissioningStage(CommissioningStage currentStage, CHIP_ERROR & lastErr)
 {
     auto nextStage = GetNextCommissioningStageInternal(currentStage, lastErr);
-    ChipLogProgress(Controller, "Going from commissioning step '%s' with lastErr = '%s' --> '%s'", StageToString(currentStage),
-                    lastErr.AsString(), StageToString(nextStage));
+    if (lastErr == CHIP_NO_ERROR)
+    {
+        ChipLogProgress(Controller, "Commissioning stage next step: '%s' -> '%s'", StageToString(currentStage),
+                        StageToString(nextStage));
+    }
+    else
+    {
+        ChipLogProgress(Controller, "Going from commissioning step '%s' with lastErr = '%s' -> '%s'", StageToString(currentStage),
+                        lastErr.AsString(), StageToString(nextStage));
+    }
     return nextStage;
 }
 
@@ -326,8 +334,16 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
 {
     CompletionStatus completionStatus;
     completionStatus.err = err;
-    ChipLogProgress(Controller, "Finished commissioning step '%s' with error '%s'", StageToString(report.stageCompleted),
-                    err.AsString());
+
+    if (err == CHIP_NO_ERROR)
+    {
+        ChipLogProgress(Controller, "Successfully finished commissioning step '%s'", StageToString(report.stageCompleted));
+    }
+    else
+    {
+        ChipLogProgress(Controller, "Error on commissioning step '%s': '%s'", StageToString(report.stageCompleted), err.AsString());
+    }
+
     if (err != CHIP_NO_ERROR)
     {
         completionStatus.failedStage = MakeOptional(report.stageCompleted);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1777,8 +1777,15 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
                                                   CommissioningDelegate * delegate, EndpointId endpoint,
                                                   Optional<System::Clock::Timeout> timeout)
 {
-    ChipLogProgress(Controller, "Performing next commissioning step '%s' with completion status = '%s'", StageToString(step),
-                    params.GetCompletionStatus().err.AsString());
+    if (params.GetCompletionStatus().err == CHIP_NO_ERROR)
+    {
+        ChipLogProgress(Controller, "Performing next commissioning step '%s'", StageToString(step));
+    }
+    else
+    {
+        ChipLogProgress(Controller, "Performing next commissioning step '%s' with completion status = '%s'", StageToString(step),
+                        params.GetCompletionStatus().err.AsString());
+    }
 
     // For now, we ignore errors coming in from the device since not all commissioning clusters are implemented on the device
     // side.


### PR DESCRIPTION
#### Problem
I am trying to debug commissioning and when we log 'success' as a regular chip error, it makes it seem as if we treat success as an error, in logs like:

```
[1649834731.516560][2724:2729] CHIP:CTL: Received NetworkConfig response
[1649834731.516609][2724:2729] CHIP:CTL: Finished commissioning step 'WiFiNetworkSetup' with error '../../examples/chip-tool/third_party/connectedhomeip/src/controller/CHIPDeviceController.cpp:1755: Success'
[1649834731.516645][2724:2729] CHIP:CTL: Going from commissioning step 'WiFiNetworkSetup' with lastErr = '../../examples/chip-tool/third_party/connectedhomeip/src/controller/CHIPDeviceController.cpp:1755: Success' --> 'WiFiNetworkEnable'
[1649834731.516675][2724:2729] CHIP:CTL: Setting wifi connection time min = 30
[1649834731.516707][2724:2729] CHIP:CTL: Performing next commissioning step 'WiFiNetworkEnable' with completion status = '../../examples/chip-tool/third_party/connectedhomeip/src/controller/CHIPDeviceController.cpp:1755: Success'
```

#### Change overview
Only log the error data if it is an actual error. This does remove the 'source of the success' information, however I expect logs to be a lot clearer of when something goes wrong if at all.

#### Testing
Compile only.