### PR TITLE
[ESP32] Added config option chip-enable-schema-check

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -95,6 +95,10 @@ if (CONFIG_BUILD_CHIP_TESTS)
     chip_gn_arg_bool("chip_build_tests"     "true")
 endif()
 
+if (CONFIG_CHIP_ENABLE_SCHEMA_CHECK)
+    chip_gn_arg_bool("chip_enable_schema_check"	"true")
+endif()
+
 if (NOT CONFIG_USE_MINIMAL_MDNS)
     chip_gn_arg_append("chip_mdns"                          "\"platform\"")
 endif()

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -755,6 +755,16 @@ menu "CHIP Device Layer"
                 When size is set to 0, the debug event buffer and all support
                 for the debug level events are disabled.
 
+
+	config CHIP_ENABLE_SCHEMA_CHECK
+	   bool "Enable Schema Check"
+	   default n
+	   help
+	     If enabled, it checks incoming messages are following the expected schema,
+             and incoming message payloads are logged in detail.
+	     To see detailed logging please set default log level to Verbose.
+	     (Component config --> Log output --> Default log verbosity --> Verbose)
+
     endmenu
 
     menu "Matter OTA Image"

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -758,12 +758,12 @@ menu "CHIP Device Layer"
 
 	config CHIP_ENABLE_SCHEMA_CHECK
 	   bool "Enable Schema Check"
-	   default n
+	   default y
 	   help
 	     If enabled, it checks incoming messages are following the expected schema,
              and incoming message payloads are logged in detail.
-	     To see detailed logging please set default log level to Verbose.
-	     (Component config --> Log output --> Default log verbosity --> Verbose)
+	     To see detailed logging please set default log level to Debug.
+	     (Component config --> Log output --> Default log verbosity --> Debug)
 
     endmenu
 

--- a/src/platform/ESP32/Logging.cpp
+++ b/src/platform/ESP32/Logging.cpp
@@ -39,7 +39,7 @@ void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char
         ESP_LOGI(tag, "%s", formattedMsg);
         break;
     case kLogCategory_Detail:
-        ESP_LOGV(tag, "%s", formattedMsg);
+        ESP_LOGD(tag, "%s", formattedMsg);
         break;
     }
 }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Added config option chip-enable-schema-check

#### Change overview
config option chip-enable-schema-check

#### Testing
Tested all clusters app by setting default log level to Verbose