### PR TITLE
Rework CASESession state machine, manage its lifespan

### DIFF
--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -37,7 +37,6 @@
 #include <messaging/ExchangeDelegate.h>
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
-#include <protocols/secure_channel/CASESession.h>
 #include <system/SystemLayer.h>
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
@@ -143,6 +142,7 @@ public:
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablished(const SessionHandle & session) override;
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
+    void OnSessionEstablishmentDone(PairingSession * pairing) override;
 
     /**
      *   Called when a connection is closing.
@@ -247,7 +247,8 @@ private:
 
     // mCASEClient is only non-null if we are in State::Connecting or just
     // allocated it as part of an attempt to enter State::Connecting.
-    CASEClient * mCASEClient = nullptr;
+    CASEClient * mCASEClient    = nullptr;
+    CHIP_ERROR mCASEClientError = CHIP_NO_ERROR;
 
     PeerId mPeerId;
 

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -86,6 +86,7 @@ public:
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
     void OnSessionEstablishmentStarted() override;
     void OnSessionEstablished(const SessionHandle & session) override;
+    void OnSessionEstablishmentDone(PairingSession * pairing) override {} // TODO: manage PASESession lifespan
 
     void Shutdown();
     void Cleanup();

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -460,6 +460,7 @@ public:
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
     void OnSessionEstablished(const SessionHandle & session) override;
+    void OnSessionEstablishmentDone(PairingSession * pairing) override {} // TODO: manage CASESession lifespan
 
     void RendezvousCleanup(CHIP_ERROR status);
 

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -46,76 +46,51 @@ CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager 
     mExchangeManager          = exchangeManager;
     mGroupDataProvider        = responderGroupDataProvider;
 
-    Cleanup();
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR CASEServer::InitCASEHandshake(Messaging::ExchangeContext * ec)
-{
-    ReturnErrorCodeIf(ec == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-
-    // Setup CASE state machine using the credentials for the current fabric.
-    GetSession().SetGroupDataProvider(mGroupDataProvider);
-    ReturnErrorOnFailure(
-        GetSession().ListenForSessionEstablishment(*mSessionManager, mFabrics, mSessionResumptionStorage, this,
-                                                   Optional<ReliableMessageProtocolConfig>::Value(GetLocalMRPConfig())));
-
-    // Hand over the exchange context to the CASE session.
-    ec->SetDelegate(&GetSession());
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR CASEServer::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate)
-{
-    // TODO: assign newDelegate to CASESession, let CASESession handle future messages.
-    newDelegate = this;
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR CASEServer::OnMessageReceived(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
-                                         System::PacketBufferHandle && payload)
-{
-    ChipLogProgress(Inet, "CASE Server received Sigma1 message. Starting handshake. EC %p", ec);
-    CHIP_ERROR err = InitCASEHandshake(ec);
-    SuccessOrExit(err);
-
-    // TODO - Enable multiple concurrent CASE session establishment
-    // https://github.com/project-chip/connectedhomeip/issues/8342
-    ChipLogProgress(Inet, "CASE Server disabling CASE session setups");
-    mExchangeManager->UnregisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_Sigma1);
-
-    err = GetSession().OnMessageReceived(ec, payloadHeader, std::move(payload));
-    SuccessOrExit(err);
-
-exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        Cleanup();
-    }
-    return err;
-}
-
-void CASEServer::Cleanup()
-{
-    // Let's re-register for CASE Sigma1 message, so that the next CASE session setup request can be processed.
-    // https://github.com/project-chip/connectedhomeip/issues/8342
     ChipLogProgress(Inet, "CASE Server enabling CASE session setups");
     mExchangeManager->RegisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_Sigma1, this);
+    return CHIP_NO_ERROR;
+}
 
-    GetSession().Clear();
+CHIP_ERROR CASEServer::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, Messaging::ExchangeDelegate *& newDelegate)
+{
+    if (mPairingSession.HasValue())
+        return CHIP_ERROR_NO_MEMORY;
+
+    CASESession * session = &mPairingSession.Emplace();
+
+    ChipLogProgress(Inet, "CASE Server allocated pairing: %p", session);
+    // Setup CASE state machine using the credentials for the current fabric.
+    session->SetGroupDataProvider(mGroupDataProvider);
+    ReturnErrorOnFailure(
+        session->ListenForSessionEstablishment(*mSessionManager, mFabrics, mSessionResumptionStorage, this,
+                                               Optional<ReliableMessageProtocolConfig>::Value(GetLocalMRPConfig())));
+    newDelegate = session;
+
+    return CHIP_NO_ERROR;
+}
+
+void CASEServer::OnExchangeCreationFailed(Messaging::ExchangeDelegate * delegate)
+{
+    mPairingSession.ClearValue();
 }
 
 void CASEServer::OnSessionEstablishmentError(CHIP_ERROR err)
 {
     ChipLogError(Inet, "CASE Session establishment failed: %s", ErrorStr(err));
-    Cleanup();
 }
 
 void CASEServer::OnSessionEstablished(const SessionHandle & session)
 {
     ChipLogProgress(Inet, "CASE Session established to peer: " ChipLogFormatScopedNodeId,
                     ChipLogValueScopedNodeId(session->GetPeer()));
-    Cleanup();
 }
+
+void CASEServer::OnSessionEstablishmentDone(PairingSession * pairing)
+{
+    CASESession * session = static_cast<CASESession *>(pairing);
+    ChipLogProgress(Inet, "CASE Server releasing pairing: %p", session);
+    VerifyOrDie(mPairingSession.HasValue() && session == &mPairingSession.Value());
+    mPairingSession.ClearValue();
+}
+
 } // namespace chip

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -24,9 +24,7 @@
 
 namespace chip {
 
-class CASEServer : public SessionEstablishmentDelegate,
-                   public Messaging::UnsolicitedMessageHandler,
-                   public Messaging::ExchangeDelegate
+class CASEServer : public SessionEstablishmentDelegate, public Messaging::UnsolicitedMessageHandler
 {
 public:
     CASEServer() {}
@@ -46,31 +44,22 @@ public:
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
     void OnSessionEstablished(const SessionHandle & session) override;
+    void OnSessionEstablishmentDone(PairingSession * pairing) override;
 
     //// UnsolicitedMessageHandler Implementation ////
-    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override;
-
-    //// ExchangeDelegate Implementation ////
-    CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
-                                 System::PacketBufferHandle && payload) override;
-    void OnResponseTimeout(Messaging::ExchangeContext * ec) override {}
-    Messaging::ExchangeMessageDispatch & GetMessageDispatch() override { return GetSession().GetMessageDispatch(); }
-
-    virtual CASESession & GetSession() { return mPairingSession; }
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader,
+                                            Messaging::ExchangeDelegate *& newDelegate) override;
+    void OnExchangeCreationFailed(Messaging::ExchangeDelegate * delegate) override;
 
 private:
     Messaging::ExchangeManager * mExchangeManager        = nullptr;
     SessionResumptionStorage * mSessionResumptionStorage = nullptr;
 
-    CASESession mPairingSession;
+    Optional<CASESession> mPairingSession; // TOOD: use a pool to enable concurrent CASE session.
     SessionManager * mSessionManager = nullptr;
 
     FabricTable * mFabrics                              = nullptr;
     Credentials::GroupDataProvider * mGroupDataProvider = nullptr;
-
-    CHIP_ERROR InitCASEHandshake(Messaging::ExchangeContext * ec);
-
-    void Cleanup();
 };
 
 } // namespace chip

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -55,7 +55,7 @@ private:
     Messaging::ExchangeManager * mExchangeManager        = nullptr;
     SessionResumptionStorage * mSessionResumptionStorage = nullptr;
 
-    Optional<CASESession> mPairingSession; // TOOD: use a pool to enable concurrent CASE session.
+    Optional<CASESession> mPairingSession; // TODO: use a pool to enable concurrent CASE session.
     SessionManager * mSessionManager = nullptr;
 
     FabricTable * mFabrics                              = nullptr;

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -276,15 +276,15 @@ exit:
         mState = State::kError;
     }
     VerifyOrDie(SanityCheck());
-    // EstablishSession is a API from delegate side, so we don't call OnSessionEstablishmentDone here, the delegate awares the error
-    // by return value.
+    // EstablishSession is called by our delegate, so we don't call OnSessionEstablishmentDone here.  The delegate
+    // will be notified of errors via our return value.
     return err;
 }
 
 void CASESession::OnResponseTimeout(ExchangeContext * ec)
 {
     ChipLogError(SecureChannel, "CASESession timed out while waiting for a response from the peer. Current state was %u",
-                 static_cast<uint8_t>(mState));
+                 to_underlying(mState));
     AbortExchange();
     mState = State::kError;
     mDelegate->OnSessionEstablishmentError(CHIP_ERROR_TIMEOUT);
@@ -1742,7 +1742,7 @@ exit:
     if (err == CHIP_ERROR_INVALID_MESSAGE_TYPE)
     {
         ChipLogError(SecureChannel, "Received message (type %d) cannot be handled in %d state.", to_underlying(msgType),
-                     static_cast<uint8_t>(mState));
+                     to_underlying(mState));
     }
 
     if (err != CHIP_NO_ERROR)

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -204,9 +204,9 @@ private:
     CHIP_ERROR ValidateSigmaResumeMIC(const ByteSpan & resumeMIC, const ByteSpan & initiatorRandom, const ByteSpan & resumptionID,
                                       const ByteSpan & skInfo, const ByteSpan & nonce);
 
-    // For CASESession not leaked, after each action (OnMessageReceived/OnResponseTimeout), it must end with a state either the
-    // establishment is done, or waiting for a message from other side with response timer being set. This function ensure that we
-    // are indeed in such state, it is called and verifed after each action.
+    // For CASESession to not leak, after each action (OnMessageReceived/OnResponseTimeout), it must end with a state where either the
+    // establishment is done, or it's waiting for a message from other side with response timer being set. This function ensures that we
+    // are indeed in such state. It is called and verifed after each action.
     bool SanityCheck() const;
 
     void OnSuccessStatusReport() override;

--- a/src/protocols/secure_channel/SessionEstablishmentDelegate.h
+++ b/src/protocols/secure_channel/SessionEstablishmentDelegate.h
@@ -52,7 +52,7 @@ public:
     virtual void OnSessionEstablished(const SessionHandle & session) {}
 
     // Triggered when the PairingSession has done its work (either finished or encountered an error), such that the PairingSession
-    // object can be release, and so does other resources associated to it.
+    // object can be released, and so can other resources associated to it.
     virtual void OnSessionEstablishmentDone(PairingSession * pairing) = 0;
 };
 

--- a/src/protocols/secure_channel/SessionEstablishmentDelegate.h
+++ b/src/protocols/secure_channel/SessionEstablishmentDelegate.h
@@ -34,6 +34,8 @@ namespace chip {
 class DLL_EXPORT SessionEstablishmentDelegate
 {
 public:
+    virtual ~SessionEstablishmentDelegate() {}
+
     /**
      *   Called when session establishment fails with an error
      */
