### PR TITLE
Use refcounter for secure session

### DIFF
--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -70,16 +70,16 @@ bool OperationalDeviceProxy::AttachToExistingSecureSession()
     ScopedNodeId peerNodeId(mPeerId.GetNodeId(), mFabricInfo->GetFabricIndex());
     auto sessionHandle =
         mInitParams.sessionManager->FindSecureSessionForNode(peerNodeId, MakeOptional(Transport::SecureSession::Type::kCASE));
-    if (sessionHandle.HasValue())
-    {
-        ChipLogProgress(Controller, "Found an existing secure session to [" ChipLogFormatX64 "-" ChipLogFormatX64 "]!",
-                        ChipLogValueX64(mPeerId.GetCompressedFabricId()), ChipLogValueX64(mPeerId.GetNodeId()));
-        mDeviceAddress = sessionHandle.Value()->AsSecureSession()->GetPeerAddress();
-        mSecureSession.Grab(sessionHandle.Value());
-        return true;
-    }
+    if (!sessionHandle.HasValue())
+        return false;
 
-    return false;
+    ChipLogProgress(Controller, "Found an existing secure session to [" ChipLogFormatX64 "-" ChipLogFormatX64 "]!",
+                    ChipLogValueX64(mPeerId.GetCompressedFabricId()), ChipLogValueX64(mPeerId.GetNodeId()));
+    mDeviceAddress = sessionHandle.Value()->AsSecureSession()->GetPeerAddress();
+    if (!mSecureSession.Grab(sessionHandle.Value()))
+        return false;
+
+    return true;
 }
 
 void OperationalDeviceProxy::Connect(Callback::Callback<OnDeviceConnected> * onConnection,
@@ -305,7 +305,9 @@ void OperationalDeviceProxy::OnSessionEstablished(const SessionHandle & session)
     VerifyOrReturn(mState != State::Uninitialized,
                    ChipLogError(Controller, "HandleCASEConnected was called while the device was not initialized"));
 
-    mSecureSession.Grab(session);
+    if (!mSecureSession.Grab(session))
+        return; // Got an invalid session, do not change any state
+
     MoveToState(State::SecureConnected);
     DequeueConnectionCallbacks(CHIP_NO_ERROR);
 

--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -97,8 +97,13 @@ CHIP_ERROR CommissioneeDeviceProxy::UpdateDeviceData(const Transport::PeerAddres
 CHIP_ERROR CommissioneeDeviceProxy::SetConnected(const SessionHandle & session)
 {
     VerifyOrReturnError(mState == ConnectionState::Connecting, CHIP_ERROR_INCORRECT_STATE);
+    if (!mSecureSession.Grab(session))
+    {
+        mState = ConnectionState::NotConnected;
+        return CHIP_ERROR_INTERNAL;
+    }
+
     mState = ConnectionState::SecureConnected;
-    mSecureSession.Grab(session);
     return CHIP_NO_ERROR;
 }
 

--- a/src/lib/core/ReferenceCounted.h
+++ b/src/lib/core/ReferenceCounted.h
@@ -39,21 +39,26 @@ public:
     static void Release(T * obj) { chip::Platform::Delete(obj); }
 };
 
+template <class T>
+class NoopDeletor
+{
+public:
+    static void Release(T * obj) {}
+};
+
 /**
  * A reference counted object maintains a count of usages and when the usage
  * count drops to 0, it deletes itself.
  */
-template <class Subclass, class Deletor = DeleteDeletor<Subclass>, int kInitRefCount = 1>
+template <class Subclass, class Deletor = DeleteDeletor<Subclass>, int kInitRefCount = 1, typename CounterType = uint32_t>
 class ReferenceCounted
 {
 public:
-    using count_type = uint32_t;
-
     /** Adds one to the usage count of this class */
     Subclass * Retain()
     {
         VerifyOrDie(!kInitRefCount || mRefCount > 0);
-        VerifyOrDie(mRefCount < std::numeric_limits<count_type>::max());
+        VerifyOrDie(mRefCount < std::numeric_limits<CounterType>::max());
         ++mRefCount;
 
         return static_cast<Subclass *>(this);
@@ -71,10 +76,10 @@ public:
     }
 
     /** Get the current reference counter value */
-    count_type GetReferenceCount() const { return mRefCount; }
+    CounterType GetReferenceCount() const { return mRefCount; }
 
 private:
-    count_type mRefCount = kInitRefCount;
+    CounterType mRefCount = kInitRefCount;
 };
 
 } // namespace chip

