### PR TITLE
OperationalDeviceProxy should not inherit from SessionEstablishmentDelegate.

### DIFF
--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -84,10 +84,7 @@ typedef void (*OnDeviceConnectionFailure)(void * context, PeerId peerId, CHIP_ER
  *    - Establish a secure channel to it via CASE
  *    - Expose to consumers the secure session for talking to the device.
  */
-class DLL_EXPORT OperationalDeviceProxy : public DeviceProxy,
-                                          SessionReleaseDelegate,
-                                          public SessionEstablishmentDelegate,
-                                          public AddressResolve::NodeListener
+class DLL_EXPORT OperationalDeviceProxy : public DeviceProxy, SessionReleaseDelegate, public AddressResolve::NodeListener
 {
 public:
     ~OperationalDeviceProxy() override;


### PR DESCRIPTION
It does not implement any of the delegate methods and doesn't call them.

#### Problem
See above.

#### Change overview
Stop inheriting from a delegate interface we don't implement.

#### Testing
No behavior changes, just slightly smaller object.