### PR TITLE
Move NewPairing from SessionEstablishDelegate to CASE/PASE session

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -41,7 +41,7 @@ CHIP_ERROR TestCommand::WaitForCommissionee(chip::NodeId nodeId)
     // or is just starting out fresh outright. Let's make sure we're not re-using any cached CASE sessions
     // that will now be stale and mismatched with the peer, causing subsequent interactions to fail.
     //
-    CurrentCommissioner().SessionMgr()->ExpireAllPairings(nodeId, fabricIndex);
+    CurrentCommissioner().SessionMgr()->ExpireAllPairings(chip::ScopedNodeId(nodeId, fabricIndex));
 
     return CurrentCommissioner().GetConnectedDevice(nodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
 }

--- a/src/app/CASEClient.h
+++ b/src/app/CASEClient.h
@@ -40,7 +40,7 @@ struct CASEClientInitParams
     Optional<ReliableMessageProtocolConfig> mrpLocalConfig = Optional<ReliableMessageProtocolConfig>::Missing();
 };
 
-class DLL_EXPORT CASEClient : public SessionEstablishmentDelegate
+class DLL_EXPORT CASEClient
 {
 public:
     CASEClient(const CASEClientInitParams & params);
@@ -48,26 +48,12 @@ public:
     void SetMRPIntervals(const ReliableMessageProtocolConfig & mrpConfig);
 
     CHIP_ERROR EstablishSession(PeerId peer, const Transport::PeerAddress & peerAddress,
-                                const ReliableMessageProtocolConfig & mrpConfig, OnCASEConnected onConnection,
-                                OnCASEConnectionFailure onFailure, void * context);
-
-    // Implementation of SessionEstablishmentDelegate
-    void OnSessionEstablishmentError(CHIP_ERROR error) override;
-
-    void OnSessionEstablished() override;
-
-    CHIP_ERROR DeriveSecureSessionHandle(SessionHolder & handle);
+                                const ReliableMessageProtocolConfig & mrpConfig, SessionEstablishmentDelegate * delegate);
 
 private:
     CASEClientInitParams mInitParams;
 
     CASESession mCASESession;
-    PeerId mPeerId;
-    Transport::PeerAddress mPeerAddress;
-
-    OnCASEConnected mConnectionSuccessCallback         = nullptr;
-    OnCASEConnectionFailure mConnectionFailureCallback = nullptr;
-    void * mConectionContext                           = nullptr;
 };
 
 } // namespace chip

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -85,7 +85,7 @@ typedef void (*OnDeviceConnectionFailure)(void * context, PeerId peerId, CHIP_ER
  *    - Expose to consumers the secure session for talking to the device.
  */
 class DLL_EXPORT OperationalDeviceProxy : public DeviceProxy,
-                                          SessionReleaseDelegate,
+                                          public SessionReleaseDelegate,
                                           public SessionEstablishmentDelegate,
                                           public AddressResolve::NodeListener
 {
@@ -139,6 +139,10 @@ public:
     bool IsConnected() const { return mState == State::SecureConnected; }
 
     bool IsConnecting() const { return mState == State::Connecting; }
+
+    //////////// SessionEstablishmentDelegate Implementation ///////////////
+    void OnSessionEstablished(const SessionHandle & session) override;
+    void OnSessionEstablishmentError(CHIP_ERROR error) override;
 
     /**
      *   Called when a connection is closing.
@@ -275,9 +279,6 @@ private:
     bool AttachToExistingSecureSession();
 
     bool IsSecureConnected() const override { return mState == State::SecureConnected; }
-
-    static void HandleCASEConnected(void * context, CASEClient * client);
-    static void HandleCASEConnectionFailure(void * context, CASEClient * client, CHIP_ERROR error);
 
     void CleanupCASEClient();
 

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -144,19 +144,9 @@ void CommissioningWindowManager::OnSessionEstablishmentStarted()
     DeviceLayer::SystemLayer().StartTimer(kPASESessionEstablishmentTimeout, HandleSessionEstablishmentTimeout, this);
 }
 
-void CommissioningWindowManager::OnSessionEstablished()
+void CommissioningWindowManager::OnSessionEstablished(const SessionHandle & session)
 {
     DeviceLayer::SystemLayer().CancelTimer(HandleSessionEstablishmentTimeout, this);
-    SessionHolder sessionHolder;
-    CHIP_ERROR err = mServer->GetSecureSessionManager().NewPairing(
-        sessionHolder, Optional<Transport::PeerAddress>::Value(mPairingSession.GetPeerAddress()), mPairingSession.GetPeerNodeId(),
-        &mPairingSession, CryptoContext::SessionRole::kResponder, 0);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(AppServer, "Commissioning failed while setting up secure channel: err %s", ErrorStr(err));
-        OnSessionEstablishmentError(err);
-        return;
-    }
 
     ChipLogProgress(AppServer, "Commissioning completed session establishment step");
     if (mAppDelegate != nullptr)
@@ -177,7 +167,7 @@ void CommissioningWindowManager::OnSessionEstablished()
     }
     else
     {
-        err = failSafeContext.ArmFailSafe(kUndefinedFabricId, System::Clock::Seconds16(60));
+        CHIP_ERROR err = failSafeContext.ArmFailSafe(kUndefinedFabricId, System::Clock::Seconds16(60));
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(AppServer, "Error arming failsafe on PASE session establishment completion");

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -85,7 +85,7 @@ public:
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
     void OnSessionEstablishmentStarted() override;
-    void OnSessionEstablished() override;
+    void OnSessionEstablished(const SessionHandle & session) override;
 
     void Shutdown();
     void Cleanup();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -646,7 +646,7 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
     exchangeCtxt = mSystemState->ExchangeMgr()->NewContext(session.Value(), &device->GetPairing());
     VerifyOrExit(exchangeCtxt != nullptr, err = CHIP_ERROR_INTERNAL);
 
-    err = device->GetPairing().Pair(*mSystemState->SessionMgr(), params.GetPeerAddress(), params.GetSetupPINCode(),
+    err = device->GetPairing().Pair(*mSystemState->SessionMgr(), params.GetSetupPINCode(),
                                     Optional<ReliableMessageProtocolConfig>::Value(GetLocalMRPConfig()), exchangeCtxt, this);
     SuccessOrExit(err);
 
@@ -827,7 +827,7 @@ void DeviceCommissioner::OnSessionEstablishmentError(CHIP_ERROR err)
     RendezvousCleanup(err);
 }
 
-void DeviceCommissioner::OnSessionEstablished()
+void DeviceCommissioner::OnSessionEstablished(const SessionHandle & session)
 {
     // PASE session established.
     CommissioneeDeviceProxy * device = mDeviceInPASEEstablishment;
@@ -837,12 +837,7 @@ void DeviceCommissioner::OnSessionEstablished()
 
     VerifyOrReturn(device != nullptr, OnSessionEstablishmentError(CHIP_ERROR_INVALID_DEVICE_DESCRIPTOR));
 
-    PASESession * pairing = &device->GetPairing();
-
-    // TODO: the session should know which peer we are trying to connect to when started
-    pairing->SetPeerNodeId(device->GetDeviceId());
-
-    CHIP_ERROR err = device->SetConnected();
+    CHIP_ERROR err = device->SetConnected(session);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "Failed in setting up secure channel: err %s", ErrorStr(err));

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -459,7 +459,7 @@ public:
 
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
-    void OnSessionEstablished() override;
+    void OnSessionEstablished(const SessionHandle & session) override;
 
     void RendezvousCleanup(CHIP_ERROR status);
 

--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -76,7 +76,7 @@ CHIP_ERROR CommissioneeDeviceProxy::UpdateDeviceData(const Transport::PeerAddres
 
     // Initialize PASE session state with any MRP parameters that DNS-SD has provided.
     // It can be overridden by PASE session protocol messages that include MRP parameters.
-    mPairing.SetMRPConfig(mMRPConfig);
+    mPairing.SetRemoteMRPConfig(mMRPConfig);
 
     if (!mSecureSession)
     {
@@ -93,26 +93,12 @@ CHIP_ERROR CommissioneeDeviceProxy::UpdateDeviceData(const Transport::PeerAddres
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CommissioneeDeviceProxy::SetConnected()
+CHIP_ERROR CommissioneeDeviceProxy::SetConnected(const SessionHandle & session)
 {
-    if (mState != ConnectionState::Connecting)
-    {
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
-
-    CHIP_ERROR err = mSessionManager->NewPairing(mSecureSession, Optional<Transport::PeerAddress>::Value(mDeviceAddress),
-                                                 GetDeviceId(), &mPairing, CryptoContext::SessionRole::kInitiator, mFabricIndex);
-
-    if (err == CHIP_NO_ERROR)
-    {
-        mState = ConnectionState::SecureConnected;
-    }
-    else
-    {
-        ChipLogError(Controller, "NewPairing returning error %" CHIP_ERROR_FORMAT, err.Format());
-        mState = ConnectionState::NotConnected;
-    }
-    return err;
+    VerifyOrReturnError(mState == ConnectionState::Connecting, CHIP_ERROR_INCORRECT_STATE);
+    mState = ConnectionState::SecureConnected;
+    mSecureSession.Grab(session);
+    return CHIP_NO_ERROR;
 }
 
 void CommissioneeDeviceProxy::Reset()

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -189,7 +189,7 @@ public:
      *
      * This stores the session details in the session manager.
      */
-    CHIP_ERROR SetConnected();
+    CHIP_ERROR SetConnected(const SessionHandle & session);
 
     bool IsSecureConnected() const override { return IsActive() && mState == ConnectionState::SecureConnected; }
 

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -407,5 +407,9 @@ bool IsCategoryEnabled(uint8_t category);
  */
 #define ChipLogFormatMessageType "0x%x"
 
+/** Logging helpers for scoped node ids, which is a tuple of <NodeId, FabricIndex> */
+#define ChipLogFormatScopedNodeId "<" ChipLogFormatX64 ", %d>"
+#define ChipLogValueScopedNodeId(id) ChipLogValueX64((id).GetNodeId()), (id).GetFabricIndex()
+
 } // namespace Logging
 } // namespace chip

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -126,6 +126,9 @@ public:
     SessionHandle GetSessionAliceToBob();
     SessionHandle GetSessionBobToFriends();
 
