### PR TITLE
Fix SessionResumption bugs

### DIFF
--- a/src/app/CASEClient.h
+++ b/src/app/CASEClient.h
@@ -26,9 +26,6 @@ namespace chip {
 
 class CASEClient;
 
-typedef void (*OnCASEConnected)(void * context, CASEClient * client);
-typedef void (*OnCASEConnectionFailure)(void * context, CASEClient * client, CHIP_ERROR error);
-
 struct CASEClientInitParams
 {
     SessionManager * sessionManager                     = nullptr;

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -55,11 +55,6 @@ void OperationalDeviceProxy::MoveToState(State aTargetState)
                       ChipLogValueX64(mPeerId.GetCompressedFabricId()), ChipLogValueX64(mPeerId.GetNodeId()), to_underlying(mState),
                       to_underlying(aTargetState));
         mState = aTargetState;
-
-        if (aTargetState != State::Connecting)
-        {
-            CleanupCASEClient();
-        }
     }
 }
 
@@ -284,31 +279,42 @@ void OperationalDeviceProxy::DequeueConnectionCallbacks(CHIP_ERROR error)
 
 void OperationalDeviceProxy::OnSessionEstablishmentError(CHIP_ERROR error)
 {
-    VerifyOrReturn(mState != State::Uninitialized && mState != State::NeedsAddress,
-                   ChipLogError(Controller, "HandleCASEConnectionFailure was called while the device was not initialized"));
-
-    //
-    // We don't need to reset the state all the way back to NeedsAddress since all that transpired
-    // was just CASE connection failure. So let's re-use the cached address to re-do CASE again
-    // if need-be.
-    //
-    MoveToState(State::Initialized);
-
-    DequeueConnectionCallbacks(error);
-
-    // Do not touch device instance anymore; it might have been destroyed by a failure callback.
+    VerifyOrReturn(mState == State::Connecting,
+                   ChipLogError(Controller, "OnSessionEstablishmentError was called while the device was not connecting"));
+    mCASEClientError = error;
 }
 
 void OperationalDeviceProxy::OnSessionEstablished(const SessionHandle & session)
 {
-    VerifyOrReturn(mState != State::Uninitialized,
-                   ChipLogError(Controller, "HandleCASEConnected was called while the device was not initialized"));
-
+    VerifyOrReturn(mState == State::Connecting,
+                   ChipLogError(Controller, "OnSessionEstablished was called while the device was not connecting"));
     mSecureSession.Grab(session);
-    MoveToState(State::SecureConnected);
-    DequeueConnectionCallbacks(CHIP_NO_ERROR);
+}
 
