### PR TITLE
[Linux] Fix some behavior of linux wifi driver

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -78,6 +78,8 @@ char ConnectivityManagerImpl::sWiFiIfName[];
 
 WiFiDriver::ScanCallback * ConnectivityManagerImpl::mpScanCallback;
 NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * ConnectivityManagerImpl::mpConnectCallback;
+uint8_t ConnectivityManagerImpl::sInterestedSSID[Internal::kMaxWiFiSSIDLength];
+uint8_t ConnectivityManagerImpl::sInterestedSSIDLen;
 
 CHIP_ERROR ConnectivityManagerImpl::_Init()
 {
@@ -423,6 +425,14 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
                             break;
                         }
 
+                        DeviceLayer::SystemLayer().ScheduleLambda([reason]() {
+                            if (mpConnectCallback != nullptr)
+                            {
+                                mpConnectCallback->OnResult(NetworkCommissioning::Status::kUnknownError, CharSpan(), reason);
+                                mpConnectCallback = nullptr;
+                            }
+                        });
+
                         delegate->OnAssociationFailureDetected(associationFailureCause, status);
                     }
 
@@ -438,6 +448,21 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
                     }
 
                     DeviceLayer::SystemLayer().ScheduleLambda([]() { ConnectivityMgrImpl().UpdateNetworkStatus(); });
+                }
+                else if (g_strcmp0(value_str, "\'completed\'") == 0)
+                {
+                    if (mAssociattionStarted)
+                    {
+                        DeviceLayer::SystemLayer().ScheduleLambda([]() {
+                            if (mpConnectCallback != nullptr)
+                            {
+                                mpConnectCallback->OnResult(NetworkCommissioning::Status::kSuccess, CharSpan(), 0);
+                                mpConnectCallback = nullptr;
+                            }
+                            ConnectivityMgrImpl().PostNetworkConnect();
+                        });
+                    }
+                    mAssociattionStarted = false;
                 }
             }
 
@@ -934,19 +959,23 @@ ConnectivityManagerImpl::ConnectWiFiNetworkAsync(ByteSpan ssid, ByteSpan credent
     // There is another ongoing connect request, reject the new one.
     VerifyOrReturnError(mpConnectCallback == nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    // Clean up current network if exists
-    if (mWpaSupplicant.networkPath)
+    const gchar * networkPath = wpa_fi_w1_wpa_supplicant1_interface_get_current_network(mWpaSupplicant.iface);
+
+    // wpa_supplicant DBus API: if network path of current network is not "/", means we have already selected some network.
+    if (strcmp(networkPath, "/") != 0)
     {
         GError * error = nullptr;
 
-        result = wpa_fi_w1_wpa_supplicant1_interface_call_remove_network_sync(mWpaSupplicant.iface, mWpaSupplicant.networkPath,
-                                                                              nullptr, &error);
+        result = wpa_fi_w1_wpa_supplicant1_interface_call_remove_network_sync(mWpaSupplicant.iface, networkPath, nullptr, &error);
 
         if (result)
         {
-            ChipLogProgress(DeviceLayer, "wpa_supplicant: removed network: %s", mWpaSupplicant.networkPath);
-            g_free(mWpaSupplicant.networkPath);
-            mWpaSupplicant.networkPath = nullptr;
+            if (mWpaSupplicant.networkPath != nullptr)
+            {
+                ChipLogProgress(DeviceLayer, "wpa_supplicant: removed network: %s", mWpaSupplicant.networkPath);
+                g_free(mWpaSupplicant.networkPath);
+                mWpaSupplicant.networkPath = nullptr;
+            }
         }
         else
         {
@@ -1023,18 +1052,6 @@ void ConnectivityManagerImpl::_ConnectWiFiNetworkAsyncCallback(GObject * source_
                     this_->mpConnectCallback = nullptr;
                 }
                 mpConnectCallback = nullptr;
-            });
-        }
-        else
-        {
-            DeviceLayer::SystemLayer().ScheduleLambda([this_]() {
-                if (this_->mpConnectCallback != nullptr)
-                {
-                    // TODO(#14175): Replace this with actual thread attach result.
-                    this_->mpConnectCallback->OnResult(NetworkCommissioning::Status::kSuccess, CharSpan(), 0);
-                    this_->mpConnectCallback = nullptr;
-                }
-                this_->PostNetworkConnect();
             });
         }
     }
