### PR TITLE
Add an API to create session for tests instead of NewPairing

### DIFF
--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -238,19 +238,9 @@ exit:
 
 CHIP_ERROR EstablishSecureSession(streamer_t * stream, const Transport::PeerAddress & peerAddress)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    Optional<Transport::PeerAddress> peerAddr;
-    SecurePairingUsingTestSecret * testSecurePairingSecret = chip::Platform::New<SecurePairingUsingTestSecret>();
-    VerifyOrExit(testSecurePairingSecret != nullptr, err = CHIP_ERROR_NO_MEMORY);
-
-    peerAddr = Optional<Transport::PeerAddress>::Value(peerAddress);
-
     // Attempt to connect to the peer.
-    err = gSessionManager.NewPairing(gSession, peerAddr, kTestDeviceNodeId, testSecurePairingSecret,
-                                     CryptoContext::SessionRole::kInitiator, gFabricIndex);
-
-exit:
+    CHIP_ERROR err = gSessionManager.InjectPaseSessionWithTestKey(gSession, 1, kTestDeviceNodeId, 1, gFabricIndex, peerAddress,
+                                                                  CryptoContext::SessionRole::kInitiator);
     if (err != CHIP_NO_ERROR)
     {
         streamer_printf(stream, "Establish secure session failed, err: %s\n", ErrorStr(err));

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -172,19 +172,9 @@ exit:
 
 CHIP_ERROR EstablishSecureSession(streamer_t * stream, Transport::PeerAddress & peerAddress)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    Optional<Transport::PeerAddress> peerAddr;
-    SecurePairingUsingTestSecret * testSecurePairingSecret = chip::Platform::New<SecurePairingUsingTestSecret>();
-    VerifyOrExit(testSecurePairingSecret != nullptr, err = CHIP_ERROR_NO_MEMORY);
-
-    peerAddr = Optional<Transport::PeerAddress>::Value(peerAddress);
-
     // Attempt to connect to the peer.
-    err = gSessionManager.NewPairing(gSession, peerAddr, kTestDeviceNodeId, testSecurePairingSecret,
-                                     CryptoContext::SessionRole::kInitiator, gFabricIndex);
-
-exit:
+    CHIP_ERROR err = gSessionManager.InjectPaseSessionWithTestKey(gSession, 1, kTestDeviceNodeId, 1, gFabricIndex, peerAddress,
+                                                                  CryptoContext::SessionRole::kInitiator);
     if (err != CHIP_NO_ERROR)
     {
         streamer_printf(stream, "Establish secure session failed, err: %s\n", ErrorStr(err));

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -429,20 +429,10 @@ CHIP_ERROR SendSubscribeRequest()
 
 CHIP_ERROR EstablishSecureSession()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    chip::SecurePairingUsingTestSecret * testSecurePairingSecret = chip::Platform::New<chip::SecurePairingUsingTestSecret>();
-    VerifyOrExit(testSecurePairingSecret != nullptr, err = CHIP_ERROR_NO_MEMORY);
-    testSecurePairingSecret->Init(gSessionManager);
-
     // Attempt to connect to the peer.
-    err = gSessionManager.NewPairing(gSession,
-                                     chip::Optional<chip::Transport::PeerAddress>::Value(
-                                         chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, chip::Inet::InterfaceId::Null())),
-                                     chip::kTestDeviceNodeId, testSecurePairingSecret, chip::CryptoContext::SessionRole::kInitiator,
-                                     gFabricIndex);
-
-exit:
+    chip::Transport::PeerAddress peer = chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, chip::Inet::InterfaceId::Null());
+    CHIP_ERROR err = gSessionManager.InjectPaseSessionWithTestKey(gSession, 1, chip::kTestDeviceNodeId, 1, gFabricIndex, peer,
+                                                                  chip::CryptoContext::SessionRole::kInitiator);
     if (err != CHIP_NO_ERROR)
     {
         printf("Establish secure session failed, err: %s\n", chip::ErrorStr(err));
@@ -451,10 +441,6 @@ exit:
     else
     {
         printf("Establish secure session succeeded\n");
-    }
-    if (testSecurePairingSecret)
-    {
-        chip::Platform::Delete(testSecurePairingSecret);
     }
 
     return err;

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -153,7 +153,6 @@ bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint)
 
 namespace {
 chip::TransportMgr<chip::Transport::UDP> gTransportManager;
-chip::SecurePairingUsingTestSecret gTestPairing;
 LivenessEventGenerator gLivenessGenerator;
 
 uint8_t gDebugEventBuffer[2048];
@@ -183,7 +182,7 @@ CHIP_ERROR InitializeEventLogging(chip::Messaging::ExchangeManager * apMgr)
 int main(int argc, char * argv[])
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
+    chip::Transport::PeerAddress peer(chip::Transport::Type::kUndefined);
     const chip::FabricIndex gFabricIndex = 0;
 
     InitializeChip();
@@ -211,9 +210,8 @@ int main(int argc, char * argv[])
     err = InitializeEventLogging(&gExchangeManager);
     SuccessOrExit(err);
 
-    gTestPairing.Init(gSessionManager);
-    err = gSessionManager.NewPairing(gSession, peer, chip::kTestControllerNodeId, &gTestPairing,
-                                     chip::CryptoContext::SessionRole::kResponder, gFabricIndex);
+    err = gSessionManager.InjectPaseSessionWithTestKey(gSession, 1, chip::kTestControllerNodeId, 1, gFabricIndex, peer,
+                                                       chip::CryptoContext::SessionRole::kResponder);
     SuccessOrExit(err);
 
     printf("Listening for IM requests...\n");

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -95,24 +95,14 @@ CHIP_ERROR MessagingContext::ShutdownAndRestoreExisting(MessagingContext & exist
 
 CHIP_ERROR MessagingContext::CreateSessionBobToAlice()
 {
-    if (!mPairingBobToAlice.GetSecureSessionHandle().HasValue())
-    {
-        mPairingBobToAlice.Init(mSessionManager);
-    }
-    return mSessionManager.NewPairing(mSessionBobToAlice, Optional<Transport::PeerAddress>::Value(mAliceAddress),
-                                      GetAliceFabric()->GetNodeId(), &mPairingBobToAlice, CryptoContext::SessionRole::kInitiator,
-                                      mBobFabricIndex);
+    return mSessionManager.InjectPaseSessionWithTestKey(mSessionBobToAlice, kBobKeyId, GetAliceFabric()->GetNodeId(), kAliceKeyId,
+                                                        mBobFabricIndex, mAliceAddress, CryptoContext::SessionRole::kInitiator);
 }
 
 CHIP_ERROR MessagingContext::CreateSessionAliceToBob()
 {
-    if (!mPairingAliceToBob.GetSecureSessionHandle().HasValue())
-    {
-        mPairingAliceToBob.Init(mSessionManager);
-    }
-    return mSessionManager.NewPairing(mSessionAliceToBob, Optional<Transport::PeerAddress>::Value(mBobAddress),
-                                      GetBobFabric()->GetNodeId(), &mPairingAliceToBob, CryptoContext::SessionRole::kResponder,
-                                      mAliceFabricIndex);
+    return mSessionManager.InjectPaseSessionWithTestKey(mSessionAliceToBob, kAliceKeyId, GetBobFabric()->GetNodeId(), kBobKeyId,
+                                                        mAliceFabricIndex, mBobAddress, CryptoContext::SessionRole::kResponder);
 }
 
 CHIP_ERROR MessagingContext::CreateSessionBobToFriends()

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -71,9 +71,7 @@ class MessagingContext : public PlatformMemoryUser
 public:
     MessagingContext() :
         mInitialized(false), mAliceAddress(Transport::PeerAddress::UDP(GetAddress(), CHIP_PORT + 1)),
-        mBobAddress(Transport::PeerAddress::UDP(GetAddress(), CHIP_PORT)),
-        mPairingAliceToBob(kBobKeyId, kAliceKeyId, GetSecureSessionManager()),
-        mPairingBobToAlice(kAliceKeyId, kBobKeyId, GetSecureSessionManager())
+        mBobAddress(Transport::PeerAddress::UDP(GetAddress(), CHIP_PORT))
     {}
     ~MessagingContext() { VerifyOrDie(mInitialized == false); }
 
@@ -152,8 +150,6 @@ private:
     GroupId mFriendsGroupId       = 0x0101;
     Transport::PeerAddress mAliceAddress;
     Transport::PeerAddress mBobAddress;
-    SecurePairingUsingTestSecret mPairingAliceToBob;
-    SecurePairingUsingTestSecret mPairingBobToAlice;
     SessionHolder mSessionAliceToBob;
     SessionHolder mSessionBobToAlice;
     Optional<Transport::OutgoingGroupSession> mSessionBobToFriends;

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -150,28 +150,19 @@ CHIP_ERROR SendEchoRequest()
 
 CHIP_ERROR EstablishSecureSession()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    chip::Optional<chip::Transport::PeerAddress> peerAddr;
-    chip::SecurePairingUsingTestSecret * testSecurePairingSecret = chip::Platform::New<chip::SecurePairingUsingTestSecret>();
-    VerifyOrExit(testSecurePairingSecret != nullptr, err = CHIP_ERROR_NO_MEMORY);
-    testSecurePairingSecret->Init(gSessionManager);
-
+    chip::Transport::PeerAddress peerAddr;
     if (gUseTCP)
     {
-        peerAddr = chip::Optional<chip::Transport::PeerAddress>::Value(chip::Transport::PeerAddress::TCP(gDestAddr, CHIP_PORT));
+        peerAddr = chip::Transport::PeerAddress::TCP(gDestAddr, CHIP_PORT);
     }
     else
     {
-        peerAddr = chip::Optional<chip::Transport::PeerAddress>::Value(
-            chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, chip::Inet::InterfaceId::Null()));
+        peerAddr = chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, chip::Inet::InterfaceId::Null());
     }
 
     // Attempt to connect to the peer.
