### PR TITLE
Fixed BindingManager to make sure it doesn't use invalid context

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
@@ -103,12 +103,18 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
     }
 }
 
+static void BoundDeviceContextReleaseHandler(void * context)
+{
+    (void) context;
+}
+
 static void InitBindingHandlerInternal(intptr_t arg)
 {
     auto & server = chip::Server::GetInstance();
     chip::BindingManager::GetInstance().Init(
         { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
     chip::BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(BoundDeviceChangedHandler);
+    chip::BindingManager::GetInstance().RegisterBoundDeviceContextReleaseHandler(BoundDeviceContextReleaseHandler);
 }
 
 CHIP_ERROR InitBindingHandlers()

--- a/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
@@ -103,7 +103,7 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
     }
 }
 
-static void BoundDeviceContextReleaseHandler(chip::BindingManagerContext * context)
+static void BoundDeviceContextReleaseHandler(void * context)
 {
     (void) context;
 }

--- a/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
@@ -103,7 +103,7 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
     }
 }
 
-static void BoundDeviceContextReleaseHandler(void * context)
+static void BoundDeviceContextReleaseHandler(chip::BindingManagerContext * context)
 {
     (void) context;
 }

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -132,13 +132,11 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DevicePro
     }
 }
 
-void LightSwitchContextReleaseHandler(BindingManagerContext * context)
+void LightSwitchContextReleaseHandler(void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "LightSwitchContextReleaseHandler: context is null"));
 
-    // Release the internal context stored in BindingManagerContext and then the BindingManagerContext itself.
-    Platform::Delete(static_cast<BindingCommandData *>(context->GetContext()));
-    Platform::Delete(context);
+    Platform::Delete(static_cast<BindingCommandData *>(context));
 }
 
 #ifdef ENABLE_CHIP_SHELL
@@ -406,9 +404,8 @@ void SwitchWorkerFunction(intptr_t context)
 {
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "SwitchWorkerFunction - Invalid work data"));
 
-    BindingCommandData * data              = reinterpret_cast<BindingCommandData *>(context);
-    BindingManagerContext * bindingContext = Platform::New<BindingManagerContext>(static_cast<void *>(data));
-    BindingManager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, bindingContext);
+    BindingCommandData * data = reinterpret_cast<BindingCommandData *>(context);
+    BindingManager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
 }
 
 void BindingWorkerFunction(intptr_t context)

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -132,6 +132,13 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DevicePro
     }
 }
 