@@ -1384,12 +1401,16 @@ CHIP_ERROR ConnectivityManagerImpl::StartWiFiScan(ByteSpan ssid, WiFiDriver::Sca
     VerifyOrReturnError(mWpaSupplicant.iface != nullptr, CHIP_ERROR_INCORRECT_STATE);
     // There is another ongoing scan request, reject the new one.
     VerifyOrReturnError(mpScanCallback == nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(ssid.size() <= sizeof(sInterestedSSID), CHIP_ERROR_INVALID_ARGUMENT);
 
     CHIP_ERROR ret  = CHIP_NO_ERROR;
     GError * err    = nullptr;
     GVariant * args = nullptr;
     GVariantBuilder builder;
     gboolean result;
+
+    memcpy(sInterestedSSID, ssid.data(), ssid.size());
+    sInterestedSSIDLen = ssid.size();
 
     g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
     g_variant_builder_add(&builder, "{sv}", "Type", g_variant_new_string("active"));
@@ -1670,7 +1691,8 @@ void ConnectivityManagerImpl::_OnWpaInterfaceScanDone(GObject * source_object, G
     for (const gchar * bssPath = (bsss != nullptr ? *bsss : nullptr); bssPath != nullptr; bssPath = *(++bsss))
     {
         WiFiScanResponse network;
-        if (_GetBssInfo(bssPath, network))
+        if (_GetBssInfo(bssPath, network) && network.ssidLen == sInterestedSSIDLen &&
+            memcmp(network.ssid, sInterestedSSID, sInterestedSSIDLen) == 0)
         {
             networkScanned->push_back(network);
         }

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -237,6 +237,8 @@ private:
     static char sWiFiIfName[IFNAMSIZ];
 #endif
 
+    static uint8_t sInterestedSSID[Internal::kMaxWiFiSSIDLength];
+    static uint8_t sInterestedSSIDLen;
     static NetworkCommissioning::WiFiDriver::ScanCallback * mpScanCallback;
     static NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * mpConnectCallback;
 };


### PR DESCRIPTION
#### Problem
- Fixes #17106 - ConnectNetwork returns result too early -- before actually connected to the network
- ScanNetwork is not filtering the discovered network with interested ssids

#### Change overview
Fixed the behavior above.

#### Testing

Scan network
```
In [4]: await devCtrl.SendCommand(1, 0, Clusters.NetworkCommissioning.Commands.ScanNetworks(ssid=b'(personal ap)'))
Out[4]: 
ScanNetworksResponse(
│   networkingStatus=<NetworkCommissioningStatus.kSuccess: 0>,
│   debugText=None,
│   wiFiScanResults=[
│   │   WiFiInterfaceScanResult(
│   │   │   security=24,
│   │   │   ssid=b'(personal ap)',
│   │   │   bssid=b'(personal ap)',
│   │   │   channel=40,
│   │   │   wiFiBand=<WiFiBand.k5g: 2>,
│   │   │   rssi=-41
│   │   ),
│   │   WiFiInterfaceScanResult(
│   │   │   security=24,
│   │   │   ssid=b'(personal ap)',
│   │   │   bssid=b'(personal ap)',
│   │   │   channel=4,
│   │   │   wiFiBand=<WiFiBand.k2g4: 0>,
│   │   │   rssi=-41
│   │   )
│   ],
│   threadScanResults=None
)

```



```
In [13]: await devCtrl.SendCommand(1, 0, Clusters.NetworkCommissioning.Commands.AddOrUpdateWiFiNetwork(ssid=b'ssid1', credentials=b'PASSWORD_1'))
Out[13]: 
NetworkConfigResponse(
│   networkingStatus=<NetworkCommissioningStatus.kSuccess: 0>,
│   debugText=None,
│   networkIndex=0
)

In [14]: await devCtrl.SendCommand(1, 0, Clusters.NetworkCommissioning.Commands.ConnectNetwork(networkID=b'ssid1'));await devCtrl.ReadAttribute(1, [(0,Clusters.NetworkCommissioning.Attributes.Networks)])
Out[14]: 
{
│   0: {
│   │   <class 'chip.clusters.Objects.NetworkCommissioning'>: {
│   │   │   <class 'chip.clusters.Attribute.DataVersion'>: 3058328082,
│   │   │   <class 'chip.clusters.Objects.NetworkCommissioning.Attributes.Networks'>: [
│   │   │   │   NetworkInfo(
│   │   │   │   │   networkID=b'ssid1',
│   │   │   │   │   connected=True
│   │   │   │   )
│   │   │   ]
│   │   }
│   }
}

In [15]: await devCtrl.SendCommand(1, 0, Clusters.NetworkCommissioning.Commands.RemoveNetwork(networkID=b'ssid1'))
Out[15]: 
NetworkConfigResponse(
│   networkingStatus=<NetworkCommissioningStatus.kSuccess: 0>,
│   debugText=None,
│   networkIndex=0
)

In [16]: await devCtrl.SendCommand(1, 0, Clusters.NetworkCommissioning.Commands.AddOrUpdateWiFiNetwork(ssid=b'ssid2', credentials=b'PASSWORD_2'))
Out[16]: 
NetworkConfigResponse(
│   networkingStatus=<NetworkCommissioningStatus.kSuccess: 0>,
│   debugText=None,
│   networkIndex=0
)

In [17]: await devCtrl.SendCommand(1, 0, Clusters.NetworkCommissioning.Commands.ConnectNetwork(networkID=b'ssid2'));await devCtrl.ReadAttribute(1, [(0, Clusters.NetworkCommissioning.Attributes.Networks)])
Out[17]: 
{
│   0: {
│   │   <class 'chip.clusters.Objects.NetworkCommissioning'>: {
│   │   │   <class 'chip.clusters.Attribute.DataVersion'>: 3058328082,
│   │   │   <class 'chip.clusters.Objects.NetworkCommissioning.Attributes.Networks'>: [
│   │   │   │   NetworkInfo(
│   │   │   │   │   networkID=b'ssid2',
│   │   │   │   │   connected=True
│   │   │   │   )
│   │   │   ]
│   │   }
│   }
}

In [18]: 
```