### PR TITLE
[CI] Allow SystemCommands cluster Start and Reboot commands to take optional parameters

### DIFF
--- a/src/app/tests/suites/TestSystemCommands.yaml
+++ b/src/app/tests/suites/TestSystemCommands.yaml
@@ -31,19 +31,76 @@ tests:
     - label: "Stop the accessory"
       command: "Stop"
 
-    - label: "Start the accessory with a given discriminator"
+    - label: "Start the accessory with no command line options"
+      command: "Start"
+
+    - label: "Stop the accessory"
+      command: "Stop"
+
+    - label: "Start the accessory with only discriminator command line option"
       command: "Start"
       arguments:
           values:
               - name: "discriminator"
                 value: 1111
 
-    - label: "Reboot the accessory with an other given discriminator"
+    - label: "Stop the accessory"
+      command: "Stop"
+
+    - label:
+          "Start the accessory with discriminator and port command line option"
+      command: "Start"
+      arguments:
+          values:
+              - name: "discriminator"
+                value: 1111
+              - name: "port"
+                value: 5560
+
+    - label: "Stop the accessory"
+      command: "Stop"
+
+    - label: "Start the accessory with all command line options"
+      command: "Start"
+      arguments:
+          values:
+              - name: "discriminator"
+                value: 1111
+              - name: "port"
+                value: 5560
+              - name: "kvs"
+                value: "/tmp/chip_kvs_test"
+
+    - label: "Reboot the accessory with no command line options"
+      command: "Reboot"
+
+    - label: "Reboot the accessory with only discriminator command line option"
       command: "Reboot"
       arguments:
           values:
               - name: "discriminator"
                 value: 2222
+
+    - label:
+          "Reboot the accessory with discriminator and port command line option"
+      command: "Reboot"
+      arguments:
+          values:
+              - name: "discriminator"
+                value: 2222
+              - name: "port"
+                value: 5565
+
+    - label: "Reboot the accessory with all command line options"
+      command: "Reboot"
+      arguments:
+          values:
+              - name: "discriminator"
+                value: 2222
+              - name: "port"
+                value: 5565
+              - name: "kvs"
+                value: "/tmp/chip_kvs_test"
 
     - label: "Factory Reset the accessory"
       command: "FactoryReset"

--- a/src/app/tests/suites/commands/system/SystemCommands.cpp
+++ b/src/app/tests/suites/commands/system/SystemCommands.cpp
@@ -16,6 +16,8 @@
  *
  */
 
+#include <lib/support/StringBuilder.h>
+
 #include "SystemCommands.h"
 
 namespace {
@@ -26,14 +28,15 @@ const char * getScriptsFolder()
 }
 } // namespace
 
-CHIP_ERROR SystemCommands::Start(uint16_t discriminator)
+constexpr size_t kCommandMaxLen = 256;
+
+CHIP_ERROR SystemCommands::Start(uint16_t discriminator, uint16_t port, const char * kvs)
 {
     const char * scriptDir            = getScriptsFolder();
     constexpr const char * scriptName = "Start.py";
 
-    char command[128];
-    VerifyOrReturnError(snprintf(command, sizeof(command), "%s%s --discriminator %u", scriptDir, scriptName, discriminator) >= 0,
-                        CHIP_ERROR_INTERNAL);
+    char command[kCommandMaxLen];
+    ReturnErrorOnFailure(CreateCommonCommandArgs(command, sizeof(command), scriptDir, scriptName, discriminator, port, kvs));
     return RunInternal(command);
 }
 
@@ -47,14 +50,13 @@ CHIP_ERROR SystemCommands::Stop()
     return RunInternal(command);
 }
 
-CHIP_ERROR SystemCommands::Reboot(uint16_t discriminator)
+CHIP_ERROR SystemCommands::Reboot(uint16_t discriminator, uint16_t port, const char * kvs)
 {
     const char * scriptDir            = getScriptsFolder();
     constexpr const char * scriptName = "Reboot.py";
 
-    char command[128];
-    VerifyOrReturnError(snprintf(command, sizeof(command), "%s%s --discriminator %u", scriptDir, scriptName, discriminator) >= 0,
-                        CHIP_ERROR_INTERNAL);
+    char command[kCommandMaxLen];
+    ReturnErrorOnFailure(CreateCommonCommandArgs(command, sizeof(command), scriptDir, scriptName, discriminator, port, kvs));
     return RunInternal(command);
 }
 
