### PR TITLE
DeviceProxy/OperationalDeviceProxy/CommissioneeDeviceProxy clean up unused codes

### DIFF
--- a/src/app/CASEClient.cpp
+++ b/src/app/CASEClient.cpp
@@ -21,17 +21,18 @@ namespace chip {
 
 CASEClient::CASEClient(const CASEClientInitParams & params) : mInitParams(params) {}
 
-void CASEClient::SetMRPIntervals(const ReliableMessageProtocolConfig & mrpConfig)
+void CASEClient::SetRemoteMRPIntervals(const ReliableMessageProtocolConfig & remoteMRPConfig)
 {
-    mCASESession.SetRemoteMRPConfig(mrpConfig);
+    mCASESession.SetRemoteMRPConfig(remoteMRPConfig);
 }
 
 CHIP_ERROR CASEClient::EstablishSession(PeerId peer, const Transport::PeerAddress & peerAddress,
-                                        const ReliableMessageProtocolConfig & mrpConfig, SessionEstablishmentDelegate * delegate)
+                                        const ReliableMessageProtocolConfig & remoteMRPConfig,
+                                        SessionEstablishmentDelegate * delegate)
 {
     // Create a UnauthenticatedSession for CASE pairing.
     // Don't use mSecureSession here, because mSecureSession is for encrypted communication.
-    Optional<SessionHandle> session = mInitParams.sessionManager->CreateUnauthenticatedSession(peerAddress, mrpConfig);
+    Optional<SessionHandle> session = mInitParams.sessionManager->CreateUnauthenticatedSession(peerAddress, remoteMRPConfig);
     VerifyOrReturnError(session.HasValue(), CHIP_ERROR_NO_MEMORY);
 
     // Allocate the exchange immediately before calling CASESession::EstablishSession.

--- a/src/app/CASEClient.h
+++ b/src/app/CASEClient.h
@@ -45,10 +45,10 @@ class DLL_EXPORT CASEClient
 public:
     CASEClient(const CASEClientInitParams & params);
 
-    void SetMRPIntervals(const ReliableMessageProtocolConfig & mrpConfig);
+    void SetRemoteMRPIntervals(const ReliableMessageProtocolConfig & remoteMRPConfig);
 
     CHIP_ERROR EstablishSession(PeerId peer, const Transport::PeerAddress & peerAddress,
-                                const ReliableMessageProtocolConfig & mrpConfig, SessionEstablishmentDelegate * delegate);
+                                const ReliableMessageProtocolConfig & remoteMRPConfig, SessionEstablishmentDelegate * delegate);
 
 private:
     CASEClientInitParams mInitParams;

--- a/src/app/DeviceProxy.h
+++ b/src/app/DeviceProxy.h
@@ -47,8 +47,6 @@ public:
 
     virtual NodeId GetDeviceId() const = 0;
 