-    // Do not touch this instance anymore; it might have been destroyed by a callback.
+void OperationalDeviceProxy::OnSessionEstablishmentDone(PairingSession * pairing)
+{
+    VerifyOrReturn(mState == State::Connecting,
+                   ChipLogError(Controller, "OnSessionEstablishmentDone was called while the device was not connecting"));
+
+    CleanupCASEClient();
+
+    if (mCASEClientError == CHIP_NO_ERROR && mSecureSession)
+    {
+        MoveToState(State::SecureConnected);
+        DequeueConnectionCallbacks(CHIP_NO_ERROR);
+    }
+    else
+    {
+        //
+        // We don't need to reset the state all the way back to NeedsAddress since all that transpired
+        // was just CASE connection failure. So let's re-use the cached address to re-do CASE again
+        // if need-be.
+        //
+        MoveToState(State::Initialized);
+        DequeueConnectionCallbacks(mCASEClientError);
+        mCASEClientError = CHIP_NO_ERROR;
+    }
+    // Do not touch device instance anymore; it might have been destroyed by a failure callback.
 }
 
 CHIP_ERROR OperationalDeviceProxy::Disconnect()

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -142,6 +142,7 @@ public:
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablished(const SessionHandle & session) override;
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
+    void OnSessionEstablishmentDone(PairingSession * pairing) override;
 
     /**
      *   Called when a connection is closing.
@@ -246,7 +247,8 @@ private:
 
     // mCASEClient is only non-null if we are in State::Connecting or just
     // allocated it as part of an attempt to enter State::Connecting.
-    CASEClient * mCASEClient = nullptr;
+    CASEClient * mCASEClient    = nullptr;
+    CHIP_ERROR mCASEClientError = CHIP_NO_ERROR;
 
     PeerId mPeerId;
 

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -37,7 +37,6 @@
 #include <messaging/ExchangeDelegate.h>
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
-#include <protocols/secure_channel/CASESession.h>
 #include <system/SystemLayer.h>
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -86,6 +86,7 @@ public:
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
     void OnSessionEstablishmentStarted() override;
     void OnSessionEstablished(const SessionHandle & session) override;
+    void OnSessionEstablishmentDone(PairingSession * pairing) override {} // TODO: manage PASESession lifespan
 
     void Shutdown();
     void Cleanup();

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -260,7 +260,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     err = mCASESessionManager.Init(&DeviceLayer::SystemLayer(), caseSessionManagerConfig);
     SuccessOrExit(err);
 
-    err = mCASEServer.ListenForSessionEstablishment(&mExchangeMgr, &mTransports,
+    err = mCASEServer.ListenForSessionEstablishment(&mExchangeMgr,
 #if CONFIG_NETWORK_LAYER_BLE
                                                     chip::DeviceLayer::ConnectivityMgr().GetBleLayer(),
 #endif

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -460,6 +460,7 @@ public:
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
     void OnSessionEstablished(const SessionHandle & session) override;
+    void OnSessionEstablishmentDone(PairingSession * pairing) override {} // TODO: manage CASESession lifespan
 
     void RendezvousCleanup(CHIP_ERROR status);
 

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -186,7 +186,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
         // especially since it will interrupt other potential usages of BLE by the controller acting in a commissioning capacity.
         //
         ReturnErrorOnFailure(stateParams.caseServer->ListenForSessionEstablishment(
-            stateParams.exchangeMgr, stateParams.transportMgr,
+            stateParams.exchangeMgr,
 #if CONFIG_NETWORK_LAYER_BLE
             nullptr,
 #endif

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -29,7 +29,7 @@ using namespace ::chip::Credentials;
 
 namespace chip {
 
-CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
+CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager,
 #if CONFIG_NETWORK_LAYER_BLE
                                                      Ble::BleLayer * bleLayer,
 #endif
@@ -37,9 +37,7 @@ CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager 
                                                      SessionResumptionStorage * sessionResumptionStorage,
                                                      Credentials::GroupDataProvider * responderGroupDataProvider)
 {
-    VerifyOrReturnError(transportMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(exchangeManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(sessionManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(sessionManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(responderGroupDataProvider != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -52,14 +50,13 @@ CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager 
     mExchangeManager          = exchangeManager;
     mGroupDataProvider        = responderGroupDataProvider;
 
-    Cleanup();
+    ChipLogProgress(Inet, "CASE Server enabling CASE session setups");
+    mExchangeManager->RegisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_Sigma1, this);
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CASEServer::InitCASEHandshake(Messaging::ExchangeContext * ec)
+CHIP_ERROR CASEServer::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, Messaging::ExchangeDelegate *& newDelegate)
 {
-    ReturnErrorCodeIf(ec == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-
 #if CONFIG_NETWORK_LAYER_BLE
     // Close all BLE connections now since a CASE handshake has been initiated.
     if (mBleLayer != nullptr)
@@ -69,68 +66,35 @@ CHIP_ERROR CASEServer::InitCASEHandshake(Messaging::ExchangeContext * ec)
     }
 #endif
 
+    if (mPairingSession.HasValue() && !mPairingSession.Value().Available())
+        return CHIP_ERROR_NO_MEMORY;
+
+    CASESession * session = &mPairingSession.Emplace();
+
     // Setup CASE state machine using the credentials for the current fabric.
-    GetSession().SetGroupDataProvider(mGroupDataProvider);
+    session->SetGroupDataProvider(mGroupDataProvider);
     ReturnErrorOnFailure(
-        GetSession().ListenForSessionEstablishment(*mSessionManager, mFabrics, mSessionResumptionStorage, this,
-                                                   Optional<ReliableMessageProtocolConfig>::Value(GetLocalMRPConfig())));
-
-    // Hand over the exchange context to the CASE session.
-    ec->SetDelegate(&GetSession());
+        session->ListenForSessionEstablishment(*mSessionManager, mFabrics, mSessionResumptionStorage, this,
+                                               Optional<ReliableMessageProtocolConfig>::Value(GetLocalMRPConfig())));
+    newDelegate = session;
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CASEServer::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate)
+void CASEServer::OnExchangeCreationFailed(Messaging::ExchangeDelegate * delegate)
 {
-    // TODO: assign newDelegate to CASESession, let CASESession handle future messages.
-    newDelegate = this;
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR CASEServer::OnMessageReceived(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
-                                         System::PacketBufferHandle && payload)
-{
-    ChipLogProgress(Inet, "CASE Server received Sigma1 message. Starting handshake. EC %p", ec);
-    CHIP_ERROR err = InitCASEHandshake(ec);
-    SuccessOrExit(err);
-
-    // TODO - Enable multiple concurrent CASE session establishment
-    // https://github.com/project-chip/connectedhomeip/issues/8342
-    ChipLogProgress(Inet, "CASE Server disabling CASE session setups");
-    mExchangeManager->UnregisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_Sigma1);
-
-    err = GetSession().OnMessageReceived(ec, payloadHeader, std::move(payload));
-    SuccessOrExit(err);
-
-exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        Cleanup();
-    }
-    return err;
-}
-
-void CASEServer::Cleanup()
-{
-    // Let's re-register for CASE Sigma1 message, so that the next CASE session setup request can be processed.
-    // https://github.com/project-chip/connectedhomeip/issues/8342
-    ChipLogProgress(Inet, "CASE Server enabling CASE session setups");
-    mExchangeManager->RegisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_Sigma1, this);
-
-    GetSession().Clear();
+    mPairingSession.ClearValue();
 }
 
 void CASEServer::OnSessionEstablishmentError(CHIP_ERROR err)
 {
     ChipLogError(Inet, "CASE Session establishment failed: %s", ErrorStr(err));
-    Cleanup();
 }
 
 void CASEServer::OnSessionEstablished(const SessionHandle & session)
 {
     ChipLogProgress(Inet, "CASE Session established to peer: " ChipLogFormatScopedNodeId,
                     ChipLogValueScopedNodeId(session->GetPeer()));
-    Cleanup();
 }
+
 } // namespace chip

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -66,11 +66,12 @@ CHIP_ERROR CASEServer::OnUnsolicitedMessageReceived(const PayloadHeader & payloa
     }
 #endif
 
-    if (mPairingSession.HasValue() && !mPairingSession.Value().Available())
+    if (mPairingSession.HasValue())
         return CHIP_ERROR_NO_MEMORY;
 
     CASESession * session = &mPairingSession.Emplace();
 
+    ChipLogProgress(Inet, "CASE Server allocated pairing: %p", session);
     // Setup CASE state machine using the credentials for the current fabric.
     session->SetGroupDataProvider(mGroupDataProvider);
     ReturnErrorOnFailure(
@@ -95,6 +96,14 @@ void CASEServer::OnSessionEstablished(const SessionHandle & session)
 {
     ChipLogProgress(Inet, "CASE Session established to peer: " ChipLogFormatScopedNodeId,
                     ChipLogValueScopedNodeId(session->GetPeer()));
+}
+
+void CASEServer::OnSessionEstablishmentDone(PairingSession * pairing)
+{
+    CASESession * session = static_cast<CASESession *>(pairing);
+    ChipLogProgress(Inet, "CASE Server releasing pairing: %p", session);
+    VerifyOrDie(mPairingSession.HasValue() && session == &mPairingSession.Value());
+    mPairingSession.ClearValue();
 }
 
 } // namespace chip

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -50,6 +50,7 @@ public:
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
     void OnSessionEstablished(const SessionHandle & session) override;
+    void OnSessionEstablishmentDone(PairingSession * pairing) override;
 
     //// UnsolicitedMessageHandler Implementation ////
     CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader,
@@ -68,8 +69,6 @@ private:
 
     FabricTable * mFabrics                              = nullptr;
     Credentials::GroupDataProvider * mGroupDataProvider = nullptr;
-
-    CHIP_ERROR InitCASEHandshake(Messaging::ExchangeContext * ec);
 };
 
 } // namespace chip

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -133,9 +133,9 @@ CASESession::~CASESession()
 
 bool CASESession::SanityCheck() const
 {
-    // This is called after handling a message, the session must be in a state of available or waiting for another message,
+    // This is called after handling a message, the session must be in a state of done or waiting for another message,
     // otherwise the object may be leaked.
-    if (Available())
+    if (IsDone())
         return true;
 
     if (mRole == CryptoContext::SessionRole::kInitiator)
@@ -159,7 +159,6 @@ void CASESession::Finish()
     DiscardExchange();
 
     CHIP_ERROR err = ActivateSecureSession(address);
-    // Do this last in case the delegate frees us.
     if (err == CHIP_NO_ERROR)
     {
         mDelegate->OnSessionEstablished(mSecureSessionHolder.Get());
@@ -272,8 +271,12 @@ CHIP_ERROR CASESession::EstablishSession(SessionManager & sessionManager, Fabric
 
 exit:
     if (err != CHIP_NO_ERROR)
+    {
         mState = State::kError;
+    }
     VerifyOrDie(SanityCheck());
+    // EstablishSession is a API from delegate side, so we don't call OnSessionEstablishmentDone here, the delegate awares the error
+    // by return value.
     return err;
 }
 
@@ -283,9 +286,10 @@ void CASESession::OnResponseTimeout(ExchangeContext * ec)
                  static_cast<uint8_t>(mState));
     AbortExchange();
     mState = State::kError;
-    VerifyOrDie(SanityCheck());
-    // Do this last in case the delegate frees us.
     mDelegate->OnSessionEstablishmentError(CHIP_ERROR_TIMEOUT);
+    VerifyOrDie(SanityCheck());
+    // Do this last because `this` is probably deleted after OnSessionEstablishmentDone
+    mDelegate->OnSessionEstablishmentDone(this);
 }
 
 CHIP_ERROR CASESession::DeriveSecureSession(CryptoContext & session) const
@@ -1774,9 +1778,16 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         // Call delegate to indicate session establishment failure.
-        // Do this last in case the delegate frees us.
         mDelegate->OnSessionEstablishmentError(err);
     }
+
+    VerifyOrDie(SanityCheck());
+    if (IsDone())
+    {
+        // Do this last because `this` is probably deleted after OnSessionEstablishmentDone
+        mDelegate->OnSessionEstablishmentDone(this);
+    }
+
     return err;
 }
 

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -68,13 +68,8 @@ public:
     ScopedNodeId GetPeer() const override { return ScopedNodeId(mPeerNodeId, GetFabricIndex()); }
     CATValues GetPeerCATs() const override { return mPeerCATs; };
 
-    /**
-     * @brief
-     *   Return whether this session object is ready for use.
-     *   When a new session request comes, CASE server will recycle an available session to serve the new request.
-     */
-    bool Available() const { return IsFinished() || mState == State::kListening || mState == State::kError; }
-
+    // Return whether the PairingSession has done its work (either finished or encountered an error)
+    bool IsDone() const { return IsFinished() || mState == State::kError; }
     bool IsFinished() const { return mState == State::kFinished || mState == State::kFinishedResumed; }
 
     /**
@@ -213,6 +208,9 @@ private:
     CHIP_ERROR ValidateSigmaResumeMIC(const ByteSpan & resumeMIC, const ByteSpan & initiatorRandom, const ByteSpan & resumptionID,
                                       const ByteSpan & skInfo, const ByteSpan & nonce);
 
+    // For CASESession not leaked, after each action (OnMessageReceived/OnResponseTimeout), it must end with a state either the
+    // establishment is done, or waiting for a message from other side with response timer being set. This function ensure that we
+    // are indeed in such state, it is called and verifed after each action.
     bool SanityCheck() const;
 
     void OnSuccessStatusReport() override;

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -55,16 +55,27 @@ namespace chip {
 
 // TODO: temporary derive from Messaging::UnsolicitedMessageHandler, actually the CASEServer should be the umh, it will be fixed
 // when implementing concurrent CASE session.
-class DLL_EXPORT CASESession : public Messaging::UnsolicitedMessageHandler,
-                               public Messaging::ExchangeDelegate,
-                               public PairingSession
+class DLL_EXPORT CASESession : public Messaging::ExchangeDelegate, public PairingSession
 {
 public:
     ~CASESession() override;
 
+    using InitiatorRandomStorage   = std::array<uint8_t, kSigmaParamRandomNumberSize>;
+    using InitiatorRandomView      = FixedSpan<uint8_t, kSigmaParamRandomNumberSize>;
+    using ConstInitiatorRandomView = FixedSpan<const uint8_t, kSigmaParamRandomNumberSize>;
+
     Transport::SecureSession::Type GetSecureSessionType() const override { return Transport::SecureSession::Type::kCASE; }
     ScopedNodeId GetPeer() const override { return ScopedNodeId(mPeerNodeId, GetFabricIndex()); }
     CATValues GetPeerCATs() const override { return mPeerCATs; };
+
+    /**
+     * @brief
+     *   Return whether this session object is ready for use.
+     *   When a new session request comes, CASE server will recycle an available session to serve the new request.
+     */
+    bool Available() const { return IsFinished() || mState == State::kListening || mState == State::kError; }
+
+    bool IsFinished() const { return mState == State::kFinished || mState == State::kFinishedResumed; }
 
     /**
      * @brief
@@ -141,13 +152,6 @@ public:
      */
     CHIP_ERROR DeriveSecureSession(CryptoContext & session) const override;
 
