### PR TITLE
Make sure we expire pending sessions that we never make active.

### DIFF
--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -68,7 +68,8 @@ bool OperationalDeviceProxy::AttachToExistingSecureSession()
     VerifyOrReturnError(mState == State::NeedsAddress || mState == State::Initialized, false);
 
     ScopedNodeId peerNodeId(mPeerId.GetNodeId(), mFabricInfo->GetFabricIndex());
-    auto sessionHandle = mInitParams.sessionManager->FindSecureSessionForNode(peerNodeId, Transport::SecureSession::Type::kCASE);
+    auto sessionHandle =
+        mInitParams.sessionManager->FindSecureSessionForNode(peerNodeId, MakeOptional(Transport::SecureSession::Type::kCASE));
     if (sessionHandle.HasValue())
     {
         ChipLogProgress(Controller, "Found an existing secure session to [" ChipLogFormatX64 "-" ChipLogFormatX64 "]!",

--- a/src/transport/PairingSession.cpp
+++ b/src/transport/PairingSession.cpp
@@ -104,16 +104,18 @@ void PairingSession::Clear()
 {
     if (mSessionManager != nullptr)
     {
-        auto handle = GetSecureSessionHandle();
-        if (handle.HasValue() && !handle.Value()->AsSecureSession()->IsActiveSession())
+        if (mSecureSessionHolder && !mSecureSessionHolder->AsSecureSession()->IsActiveSession())
         {
             // Make sure to clean up our pending session, since we're the only
             // ones who have access to it do do so.
-            mSessionManager->ExpirePairing(handle.Value());
+            mSessionManager->ExpirePairing(mSecureSessionHolder.Get());
         }
     }
 
     mPeerSessionId.ClearValue();
+    // If we called ExpirePairing above, the holder has already released the
+    // session (due to it being destroyed).  If not, we need to release it.
+    // Release is idempotent, so it's OK to just call it here.
     mSecureSessionHolder.Release();
     mSessionManager = nullptr;
 }

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -35,10 +35,12 @@
 
 namespace chip {
 
+class SessionManager;
+
 class DLL_EXPORT PairingSession
 {
 public:
-    virtual ~PairingSession() {}
+    virtual ~PairingSession() { Clear(); }
 
     virtual Transport::SecureSession::Type GetSecureSessionType() const = 0;
     virtual ScopedNodeId GetPeer() const                                = 0;
@@ -158,15 +160,14 @@ protected:
     CHIP_ERROR DecodeMRPParametersIfPresent(TLV::Tag expectedTag, TLV::ContiguousBufferTLVReader & tlvReader);
 
     // TODO: remove Clear, we should create a new instance instead reset the old instance.
-    void Clear()
-    {
-        mPeerSessionId.ClearValue();
-        mSecureSessionHolder.Release();
-    }
+    void Clear();
 
 protected:
     CryptoContext::SessionRole mRole;
     SessionHolder mSecureSessionHolder;
+    // mSessionManager is set if we actually allocate a secure session, so we
+    // can clean it up later as needed.
+    SessionManager * mSessionManager = nullptr;
 
     // mLocalMRPConfig is our config which is sent to the other end and used by the peer session.
     // mRemoteMRPConfig is received from other end and set to our session.

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -58,9 +58,8 @@ public:
      */
     enum class Type : uint8_t
     {
-        kUndefined = 0,
-        kPASE      = 1,
-        kCASE      = 2,
+        kPASE = 1,
+        kCASE = 2,
         // kPending denotes a secure session object that is internally
         // reserved by the stack before and during session establishment.
         //
@@ -71,6 +70,8 @@ public:
         kPending = 3,
     };
 
+    // TODO: This constructor should be private.  Tests should allocate a
+    // kPending session and then call Activate(), just like non-test code does.
     SecureSession(Type secureSessionType, uint16_t localSessionId, NodeId peerNodeId, CATValues peerCATs, uint16_t peerSessionId,
                   FabricIndex fabric, const ReliableMessageProtocolConfig & config) :
         mSecureSessionType(secureSessionType),
@@ -142,6 +143,9 @@ public:
     void SetPeerAddress(const PeerAddress & address) { mPeerAddress = address; }
 
     Type GetSecureSessionType() const { return mSecureSessionType; }
+    bool IsCASESession() const { return GetSecureSessionType() == Type::kCASE; }
+    bool IsPASESession() const { return GetSecureSessionType() == Type::kPASE; }
+    bool IsActiveSession() const { return GetSecureSessionType() != Type::kPending; }
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
     CATValues GetPeerCATs() const { return mPeerCATs; }
 

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -780,12 +780,12 @@ void SessionManager::ExpiryTimerCallback(System::Layer * layer, void * param)
     mgr->ScheduleExpiryTimer(); // re-schedule the oneshot timer
 }
 
-Optional<SessionHandle> SessionManager::FindSecureSessionForNode(ScopedNodeId peerNodeId, Transport::SecureSession::Type type)
+Optional<SessionHandle> SessionManager::FindSecureSessionForNode(ScopedNodeId peerNodeId,
+                                                                 const Optional<Transport::SecureSession::Type> & type)
 {
     SecureSession * found = nullptr;
-    mSecureSessions.ForEachSession([&peerNodeId, type, &found](auto session) {
-        if (session->GetPeer() == peerNodeId &&
-            (type == SecureSession::Type::kUndefined || type == session->GetSecureSessionType()))
+    mSecureSessions.ForEachSession([&peerNodeId, &type, &found](auto session) {
+        if (session->GetPeer() == peerNodeId && (!type.HasValue() || type.Value() == session->GetSecureSessionType()))
         {
             found = session;
             return Loop::Break;

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -231,7 +231,7 @@ public:
 
     //
     // Find an existing secure session given a peer's scoped NodeId and a type of session to match against.
-    // If matching against all types of sessions is desired, kUndefined should be passed into type.
+    // If matching against all types of sessions is desired, NullOptional should be passed into type.
     //
     // If a valid session is found, an Optional<SessionHandle> with the value set to the SessionHandle of the session
     // is returned. Otherwise, an Optional<SessionHandle> with no value set is returned.

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -237,9 +237,8 @@ public:
     // is returned. Otherwise, an Optional<SessionHandle> with no value set is returned.
     //
     //
-    Optional<SessionHandle>
-    FindSecureSessionForNode(ScopedNodeId peerNodeId,
-                             Transport::SecureSession::Type type = Transport::SecureSession::Type::kUndefined);
+    Optional<SessionHandle> FindSecureSessionForNode(ScopedNodeId peerNodeId,
+                                                     const Optional<Transport::SecureSession::Type> & type = NullOptional);
 
     using SessionHandleCallback = bool (*)(void * context, SessionHandle & sessionHandle);
     CHIP_ERROR ForEachSessionHandle(void * context, SessionHandleCallback callback);


### PR DESCRIPTION
When we started allocating secure sessions at the start of the
CASE/PASE handshake, not at the end, we ended up in a situation where
if the session handshake fails the pending session still sticks around
and never gets cleaned up.  Eventually the secure session pool fills
up, and we are unable to create any new sessions.

The fix is to make PairingSession clean things up properly.

Fixes https://github.com/project-chip/connectedhomeip/issues/17167

#### Problem
See above.

#### Change overview
See above.

#### Testing
Followed the steps in #17167 and was able to go for 20 PASE attempts before the server closed the commisssioning window.