--- a/src/protocols/secure_channel/PairingSession.cpp
+++ b/src/protocols/secure_channel/PairingSession.cpp
@@ -27,7 +27,7 @@ CHIP_ERROR PairingSession::AllocateSecureSession(SessionManager & sessionManager
 {
     auto handle = sessionManager.AllocateSession(GetSecureSessionType());
     VerifyOrReturnError(handle.HasValue(), CHIP_ERROR_NO_MEMORY);
-    mSecureSessionHolder.GrabPairing(handle.Value());
+    VerifyOrReturnError(mSecureSessionHolder.GrabPairing(handle.Value()), CHIP_ERROR_INTERNAL);
     mSessionManager = &sessionManager;
     return CHIP_NO_ERROR;
 }

--- a/src/protocols/secure_channel/PairingSession.cpp
+++ b/src/protocols/secure_channel/PairingSession.cpp
@@ -25,9 +25,9 @@ namespace chip {
 
 CHIP_ERROR PairingSession::AllocateSecureSession(SessionManager & sessionManager)
 {
-    auto handle = sessionManager.AllocateSession();
+    auto handle = sessionManager.AllocateSession(GetSecureSessionType());
     VerifyOrReturnError(handle.HasValue(), CHIP_ERROR_NO_MEMORY);
-    mSecureSessionHolder.Grab(handle.Value());
+    mSecureSessionHolder.GrabPairing(handle.Value());
     mSessionManager = &sessionManager;
     return CHIP_NO_ERROR;
 }
@@ -48,8 +48,7 @@ CHIP_ERROR PairingSession::ActivateSecureSession(const Transport::PeerAddress & 
 
     // Call Activate last, otherwise errors on anything after would lead to
     // a partially valid session.
-    secureSession->Activate(GetSecureSessionType(), GetLocalScopedNodeId(), GetPeer(), GetPeerCATs(), peerSessionId,
-                            mRemoteMRPConfig);
+    secureSession->Activate(GetLocalScopedNodeId(), GetPeer(), GetPeerCATs(), peerSessionId, mRemoteMRPConfig);
 
     ChipLogDetail(Inet, "New secure session created for device " ChipLogFormatScopedNodeId ", LSID:%d PSID:%d!",
                   ChipLogValueScopedNodeId(GetPeer()), secureSession->GetLocalSessionId(), peerSessionId);
@@ -154,19 +153,7 @@ void PairingSession::Clear()
         mExchangeCtxt = nullptr;
     }
 
-    if (mSecureSessionHolder)
-    {
-        auto session = mSecureSessionHolder.Get();
-        // Call Release before ExpirePairing because we don't want to receive OnSessionReleased() event here
-        mSecureSessionHolder.Release();
-        if (!session.Value()->AsSecureSession()->IsActiveSession() && mSessionManager != nullptr)
-        {
-            // Make sure to clean up our pending session, since we're the only
-            // ones who have access to it do do so.
-            mSessionManager->ExpirePairing(session.Value());
-        }
-    }
-
+    mSecureSessionHolder.Release();
     mPeerSessionId.ClearValue();
     mSessionManager = nullptr;
 }

--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -41,6 +41,8 @@ public:
     void Retain() override { ReferenceCounted<IncomingGroupSession, NoopDeletor<IncomingGroupSession>, 0>::Retain(); }
     void Release() override { ReferenceCounted<IncomingGroupSession, NoopDeletor<IncomingGroupSession>, 0>::Release(); }
 
+    bool IsActiveSession() const override { return true; }
+
     Session::SessionType GetSessionType() const override { return Session::SessionType::kGroupIncoming; }
 #if CHIP_PROGRESS_LOGGING
     const char * GetSessionTypeString() const override { return "incoming group"; };
@@ -94,6 +96,8 @@ public:
 
     void Retain() override { ReferenceCounted<OutgoingGroupSession, NoopDeletor<OutgoingGroupSession>, 0>::Retain(); }
     void Release() override { ReferenceCounted<OutgoingGroupSession, NoopDeletor<OutgoingGroupSession>, 0>::Release(); }
+
+    bool IsActiveSession() const override { return true; }
 
     Session::SessionType GetSessionType() const override { return Session::SessionType::kGroupOutgoing; }
 #if CHIP_PROGRESS_LOGGING

--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -18,20 +18,28 @@
 
 #include <app/util/basic-types.h>
 #include <lib/core/GroupId.h>
+#include <lib/core/ReferenceCounted.h>
 #include <lib/support/Pool.h>
 #include <transport/Session.h>
 
 namespace chip {
 namespace Transport {
 
-class IncomingGroupSession : public Session
+class IncomingGroupSession : public Session, public ReferenceCounted<IncomingGroupSession, NoopDeletor<IncomingGroupSession>, 0>
 {
 public:
     IncomingGroupSession(GroupId group, FabricIndex fabricIndex, NodeId peerNodeId) : mGroupId(group), mPeerNodeId(peerNodeId)
     {
         SetFabricIndex(fabricIndex);
     }
-    ~IncomingGroupSession() override { NotifySessionReleased(); }
+    ~IncomingGroupSession() override
+    {
+        NotifySessionReleased();
+        VerifyOrDie(GetReferenceCount() == 0);
+    }
+
+    void Retain() override { ReferenceCounted<IncomingGroupSession, NoopDeletor<IncomingGroupSession>, 0>::Retain(); }
+    void Release() override { ReferenceCounted<IncomingGroupSession, NoopDeletor<IncomingGroupSession>, 0>::Release(); }
 
     Session::SessionType GetSessionType() const override { return Session::SessionType::kGroupIncoming; }
 #if CHIP_PROGRESS_LOGGING
@@ -74,11 +82,18 @@ private:
     const NodeId mPeerNodeId;
 };
 
-class OutgoingGroupSession : public Session
+class OutgoingGroupSession : public Session, public ReferenceCounted<OutgoingGroupSession, NoopDeletor<OutgoingGroupSession>, 0>
 {
 public:
     OutgoingGroupSession(GroupId group, FabricIndex fabricIndex) : mGroupId(group) { SetFabricIndex(fabricIndex); }
-    ~OutgoingGroupSession() override { NotifySessionReleased(); }
+    ~OutgoingGroupSession() override
+    {
+        NotifySessionReleased();
+        VerifyOrDie(GetReferenceCount() == 0);
+    }
+
+    void Retain() override { ReferenceCounted<OutgoingGroupSession, NoopDeletor<OutgoingGroupSession>, 0>::Retain(); }
+    void Release() override { ReferenceCounted<OutgoingGroupSession, NoopDeletor<OutgoingGroupSession>, 0>::Release(); }
 
     Session::SessionType GetSessionType() const override { return Session::SessionType::kGroupOutgoing; }
 #if CHIP_PROGRESS_LOGGING

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -22,19 +22,22 @@
 #pragma once
 
 #include <app/util/basic-types.h>
-#include <credentials/CHIPCert.h>
+#include <lib/core/ReferenceCounted.h>
 #include <messaging/ReliableMessageProtocolConfig.h>
 #include <transport/CryptoContext.h>
 #include <transport/Session.h>
 #include <transport/SessionMessageCounter.h>
-#include <transport/raw/Base.h>
-#include <transport/raw/MessageHeader.h>
 #include <transport/raw/PeerAddress.h>
 
 namespace chip {
 namespace Transport {
 
-static constexpr uint32_t kUndefinedMessageIndex = UINT32_MAX;
+class SecureSessionTable;
+class SecureSessionDeleter
+{
+public:
+    static void Release(SecureSession * entry);
+};
 
 /**
  * Defines state of a peer connection at a transport layer.
@@ -49,7 +52,7 @@ static constexpr uint32_t kUndefinedMessageIndex = UINT32_MAX;
  *     last used. Inactive connections can expire.
  *   - CryptoContext contains the encryption context of a connection
  */
-class SecureSession : public Session
+class SecureSession : public Session, public ReferenceCounted<SecureSession, SecureSessionDeleter, 0, uint16_t>
 {
 public:
     /**
@@ -60,26 +63,20 @@ public:
     {
         kPASE = 1,
         kCASE = 2,
-        // kPending denotes a secure session object that is internally
-        // reserved by the stack before and during session establishment.
-        //
-        // Although the stack can tolerate eviction of these (releasing one
-        // out from under the holder would exhibit as CHIP_ERROR_INCORRECT_STATE
-        // during CASE or PASE), intent is that we should not and would leave
-        // these untouched until CASE or PASE complete.
-        kPending = 3,
     };
 
-    // TODO: This constructor should be private.  Tests should allocate a
-    // kPending session and then call Activate(), just like non-test code does.
-    SecureSession(Type secureSessionType, uint16_t localSessionId, NodeId localNodeId, NodeId peerNodeId, CATValues peerCATs,
-                  uint16_t peerSessionId, FabricIndex fabric, const ReliableMessageProtocolConfig & config) :
-        mSecureSessionType(secureSessionType),
-        mLocalSessionId(localSessionId), mLocalNodeId(localNodeId), mPeerNodeId(peerNodeId), mPeerCATs(peerCATs),
-        mPeerSessionId(peerSessionId), mLastActivityTime(System::SystemClock().GetMonotonicTimestamp()),
-        mLastPeerActivityTime(System::SystemClock().GetMonotonicTimestamp()), mMRPConfig(config)
+    // Test-only: inject a session in Active state.
+    SecureSession(SecureSessionTable & table, Type secureSessionType, uint16_t localSessionId, NodeId localNodeId,
+                  NodeId peerNodeId, CATValues peerCATs, uint16_t peerSessionId, FabricIndex fabric,
+                  const ReliableMessageProtocolConfig & config) :
+        mTable(table),
+        mState(State::kActive), mSecureSessionType(secureSessionType), mLocalNodeId(localNodeId), mPeerNodeId(peerNodeId),
+        mPeerCATs(peerCATs), mLocalSessionId(localSessionId), mPeerSessionId(peerSessionId), mMRPConfig(config)
     {
+        Retain(); // Put the test session in Active state
         SetFabricIndex(fabric);
+        ChipLogDetail(Inet, "SecureSession Allocated for test %p Type:%d LSID:%d", this, to_underlying(mSecureSessionType),
+                      mLocalSessionId);
     }
 
     /**
@@ -88,10 +85,11 @@ public:
      *   session establishment attempt.  The object for the pending session
      *   receives a local session ID, but no other state.
      */
-    SecureSession(uint16_t localSessionId) :
-        SecureSession(Type::kPending, localSessionId, kUndefinedNodeId, kUndefinedNodeId, CATValues{}, 0, kUndefinedFabricIndex,
-                      GetLocalMRPConfig())
-    {}
+    SecureSession(SecureSessionTable & table, Type secureSessionType, uint16_t localSessionId) :
+        mTable(table), mState(State::kPairing), mSecureSessionType(secureSessionType), mLocalSessionId(localSessionId)
+    {
+        ChipLogDetail(Inet, "SecureSession Allocated %p Type:%d LSID:%d", this, to_underlying(mSecureSessionType), mLocalSessionId);
+    }
 
     /**
      * @brief
@@ -99,33 +97,48 @@ public:
      *   PASE, setting internal state according to the parameters used and
      *   discovered during session establishment.
      */
-    void Activate(Type secureSessionType, const ScopedNodeId & localNode, const ScopedNodeId & peerNode, CATValues peerCATs,
-                  uint16_t peerSessionId, const ReliableMessageProtocolConfig & config)
+    void Activate(const ScopedNodeId & localNode, const ScopedNodeId & peerNode, CATValues peerCATs, uint16_t peerSessionId,
+                  const ReliableMessageProtocolConfig & config)
     {
+        VerifyOrDie(mState == State::kPairing);
         VerifyOrDie(peerNode.GetFabricIndex() == localNode.GetFabricIndex());
 
         // PASE sessions must always start unassociated with a Fabric!
-        VerifyOrDie(!((secureSessionType == Type::kPASE) && (peerNode.GetFabricIndex() != kUndefinedFabricIndex)));
+        VerifyOrDie(!((mSecureSessionType == Type::kPASE) && (peerNode.GetFabricIndex() != kUndefinedFabricIndex)));
         // CASE sessions must always start "associated" a given Fabric!
-        VerifyOrDie(!((secureSessionType == Type::kCASE) && (peerNode.GetFabricIndex() == kUndefinedFabricIndex)));
+        VerifyOrDie(!((mSecureSessionType == Type::kCASE) && (peerNode.GetFabricIndex() == kUndefinedFabricIndex)));
         // CASE sessions can only be activated against operational node IDs!
-        VerifyOrDie(!((secureSessionType == Type::kCASE) &&
+        VerifyOrDie(!((mSecureSessionType == Type::kCASE) &&
                       (!IsOperationalNodeId(peerNode.GetNodeId()) || !IsOperationalNodeId(localNode.GetNodeId()))));
 
-        mSecureSessionType = secureSessionType;
-        mPeerNodeId        = peerNode.GetNodeId();
-        mLocalNodeId       = localNode.GetNodeId();
-        mPeerCATs          = peerCATs;
-        mPeerSessionId     = peerSessionId;
-        mMRPConfig         = config;
+        mPeerNodeId    = peerNode.GetNodeId();
+        mLocalNodeId   = localNode.GetNodeId();
+        mPeerCATs      = peerCATs;
+        mPeerSessionId = peerSessionId;
+        mMRPConfig     = config;
         SetFabricIndex(peerNode.GetFabricIndex());
+
+        Retain();
+        mState = State::kActive;
+        ChipLogDetail(Inet, "SecureSession Active %p Type:%d LSID:%d", this, to_underlying(mSecureSessionType), mLocalSessionId);
     }
-    ~SecureSession() override { NotifySessionReleased(); }
+    ~SecureSession() override
+    {
+        ChipLogDetail(Inet, "SecureSession Released %p Type:%d LSID:%d", this, to_underlying(mSecureSessionType), mLocalSessionId);
+    }
 
     SecureSession(SecureSession &&)      = delete;
     SecureSession(const SecureSession &) = delete;
     SecureSession & operator=(const SecureSession &) = delete;
     SecureSession & operator=(SecureSession &&) = delete;
+
+    void Retain() override { ReferenceCounted<SecureSession, SecureSessionDeleter, 0, uint16_t>::Retain(); }
+    void Release() override { ReferenceCounted<SecureSession, SecureSessionDeleter, 0, uint16_t>::Release(); }
+
+    bool IsActiveSession() const override { return mState == State::kActive; }
+    bool IsPairing() const { return mState == State::kPairing; }
+    /// @brief Mark as pending removal, all holders to this session will be cleared, and disallow future grab
+    void MarkForRemoval();
 
     Session::SessionType GetSessionType() const override { return Session::SessionType::kSecure; }
 #if CHIP_PROGRESS_LOGGING
@@ -160,7 +173,6 @@ public:
     Type GetSecureSessionType() const { return mSecureSessionType; }
     bool IsCASESession() const { return GetSecureSessionType() == Type::kCASE; }
     bool IsPASESession() const { return GetSecureSessionType() == Type::kPASE; }
-    bool IsActiveSession() const { return GetSecureSessionType() != Type::kPending; }
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
     NodeId GetLocalNodeId() const { return mLocalNodeId; }
 
@@ -209,17 +221,45 @@ public:
     SessionMessageCounter & GetSessionMessageCounter() { return mSessionMessageCounter; }
 
 private:
-    Type mSecureSessionType;
+    enum class State : uint8_t
+    {
+        // kPending denotes a secure session object that is internally
+        // reserved by the stack before and during session establishment.
+        //
+        // Although the stack can tolerate eviction of these (releasing one
+        // out from under the holder would exhibit as CHIP_ERROR_INCORRECT_STATE
+        // during CASE or PASE), intent is that we should not and would leave
+        // these untouched until CASE or PASE complete.
+        //
+        // During this stage, the reference counter is hold by the PairingSession
+        kPairing = 1,
+
+        // The session is active, ready for use. During this stage, the
+        // reference counter increased by 1 in Activate, and will be decreased
+        // by 1 when MarkForRemoval is called.
+        kActive = 2,
+
+        // The session is pending for removal, all SessionHolders are already
+        // cleared during MarkForRemoval, no future SessionHolder is able grab
+        // this session, when all SessionHandles goes out of scope, the session
+        // object will be released automatically.
+        kPendingRemoval = 3,
+    };
+
+    friend class SecureSessionDeleter;
+    SecureSessionTable & mTable;
+    State mState;
+    const Type mSecureSessionType;
+    NodeId mLocalNodeId = kUndefinedNodeId;
+    NodeId mPeerNodeId  = kUndefinedNodeId;
+    CATValues mPeerCATs = CATValues{};
     const uint16_t mLocalSessionId;
-    NodeId mLocalNodeId;
-    NodeId mPeerNodeId;
-    CATValues mPeerCATs;
-    uint16_t mPeerSessionId;
+    uint16_t mPeerSessionId = 0;
 
     PeerAddress mPeerAddress;
-    System::Clock::Timestamp mLastActivityTime;     ///< Timestamp of last tx or rx
-    System::Clock::Timestamp mLastPeerActivityTime; ///< Timestamp of last rx
-    ReliableMessageProtocolConfig mMRPConfig;
+    System::Clock::Timestamp mLastActivityTime     = System::SystemClock().GetMonotonicTimestamp(); ///< Timestamp of last tx or rx
+    System::Clock::Timestamp mLastPeerActivityTime = System::SystemClock().GetMonotonicTimestamp(); ///< Timestamp of last rx
+    ReliableMessageProtocolConfig mMRPConfig       = GetLocalMRPConfig();
     CryptoContext mCryptoContext;
     SessionMessageCounter mSessionMessageCounter;
 };

--- a/src/transport/SecureSessionTable.h
+++ b/src/transport/SecureSessionTable.h
@@ -35,7 +35,6 @@ constexpr uint16_t kUnsecuredSessionId = 0;
  *   - handle session active time and expiration
  *   - allocate and free space for sessions.
  */
-template <size_t kMaxSessionCount>
 class SecureSessionTable
 {
 public:
@@ -89,36 +88,9 @@ public:
             }
         }
 
-        SecureSession * result = mEntries.CreateObject(secureSessionType, localSessionId, localNodeId, peerNodeId, peerCATs,
+        SecureSession * result = mEntries.CreateObject(*this, secureSessionType, localSessionId, localNodeId, peerNodeId, peerCATs,
                                                        peerSessionId, fabricIndex, config);
         return result != nullptr ? MakeOptional<SessionHandle>(*result) : Optional<SessionHandle>::Missing();
-    }
-
-    /**
-     * Allocate a new secure session out of the internal resource pool with the
-     * specified session ID.  The returned secure session will not become active
-     * until the call to SecureSession::Activate.  If there is a resident
-     * session at the passed ID, an empty Optional will be returned to signal
-     * the error.
-     *
-     * This variant of the interface is primarily useful in testing, where
-     * session IDs may need to be predetermined.
-     *
-     * @param localSessionId unique identifier for the local node's secure unicast session context
-     * @returns allocated session, or NullOptional on failure
-     */
-    CHECK_RETURN_VALUE
-    Optional<SessionHandle> CreateNewSecureSession(uint16_t localSessionId)
-    {
-        Optional<SessionHandle> rv = Optional<SessionHandle>::Missing();
-        SecureSession * allocated  = nullptr;
-        VerifyOrExit(localSessionId != kUnsecuredSessionId, rv = NullOptional);
-        VerifyOrExit(!FindSecureSessionByLocalKey(localSessionId).HasValue(), rv = NullOptional);
-        allocated = mEntries.CreateObject(localSessionId);
-        VerifyOrExit(allocated != nullptr, rv = Optional<SessionHandle>::Missing());
-        rv = MakeOptional<SessionHandle>(*allocated);
-    exit:
-        return rv;
     }
 
     /**
@@ -130,13 +102,13 @@ public:
      * @returns allocated session, or NullOptional on failure
      */
     CHECK_RETURN_VALUE
-    Optional<SessionHandle> CreateNewSecureSession()
+    Optional<SessionHandle> CreateNewSecureSession(SecureSession::Type secureSessionType)
     {
         Optional<SessionHandle> rv = Optional<SessionHandle>::Missing();
         auto sessionId             = FindUnusedSessionId();
         SecureSession * allocated  = nullptr;
         VerifyOrExit(sessionId.HasValue(), rv = Optional<SessionHandle>::Missing());
-        allocated = mEntries.CreateObject(sessionId.Value());
+        allocated = mEntries.CreateObject(*this, secureSessionType, sessionId.Value());
         VerifyOrExit(allocated != nullptr, rv = Optional<SessionHandle>::Missing());
         rv             = MakeOptional<SessionHandle>(*allocated);
         mNextSessionId = sessionId.Value() == kMaxSessionID ? static_cast<uint16_t>(kUnsecuredSessionId + 1)
@@ -175,26 +147,6 @@ public:
         return result != nullptr ? MakeOptional<SessionHandle>(*result) : Optional<SessionHandle>::Missing();
     }
 
-    /**
-     * Iterates through all active sessions and expires any sessions with an idle time
-     * larger than the given amount.
-     *
-     * Expiring a session involves callback execution and then clearing the internal state.
-     */
-    template <typename Callback>
-    void ExpireInactiveSessions(System::Clock::Timestamp maxIdleTime, Callback callback)
-    {
-        mEntries.ForEachActiveObject([&](auto session) {
-            if (session->GetSecureSessionType() != SecureSession::Type::kPending &&
-                session->GetLastActivityTime() + maxIdleTime < System::SystemClock().GetMonotonicTimestamp())
-            {
-                callback(*session);
-                ReleaseSession(session);
-            }
-            return Loop::Continue;
-        });
-    }
-
 private:
     /**
      * Find an available session ID that is unused in the secure session table.
@@ -204,7 +156,7 @@ private:
      * from the starting mNextSessionId clue.
      *
      * The outer-loop considers 64 session IDs in each iteration to give a
-     * runtime complexity of O(kMaxSessionCount^2/64).  Speed up could be
+     * runtime complexity of O(CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE^2/64).  Speed up could be
      * achieved with a sorted session table or additional storage.
      *
      * @return an unused session ID if any is found, else NullOptional
@@ -262,7 +214,7 @@ private:
         return NullOptional;
     }
 
-    BitMapObjectPool<SecureSession, kMaxSessionCount> mEntries;
+    BitMapObjectPool<SecureSession, CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE> mEntries;
     uint16_t mNextSessionId = 0;
 };
 

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -68,7 +68,7 @@ public:
     virtual void Retain()  = 0;
     virtual void Release() = 0;
 
-    virtual bool IsActiveSession() const { return true; }
+    virtual bool IsActiveSession() const = 0;
 
     virtual ScopedNodeId GetPeer() const                               = 0;
     virtual ScopedNodeId GetLocalScopedNodeId() const                  = 0;

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -65,9 +65,10 @@ public:
         mHolders.Remove(&holder);
     }
 
-    // For types of sessions using reference counter, override these functions, otherwise leave it empty.
-    virtual void Retain() {}
-    virtual void Release() {}
+    virtual void Retain()  = 0;
+    virtual void Release() = 0;
+
+    virtual bool IsActiveSession() const { return true; }
 
     virtual ScopedNodeId GetPeer() const                               = 0;
     virtual ScopedNodeId GetLocalScopedNodeId() const                  = 0;

--- a/src/transport/SessionHandle.h
+++ b/src/transport/SessionHandle.h
@@ -26,12 +26,14 @@ namespace Transport {
 class Session;
 } // namespace Transport
 
-class SessionHolder;
-
 /** @brief
- *    Non-copyable session reference. All SessionHandles are created within SessionManager. SessionHandle is not
- *    reference *counted, hence it is not allowed to store SessionHandle anywhere except for function arguments and
- *    return values. SessionHandle is short-lived as it is only available as stack variable, so it is never dangling. */
+ *    Non-copyable session reference. All SessionHandles are created within SessionManager. It is not allowed to store SessionHandle
+ * anywhere except for function arguments and return values.
+ *
+ *    SessionHandle is reference counted such that it never dangling, but there can be a gray period when the session is mark as
+ * pending removal but not actually removed yet. During this period, the handle is functional, but the underlying session won't be
+ * able to grabbed by any SessionHolder. SessionHandle->IsActiveSession can be used to check if the session is active.
+ */
 class SessionHandle
 {
 public:

--- a/src/transport/SessionHolder.cpp
+++ b/src/transport/SessionHolder.cpp
@@ -74,24 +74,31 @@ SessionHolder & SessionHolder::operator=(SessionHolder && that)
     return *this;
 }
 
-void SessionHolder::GrabPairing(const SessionHandle & session)
+bool SessionHolder::GrabPairing(const SessionHandle & session)
 {
     Release();
-    if (session->IsSecureSession() && session->AsSecureSession()->IsPairing())
-    {
-        mSession.Emplace(session.mSession);
-        session->AddHolder(*this);
-    }
+
+    if (!session->IsSecureSession())
+        return false;
+
+    if (!session->AsSecureSession()->IsPairing())
+        return false;
+
+    mSession.Emplace(session.mSession);
+    session->AddHolder(*this);
+    return true;
 }
 
-void SessionHolder::Grab(const SessionHandle & session)
+bool SessionHolder::Grab(const SessionHandle & session)
 {
     Release();
-    if (session->IsActiveSession())
-    {
-        mSession.Emplace(session.mSession);
-        session->AddHolder(*this);
-    }
+
+    if (!session->IsActiveSession())
+        return false;
+
+    mSession.Emplace(session.mSession);
+    session->AddHolder(*this);
+    return true;
 }
 
 void SessionHolder::Release()

--- a/src/transport/SessionHolder.cpp
+++ b/src/transport/SessionHolder.cpp
@@ -14,8 +14,10 @@
  *    limitations under the License.
  */
 
-#include <transport/Session.h>
 #include <transport/SessionHolder.h>
+
+#include <transport/SecureSession.h>
+#include <transport/Session.h>
 
 namespace chip {
 
@@ -72,11 +74,24 @@ SessionHolder & SessionHolder::operator=(SessionHolder && that)
     return *this;
 }
 
+void SessionHolder::GrabPairing(const SessionHandle & session)
+{
+    Release();
+    if (session->IsSecureSession() && session->AsSecureSession()->IsPairing())
+    {
+        mSession.Emplace(session.mSession);
+        session->AddHolder(*this);
+    }
+}
+
 void SessionHolder::Grab(const SessionHandle & session)
 {
     Release();
-    mSession.Emplace(session.mSession);
-    session->AddHolder(*this);
+    if (session->IsActiveSession())
+    {
+        mSession.Emplace(session.mSession);
+        session->AddHolder(*this);
+    }
 }
 
 void SessionHolder::Release()

--- a/src/transport/SessionHolder.h
+++ b/src/transport/SessionHolder.h
@@ -47,6 +47,7 @@ public:
         return mSession.HasValue() && &mSession.Value().Get() == &session.mSession.Get();
     }
 
+    void GrabPairing(const SessionHandle & session); // Should be only used inside CASE/PASE pairing.
     void Grab(const SessionHandle & session);
     void Release();
 

--- a/src/transport/SessionHolder.h
+++ b/src/transport/SessionHolder.h
@@ -47,8 +47,8 @@ public:
         return mSession.HasValue() && &mSession.Value().Get() == &session.mSession.Get();
     }
 
-    void GrabPairing(const SessionHandle & session); // Should be only used inside CASE/PASE pairing.
-    void Grab(const SessionHandle & session);
+    bool GrabPairing(const SessionHandle & session); // Should be only used inside CASE/PASE pairing.
+    bool Grab(const SessionHandle & session);
     void Release();
 
     operator bool() const { return mSession.HasValue(); }

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -337,7 +337,7 @@ CHIP_ERROR SessionManager::SendPreparedMessage(const SessionHandle & sessionHand
 
 void SessionManager::ExpirePairing(const SessionHandle & sessionHandle)
 {
-    mSecureSessions.ReleaseSession(sessionHandle->AsSecureSession());
+    sessionHandle->AsSecureSession()->MarkForRemoval();
 }
 
 void SessionManager::ExpireAllPairings(const ScopedNodeId & node)
@@ -345,7 +345,7 @@ void SessionManager::ExpireAllPairings(const ScopedNodeId & node)
     mSecureSessions.ForEachSession([&](auto session) {
         if (session->GetPeer() == node)
         {
-            mSecureSessions.ReleaseSession(session);
+            session->MarkForRemoval();
         }
         return Loop::Continue;
     });
@@ -354,11 +354,12 @@ void SessionManager::ExpireAllPairings(const ScopedNodeId & node)
 void SessionManager::ExpireAllPairingsForPeerExceptPending(const ScopedNodeId & node)
 {
     mSecureSessions.ForEachSession([&](auto session) {
-        if ((session->GetPeer() == node) && (session->GetSecureSessionType() == SecureSession::Type::kCASE))
+        if ((session->GetPeer() == node) && session->IsActiveSession() &&
+            (session->GetSecureSessionType() == SecureSession::Type::kCASE))
         {
             ChipLogDetail(Inet, "Expired/released previous local session ID %u for peer " ChipLogFormatScopedNodeId,
                           static_cast<unsigned>(session->GetLocalSessionId()), ChipLogValueScopedNodeId(session->GetPeer()));
-            mSecureSessions.ReleaseSession(session);
+            session->MarkForRemoval();
         }
         return Loop::Continue;
     });
@@ -370,7 +371,7 @@ void SessionManager::ExpireAllPairingsForFabric(FabricIndex fabric)
     mSecureSessions.ForEachSession([&](auto session) {
         if (session->GetFabricIndex() == fabric)
         {
-            mSecureSessions.ReleaseSession(session);
+            session->MarkForRemoval();
         }
         return Loop::Continue;
     });
@@ -382,15 +383,15 @@ void SessionManager::ExpireAllPASEPairings()
     mSecureSessions.ForEachSession([&](auto session) {
         if (session->GetSecureSessionType() == Transport::SecureSession::Type::kPASE)
         {
-            mSecureSessions.ReleaseSession(session);
+            session->MarkForRemoval();
         }
         return Loop::Continue;
     });
 }
 
-Optional<SessionHandle> SessionManager::AllocateSession()
+Optional<SessionHandle> SessionManager::AllocateSession(SecureSession::Type secureSessionType)
 {
-    return mSecureSessions.CreateNewSecureSession();
+    return mSecureSessions.CreateNewSecureSession(secureSessionType);
 }
 
 CHIP_ERROR SessionManager::InjectPaseSessionWithTestKey(SessionHolder & sessionHolder, uint16_t localSessionId, NodeId peerNodeId,
@@ -776,12 +777,6 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
 void SessionManager::ExpiryTimerCallback(System::Layer * layer, void * param)
 {
     SessionManager * mgr = reinterpret_cast<SessionManager *>(param);
-#if CHIP_CONFIG_SESSION_REKEYING
-    // TODO(#14217): session expiration is currently disabled until rekeying is supported
-    // the #ifdef should be removed after that.
-    mgr->mSecureSessions.ExpireInactiveSessions(System::SystemClock().GetMonotonicTimestamp(),
-                                                System::Clock::Milliseconds32(CHIP_PEER_CONNECTION_TIMEOUT_MS));
-#endif
     mgr->ScheduleExpiryTimer(); // re-schedule the oneshot timer
 }
 
@@ -790,7 +785,8 @@ Optional<SessionHandle> SessionManager::FindSecureSessionForNode(ScopedNodeId pe
 {
     SecureSession * found = nullptr;
     mSecureSessions.ForEachSession([&peerNodeId, &type, &found](auto session) {
-        if (session->GetPeer() == peerNodeId && (!type.HasValue() || type.Value() == session->GetSecureSessionType()))
+        if (session->IsActiveSession() && session->GetPeer() == peerNodeId &&
+            (!type.HasValue() || type.Value() == session->GetSecureSessionType()))
         {
             found = session;
             return Loop::Break;

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -167,7 +167,7 @@ public:
      * @return SessionHandle with a reference to a SecureSession, else NullOptional on failure
      */
     CHECK_RETURN_VALUE
-    Optional<SessionHandle> AllocateSession();
+    Optional<SessionHandle> AllocateSession(Transport::SecureSession::Type secureSessionType);
 
     void ExpirePairing(const SessionHandle & session);
     void ExpireAllPairings(const ScopedNodeId & node);
@@ -261,7 +261,7 @@ private:
     System::Layer * mSystemLayer = nullptr;
     FabricTable * mFabricTable   = nullptr;
     Transport::UnauthenticatedSessionTable<CHIP_CONFIG_UNAUTHENTICATED_CONNECTION_POOL_SIZE> mUnauthenticatedSessions;
-    Transport::SecureSessionTable<CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE> mSecureSessions;
+    Transport::SecureSessionTable mSecureSessions;
     State mState; // < Initialization state of the object
     chip::Transport::GroupOutgoingCounters mGroupClientCounter;
 
@@ -274,8 +274,6 @@ private:
     Transport::MessageCounterManagerInterface * mMessageCounterManager = nullptr;
 
     GlobalUnencryptedMessageCounter mGlobalUnencryptedMessageCounter;
-
-    friend class SessionHandle;
 
     /** Schedules a new oneshot timer for checking connection expiry. */
     void ScheduleExpiryTimer();

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -73,6 +73,8 @@ public:
     void Retain() override { ReferenceCounted<UnauthenticatedSession, NoopDeletor<UnauthenticatedSession>, 0>::Retain(); }
     void Release() override { ReferenceCounted<UnauthenticatedSession, NoopDeletor<UnauthenticatedSession>, 0>::Release(); }
 
+    bool IsActiveSession() const override { return true; }
+
     ScopedNodeId GetPeer() const override { return ScopedNodeId(GetPeerNodeId(), kUndefinedFabricIndex); }
     ScopedNodeId GetLocalScopedNodeId() const override { return ScopedNodeId(kUndefinedNodeId, kUndefinedFabricIndex); }
 

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -20,11 +20,8 @@
 #include <lib/core/ReferenceCounted.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/Pool.h>
-#include <lib/support/ReferenceCountedHandle.h>
-#include <lib/support/logging/CHIPLogging.h>
 #include <messaging/ReliableMessageProtocolConfig.h>
 #include <system/TimeSource.h>
-#include <transport/MessageCounter.h>
 #include <transport/PeerMessageCounter.h>
 #include <transport/Session.h>
 #include <transport/raw/PeerAddress.h>
@@ -32,18 +29,12 @@
 namespace chip {
 namespace Transport {
 
-class UnauthenticatedSessionDeleter
-{
-public:
-    // This is a no-op because life-cycle of UnauthenticatedSessionTable is rotated by LRU
-    static void Release(UnauthenticatedSession * entry) {}
-};
-
 /**
  * @brief
  *   An UnauthenticatedSession stores the binding of TransportAddress, and message counters.
  */
-class UnauthenticatedSession : public Session, public ReferenceCounted<UnauthenticatedSession, UnauthenticatedSessionDeleter, 0>
+class UnauthenticatedSession : public Session,
+                               public ReferenceCounted<UnauthenticatedSession, NoopDeletor<UnauthenticatedSession>, 0>
 {
 public:
     enum class SessionRole
@@ -58,7 +49,7 @@ public:
         mLastPeerActivityTime(System::Clock::kZero), // Start at zero to default to IDLE state
         mMRPConfig(config)
     {}
-    ~UnauthenticatedSession() override { NotifySessionReleased(); }
+    ~UnauthenticatedSession() override { VerifyOrDie(GetReferenceCount() == 0); }
 
     UnauthenticatedSession(const UnauthenticatedSession &) = delete;
     UnauthenticatedSession & operator=(const UnauthenticatedSession &) = delete;
@@ -79,8 +70,8 @@ public:
     const char * GetSessionTypeString() const override { return "unauthenticated"; };
 #endif
 
-    void Retain() override { ReferenceCounted<UnauthenticatedSession, UnauthenticatedSessionDeleter, 0>::Retain(); }
-    void Release() override { ReferenceCounted<UnauthenticatedSession, UnauthenticatedSessionDeleter, 0>::Release(); }
+    void Retain() override { ReferenceCounted<UnauthenticatedSession, NoopDeletor<UnauthenticatedSession>, 0>::Retain(); }
+    void Release() override { ReferenceCounted<UnauthenticatedSession, NoopDeletor<UnauthenticatedSession>, 0>::Release(); }
 
     ScopedNodeId GetPeer() const override { return ScopedNodeId(GetPeerNodeId(), kUndefinedFabricIndex); }
     ScopedNodeId GetLocalScopedNodeId() const override { return ScopedNodeId(kUndefinedNodeId, kUndefinedFabricIndex); }

--- a/src/transport/tests/TestSessionManager.cpp
+++ b/src/transport/tests/TestSessionManager.cpp
@@ -58,13 +58,6 @@ const char PAYLOAD[] = "Hello!";
 
 const char LARGE_PAYLOAD[kMaxAppMessageLen + 1] = "test message";
 
-class TestSessionReleaseCallback : public SessionDelegate
-{
-public:
-    void OnSessionReleased() override { mOldConnectionDropped = true; }
-    bool mOldConnectionDropped = false;
-};
-
 class TestSessMgrCallback : public SessionMessageDelegate
 {
 public:
@@ -663,7 +656,7 @@ static void RandomSessionIdAllocatorOffset(nlTestSuite * inSuite, SessionManager
     const int bound = rand() % max;
     for (int i = 0; i < bound; ++i)
     {
-        auto handle = sessionManager.AllocateSession();
+        auto handle = sessionManager.AllocateSession(Transport::SecureSession::Type::kPASE);
         NL_TEST_ASSERT(inSuite, handle.HasValue());
         sessionManager.ExpirePairing(handle.Value());
     }
@@ -672,14 +665,14 @@ static void RandomSessionIdAllocatorOffset(nlTestSuite * inSuite, SessionManager
 void SessionAllocationTest(nlTestSuite * inSuite, void * inContext)
 {
     SessionManager sessionManager;
-    TestSessionReleaseCallback callback;
 
     // Allocate a session.
     uint16_t sessionId1;
     {
-        auto handle = sessionManager.AllocateSession();
+        auto handle = sessionManager.AllocateSession(Transport::SecureSession::Type::kPASE);
         NL_TEST_ASSERT(inSuite, handle.HasValue());
-        SessionHolderWithDelegate session(handle.Value(), callback);
+        SessionHolder session;
+        session.GrabPairing(handle.Value());
         sessionId1 = session->AsSecureSession()->GetLocalSessionId();
     }
 
@@ -688,7 +681,7 @@ void SessionAllocationTest(nlTestSuite * inSuite, void * inContext)
     auto prevSessionId = sessionId1;
     for (uint32_t i = 0; i < 10; ++i)
     {
-        auto handle = sessionManager.AllocateSession();
+        auto handle = sessionManager.AllocateSession(Transport::SecureSession::Type::kPASE);
         if (!handle.HasValue())
         {
             break;
@@ -709,7 +702,7 @@ void SessionAllocationTest(nlTestSuite * inSuite, void * inContext)
     // sessions are immediately freed.
     for (uint32_t i = 0; i < UINT16_MAX + 10; ++i)
     {
-        auto handle = sessionManager.AllocateSession();
+        auto handle = sessionManager.AllocateSession(Transport::SecureSession::Type::kPASE);
         NL_TEST_ASSERT(inSuite, handle.HasValue());
         auto sessionId = handle.Value()->AsSecureSession()->GetLocalSessionId();
         NL_TEST_ASSERT(inSuite, sessionId - prevSessionId == 1 || (sessionId == 1 && prevSessionId == 65535));
@@ -730,7 +723,7 @@ void SessionAllocationTest(nlTestSuite * inSuite, void * inContext)
         for (size_t h = 0; h < numHandles; ++h)
         {
             constexpr int maxOffset = 5000;
-            handles[h]              = sessionManager.AllocateSession();
+            handles[h]              = sessionManager.AllocateSession(Transport::SecureSession::Type::kPASE);
             NL_TEST_ASSERT(inSuite, handles[h].HasValue());
             sessionIds[h] = handles[h].Value()->AsSecureSession()->GetLocalSessionId();
             RandomSessionIdAllocatorOffset(inSuite, sessionManager, maxOffset);
@@ -746,7 +739,7 @@ void SessionAllocationTest(nlTestSuite * inSuite, void * inContext)
         // these collide either.
         for (int j = 0; j < UINT16_MAX; ++j)
         {
-            auto handle = sessionManager.AllocateSession();
+            auto handle = sessionManager.AllocateSession(Transport::SecureSession::Type::kPASE);
             NL_TEST_ASSERT(inSuite, handle.HasValue());
             auto potentialCollision = handle.Value()->AsSecureSession()->GetLocalSessionId();
             for (size_t h = 0; h < numHandles; ++h)


### PR DESCRIPTION
#### Problem
Fix #17558

Use ref counter for secure session, here are how it works: 

1. `SecureSession`  starts at 0 ref
1. `PairingSession::mSecureSessionHolder`  is its first ref
1. On `SecureSession::Activate` it obtain a ref for itself
1. `SecureSession::MarkForRemoval` release the ref at step 3.
1. `SecureSession::MarkForRemoval` will clear all session holder, and prevent any future holder grabbing the session
1. After all `SessionHandle` is released, the ref count of the session will be decreased to 0
1. Release the session object

#### Change overview
* Use ref count for all types of sessions.
* Use a state machine for secure session with 3 states: `kPairing`, `kActive`, `kPendingRemoval`
  * Decouple `kPairing` (was `kPending`) from `SessionType`
  * `SessionType` is assigned at beginning of pairing, shifted from `Activate` 

#### Testing
WIP