### PR TITLE
Do not disable BLE when receiving CASE sigma1

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -260,11 +260,8 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     err = mCASESessionManager.Init(&DeviceLayer::SystemLayer(), caseSessionManagerConfig);
     SuccessOrExit(err);
 
-    err = mCASEServer.ListenForSessionEstablishment(&mExchangeMgr, &mTransports,
-#if CONFIG_NETWORK_LAYER_BLE
-                                                    chip::DeviceLayer::ConnectivityMgr().GetBleLayer(),
-#endif
-                                                    &mSessions, &mFabrics, mSessionResumptionStorage, mGroupsProvider);
+    err = mCASEServer.ListenForSessionEstablishment(&mExchangeMgr, &mTransports, &mSessions, &mFabrics, mSessionResumptionStorage,
+                                                    mGroupsProvider);
     SuccessOrExit(err);
 
     // This code is necessary to restart listening to existing groups after a reboot

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -179,18 +179,10 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     {
         stateParams.caseServer = chip::Platform::New<CASEServer>();
 
-        //
         // Enable listening for session establishment messages.
-        //
-        // We pass in a nullptr for the BLELayer since we're not permitting usage of BLE in this server modality for the controller,
-        // especially since it will interrupt other potential usages of BLE by the controller acting in a commissioning capacity.
-        //
         ReturnErrorOnFailure(stateParams.caseServer->ListenForSessionEstablishment(
-            stateParams.exchangeMgr, stateParams.transportMgr,
-#if CONFIG_NETWORK_LAYER_BLE
-            nullptr,
-#endif
-            stateParams.sessionMgr, stateParams.fabricTable, stateParams.sessionResumptionStorage, stateParams.groupDataProvider));
+            stateParams.exchangeMgr, stateParams.transportMgr, stateParams.sessionMgr, stateParams.fabricTable,
+            stateParams.sessionResumptionStorage, stateParams.groupDataProvider));
 
         //
         // We need to advertise the port that we're listening to for unsolicited messages over UDP. However, we have both a IPv4

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -30,9 +30,6 @@ using namespace ::chip::Credentials;
 namespace chip {
 
 CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
-#if CONFIG_NETWORK_LAYER_BLE
-                                                     Ble::BleLayer * bleLayer,
-#endif
                                                      SessionManager * sessionManager, FabricTable * fabrics,
                                                      SessionResumptionStorage * sessionResumptionStorage,
                                                      Credentials::GroupDataProvider * responderGroupDataProvider)
@@ -43,9 +40,6 @@ CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager 
     VerifyOrReturnError(sessionManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(responderGroupDataProvider != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-#if CONFIG_NETWORK_LAYER_BLE
-    mBleLayer = bleLayer;
-#endif
     mSessionManager           = sessionManager;
     mSessionResumptionStorage = sessionResumptionStorage;
     mFabrics                  = fabrics;
@@ -59,15 +53,6 @@ CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager 
 CHIP_ERROR CASEServer::InitCASEHandshake(Messaging::ExchangeContext * ec)
 {
     ReturnErrorCodeIf(ec == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-
-#if CONFIG_NETWORK_LAYER_BLE
-    // Close all BLE connections now since a CASE handshake has been initiated.
-    if (mBleLayer != nullptr)
-    {
-        ChipLogProgress(Discovery, "CASE handshake initiated, closing all BLE Connections");
-        mBleLayer->CloseAllBleConnections();
-    }
-#endif
 
     // Setup CASE state machine using the credentials for the current fabric.
     GetSession().SetGroupDataProvider(mGroupDataProvider);

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -17,9 +17,6 @@
 
 #pragma once
 
-#if CONFIG_NETWORK_LAYER_BLE
-#include <ble/BleLayer.h>
-#endif
 #include <credentials/GroupDataProvider.h>
 #include <messaging/ExchangeDelegate.h>
 #include <messaging/ExchangeMgr.h>
@@ -42,9 +39,6 @@ public:
     }
 
     CHIP_ERROR ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
-#if CONFIG_NETWORK_LAYER_BLE
-                                             Ble::BleLayer * bleLayer,
-#endif
                                              SessionManager * sessionManager, FabricTable * fabrics,
                                              SessionResumptionStorage * sessionResumptionStorage,
                                              Credentials::GroupDataProvider * responderGroupDataProvider);
@@ -70,9 +64,6 @@ private:
 
     CASESession mPairingSession;
     SessionManager * mSessionManager = nullptr;
-#if CONFIG_NETWORK_LAYER_BLE
-    Ble::BleLayer * mBleLayer = nullptr;
-#endif
 
     FabricTable * mFabrics                              = nullptr;
     Credentials::GroupDataProvider * mGroupDataProvider = nullptr;

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -311,9 +311,6 @@ void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inConte
     // components may work simultaneously on a single device.
     NL_TEST_ASSERT(inSuite,
                    gPairingServer.ListenForSessionEstablishment(&ctx.GetExchangeManager(), &ctx.GetTransportMgr(),
-#if CONFIG_NETWORK_LAYER_BLE
-                                                                nullptr,
-#endif
                                                                 &ctx.GetSecureSessionManager(), &gDeviceFabrics, nullptr,
                                                                 &gDeviceGroupDataProvider) == CHIP_NO_ERROR);
 


### PR DESCRIPTION
#### Problem
All BLE connections are closed when a CASE sigma1 message is received. This is a potential attack vector of DoS attack. A malicious client can spam sigma1 message to deny all BLE connections.

#### Change overview
Do not disable BLE when receiving CASE sigma1

#### Testing
Passed unit-tests