+void LightSwitchContextReleaseHandler(void * context)
+{
+    VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "LightSwitchContextReleaseHandler: context is null"));
+    BindingCommandData * data = static_cast<BindingCommandData *>(context);
+    Platform::Delete(data);
+}
+
 #ifdef ENABLE_CHIP_SHELL
 
 /********************************************************
@@ -384,6 +391,7 @@ void InitBindingHandlerInternal(intptr_t arg)
     chip::BindingManager::GetInstance().Init(
         { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
     chip::BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
+    chip::BindingManager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
 }
 
 } // namespace
@@ -398,8 +406,6 @@ void SwitchWorkerFunction(intptr_t context)
 
     BindingCommandData * data = reinterpret_cast<BindingCommandData *>(context);
     BindingManager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
-
-    Platform::Delete(data);
 }
 
 void BindingWorkerFunction(intptr_t context)

--- a/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
+++ b/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
@@ -60,10 +60,10 @@ void BindingHandler::OnInvokeCommandFailure(DeviceProxy * aDevice, BindingData &
         // Allocate new object to make sure its life time will be appropriate.
         BindingHandler::BindingData * data = Platform::New<BindingHandler::BindingData>();
         *data                              = aBindingData;
-        BindingManagerContext * context    = Platform::New<BindingManagerContext>(static_cast<void *>(data));
 
         // Establish new CASE session and retrasmit command that was not applied.
-        error = BindingManager::GetInstance().NotifyBoundClusterChanged(aBindingData.EndpointId, aBindingData.ClusterId, context);
+        error = BindingManager::GetInstance().NotifyBoundClusterChanged(aBindingData.EndpointId, aBindingData.ClusterId,
+                                                                        static_cast<void *>(data));
     }
     else
     {
@@ -226,13 +226,11 @@ void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & bi
     }
 }
 
-void BindingHandler::LightSwitchContextReleaseHandler(BindingManagerContext * context)
+void BindingHandler::LightSwitchContextReleaseHandler(void * context)
 {
     VerifyOrReturn(context != nullptr, LOG_ERR("Invalid context for Light switch context release handler"););
 
-    // Release the internal context stored in BindingManagerContext and then the BindingManagerContext itself.
-    Platform::Delete(static_cast<BindingData *>(context->GetContext()));
-    Platform::Delete(context);
+    Platform::Delete(static_cast<BindingData *>(context));
 }
 
 void BindingHandler::InitInternal(intptr_t aArg)
@@ -309,8 +307,7 @@ void BindingHandler::SwitchWorkerHandler(intptr_t aContext)
 {
     VerifyOrReturn(aContext != 0, LOG_ERR("Invalid Swich data"));
 
-    BindingData * data              = reinterpret_cast<BindingData *>(aContext);
-    BindingManagerContext * context = Platform::New<BindingManagerContext>(static_cast<void *>(data));
+    BindingData * data = reinterpret_cast<BindingData *>(aContext);
     LOG_INF("Notify Bounded Cluster | endpoint: %d cluster: %d", data->EndpointId, data->ClusterId);
-    BindingManager::GetInstance().NotifyBoundClusterChanged(data->EndpointId, data->ClusterId, context);
+    BindingManager::GetInstance().NotifyBoundClusterChanged(data->EndpointId, data->ClusterId, static_cast<void *>(data));
 }

--- a/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
+++ b/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
@@ -57,9 +57,13 @@ void BindingHandler::OnInvokeCommandFailure(DeviceProxy * aDevice, BindingData &
         // Set flag to not try recover session multiple times.
         BindingHandler::GetInstance().mCaseSessionRecovered = true;
 
+        // Allocate new object to make sure its life time will be appropriate.
+        BindingHandler::BindingData * data = Platform::New<BindingHandler::BindingData>();
+        *data                              = aBindingData;
+
         // Establish new CASE session and retrasmit command that was not applied.
         error = BindingManager::GetInstance().NotifyBoundClusterChanged(aBindingData.EndpointId, aBindingData.ClusterId,
-                                                                        static_cast<void *>(&aBindingData));
+                                                                        static_cast<void *>(data));
     }
     else
     {
@@ -222,6 +226,13 @@ void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & bi
     }
 }
 
+void BindingHandler::LightSwitchContextReleaseHandler(void * context)
+{
+    VerifyOrReturn(context != nullptr, LOG_ERR("Invalid context for Light switch context release handler"););
+    BindingData * data = static_cast<BindingData *>(context);
+    Platform::Delete(data);
+}
+
 void BindingHandler::InitInternal(intptr_t aArg)
 {
     LOG_INF("Initialize binding Handler");
@@ -234,6 +245,7 @@ void BindingHandler::InitInternal(intptr_t aArg)
     }
 
     BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
+    BindingManager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
     BindingHandler::GetInstance().PrintBindingTable();
 }
 
@@ -298,6 +310,4 @@ void BindingHandler::SwitchWorkerHandler(intptr_t aContext)
     BindingData * data = reinterpret_cast<BindingData *>(aContext);
     LOG_INF("Notify Bounded Cluster | endpoint: %d cluster: %d", data->EndpointId, data->ClusterId);
     BindingManager::GetInstance().NotifyBoundClusterChanged(data->EndpointId, data->ClusterId, static_cast<void *>(data));
-
-    Platform::Delete(data);
 }

--- a/examples/light-switch-app/nrfconnect/main/LightSwitch.cpp
+++ b/examples/light-switch-app/nrfconnect/main/LightSwitch.cpp
@@ -57,7 +57,6 @@ void LightSwitch::InitiateActionSwitch(Action mAction)
         }
         data->IsGroup = BindingHandler::GetInstance().IsGroupBound();
         DeviceLayer::PlatformMgr().ScheduleWork(BindingHandler::SwitchWorkerHandler, reinterpret_cast<intptr_t>(data));
-        Platform::Delete(data);
     }
 }
 
@@ -79,6 +78,5 @@ void LightSwitch::DimmerChangeBrightness()
         data->Value   = (uint8_t) sBrightness;
         data->IsGroup = BindingHandler::GetInstance().IsGroupBound();
         DeviceLayer::PlatformMgr().ScheduleWork(BindingHandler::SwitchWorkerHandler, reinterpret_cast<intptr_t>(data));
-        Platform::Delete(data);
     }
 }

--- a/examples/light-switch-app/nrfconnect/main/include/BindingHandler.h
+++ b/examples/light-switch-app/nrfconnect/main/include/BindingHandler.h
@@ -54,6 +54,7 @@ private:
     static void OnOffProcessCommand(chip::CommandId, const EmberBindingTableEntry &, chip::DeviceProxy *, void *);
     static void LevelControlProcessCommand(chip::CommandId, const EmberBindingTableEntry &, chip::DeviceProxy *, void *);
     static void LightSwitchChangedHandler(const EmberBindingTableEntry &, chip::DeviceProxy *, void *);
+    static void LightSwitchContextReleaseHandler(void * context);
     static void InitInternal(intptr_t);
 
     bool mCaseSessionRecovered = false;

--- a/examples/light-switch-app/nrfconnect/main/include/BindingHandler.h
+++ b/examples/light-switch-app/nrfconnect/main/include/BindingHandler.h
@@ -54,7 +54,7 @@ private:
     static void OnOffProcessCommand(chip::CommandId, const EmberBindingTableEntry &, chip::DeviceProxy *, void *);
     static void LevelControlProcessCommand(chip::CommandId, const EmberBindingTableEntry &, chip::DeviceProxy *, void *);
     static void LightSwitchChangedHandler(const EmberBindingTableEntry &, chip::DeviceProxy *, void *);
-    static void LightSwitchContextReleaseHandler(chip::BindingManagerContext * context);
+    static void LightSwitchContextReleaseHandler(void * context);
     static void InitInternal(intptr_t);
 
     bool mCaseSessionRecovered = false;

--- a/examples/light-switch-app/nrfconnect/main/include/BindingHandler.h
+++ b/examples/light-switch-app/nrfconnect/main/include/BindingHandler.h
@@ -54,7 +54,7 @@ private:
     static void OnOffProcessCommand(chip::CommandId, const EmberBindingTableEntry &, chip::DeviceProxy *, void *);
     static void LevelControlProcessCommand(chip::CommandId, const EmberBindingTableEntry &, chip::DeviceProxy *, void *);
     static void LightSwitchChangedHandler(const EmberBindingTableEntry &, chip::DeviceProxy *, void *);
-    static void LightSwitchContextReleaseHandler(void * context);
+    static void LightSwitchContextReleaseHandler(chip::BindingManagerContext * context);
     static void InitInternal(intptr_t);
 
     bool mCaseSessionRecovered = false;

--- a/src/app/clusters/bindings/BindingManager.cpp
+++ b/src/app/clusters/bindings/BindingManager.cpp
@@ -186,33 +186,6 @@ void BindingManager::HandleDeviceConnectionFailure(PeerId peerId, CHIP_ERROR err
 {
     // Simply release the entry, the connection will be re-established as needed.
     ChipLogError(AppServer, "Failed to establish connection to node 0x" ChipLogFormatX64, ChipLogValueX64(peerId.GetNodeId()));
-
-    FabricIndex fabricToRemove = kUndefinedFabricIndex;
-    NodeId nodeToRemove        = kUndefinedNodeId;
-
-    for (PendingNotificationEntry pendingNotification : mPendingNotificationMap)
-    {
-        EmberBindingTableEntry entry = BindingTable::GetInstance().GetAt(pendingNotification.mBindingEntryId);
-
-        PeerId peer = PeerIdForNode(mInitParams.mFabricTable, entry.fabricIndex, entry.nodeId);
-
-        if (peerId == peer)
-        {
-            fabricToRemove = entry.fabricIndex;
-            nodeToRemove   = entry.nodeId;
-
-            BindingManagerContext * context = static_cast<BindingManagerContext *>(pendingNotification.mContext);
-
-            context->DecrementConsumersNumber();
-            if (context->GetConsumersNumber() == 0)
-            {
-                mBoundDeviceContextReleaseHandler(context->GetContext());
-                Platform::Delete(context);
-            }
-        }
-    }
-    mPendingNotificationMap.RemoveAllEntriesForNode(fabricToRemove, nodeToRemove);
-
     mInitParams.mCASESessionManager->ReleaseSession(peerId);
 }
 

--- a/src/app/clusters/bindings/BindingManager.h
+++ b/src/app/clusters/bindings/BindingManager.h
@@ -26,26 +26,6 @@
 
 namespace chip {
 
-class BindingManagerContext
-{
-public:
-    BindingManagerContext(void * context) : mContext(context) {}
-    void * GetContext() { return mContext; };
-    uint8_t GetConsumersNumber() { return mConsumersNumber; }
-    void IncrementConsumersNumber() { mConsumersNumber++; }
-    void DecrementConsumersNumber()
-    {
-        if (mConsumersNumber > 0)
-        {
-            mConsumersNumber--;
-        }
-    }
-
-private:
-    void * mContext;
-    uint8_t mConsumersNumber = 0;
-};
-
 /**
  * Application callback function when a cluster associated with a binding changes.
  *
@@ -64,7 +44,7 @@ using BoundDeviceChangedHandler = void (*)(const EmberBindingTableEntry & bindin
  * Application callback function when a context used in NotifyBoundClusterChanged will not be needed and should be
  * released.
  */
