### PR TITLE
[case] Do not expire reserved secure sessions on Sigma1 reception

### DIFF
--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -60,13 +60,6 @@ CHIP_ERROR CASEServer::InitCASEHandshake(Messaging::ExchangeContext * ec)
 {
     ReturnErrorCodeIf(ec == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    // Mark any PASE sessions used for commissioning as stale.
-    // This is a workaround, as we currently don't have a way to identify
-    // secure sessions established via PASE protocol.
-    // TODO - Identify which PASE base secure channel was used
-    //        for commissioning and drop it once commissioning is complete.
-    mSessionManager->ExpireAllPairings(kUndefinedNodeId, kUndefinedFabricIndex);
-
 #if CONFIG_NETWORK_LAYER_BLE
     // Close all BLE connections now since a CASE handshake has been initiated.
     if (mBleLayer != nullptr)


### PR DESCRIPTION
#### Problem
Upon reception of Sigma1 CASEServer expires all sessions with undefined fabric index and node ID, supposedly to
expire stale PASE sessions, but the code seems obsolete since PASE sessions are already deleted by Commissioning
Window Manager on receiving CommissioningComplete command.

In fact, the code causes a problem in the following scenario:
1. A device tries to establish a connection to another device, for example OTA Provider.
2. The controller tries establish a connection with the device, for example to read its cluster attribute.

In such a case, although CASE session between the device and the OTA Provider will succeed, deriving a secure session
will fail because the CASE server will already have released the session reserved by the CASE client.

#### Change overview
Remove the obsolete code.

#### Testing
Extended a unit test.
Also tested with nRF Connect lock-app using the following command sequence (after commissioning):
```
# Node 1 is OTA Provider, node 2 is the lock-app
chip-tool otasoftwareupdaterequestor announce-ota-provider 1 0 0 0 2 0 &&
sleep 0.1 &&
chip-tool otasoftwareupdaterequestor read update-state 2 0
```
