### PR TITLE
Fix test driver Build (MAC) + Enable a test on efr32 platform

### DIFF
--- a/scripts/python.json
+++ b/scripts/python.json
@@ -3,7 +3,7 @@
         {
             "path": "infra/3pp/tools/cpython3/${platform}",
             "platforms": ["mac-amd64", "windows-amd64"],
-            "tags": ["version:3.8.2.chromium.10"]
+            "tags": ["version:2@3.9.5.chromium.19"]
         },
         {
             "path": "fuchsia/third_party/cmake/${platform}",

--- a/src/credentials/BUILD.gn
+++ b/src/credentials/BUILD.gn
@@ -64,7 +64,8 @@ static_library("credentials") {
     sources += [ "${chip_root}/examples/platform/nxp/se05x/DeviceAttestationSe05xCredsExample.cpp" ]
   }
 
-  if (chip_device_platform == "esp32" || chip_device_platform == "nrfconnect") {
+  if (chip_device_platform == "esp32" || chip_device_platform == "nrfconnect" ||
+      chip_device_platform == "efr32") {
     defines = [ "CURRENT_TIME_NOT_IMPLEMENTED=1" ]
   }
 
@@ -89,7 +90,8 @@ static_library("default_attestation_verifier") {
     "attestation_verifier/DeviceAttestationDelegate.h",
   ]
 
-  if (chip_device_platform == "esp32" || chip_device_platform == "nrfconnect") {
+  if (chip_device_platform == "esp32" || chip_device_platform == "nrfconnect" ||
+      chip_device_platform == "efr32") {
     defines = [ "CURRENT_TIME_NOT_IMPLEMENTED=1" ]
   }
 

--- a/src/crypto/tests/BUILD.gn
+++ b/src/crypto/tests/BUILD.gn
@@ -24,6 +24,7 @@ chip_test_suite("tests") {
   sources = [
     "AES_CCM_128_test_vectors.h",
     "AES_CCM_256_test_vectors.h",
+    "CHIPCryptoPALTest.cpp",
     "DerSigConversion_test_vectors.h",
     "ECDH_P256_test_vectors.h",
     "HKDF_SHA256_test_vectors.h",
@@ -43,12 +44,8 @@ chip_test_suite("tests") {
     "TestCryptoLayer.h",
   ]
 
-  if (chip_device_platform != "efr32") {
-    # Removed on EFR32, using too much HEAP.
-    sources += [ "CHIPCryptoPALTest.cpp" ]
-  }
-
-  if (chip_device_platform == "esp32" || chip_device_platform == "nrfconnect") {
+  if (chip_device_platform == "esp32" || chip_device_platform == "nrfconnect" ||
+      chip_device_platform == "efr32") {
     defines = [ "CURRENT_TIME_NOT_IMPLEMENTED=1" ]
   }
 

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -1522,7 +1522,7 @@ void CheckGetBackoff(nlTestSuite * inSuite, void * inContext)
         {
             struct BackoffComplianceTestVector * test = &theBackoffComplianceTestVector[i];
             System::Clock::Timestamp backoff          = ReliableMessageMgr::GetBackoff(test->backoffBase, test->sendCount);
-            ChipLogProgress(Test, "Backoff # %d: %d", test->sendCount, (uint32_t) backoff.count());
+            ChipLogProgress(Test, "Backoff # %d: %" PRIu32, test->sendCount, (uint32_t) backoff.count());
 
             NL_TEST_ASSERT(inSuite, backoff >= test->backoffMin);
             NL_TEST_ASSERT(inSuite, backoff <= test->backoffMax);

--- a/src/pybindings/pycontroller/BUILD.gn
+++ b/src/pybindings/pycontroller/BUILD.gn
@@ -46,7 +46,7 @@ shared_library("CHIPController") {
   include_dirs = [ "${chip_root}/third_party/pybind11/repo/include" ]
   if (current_os == "mac") {
     include_dirs +=
-        [ "${chip_root}/.environment/cipd/packages/python/include/python3.8" ]
+        [ "${chip_root}/.environment/cipd/packages/python/include/python3.9" ]
   } else if (current_os == "linux") {
     include_dirs += [ "/usr/include/python3.9" ]
   } else {

--- a/src/test_driver/efr32/include/FreeRTOSConfig.h
+++ b/src/test_driver/efr32/include/FreeRTOSConfig.h
@@ -237,7 +237,7 @@ See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 #define configENABLE_BACKWARD_COMPATIBILITY (1)
 #define configSUPPORT_STATIC_ALLOCATION (1)
 #define configSUPPORT_DYNAMIC_ALLOCATION (1)
-#define configTOTAL_HEAP_SIZE ((size_t)(16 * 1024))
+#define configTOTAL_HEAP_SIZE ((size_t)(20 * 1024))
 
 /* Optional functions - most linkers will remove unused functions anyway. */
 #define INCLUDE_vTaskPrioritySet (1)


### PR DESCRIPTION
#### Problem
Test driver is not building on MAC. 

#### Change overview
Install/use python 3.9 for mac and windows as pigweed now uses some 3.9 modules
Enable `CHIPCryptoPALTest` on efr32 test driver

#### Testing
Build test-driver for efr32 and run it with success

