### PR TITLE
Fix for 17343: DiscoveryController does not support multiple instances on the same host

### DIFF
--- a/src/controller/AbstractDnssdDiscoveryController.cpp
+++ b/src/controller/AbstractDnssdDiscoveryController.cpp
@@ -34,7 +34,7 @@ void AbstractDnssdDiscoveryController::OnNodeDiscovered(const chip::Dnssd::Disco
         {
             continue;
         }
-        if (strcmp(discoveredNode.hostName, nodeData.hostName) == 0)
+        if (strcmp(discoveredNode.hostName, nodeData.hostName) == 0 && discoveredNode.port == nodeData.port)
         {
             discoveredNode = nodeData;
             if (mDeviceDiscoveryDelegate != nullptr)


### PR DESCRIPTION
#### Problem
https://github.com/project-chip/connectedhomeip/issues/17343
When using the DiscoveryController, if there are multiple Matter servers on the same host, only one is discovered.
- desired: list of each server (or mDNS response) is returned
- actual: only the last server (or mDNS response) is returned

The result is that you can encounter problems when running multiple matter processes on the same machine (Mac, linux/docker, etc).

#### Change overview
DiscoveryController maintains a list of all discovered nodes but when checking the list for repeats, it only compares hostname and not port so fix is to change the check to include both host and port.

#### Testing
* Tested running tv-casting-app and tv-app against each other on same host