+    const Transport::PeerAddress & GetAliceAddress() { return mAliceAddress; }
+    const Transport::PeerAddress & GetBobAddress() { return mBobAddress; }
+
     Messaging::ExchangeContext * NewUnauthenticatedExchangeToAlice(Messaging::ExchangeDelegate * delegate);
     Messaging::ExchangeContext * NewUnauthenticatedExchangeToBob(Messaging::ExchangeDelegate * delegate);
 

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -127,23 +127,10 @@ void CASEServer::OnSessionEstablishmentError(CHIP_ERROR err)
     Cleanup();
 }
 
-void CASEServer::OnSessionEstablished()
+void CASEServer::OnSessionEstablished(const SessionHandle & session)
 {
-    ChipLogProgress(Inet, "CASE Session established. Setting up the secure channel.");
-    mSessionManager->ExpireAllPairings(GetSession().GetPeerNodeId(), GetSession().GetFabricIndex());
-
-    SessionHolder sessionHolder;
-    CHIP_ERROR err = mSessionManager->NewPairing(
-        sessionHolder, Optional<Transport::PeerAddress>::Value(GetSession().GetPeerAddress()), GetSession().GetPeerNodeId(),
-        &GetSession(), CryptoContext::SessionRole::kResponder, GetSession().GetFabricIndex());
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Inet, "Failed in setting up secure channel: err %s", ErrorStr(err));
-        OnSessionEstablishmentError(err);
-        return;
-    }
-
-    ChipLogProgress(Inet, "CASE secure channel is available now.");
+    ChipLogProgress(Inet, "CASE Session established to peer: " ChipLogFormatScopedNodeId,
+                    ChipLogValueScopedNodeId(session->GetPeer()));
     Cleanup();
 }
 } // namespace chip

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -51,7 +51,7 @@ public:
 
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
-    void OnSessionEstablished() override;
+    void OnSessionEstablished(const SessionHandle & session) override;
 
     //// UnsolicitedMessageHandler Implementation ////
     CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override;

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -282,7 +282,7 @@ void CASESession::OnResponseTimeout(ExchangeContext * ec)
     mDelegate->OnSessionEstablishmentError(CHIP_ERROR_TIMEOUT);
 }
 
-CHIP_ERROR CASESession::DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) const
+CHIP_ERROR CASESession::DeriveSecureSession(CryptoContext & session) const
 {
     size_t saltlen;
 
@@ -305,7 +305,7 @@ CHIP_ERROR CASESession::DeriveSecureSession(CryptoContext & session, CryptoConte
     }
 
     ReturnErrorOnFailure(session.InitFromSecret(ByteSpan(mSharedSecret, mSharedSecret.Length()), ByteSpan(msg_salt.Get(), saltlen),
-                                                CryptoContext::SessionInfoType::kSessionEstablishment, role));
+                                                CryptoContext::SessionInfoType::kSessionEstablishment, mRole));
 
     return CHIP_NO_ERROR;
 }

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -123,12 +123,30 @@ using HKDF_sha_crypto = HKDF_sha;
 // The session establishment fails if the response is not received within timeout window.
 static constexpr ExchangeContext::Timeout kSigma_Response_Timeout = System::Clock::Seconds16(30);
 
-CASESession::CASESession() : PairingSession(Transport::SecureSession::Type::kCASE) {}
-
 CASESession::~CASESession()
 {
     // Let's clear out any security state stored in the object, before destroying it.
     Clear();
+}
+
+void CASESession::Finish()
+{
+    mCASESessionEstablished = true;
+
+    Transport::PeerAddress address = mExchangeCtxt->GetSessionHandle()->AsUnauthenticatedSession()->GetPeerAddress();
+
+    // Discard the exchange so that Clear() doesn't try closing it. The exchange will handle that.
+    DiscardExchange();
+
+    CHIP_ERROR err = ActivateSecureSession(address);
+    if (err == CHIP_NO_ERROR)
+    {
+        mDelegate->OnSessionEstablished(mSecureSessionHolder.Get());
+    }
+    else
+    {
+        mDelegate->OnSessionEstablishmentError(err);
+    }
 }
 
 void CASESession::Clear()
