### PR TITLE
Fix NFC enabling

### DIFF
--- a/examples/lighting-app/nxp/k32w/k32w0/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/nxp/k32w/k32w0/include/CHIPProjectConfig.h
@@ -129,14 +129,6 @@
 #define CHIP_DEVICE_CONFIG_BLE_ADVERTISING_TIMEOUT (15 * 60 * 1000)
 
 /**
- * CONFIG_CHIP_NFC_COMMISSIONING, CHIP_DEVICE_CONFIG_ENABLE_NFC
- *
- * Set these defines to 1 if NFC Commissioning is needed
- */
-#define CONFIG_CHIP_NFC_COMMISSIONING 1
-#define CHIP_DEVICE_CONFIG_ENABLE_NFC 1
-
-/**
  *  @def CHIP_CONFIG_MAX_FABRICS
  *
  *  @brief

--- a/examples/lock-app/nxp/k32w/k32w0/include/CHIPProjectConfig.h
+++ b/examples/lock-app/nxp/k32w/k32w0/include/CHIPProjectConfig.h
@@ -129,14 +129,6 @@
 #define CHIP_DEVICE_CONFIG_BLE_ADVERTISING_TIMEOUT (15 * 60 * 1000)
 
 /**
- * CONFIG_CHIP_NFC_COMMISSIONING, CHIP_DEVICE_CONFIG_ENABLE_NFC
- *
- * Set these defines to 1 if NFC Commissioning is needed
- */
-#define CONFIG_CHIP_NFC_COMMISSIONING 1
-#define CHIP_DEVICE_CONFIG_ENABLE_NFC 1
-
-/**
  *  @def CHIP_CONFIG_MAX_FABRICS
  *
  *  @brief

--- a/examples/shell/nxp/k32w/k32w0/include/CHIPProjectConfig.h
+++ b/examples/shell/nxp/k32w/k32w0/include/CHIPProjectConfig.h
@@ -136,14 +136,6 @@
 #define CHIP_DEVICE_CONFIG_BLE_ADVERTISING_TIMEOUT (15 * 60 * 1000)
 
 /**
- * CONFIG_CHIP_NFC_COMMISSIONING, CHIP_DEVICE_CONFIG_ENABLE_NFC
- *
- * Set these defines to 1 if NFC Commissioning is needed
- */
-#define CONFIG_CHIP_NFC_COMMISSIONING 0
-#define CHIP_DEVICE_CONFIG_ENABLE_NFC 0
-
-/**
  *  @def CHIP_CONFIG_MAX_FABRICS
  *
  *  @brief

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -117,7 +117,10 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
     }
 
     if (chip_enable_nfc) {
-      defines += [ "CHIP_DEVICE_CONFIG_ENABLE_NFC=1" ]
+      defines += [
+        "CHIP_DEVICE_CONFIG_ENABLE_NFC=1",
+        "CONFIG_CHIP_NFC_COMMISSIONING=1",
+        ]
     }
 
     if (chip_enable_ota_requestor) {

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -120,7 +120,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
       defines += [
         "CHIP_DEVICE_CONFIG_ENABLE_NFC=1",
         "CONFIG_CHIP_NFC_COMMISSIONING=1",
-        ]
+      ]
     }
 
     if (chip_enable_ota_requestor) {


### PR DESCRIPTION
#### Problem
* both CONFIG_CHIP_NFC_COMMISSIONING and CHIP_DEVICE_CONFIG_ENABLE_NFC needs to be set in order to enable NFC functionality;
* until now, only CHIP_DEVICE_CONFIG_ENABLE_NFC was set if chip_enable_nfc was true
* probably we should keep a single define, but this should be addressed in a separate PR

#### Change overview
* set both NFC defines when chip_enable_nfc is true.

#### Testing
* compiled both with chip_enable_nfc enabled and disabled.