-    err = gSessionManager.NewPairing(gSession, peerAddr, chip::kTestDeviceNodeId, testSecurePairingSecret,
-                                     chip::CryptoContext::SessionRole::kInitiator, gFabricIndex);
-
-exit:
+    CHIP_ERROR err = gSessionManager.InjectPaseSessionWithTestKey(gSession, 1, chip::kTestDeviceNodeId, 1, gFabricIndex, peerAddr,
+                                                                  chip::CryptoContext::SessionRole::kInitiator);
     if (err != CHIP_NO_ERROR)
     {
         printf("Establish secure session failed, err: %s\n", chip::ErrorStr(err));
@@ -180,10 +171,6 @@ exit:
     else
     {
         printf("Establish secure session succeeded\n");
-    }
-    if (testSecurePairingSecret)
-    {
-        chip::Platform::Delete(testSecurePairingSecret);
     }
 
     return err;

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -44,7 +44,6 @@ namespace {
 chip::Protocols::Echo::EchoServer gEchoServer;
 chip::TransportMgr<chip::Transport::UDP> gUDPManager;
 chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>> gTCPManager;
-chip::SecurePairingUsingTestSecret gTestPairing;
 chip::SessionHolder gSession;
 
 // Callback handler when a CHIP EchoRequest is received.
@@ -58,7 +57,7 @@ void HandleEchoRequestReceived(chip::Messaging::ExchangeContext * ec, chip::Syst
 int main(int argc, char * argv[])
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
+    chip::Transport::PeerAddress peer(chip::Transport::Type::kUndefined);
     bool useTCP      = false;
     bool disableEcho = false;
 
@@ -123,9 +122,8 @@ int main(int argc, char * argv[])
         SuccessOrExit(err);
     }
 
-    gTestPairing.Init(gSessionManager);
-    err = gSessionManager.NewPairing(gSession, peer, chip::kTestControllerNodeId, &gTestPairing,
-                                     chip::CryptoContext::SessionRole::kResponder, gFabricIndex);
+    err = gSessionManager.InjectPaseSessionWithTestKey(gSession, 1, chip::kTestControllerNodeId, 1, gFabricIndex, peer,
+                                                       chip::CryptoContext::SessionRole::kResponder);
     SuccessOrExit(err);
 
     if (!disableEcho)

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -255,56 +255,8 @@ protected:
     bool mPairingComplete = false;
 };
 
-/*
- * The following constants are node IDs that test devices and test
- * controllers use while using the SecurePairingUsingTestSecret to
- * establish secure channel
- */
+// The following constants are node IDs that test devices and test controllers use.
 constexpr chip::NodeId kTestControllerNodeId = 112233;
 constexpr chip::NodeId kTestDeviceNodeId     = 12344321;
-
-/*
- * The following class should only be used for test usecases.
- * The class is currently also used for devices that do no yet support
- * rendezvous. Once all the non-test usecases start supporting
- * rendezvous, this class will be moved to the test code.
- */
-class SecurePairingUsingTestSecret : public PairingSession
-{
-public:
-    SecurePairingUsingTestSecret() : PairingSession(Transport::SecureSession::Type::kPASE)
-    {
-        // Do not set to 0 to prevent an unwanted unsecured session
-        // since the session type is unknown.
-        SetPeerSessionId(1);
-    }
-
-    void Init(SessionManager & sessionManager)
-    {
-        // Do not set to 0 to prevent an unwanted unsecured session
-        // since the session type is unknown.
-        AllocateSecureSession(sessionManager, mLocalSessionId);
-    }
-
-    SecurePairingUsingTestSecret(uint16_t peerSessionId, uint16_t localSessionId, SessionManager & sessionManager) :
-        PairingSession(Transport::SecureSession::Type::kPASE), mLocalSessionId(localSessionId)
-    {
-        AllocateSecureSession(sessionManager, localSessionId);
-        SetPeerSessionId(peerSessionId);
-    }
-
-    CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) override
-    {
-        size_t secretLen = strlen(kTestSecret);
-        return session.InitFromSecret(ByteSpan(reinterpret_cast<const uint8_t *>(kTestSecret), secretLen), ByteSpan(nullptr, 0),
-                                      CryptoContext::SessionInfoType::kSessionEstablishment, role);
-    }
-
-private:
-    // Do not set to 0 to prevent an unwanted unsecured session
-    // since the session type is unknown.
-    uint16_t mLocalSessionId = 1;
-    const char * kTestSecret = CHIP_CONFIG_TEST_SHARED_SECRET_VALUE;
-};
 
 } // namespace chip

