### PR TITLE
[Android] Add device param of GetAttestationChallenge.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -768,6 +768,19 @@ DeviceCommissioner::ContinueCommissioningAfterDeviceAttestationFailure(DevicePro
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR DeviceCommissioner::GetAttestationChallenge(ByteSpan & attestationChallenge)
+{
+    Optional<SessionHandle> secureSessionHandle;
+
+    VerifyOrReturnError(mDeviceBeingCommissioned != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    secureSessionHandle = mDeviceBeingCommissioned->GetSecureSession();
+    VerifyOrReturnError(secureSessionHandle.HasValue(), CHIP_ERROR_INCORRECT_STATE);
+
+    attestationChallenge = secureSessionHandle.Value()->AsSecureSession()->GetCryptoContext().GetAttestationChallenge();
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR DeviceCommissioner::GetAttestationChallenge(DeviceProxy * device, ByteSpan & attestationChallenge)
 {
     Optional<SessionHandle> secureSessionHandle;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -768,13 +768,13 @@ DeviceCommissioner::ContinueCommissioningAfterDeviceAttestationFailure(DevicePro
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DeviceCommissioner::GetAttestationChallenge(ByteSpan & attestationChallenge)
+CHIP_ERROR DeviceCommissioner::GetAttestationChallenge(DeviceProxy * device, ByteSpan & attestationChallenge)
 {
     Optional<SessionHandle> secureSessionHandle;
 
-    VerifyOrReturnError(mDeviceBeingCommissioned != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    secureSessionHandle = mDeviceBeingCommissioned->GetSecureSession();
+    secureSessionHandle = device->GetSecureSession();
     VerifyOrReturnError(secureSessionHandle.HasValue(), CHIP_ERROR_INCORRECT_STATE);
 
     attestationChallenge = secureSessionHandle.Value()->AsSecureSession()->GetCryptoContext().GetAttestationChallenge();

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -430,11 +430,12 @@ public:
      * @brief
      *   This function returns the attestation challenge for the secure session of the device being commissioned.
      *
+     * @param[in] device                The device being commissioned.
      * @param[out] attestationChallenge The output for the attestationChallenge
      *
      * @return CHIP_ERROR               CHIP_NO_ERROR on success, or CHIP_ERROR_INVALID_ARGUMENT if no secure session is active
      */
-    CHIP_ERROR GetAttestationChallenge(ByteSpan & attestationChallenge);
+    CHIP_ERROR GetAttestationChallenge(DeviceProxy * device, ByteSpan & attestationChallenge);
 
     /**
      * @brief

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -430,7 +430,17 @@ public:
      * @brief
      *   This function returns the attestation challenge for the secure session of the device being commissioned.
      *
-     * @param[in] device                The device being commissioned.
+     * @param[out] attestationChallenge The output for the attestationChallenge
+     *
+     * @return CHIP_ERROR               CHIP_NO_ERROR on success, or CHIP_ERROR_INVALID_ARGUMENT if no secure session is active
+     */
+    CHIP_ERROR GetAttestationChallenge(ByteSpan & attestationChallenge);
+
+    /**
+     * @brief
+     *   This function returns the attestation challenge for the secure session of the device being commissioned.
+     *
+     * @param[in] device                The device being commissioned
      * @param[out] attestationChallenge The output for the attestationChallenge
      *
      * @return CHIP_ERROR               CHIP_NO_ERROR on success, or CHIP_ERROR_INVALID_ARGUMENT if no secure session is active

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -653,12 +653,12 @@ JNI_METHOD(jbyteArray, getAttestationChallenge)
     }
 
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-    err = wrapper->Controller()->GetAttestationChallenge(attestationChallenge);
+    err                                      wrapper->Controller()->GetAttestationChallenge(attestationChallenge);
     SuccessOrExit(err);
     VerifyOrExit(attestationChallenge.size() == 16, err = CHIP_ERROR_INVALID_ARGUMENT);
 
     err = JniReferences::GetInstance().N2J_ByteArray(env, attestationChallenge.data(), attestationChallenge.size(),
-        attestationChallengeJbytes);
+                                                     attestationChallengeJbytes);
     SuccessOrExit(err);
 
 exit:
@@ -685,12 +685,12 @@ JNI_METHOD(jbyteArray, getAttestationChallengeWithDevice)
     }
 
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-    err = wrapper->Controller()->GetAttestationChallenge(chipDevice, attestationChallenge);
+    err                                      wrapper->Controller()->GetAttestationChallenge(chipDevice, attestationChallenge);
     SuccessOrExit(err);
     VerifyOrExit(attestationChallenge.size() == 16, err = CHIP_ERROR_INVALID_ARGUMENT);
 
     err = JniReferences::GetInstance().N2J_ByteArray(env, attestationChallenge.data(), attestationChallenge.size(),
-        attestationChallengeJbytes);
+                                                     attestationChallengeJbytes);
     SuccessOrExit(err);
 
 exit:

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -653,7 +653,7 @@ JNI_METHOD(jbyteArray, getAttestationChallenge)
     }
 
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-    err                                      wrapper->Controller()->GetAttestationChallenge(attestationChallenge);
+    err                                      = wrapper->Controller()->GetAttestationChallenge(attestationChallenge);
     SuccessOrExit(err);
     VerifyOrExit(attestationChallenge.size() == 16, err = CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -685,7 +685,7 @@ JNI_METHOD(jbyteArray, getAttestationChallengeWithDevice)
     }
 
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-    err                                      wrapper->Controller()->GetAttestationChallenge(chipDevice, attestationChallenge);
+    err                                      = wrapper->Controller()->GetAttestationChallenge(chipDevice, attestationChallenge);
     SuccessOrExit(err);
     VerifyOrExit(attestationChallenge.size() == 16, err = CHIP_ERROR_INVALID_ARGUMENT);
 

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -653,7 +653,7 @@ JNI_METHOD(jbyteArray, getAttestationChallenge)
     }
 
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-    err                                      = wrapper->Controller()->GetAttestationChallenge(attestationChallenge);
+    err                                      = wrapper->Controller()->GetAttestationChallenge(chipDevice, attestationChallenge);
     SuccessOrExit(err);
     VerifyOrExit(attestationChallenge.size() == 16, err = CHIP_ERROR_INVALID_ARGUMENT);
 

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -322,6 +322,17 @@ public class ChipDeviceController {
     return getAttestationChallenge(deviceControllerPtr, devicePtr);
   }
 
+  /**
+   * Returns an attestation challenge for the given device, for which there must be an existing
+   * secure session.
+   *
+   * @param devicePtr a pointer to the device from which to retrieve the challenge
+   * @throws ChipDeviceControllerException if there is no secure session for the given device
+   */
+  public byte[] getAttestationChallengeWithDevice(long devicePtr) {
+    return getAttestationChallengeWithDevice(deviceControllerPtr, devicePtr);
+  }
+
   /** Subscribe to the given attribute path. */
   public void subscribeToPath(
       SubscriptionEstablishedCallback subscriptionEstablishedCallback,
@@ -449,6 +460,8 @@ public class ChipDeviceController {
   private native boolean isActive(long deviceControllerPtr, long deviceId);
 
   private native byte[] getAttestationChallenge(long deviceControllerPtr, long devicePtr);
+
+  private native byte[] getAttestationChallengeWithDevice(long deviceControllerPtr, long devicePtr);
 
   private native void shutdownSubscriptions(long deviceControllerPtr, long devicePtr);
 


### PR DESCRIPTION
Signed-off-by: sanghyukko <sanghyuk.ko@samsung.com>
Signed-off-by: Charles Kim <chulspro.kim@samsung.com>

#### Problem
We need to update info of device proxy during attestation step.

#### Change overview
Change to set device proxy value on attestation step and use device secure session.

#### Testing
Device commissioning