### PR TITLE
Added Check for RCAC Id Validity Stored in the Commissioner Memory.

### DIFF
--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -151,9 +151,12 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
                       err = mStorage->SyncGetKeyValue(key, icac.data(), icacBufLen));
     if (err == CHIP_NO_ERROR)
     {
+        uint64_t icacId;
         // Found intermediate certificate in the storage.
         icac.reduce_size(icacBufLen);
         ReturnErrorOnFailure(ExtractSubjectDNFromX509Cert(icac, icac_dn));
+        ReturnErrorOnFailure(icac_dn.GetCertChipId(icacId));
+        VerifyOrReturnError(icacId == mIntermediateIssuerId, CHIP_ERROR_INTERNAL);
     }
     // If intermediate certificate not found in the storage, generate new intermediate certificate.
     else

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -124,9 +124,12 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
                       err = mStorage->SyncGetKeyValue(key, rcac.data(), rcacBufLen));
     if (err == CHIP_NO_ERROR)
     {
+        uint64_t rcacId;
         // Found root certificate in the storage.
         rcac.reduce_size(rcacBufLen);
         ReturnErrorOnFailure(ExtractSubjectDNFromX509Cert(rcac, rcac_dn));
+        ReturnErrorOnFailure(rcac_dn.GetCertChipId(rcacId));
+        VerifyOrReturnError(rcacId == mIssuerId, CHIP_ERROR_INTERNAL);
     }
     // If root certificate not found in the storage, generate new root certificate.
     else

--- a/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
+++ b/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
@@ -90,9 +90,12 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
                       err = mStorage->SyncGetKeyValue(key, rcac.data(), rcacBufLen));
     if (err == CHIP_NO_ERROR)
     {
+        uint64_t rcacId;
         // Found root certificate in the storage.
         rcac.reduce_size(rcacBufLen);
         ReturnErrorOnFailure(ExtractSubjectDNFromX509Cert(rcac, rcac_dn));
+        ReturnErrorOnFailure(rcac_dn.GetCertChipId(rcacId));
+        VerifyOrReturnError(rcacId == mIssuerId, CHIP_ERROR_INTERNAL);
     }
     // If root certificate not found in the storage, generate new root certificate.
     else

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -341,8 +341,11 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChainAfterValidation(N
         PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
             haveRootCert = (mStorage->SyncGetKeyValue(key, rcac.data(), rcacBufLen) == CHIP_NO_ERROR));
         if (haveRootCert) {
+            uint64_t rcacId;
             rcac.reduce_size(rcacBufLen);
             ReturnErrorOnFailure(ExtractSubjectDNFromX509Cert(rcac, rcac_dn));
+            ReturnErrorOnFailure(rcac_dn.GetCertChipId(rcacId));
+            VerifyOrReturnError(rcacId == mIssuerId, CHIP_ERROR_INTERNAL);
         }
     }
     if (!haveRootCert) {


### PR DESCRIPTION
#### Problem
Need to check that RCAC certificate stored in the commissioner memory has expected Certificate Id.

#### Change overview
Added checks

#### Testing
existing tests