@@ -49,7 +51,9 @@ public:
      */
     virtual void OnSessionEstablished(const SessionHandle & session) {}
 
-    virtual ~SessionEstablishmentDelegate() {}
+    // Triggered when the PairingSession has done its work (either finished or encountered an error), such that the PairingSession
+    // object can be release, and so does other resources associated to it.
+    virtual void OnSessionEstablishmentDone(PairingSession * pairing) = 0;
 };
 
 } // namespace chip

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -81,6 +81,8 @@ public:
         mNumPairingComplete++;
     }
 
+    void OnSessionEstablishmentDone(PairingSession * pairing) override {}
+
     SessionHolder & GetSessionHolder() { return mSession; }
 
     SessionHolder mSession;
@@ -88,15 +90,6 @@ public:
     // TODO: Rename mNumPairing* to mNumEstablishment*
     uint32_t mNumPairingErrors   = 0;
     uint32_t mNumPairingComplete = 0;
-};
-
-class CASEServerForTest : public CASEServer
-{
-public:
-    CASESession & GetSession() override { return mCaseSession; }
-
-private:
-    CASESession mCaseSession;
 };
 
 CHIP_ERROR InitTestIpk(GroupDataProvider & groupDataProvider, const FabricInfo & fabricInfo, size_t numIpks)
