### PR TITLE
[Android] Enable chip_enable_schema_check for android platform.

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -21,7 +21,8 @@ import("common_flags.gni")
 declare_args() {
   # Enable strict schema checks.
   chip_enable_schema_check =
-      is_debug && (current_os == "linux" || current_os == "mac")
+      is_debug &&
+      (current_os == "linux" || current_os == "mac" || current_os == "android")
 
   # Logging verbosity control for Access Control implementation
   #


### PR DESCRIPTION
Signed-off-by: sanghyukko <sanghyuk.ko@samsung.com>
Signed-off-by: Charles Kim <chulspro.kim@samsung.com>

#### Problem
MAC/Linux already enabled detail info for certification,
We also want to enable detail info of cluster message on Android platform.

#### Change overview
Enable android platform os on GN build

#### Testing
Example message detail info after changes.
[1646313566.134637][8200:8200] CHIP:DMG: IM WH moving to [Initialized]
[1646313566.134745][8200:8200] CHIP:DMG: WriteRequestMessage =
[1646313566.134804][8200:8200] CHIP:DMG: {
[1646313566.134861][8200:8200] CHIP:DMG:        timedRequest = false,
[1646313566.134920][8200:8200] CHIP:DMG:        AttributeDataIBs =
[1646313566.134998][8200:8200] CHIP:DMG:        [
[1646313566.135058][8200:8200] CHIP:DMG:                AttributeDataIB =
[1646313566.135128][8200:8200] CHIP:DMG:                {
[1646313566.135195][8200:8200] CHIP:DMG:                        AttributePathIB =
[1646313566.135281][8200:8200] CHIP:DMG:                        {
[1646313566.135349][8200:8200] CHIP:DMG:                                Endpoint = 0x0,
[1646313566.135429][8200:8200] CHIP:DMG:                                Cluster = 0x28,
[1646313566.135519][8200:8200] CHIP:DMG:                                Attribute = 0x0000_0005,
[1646313566.135599][8200:8200] CHIP:DMG:                        }
[1646313566.135682][8200:8200] CHIP:DMG:
[1646313566.135764][8200:8200] CHIP:DMG:                                Data = "te5new",
[1646313566.135877][8200:8200] CHIP:DMG:                },
[1646313566.135955][8200:8200] CHIP:DMG:
[1646313566.136013][8200:8200] CHIP:DMG:        ],
[1646313566.136083][8200:8200] CHIP:DMG:
[1646313566.136141][8200:8200] CHIP:DMG:        moreChunkedMessages = false,
[1646313566.136205][8200:8200] CHIP:DMG:        InteractionModelRevision = 1
[1646313566.136260][8200:8200] CHIP:DMG: },