### PR TITLE
[CI] Allow test suite applications to be launched with custom commandline options

### DIFF
--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -38,13 +38,14 @@ class App:
         self.cv_stopped = threading.Condition()
         self.stopped = False
         self.lastLogIndex = 0
+        self.kvs = '/tmp/chip_kvs'
 
-    def start(self, discriminator):
+    def start(self, options=None):
         if not self.process:
             # Make sure to assign self.process before we do any operations that
             # might fail, so attempts to kill us on failure actually work.
             self.process, self.outpipe, errpipe = self.__startServer(
-                self.runner, self.command, discriminator)
+                self.runner, self.command, options)
             self.waitForAnyAdvertisement()
             self.__updateSetUpCode()
             with self.cv_stopped:
@@ -65,18 +66,9 @@ class App:
             return True
         return False
 
-    def reboot(self, discriminator):
-        if self.process:
-            self.stop()
-            self.start(discriminator)
-            return True
-        return False
-
     def factoryReset(self):
-        storage = '/tmp/chip_kvs'
-        if os.path.exists(storage):
-            os.unlink(storage)
-
+        if os.path.exists(self.kvs):
+            os.unlink(self.kvs)
         return True
 
     def waitForAnyAdvertisement(self):
@@ -108,12 +100,18 @@ class App:
                 while self.stopped:
                     self.cv_stopped.wait()
 
-    def __startServer(self, runner, command, discriminator):
-        logging.debug(
-            'Executing application under test with discriminator %s.' %
-            discriminator)
-        app_cmd = command + ['--discriminator', str(discriminator)]
-        app_cmd = app_cmd + ['--interface-id', str(-1)]
+    def __startServer(self, runner, command, options):
+        app_cmd = command + ['--interface-id', str(-1)]
+
+        if not options:
+            logging.debug('Executing application under test with default args')
+        else:
+            logging.debug('Executing application under test with the following args:')
+            for key, value in options.items():
+                logging.debug('   %s: %s' % (key, value))
+                app_cmd = app_cmd + [key, value]
+                if key == '--KVS':
+                    self.kvs = value
         return runner.RunSubprocess(app_cmd, name='APP ', wait=False)
 
     def __waitFor(self, waitForString, server_process, outpipe):
@@ -239,7 +237,7 @@ class TestDefinition:
             # Remove server application storage (factory reset),
             # so it will be commissionable again.
             app.factoryReset()
-            app.start(str(randrange(1, 4096)))
+            app.start()
             pairing_cmd = tool_cmd + ['pairing', 'qrcode', TEST_NODE_ID, app.setupCode]
             if sys.platform != 'darwin':
                 pairing_cmd.append('--paa-trust-store-path')

--- a/src/app/tests/suites/commands/system/SystemCommands.cpp
+++ b/src/app/tests/suites/commands/system/SystemCommands.cpp
@@ -32,7 +32,7 @@ CHIP_ERROR SystemCommands::Start(uint16_t discriminator)
     constexpr const char * scriptName = "Start.py";
 
     char command[128];
-    VerifyOrReturnError(snprintf(command, sizeof(command), "%s%s %u", scriptDir, scriptName, discriminator) >= 0,
+    VerifyOrReturnError(snprintf(command, sizeof(command), "%s%s --discriminator %u", scriptDir, scriptName, discriminator) >= 0,
                         CHIP_ERROR_INTERNAL);
     return RunInternal(command);
 }
@@ -53,7 +53,7 @@ CHIP_ERROR SystemCommands::Reboot(uint16_t discriminator)
     constexpr const char * scriptName = "Reboot.py";
 
     char command[128];
-    VerifyOrReturnError(snprintf(command, sizeof(command), "%s%s %u", scriptDir, scriptName, discriminator) >= 0,
+    VerifyOrReturnError(snprintf(command, sizeof(command), "%s%s --discriminator %u", scriptDir, scriptName, discriminator) >= 0,
                         CHIP_ERROR_INTERNAL);
     return RunInternal(command);
 }

--- a/src/app/tests/suites/commands/system/scripts/Reboot.py
+++ b/src/app/tests/suites/commands/system/scripts/Reboot.py
@@ -23,5 +23,7 @@ PORT = 9000
 if sys.platform == 'linux':
     IP = '10.10.10.5'
 
+# Passing in sys.argv[1:] gets rid of the script name with the remaining values in the list as
+# key-value pairs, e.g. [option1, value1, option2, value2, ...]
 with xmlrpc.client.ServerProxy('http://' + IP + ':' + str(PORT) + '/', allow_none=True) as proxy:
-    proxy.reboot('default', sys.argv[1])
+    proxy.reboot('default', sys.argv[1:])

--- a/src/app/tests/suites/commands/system/scripts/Start.py
+++ b/src/app/tests/suites/commands/system/scripts/Start.py
@@ -23,5 +23,7 @@ PORT = 9000
 if sys.platform == 'linux':
     IP = '10.10.10.5'
 
+# Passing in sys.argv[1:] gets rid of the script name with the remaining values in the list as
+# key-value pairs, e.g. [option1, value1, option2, value2, ...]
 with xmlrpc.client.ServerProxy('http://' + IP + ':' + str(PORT) + '/', allow_none=True) as proxy:
-    proxy.start('default', sys.argv[1])
+    proxy.start('default', sys.argv[1:])


### PR DESCRIPTION
#### Problem
The applications launched in the test suite only takes discriminator as a command line option

#### Change overview
- Allow a dictionary of command line options to be passed in when launching or rebooting an application
- Modify `SystemCommands::Start` and `SystemCommand::Reboot` to pass in `--discriminator` so that the command line options can be generically generated
- Note that there is no functional change with this PR (still only passing in discriminator when launching applications) but does set up for future changes which can easily pass in more command line options for testing needs

#### Testing
No functional change, tree compiles, test suite tests pass
