### PR TITLE
[linux] Fix DUT is aborted when send network-fault-change event

### DIFF
--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -75,7 +75,7 @@ void SignalHandler(int signum)
     case SIGHUP:
         PlatformMgrImpl().HandleGeneralFault(GeneralDiagnostics::Events::RadioFaultChange::Id);
         break;
-    case SIGTERM:
+    case SIGTTIN:
         PlatformMgrImpl().HandleGeneralFault(GeneralDiagnostics::Events::NetworkFaultChange::Id);
         break;
     case SIGTSTP:
@@ -179,7 +179,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     memset(&action, 0, sizeof(action));
     action.sa_handler = SignalHandler;
     sigaction(SIGHUP, &action, nullptr);
-    sigaction(SIGTERM, &action, nullptr);
+    sigaction(SIGTTIN, &action, nullptr);
     sigaction(SIGUSR1, &action, nullptr);
     sigaction(SIGUSR2, &action, nullptr);
     sigaction(SIGTSTP, &action, nullptr);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Reported by CSG, currently signal SIGTERM is for network-fault-change event but I tried to kill DUT using the the signal SIGTERM but DUT is aborted (edited) 
[12:47](https://csamembers.slack.com/archives/C030HSAPY4X/p1649922449291019)
[1649922272.997180][2272:2272] CHIP:DL: Caught signal 15
[1649922272.997285][2272:2272] CHIP:-: Unhandled signal: Should never happens
[1649922272.997337][2272:2272] CHIP:-: chipDie chipDie chipDie
Aborted

* The SIGTERM signal is sent to a process to request its termination. We should switch to another signal to trigger network-fault event.

#### Change overview
Use SIGTTIN instead of SIGTERM to simulate network-fault-change event

#### Testing
How was this tested? (at least one bullet point required)
```
yufengw@yufengw-SEi:~$ ps -A | grep chip
 204730 pts/4    00:00:00 chip-lighting-a
yufengw@yufengw-SEi:~$ kill -SIGTTIN 204730
```

* confirm the DUT is not crash
 

