### PR TITLE
[Android] Add shutdownCommissioning for commissioning step.

### DIFF
--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -637,6 +637,17 @@ JNI_METHOD(jboolean, openPairingWindowWithPIN)
     return true;
 }
 
+JNI_METHOD(void, shutdownCommissioning)
+(JNIEnv * env, jobject self, jlong handle)
+{
+    chip::DeviceLayer::StackLock lock;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
+    err                                      = wrapper->Controller()->Shutdown();
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Error invoking shutdownCommissioning: %s", ErrorStr(err)));
+}
+
 JNI_METHOD(jbyteArray, getAttestationChallenge)
 (JNIEnv * env, jobject self, jlong handle, jlong devicePtr)
 {

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -369,6 +369,10 @@ public class ChipDeviceController {
     return computePaseVerifier(deviceControllerPtr, devicePtr, setupPincode, iterations, salt);
   }
 
+  public void shutdownCommissioning() {
+    shutdownCommissioning(deviceControllerPtr);
+  }
+
   private native PaseVerifierParams computePaseVerifier(
       long deviceControllerPtr, long devicePtr, long setupPincode, long iterations, byte[] salt);
 
@@ -451,6 +455,8 @@ public class ChipDeviceController {
   private native byte[] getAttestationChallenge(long deviceControllerPtr, long devicePtr);
 
   private native void shutdownSubscriptions(long deviceControllerPtr, long devicePtr);
+
+  private native void shutdownCommissioning(long deviceControllerPtr);
 
   static {
     System.loadLibrary("CHIPController");


### PR DESCRIPTION
Signed-off-by: sanghyukko <sanghyuk.ko@samsung.com>
Signed-off-by: Charles Kim <chulspro.kim@samsung.com>

#### Problem
We want to call shutdown commissioning to get callback

#### Change overview
Added shutdownCommissioning api

#### Testing
Need to check shutdownCommissioning Callback during device commissioning