### PR TITLE
Add python building build capabilities to build_examples.py

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -270,6 +270,7 @@ jobs:
                     ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-all-clusters-${BUILD_VARIANT} \
+                        --target linux-x64-python-bindings \
                         build \
                         --copy-artifacts-to objdir-clone \
                      "

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -246,6 +246,7 @@ def HostTargets():
             'ota-provider', app=HostApp.OTA_PROVIDER, enable_ble=False))
         app_targets.append(target.Extend(
             'ota-requestor', app=HostApp.OTA_REQUESTOR, enable_ble=False))
+        app_targets.append(target.Extend('python-bindings', app=HostApp.PYTHON_BINDINGS))
 
     builder = VariantBuilder()
 
@@ -270,8 +271,8 @@ def HostTargets():
     builder.WhitelistVariantNameForGlob('ipv6only')
 
     for target in app_targets:
-        if 'rpc-console' in target.name:
-            # rpc console  has only one build variant right now
+        if ('-rpc-console' in target.name) or ('-python-bindings' in target.name):
+            # Single-variant builds
             yield target
         else:
             builder.targets.append(target)

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -104,7 +104,7 @@ class HostApp(Enum):
             yield 'chip-ota-requestor-app'
             yield 'chip-ota-requestor-app.map'
         elif self == HostApp.PYTHON_BINDINGS:
-            yield 'controller/python' # Directory containing WHL files
+            yield 'controller/python'  # Directory containing WHL files
         else:
             raise Exception('Unknown app type: %r' % self)
 

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -33,6 +33,7 @@ class HostApp(Enum):
     CERT_TOOL = auto()
     OTA_PROVIDER = auto()
     OTA_REQUESTOR = auto()
+    PYTHON_BINDINGS = auto()
 
     def ExamplePath(self):
         if self == HostApp.ALL_CLUSTERS:
@@ -45,22 +46,18 @@ class HostApp(Enum):
             return 'common/pigweed/rpc_console'
         elif self == HostApp.MIN_MDNS:
             return 'minimal-mdns'
-        elif self == HostApp.ADDRESS_RESOLVE:
-            return '../'
         elif self == HostApp.TV_APP:
             return 'tv-app/linux'
         elif self == HostApp.LOCK:
             return 'door-lock-app/linux'
-        elif self == HostApp.TESTS:
-            return '../'
         elif self == HostApp.SHELL:
             return 'shell/standalone'
-        elif self == HostApp.CERT_TOOL:
-            return '..'
         elif self == HostApp.OTA_PROVIDER:
             return 'ota-provider-app/linux'
         elif self == HostApp.OTA_REQUESTOR:
             return 'ota-requestor-app/linux'
+        elif self in [HostApp.ADDRESS_RESOLVE, HostApp.TESTS, HostApp.PYTHON_BINDINGS, HostApp.CERT_TOOL]:
+            return '../'
         else:
             raise Exception('Unknown app type: %r' % self)
 
@@ -106,6 +103,8 @@ class HostApp(Enum):
         elif self == HostApp.OTA_REQUESTOR:
             yield 'chip-ota-requestor-app'
             yield 'chip-ota-requestor-app.map'
+        elif self == HostApp.PYTHON_BINDINGS:
+            yield 'controller/python' # Directory containing WHL files
         else:
             raise Exception('Unknown app type: %r' % self)
 
@@ -211,9 +210,12 @@ class HostBuilder(GnBuilder):
                     "Cannot cross compile CERT TOOL: ssl library conflict")
             self.extra_gn_options.append('chip_crypto="openssl"')
             self.build_command = 'src/tools/chip-cert'
-
-        if app == HostApp.ADDRESS_RESOLVE:
+        elif app == HostApp.ADDRESS_RESOLVE:
             self.build_command = 'src/lib/address_resolve:address-resolve-tool'
+        elif app == HostApp.PYTHON_BINDINGS:
+            self.extra_gn_options.append('enable_rtti=false')
+            self.extra_gn_options.append('chip_project_config_include_dirs=["//config/python"]')
+            self.build_command = 'python'
 
     def GnBuildArgs(self):
         if self.board == HostBoard.NATIVE:

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -56,6 +56,11 @@ bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor-ipv6only'
 
+# Generating linux-arm64-python-bindings
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '"'"'--args=enable_rtti=false chip_project_config_include_dirs=["//config/python"] target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-python-bindings'
+
 # Generating linux-arm64-shell
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
@@ -124,6 +129,9 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Generating linux-x64-ota-requestor-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false' {out}/linux-x64-ota-requestor-ipv6only
 
+# Generating linux-x64-python-bindings
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--args=enable_rtti=false chip_project_config_include_dirs=["//config/python"]' {out}/linux-x64-python-bindings
+
 # Generating linux-x64-rpc-console
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/common/pigweed/rpc_console {out}/linux-x64-rpc-console
 
@@ -180,6 +188,9 @@ ninja -C {out}/linux-arm64-ota-requestor
 
 # Building linux-arm64-ota-requestor-ipv6only
 ninja -C {out}/linux-arm64-ota-requestor-ipv6only
+
+# Building linux-arm64-python-bindings
+ninja -C {out}/linux-arm64-python-bindings python
 
 # Building linux-arm64-shell
 ninja -C {out}/linux-arm64-shell
@@ -240,6 +251,9 @@ ninja -C {out}/linux-x64-ota-requestor
 
 # Building linux-x64-ota-requestor-ipv6only
 ninja -C {out}/linux-x64-ota-requestor-ipv6only
+
+# Building linux-x64-python-bindings
+ninja -C {out}/linux-x64-python-bindings python
 
 # Building linux-x64-rpc-console
 ninja -C {out}/linux-x64-rpc-console


### PR DESCRIPTION
#### Problem
Looking to have a very uniform build logic by using build_examples.

#### Change overview
Adds python binding compile support - both host and cross compile if applicable.

#### Testing
CI and unit tests were updated. Compiled locally too.