@@ -199,6 +217,7 @@ CASESession::ListenForSessionEstablishment(SessionManager & sessionManager, Fabr
     VerifyOrReturnError(fabrics != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorOnFailure(Init(sessionManager, delegate));
 
+    mRole                     = CryptoContext::SessionRole::kResponder;
     mFabricsTable             = fabrics;
     mSessionResumptionStorage = sessionResumptionStorage;
     mLocalMRPConfig           = mrpConfig;
@@ -210,25 +229,20 @@ CASESession::ListenForSessionEstablishment(SessionManager & sessionManager, Fabr
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CASESession::EstablishSession(SessionManager & sessionManager, const Transport::PeerAddress peerAddress,
-                                         FabricInfo * fabric, NodeId peerNodeId, ExchangeContext * exchangeCtxt,
-                                         SessionResumptionStorage * sessionResumptionStorage,
+CHIP_ERROR CASESession::EstablishSession(SessionManager & sessionManager, FabricInfo * fabric, NodeId peerNodeId,
+                                         ExchangeContext * exchangeCtxt, SessionResumptionStorage * sessionResumptionStorage,
                                          SessionEstablishmentDelegate * delegate, Optional<ReliableMessageProtocolConfig> mrpConfig)
 {
     MATTER_TRACE_EVENT_SCOPE("EstablishSession", "CASESession");
     CHIP_ERROR err = CHIP_NO_ERROR;
-
-#if CHIP_PROGRESS_LOGGING
-    char peerAddrBuff[Transport::PeerAddress::kMaxToStringSize];
-    peerAddress.ToString(peerAddrBuff);
-    ChipLogProgress(SecureChannel, "Establishing CASE session to %s", peerAddrBuff);
-#endif
 
     // Return early on error here, as we have not initialized any state yet
     ReturnErrorCodeIf(exchangeCtxt == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorCodeIf(fabric == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     err = Init(sessionManager, delegate);
+
+    mRole = CryptoContext::SessionRole::kInitiator;
 
     // We are setting the exchange context specifically before checking for error.
     // This is to make sure the exchange will get closed if Init() returned an error.
@@ -242,8 +256,7 @@ CHIP_ERROR CASESession::EstablishSession(SessionManager & sessionManager, const 
     mLocalMRPConfig = mrpConfig;
 
     mExchangeCtxt->SetResponseTimeout(kSigma_Response_Timeout + mExchangeCtxt->GetSessionHandle()->GetAckTimeout());
-    SetPeerAddress(peerAddress);
-    SetPeerNodeId(peerNodeId);
+    mPeerNodeId = peerNodeId;
 
     err = SendSigma1();
     SuccessOrExit(err);
@@ -269,7 +282,7 @@ void CASESession::OnResponseTimeout(ExchangeContext * ec)
     mDelegate->OnSessionEstablishmentError(CHIP_ERROR_TIMEOUT);
 }
 
-CHIP_ERROR CASESession::DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role)
+CHIP_ERROR CASESession::DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) const
 {
     size_t saltlen;
 
@@ -378,7 +391,7 @@ CHIP_ERROR CASESession::SendSigma1()
 
         MutableByteSpan destinationIdSpan(destinationIdentifier);
         ReturnErrorOnFailure(GenerateCaseDestinationId(ByteSpan(mIPK), ByteSpan(mInitiatorRandom), rootPubKeySpan, fabricId,
-                                                       GetPeerNodeId(), destinationIdSpan));
+                                                       mPeerNodeId, destinationIdSpan));
     }
     ReturnErrorOnFailure(tlvWriter.PutBytes(TLV::ContextTag(3), destinationIdentifier, sizeof(destinationIdentifier)));
 
@@ -396,7 +409,7 @@ CHIP_ERROR CASESession::SendSigma1()
     if (mSessionResumptionStorage != nullptr)
     {
         SessionResumptionStorage::ResumptionIdStorage resumptionId;
-        CHIP_ERROR err = mSessionResumptionStorage->FindByScopedNodeId(mFabricInfo->GetScopedNodeIdForNode(GetPeerNodeId()),
+        CHIP_ERROR err = mSessionResumptionStorage->FindByScopedNodeId(mFabricInfo->GetScopedNodeIdForNode(mPeerNodeId),
                                                                        resumptionId, mSharedSecret, mPeerCATs);
         if (err == CHIP_NO_ERROR)
         {
@@ -821,27 +834,14 @@ CHIP_ERROR CASESession::HandleSigma2Resume(System::PacketBufferHandle && msg)
 
     if (mSessionResumptionStorage != nullptr)
     {
-        CHIP_ERROR err2 = mSessionResumptionStorage->Save(ScopedNodeId(GetPeerNodeId(), GetFabricIndex()), resumptionId,
-                                                          mSharedSecret, mPeerCATs);
+        CHIP_ERROR err2 = mSessionResumptionStorage->Save(GetPeer(), resumptionId, mSharedSecret, mPeerCATs);
         if (err2 != CHIP_NO_ERROR)
             ChipLogError(SecureChannel, "Unable to save session resumption state: %" CHIP_ERROR_FORMAT, err2.Format());
     }
 
     SendStatusReport(mExchangeCtxt, kProtocolCodeSuccess);
 
-    // TODO: Set timestamp on the new session, to allow selecting a least-recently-used session for eviction
-    // on running out of session contexts.
-
-    mCASESessionEstablished = true;
-
-    // Discard the exchange so that Clear() doesn't try closing it.  The
-    // exchange will handle that.
-    DiscardExchange();
-
-    // Call delegate to indicate session establishment is successful
-    // Do this last in case the delegate frees us.
-    mDelegate->OnSessionEstablished();
-
+    Finish();
 exit:
     if (err != CHIP_NO_ERROR)
     {
@@ -977,7 +977,7 @@ CHIP_ERROR CASESession::HandleSigma2(System::PacketBufferHandle && msg)
 
     // Verify that responderNodeId (from responderNOC) matches one that was included
     // in the computation of the Destination Identifier when generating Sigma1.
-    VerifyOrReturnError(GetPeerNodeId() == responderNodeId, CHIP_ERROR_INVALID_CASE_PARAMETER);
+    VerifyOrReturnError(mPeerNodeId == responderNodeId, CHIP_ERROR_INVALID_CASE_PARAMETER);
 
     // Construct msg_R2_Signed and validate the signature in msg_r2_encrypted
     msg_r2_signed_len = TLV::EstimateStructOverhead(sizeof(uint16_t), responderNOC.size(), responderICAC.size(),
@@ -1245,7 +1245,7 @@ CHIP_ERROR CASESession::HandleSigma3(System::PacketBufferHandle && msg)
     // Validate initiator identity located in msg->Start()
     // Constructing responder identity
     SuccessOrExit(err = ValidatePeerIdentity(initiatorNOC, initiatorICAC, initiatorNodeId, initiatorPublicKey));
-    SetPeerNodeId(initiatorNodeId);
+    mPeerNodeId = initiatorNodeId;
 
     // Step 4 - Construct Sigma3 TBS Data
     msg_r3_signed_len = TLV::EstimateStructOverhead(sizeof(uint16_t), initiatorNOC.size(), initiatorICAC.size(),
@@ -1288,27 +1288,14 @@ CHIP_ERROR CASESession::HandleSigma3(System::PacketBufferHandle && msg)
 
     if (mSessionResumptionStorage != nullptr)
     {
-        CHIP_ERROR err2 = mSessionResumptionStorage->Save(ScopedNodeId(GetPeerNodeId(), GetFabricIndex()), mResumptionId,
-                                                          mSharedSecret, mPeerCATs);
+        CHIP_ERROR err2 = mSessionResumptionStorage->Save(GetPeer(), mResumptionId, mSharedSecret, mPeerCATs);
         if (err2 != CHIP_NO_ERROR)
             ChipLogError(SecureChannel, "Unable to save session resumption state: %" CHIP_ERROR_FORMAT, err2.Format());
     }
 
     SendStatusReport(mExchangeCtxt, kProtocolCodeSuccess);
 
-    // TODO: Set timestamp on the new session, to allow selecting a least-recently-used session for eviction
-    // on running out of session contexts.
-
-    mCASESessionEstablished = true;
-
-    // Discard the exchange so that Clear() doesn't try closing it.  The
-    // exchange will handle that.
-    DiscardExchange();
-
-    // Call delegate to indicate session establishment is successful
-    // Do this last in case the delegate frees us.
-    mDelegate->OnSessionEstablished();
-
+    Finish();
 exit:
     if (err != CHIP_NO_ERROR)
     {
@@ -1503,24 +1490,13 @@ void CASESession::OnSuccessStatusReport()
 
     if (mSessionResumptionStorage != nullptr)
     {
-        CHIP_ERROR err2 = mSessionResumptionStorage->Save(ScopedNodeId(GetPeerNodeId(), GetFabricIndex()), mResumptionId,
-                                                          mSharedSecret, mPeerCATs);
+        CHIP_ERROR err2 = mSessionResumptionStorage->Save(GetPeer(), mResumptionId, mSharedSecret, mPeerCATs);
         if (err2 != CHIP_NO_ERROR)
             ChipLogError(SecureChannel, "Unable to save session resumption state: %" CHIP_ERROR_FORMAT, err2.Format());
     }
 
-    // Discard the exchange so that Clear() doesn't try closing it.  The
-    // exchange will handle that.
-    DiscardExchange();
-
     mState = kInitialized;
-
-    // TODO: Set timestamp on the new session, to allow selecting a least-recently-used session for eviction
-    // on running out of session contexts.
-
-    // Call delegate to indicate pairing completion.
-    // Do this last in case the delegate frees us.
-    mDelegate->OnSessionEstablished();
+    Finish();
 }
 
 CHIP_ERROR CASESession::OnFailureStatusReport(Protocols::SecureChannel::GeneralStatusCode generalCode, uint16_t protocolCode)

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -134,15 +134,12 @@ public:
 
     /**
      * @brief
-     *   Derive a secure session from the established session. The API will return error
-     *   if called before session is established.
+     *   Derive a secure session from the established session. The API will return error if called before session is established.
      *
-     * @param session     Reference to the secure session that will be
-     *                    initialized once session establishment is complete
-     * @param role        Role of the new session (initiator or responder)
+     * @param session     Reference to the secure session that will be initialized once session establishment is complete
      * @return CHIP_ERROR The result of session derivation
      */
-    CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) const override;
+    CHIP_ERROR DeriveSecureSession(CryptoContext & session) const override;
 
     //// UnsolicitedMessageHandler Implementation ////
     CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -60,11 +60,11 @@ class DLL_EXPORT CASESession : public Messaging::UnsolicitedMessageHandler,
                                public PairingSession
 {
 public:
-    CASESession();
-    CASESession(CASESession &&)      = default;
-    CASESession(const CASESession &) = default;
-
     ~CASESession() override;
+
+    Transport::SecureSession::Type GetSecureSessionType() const override { return Transport::SecureSession::Type::kCASE; }
+    ScopedNodeId GetPeer() const override { return ScopedNodeId(mPeerNodeId, GetFabricIndex()); }
+    CATValues GetPeerCATs() const override { return mPeerCATs; };
 
     /**
      * @brief
@@ -86,7 +86,6 @@ public:
      *   Create and send session establishment request using device's operational credentials.
      *
      * @param sessionManager                session manager from which to allocate a secure session object
-     * @param peerAddress                   Address of peer with which to establish a session.
      * @param fabric                        The fabric that should be used for connecting with the peer
      * @param peerNodeId                    Node id of the peer node
      * @param exchangeCtxt                  The exchange context to send and receive messages with the peer
@@ -95,9 +94,9 @@ public:
      * @return CHIP_ERROR      The result of initialization
      */
     CHIP_ERROR
-    EstablishSession(SessionManager & sessionManager, const Transport::PeerAddress peerAddress, FabricInfo * fabric,
-                     NodeId peerNodeId, Messaging::ExchangeContext * exchangeCtxt,
-                     SessionResumptionStorage * sessionResumptionStorage, SessionEstablishmentDelegate * delegate,
+    EstablishSession(SessionManager & sessionManager, FabricInfo * fabric, NodeId peerNodeId,
+                     Messaging::ExchangeContext * exchangeCtxt, SessionResumptionStorage * sessionResumptionStorage,
+                     SessionEstablishmentDelegate * delegate,
                      Optional<ReliableMessageProtocolConfig> mrpConfig = Optional<ReliableMessageProtocolConfig>::Missing());
 
     /**
@@ -143,7 +142,7 @@ public:
      * @param role        Role of the new session (initiator or responder)
      * @return CHIP_ERROR The result of session derivation
      */
-    CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) override;
+    CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) const override;
 
     //// UnsolicitedMessageHandler Implementation ////
     CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override
@@ -217,6 +216,9 @@ private:
     void OnSuccessStatusReport() override;
     CHIP_ERROR OnFailureStatusReport(Protocols::SecureChannel::GeneralStatusCode generalCode, uint16_t protocolCode) override;
 
+    // TODO: pull up Finish to PairingSession class
+    void Finish();
+
     void AbortExchange();
 
     /**
@@ -253,6 +255,8 @@ private:
 
     FabricTable * mFabricsTable    = nullptr;
     const FabricInfo * mFabricInfo = nullptr;
+    NodeId mPeerNodeId             = kUndefinedNodeId;
+    CATValues mPeerCATs;
 
     // This field is only used for CASE responder, when during sending sigma2 and waiting for sigma3
     SessionResumptionStorage::ResumptionIdStorage mResumptionId;
@@ -260,8 +264,6 @@ private:
     uint8_t mInitiatorRandom[kSigmaParamRandomNumberSize];
 
     State mState;
-
-    Optional<ReliableMessageProtocolConfig> mLocalMRPConfig;
 
 protected:
     bool mCASESessionEstablished = false;

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -63,12 +63,30 @@ const char * kSpake2pR2ISessionInfo = "Commissioning R2I Key";
 // The session establishment fails if the response is not received with in timeout window.
 static constexpr ExchangeContext::Timeout kSpake2p_Response_Timeout = System::Clock::Seconds16(30);
 
-PASESession::PASESession() : PairingSession(Transport::SecureSession::Type::kPASE) {}
-
 PASESession::~PASESession()
 {
     // Let's clear out any security state stored in the object, before destroying it.
     Clear();
+}
+
+void PASESession::Finish()
+{
+    mPairingComplete = true;
+
+    Transport::PeerAddress address = mExchangeCtxt->GetSessionHandle()->AsUnauthenticatedSession()->GetPeerAddress();
+
+    // Discard the exchange so that Clear() doesn't try closing it. The exchange will handle that.
+    DiscardExchange();
+
+    CHIP_ERROR err = ActivateSecureSession(address);
+    if (err == CHIP_NO_ERROR)
+    {
+        mDelegate->OnSessionEstablished(mSecureSessionHolder.Get());
+    }
+    else
+    {
+        mDelegate->OnSessionEstablishmentError(err);
+    }
 }
 
 void PASESession::Clear()
@@ -181,6 +199,8 @@ CHIP_ERROR PASESession::WaitForPairing(SessionManager & sessionManager, const Sp
     // been initialized
     SuccessOrExit(err);
 
+    mRole = CryptoContext::SessionRole::kResponder;
+
     VerifyOrExit(CanCastTo<uint16_t>(salt.size()), err = CHIP_ERROR_INVALID_ARGUMENT);
     mSaltLength = static_cast<uint16_t>(salt.size());
 
@@ -201,8 +221,6 @@ CHIP_ERROR PASESession::WaitForPairing(SessionManager & sessionManager, const Sp
     mPairingComplete = false;
     mLocalMRPConfig  = mrpConfig;
 
-    SetPeerNodeId(NodeIdFromPAKEKeyId(kDefaultCommissioningPasscodeId));
-
     ChipLogDetail(SecureChannel, "Waiting for PBKDF param request");
 
 exit:
@@ -213,7 +231,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR PASESession::Pair(SessionManager & sessionManager, const Transport::PeerAddress peerAddress, uint32_t peerSetUpPINCode,
+CHIP_ERROR PASESession::Pair(SessionManager & sessionManager, uint32_t peerSetUpPINCode,
                              Optional<ReliableMessageProtocolConfig> mrpConfig, Messaging::ExchangeContext * exchangeCtxt,
                              SessionEstablishmentDelegate * delegate)
 {
@@ -222,13 +240,12 @@ CHIP_ERROR PASESession::Pair(SessionManager & sessionManager, const Transport::P
     CHIP_ERROR err = Init(sessionManager, peerSetUpPINCode, delegate);
     SuccessOrExit(err);
 
+    mRole = CryptoContext::SessionRole::kInitiator;
+
     mExchangeCtxt = exchangeCtxt;
     mExchangeCtxt->SetResponseTimeout(kSpake2p_Response_Timeout + mExchangeCtxt->GetSessionHandle()->GetAckTimeout());
 
-    SetPeerAddress(peerAddress);
-
     mLocalMRPConfig = mrpConfig;
-    SetPeerNodeId(NodeIdFromPAKEKeyId(kDefaultCommissioningPasscodeId));
 
     err = SendPBKDFParamRequest();
     SuccessOrExit(err);
@@ -258,7 +275,7 @@ void PASESession::OnResponseTimeout(ExchangeContext * ec)
     mDelegate->OnSessionEstablishmentError(CHIP_ERROR_TIMEOUT);
 }
 
-CHIP_ERROR PASESession::DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role)
+CHIP_ERROR PASESession::DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) const
 {
     VerifyOrReturnError(mPairingComplete, CHIP_ERROR_INCORRECT_STATE);
     return session.InitFromSecret(ByteSpan(mKe, mKeLen), ByteSpan(nullptr, 0),
@@ -743,16 +760,7 @@ CHIP_ERROR PASESession::HandleMsg3(System::PacketBufferHandle && msg)
     // Send confirmation to peer that we succeeded so they can start using the session.
     SendStatusReport(mExchangeCtxt, kProtocolCodeSuccess);
 
-    mPairingComplete = true;
-
-    // Discard the exchange so that Clear() doesn't try closing it.  The
-    // exchange will handle that.
-    DiscardExchange();
-
-    // Call delegate to indicate pairing completion
-    // Do this last in case the delegate frees us.
-    mDelegate->OnSessionEstablished();
-
+    Finish();
 exit:
 
     if (err != CHIP_NO_ERROR)
@@ -764,15 +772,7 @@ exit:
 
 void PASESession::OnSuccessStatusReport()
 {
-    mPairingComplete = true;
-
-    // Discard the exchange so that Clear() doesn't try closing it.  The
-    // exchange will handle that.
-    DiscardExchange();
-
-    // Call delegate to indicate pairing completion
-    // Do this last in case the delegate frees us.
-    mDelegate->OnSessionEstablished();
+    Finish();
 }
 
 CHIP_ERROR PASESession::OnFailureStatusReport(Protocols::SecureChannel::GeneralStatusCode generalCode, uint16_t protocolCode)

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -275,11 +275,11 @@ void PASESession::OnResponseTimeout(ExchangeContext * ec)
     mDelegate->OnSessionEstablishmentError(CHIP_ERROR_TIMEOUT);
 }
 
-CHIP_ERROR PASESession::DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) const
+CHIP_ERROR PASESession::DeriveSecureSession(CryptoContext & session) const
 {
     VerifyOrReturnError(mPairingComplete, CHIP_ERROR_INCORRECT_STATE);
     return session.InitFromSecret(ByteSpan(mKe, mKeLen), ByteSpan(nullptr, 0),
-                                  CryptoContext::SessionInfoType::kSessionEstablishment, role);
+                                  CryptoContext::SessionInfoType::kSessionEstablishment, mRole);
 }
 
 CHIP_ERROR PASESession::SendPBKDFParamRequest()

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -132,15 +132,12 @@ public:
 
     /**
      * @brief
-     *   Derive a secure session from the paired session. The API will return error
-     *   if called before pairing is established.
+     *   Derive a secure session from the paired session. The API will return error if called before pairing is established.
      *
-     * @param session     Reference to the secure session that will be
-     *                    initialized once pairing is complete
-     * @param role        Role of the new session (initiator or responder)
+     * @param session     Reference to the secure session that will be initialized once pairing is complete
      * @return CHIP_ERROR The result of session derivation
      */
-    CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) const override;
+    CHIP_ERROR DeriveSecureSession(CryptoContext & session) const override;
 
     // TODO: remove Clear, we should create a new instance instead reset the old instance.
     /** @brief This function zeroes out and resets the memory used by the object.

--- a/src/protocols/secure_channel/SessionEstablishmentDelegate.h
+++ b/src/protocols/secure_channel/SessionEstablishmentDelegate.h
@@ -47,7 +47,7 @@ public:
     /**
      *   Called when the new secure session has been established
      */
-    virtual void OnSessionEstablished() {}
+    virtual void OnSessionEstablished(const SessionHandle & session) {}
 
     virtual ~SessionEstablishmentDelegate() {}
 };

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -75,7 +75,15 @@ class TestCASESecurePairingDelegate : public SessionEstablishmentDelegate
 public:
     void OnSessionEstablishmentError(CHIP_ERROR error) override { mNumPairingErrors++; }
 
-    void OnSessionEstablished() override { mNumPairingComplete++; }
+    void OnSessionEstablished(const SessionHandle & session) override
+    {
+        mSession.Grab(session);
+        mNumPairingComplete++;
+    }
+
+    SessionHolder & GetSessionHolder() { return mSession; }
+
+    SessionHolder mSession;
 
     // TODO: Rename mNumPairing* to mNumEstablishment*
     uint32_t mNumPairingErrors   = 0;
@@ -182,9 +190,6 @@ void CASE_SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext)
     SessionManager sessionManager;
 
     NL_TEST_ASSERT(inSuite, pairing.GetSecureSessionType() == SecureSession::Type::kCASE);
-    CATValues peerCATs;
-    peerCATs = pairing.GetPeerCATs();
-    NL_TEST_ASSERT(inSuite, memcmp(&peerCATs, &kUndefinedCATs, sizeof(CATValues)) == 0);
 
     pairing.SetGroupDataProvider(&gDeviceGroupDataProvider);
     NL_TEST_ASSERT(inSuite,
@@ -210,18 +215,15 @@ void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     ExchangeContext * context = ctx.NewUnauthenticatedExchangeToBob(&pairing);
 
     NL_TEST_ASSERT(inSuite,
-                   pairing.EstablishSession(sessionManager, Transport::PeerAddress(Transport::Type::kBle), nullptr, Node01_01,
-                                            nullptr, nullptr, nullptr) != CHIP_NO_ERROR);
+                   pairing.EstablishSession(sessionManager, nullptr, Node01_01, nullptr, nullptr, nullptr) != CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite,
-                   pairing.EstablishSession(sessionManager, Transport::PeerAddress(Transport::Type::kBle), fabric, Node01_01,
-                                            nullptr, nullptr, nullptr) != CHIP_NO_ERROR);
+                   pairing.EstablishSession(sessionManager, fabric, Node01_01, nullptr, nullptr, nullptr) != CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite,
-                   pairing.EstablishSession(sessionManager, Transport::PeerAddress(Transport::Type::kBle), fabric, Node01_01,
-                                            context, nullptr, &delegate) == CHIP_NO_ERROR);
+                   pairing.EstablishSession(sessionManager, fabric, Node01_01, context, nullptr, &delegate) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
@@ -241,8 +243,8 @@ void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     ExchangeContext * context1  = ctx.NewUnauthenticatedExchangeToBob(&pairing1);
 
     NL_TEST_ASSERT(inSuite,
-                   pairing1.EstablishSession(sessionManager, Transport::PeerAddress(Transport::Type::kBle), fabric, Node01_01,
-                                             context1, nullptr, &delegate) == CHIP_ERROR_BAD_REQUEST);
+                   pairing1.EstablishSession(sessionManager, fabric, Node01_01, context1, nullptr, &delegate) ==
+                       CHIP_ERROR_BAD_REQUEST);
     ctx.DrainAndServiceIO();
 
     gLoopback.mMessageSendError = CHIP_NO_ERROR;
@@ -274,8 +276,7 @@ void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inConte
                    pairingAccessory.ListenForSessionEstablishment(sessionManager, &gDeviceFabrics, nullptr, &delegateAccessory) ==
                        CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner.EstablishSession(sessionManager, Transport::PeerAddress(Transport::Type::kBle), fabric,
-                                                        Node01_01, contextCommissioner, nullptr,
+                   pairingCommissioner.EstablishSession(sessionManager, fabric, Node01_01, contextCommissioner, nullptr,
                                                         &delegateCommissioner) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
@@ -323,29 +324,25 @@ void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inConte
     NL_TEST_ASSERT(inSuite, fabric != nullptr);
 
     NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner->EstablishSession(ctx.GetSecureSessionManager(),
-                                                         Transport::PeerAddress(Transport::Type::kBle), fabric, Node01_01,
-                                                         contextCommissioner, nullptr, &delegateCommissioner) == CHIP_NO_ERROR);
+                   pairingCommissioner->EstablishSession(ctx.GetSecureSessionManager(), fabric, Node01_01, contextCommissioner,
+                                                         nullptr, &delegateCommissioner) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 5);
     NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
 
-    // Validate that secure session can be created after the pairing
-    SessionHolder sessionHolder;
-    NL_TEST_ASSERT(inSuite,
-                   ctx.GetSecureSessionManager().NewPairing(sessionHolder, NullOptional, Node01_01, pairingCommissioner,
-                                                            CryptoContext::SessionRole::kInitiator,
-                                                            gCommissionerFabricIndex) == CHIP_NO_ERROR);
+    // Validate that secure session is created
+    SessionHolder & holder = delegateCommissioner.GetSessionHolder();
+    NL_TEST_ASSERT(inSuite, bool(holder));
+    NL_TEST_ASSERT(inSuite, holder->GetPeer() == fabric->GetScopedNodeIdForNode(Node01_01));
 
     auto * pairingCommissioner1 = chip::Platform::New<CASESession>();
     pairingCommissioner1->SetGroupDataProvider(&gCommissionerGroupDataProvider);
     ExchangeContext * contextCommissioner1 = ctx.NewUnauthenticatedExchangeToBob(pairingCommissioner1);
 
     NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner1->EstablishSession(ctx.GetSecureSessionManager(),
-                                                          Transport::PeerAddress(Transport::Type::kBle), fabric, Node01_01,
-                                                          contextCommissioner1, nullptr, &delegateCommissioner) == CHIP_NO_ERROR);
+                   pairingCommissioner1->EstablishSession(ctx.GetSecureSessionManager(), fabric, Node01_01, contextCommissioner1,
+                                                          nullptr, &delegateCommissioner) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
     chip::Platform::Delete(pairingCommissioner);

--- a/src/transport/PairingSession.cpp
+++ b/src/transport/PairingSession.cpp
@@ -40,7 +40,7 @@ CHIP_ERROR PairingSession::ActivateSecureSession(const Transport::PeerAddress & 
                   ChipLogValueScopedNodeId(GetPeer()), secureSession->GetLocalSessionId(), peerSessionId);
     secureSession->Activate(GetSecureSessionType(), GetPeer(), GetPeerCATs(), peerSessionId, mRemoteMRPConfig);
     secureSession->SetPeerAddress(peerAddress);
-    ReturnErrorOnFailure(DeriveSecureSession(secureSession->GetCryptoContext(), mRole));
+    ReturnErrorOnFailure(DeriveSecureSession(secureSession->GetCryptoContext()));
     secureSession->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(LocalSessionMessageCounter::kInitialSyncValue);
 
     return CHIP_NO_ERROR;

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -38,17 +38,11 @@ namespace chip {
 class DLL_EXPORT PairingSession
 {
 public:
-    PairingSession(Transport::SecureSession::Type secureSessionType) : mSecureSessionType(secureSessionType) {}
     virtual ~PairingSession() {}
 
-    Transport::SecureSession::Type GetSecureSessionType() const { return mSecureSessionType; }
-
-    // TODO: the session should know which peer we are trying to connect to at start
-    // mPeerNodeId should be const and assigned at the construction, such that GetPeerNodeId will never return kUndefinedNodeId, and
-    // SetPeerNodeId is not necessary.
-    NodeId GetPeerNodeId() const { return mPeerNodeId; }
-
-    CATValues GetPeerCATs() const { return mPeerCATs; }
+    virtual Transport::SecureSession::Type GetSecureSessionType() const = 0;
+    virtual ScopedNodeId GetPeer() const                                = 0;
+    virtual CATValues GetPeerCATs() const                               = 0;
 
     Optional<uint16_t> GetLocalSessionId() const
     {
@@ -61,18 +55,12 @@ public:
         return localSessionId;
     }
 
-    auto GetSecureSessionHandle() const { return mSecureSessionHolder.ToOptional(); }
-
     uint16_t GetPeerSessionId() const
     {
         VerifyOrDie(mPeerSessionId.HasValue());
         return mPeerSessionId.Value();
     }
     bool IsValidPeerSessionId() const { return mPeerSessionId.HasValue(); }
-
-    // TODO: decouple peer address into transport, such that pairing session do not need to handle peer address
-    const Transport::PeerAddress & GetPeerAddress() const { return mPeerAddress; }
-    Transport::PeerAddress & GetPeerAddress() { return mPeerAddress; }
 
     /**
      * @brief
@@ -84,15 +72,10 @@ public:
      * @param role        Role of the new session (initiator or responder)
      * @return CHIP_ERROR The result of session derivation
      */
-    virtual CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) = 0;
+    virtual CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) const = 0;
 
-    /**
-     * @brief
-     *   Get the MRP config that was communicated during the session establishment.
-     */
-    virtual const ReliableMessageProtocolConfig & GetMRPConfig() const { return mMRPConfig; }
-
-    void SetMRPConfig(const ReliableMessageProtocolConfig & config) { mMRPConfig = config; }
+    const ReliableMessageProtocolConfig & GetRemoteMRPConfig() const { return mRemoteMRPConfig; }
+    void SetRemoteMRPConfig(const ReliableMessageProtocolConfig & config) { mRemoteMRPConfig = config; }
 
     /**
      * Encode the provided MRP parameters using the provided TLV tag.
@@ -110,22 +93,9 @@ protected:
      */
     CHIP_ERROR AllocateSecureSession(SessionManager & sessionManager);
 
-    /**
-     * Allocate a secure session object from the passed session manager with the
-     * specified session ID.
-     *
-     * This variant of the interface may be used in test scenarios where
-     * session IDs need to be predetermined.
+    CHIP_ERROR ActivateSecureSession(const Transport::PeerAddress & peerAddress);
 
-     * @param sessionManager session manager from which to allocate a secure session object
-     * @param sessionId caller-requested session ID
-     * @return CHIP_ERROR The outcome of the allocation attempt
-     */
-    CHIP_ERROR AllocateSecureSession(SessionManager & sessionManager, uint16_t sessionId);
-
-    void SetPeerNodeId(NodeId peerNodeId) { mPeerNodeId = peerNodeId; }
     void SetPeerSessionId(uint16_t id) { mPeerSessionId.SetValue(id); }
-    void SetPeerAddress(const Transport::PeerAddress & address) { mPeerAddress = address; }
     virtual void OnSuccessStatusReport() {}
     virtual CHIP_ERROR OnFailureStatusReport(Protocols::SecureChannel::GeneralStatusCode generalCode, uint16_t protocolCode)
     {
@@ -180,7 +150,7 @@ protected:
 
     /**
      * Try to decode the current element (pointed by the TLV reader) as MRP parameters.
-     * If the MRP parameters are found, mMRPConfig is updated with the devoded values.
+     * If the MRP parameters are found, mRemoteMRPConfig is updated with the devoded values.
      *
      * MRP parameters are optional. So, if the TLV reader is not pointing to the MRP parameters,
      * the function is a noop.
@@ -193,29 +163,21 @@ protected:
     // TODO: remove Clear, we should create a new instance instead reset the old instance.
     void Clear()
     {
-        mPeerNodeId  = kUndefinedNodeId;
-        mPeerCATs    = kUndefinedCATs;
-        mPeerAddress = Transport::PeerAddress::Uninitialized();
         mPeerSessionId.ClearValue();
         mSecureSessionHolder.Release();
     }
 
-private:
-    const Transport::SecureSession::Type mSecureSessionType;
-
 protected:
-    NodeId mPeerNodeId = kUndefinedNodeId;
-    CATValues mPeerCATs;
-
-private:
+    CryptoContext::SessionRole mRole;
     SessionHolder mSecureSessionHolder;
 
-    // TODO: decouple peer address into transport, such that pairing session do not need to handle peer address
-    Transport::PeerAddress mPeerAddress = Transport::PeerAddress::Uninitialized();
+    // mLocalMRPConfig is our config which is sent to the other end and used by the peer session.
+    // mRemoteMRPConfig is received from other end and set to our session.
+    Optional<ReliableMessageProtocolConfig> mLocalMRPConfig;
+    ReliableMessageProtocolConfig mRemoteMRPConfig = GetLocalMRPConfig();
 
+private:
     Optional<uint16_t> mPeerSessionId;
-
-    ReliableMessageProtocolConfig mMRPConfig = GetLocalMRPConfig();
 };
 
 } // namespace chip

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -64,15 +64,12 @@ public:
 
     /**
      * @brief
-     *   Derive a secure session from the paired session. The API will return error
-     *   if called before pairing is established.
+     *   Derive a secure session from the paired session. The API will return error if called before pairing is established.
      *
-     * @param session     Reference to the secure session that will be
-     *                    initialized once pairing is complete
-     * @param role        Role of the new session (initiator or responder)
+     * @param session     Reference to the secure session that will be initialized once pairing is complete
      * @return CHIP_ERROR The result of session derivation
      */
-    virtual CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) const = 0;
+    virtual CHIP_ERROR DeriveSecureSession(CryptoContext & session) const = 0;
 
     const ReliableMessageProtocolConfig & GetRemoteMRPConfig() const { return mRemoteMRPConfig; }
     void SetRemoteMRPConfig(const ReliableMessageProtocolConfig & config) { mRemoteMRPConfig = config; }

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -97,15 +97,15 @@ public:
      *   PASE, setting internal state according to the parameters used and
      *   discovered during session establishment.
      */
-    void Activate(Type secureSessionType, NodeId peerNodeId, CATValues peerCATs, uint16_t peerSessionId, FabricIndex fabric,
+    void Activate(Type secureSessionType, const ScopedNodeId & peer, CATValues peerCATs, uint16_t peerSessionId,
                   const ReliableMessageProtocolConfig & config)
     {
         mSecureSessionType = secureSessionType;
-        mPeerNodeId        = peerNodeId;
+        mPeerNodeId        = peer.GetNodeId();
         mPeerCATs          = peerCATs;
         mPeerSessionId     = peerSessionId;
         mMRPConfig         = config;
-        SetFabricIndex(fabric);
+        SetFabricIndex(peer.GetFabricIndex());
     }
     ~SecureSession() override { NotifySessionReleased(); }
 

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -163,18 +163,6 @@ public:
 
     /**
      * @brief
-     *   Establish a new pairing with a peer node
-     *
-     * @details
-     *   This method sets up a new pairing with the peer node. It also
-     *   establishes the security keys for secure communication with the
-     *   peer node.
-     */
-    CHIP_ERROR NewPairing(SessionHolder & sessionHolder, const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId,
-                          PairingSession * pairing, CryptoContext::SessionRole direction, FabricIndex fabric);
-
-    /**
-     * @brief
      *   Allocate a secure session and non-colliding session ID in the secure
      *   session table.
      *
@@ -183,21 +171,8 @@ public:
     CHECK_RETURN_VALUE
     Optional<SessionHandle> AllocateSession();
 
-    /**
-     * @brief
-     *   Allocate a secure session in the secure session table at the specified
-     *   session ID.  If the session ID collides with an existing session, evict
-     *   it.  This variant of the interface may be used in test scenarios where
-     *   session IDs need to be predetermined.
-     *
-     * @param localSessionId a unique identifier for the local node's secure unicast session context
-     * @return SessionHandle with a reference to a SecureSession, else NullOptional on failure
-     */
-    CHECK_RETURN_VALUE
-    Optional<SessionHandle> AllocateSession(uint16_t localSessionId);
-
     void ExpirePairing(const SessionHandle & session);
-    void ExpireAllPairings(NodeId peerNodeId, FabricIndex fabric);
+    void ExpireAllPairings(const ScopedNodeId & node);
     void ExpireAllPairingsForFabric(FabricIndex fabric);
     void ExpireAllPASEPairings();
 

--- a/src/transport/tests/TestPairingSession.cpp
+++ b/src/transport/tests/TestPairingSession.cpp
@@ -41,9 +41,16 @@ using namespace chip::System::Clock;
 class TestPairingSession : public PairingSession
 {
 public:
-    TestPairingSession(Transport::SecureSession::Type secureSessionType) : PairingSession(secureSessionType) {}
+    Transport::SecureSession::Type GetSecureSessionType() const override { return Transport::SecureSession::Type::kPASE; }
+    ScopedNodeId GetPeer() const override { return ScopedNodeId(); }
+    CATValues GetPeerCATs() const override { return CATValues(); };
 
-    CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) override { return CHIP_NO_ERROR; }
+    const ReliableMessageProtocolConfig & GetRemoteMRPConfig() const { return mRemoteMRPConfig; }
+
+    CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) const override
+    {
+        return CHIP_NO_ERROR;
+    }
 
     CHIP_ERROR DecodeMRPParametersIfPresent(TLV::Tag expectedTag, System::PacketBufferTLVReader & tlvReader)
     {
@@ -53,7 +60,7 @@ public:
 
 void PairingSessionEncodeDecodeMRPParams(nlTestSuite * inSuite, void * inContext)
 {
-    TestPairingSession session(Transport::SecureSession::Type::kCASE);
+    TestPairingSession session;
 
     ReliableMessageProtocolConfig config(Milliseconds32(100), Milliseconds32(200));
 
@@ -80,13 +87,13 @@ void PairingSessionEncodeDecodeMRPParams(nlTestSuite * inSuite, void * inContext
     NL_TEST_ASSERT(inSuite, reader.Next() == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, session.DecodeMRPParametersIfPresent(TLV::ContextTag(1), reader) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, session.GetMRPConfig().mIdleRetransTimeout == config.mIdleRetransTimeout);
-    NL_TEST_ASSERT(inSuite, session.GetMRPConfig().mActiveRetransTimeout == config.mActiveRetransTimeout);
+    NL_TEST_ASSERT(inSuite, session.GetRemoteMRPConfig().mIdleRetransTimeout == config.mIdleRetransTimeout);
+    NL_TEST_ASSERT(inSuite, session.GetRemoteMRPConfig().mActiveRetransTimeout == config.mActiveRetransTimeout);
 }
 
 void PairingSessionTryDecodeMissingMRPParams(nlTestSuite * inSuite, void * inContext)
 {
-    TestPairingSession session(Transport::SecureSession::Type::kPASE);
+    TestPairingSession session;
 
     System::PacketBufferHandle buf = System::PacketBufferHandle::New(64, 0);
     System::PacketBufferTLVWriter writer;
@@ -108,8 +115,8 @@ void PairingSessionTryDecodeMissingMRPParams(nlTestSuite * inSuite, void * inCon
     NL_TEST_ASSERT(inSuite, reader.Next() == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, session.DecodeMRPParametersIfPresent(TLV::ContextTag(2), reader) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, session.GetMRPConfig().mIdleRetransTimeout == GetLocalMRPConfig().mIdleRetransTimeout);
-    NL_TEST_ASSERT(inSuite, session.GetMRPConfig().mActiveRetransTimeout == GetLocalMRPConfig().mActiveRetransTimeout);
+    NL_TEST_ASSERT(inSuite, session.GetRemoteMRPConfig().mIdleRetransTimeout == GetLocalMRPConfig().mIdleRetransTimeout);
+    NL_TEST_ASSERT(inSuite, session.GetRemoteMRPConfig().mActiveRetransTimeout == GetLocalMRPConfig().mActiveRetransTimeout);
 }
 
 // Test Suite

--- a/src/transport/tests/TestPairingSession.cpp
+++ b/src/transport/tests/TestPairingSession.cpp
@@ -47,10 +47,7 @@ public:
 
     const ReliableMessageProtocolConfig & GetRemoteMRPConfig() const { return mRemoteMRPConfig; }
 
-    CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) const override
-    {
-        return CHIP_NO_ERROR;
-    }
+    CHIP_ERROR DeriveSecureSession(CryptoContext & session) const override { return CHIP_NO_ERROR; }
 
     CHIP_ERROR DecodeMRPParametersIfPresent(TLV::Tag expectedTag, System::PacketBufferTLVReader & tlvReader)
     {


### PR DESCRIPTION
#### Problem
`SessionManager::NewPairing` should not be a public API.

#### Change overview
* Move NewPairing from establish delegate to CASE/PASE session
* `OnSessionEstablished` will receive an `SessionHandle` argument pointing to the newly created session
* NodeId won't be assigned to PASE sessions
* Remove `SessionManager::AllocateSession(uint16_t)` because it is only used by test-cases.
* `CASEClient::EstablishSession` now takes a delegate instead of function pointers
* Do not expire old sessions when a new CASE session is established
* Refactor `PairingSession` a bit
  * Add `mRole: CryptoContext::SessionRole`
  * Pull up common field `mLocalMRPConfig`
  * Rename `mMRPConfig` => `mRemoteMRPConfig`
  * Replace `mSecureSessionType` with a virtual function.
  * Push down `mPeerNodeId`, `mPeerCATs` because PASE session do not need them
  * Remove `mPeerAddress`, address is handled by the unsecure session

~~**NOTE**: this PR includes PR #17411~~

#### Testing
Passed unit-tests