-    //// UnsolicitedMessageHandler Implementation ////
-    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override
-    {
-        newDelegate = this;
-        return CHIP_NO_ERROR;
-    }
-
     //// ExchangeDelegate Implementation ////
     CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
                                  System::PacketBufferHandle && payload) override;
@@ -156,20 +160,19 @@ public:
 
     FabricIndex GetFabricIndex() const { return mFabricInfo != nullptr ? mFabricInfo->GetFabricIndex() : kUndefinedFabricIndex; }
 
-    // TODO: remove Clear, we should create a new instance instead reset the old instance.
-    /** @brief This function zeroes out and resets the memory used by the object.
-     **/
-    void Clear();
-
 private:
-    enum State : uint8_t
+    enum class State : uint8_t
     {
-        kInitialized      = 0,
+        kInitial          = 0,
+        kListening        = 0,
         kSentSigma1       = 1,
         kSentSigma2       = 2,
         kSentSigma3       = 3,
         kSentSigma1Resume = 4,
         kSentSigma2Resume = 5,
+        kFinished         = 6,
+        kFinishedResumed  = 7,
+        kError            = 8,
     };
 
     CHIP_ERROR Init(SessionManager & sessionManager, SessionEstablishmentDelegate * delegate);
@@ -192,7 +195,7 @@ private:
     CHIP_ERROR SendSigma3();
     CHIP_ERROR HandleSigma3(System::PacketBufferHandle && msg);
 
