### PR TITLE
de-duplicate non-wildcard attribute paths in the original request

### DIFF
--- a/src/app/AttributeCache.cpp
+++ b/src/app/AttributeCache.cpp
@@ -351,7 +351,7 @@ CHIP_ERROR AttributeCache::OnUpdateDataVersionFilterList(DataVersionFilterIBs::B
 
     for (auto & attribute : aAttributePaths)
     {
-        if (attribute.HasAttributeWildcard())
+        if (attribute.HasAttributeWildcard() && !attribute.IsDuplicate())
         {
             mRequestPathSet.insert(attribute);
         }

--- a/src/app/AttributePathParams.h
+++ b/src/app/AttributePathParams.h
@@ -99,10 +99,25 @@ struct AttributePathParams
         return HasWildcardAttributeId();
     }
 
+    // check if input concrete attribute path is subset of current wildcard attribute
+    bool IncludesSingleAttributesInCluster(const ConcreteAttributePath & aOther) const
+    {
+        return IncludesAllAttributesInCluster(aOther);
+    }
+
+    // check if input attribute path is same as current one.
+    bool IsSameAttribute(const AttributePathParams & aOther) const
+    {
+        return (mEndpointId == aOther.mEndpointId) && (mClusterId == aOther.mClusterId) && (mAttributeId == aOther.mAttributeId);
+    }
+
+    bool IsDuplicate() { return mIsDuplicate; }
+
     ClusterId mClusterId     = kInvalidClusterId;   // uint32
     AttributeId mAttributeId = kInvalidAttributeId; // uint32
     EndpointId mEndpointId   = kInvalidEndpointId;  // uint16
     ListIndex mListIndex     = kInvalidListIndex;   // uint16
+    bool mIsDuplicate        = false;               // uint8
 };
 
 } // namespace app

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -213,6 +213,8 @@ CHIP_ERROR ReadClient::SendReadRequest(ReadPrepareParams & aReadPrepareParams)
     Span<DataVersionFilter> dataVersionFilters(aReadPrepareParams.mpDataVersionFilterList,
                                                aReadPrepareParams.mDataVersionFilterListSize);
 
+    DeduplicateNonWildcardAttributePath(attributePaths);
+
     System::PacketBufferHandle msgBuf;
     ReadRequestMessage::Builder request;
     System::PacketBufferTLVWriter writer;
@@ -302,11 +304,40 @@ CHIP_ERROR ReadClient::GenerateEventPaths(EventPathIBs::Builder & aEventPathsBui
     return aEventPathsBuilder.GetError();
 }
 
+void ReadClient::DeduplicateNonWildcardAttributePath(const Span<AttributePathParams> & aAttributePaths)
+{
+    for (auto first = aAttributePaths.begin(); first != aAttributePaths.end(); ++first)
+    {
+        if (first->HasAttributeWildcard())
+        {
+            continue;
+        }
+        ConcreteAttributePath concreteAttributePath(first->mEndpointId, first->mClusterId, first->mAttributeId);
+        for (auto second = aAttributePaths.begin(); second != first; ++second)
+        {
+            if (second->IncludesSingleAttributesInCluster(concreteAttributePath))
+            {
+                first->mIsDuplicate = true;
+                break;
+            }
+            if (second->IsSameAttribute(*first))
+            {
+                first->mIsDuplicate = true;
+                break;
+            }
+        }
+    }
+}
+
 CHIP_ERROR ReadClient::GenerateAttributePaths(AttributePathIBs::Builder & aAttributePathIBsBuilder,
                                               const Span<AttributePathParams> & aAttributePaths)
 {
     for (auto & attribute : aAttributePaths)
     {
+        if (attribute.IsDuplicate())
+        {
+            continue;
+        }
         VerifyOrReturnError(attribute.IsValidAttributePath(), CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
         AttributePathIB::Builder & path = aAttributePathIBsBuilder.CreatePath();
         ReturnErrorOnFailure(aAttributePathIBsBuilder.GetError());
@@ -852,6 +883,7 @@ CHIP_ERROR ReadClient::SendSubscribeRequest(ReadPrepareParams & aReadPreparePara
     VerifyOrReturnError(aReadPrepareParams.mMinIntervalFloorSeconds <= aReadPrepareParams.mMaxIntervalCeilingSeconds,
                         err = CHIP_ERROR_INVALID_ARGUMENT);
 
+    DeduplicateNonWildcardAttributePath(attributePaths);
     System::PacketBufferHandle msgBuf;
     System::PacketBufferTLVWriter writer;
     SubscribeRequestMessage::Builder request;
@@ -981,5 +1013,6 @@ void ReadClient::UpdateDataVersionFilters(const ConcreteDataAttributePath & aPat
         }
     }
 }
+
 } // namespace app
 } // namespace chip

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -332,6 +332,7 @@ private:
     CHIP_ERROR ProcessAttributeReportIBs(TLV::TLVReader & aAttributeDataIBsReader);
     CHIP_ERROR ProcessEventReportIBs(TLV::TLVReader & aEventReportIBsReader);
 
