### PR TITLE
AddressSanitizer: heap-use-after-free in chip::Controller::DeviceComm…

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1553,12 +1553,6 @@ void DeviceCommissioner::OnDeviceConnectionFailureFn(void * context, PeerId peer
         ChipLogError(Controller, "Device connection failed without a valid error code. Making one up.");
         error = CHIP_ERROR_INTERNAL;
     }
-    // TODO: Determine if we really want the PASE session removed here. See #16089.
-    CommissioneeDeviceProxy * commissionee = commissioner->FindCommissioneeDevice(peerId.GetNodeId());
-    if (commissionee != nullptr)
-    {
-        commissioner->ReleaseCommissioneeDevice(commissionee);
-    }
 
     commissioner->mSystemState->CASESessionMgr()->ReleaseSession(peerId);
     if (commissioner->mCommissioningStage == CommissioningStage::kFindOperational &&
@@ -1569,6 +1563,13 @@ void DeviceCommissioner::OnDeviceConnectionFailureFn(void * context, PeerId peer
     else
     {
         commissioner->mPairingDelegate->OnPairingComplete(error);
+    }
+
+    CommissioneeDeviceProxy * commissionee = commissioner->FindCommissioneeDevice(peerId.GetNodeId());
+    // TODO: Determine if we really want the PASE session removed here. See #16089.
+    if (commissionee != nullptr)
+    {
+        commissioner->ReleaseCommissioneeDevice(commissionee);
     }
 }
 


### PR DESCRIPTION
…issioner::CommissioningStageComplete

#### Problem

When a device is in the process of being commissioned but the operation node discovery timeouts there is a `use-after-free` because the failure callback release the actual `OperationDeviceProxy` before calling `CommissioningStageComplete` that is trying to use it.

#### Change overview
 * Move the call to release once `CommissioningStageComplete` has been called.

#### Testing
I have tested it by modifying the mdns code on darwin to advertise the operational data after a delay longer than the one use  by the commissioner.