### PR TITLE
Allow SetGroupDataProvider(nullptr) for resource mgmt

### DIFF
--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -400,7 +400,7 @@ inline CHIP_ERROR SetSingleIpkEpochKey(GroupDataProvider * provider, FabricIndex
  *
  * Callers have to externally synchronize usage of this function.
  *
- * @return The global Group Data Provider. Assume never null.
+ * @return The global Group Data Provider
  */
 GroupDataProvider * GetGroupDataProvider();
 
@@ -409,9 +409,9 @@ GroupDataProvider * GetGroupDataProvider();
  *
  * Callers have to externally synchronize usage of this function.
  *
- * If the `provider` is nullptr, no change is done.
+ * The `provider` can be set to nullptr if the owner is done with it fully.
  *
- * @param[in] provider the Group Data Provider
+ * @param[in] provider pointer to the Group Data Provider global isntance to use
  */
 void SetGroupDataProvider(GroupDataProvider * provider);
 

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -2015,33 +2015,14 @@ GroupDataProvider * gGroupsProvider = nullptr;
 
 } // namespace
 
-/**
- * Instance getter for the global GroupDataProvider.
- *
- * Callers have to externally synchronize usage of this function.
- *
- * @return The global device attestation credentials provider. Assume never null.
- */
 GroupDataProvider * GetGroupDataProvider()
 {
     return gGroupsProvider;
 }
 
-/**
- * Instance setter for the global GroupDataProvider.
- *
- * Callers have to externally synchronize usage of this function.
- *
- * If the `provider` is nullptr, no change is done.
- *
- * @param[in] provider the GroupDataProvider to start returning with the getter
- */
 void SetGroupDataProvider(GroupDataProvider * provider)
 {
-    if (provider)
-    {
-        gGroupsProvider = provider;
-    }
+    gGroupsProvider = provider;
 }
 
 } // namespace Credentials


### PR DESCRIPTION
#### Problem
- Users implementing clean system shutdown must ensure that
  once they release their GroupDataProvider, the implementation
  does not dangle. After proper shutdown, GetGroupDataProvider()
  will never be called again, so it's fine to set it to nullptr.
  If it is indeed called, then next access will crash will null
  pointer dereference, which is more deterministic than use-after-free
  that would occur today.

Fixes #17407 

#### Change overview
- Allow setting GroupDataProvider singleton to nullptr

#### Testing
- Unit tests pass
- Integration tests pass
