### PR TITLE
Fix SimpleSessionResumptionStorage Save/Load index

### DIFF
--- a/src/protocols/secure_channel/SimpleSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/SimpleSessionResumptionStorage.cpp
@@ -57,7 +57,7 @@ CHIP_ERROR SimpleSessionResumptionStorage::SaveIndex(const SessionIndex & index)
     TLV::TLVType arrayType;
     ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, arrayType));
 
-    for (size_t i = index.mSize; i < index.mSize; ++i)
+    for (size_t i = 0; i < index.mSize; ++i)
     {
         TLV::TLVType innerType;
         ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, innerType));
@@ -83,7 +83,11 @@ CHIP_ERROR SimpleSessionResumptionStorage::LoadIndex(SessionIndex & index)
     uint16_t len = static_cast<uint16_t>(buf.size());
 
     DefaultStorageKeyAllocator keyAlloc;
-    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(keyAlloc.SessionResumptionIndex(), buf.data(), len));
+    if (mStorage->SyncGetKeyValue(keyAlloc.SessionResumptionIndex(), buf.data(), len) != CHIP_NO_ERROR)
+    {
+        index.mSize = 0;
+        return CHIP_NO_ERROR;
+    }
 
     TLV::ContiguousBufferTLVReader reader;
     reader.Init(buf.data(), len);

--- a/src/protocols/secure_channel/tests/TestSimpleSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/tests/TestSimpleSessionResumptionStorage.cpp
@@ -87,6 +87,10 @@ void TestIndex(nlTestSuite * inSuite, void * inContext)
 
     chip::ScopedNodeId node(node1, fabric1);
 
+    chip::SessionResumptionStorage::SessionIndex index0o;
+    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == sessionStorage.LoadIndex(index0o));
+    NL_TEST_ASSERT(inSuite, index0o.mSize == 0);
+
     chip::SessionResumptionStorage::SessionIndex index1;
     index1.mSize = 0;
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == sessionStorage.SaveIndex(index1));
@@ -116,6 +120,7 @@ static const nlTest sTests[] =
 {
     NL_TEST_DEF("TestLink", TestLink),
     NL_TEST_DEF("TestState", TestState),
+    NL_TEST_DEF("TestIndex", TestState),
 
     NL_TEST_SENTINEL()
 };


### PR DESCRIPTION
#### Problem
Fixes #17438

#### Change overview
* Fix `SimpleSessionResumptionStorage::SaveIndex` and `LoadIndex`
* Added unit tests for it

#### Testing
Added unit-tests for the error case