### PR TITLE
Simple support of composed Bridged Devices. 

### DIFF
--- a/src/app/clusters/descriptor/descriptor.cpp
+++ b/src/app/clusters/descriptor/descriptor.cpp
@@ -84,7 +84,7 @@ CHIP_ERROR DescriptorAttrAccess::ReadPartsAttribute(EndpointId endpoint, Attribu
             {
                 if (emberAfEndpointIndexIsEnabled(index))
                 {
-                    EndpointId composedEndpointId = emberAfComposedEndpointFromIndex(index);
+                    EndpointId composedEndpointId = emberAfParentEndpointFromIndex(index);
                     if (composedEndpointId == chip::kInvalidEndpointId || composedEndpointId != endpoint)
                         continue;
 

--- a/src/app/clusters/descriptor/descriptor.cpp
+++ b/src/app/clusters/descriptor/descriptor.cpp
@@ -79,7 +79,21 @@ CHIP_ERROR DescriptorAttrAccess::ReadPartsAttribute(EndpointId endpoint, Attribu
     }
     else
     {
-        err = aEncoder.EncodeEmptyList();
+        err = aEncoder.EncodeList([endpoint](const auto & encoder) -> CHIP_ERROR {
+            for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
+            {
+                if (emberAfEndpointIndexIsEnabled(index))
+                {
+                    EndpointId composedEndpointId = emberAfComposedEndpointFromIndex(index);
+                    if (composedEndpointId == chip::kInvalidEndpointId || composedEndpointId != endpoint)
+                        continue;
+
+                    ReturnErrorOnFailure(encoder.Encode(emberAfEndpointFromIndex(index)));
+                }
+            }
+
+            return CHIP_NO_ERROR;
+        });
     }
 
     return err;

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -415,6 +415,11 @@ struct EmberAfDefinedEndpoint
      * endpoint
      */
     chip::DataVersion * dataVersions = nullptr;
+
+    /**
+     * Root endpoint id for composed device type.
+     */
+    chip::EndpointId composedEpId = chip::kInvalidEndpointId;
 };
 
 // Cluster specific types

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -419,7 +419,7 @@ struct EmberAfDefinedEndpoint
     /**
      * Root endpoint id for composed device type.
      */
-    chip::EndpointId composedEpId = chip::kInvalidEndpointId;
+    chip::EndpointId parentEndpointId = chip::kInvalidEndpointId;
 };
 
 // Cluster specific types

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -288,6 +288,11 @@ extern EmberAfDefinedEndpoint emAfEndpoints[];
 chip::EndpointId emberAfEndpointFromIndex(uint16_t index);
 
 /**
+ * @brief Returns root endpoint of a composed bridged device
+ */
+chip::EndpointId emberAfComposedEndpointFromIndex(uint16_t index);
+
+/**
  * Returns the index of a given endpoint.  Will return 0xFFFF if this is not a
  * valid endpoint id or if the endpoint is disabled.
  */

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -290,7 +290,7 @@ chip::EndpointId emberAfEndpointFromIndex(uint16_t index);
 /**
  * @brief Returns root endpoint of a composed bridged device
  */
-chip::EndpointId emberAfComposedEndpointFromIndex(uint16_t index);
+chip::EndpointId emberAfParentEndpointFromIndex(uint16_t index);
 
 /**
  * Returns the index of a given endpoint.  Will return 0xFFFF if this is not a

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -200,7 +200,7 @@ uint16_t emberAfGetDynamicIndexFromEndpoint(EndpointId id)
 
 EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, EndpointId id, const EmberAfEndpointType * ep,
                                         const chip::Span<chip::DataVersion> & dataVersionStorage,
-                                        chip::Span<const EmberAfDeviceType> deviceTypeList)
+                                        chip::Span<const EmberAfDeviceType> deviceTypeList, EndpointId composedEpId)
 {
     auto realIndex = index + FIXED_ENDPOINT_COUNT;
 
@@ -233,7 +233,8 @@ EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, EndpointId id, const Emb
     emAfEndpoints[index].endpointType   = ep;
     emAfEndpoints[index].dataVersions   = dataVersionStorage.data();
     // Start the endpoint off as disabled.
-    emAfEndpoints[index].bitmask = EMBER_AF_ENDPOINT_DISABLED;
+    emAfEndpoints[index].bitmask      = EMBER_AF_ENDPOINT_DISABLED;
+    emAfEndpoints[index].composedEpId = composedEpId;
 
     emberAfSetDynamicEndpointCount(MAX_ENDPOINT_COUNT - FIXED_ENDPOINT_COUNT);
 
@@ -982,6 +983,11 @@ uint16_t emberAfIndexFromEndpointIncludingDisabledEndpoints(EndpointId endpoint)
 EndpointId emberAfEndpointFromIndex(uint16_t index)
 {
     return emAfEndpoints[index].endpoint;
+}
+
+EndpointId emberAfComposedEndpointFromIndex(uint16_t index)
+{
+    return emAfEndpoints[index].composedEpId;
 }
 
 // If server == true, returns the number of server clusters,

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -200,7 +200,7 @@ uint16_t emberAfGetDynamicIndexFromEndpoint(EndpointId id)
 
 EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, EndpointId id, const EmberAfEndpointType * ep,
                                         const chip::Span<chip::DataVersion> & dataVersionStorage,
-                                        chip::Span<const EmberAfDeviceType> deviceTypeList, EndpointId composedEpId)
+                                        chip::Span<const EmberAfDeviceType> deviceTypeList, EndpointId parentEndpointId)
 {
     auto realIndex = index + FIXED_ENDPOINT_COUNT;
 
@@ -233,8 +233,8 @@ EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, EndpointId id, const Emb
     emAfEndpoints[index].endpointType   = ep;
     emAfEndpoints[index].dataVersions   = dataVersionStorage.data();
     // Start the endpoint off as disabled.
-    emAfEndpoints[index].bitmask      = EMBER_AF_ENDPOINT_DISABLED;
-    emAfEndpoints[index].composedEpId = composedEpId;
+    emAfEndpoints[index].bitmask          = EMBER_AF_ENDPOINT_DISABLED;
+    emAfEndpoints[index].parentEndpointId = parentEndpointId;
 
     emberAfSetDynamicEndpointCount(MAX_ENDPOINT_COUNT - FIXED_ENDPOINT_COUNT);
 
@@ -985,9 +985,9 @@ EndpointId emberAfEndpointFromIndex(uint16_t index)
     return emAfEndpoints[index].endpoint;
 }
 
-EndpointId emberAfComposedEndpointFromIndex(uint16_t index)
+EndpointId emberAfParentEndpointFromIndex(uint16_t index)
 {
-    return emAfEndpoints[index].composedEpId;
+    return emAfEndpoints[index].parentEndpointId;
 }
 
 // If server == true, returns the number of server clusters,

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -271,7 +271,7 @@ CHIP_ERROR emberAfSetDeviceTypeList(chip::EndpointId endpoint, chip::Span<const 
 EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, chip::EndpointId id, const EmberAfEndpointType * ep,
                                         const chip::Span<chip::DataVersion> & dataVersionStorage,
                                         chip::Span<const EmberAfDeviceType> deviceTypeList = {},
-                                        chip::EndpointId composedEpId = chip::kInvalidEndpointId);
+                                        chip::EndpointId composedEpId                      = chip::kInvalidEndpointId);
 chip::EndpointId emberAfClearDynamicEndpoint(uint16_t index);
 uint16_t emberAfGetDynamicIndexFromEndpoint(chip::EndpointId id);
 

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -268,10 +268,12 @@ CHIP_ERROR emberAfSetDeviceTypeList(chip::EndpointId endpoint, chip::Span<const 
 // An optional device type list can be passed in as well. If provided, the memory
 // backing the list needs to remain allocated until this dynamic endpoint is cleared.
 //
+// An optional parent endpoint id should be passed for child endpoints of composed device.
+//
 EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, chip::EndpointId id, const EmberAfEndpointType * ep,
                                         const chip::Span<chip::DataVersion> & dataVersionStorage,
                                         chip::Span<const EmberAfDeviceType> deviceTypeList = {},
-                                        chip::EndpointId composedEpId                      = chip::kInvalidEndpointId);
+                                        chip::EndpointId parentEndpointId                  = chip::kInvalidEndpointId);
 chip::EndpointId emberAfClearDynamicEndpoint(uint16_t index);
 uint16_t emberAfGetDynamicIndexFromEndpoint(chip::EndpointId id);
 

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -270,7 +270,8 @@ CHIP_ERROR emberAfSetDeviceTypeList(chip::EndpointId endpoint, chip::Span<const 
 //
 EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, chip::EndpointId id, const EmberAfEndpointType * ep,
                                         const chip::Span<chip::DataVersion> & dataVersionStorage,
-                                        chip::Span<const EmberAfDeviceType> deviceTypeList = {});
+                                        chip::Span<const EmberAfDeviceType> deviceTypeList = {},
+                                        chip::EndpointId composedEpId = chip::kInvalidEndpointId);
 chip::EndpointId emberAfClearDynamicEndpoint(uint16_t index);
 uint16_t emberAfGetDynamicIndexFromEndpoint(chip::EndpointId id);
 


### PR DESCRIPTION
#### Matter doesn't have support of  composed Bridged Devices.
The problem is that sdk currently provides no way to access(fill or read) PartsList on endpoints other than EP0. 
Link to [Topology or logical grouping](https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/data_model/bridge-architecture.adoc#21-topology-or-logical-grouping) chapter which describe exposure of composed Bridged Devices.

#### Change overview
* Add link to root endpoint for endpoints of a composed Bridged Devices.
* Encode PartsList for a root endpoint of a composed Bridged Devices.
