### PR TITLE
[Darwin] Add a new API for converting from x509 to matter cert

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -105,7 +105,7 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
 /**
  * Converts a given X.509v3 certificate into a Matter certificate.
  */
-- (NSData *)convertX509CertToMatterCert:(NSData *) x509Cert;
+- (NSData *)convertX509CertToMatterCert:(NSData *)x509Cert;
 
 @end
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -102,6 +102,11 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
  */
 - (void)shutdown;
 
+/**
+ * Converts a given X.509v3 certificate into a Matter certificate.
+ */
+- (NSData *)convertX509CertToMatterCert:(NSData *) x509Cert;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -684,7 +684,8 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
     uint8_t outCertBuf[chip::Credentials::kMaxCHIPCertLength];
     chip::MutableByteSpan outCert(outCertBuf);
 
-    errorCode = chip::Credentials::ConvertX509CertToChipCert(chip::ByteSpan((const uint8_t *) x509Cert.bytes, x509Cert.length), outCert);
+    errorCode
+        = chip::Credentials::ConvertX509CertToChipCert(chip::ByteSpan((const uint8_t *) x509Cert.bytes, x509Cert.length), outCert);
     if (errorCode != CHIP_NO_ERROR) {
         CHIP_LOG_ERROR("Error(%s): Convert X509Cert to MatterCert failed", chip::ErrorStr(errorCode));
         return nil;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -678,6 +678,21 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
     return deviceProxy->GetDeviceTransportType() == chip::Transport::Type::kBle;
 }
 
+- (NSData *)convertX509CertToMatterCert:(NSData *)x509Cert
+{
+    CHIP_ERROR errorCode = CHIP_NO_ERROR;
+    uint8_t outCertBuf[chip::Credentials::kMaxCHIPCertLength];
+    chip::MutableByteSpan outCert(outCertBuf);
+
+    errorCode = chip::Credentials::ConvertX509CertToChipCert(chip::ByteSpan((const uint8_t *) x509Cert.bytes, x509Cert.length), outCert);
+    if (errorCode != CHIP_NO_ERROR) {
+        CHIP_LOG_ERROR("Error(%s): Convert X509Cert to MatterCert failed", chip::ErrorStr(errorCode));
+        return nil;
+    }
+
+    return [NSData dataWithBytes:outCert.data() length:outCert.size()];
+}
+
 @end
 
 @implementation CHIPDeviceController (InternalMethods)


### PR DESCRIPTION
Signed-off-by: Charles Kim <chulspro.kim@samsung.com>

#### Problem
We need to provide covert API for app.

#### Change overview
Add a new API, convertX509CertToMatterCert(), that converts a
 x509 certificate to a matter certificate required to send it to a matter

#### Testing
Use X.509 cert and check device commissioning