@@ -256,32 +249,25 @@ void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inConte
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
     // Test all combinations of invalid parameters
-    TestCASESecurePairingDelegate delegateAccessory;
-    CASESession pairingAccessory;
-    SessionManager sessionManager;
+    CASEServer pairingAccessory;
 
     gLoopback.mSentMessageCount = 0;
-
-    NL_TEST_ASSERT(inSuite,
-                   ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_Sigma1,
-                                                                                     &pairingAccessory) == CHIP_NO_ERROR);
 
     ExchangeContext * contextCommissioner = ctx.NewUnauthenticatedExchangeToBob(&pairingCommissioner);
 
     FabricInfo * fabric = gCommissionerFabrics.FindFabricWithIndex(gCommissionerFabricIndex);
     NL_TEST_ASSERT(inSuite, fabric != nullptr);
 
-    pairingAccessory.SetGroupDataProvider(&gDeviceGroupDataProvider);
     NL_TEST_ASSERT(inSuite,
-                   pairingAccessory.ListenForSessionEstablishment(sessionManager, &gDeviceFabrics, nullptr, &delegateAccessory) ==
-                       CHIP_NO_ERROR);
+                   pairingAccessory.ListenForSessionEstablishment(&ctx.GetExchangeManager(), &ctx.GetTransportMgr(),
+                                                                  &ctx.GetSecureSessionManager(), &gDeviceFabrics, nullptr,
+                                                                  &gDeviceGroupDataProvider) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner.EstablishSession(sessionManager, fabric, Node01_01, contextCommissioner, nullptr,
-                                                        &delegateCommissioner) == CHIP_NO_ERROR);
+                   pairingCommissioner.EstablishSession(ctx.GetSecureSessionManager(), fabric, Node01_01, contextCommissioner,
+                                                        nullptr, &delegateCommissioner) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 5);
-    NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);
     NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
 }
 