--- a/src/transport/SecureSessionTable.h
+++ b/src/transport/SecureSessionTable.h
@@ -60,9 +60,9 @@ public:
      *          has been reached (with CHIP_ERROR_NO_MEMORY).
      */
     CHECK_RETURN_VALUE
-    Optional<SessionHandle> CreateNewSecureSession(SecureSession::Type secureSessionType, uint16_t localSessionId,
-                                                   NodeId peerNodeId, CATValues peerCATs, uint16_t peerSessionId,
-                                                   FabricIndex fabric, const ReliableMessageProtocolConfig & config)
+    Optional<SessionHandle> CreateNewSecureSessionForTest(SecureSession::Type secureSessionType, uint16_t localSessionId,
+                                                          NodeId peerNodeId, CATValues peerCATs, uint16_t peerSessionId,
+                                                          FabricIndex fabric, const ReliableMessageProtocolConfig & config)
     {
         SecureSession * result =
             mEntries.CreateObject(secureSessionType, localSessionId, peerNodeId, peerCATs, peerSessionId, fabric, config);

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -156,6 +156,11 @@ public:
     void UnregisterRecoveryDelegate(SessionRecoveryDelegate & cb);
     void RefreshSessionOperationalData(const SessionHandle & sessionHandle);
 
+    // Test-only: create a session on the fly.
+    CHIP_ERROR InjectPaseSessionWithTestKey(SessionHolder & sessionHolder, uint16_t localSessionId, NodeId peerNodeId,
+                                            uint16_t peerSessionId, FabricIndex fabric, const Transport::PeerAddress & peerAddress,
+                                            CryptoContext::SessionRole role);
+
     /**
      * @brief
      *   Establish a new pairing with a peer node

--- a/src/transport/tests/TestPeerConnections.cpp
+++ b/src/transport/tests/TestPeerConnections.cpp
@@ -70,8 +70,8 @@ void TestBasicFunctionality(nlTestSuite * inSuite, void * inContext)
     CATValues peerCATs;
 
     // Node ID 1, peer key 1, local key 2
-    auto optionalSession = connections.CreateNewSecureSession(kPeer1SessionType, 2, kPeer1NodeId, kPeer1CATs, 1,
-                                                              0 /* fabricIndex */, GetLocalMRPConfig());
+    auto optionalSession = connections.CreateNewSecureSessionForTest(kPeer1SessionType, 2, kPeer1NodeId, kPeer1CATs, 1,
+                                                                     0 /* fabricIndex */, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetSecureSessionType() == kPeer1SessionType);
     NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetPeerNodeId() == kPeer1NodeId);