-    virtual bool GetAddress(Inet::IPAddress & addr, uint16_t & port) const { return false; }
-
     virtual CHIP_ERROR ShutdownSubscriptions() { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
     virtual CHIP_ERROR SendCommands(app::CommandSender * commandObj, chip::Optional<System::Clock::Timeout> timeout = NullOptional);
@@ -57,18 +55,14 @@ public:
 
     virtual chip::Optional<SessionHandle> GetSecureSession() const = 0;
 
-    virtual bool IsActive() const { return true; }
-
     virtual CHIP_ERROR SetPeerId(ByteSpan rcac, ByteSpan noc) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
-    const ReliableMessageProtocolConfig & GetMRPConfig() const { return mMRPConfig; }
+    const ReliableMessageProtocolConfig & GetRemoteMRPConfig() const { return mRemoteMRPConfig; }
 
 protected:
     virtual bool IsSecureConnected() const = 0;
 
-    virtual uint8_t GetNextSequenceNumber() = 0;
-
-    ReliableMessageProtocolConfig mMRPConfig = GetLocalMRPConfig();
+    ReliableMessageProtocolConfig mRemoteMRPConfig = GetLocalMRPConfig();
 };
 
 } // namespace chip

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -162,13 +162,13 @@ CHIP_ERROR OperationalDeviceProxy::UpdateDeviceData(const Transport::PeerAddress
     CHIP_ERROR err = CHIP_NO_ERROR;
     mDeviceAddress = addr;
 
-    mMRPConfig = config;
+    mRemoteMRPConfig = config;
 
     // Initialize CASE session state with any MRP parameters that DNS-SD has provided.
     // It can be overridden by CASE session protocol messages that include MRP parameters.
     if (mCASEClient)
     {
-        mCASEClient->SetMRPIntervals(mMRPConfig);
+        mCASEClient->SetRemoteMRPIntervals(mRemoteMRPConfig);
     }
 
     if (mState == State::NeedsAddress)
@@ -197,18 +197,6 @@ CHIP_ERROR OperationalDeviceProxy::UpdateDeviceData(const Transport::PeerAddress
     return err;
 }
 
-bool OperationalDeviceProxy::GetAddress(Inet::IPAddress & addr, uint16_t & port) const
-{
-    if (mState == State::Uninitialized || mState == State::NeedsAddress)
-    {
-        return false;
-    }
-
-    addr = mDeviceAddress.GetIPAddress();
-    port = mDeviceAddress.GetPort();
-    return true;
-}
-
 CHIP_ERROR OperationalDeviceProxy::EstablishConnection()
 {
     mCASEClient = mInitParams.clientPool->Allocate(
@@ -216,7 +204,7 @@ CHIP_ERROR OperationalDeviceProxy::EstablishConnection()
                               mFabricInfo, mInitParams.groupDataProvider, mInitParams.mrpLocalConfig });
     ReturnErrorCodeIf(mCASEClient == nullptr, CHIP_ERROR_NO_MEMORY);
 
-    CHIP_ERROR err = mCASEClient->EstablishSession(mPeerId, mDeviceAddress, mMRPConfig, this);
+    CHIP_ERROR err = mCASEClient->EstablishSession(mPeerId, mDeviceAddress, mRemoteMRPConfig, this);
     if (err != CHIP_NO_ERROR)
     {
         CleanupCASEClient();

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -154,7 +154,7 @@ public:
     {
         mDeviceAddress = ToPeerAddress(nodeResolutionData);
 
-        mMRPConfig = nodeResolutionData.GetMRPConfig();
+        mRemoteMRPConfig = nodeResolutionData.GetMRPConfig();
 
         if (mState == State::NeedsAddress)
         {
@@ -181,15 +181,11 @@ public:
 
     bool MatchesSession(const SessionHandle & session) const { return mSecureSession.Contains(session); }
 
-    uint8_t GetNextSequenceNumber() override { return mSequenceNumber++; };
-
     CHIP_ERROR ShutdownSubscriptions() override;
 
     Messaging::ExchangeManager * GetExchangeManager() const override { return mInitParams.exchangeMgr; }
 
     chip::Optional<SessionHandle> GetSecureSession() const override { return mSecureSession.ToOptional(); }
-
-    bool GetAddress(Inet::IPAddress & addr, uint16_t & port) const override;
 
     Transport::PeerAddress GetPeerAddress() const { return mDeviceAddress; }
 
@@ -258,8 +254,6 @@ private:
     State mState = State::Uninitialized;
 
     SessionHolderWithDelegate mSecureSession;
-
-    uint8_t mSequenceNumber = 0;
 
     Callback::CallbackDeque mConnectionSuccess;
     Callback::CallbackDeque mConnectionFailure;

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -279,6 +279,15 @@ private:
     CHIP_ERROR ProcessControllerNOCChain(const ControllerInitParams & params);
 };
 
+#if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
+using UdcTransportMgr = TransportMgr<Transport::UDP /* IPv6 */
+#if INET_CONFIG_ENABLE_IPV4
+                                     ,
+                                     Transport::UDP /* IPv4 */
+#endif
+                                     >;
+#endif
+
 /**
  * @brief
  *   The commissioner applications can use this class to pair new/unpaired CHIP devices. The application is
@@ -579,8 +588,8 @@ private:
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY // make this commissioner discoverable
     UserDirectedCommissioningServer * mUdcServer = nullptr;
     // mUdcTransportMgr is for insecure communication (ex. user directed commissioning)
-    DeviceIPTransportMgr * mUdcTransportMgr = nullptr;
-    uint16_t mUdcListenPort                 = CHIP_UDC_PORT;
+    UdcTransportMgr * mUdcTransportMgr = nullptr;
+    uint16_t mUdcListenPort            = CHIP_UDC_PORT;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
     CHIP_ERROR LoadKeyId(PersistentStorageDelegate * delegate, uint16_t & out);

--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -72,11 +72,11 @@ CHIP_ERROR CommissioneeDeviceProxy::UpdateDeviceData(const Transport::PeerAddres
 {
     mDeviceAddress = addr;
 
-    mMRPConfig = config;
+    mRemoteMRPConfig = config;
 
     // Initialize PASE session state with any MRP parameters that DNS-SD has provided.
     // It can be overridden by PASE session protocol messages that include MRP parameters.
-    mPairing.SetRemoteMRPConfig(mMRPConfig);
+    mPairing.SetRemoteMRPConfig(mRemoteMRPConfig);
 
     if (!mSecureSession)
     {
@@ -99,26 +99,6 @@ CHIP_ERROR CommissioneeDeviceProxy::SetConnected(const SessionHandle & session)
     mState = ConnectionState::SecureConnected;
     mSecureSession.Grab(session);
     return CHIP_NO_ERROR;
-}
-
-void CommissioneeDeviceProxy::Reset()
-{
-    SetActive(false);
-
-    mState              = ConnectionState::NotConnected;
-    mSessionManager     = nullptr;
-    mUDPEndPointManager = nullptr;
-    mExchangeMgr        = nullptr;
-}
-
-bool CommissioneeDeviceProxy::GetAddress(Inet::IPAddress & addr, uint16_t & port) const
-{
-    if (mState == ConnectionState::NotConnected)
-        return false;
-
-    addr = mDeviceAddress.GetIPAddress();
-    port = mDeviceAddress.GetPort();
-    return true;
 }
 
 CommissioneeDeviceProxy::~CommissioneeDeviceProxy() {}

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -49,20 +49,10 @@ namespace chip {
 
 constexpr size_t kAttestationNonceLength = 32;
 
-using DeviceIPTransportMgr = TransportMgr<Transport::UDP /* IPv6 */
-#if INET_CONFIG_ENABLE_IPV4
-                                          ,
-                                          Transport::UDP /* IPv4 */
-#endif
-                                          >;
-
 struct ControllerDeviceInitParams
 {
-    DeviceTransportMgr * transportMgr                             = nullptr;
-    SessionManager * sessionManager                               = nullptr;
-    Messaging::ExchangeManager * exchangeMgr                      = nullptr;
-    Inet::EndPointManager<Inet::UDPEndPoint> * udpEndPointManager = nullptr;
-    FabricTable * fabricsTable                                    = nullptr;
+    SessionManager * sessionManager          = nullptr;
+    Messaging::ExchangeManager * exchangeMgr = nullptr;
 };
 
 class CommissioneeDeviceProxy : public DeviceProxy, public SessionReleaseDelegate
@@ -79,39 +69,6 @@ public:
     CHIP_ERROR SendCommands(app::CommandSender * commandObj, Optional<System::Clock::Timeout> timeout) override;
 
     /**
-     * @brief Get the IP address and port assigned to the device.
-     *
-     * @param[out] addr   IP address of the device.
-     * @param[out] port   Port number of the device.
-     *
-     * @return true, if the IP address and port were filled in the out parameters, false otherwise
-     */
-    bool GetAddress(Inet::IPAddress & addr, uint16_t & port) const override;
-
-    /**
-     * @brief
-     *   Initialize the device object with secure session manager and inet layer object
-     *   references. This variant of function is typically used when the device object
-     *   is created from a serialized device information. The other parameters (address, port,
-     *   interface etc) are part of the serialized device, so those are not required to be
-     *   initialized.
-     *
-     *   Note: The lifetime of session manager and inet layer objects must be longer than
-     *   that of this device object. If these objects are freed, while the device object is
-     *   still using them, it can lead to unknown behavior and crashes.
-     *
-     * @param[in] params       Wrapper object for transport manager etc.
-     * @param[in] fabric        Local administrator that's initializing this device object
-     */
-    void Init(ControllerDeviceInitParams params, FabricIndex fabric)
-    {
-        mSessionManager     = params.sessionManager;
-        mExchangeMgr        = params.exchangeMgr;
-        mUDPEndPointManager = params.udpEndPointManager;
-        mFabricIndex        = fabric;
-    }
-
-    /**
      * @brief
      *   Initialize a new device object with secure session manager, inet layer object,
      *   and other device specific parameters. This variant of function is typically used when
@@ -125,13 +82,13 @@ public:
      * @param[in] params       Wrapper object for transport manager etc.
      * @param[in] deviceId     Node ID of the device
      * @param[in] peerAddress  The location of the peer. MUST be of type Transport::Type::kUdp
-     * @param[in] fabric        Local administrator that's initializing this device object
      */
-    void Init(ControllerDeviceInitParams params, NodeId deviceId, const Transport::PeerAddress & peerAddress, FabricIndex fabric)
+    void Init(ControllerDeviceInitParams params, NodeId deviceId, const Transport::PeerAddress & peerAddress)
     {
-        Init(params, fabric);
-        mPeerId = PeerId().SetNodeId(deviceId);
-        mState  = ConnectionState::Connecting;
+        mSessionManager = params.sessionManager;
+        mExchangeMgr    = params.exchangeMgr;
+        mPeerId         = PeerId().SetNodeId(deviceId);
+        mState          = ConnectionState::Connecting;
 
         mDeviceAddress = peerAddress;
     }
@@ -163,14 +120,6 @@ public:
      * @return CHIP_NO_ERROR if the data has been updated, an error code otherwise.
      */
     CHIP_ERROR UpdateDeviceData(const Transport::PeerAddress & addr, const ReliableMessageProtocolConfig & config);
-    /**
-     * @brief
-     *   Return whether the current device object is actively associated with a paired CHIP
-     *   device. An active object can be used to communicate with the corresponding device.
-     */
-    bool IsActive() const override { return mActive; }
-
-    void SetActive(bool active) { mActive = active; }
 
     /**
      * @brief
@@ -180,11 +129,9 @@ public:
      */
     CHIP_ERROR SetConnected(const SessionHandle & session);
 
-    bool IsSecureConnected() const override { return IsActive() && mState == ConnectionState::SecureConnected; }
+    bool IsSecureConnected() const override { return mState == ConnectionState::SecureConnected; }
 
-    bool IsSessionSetupInProgress() const { return IsActive() && mState == ConnectionState::Connecting; }
-
-    void Reset();
+    bool IsSessionSetupInProgress() const { return mState == ConnectionState::Connecting; }
 
     NodeId GetDeviceId() const override { return mPeerId.GetNodeId(); }
     PeerId GetPeerId() const { return mPeerId; }
@@ -198,11 +145,7 @@ public:
 
     Messaging::ExchangeManager * GetExchangeManager() const override { return mExchangeMgr; }
 
-    void SetAddress(const Inet::IPAddress & deviceAddr) { mDeviceAddress.SetIPAddress(deviceAddr); }
-
     PASESession & GetPairing() { return mPairing; }
-
-    uint8_t GetNextSequenceNumber() override { return mSequenceNumber++; };
 
     Transport::Type GetDeviceTransportType() const { return mDeviceAddress.GetTransportType(); }
 
@@ -214,12 +157,6 @@ private:
         SecureConnected,
     };
 
-    enum class ResetTransport
-    {
-        kYes,
-        kNo,
-    };
-
     /* Compressed fabric ID and node ID assigned to the device. */
     PeerId mPeerId;
 
@@ -227,9 +164,6 @@ private:
      */
     Transport::PeerAddress mDeviceAddress = Transport::PeerAddress::UDP(Inet::IPAddress::Any);
 
-    Inet::EndPointManager<Inet::UDPEndPoint> * mUDPEndPointManager = nullptr;
-
-    bool mActive           = false;
     ConnectionState mState = ConnectionState::NotConnected;
 
     PASESession mPairing;
@@ -239,10 +173,6 @@ private:
     Messaging::ExchangeManager * mExchangeMgr = nullptr;
 
     SessionHolderWithDelegate mSecureSession;
-
-    uint8_t mSequenceNumber = 0;
-
-    FabricIndex mFabricIndex = kUndefinedFabricIndex;
 };
 
 } // namespace chip

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -454,14 +454,6 @@ JNI_METHOD(void, disconnectDevice)(JNIEnv * env, jobject self, jlong handle, jlo
     wrapper->Controller()->ReleaseOperationalDevice(deviceId);
 }
 
