### PR TITLE
[nrfconnect] Adapt lock-app to Door Lock cluster

### DIFF
--- a/examples/lock-app/nrfconnect/main/BoltLockManager.cpp
+++ b/examples/lock-app/nrfconnect/main/BoltLockManager.cpp
@@ -20,170 +20,73 @@
 #include "BoltLockManager.h"
 
 #include "AppConfig.h"
+#include "AppEvent.h"
 #include "AppTask.h"
-
-#include <logging/log.h>
-#include <zephyr.h>
-
-LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
-
-static k_timer sLockTimer;
 
 BoltLockManager BoltLockManager::sLock;
 
-void BoltLockManager::Init()
+void BoltLockManager::Init(StateChangeCallback callback)
 {
-    k_timer_init(&sLockTimer, &BoltLockManager::TimerEventHandler, nullptr);
-    k_timer_user_data_set(&sLockTimer, this);
+    mStateChangeCallback = callback;
 
-    mState              = kState_LockingCompleted;
-    mAutoLockTimerArmed = false;
-    mAutoRelock         = false;
-    mAutoLockDuration   = 0;
+    k_timer_init(&mActuatorTimer, &BoltLockManager::ActuatorTimerEventHandler, nullptr);
+    k_timer_user_data_set(&mActuatorTimer, this);
 }
 
-void BoltLockManager::SetCallbacks(Callback_fn_initiated aActionInitiated_CB, Callback_fn_completed aActionCompleted_CB)
+void BoltLockManager::Lock(OperationSource source)
 {
-    mActionInitiated_CB = aActionInitiated_CB;
-    mActionCompleted_CB = aActionCompleted_CB;
+    VerifyOrReturn(mState != State::kLockingCompleted);
+    SetState(State::kLockingInitiated, source);
+
+    mActuatorOperationSource = source;
+    k_timer_start(&mActuatorTimer, K_MSEC(kActuatorMovementTimeMs), K_NO_WAIT);
 }
 
-bool BoltLockManager::IsActionInProgress()
+void BoltLockManager::Unlock(OperationSource source)
 {
-    return (mState == kState_LockingInitiated || mState == kState_UnlockingInitiated) ? true : false;
+    VerifyOrReturn(mState != State::kUnlockingCompleted);
+    SetState(State::kUnlockingInitiated, source);
+
+    mActuatorOperationSource = source;
+    k_timer_start(&mActuatorTimer, K_MSEC(kActuatorMovementTimeMs), K_NO_WAIT);
 }
 
-bool BoltLockManager::IsUnlocked()
+void BoltLockManager::ActuatorTimerEventHandler(k_timer * timer)
 {
-    return (mState == kState_UnlockingCompleted) ? true : false;
-}
+    // The timer event handler is called in the context of the system clock ISR.
+    // Post an event to the application task queue to process the event in the
+    // context of the application thread.
 