@@ -79,8 +79,8 @@ void TestBasicFunctionality(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, memcmp(&peerCATs, &kPeer1CATs, sizeof(CATValues)) == 0);
 
     // Node ID 2, peer key 3, local key 4
-    optionalSession = connections.CreateNewSecureSession(kPeer2SessionType, 4, kPeer2NodeId, kPeer2CATs, 3, 0 /* fabricIndex */,
-                                                         GetLocalMRPConfig());
+    optionalSession = connections.CreateNewSecureSessionForTest(kPeer2SessionType, 4, kPeer2NodeId, kPeer2CATs, 3,
+                                                                0 /* fabricIndex */, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetSecureSessionType() == kPeer2SessionType);
     NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetPeerNodeId() == kPeer2NodeId);
@@ -89,8 +89,8 @@ void TestBasicFunctionality(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, memcmp(&peerCATs, &kPeer2CATs, sizeof(CATValues)) == 0);
 
     // Insufficient space for new connections. Object is max size 2
-    optionalSession = connections.CreateNewSecureSession(kPeer3SessionType, 6, kPeer3NodeId, kPeer3CATs, 5, 0 /* fabricIndex */,
-                                                         GetLocalMRPConfig());
+    optionalSession = connections.CreateNewSecureSessionForTest(kPeer3SessionType, 6, kPeer3NodeId, kPeer3CATs, 5,
+                                                                0 /* fabricIndex */, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, !optionalSession.HasValue());
     System::Clock::Internal::SetSystemClockForTesting(realClock);
 }
