### PR TITLE
[System] Rename SystemLayer to Make abstraction of IP Lib

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
@@ -175,7 +175,7 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_RunEventLoop(void)
 
                 // Call into the system layer to dispatch the callback functions for all timers
                 // that have expired.
-                err = static_cast<System::LayerImplLwIP &>(DeviceLayer::SystemLayer()).HandlePlatformTimer();
+                err = static_cast<System::LayerImplFreeRTOS &>(DeviceLayer::SystemLayer()).HandlePlatformTimer();
                 if (err != CHIP_NO_ERROR)
                 {
                     ChipLogError(DeviceLayer, "Error handling CHIP timers: %s", ErrorStr(err));

--- a/src/inet/TCPEndPointImplLwIP.cpp
+++ b/src/inet/TCPEndPointImplLwIP.cpp
@@ -991,8 +991,8 @@ void TCPEndPointImplLwIP::LwIPHandleError(void * arg, err_t lwipErr)
 {
     if (arg != NULL)
     {
-        TCPEndPointImplLwIP * ep         = static_cast<TCPEndPointImplLwIP *>(arg);
-        System::LayerLwIP & lSystemLayer = static_cast<System::LayerLwIP &>(ep->GetSystemLayer());
+        TCPEndPointImplLwIP * ep             = static_cast<TCPEndPointImplLwIP *>(arg);
+        System::LayerFreeRTOS & lSystemLayer = static_cast<System::LayerFreeRTOS &>(ep->GetSystemLayer());
 
         // At this point LwIP has already freed the PCB.  Since the thread that owns the TCPEndPoint may
         // try to use the PCB before it receives the TCPError event posted below, we set the PCB to NULL

--- a/src/platform/CYW30739/PlatformManagerImpl.cpp
+++ b/src/platform/CYW30739/PlatformManagerImpl.cpp
@@ -193,7 +193,7 @@ void PlatformManagerImpl::SetEventFlags(uint32_t flags)
 
 void PlatformManagerImpl::HandleTimerEvent(void)
 {
-    const CHIP_ERROR err = static_cast<System::LayerImplLwIP &>(DeviceLayer::SystemLayer()).HandlePlatformTimer();
+    const CHIP_ERROR err = static_cast<System::LayerImplFreeRTOS &>(DeviceLayer::SystemLayer()).HandlePlatformTimer();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "HandlePlatformTimer %ld", err.AsInteger());

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -58,7 +58,7 @@ using TimerCompleteCallback = void (*)(Layer * aLayer, void * appState);
  *
  * The abstract class hierarchy is:
  * - Layer: Core timer methods.
- *   - LayerLwIP: Adds methods specific to CHIP_SYSTEM_CONFIG_USING_LWIP.
+ *   - LayerFreeRTOS: Adds methods specific to CHIP_SYSTEM_CONFIG_USING_LWIP and CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT.
  *   - LayerSockets: Adds I/O event methods specific to CHIP_SYSTEM_CONFIG_USING_SOCKETS.
  *     - LayerSocketsLoop: Adds methods for event-loop-based implementations.
  *
@@ -174,7 +174,7 @@ private:
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 
-class LayerLwIP : public Layer
+class LayerFreeRTOS : public Layer
 {
 };
 

--- a/src/system/SystemLayerImplFreeRTOS.cpp
+++ b/src/system/SystemLayerImplFreeRTOS.cpp
@@ -18,21 +18,21 @@
 
 /**
  *    @file
- *      This file implements LayerImplLwIP using LwIP.
+ *      This file implements LayerImplFreeRTOS. Used by LwIP implementation and OpenThread
  */
 
 #include <lib/support/CodeUtils.h>
 #include <system/PlatformEventSupport.h>
 #include <system/SystemFaultInjection.h>
 #include <system/SystemLayer.h>
-#include <system/SystemLayerImplLwIP.h>
+#include <system/SystemLayerImplFreeRTOS.h>
 
 namespace chip {
 namespace System {
 
-LayerImplLwIP::LayerImplLwIP() : mHandlingTimerComplete(false) {}
+LayerImplFreeRTOS::LayerImplFreeRTOS() : mHandlingTimerComplete(false) {}
 
-CHIP_ERROR LayerImplLwIP::Init()
+CHIP_ERROR LayerImplFreeRTOS::Init()
 {
     VerifyOrReturnError(mLayerState.SetInitializing(), CHIP_ERROR_INCORRECT_STATE);
 
@@ -44,13 +44,13 @@ CHIP_ERROR LayerImplLwIP::Init()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR LayerImplLwIP::Shutdown()
+CHIP_ERROR LayerImplFreeRTOS::Shutdown()
 {
     VerifyOrReturnError(mLayerState.ResetFromInitialized(), CHIP_ERROR_INCORRECT_STATE);
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR LayerImplLwIP::StartTimer(Clock::Timeout delay, TimerCompleteCallback onComplete, void * appState)
+CHIP_ERROR LayerImplFreeRTOS::StartTimer(Clock::Timeout delay, TimerCompleteCallback onComplete, void * appState)
 {
     VerifyOrReturnError(mLayerState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 
@@ -74,7 +74,7 @@ CHIP_ERROR LayerImplLwIP::StartTimer(Clock::Timeout delay, TimerCompleteCallback
     return CHIP_NO_ERROR;
 }
 
-void LayerImplLwIP::CancelTimer(TimerCompleteCallback onComplete, void * appState)
+void LayerImplFreeRTOS::CancelTimer(TimerCompleteCallback onComplete, void * appState)
 {
     VerifyOrReturn(mLayerState.IsInitialized());
 
@@ -85,7 +85,7 @@ void LayerImplLwIP::CancelTimer(TimerCompleteCallback onComplete, void * appStat
     }
 }
 
-CHIP_ERROR LayerImplLwIP::ScheduleWork(TimerCompleteCallback onComplete, void * appState)
+CHIP_ERROR LayerImplFreeRTOS::ScheduleWork(TimerCompleteCallback onComplete, void * appState)
 {
     VerifyOrReturnError(mLayerState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 
@@ -98,7 +98,7 @@ CHIP_ERROR LayerImplLwIP::ScheduleWork(TimerCompleteCallback onComplete, void * 
 /**
  * Start the platform timer with specified millsecond duration.
  */
-CHIP_ERROR LayerImplLwIP::StartPlatformTimer(System::Clock::Timeout aDelay)
+CHIP_ERROR LayerImplFreeRTOS::StartPlatformTimer(System::Clock::Timeout aDelay)
 {
     VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
     CHIP_ERROR status = PlatformEventing::StartTimer(*this, aDelay);
@@ -120,7 +120,7 @@ CHIP_ERROR LayerImplLwIP::StartPlatformTimer(System::Clock::Timeout aDelay)
  *  @return CHIP_NO_ERROR on success, error code otherwise.
  *
  */
-CHIP_ERROR LayerImplLwIP::HandlePlatformTimer()
+CHIP_ERROR LayerImplFreeRTOS::HandlePlatformTimer()
 {
     VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 

--- a/src/system/SystemLayerImplFreeRTOS.h
+++ b/src/system/SystemLayerImplFreeRTOS.h
@@ -17,7 +17,7 @@
 
 /**
  *    @file
- *      This file declares an implementation of LayerImplLwIP using LwIP.
+ *      This file declares an implementation of LayerImplFreeRTOS using LwIP.
  */
 
 #pragma once
@@ -29,11 +29,11 @@
 namespace chip {
 namespace System {
 
-class LayerImplLwIP : public LayerLwIP
+class LayerImplFreeRTOS : public LayerFreeRTOS
 {
 public:
-    LayerImplLwIP();
-    ~LayerImplLwIP() { VerifyOrDie(mLayerState.Destroy()); }
+    LayerImplFreeRTOS();
+    ~LayerImplFreeRTOS() { VerifyOrDie(mLayerState.Destroy()); }
 
     // Layer overrides.
     CHIP_ERROR Init() override;
@@ -58,7 +58,7 @@ private:
     ObjectLifeCycle mLayerState;
 };
 
-using LayerImpl = LayerImplLwIP;
+using LayerImpl = LayerImplFreeRTOS;
 
 } // namespace System
 } // namespace chip

--- a/src/system/system.gni
+++ b/src/system/system.gni
@@ -46,7 +46,7 @@ declare_args() {
   # Event loop type.
   if (chip_system_config_use_lwip ||
       chip_system_config_use_open_thread_inet_endpoints) {
-    chip_system_config_event_loop = "LwIP"
+    chip_system_config_event_loop = "FreeRTOS"
   } else {
     chip_system_config_event_loop = "Select"
   }

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -78,13 +78,13 @@ public:
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
 template <class LayerImpl>
-class LayerEvents<LayerImpl, typename std::enable_if<std::is_base_of<LayerImplLwIP, LayerImpl>::value>::type>
+class LayerEvents<LayerImpl, typename std::enable_if<std::is_base_of<LayerImplFreeRTOS, LayerImpl>::value>::type>
 {
 public:
     static bool HasServiceEvents() { return true; }
     static void ServiceEvents(Layer & aLayer)
     {
-        LayerImplLwIP & layer = static_cast<LayerImplLwIP &>(aLayer);
+        LayerImplFreeRTOS & layer = static_cast<LayerImplFreeRTOS &>(aLayer);
         if (layer.IsInitialized())
         {
             layer.HandlePlatformTimer();


### PR DESCRIPTION
#### Problem
The event loop for FreeRTOS LwIP/OpenThread implementation bear the name LwIP while having only a single line of code specific to the LwIP stack. This is misleading.

#### Change overview
Rename src/system/SystemLayerImplLwIP.cpp -> src/system/SystemLayerImplFreeRTOS.cpp

#### Testing
Simple renaming operation. Validated with Unit Test.