-    CHIP_ERROR SendSigma2Resume(const ByteSpan & initiatorRandom);
+    CHIP_ERROR SendSigma2Resume();
 
     CHIP_ERROR ConstructSaltSigma2(const ByteSpan & rand, const Crypto::P256PublicKey & pubkey, const ByteSpan & ipk,
                                    MutableByteSpan & salt);
@@ -209,6 +212,8 @@ private:
                                       const ByteSpan & nonce, MutableByteSpan & resumeMIC);
     CHIP_ERROR ValidateSigmaResumeMIC(const ByteSpan & resumeMIC, const ByteSpan & initiatorRandom, const ByteSpan & resumptionID,
                                       const ByteSpan & skInfo, const ByteSpan & nonce);
+
+    bool SanityCheck() const;
 
     void OnSuccessStatusReport() override;
     CHIP_ERROR OnFailureStatusReport(Protocols::SecureChannel::GeneralStatusCode generalCode, uint16_t protocolCode) override;
@@ -255,15 +260,12 @@ private:
     NodeId mPeerNodeId             = kUndefinedNodeId;
     CATValues mPeerCATs;
 
-    // This field is only used for CASE responder, when during sending sigma2 and waiting for sigma3
-    SessionResumptionStorage::ResumptionIdStorage mResumptionId;
+    SessionResumptionStorage::ResumptionIdStorage mResumeResumptionId; // ResumptionId which is used to resume this session
+    SessionResumptionStorage::ResumptionIdStorage mNewResumptionId;    // ResumptionId which is stored to resume future session
     // Sigma1 initiator random, maintained to be reused post-Sigma1, such as when generating Sigma2 S2RK key
