### PR TITLE
[qpg] Re-enable QPG6105 example apps builds in github workflow

### DIFF
--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -67,12 +67,12 @@ jobs:
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
             - name: Build QPG6105 example apps
-              timeout-minutes: 5
+              timeout-minutes: 20
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --enable-flashbundle \
-                        --target-glob 'qpg6105-{lock,light,shell,persistent-storage}' \
+                        --target-glob 'qpg-{lock,light,shell,persistent-storage}' \
                         build \
                         --copy-artifacts-to out/artifacts \
                      "


### PR DESCRIPTION
#### Problem
* QPG builds were disabled in the GitHub workflow

#### Change overview
* Added QPG6105 example builds again in the GitHub workflow
* Update in QPG6105 linker script

#### Testing
* Manual verification on QPG6105 example applications 