@@ -293,13 +279,12 @@ void CASE_SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
     CASE_SecurePairingHandshakeTestCommon(inSuite, inContext, pairingCommissioner, delegateCommissioner);
 }
 
-CASEServerForTest gPairingServer;
-
 void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inContext)
 {
     // TODO: Add cases for mismatching IPK config between initiator/responder
 
     TestCASESecurePairingDelegate delegateCommissioner;
+    CASEServer gPairingServer;
 
     auto * pairingCommissioner = chip::Platform::New<CASESession>();
     pairingCommissioner->SetGroupDataProvider(&gCommissionerGroupDataProvider);

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -92,8 +92,8 @@ class TestSecurePairingDelegate : public SessionEstablishmentDelegate
 {
 public:
     void OnSessionEstablishmentError(CHIP_ERROR error) override { mNumPairingErrors++; }
-
     void OnSessionEstablished(const SessionHandle & session) override { mNumPairingComplete++; }
+    void OnSessionEstablishmentDone(PairingSession * pairing) override {}
 
     uint32_t mNumPairingErrors   = 0;
     uint32_t mNumPairingComplete = 0;


### PR DESCRIPTION
#### Problem
Prepare for concurrent CASE session

#### Change overview
* Rework on the state machine of CASE session class
* Remove `CASESession::Clear`, always create a new object instead of reusing the old one.
* Add a new callback `SessionEstablishmentDelegate::OnSessionEstablishmentDone` to indicate that the pairing has done its work and can be safely released. 

Extracted from #17448

#### Testing
Passed unit-tests.