### PR TITLE
Ensure we deallocate CASEClient if EstablishSession fails synchronously.

### DIFF
--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -241,6 +241,8 @@ private:
     FabricInfo * mFabricInfo;
     System::Layer * mSystemLayer;
 
+    // mCASEClient is only non-null if we are in State::Connecting or just
+    // allocated it as part of an attempt to enter State::Connecting.
     CASEClient * mCASEClient = nullptr;
 
     PeerId mPeerId;
@@ -277,9 +279,7 @@ private:
     static void HandleCASEConnected(void * context, CASEClient * client);
     static void HandleCASEConnectionFailure(void * context, CASEClient * client, CHIP_ERROR error);
 
-    static void CloseCASESessionTask(System::Layer * layer, void * context);
-
-    void CloseCASESession();
+    void CleanupCASEClient();
 
     void EnqueueConnectionCallbacks(Callback::Callback<OnDeviceConnected> * onConnection,
                                     Callback::Callback<OnDeviceConnectionFailure> * onFailure);


### PR DESCRIPTION
We could end up in a state where we allocated mCASEClient in
OperationalDeviceProxy::EstablishConnection and then EstablishSession
on the CASEClient would fail and we would be left with a stale
pointer.  And then later nothing would deallocate the CASEClient and
if we had another connection attempt we'd just allocate a new one and
leak the old one.

The fix is two-fold:

1. Make sure to call CleanupCASEClient (renamed from CloseCASESession)
   if EstablishSession fails.

2. Make it harder to forget to call CleanupCASEClient in various
   places by just doing it when we transition out of the Connecting
   state.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Should be no behavior changes except in error cases where EstablishSession sync-fails for some reason.