-JNI_METHOD(jboolean, isActive)(JNIEnv * env, jobject self, jlong handle)
-{
-    chip::DeviceLayer::StackLock lock;
-
-    DeviceProxy * chipDevice = reinterpret_cast<DeviceProxy *>(handle);
-    return chipDevice->IsActive();
-}
-
 JNI_METHOD(void, shutdownSubscriptions)(JNIEnv * env, jobject self, jlong handle, jlong devicePtr)
 {
     chip::DeviceLayer::StackLock lock;

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -302,10 +302,6 @@ public class ChipDeviceController {
         deviceControllerPtr, devicePtr, duration, iteration, discriminator, setupPinCode);
   }
 
-  public boolean isActive(long deviceId) {
-    return isActive(deviceControllerPtr, deviceId);
-  }
-
   /* Shutdown all cluster attribute subscriptions for a given device */
   public void shutdownSubscriptions(long devicePtr) {
     shutdownSubscriptions(deviceControllerPtr, devicePtr);
@@ -445,8 +441,6 @@ public class ChipDeviceController {
       long iteration,
       int discriminator,
       long setupPinCode);
-
-  private native boolean isActive(long deviceControllerPtr, long deviceId);
 
   private native byte[] getAttestationChallenge(long deviceControllerPtr, long devicePtr);
 


### PR DESCRIPTION
#### Problem
Those unused code is distracting while reading codes.

#### Change overview
* Remove several unused interface and member fields
* Rename `mMRPConfig` to `mRemoteMRPConfig` to reduce confusion

#### Testing
Passed unit-tests