@@ -72,4 +74,33 @@ CHIP_ERROR SystemCommands::RunInternal(const char * command)
 {
     VerifyOrReturnError(system(command) == 0, CHIP_ERROR_INTERNAL);
     return ContinueOnChipMainThread(CHIP_NO_ERROR);
+}
+
+CHIP_ERROR SystemCommands::CreateCommonCommandArgs(char * commandBuffer, size_t commandBufferSize, const char * scriptDir,
+                                                   const char * scriptName, uint16_t discriminator, uint16_t port, const char * kvs)
+{
+    chip::StringBuilder<kCommandMaxLen> builder;
+    builder.Add(scriptDir);
+    builder.Add(scriptName);
+
+    // Add any applicable optional command line options
+    if (discriminator != 0xFFFF)
+    {
+        builder.Add(" --discriminator ");
+        builder.Add(discriminator);
+    }
+    if (port != CHIP_PORT)
+    {
+        builder.Add(" --secured-device-port ");
+        builder.Add(port);
+    }
+    if (kvs != nullptr)
+    {
+        builder.Add(" --KVS ");
+        builder.Add(kvs);
+    }
+    VerifyOrReturnError(builder.Fit(), CHIP_ERROR_BUFFER_TOO_SMALL);
+    strncpy(commandBuffer, builder.c_str(), commandBufferSize);
+
+    return CHIP_NO_ERROR;
 }

--- a/src/app/tests/suites/commands/system/SystemCommands.h
+++ b/src/app/tests/suites/commands/system/SystemCommands.h
@@ -28,11 +28,13 @@ public:
 
     virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) = 0;
 
-    CHIP_ERROR Start(uint16_t discriminator);
+    CHIP_ERROR Start(uint16_t discriminator = 0xFFFF, uint16_t port = CHIP_PORT, const char * kvs = nullptr);
     CHIP_ERROR Stop();
-    CHIP_ERROR Reboot(uint16_t discriminator);
+    CHIP_ERROR Reboot(uint16_t discriminator = 0xFFFF, uint16_t port = CHIP_PORT, const char * kvs = nullptr);
     CHIP_ERROR FactoryReset();
 
 private:
     CHIP_ERROR RunInternal(const char * command);
+    CHIP_ERROR CreateCommonCommandArgs(char * commandBuffer, size_t commandBufferSize, const char * scriptDir,
+                                       const char * scriptName, uint16_t discriminator, uint16_t port, const char * kvs);
 };

--- a/src/app/zap-templates/common/simulated-clusters/clusters/SystemCommands.js
+++ b/src/app/zap-templates/common/simulated-clusters/clusters/SystemCommands.js
@@ -26,7 +26,10 @@
 
 const Start = {
   name : 'Start',
-  arguments : [ { 'name' : 'discriminator', type : 'INT16U' } ],
+  arguments : [
+    { 'name' : 'discriminator', type : 'INT16U', isOptional : true }, { 'name' : 'port', type : 'INT16U', isOptional : true },
+    { 'name' : 'kvs', type : 'CHAR_STRING', isOptional : true }
+  ],
   response : { arguments : [] }
 };
 
@@ -38,7 +41,10 @@ const Stop = {
 
 const Reboot = {
   name : 'Reboot',
-  arguments : [ { 'name' : 'discriminator', type : 'INT16U' } ],
+  arguments : [
+    { 'name' : 'discriminator', type : 'INT16U', isOptional : true }, { 'name' : 'port', type : 'INT16U', isOptional : true },
+    { 'name' : 'kvs', type : 'CHAR_STRING', isOptional : true }
+  ],
   response : { arguments : [] }
 };
 


### PR DESCRIPTION
#### Problem
The `start` function in test_definition.py can take a dictionary which indicates the command line arguments to be used to launch an application. The `Start` and `Reboot` commands of SystemCommands cluster calls into the `start` function and should therefore make the parameters optional.

#### Change overview
- Added the typical optional parameters to `Start` and `Reboot`: discriminator, secured-device-port, and KVS
- Made the parameters optional (defaults to some value if one is not specified in the yaml file)
- Added extra test cases to TestSystemCommands.yaml

#### Testing
- Ran TestSystemCommands.yaml successfully and verified that the command line options are set accordingly