@@ -103,16 +103,16 @@ void TestFindByKeyId(nlTestSuite * inSuite, void * inContext)
     System::Clock::Internal::SetSystemClockForTesting(&clock);
 
     // Node ID 1, peer key 1, local key 2
-    auto optionalSession = connections.CreateNewSecureSession(kPeer1SessionType, 2, kPeer1NodeId, kPeer1CATs, 1,
-                                                              0 /* fabricIndex */, GetLocalMRPConfig());
+    auto optionalSession = connections.CreateNewSecureSessionForTest(kPeer1SessionType, 2, kPeer1NodeId, kPeer1CATs, 1,
+                                                                     0 /* fabricIndex */, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
 
     NL_TEST_ASSERT(inSuite, !connections.FindSecureSessionByLocalKey(1).HasValue());
     NL_TEST_ASSERT(inSuite, connections.FindSecureSessionByLocalKey(2).HasValue());
 
     // Node ID 2, peer key 3, local key 4
-    optionalSession = connections.CreateNewSecureSession(kPeer2SessionType, 4, kPeer2NodeId, kPeer2CATs, 3, 0 /* fabricIndex */,
-                                                         GetLocalMRPConfig());
+    optionalSession = connections.CreateNewSecureSessionForTest(kPeer2SessionType, 4, kPeer2NodeId, kPeer2CATs, 3,
+                                                                0 /* fabricIndex */, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
 
     NL_TEST_ASSERT(inSuite, !connections.FindSecureSessionByLocalKey(3).HasValue());
@@ -140,22 +140,22 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
     clock.SetMonotonic(100_ms64);
 
     // Node ID 1, peer key 1, local key 2
-    auto optionalSession = connections.CreateNewSecureSession(kPeer1SessionType, 2, kPeer1NodeId, kPeer1CATs, 1,
-                                                              0 /* fabricIndex */, GetLocalMRPConfig());
+    auto optionalSession = connections.CreateNewSecureSessionForTest(kPeer1SessionType, 2, kPeer1NodeId, kPeer1CATs, 1,
+                                                                     0 /* fabricIndex */, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     optionalSession.Value()->AsSecureSession()->SetPeerAddress(kPeer1Addr);
 
     clock.SetMonotonic(200_ms64);
     // Node ID 2, peer key 3, local key 4
-    optionalSession = connections.CreateNewSecureSession(kPeer2SessionType, 4, kPeer2NodeId, kPeer2CATs, 3, 0 /* fabricIndex */,
-                                                         GetLocalMRPConfig());
+    optionalSession = connections.CreateNewSecureSessionForTest(kPeer2SessionType, 4, kPeer2NodeId, kPeer2CATs, 3,
+                                                                0 /* fabricIndex */, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     optionalSession.Value()->AsSecureSession()->SetPeerAddress(kPeer2Addr);
 
     // cannot add before expiry
     clock.SetMonotonic(300_ms64);
-    optionalSession = connections.CreateNewSecureSession(kPeer3SessionType, 6, kPeer3NodeId, kPeer3CATs, 5, 0 /* fabricIndex */,
-                                                         GetLocalMRPConfig());
+    optionalSession = connections.CreateNewSecureSessionForTest(kPeer3SessionType, 6, kPeer3NodeId, kPeer3CATs, 5,
+                                                                0 /* fabricIndex */, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, !optionalSession.HasValue());
 
     // at time 300, this expires ip addr 1
@@ -172,8 +172,8 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
     // now that the connections were expired, we can add peer3
     clock.SetMonotonic(300_ms64);
     // Node ID 3, peer key 5, local key 6
-    optionalSession = connections.CreateNewSecureSession(kPeer3SessionType, 6, kPeer3NodeId, kPeer3CATs, 5, 0 /* fabricIndex */,
-                                                         GetLocalMRPConfig());
+    optionalSession = connections.CreateNewSecureSessionForTest(kPeer3SessionType, 6, kPeer3NodeId, kPeer3CATs, 5,
+                                                                0 /* fabricIndex */, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     optionalSession.Value()->AsSecureSession()->SetPeerAddress(kPeer3Addr);
 
@@ -205,8 +205,8 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !connections.FindSecureSessionByLocalKey(6).HasValue());
 
     // Node ID 1, peer key 1, local key 2
-    optionalSession = connections.CreateNewSecureSession(kPeer1SessionType, 2, kPeer1NodeId, kPeer1CATs, 1, 0 /* fabricIndex */,
-                                                         GetLocalMRPConfig());
+    optionalSession = connections.CreateNewSecureSessionForTest(kPeer1SessionType, 2, kPeer1NodeId, kPeer1CATs, 1,
+                                                                0 /* fabricIndex */, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     NL_TEST_ASSERT(inSuite, connections.FindSecureSessionByLocalKey(2).HasValue());
     NL_TEST_ASSERT(inSuite, connections.FindSecureSessionByLocalKey(4).HasValue());

--- a/src/transport/tests/TestSessionManager.cpp
+++ b/src/transport/tests/TestSessionManager.cpp
@@ -145,7 +145,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
 
     sessionManager.SetMessageDelegate(&callback);
 
-    Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
+    Transport::PeerAddress peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
 
     FabricIndex aliceFabricIndex;
     FabricInfo aliceFabric;
@@ -168,15 +168,15 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.AddNewFabric(bobFabric, &bobFabricIndex));
 
     SessionHolder aliceToBobSession;
-    SecurePairingUsingTestSecret aliceToBobPairing(1, 2, sessionManager);
-    err = sessionManager.NewPairing(aliceToBobSession, peer, fabricTable.FindFabricWithIndex(bobFabricIndex)->GetNodeId(),
-                                    &aliceToBobPairing, CryptoContext::SessionRole::kInitiator, aliceFabricIndex);
+    err = sessionManager.InjectPaseSessionWithTestKey(aliceToBobSession, 2,
+                                                      fabricTable.FindFabricWithIndex(bobFabricIndex)->GetNodeId(), 1,
+                                                      aliceFabricIndex, peer, CryptoContext::SessionRole::kInitiator);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecurePairingUsingTestSecret bobToAlicePairing(2, 1, sessionManager);
     SessionHolder bobToAliceSession;
-    err = sessionManager.NewPairing(bobToAliceSession, peer, fabricTable.FindFabricWithIndex(aliceFabricIndex)->GetNodeId(),
-                                    &bobToAlicePairing, CryptoContext::SessionRole::kResponder, bobFabricIndex);
+    err = sessionManager.InjectPaseSessionWithTestKey(bobToAliceSession, 1,
+                                                      fabricTable.FindFabricWithIndex(aliceFabricIndex)->GetNodeId(), 2,
+                                                      bobFabricIndex, peer, CryptoContext::SessionRole::kResponder);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // Should be able to send a message to itself by just calling send.
@@ -260,7 +260,7 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     sessionManager.SetMessageDelegate(&callback);
 
-    Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
+    Transport::PeerAddress peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
 
     FabricIndex aliceFabricIndex;
     FabricInfo aliceFabric;
@@ -283,15 +283,15 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.AddNewFabric(bobFabric, &bobFabricIndex));
 
     SessionHolder aliceToBobSession;
-    SecurePairingUsingTestSecret aliceToBobPairing(1, 2, sessionManager);
-    err = sessionManager.NewPairing(aliceToBobSession, peer, fabricTable.FindFabricWithIndex(bobFabricIndex)->GetNodeId(),
-                                    &aliceToBobPairing, CryptoContext::SessionRole::kInitiator, aliceFabricIndex);
+    err = sessionManager.InjectPaseSessionWithTestKey(aliceToBobSession, 2,
+                                                      fabricTable.FindFabricWithIndex(bobFabricIndex)->GetNodeId(), 1,
+                                                      aliceFabricIndex, peer, CryptoContext::SessionRole::kInitiator);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecurePairingUsingTestSecret bobToAlicePairing(2, 1, sessionManager);
     SessionHolder bobToAliceSession;
-    err = sessionManager.NewPairing(bobToAliceSession, peer, fabricTable.FindFabricWithIndex(aliceFabricIndex)->GetNodeId(),
-                                    &bobToAlicePairing, CryptoContext::SessionRole::kResponder, bobFabricIndex);
+    err = sessionManager.InjectPaseSessionWithTestKey(bobToAliceSession, 1,
+                                                      fabricTable.FindFabricWithIndex(aliceFabricIndex)->GetNodeId(), 2,
+                                                      bobFabricIndex, peer, CryptoContext::SessionRole::kResponder);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // Should be able to send a message to itself by just calling send.
@@ -361,7 +361,7 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     sessionManager.SetMessageDelegate(&callback);
 
-    Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
+    Transport::PeerAddress peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
 
     FabricIndex aliceFabricIndex;
     FabricInfo aliceFabric;
@@ -384,15 +384,15 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.AddNewFabric(bobFabric, &bobFabricIndex));
 
     SessionHolder aliceToBobSession;
-    SecurePairingUsingTestSecret aliceToBobPairing(1, 2, sessionManager);
-    err = sessionManager.NewPairing(aliceToBobSession, peer, fabricTable.FindFabricWithIndex(bobFabricIndex)->GetNodeId(),
-                                    &aliceToBobPairing, CryptoContext::SessionRole::kInitiator, aliceFabricIndex);
+    err = sessionManager.InjectPaseSessionWithTestKey(aliceToBobSession, 2,
+                                                      fabricTable.FindFabricWithIndex(bobFabricIndex)->GetNodeId(), 1,
+                                                      aliceFabricIndex, peer, CryptoContext::SessionRole::kInitiator);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecurePairingUsingTestSecret bobToAlicePairing(2, 1, sessionManager);
     SessionHolder bobToAliceSession;
-    err = sessionManager.NewPairing(bobToAliceSession, peer, fabricTable.FindFabricWithIndex(aliceFabricIndex)->GetNodeId(),
-                                    &bobToAlicePairing, CryptoContext::SessionRole::kResponder, bobFabricIndex);
+    err = sessionManager.InjectPaseSessionWithTestKey(bobToAliceSession, 1,
+                                                      fabricTable.FindFabricWithIndex(aliceFabricIndex)->GetNodeId(), 2,
+                                                      bobFabricIndex, peer, CryptoContext::SessionRole::kResponder);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // Should be able to send a message to itself by just calling send.
@@ -464,6 +464,44 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     sessionManager.Shutdown();
 }
+
+class SecurePairingUsingTestSecret : public PairingSession
+{
+public:
+    SecurePairingUsingTestSecret() : PairingSession(Transport::SecureSession::Type::kPASE)
+    {
+        // Do not set to 0 to prevent an unwanted unsecured session
+        // since the session type is unknown.
+        SetPeerSessionId(1);
+    }
+
+    void Init(SessionManager & sessionManager)
+    {
+        // Do not set to 0 to prevent an unwanted unsecured session
+        // since the session type is unknown.
+        AllocateSecureSession(sessionManager, mLocalSessionId);
+    }
+
+    SecurePairingUsingTestSecret(uint16_t peerSessionId, uint16_t localSessionId, SessionManager & sessionManager) :
+        PairingSession(Transport::SecureSession::Type::kPASE), mLocalSessionId(localSessionId)
+    {
+        AllocateSecureSession(sessionManager, localSessionId);
+        SetPeerSessionId(peerSessionId);
+    }
+
+    CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) override
+    {
+        size_t secretLen = strlen(kTestSecret);
+        return session.InitFromSecret(ByteSpan(reinterpret_cast<const uint8_t *>(kTestSecret), secretLen), ByteSpan(nullptr, 0),
+                                      CryptoContext::SessionInfoType::kSessionEstablishment, role);
+    }
+
+private:
+    // Do not set to 0 to prevent an unwanted unsecured session
+    // since the session type is unknown.
+    uint16_t mLocalSessionId = 1;
+    const char * kTestSecret = CHIP_CONFIG_TEST_SHARED_SECRET_VALUE;
+};
 
 void StaleConnectionDropTest(nlTestSuite * inSuite, void * inContext)
 {
@@ -567,7 +605,7 @@ void SendPacketWithOldCounterTest(nlTestSuite * inSuite, void * inContext)
 
     sessionManager.SetMessageDelegate(&callback);
 
-    Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
+    Transport::PeerAddress peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
 
     FabricIndex aliceFabricIndex;
     FabricInfo aliceFabric;
@@ -590,15 +628,15 @@ void SendPacketWithOldCounterTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.AddNewFabric(bobFabric, &bobFabricIndex));
 
     SessionHolder aliceToBobSession;