-    uint8_t mInitiatorRandom[kSigmaParamRandomNumberSize];
+    InitiatorRandomStorage mInitiatorRandom;
 
-    State mState;
-
-protected:
-    bool mCASESessionEstablished = false;
+    State mState = State::kInitial;
 };
 
 } // namespace chip

--- a/src/protocols/secure_channel/SessionEstablishmentDelegate.h
+++ b/src/protocols/secure_channel/SessionEstablishmentDelegate.h
@@ -34,6 +34,8 @@ namespace chip {
 class DLL_EXPORT SessionEstablishmentDelegate
 {
 public:
+    virtual ~SessionEstablishmentDelegate() {}
+
     /**
      *   Called when session establishment fails with an error
      */
@@ -49,7 +51,9 @@ public:
      */
     virtual void OnSessionEstablished(const SessionHandle & session) {}
 
-    virtual ~SessionEstablishmentDelegate() {}
+    // Triggered when the PairingSession has done its work (either finished or encountered an error), such that the PairingSession
+    // object can be release, and so does other resources associated to it.
+    virtual void OnSessionEstablishmentDone(PairingSession * pairing) = 0;
 };
 
 } // namespace chip

--- a/src/protocols/secure_channel/SimpleSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/SimpleSessionResumptionStorage.cpp
@@ -57,7 +57,7 @@ CHIP_ERROR SimpleSessionResumptionStorage::SaveIndex(const SessionIndex & index)
     TLV::TLVType arrayType;
     ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, arrayType));
 
