### PR TITLE
Remove replacing underscores with spaces in scanned NFC tag on iOS

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -432,11 +432,7 @@
                         NSURL * payloadURI = [payload wellKnownTypeURIPayload];
                         NSLog(@"Payload text:%@", payloadURI);
                         if (payloadURI) {
-                            /* CHIP Issue #415
-                             Once #415 goes in, there will b no need to replace _ with spaces.
-                            */
-                            NSString * qrCode = [[payloadURI absoluteString] stringByReplacingOccurrencesOfString:@"_"
-                                                                                                       withString:@" "];
+                            NSString * qrCode = [payloadURI absoluteString];
                             NSLog(@"Scanned code string:%@", qrCode);
                             [self scannedQRCode:qrCode];
                         }


### PR DESCRIPTION
#### Problem

Underscore are replaced with spaces for scanned NFC.

fix #6131

#### Change overview
* Remove the replacement code now that the spec issue has been resolved

#### Testing
Sadly I do not have the necessary equipment to validate that.