-    SecurePairingUsingTestSecret aliceToBobPairing(1, 2, sessionManager);
-    err = sessionManager.NewPairing(aliceToBobSession, peer, fabricTable.FindFabricWithIndex(bobFabricIndex)->GetNodeId(),
-                                    &aliceToBobPairing, CryptoContext::SessionRole::kInitiator, aliceFabricIndex);
+    err = sessionManager.InjectPaseSessionWithTestKey(aliceToBobSession, 2,
+                                                      fabricTable.FindFabricWithIndex(bobFabricIndex)->GetNodeId(), 1,
+                                                      aliceFabricIndex, peer, CryptoContext::SessionRole::kInitiator);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecurePairingUsingTestSecret bobToAlicePairing(2, 1, sessionManager);
     SessionHolder bobToAliceSession;
-    err = sessionManager.NewPairing(bobToAliceSession, peer, fabricTable.FindFabricWithIndex(aliceFabricIndex)->GetNodeId(),
-                                    &bobToAlicePairing, CryptoContext::SessionRole::kResponder, bobFabricIndex);
+    err = sessionManager.InjectPaseSessionWithTestKey(bobToAliceSession, 1,
+                                                      fabricTable.FindFabricWithIndex(aliceFabricIndex)->GetNodeId(), 2,
+                                                      bobFabricIndex, peer, CryptoContext::SessionRole::kResponder);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     callback.ReceiveHandlerCallCount = 0;
@@ -681,7 +719,7 @@ void SendPacketWithTooOldCounterTest(nlTestSuite * inSuite, void * inContext)
 
     sessionManager.SetMessageDelegate(&callback);
 