-void BoltLockManager::EnableAutoRelock(bool aOn)
-{
-    mAutoRelock = aOn;
-}
-
-void BoltLockManager::SetAutoLockDuration(uint32_t aDurationInSecs)
-{
-    mAutoLockDuration = aDurationInSecs;
-}
-
-bool BoltLockManager::InitiateAction(int32_t aActor, Action_t aAction)
-{
-    bool action_initiated = false;
-    State_t new_state;
-
-    // Initiate Lock/Unlock Action only when the previous one is complete.
-    if (mState == kState_LockingCompleted && aAction == UNLOCK_ACTION)
-    {
-        action_initiated = true;
-        mCurrentActor    = aActor;
-        new_state        = kState_UnlockingInitiated;
-    }
-    else if (mState == kState_UnlockingCompleted && aAction == LOCK_ACTION)
-    {
-        action_initiated = true;
-        mCurrentActor    = aActor;
-        new_state        = kState_LockingInitiated;
-    }
-
-    if (action_initiated)
-    {
-        if (mAutoLockTimerArmed && new_state == kState_LockingInitiated)
-        {
-            // If auto lock timer has been armed and someone initiates locking,
-            // cancel the timer and continue as normal.
-            mAutoLockTimerArmed = false;
-
-            CancelTimer();
-        }
-
-        StartTimer(ACTUATOR_MOVEMENT_PERIOS_MS);
-
-        // Since the timer started successfully, update the state and trigger callback
-        mState = new_state;
-
-        if (mActionInitiated_CB)
-        {
-            mActionInitiated_CB(aAction, aActor);
-        }
-    }
-
-    return action_initiated;
-}
-
-void BoltLockManager::StartTimer(uint32_t aTimeoutMs)
-{
-    k_timer_start(&sLockTimer, K_MSEC(aTimeoutMs), K_NO_WAIT);
-}
-
-void BoltLockManager::CancelTimer(void)
-{
-    k_timer_stop(&sLockTimer);
-}
-
-void BoltLockManager::TimerEventHandler(k_timer * timer)
-{
-    BoltLockManager * lock = static_cast<BoltLockManager *>(k_timer_user_data_get(timer));
-
-    // The timer event handler will be called in the context of the timer task
-    // once sLockTimer expires. Post an event to apptask queue with the actual handler
-    // so that the event can be handled in the context of the apptask.
     AppEvent event;
     event.Type               = AppEvent::kEventType_Timer;
-    event.TimerEvent.Context = lock;
-    event.Handler            = lock->mAutoLockTimerArmed ? AutoReLockTimerEventHandler : ActuatorMovementTimerEventHandler;
+    event.TimerEvent.Context = static_cast<BoltLockManager *>(k_timer_user_data_get(timer));
+    event.Handler            = BoltLockManager::ActuatorAppEventHandler;
     GetAppTask().PostEvent(&event);
 }
 
-void BoltLockManager::AutoReLockTimerEventHandler(AppEvent * aEvent)
+void BoltLockManager::ActuatorAppEventHandler(AppEvent * aEvent)
 {
     BoltLockManager * lock = static_cast<BoltLockManager *>(aEvent->TimerEvent.Context);
-    int32_t actor          = 0;
 
-    // Make sure auto lock timer is still armed.
-    if (!lock->mAutoLockTimerArmed)
-        return;
-
-    lock->mAutoLockTimerArmed = false;
-
-    LOG_INF("Auto Re-Lock has been triggered!");
-
-    lock->InitiateAction(actor, LOCK_ACTION);
+    switch (lock->mState)
+    {
+    case State::kLockingInitiated:
+        lock->SetState(State::kLockingCompleted, lock->mActuatorOperationSource);
+        break;
+    case State::kUnlockingInitiated:
+        lock->SetState(State::kUnlockingCompleted, lock->mActuatorOperationSource);
+        break;
+    default:
+        break;
+    }
 }
 
-void BoltLockManager::ActuatorMovementTimerEventHandler(AppEvent * aEvent)
+void BoltLockManager::SetState(State state, OperationSource source)
 {
-    Action_t actionCompleted = INVALID_ACTION;
+    mState = state;
 
-    BoltLockManager * lock = static_cast<BoltLockManager *>(aEvent->TimerEvent.Context);
-
-    if (lock->mState == kState_LockingInitiated)
+    if (mStateChangeCallback != nullptr)
     {
-        lock->mState    = kState_LockingCompleted;
-        actionCompleted = LOCK_ACTION;
-    }
-    else if (lock->mState == kState_UnlockingInitiated)
-    {
-        lock->mState    = kState_UnlockingCompleted;
-        actionCompleted = UNLOCK_ACTION;
-    }
-
-    if (actionCompleted != INVALID_ACTION)
-    {
-        if (lock->mActionCompleted_CB)
-        {
-            lock->mActionCompleted_CB(actionCompleted, lock->mCurrentActor);
-        }
-
-        if (lock->mAutoRelock && actionCompleted == UNLOCK_ACTION)
-        {
-            // Start the timer for auto relock
-            lock->StartTimer(lock->mAutoLockDuration * 1000);
-
-            lock->mAutoLockTimerArmed = true;
-
-            LOG_INF("Auto Re-lock enabled. Will be triggered in %u seconds", lock->mAutoLockDuration);
-        }
+        mStateChangeCallback(state, source);
     }
 }