-using BoundDeviceContextReleaseHandler = void (*)(void * context);
+using BoundDeviceContextReleaseHandler = PendingNotificationContextReleaseHandler;
 
 struct BindingManagerInitParams
 {
@@ -103,7 +83,7 @@ public:
      */
     void RegisterBoundDeviceContextReleaseHandler(BoundDeviceContextReleaseHandler handler)
     {
-        mBoundDeviceContextReleaseHandler = handler;
+        mPendingNotificationMap.RegisterPendingNotificationContextReleaseHandler(handler);
     }
 
     CHIP_ERROR Init(const BindingManagerInitParams & params);
@@ -153,7 +133,6 @@ private:
 
     PendingNotificationMap mPendingNotificationMap;
     BoundDeviceChangedHandler mBoundDeviceChangedHandler;
-    BoundDeviceContextReleaseHandler mBoundDeviceContextReleaseHandler;
     BindingManagerInitParams mInitParams;
 
     Callback::Callback<OnDeviceConnected> mOnConnectedCallback;

--- a/src/app/clusters/bindings/BindingManager.h
+++ b/src/app/clusters/bindings/BindingManager.h
@@ -64,7 +64,7 @@ using BoundDeviceChangedHandler = void (*)(const EmberBindingTableEntry & bindin
  * Application callback function when a context used in NotifyBoundClusterChanged will not be needed and should be
  * released.
  */
-using BoundDeviceContextReleaseHandler = void (*)(BindingManagerContext * context);
+using BoundDeviceContextReleaseHandler = void (*)(void * context);
 
 struct BindingManagerInitParams
 {
@@ -136,7 +136,7 @@ public:
      * be initiated. The BoundDeviceChangedHandler will be called once the session is established.
      *
      */
-    CHIP_ERROR NotifyBoundClusterChanged(EndpointId endpoint, ClusterId cluster, BindingManagerContext * context);
+    CHIP_ERROR NotifyBoundClusterChanged(EndpointId endpoint, ClusterId cluster, void * context);
 
     static BindingManager & GetInstance() { return sBindingManager; }
 

--- a/src/app/clusters/bindings/BindingManager.h
+++ b/src/app/clusters/bindings/BindingManager.h
@@ -26,6 +26,26 @@
 
 namespace chip {
 
+class BindingManagerContext
+{
+public:
+    BindingManagerContext(void * context) : mContext(context) {}
+    void * GetContext() { return mContext; };
+    uint8_t GetConsumersNumber() { return mConsumersNumber; }
+    void IncrementConsumersNumber() { mConsumersNumber++; }
+    void DecrementConsumersNumber()
+    {
+        if (mConsumersNumber > 0)
+        {
+            mConsumersNumber--;
+        }
+    }
+
+private:
+    void * mContext;
+    uint8_t mConsumersNumber = 0;
+};
+
 /**
  * Application callback function when a cluster associated with a binding changes.
  *
@@ -40,7 +60,11 @@ namespace chip {
  */
 using BoundDeviceChangedHandler = void (*)(const EmberBindingTableEntry & binding, DeviceProxy * peer_device, void * context);
 
-using BoundDeviceContextReleaseHandler = void (*)(void * context);
+/**
+ * Application callback function when a context used in NotifyBoundClusterChanged will not be needed and should be
+ * released.
+ */
+using BoundDeviceContextReleaseHandler = void (*)(BindingManagerContext * context);
 
 struct BindingManagerInitParams
 {
@@ -112,7 +136,7 @@ public:
      * be initiated. The BoundDeviceChangedHandler will be called once the session is established.
      *
      */
-    CHIP_ERROR NotifyBoundClusterChanged(EndpointId endpoint, ClusterId cluster, void * context);
+    CHIP_ERROR NotifyBoundClusterChanged(EndpointId endpoint, ClusterId cluster, BindingManagerContext * context);
 
     static BindingManager & GetInstance() { return sBindingManager; }
 

--- a/src/app/clusters/bindings/BindingManager.h
+++ b/src/app/clusters/bindings/BindingManager.h
@@ -40,6 +40,8 @@ namespace chip {
  */
 using BoundDeviceChangedHandler = void (*)(const EmberBindingTableEntry & binding, DeviceProxy * peer_device, void * context);
 
+using BoundDeviceContextReleaseHandler = void (*)(void * context);
+
 struct BindingManagerInitParams
 {
     FabricTable * mFabricTable               = nullptr;
@@ -69,6 +71,16 @@ public:
     {}
 
     void RegisterBoundDeviceChangedHandler(BoundDeviceChangedHandler handler) { mBoundDeviceChangedHandler = handler; }
+
+    /*
+     * Registers handler that will be called when context used in NotifyBoundClusterChanged will not be needed and could be
+     * released.
+     *
+     */
+    void RegisterBoundDeviceContextReleaseHandler(BoundDeviceContextReleaseHandler handler)
+    {
+        mBoundDeviceContextReleaseHandler = handler;
+    }
 
     CHIP_ERROR Init(const BindingManagerInitParams & params);
 
@@ -117,6 +129,7 @@ private:
 
     PendingNotificationMap mPendingNotificationMap;
     BoundDeviceChangedHandler mBoundDeviceChangedHandler;
+    BoundDeviceContextReleaseHandler mBoundDeviceContextReleaseHandler;
     BindingManagerInitParams mInitParams;
 
     Callback::Callback<OnDeviceConnected> mOnConnectedCallback;

--- a/src/app/clusters/bindings/PendingNotificationMap.cpp
+++ b/src/app/clusters/bindings/PendingNotificationMap.cpp
@@ -79,11 +79,15 @@ CHIP_ERROR PendingNotificationMap::FindLRUConnectPeer(FabricIndex * fabric, Node
     return CHIP_ERROR_NOT_FOUND;
 }
 
-void PendingNotificationMap::AddPendingNotification(uint8_t bindingEntryId, void * context)
+void PendingNotificationMap::AddPendingNotification(uint8_t bindingEntryId, PendingNotificationContext * context)
 {
     RemoveEntry(bindingEntryId);
     mPendingBindingEntries[mNumEntries] = bindingEntryId;
     mPendingContexts[mNumEntries]       = context;
+    if (context)
+    {
+        context->IncrementConsumersNumber();
+    }
     mNumEntries++;
 }
 
@@ -97,6 +101,10 @@ void PendingNotificationMap::RemoveEntry(uint8_t bindingEntryId)
             mPendingBindingEntries[newEntryCount] = mPendingBindingEntries[i];
             mPendingContexts[newEntryCount]       = mPendingContexts[i];
             newEntryCount++;
+        }
+        else if (mPendingContexts[i] != nullptr)
+        {
+            mPendingContexts[i]->DecrementConsumersNumber();
         }
     }
     mNumEntries = newEntryCount;
@@ -114,6 +122,10 @@ void PendingNotificationMap::RemoveAllEntriesForNode(FabricIndex fabric, NodeId 
             mPendingContexts[newEntryCount]       = mPendingContexts[i];
             newEntryCount++;
         }
+        else if (mPendingContexts[i] != nullptr)
+        {
+            mPendingContexts[i]->DecrementConsumersNumber();
+        }
     }
     mNumEntries = newEntryCount;
 }
@@ -129,6 +141,10 @@ void PendingNotificationMap::RemoveAllEntriesForFabric(FabricIndex fabric)
             mPendingBindingEntries[newEntryCount] = mPendingBindingEntries[i];
             mPendingContexts[newEntryCount]       = mPendingContexts[i];
             newEntryCount++;
+        }
+        else if (mPendingContexts[i] != nullptr)
+        {
+            mPendingContexts[i]->DecrementConsumersNumber();
         }
     }
     mNumEntries = newEntryCount;

--- a/src/app/clusters/bindings/PendingNotificationMap.h
+++ b/src/app/clusters/bindings/PendingNotificationMap.h
@@ -38,11 +38,8 @@ public:
     void IncrementConsumersNumber() { mConsumersNumber++; }
     void DecrementConsumersNumber()
     {
-        if (mConsumersNumber > 0)
-        {
-            mConsumersNumber--;
-        }
-        else
+        VerifyOrDie(mConsumersNumber > 0);
+        if (--mConsumersNumber == 0)
         {
             // Release the context only if there is no pending notification pointing to it context.
             if (mPendingNotificationContextReleaseHandler != nullptr)

--- a/src/app/clusters/bindings/PendingNotificationMap.h
+++ b/src/app/clusters/bindings/PendingNotificationMap.h
@@ -21,11 +21,49 @@
 
 namespace chip {
 
+/**
+ * Application callback function when a context used in PendingNotificationEntry will not be needed and should be
+ * released.
+ */
+using PendingNotificationContextReleaseHandler = void (*)(void * context);
+
+class PendingNotificationContext
+{
+public:
+    PendingNotificationContext(void * context, PendingNotificationContextReleaseHandler contextReleaseHandler) :
+        mContext(context), mPendingNotificationContextReleaseHandler(contextReleaseHandler)
+    {}
+    void * GetContext() { return mContext; };
+    uint8_t GetConsumersNumber() { return mConsumersNumber; }
+    void IncrementConsumersNumber() { mConsumersNumber++; }
+    void DecrementConsumersNumber()
+    {
+        if (mConsumersNumber > 0)
+        {
+            mConsumersNumber--;
+        }
+        else
+        {
+            // Release the context only if there is no pending notification pointing to it context.
+            if (mPendingNotificationContextReleaseHandler != nullptr)
+            {
+                mPendingNotificationContextReleaseHandler(mContext);
+            }
+            Platform::Delete(this);
+        }
+    }
+
+private:
+    void * mContext;
+    uint8_t mConsumersNumber = 0;
+    PendingNotificationContextReleaseHandler mPendingNotificationContextReleaseHandler;
+};
+
 struct PendingNotificationEntry
 {
 public:
     uint8_t mBindingEntryId;
-    void * mContext;
+    PendingNotificationContext * mContext;
 };
 
 // The pool for all the pending comands.
@@ -67,7 +105,7 @@ public:
 
     CHIP_ERROR FindLRUConnectPeer(FabricIndex * fabric, NodeId * node);
 
-    void AddPendingNotification(uint8_t bindingEntryId, void * context);
+    void AddPendingNotification(uint8_t bindingEntryId, PendingNotificationContext * context);
 
     void RemoveEntry(uint8_t bindingEntryId);
 
@@ -77,9 +115,20 @@ public:
 
     void RemoveAllEntriesForFabric(FabricIndex fabric);
 
+    void RegisterPendingNotificationContextReleaseHandler(PendingNotificationContextReleaseHandler handler)
+    {
+        mPendingNotificationContextReleaseHandler = handler;
+    }
+
+    PendingNotificationContext * NewPendingNotificationContext(void * context)
+    {
+        return Platform::New<PendingNotificationContext>(context, mPendingNotificationContextReleaseHandler);
+    };
+
 private:
     uint8_t mPendingBindingEntries[kMaxPendingNotifications];
-    void * mPendingContexts[kMaxPendingNotifications];
+    PendingNotificationContext * mPendingContexts[kMaxPendingNotifications];
+    PendingNotificationContextReleaseHandler mPendingNotificationContextReleaseHandler;
 
     uint8_t mNumEntries = 0;
 };

--- a/src/app/clusters/bindings/PendingNotificationMap.h
+++ b/src/app/clusters/bindings/PendingNotificationMap.h
@@ -34,14 +34,14 @@ public:
         mContext(context), mPendingNotificationContextReleaseHandler(contextReleaseHandler)
     {}
     void * GetContext() { return mContext; };
-    uint8_t GetConsumersNumber() { return mConsumersNumber; }
+    uint32_t GetConsumersNumber() { return mConsumersNumber; }
     void IncrementConsumersNumber() { mConsumersNumber++; }
     void DecrementConsumersNumber()
     {
         VerifyOrDie(mConsumersNumber > 0);
         if (--mConsumersNumber == 0)
         {
-            // Release the context only if there is no pending notification pointing to it context.
+            // Release the context only if there is no pending notification pointing to us.
             if (mPendingNotificationContextReleaseHandler != nullptr)
             {
                 mPendingNotificationContextReleaseHandler(mContext);
@@ -52,7 +52,7 @@ public:
 
 private:
     void * mContext;
-    uint8_t mConsumersNumber = 0;
+    uint32_t mConsumersNumber = 0;
     PendingNotificationContextReleaseHandler mPendingNotificationContextReleaseHandler;
 };
 


### PR DESCRIPTION
#### Problem
BindingManager uses application context passed to
NotifyBoundClusterChanged and doesn't care about its life time.
Applications delete the context after calling the method, so if
the context will be used asynchronously (like for HandleDeviceConnect)
it may have invalid value.

#### Change overview
* Added for BindingManager method that allows to register handler
called when context is not used anymore and can be released.
* Added releasing context in applications using context release
handler.

#### Testing
Tested manually with nrfconnect light switch app and chiptool.