### PR TITLE
Make PacketBufferHandle::Get private again.

### DIFF
--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -651,8 +651,6 @@ public:
 #endif
     }
 
-    PacketBuffer * Get() const { return mBuffer; }
-
 protected:
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     // For use via LwIPPacketBufferView only.
@@ -678,6 +676,8 @@ private:
         }
         return PacketBufferHandle(buffer);
     }
+
+    PacketBuffer * Get() const { return mBuffer; }
 
     bool operator==(const PacketBufferHandle & aOther) { return mBuffer == aOther.mBuffer; }
 


### PR DESCRIPTION
People who need a raw buffer that they own should be calling
UnsafeRelease.  Get() should not have been made public.

#### Problem
The API that was made public in #17512 is too easy to misuse.

#### Change overview
Make it private again.

#### Testing
No behavior changes.