-    Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
+    Transport::PeerAddress peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
 
     FabricIndex aliceFabricIndex;
     FabricInfo aliceFabric;
@@ -704,15 +742,15 @@ void SendPacketWithTooOldCounterTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == fabricTable.AddNewFabric(bobFabric, &bobFabricIndex));
 
     SessionHolder aliceToBobSession;
-    SecurePairingUsingTestSecret aliceToBobPairing(1, 2, sessionManager);
-    err = sessionManager.NewPairing(aliceToBobSession, peer, fabricTable.FindFabricWithIndex(bobFabricIndex)->GetNodeId(),
-                                    &aliceToBobPairing, CryptoContext::SessionRole::kInitiator, aliceFabricIndex);
+    err = sessionManager.InjectPaseSessionWithTestKey(aliceToBobSession, 2,
+                                                      fabricTable.FindFabricWithIndex(bobFabricIndex)->GetNodeId(), 1,
+                                                      aliceFabricIndex, peer, CryptoContext::SessionRole::kInitiator);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecurePairingUsingTestSecret bobToAlicePairing(2, 1, sessionManager);
     SessionHolder bobToAliceSession;
-    err = sessionManager.NewPairing(bobToAliceSession, peer, fabricTable.FindFabricWithIndex(aliceFabricIndex)->GetNodeId(),
-                                    &bobToAlicePairing, CryptoContext::SessionRole::kResponder, bobFabricIndex);
+    err = sessionManager.InjectPaseSessionWithTestKey(bobToAliceSession, 1,
+                                                      fabricTable.FindFabricWithIndex(aliceFabricIndex)->GetNodeId(), 2,
+                                                      bobFabricIndex, peer, CryptoContext::SessionRole::kResponder);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     callback.ReceiveHandlerCallCount = 0;


### PR DESCRIPTION
#### Problem
`NewPairing` takes too many arguments, actually it only need to take a `PairingSession` argument. All other arguments are used for tests.

#### Change overview
* Add an API `SessionManager::InjectPaseSessionWithTestKey` to replace `NewPairing` in tests
* Remove class `SecurePairingUsingTestSecret` (moved to TestSessionManager.cpp, this is the only place it is used).

All changes are test-only

TODO: Currently the `SessionManager::NewPairing` is called by `SessionEstablishmentDelegate` implementations. In the following PR, it will be called inside `CASESession` and `PASESession`, such that `NewPairing` will be a SDK internal API, rather than a public API.

#### Testing
Passed unit tests.