--- a/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
@@ -23,6 +23,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/clusters/door-lock-server/door-lock-server.h>
+#include <lib/support/CodeUtils.h>
 
 using namespace ::chip;
 using namespace ::chip::app::Clusters;
@@ -30,35 +31,52 @@ using namespace ::chip::app::Clusters::DoorLock;
 
 LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value)
+{
+    VerifyOrReturn(attributePath.mClusterId == DoorLock::Id && attributePath.mAttributeId == DoorLock::Attributes::LockState::Id);
+
+    switch (*value)
+    {
+    case to_underlying(DlLockState::kLocked):
+        BoltLockMgr().Lock(BoltLockManager::OperationSource::kRemote);
+        break;
+    case to_underlying(DlLockState::kUnlocked):
+        BoltLockMgr().Unlock(BoltLockManager::OperationSource::kRemote);
+        break;
+    default:
+        break;
+    }
+}
+
 bool emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode, DlOperationError & err)
 {
-    LOG_INF("Locking");
-    BoltLockMgr().InitiateAction(0, BoltLockManager::LOCK_ACTION);
     return true;
 }
 
 bool emberAfPluginDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode,
                                               DlOperationError & err)
 {
-    LOG_INF("Unlocking");
-    BoltLockMgr().InitiateAction(0, BoltLockManager::UNLOCK_ACTION);
     return true;
 }
 
 void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
 {
     DoorLockServer::Instance().InitServer(endpoint);
+
     EmberAfStatus status = DoorLock::Attributes::LockType::Set(endpoint, DlLockType::kDeadBolt);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         LOG_ERR("Updating type %x", status);
     }
-    // Set FeatureMap to 0, defaults is
-    //(kUsersManagement|kAccessSchedules|kRFIDCredentials|kPINCredentials) 0x113
+
+    // Set FeatureMap to 0, default is:
+    // (kUsersManagement|kAccessSchedules|kRFIDCredentials|kPINCredentials) 0x113
     status = DoorLock::Attributes::FeatureMap::Set(endpoint, 0);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        LOG_ERR("Updating type %x", status);
+        LOG_ERR("Updating feature map %x", status);
     }
-    GetAppTask().UpdateClusterState();
+
+    GetAppTask().UpdateClusterState(BoltLockMgr().GetState(), BoltLockManager::OperationSource::kUnspecified);
 }

--- a/examples/lock-app/nrfconnect/main/include/AppConfig.h
+++ b/examples/lock-app/nrfconnect/main/include/AppConfig.h
@@ -31,6 +31,3 @@
 
 #define SYSTEM_STATE_LED DK_LED1
 #define LOCK_STATE_LED DK_LED2
-
-// Time it takes in ms for the simulated actuator to move from one state to another.
-#define ACTUATOR_MOVEMENT_PERIOS_MS 2000

--- a/examples/lock-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lock-app/nrfconnect/main/include/AppTask.h
@@ -36,17 +36,15 @@ class AppTask
 public:
     CHIP_ERROR StartApp();
 
-    void PostLockActionRequest(int32_t aActor, BoltLockManager::Action_t aAction);
     void PostEvent(AppEvent * event);
-    void UpdateClusterState();
+    void UpdateClusterState(BoltLockManager::State state, BoltLockManager::OperationSource source);
 
 private:
     friend AppTask & GetAppTask(void);
 
     CHIP_ERROR Init();
 
-    static void ActionInitiated(BoltLockManager::Action_t aAction, int32_t aActor);
-    static void ActionCompleted(BoltLockManager::Action_t aAction, int32_t aActor);
+    static void LockStateChanged(BoltLockManager::State state, BoltLockManager::OperationSource source);
 
     void CancelTimer(void);
 


### PR DESCRIPTION
#### Problem
nRF Connect lock-app needs to be updated/cleaned up after switching to DoorLock cluster.

#### Change overview
1. Listen to lock-state attribute changes rather than lock/unlock commands to support the auto-relock feature.
2. Remove obsolete code from BoltLockManager as now the auto-relock feature is handled in the common cluster code.

#### Testing
Tested on nRF52840 DK.