-    for (size_t i = index.mSize; i < index.mSize; ++i)
+    for (size_t i = 0; i < index.mSize; ++i)
     {
         TLV::TLVType innerType;
         ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, innerType));
@@ -83,7 +83,11 @@ CHIP_ERROR SimpleSessionResumptionStorage::LoadIndex(SessionIndex & index)
     uint16_t len = static_cast<uint16_t>(buf.size());
 
     DefaultStorageKeyAllocator keyAlloc;
-    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(keyAlloc.SessionResumptionIndex(), buf.data(), len));
+    if (mStorage->SyncGetKeyValue(keyAlloc.SessionResumptionIndex(), buf.data(), len) != CHIP_NO_ERROR)
+    {
+        index.mSize = 0;
+        return CHIP_NO_ERROR;
+    }
 
     TLV::ContiguousBufferTLVReader reader;
     reader.Init(buf.data(), len);

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -81,6 +81,8 @@ public:
         mNumPairingComplete++;
     }
 
+    void OnSessionEstablishmentDone(PairingSession * pairing) override {}
+
     SessionHolder & GetSessionHolder() { return mSession; }
 
     SessionHolder mSession;

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -90,15 +90,6 @@ public:
     uint32_t mNumPairingComplete = 0;
 };
 
-class CASEServerForTest : public CASEServer
-{
-public:
-    CASESession & GetSession() override { return mCaseSession; }
-
-private:
-    CASESession mCaseSession;
-};
-
 CHIP_ERROR InitTestIpk(GroupDataProvider & groupDataProvider, const FabricInfo & fabricInfo, size_t numIpks)
 {
     VerifyOrReturnError((numIpks > 0) && (numIpks <= 3), CHIP_ERROR_INVALID_ARGUMENT);
@@ -256,32 +247,28 @@ void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inConte
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
     // Test all combinations of invalid parameters
-    TestCASESecurePairingDelegate delegateAccessory;
-    CASESession pairingAccessory;
-    SessionManager sessionManager;
+    CASEServer pairingAccessory;
 
     gLoopback.mSentMessageCount = 0;
-
-    NL_TEST_ASSERT(inSuite,
-                   ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_Sigma1,
-                                                                                     &pairingAccessory) == CHIP_NO_ERROR);
 
     ExchangeContext * contextCommissioner = ctx.NewUnauthenticatedExchangeToBob(&pairingCommissioner);
 
     FabricInfo * fabric = gCommissionerFabrics.FindFabricWithIndex(gCommissionerFabricIndex);
     NL_TEST_ASSERT(inSuite, fabric != nullptr);
 