+    void DeduplicateNonWildcardAttributePath(const Span<AttributePathParams> & aAttributePaths);
     void ClearExchangeContext() { mpExchangeCtx = nullptr; }
     static void OnLivenessTimeoutCallback(System::Layer * apSystemLayer, void * apAppState);
     CHIP_ERROR ProcessSubscribeResponse(System::PacketBufferHandle && aPayload);

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -310,6 +310,7 @@ public:
     static void TestSubscribeRoundtripChunkStatusReportTimeout(nlTestSuite * apSuite, void * apContext);
     static void TestPostSubscribeRoundtripChunkStatusReportTimeout(nlTestSuite * apSuite, void * apContext);
     static void TestPostSubscribeRoundtripChunkReportTimeout(nlTestSuite * apSuite, void * apContext);
+    static void TestDeduplicateNonWildcardAttributePath(nlTestSuite * apSuite, void * apContext);
 
 private:
     static void GenerateReportData(nlTestSuite * apSuite, void * apContext, System::PacketBufferHandle & aPayload,
@@ -2544,6 +2545,201 @@ void TestReadInteraction::TestPostSubscribeRoundtripChunkReportTimeout(nlTestSui
     NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
     ctx.CreateSessionBobToAlice();
 }
+
+void TestReadInteraction::TestDeduplicateNonWildcardAttributePath(nlTestSuite * apSuite, void * apContext)
+{
+    TestContext & ctx = *static_cast<TestContext *>(apContext);
+    MockInteractionModelApp delegate;
+    app::ReadClient client(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
+                           chip::app::ReadClient::InteractionType::Read);
+
+    // Duplicate detects
+    {
+        AttributePathParams attribute[2];
+        attribute[0].mEndpointId  = kInvalidEndpointId;
+        attribute[0].mClusterId   = 1;
+        attribute[0].mAttributeId = kInvalidAttributeId;
+
+        attribute[1].mEndpointId  = 1;
+        attribute[1].mClusterId   = 1;
+        attribute[1].mAttributeId = 1;
+
+        Span<AttributePathParams> attributePaths(attribute, 2);
+        client.DeduplicateNonWildcardAttributePath(attributePaths);
+        NL_TEST_ASSERT(apSuite, !attribute[0].IsDuplicate());
+        NL_TEST_ASSERT(apSuite, attribute[1].IsDuplicate());
+    }
+
+    // Duplicate detects
+    {
+        AttributePathParams attribute[2];
+        attribute[0].mEndpointId  = 1;
+        attribute[0].mClusterId   = kInvalidClusterId;
+        attribute[0].mAttributeId = kInvalidAttributeId;
+
+        attribute[1].mEndpointId  = 1;
+        attribute[1].mClusterId   = 1;
+        attribute[1].mAttributeId = 1;
+
+        Span<AttributePathParams> attributePaths(attribute, 2);
+        client.DeduplicateNonWildcardAttributePath(attributePaths);
+        NL_TEST_ASSERT(apSuite, !attribute[0].IsDuplicate());
+        NL_TEST_ASSERT(apSuite, attribute[1].IsDuplicate());
+    }
+
+    // Duplicate detects
+    {
+        AttributePathParams attribute[2];
+        attribute[0].mEndpointId  = kInvalidEndpointId;
+        attribute[0].mClusterId   = kInvalidClusterId;
+        attribute[0].mAttributeId = kInvalidAttributeId;
+
+        attribute[1].mEndpointId  = 1;
+        attribute[1].mClusterId   = 1;
+        attribute[1].mAttributeId = 1;
+
+        Span<AttributePathParams> attributePaths(attribute, 2);
+        client.DeduplicateNonWildcardAttributePath(attributePaths);
+        NL_TEST_ASSERT(apSuite, !attribute[0].IsDuplicate());
+        NL_TEST_ASSERT(apSuite, attribute[1].IsDuplicate());
+    }
+
+    // Duplicate detects
+    {
+        AttributePathParams attribute[2];
+        attribute[0].mEndpointId  = 1;
+        attribute[0].mClusterId   = 1;
+        attribute[0].mAttributeId = kInvalidAttributeId;
+
+        attribute[1].mEndpointId  = 1;
+        attribute[1].mClusterId   = 1;
+        attribute[1].mAttributeId = 1;
+
+        Span<AttributePathParams> attributePaths(attribute, 2);
+        client.DeduplicateNonWildcardAttributePath(attributePaths);
+        NL_TEST_ASSERT(apSuite, !attribute[0].IsDuplicate());
+        NL_TEST_ASSERT(apSuite, attribute[1].IsDuplicate());
+    }
+
+    // Duplicate detects
+    {
+        AttributePathParams attribute[2];
+        attribute[0].mEndpointId  = 1;
+        attribute[0].mClusterId   = 1;
+        attribute[0].mAttributeId = 1;
+
+        attribute[1].mEndpointId  = 1;
+        attribute[1].mClusterId   = 1;
+        attribute[1].mAttributeId = 1;
+
+        Span<AttributePathParams> attributePaths(attribute, 2);
+        client.DeduplicateNonWildcardAttributePath(attributePaths);
+        NL_TEST_ASSERT(apSuite, !attribute[0].IsDuplicate());
+        NL_TEST_ASSERT(apSuite, attribute[1].IsDuplicate());
+    }
+
+    // No duplicate
+    {
+        AttributePathParams attribute[2];
+        attribute[0].mEndpointId  = kInvalidEndpointId;
+        attribute[0].mClusterId   = 1;
+        attribute[0].mAttributeId = 1;
+
+        attribute[1].mEndpointId  = 1;
+        attribute[1].mClusterId   = 1;
+        attribute[1].mAttributeId = 1;
+
+        Span<AttributePathParams> attributePaths(attribute, 2);
+        client.DeduplicateNonWildcardAttributePath(attributePaths);
+        NL_TEST_ASSERT(apSuite, !attribute[0].IsDuplicate());
+        NL_TEST_ASSERT(apSuite, !attribute[1].IsDuplicate());
+    }
+
+    // No duplicate
+    {
+        AttributePathParams attribute[2];
+        attribute[0].mEndpointId  = 1;
+        attribute[0].mClusterId   = kInvalidClusterId;
+        attribute[0].mAttributeId = 1;
+
+        attribute[1].mEndpointId  = 1;
+        attribute[1].mClusterId   = 1;
+        attribute[1].mAttributeId = 1;
+
+        Span<AttributePathParams> attributePaths(attribute, 2);
+        client.DeduplicateNonWildcardAttributePath(attributePaths);
+        NL_TEST_ASSERT(apSuite, !attribute[0].IsDuplicate());
+        NL_TEST_ASSERT(apSuite, !attribute[1].IsDuplicate());
+    }
+
+    // No duplicate
+    {
+        AttributePathParams attribute[2];
+        attribute[0].mEndpointId  = kInvalidEndpointId;
+        attribute[0].mClusterId   = kInvalidClusterId;
+        attribute[0].mAttributeId = 1;
+
+        attribute[1].mEndpointId  = 1;
+        attribute[1].mClusterId   = 1;
+        attribute[1].mAttributeId = 1;
+
+        Span<AttributePathParams> attributePaths(attribute, 2);
+        client.DeduplicateNonWildcardAttributePath(attributePaths);
+        NL_TEST_ASSERT(apSuite, !attribute[0].IsDuplicate());
+        NL_TEST_ASSERT(apSuite, !attribute[1].IsDuplicate());
+    }
+
+    // No duplicate
+    {
+        AttributePathParams attribute[2];
+        attribute[0].mEndpointId  = 1;
+        attribute[0].mClusterId   = 2;
+        attribute[0].mAttributeId = 1;
+
+        attribute[1].mEndpointId  = 1;
+        attribute[1].mClusterId   = 1;
+        attribute[1].mAttributeId = 1;
+
+        Span<AttributePathParams> attributePaths(attribute, 2);
+        client.DeduplicateNonWildcardAttributePath(attributePaths);
+        NL_TEST_ASSERT(apSuite, !attribute[0].IsDuplicate());
+        NL_TEST_ASSERT(apSuite, !attribute[1].IsDuplicate());
+    }
+
+    // two wildcard paths, the second path is part of the first path, No duplicate
+    {
+        AttributePathParams attribute[2];
+        attribute[0].mEndpointId  = kInvalidEndpointId;
+        attribute[0].mClusterId   = kInvalidClusterId;
+        attribute[0].mAttributeId = kInvalidAttributeId;
+
+        attribute[1].mEndpointId  = kInvalidEndpointId;
+        attribute[1].mClusterId   = kInvalidClusterId;
+        attribute[1].mAttributeId = 1;
+
+        Span<AttributePathParams> attributePaths(attribute, 2);
+        client.DeduplicateNonWildcardAttributePath(attributePaths);
+        NL_TEST_ASSERT(apSuite, !attribute[0].IsDuplicate());
+        NL_TEST_ASSERT(apSuite, !attribute[1].IsDuplicate());
+    }
+
+    // two wildcard paths, the second path is not intersected with the first path, no duplicate
+    {
+        AttributePathParams attribute[2];
+        attribute[0].mEndpointId  = 1;
+        attribute[0].mClusterId   = kInvalidClusterId;
+        attribute[0].mAttributeId = kInvalidAttributeId;
+
+        attribute[1].mEndpointId  = 2;
+        attribute[1].mClusterId   = kInvalidClusterId;
+        attribute[1].mAttributeId = kInvalidAttributeId;
+
+        Span<AttributePathParams> attributePaths(attribute, 2);
+        client.DeduplicateNonWildcardAttributePath(attributePaths);
+        NL_TEST_ASSERT(apSuite, !attribute[0].IsDuplicate());
+        NL_TEST_ASSERT(apSuite, !attribute[1].IsDuplicate());
+    }
+}
 } // namespace app
 } // namespace chip
 
@@ -2591,6 +2787,7 @@ const nlTest sTests[] =
     NL_TEST_DEF("TestPostSubscribeRoundtripChunkStatusReportTimeout", chip::app::TestReadInteraction::TestPostSubscribeRoundtripChunkStatusReportTimeout),
     NL_TEST_DEF("TestPostSubscribeRoundtripChunkReportTimeout", chip::app::TestReadInteraction::TestPostSubscribeRoundtripChunkReportTimeout),
     NL_TEST_DEF("TestReadShutdown", chip::app::TestReadInteraction::TestReadShutdown),
+    NL_TEST_DEF("TestDeduplicateNonWildcardAttributePath", chip::app::TestReadInteraction::TestDeduplicateNonWildcardAttributePath),
     NL_TEST_SENTINEL()
 };
 // clang-format on


### PR DESCRIPTION
#### Problem
Need de-duplicate non-wildcard attribute paths in the original request

#### Change overview
See above

#### Testing
Add several unit tests to cover de-duplicate situation
