### PR TITLE
Fix memory leak occurs every one second

### DIFF
--- a/src/lib/support/Pool.h
+++ b/src/lib/support/Pool.h
@@ -343,9 +343,17 @@ public:
             internal::HeapObjectListNode * node = mObjects.FindNode(object);
             if (node != nullptr)
             {
-                // Note that the node is not removed here; that is deferred until the end of the next pool iteration.
                 node->mObject = nullptr;
                 Platform::Delete(object);
+
+                // Note need to be released immediately if not in the middle of iteration, otherwise cleanup is deferred
+                // until the end of the next pool iteration.
+                if (mObjects.mIterationDepth == 0)
+                {
+                    node->Remove();
+                    Platform::Delete(node);
+                }
+
                 DecreaseUsage();
             }
         }

--- a/src/lib/support/Pool.h
+++ b/src/lib/support/Pool.h
@@ -346,8 +346,8 @@ public:
                 node->mObject = nullptr;
                 Platform::Delete(object);
 
-                // Note need to be released immediately if not in the middle of iteration, otherwise cleanup is deferred
-                // until the end of the next pool iteration.
+                // The node needs to be released immediately if we are not in the middle of iteration.
+                // Otherwise cleanup is deferred until all iteration on this pool completes and it's safe to release nodes.
                 if (mObjects.mIterationDepth == 0)
                 {
                     node->Remove();


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* our stack has memory leak every second.
[1650341313.924547][224805:224805] CHIP:DL: :MemoryFree:94056079034944
[1650341313.924624][224805:224805] CHIP:DL: : SessionManager::ExpiryTimerCallback
[1650341313.924644][224805:224805] CHIP:DL: : SessionManager::ScheduleExpiryTimer
[1650341313.924663][224805:224805] CHIP:DL: : LayerImplSelect::StartTimer
[1650341313.924680][224805:224805] CHIP:DL: : TimerPool::Create
[1650341313.924696][224805:224805] CHIP:DL: :MemoryAlloc:94056079034944: size:40
[1650341313.924715][224805:224805] CHIP:DL: :MemoryAlloc:94056079036288: size:24
[1650341313.924733][224805:224805] CHIP:DL: : LayerImplSelect::StartTimer:94056079034944
[1650341318.930224][224805:224805] CHIP:DL: :MemoryFree:94056079034944
[1650341318.930301][224805:224805] CHIP:DL: : SessionManager::ExpiryTimerCallback
[1650341318.930321][224805:224805] CHIP:DL: : SessionManager::ScheduleExpiryTimer
[1650341318.930340][224805:224805] CHIP:DL: : LayerImplSelect::StartTimer
[1650341318.930356][224805:224805] CHIP:DL: : TimerPool::Create
[1650341318.930373][224805:224805] CHIP:DL: :MemoryAlloc:94056079034944: size:40
[1650341318.930391][224805:224805] CHIP:DL: :MemoryAlloc:94056079036192: size:24
[1650341318.930410][224805:224805] CHIP:DL: : LayerImplSelect::StartTimer:94056079034944
[1650341323.935877][224805:224805] CHIP:DL: :MemoryFree:94056079034944
[1650341323.935945][224805:224805] CHIP:DL: : SessionManager::ExpiryTimerCallback
[1650341323.935961][224805:224805] CHIP:DL: : SessionManager::ScheduleExpiryTimer
[1650341323.935977][224805:224805] CHIP:DL: : LayerImplSelect::StartTimer
[1650341323.935991][224805:224805] CHIP:DL: : TimerPool::Create
[1650341323.936004][224805:224805] CHIP:DL: :MemoryAlloc:94056079034944: size:40
[1650341323.936020][224805:224805] CHIP:DL: :MemoryAlloc:94056079036224: size:24
[1650341323.936033][224805:224805] CHIP:DL: : LayerImplSelect::StartTimer:94056079034944
For each timer created, we call MemoryAlloc twice, but only MemoryFree one of them after


#### Change overview
Release the node together with object immediately if not in the middle of iteration

#### Testing
How was this tested? (at least one bullet point required)
* Confirm there is no periodic leak from log

```
[1650390036.420289][2891797:2891797] CHIP:EVL: : CreateObject
[1650390036.420296][2891797:2891797] CHIP:EVL: : MemoryAlloc:94260402623072, size:40
[1650390036.420304][2891797:2891797] CHIP:EVL: : MemoryAlloc:94260402623968, size:24
[1650390041.420679][2891797:2891797] CHIP:EVL: : ReleaseObject
[1650390041.420704][2891797:2891797] CHIP:EVL: : MemoryFree:94260402623072
[1650390041.420713][2891797:2891797] CHIP:EVL: : ReleaseObject:node
[1650390041.420721][2891797:2891797] CHIP:EVL: : MemoryFree:94260402623968
```