-    pairingAccessory.SetGroupDataProvider(&gDeviceGroupDataProvider);
     NL_TEST_ASSERT(inSuite,
-                   pairingAccessory.ListenForSessionEstablishment(sessionManager, &gDeviceFabrics, nullptr, &delegateAccessory) ==
-                       CHIP_NO_ERROR);
+                   pairingAccessory.ListenForSessionEstablishment(&ctx.GetExchangeManager(),
+#if CONFIG_NETWORK_LAYER_BLE
+                                                                  nullptr,
+#endif
+                                                                  &ctx.GetSecureSessionManager(), &gDeviceFabrics, nullptr,
+                                                                  &gDeviceGroupDataProvider) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner.EstablishSession(sessionManager, fabric, Node01_01, contextCommissioner, nullptr,
-                                                        &delegateCommissioner) == CHIP_NO_ERROR);
+                   pairingCommissioner.EstablishSession(ctx.GetSecureSessionManager(), fabric, Node01_01, contextCommissioner,
+                                                        nullptr, &delegateCommissioner) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 5);
-    NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);
     NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
 }
 
@@ -293,13 +280,12 @@ void CASE_SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
     CASE_SecurePairingHandshakeTestCommon(inSuite, inContext, pairingCommissioner, delegateCommissioner);
 }
 
-CASEServerForTest gPairingServer;
-
 void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inContext)
 {
     // TODO: Add cases for mismatching IPK config between initiator/responder
 
     TestCASESecurePairingDelegate delegateCommissioner;
+    CASEServer gPairingServer;
 
     auto * pairingCommissioner = chip::Platform::New<CASESession>();
     pairingCommissioner->SetGroupDataProvider(&gCommissionerGroupDataProvider);
@@ -311,7 +297,7 @@ void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inConte
     // Use the same session manager on both CASE client and server sides to validate that both
     // components may work simultaneously on a single device.
     NL_TEST_ASSERT(inSuite,
-                   gPairingServer.ListenForSessionEstablishment(&ctx.GetExchangeManager(), &ctx.GetTransportMgr(),
+                   gPairingServer.ListenForSessionEstablishment(&ctx.GetExchangeManager(),
 #if CONFIG_NETWORK_LAYER_BLE
                                                                 nullptr,
 #endif

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -92,8 +92,8 @@ class TestSecurePairingDelegate : public SessionEstablishmentDelegate
 {
 public:
     void OnSessionEstablishmentError(CHIP_ERROR error) override { mNumPairingErrors++; }
-
     void OnSessionEstablished(const SessionHandle & session) override { mNumPairingComplete++; }
+    void OnSessionEstablishmentDone(PairingSession * pairing) override {}
 
     uint32_t mNumPairingErrors   = 0;
     uint32_t mNumPairingComplete = 0;

--- a/src/protocols/secure_channel/tests/TestSimpleSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/tests/TestSimpleSessionResumptionStorage.cpp
@@ -87,6 +87,10 @@ void TestIndex(nlTestSuite * inSuite, void * inContext)
 
     chip::ScopedNodeId node(node1, fabric1);
 
+    chip::SessionResumptionStorage::SessionIndex index0o;
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == sessionStorage.LoadIndex(index0o));
+    NL_TEST_ASSERT(inSuite, index0o.mSize == 0);
+
     chip::SessionResumptionStorage::SessionIndex index1;
     index1.mSize = 0;
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == sessionStorage.SaveIndex(index1));
@@ -116,6 +120,7 @@ static const nlTest sTests[] =
 {
     NL_TEST_DEF("TestLink", TestLink),
     NL_TEST_DEF("TestState", TestState),
+    NL_TEST_DEF("TestIndex", TestState),
 
     NL_TEST_SENTINEL()
 };


### PR DESCRIPTION
#### Problem
Fixes #17438 #17439 #17440 #17450

#### Change overview
* Rework `CASESession` state machine.
* Remove `CASESession::Clear`, always create a new object instead of reusing the old one.
* Fixes #17438 #17439 #17440 #17450

* Add a new callback `SessionEstablishmentDelegate::OnSessionEstablishmentDone` to indicate that the pairing has done its work and can be safely released. 

**Note**: This PR includes #17422

#### Testing
Passes unit-tests