### PR TITLE
[QPG] Use OpenThread endpoint + Re-enable check_system-includes [Issue #17404]

### DIFF
--- a/config/qpg/chip-gn/.gn
+++ b/config/qpg/chip-gn/.gn
@@ -19,9 +19,7 @@ import("//build_overrides/chip.gni")
 buildconfig = "//build/config/BUILDCONFIG.gn"
 
 # CHIP uses angle bracket includes.
-# DISABLED since CI failed on PR 17352
-# Build error out for unused/unavailble include file (IPAddress.h : <openthread/ip6.h>)
-check_system_includes = false
+check_system_includes = true
 
 default_args = {
   target_cpu = "arm"

--- a/examples/lighting-app/qpg/.gn
+++ b/examples/lighting-app/qpg/.gn
@@ -17,9 +17,8 @@ import("//build_overrides/build.gni")
 # The location of the build configuration file.
 buildconfig = "${build_root}/config/BUILDCONFIG.gn"
 
-# DISABLED since CI failed on PR 17352
-# Build error out for unused/unavailble include file (IPAddress.h : <openthread/ip6.h>)
-check_system_includes = false
+# CHIP uses angle bracket includes.
+check_system_includes = true
 
 default_args = {
   target_cpu = "arm"

--- a/examples/lock-app/qpg/.gn
+++ b/examples/lock-app/qpg/.gn
@@ -17,9 +17,8 @@ import("//build_overrides/build.gni")
 # The location of the build configuration file.
 buildconfig = "${build_root}/config/BUILDCONFIG.gn"
 
-# DISABLED since CI failed on PR 17352
-# Build error out for unused/unavailble include file (IPAddress.h : <openthread/ip6.h>)
-check_system_includes = false
+# CHIP uses angle bracket includes.
+check_system_includes = true
 
 default_args = {
   target_cpu = "arm"

--- a/examples/persistent-storage/qpg/.gn
+++ b/examples/persistent-storage/qpg/.gn
@@ -17,9 +17,8 @@ import("//build_overrides/build.gni")
 # The location of the build configuration file.
 buildconfig = "${build_root}/config/BUILDCONFIG.gn"
 
-# DISABLED since CI failed on PR 17352
-# Build error out for unused/unavailble include file (IPAddress.h : <openthread/ip6.h>)
-check_system_includes = false
+# CHIP uses angle bracket includes.
+check_system_includes = true
 
 default_args = {
   target_cpu = "arm"

--- a/examples/persistent-storage/qpg/args.gni
+++ b/examples/persistent-storage/qpg/args.gni
@@ -19,6 +19,7 @@ qpg_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 chip_enable_openthread = false
 chip_openthread_ftd = false
 chip_system_config_use_open_thread_inet_endpoints = false
+chip_with_lwip = true
 
 declare_args() {
   # Disable lock tracking, since our FreeRTOS configuration does not set

--- a/examples/platform/qpg/args.gni
+++ b/examples/platform/qpg/args.gni
@@ -17,6 +17,8 @@ import("//build_overrides/chip.gni")
 import("${chip_root}/src/platform/qpg/args.gni")
 
 chip_enable_openthread = true
+chip_system_config_use_open_thread_inet_endpoints = true
+chip_with_lwip = false
 openthread_project_core_config_file = "OpenThreadConfig.h"
 openthread_core_config_deps = []
 openthread_core_config_deps = [

--- a/examples/shell/qpg/.gn
+++ b/examples/shell/qpg/.gn
@@ -17,9 +17,8 @@ import("//build_overrides/build.gni")
 # The location of the build configuration file.
 buildconfig = "${build_root}/config/BUILDCONFIG.gn"
 
-# DISABLED since CI failed on PR 17352
-# Build error out for unused/unavailble include file (IPAddress.h : <openthread/ip6.h>)
-check_system_includes = false
+# CHIP uses angle bracket includes.
+check_system_includes = true
 
 default_args = {
   target_cpu = "arm"

--- a/examples/shell/qpg/BUILD.gn
+++ b/examples/shell/qpg/BUILD.gn
@@ -54,6 +54,12 @@ qpg_executable("shell_app") {
     "${examples_plat_dir}:qpg-matter-shell",
   ]
 
+  #fixme Added lock-app dependency as linker errors get generated if no
+  #chip datamodel is given [import("${chip_root}/src/app/chip_data_model.gni")]
+  deps += [
+    "${chip_root}/examples/lock-app/lock-common",
+  ]
+
   include_dirs = [ "include" ]
 
   defines = []

--- a/examples/shell/qpg/BUILD.gn
+++ b/examples/shell/qpg/BUILD.gn
@@ -56,9 +56,7 @@ qpg_executable("shell_app") {
 
   #fixme Added lock-app dependency as linker errors get generated if no
   #chip datamodel is given [import("${chip_root}/src/app/chip_data_model.gni")]
-  deps += [
-    "${chip_root}/examples/lock-app/lock-common",
-  ]
+  deps += [ "${chip_root}/examples/lock-app/lock-common" ]
 
   include_dirs = [ "include" ]
 

--- a/examples/shell/qpg/args.gni
+++ b/examples/shell/qpg/args.gni
@@ -27,4 +27,3 @@ chip_build_libshell = true
 chip_stack_lock_tracking = "none"
 
 chip_openthread_ftd = false
-

--- a/examples/shell/qpg/args.gni
+++ b/examples/shell/qpg/args.gni
@@ -27,3 +27,8 @@ chip_build_libshell = true
 chip_stack_lock_tracking = "none"
 
 chip_openthread_ftd = false
+
+#Fix me : shell app should use same config as examples
+#Problem : Linker issue if set to true
+chip_system_config_use_open_thread_inet_endpoints = false
+chip_with_lwip = true

--- a/examples/shell/qpg/args.gni
+++ b/examples/shell/qpg/args.gni
@@ -28,7 +28,3 @@ chip_stack_lock_tracking = "none"
 
 chip_openthread_ftd = false
 
-#Fix me : shell app should use same config as examples
-#Problem : Linker issue if set to true
-chip_system_config_use_open_thread_inet_endpoints = false
-chip_with_lwip = true

--- a/src/platform/qpg/ConnectivityManagerImpl.cpp
+++ b/src/platform/qpg/ConnectivityManagerImpl.cpp
@@ -30,11 +30,6 @@
 #include <platform/ConnectivityManager.h>
 #include <platform/internal/BLEManager.h>
 
-#include <lwip/dns.h>
-#include <lwip/ip_addr.h>
-#include <lwip/nd6.h>
-#include <lwip/netif.h>
-
 using namespace ::chip;
 using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;

--- a/src/platform/qpg/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/qpg/DiagnosticDataProviderImpl.cpp
@@ -27,8 +27,6 @@
 #include <platform/PlatformManager.h>
 #include <platform/qpg/DiagnosticDataProviderImpl.h>
 
-#include <lwip/tcpip.h>
-
 namespace chip {
 namespace DeviceLayer {
 

--- a/src/platform/qpg/Logging.cpp
+++ b/src/platform/qpg/Logging.cpp
@@ -11,6 +11,7 @@
 
 #include <ctype.h>
 #include <string.h>
+#include <cstdio>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include <openthread/platform/logging.h>
@@ -86,6 +87,7 @@ void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char
 } // namespace Logging
 } // namespace chip
 
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
 /**
  * LwIP log output function.
  */
@@ -110,6 +112,7 @@ extern "C" void LwIPLog(const char * msg, ...)
     // Let the application know that a log message has been emitted.
     chip::DeviceLayer::OnLogOutput();
 }
+#endif // #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 extern "C" void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char * aFormat, ...)

--- a/src/platform/qpg/Logging.cpp
+++ b/src/platform/qpg/Logging.cpp
@@ -9,9 +9,9 @@
 #include <lib/support/logging/Constants.h>
 #include <platform/CHIPDeviceConfig.h>
 
+#include <cstdio>
 #include <ctype.h>
 #include <string.h>
-#include <cstdio>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include <openthread/platform/logging.h>

--- a/src/platform/qpg/PlatformManagerImpl.cpp
+++ b/src/platform/qpg/PlatformManagerImpl.cpp
@@ -30,7 +30,7 @@
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 #include <lwip/tcpip.h>
-#endif //CHIP_SYSTEM_CONFIG_USE_LWIP
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 namespace chip {
 namespace DeviceLayer {
@@ -50,7 +50,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     // Initialize LwIP.
     tcpip_init(NULL, NULL);
-#endif //CHIP_SYSTEM_CONFIG_USE_LWIP
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
     ReturnErrorOnFailure(System::Clock::InitClock_RealTime());
 

--- a/src/platform/qpg/PlatformManagerImpl.cpp
+++ b/src/platform/qpg/PlatformManagerImpl.cpp
@@ -28,7 +28,9 @@
 #include <platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp>
 #include <platform/qpg/DiagnosticDataProviderImpl.h>
 
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
 #include <lwip/tcpip.h>
+#endif //CHIP_SYSTEM_CONFIG_USE_LWIP
 
 namespace chip {
 namespace DeviceLayer {
@@ -45,8 +47,10 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
     SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
     // Initialize LwIP.
     tcpip_init(NULL, NULL);
+#endif //CHIP_SYSTEM_CONFIG_USE_LWIP
 
     ReturnErrorOnFailure(System::Clock::InitClock_RealTime());
 

--- a/src/platform/qpg/ThreadStackManagerImpl.cpp
+++ b/src/platform/qpg/ThreadStackManagerImpl.cpp
@@ -26,7 +26,7 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include <platform/FreeRTOS/GenericThreadStackManagerImpl_FreeRTOS.cpp>
-#include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp>
+#include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp>
 
 #include <platform/OpenThread/OpenThreadUtils.h>
 #include <platform/ThreadStackManager.h>
@@ -66,7 +66,7 @@ CHIP_ERROR ThreadStackManagerImpl::InitThreadStack(otInstance * otInst)
     // Initialize the generic implementation base classes.
     err = GenericThreadStackManagerImpl_FreeRTOS<ThreadStackManagerImpl>::DoInit();
     SuccessOrExit(err);
-    err = GenericThreadStackManagerImpl_OpenThread_LwIP<ThreadStackManagerImpl>::DoInit(otInst);
+    err = GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>::DoInit(otInst);
     SuccessOrExit(err);
 
 exit:

--- a/src/platform/qpg/ThreadStackManagerImpl.h
+++ b/src/platform/qpg/ThreadStackManagerImpl.h
@@ -25,7 +25,7 @@
 #pragma once
 
 #include <platform/FreeRTOS/GenericThreadStackManagerImpl_FreeRTOS.h>
-#include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.h>
+#include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h>
 
 #include <openthread/tasklet.h>
 #include <openthread/thread.h>
@@ -46,7 +46,7 @@ extern int GetEntropy(uint8_t * buf, size_t bufSize);
  * using the OpenThread stack.
  */
 class ThreadStackManagerImpl final : public ThreadStackManager,
-                                     public Internal::GenericThreadStackManagerImpl_OpenThread_LwIP<ThreadStackManagerImpl>,
+                                     public Internal::GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>,
                                      public Internal::GenericThreadStackManagerImpl_FreeRTOS<ThreadStackManagerImpl>
 {
     // Allow the ThreadStackManager interface class to delegate method calls to
@@ -57,7 +57,7 @@ class ThreadStackManagerImpl final : public ThreadStackManager,
     // this class.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
     friend Internal::GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>;
-    friend Internal::GenericThreadStackManagerImpl_OpenThread_LwIP<ThreadStackManagerImpl>;
+    friend Internal::GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>;
     friend Internal::GenericThreadStackManagerImpl_FreeRTOS<ThreadStackManagerImpl>;
 #endif
 

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -142,6 +142,9 @@ source_set("system_config_header") {
       if (chip_device_platform == "efr32") {
         public_deps += [ "${efr32_sdk_build_root}:efr32_sdk" ]
       }
+      if (chip_device_platform == "qpg") {
+        public_deps += [ "${qpg_sdk_build_root}:qpg_sdk" ]
+      }
       # Add platform here as needed.
     }
   }

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -145,6 +145,7 @@ source_set("system_config_header") {
       if (chip_device_platform == "qpg") {
         public_deps += [ "${qpg_sdk_build_root}:qpg_sdk" ]
       }
+
       # Add platform here as needed.
     }
   }

--- a/third_party/qpg_sdk/qpg_sdk.gni
+++ b/third_party/qpg_sdk/qpg_sdk.gni
@@ -99,7 +99,10 @@ template("qpg_sdk") {
     cflags = []
 
     # Allow warning due to mbedtls
-    cflags += [ "-Wno-maybe-uninitialized" ]
+    cflags += [
+      "-Wno-maybe-uninitialized",
+      "-Wno-shadow",
+    ]
 
     if (defined(invoker.defines)) {
       defines += invoker.defines


### PR DESCRIPTION
#### Problem
* Fixes #17404 to re-enable the check_system_includes during build tests

#### Change overview
* System include testing is activated again
* Remove LwIP usage. Use OpenThread endpoint implementation instead.

#### Testing
How was this tested? (at least one bullet point required)
* Manual build test
* Manual functional testing of the lighting and shell application