### PR TITLE
Enable custom port for all-clusters-app

### DIFF
--- a/examples/all-clusters-app/linux/args.gni
+++ b/examples/all-clusters-app/linux/args.gni
@@ -15,3 +15,11 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+
+chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
+chip_project_config_include = "<CHIPProjectAppConfig.h>"
+chip_system_project_config_include = "<SystemProjectConfig.h>"
+
+chip_project_config_include_dirs =
+    [ "${chip_root}/examples/all-clusters-app/linux/include" ]
+chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]

--- a/examples/all-clusters-app/linux/include/CHIPProjectAppConfig.h
+++ b/examples/all-clusters-app/linux/include/CHIPProjectAppConfig.h
@@ -1,0 +1,34 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Example project configuration file for CHIP.
+ *
+ *          This is a place to put application or project-specific overrides
+ *          to the default configuration values for general CHIP features.
+ *
+ */
+
+#pragma once
+
+// include the CHIPProjectConfig from config/standalone
+#include <CHIPProjectConfig.h>
+
+// Allows app options (ports) to be configured on launch of app
+#define CHIP_DEVICE_ENABLE_PORT_PARAMS 1


### PR DESCRIPTION
#### Problem
There is no way to specify a custom port for the all-clusters-app

#### Change overview
Enable `CHIP_DEVICE_ENABLE_PORT_PARAMS` which allows for custom ports to be used

#### Testing
- Verify that when all-clusters-app is launched without `--secured-device-port` command line option, the default value of 5540 is used
- Verify that when all-clusters-app is launched with `--secured-device-port` command line option, the port specified is used