### PR TITLE
Partial fix to Fail-Safe init data dependency issue

### DIFF
--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -249,7 +249,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::Init()
         ReturnErrorOnFailure(StoreUniqueId(uniqueId, strlen(uniqueId)));
     }
 
-    bool failSafeArmed;
+    bool failSafeArmed = false;
 
     // If the fail-safe was armed when the device last shutdown, initiate cleanup based on the pending Fail Safe Context with
     // which the fail-safe timer was armed.
@@ -262,12 +262,19 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::Init()
         ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot");
 
         err = FailSafeContext::LoadFromStorage(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
-        SuccessOrExit(err);
-
-        DeviceControlServer::DeviceControlSvr().GetFailSafeContext().ScheduleFailSafeCleanup(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
+        if (err == CHIP_NO_ERROR)
+        {
+            DeviceControlServer::DeviceControlSvr().GetFailSafeContext().ScheduleFailSafeCleanup(fabricIndex, addNocCommandInvoked, updateNocCommandInvoked);
+        }
+        else
+        {
+            // This should not happen, but we should not fail system init based on it!
+            ChipLogError(DeviceLayer, "Failed to load fail-safe context from storage (err= %" CHIP_ERROR_FORMAT "), cleaning-up!", err.Format());
+            (void)SetFailSafeArmed(false);
+            err = CHIP_NO_ERROR;
+        }
     }
 
-exit:
     return err;
 }
 


### PR DESCRIPTION
#### Problem
- Fail-safe init in `CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::Init()`
  can cause failure to init Matter stack whenever there is a partial state of storage
  of the fail-safe (i.e. `ConfigurationManager` has the failsafe set, but somehow
  `FailSafeContext::LoadFromStorage()` fails to find its part of the context.
  This should not happen, in general, but I have seen it happen on
  aborted chip-tool-based-commissioning and it crashes Linux-based tests at least.

Issue #17324

#### Change overview
This PR cleans-up of this partial state is found, rather than failing
`GenericConfigurationManagerImpl<ConfigClass>::Init()` which is catastrophic.

Further PRs need to deal with a more root-cause solution

#### Testing
- Ran cert tests, aborted midway, then ran unit tests, failed before this change,
  now passes after this change.
- Other unit tests still pass
