### PR TITLE
[ESP32] Update ESP-IDF in CHIP to v4.4.1 release

### DIFF
--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -56,26 +56,26 @@ The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
 -   Clone the Espressif ESP-IDF and checkout
-    [v4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4)
+    [v4.4.1 release](https://github.com/espressif/esp-idf/releases/tag/v4.4.1)
 
           ```
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout v4.4
+          $ git checkout v4.4.1
           $ git submodule update --init
           $ ./install.sh
           $ . ./export.sh
           ```
 
-    To update an existing esp-idf toolchain to v4.4:
+    To update an existing esp-idf toolchain to v4.4.1:
 
           ```
           $ cd ~/tools/esp-idf
           $ git fetch origin
-          $ git checkout v4.4
-          $ git reset --hard origin/v4.4
+          $ git checkout v4.4.1
+          $ git reset --hard origin/v4.4.1
           $ git submodule update --init
           $ git clean -fdx
           $ ./install.sh

--- a/examples/bridge-app/esp32/README.md
+++ b/examples/bridge-app/esp32/README.md
@@ -86,14 +86,14 @@ The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
 -   Clone the Espressif ESP-IDF and checkout
-    [v4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4)
+    [v4.4.1 release](https://github.com/espressif/esp-idf/releases/tag/v4.4.1)
 
           ```
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout v4.4
+          $ git checkout v4.4.1
           $ git submodule update --init
           $ ./install.sh
           ```

--- a/examples/ipv6only-app/esp32/README.md
+++ b/examples/ipv6only-app/esp32/README.md
@@ -21,14 +21,14 @@ The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
 -   Clone the Espressif ESP-IDF and checkout
-    [v4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4)
+    [v4.4.1 release](https://github.com/espressif/esp-idf/releases/tag/v4.4.1)
 
           ```
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout v4.4
+          $ git checkout v4.4.1
           $ git submodule update --init
           $ ./install.sh
           ```

--- a/examples/lighting-app/esp32/README.md
+++ b/examples/lighting-app/esp32/README.md
@@ -33,13 +33,13 @@ The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
 -   Clone the Espressif ESP-IDF and checkout
-    [v4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4)
+    [v4.4.1 release](https://github.com/espressif/esp-idf/releases/tag/v4.4.1)
 
         $ mkdir ${HOME}/tools
         $ cd ${HOME}/tools
         $ git clone https://github.com/espressif/esp-idf.git
         $ cd esp-idf
-        $ git checkout v4.4
+        $ git checkout v4.4.1
         $ git submodule update --init
         $ ./install.sh
 

--- a/examples/lock-app/esp32/README.md
+++ b/examples/lock-app/esp32/README.md
@@ -24,13 +24,13 @@ The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
 -   Clone the Espressif ESP-IDF and checkout
-    [v4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4)
+    [v4.4.1 release](https://github.com/espressif/esp-idf/releases/tag/v4.4.1)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout v4.4
+          $ git checkout v4.4.1
           $ git submodule update --init
           $ ./install.sh
 

--- a/examples/persistent-storage/esp32/README.md
+++ b/examples/persistent-storage/esp32/README.md
@@ -43,13 +43,13 @@ The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
 -   Clone the Espressif ESP-IDF and checkout
-    [v4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4)
+    [v4.4.1 release](https://github.com/espressif/esp-idf/releases/tag/v4.4.1)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout v4.4
+          $ git checkout v4.4.1
           $ git submodule update --init
           $ ./install.sh
 

--- a/examples/pigweed-app/esp32/README.md
+++ b/examples/pigweed-app/esp32/README.md
@@ -36,13 +36,13 @@ The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
 -   Clone the Espressif ESP-IDF and checkout
-    [v4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4)
+    [v4.4.1 release](https://github.com/espressif/esp-idf/releases/tag/v4.4.1)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout v4.4
+          $ git checkout v4.4.1
           $ git submodule update --init
           $ ./install.sh
 

--- a/examples/temperature-measurement-app/esp32/README.md
+++ b/examples/temperature-measurement-app/esp32/README.md
@@ -24,13 +24,13 @@ The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
 -   Clone the Espressif ESP-IDF and checkout
-    [v4.4 release](https://github.com/espressif/esp-idf/releases/tag/v4.4)
+    [v4.4.1 release](https://github.com/espressif/esp-idf/releases/tag/v4.4.1)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools
           $ git clone https://github.com/espressif/esp-idf.git
           $ cd esp-idf
-          $ git checkout v4.4
+          $ git checkout v4.4.1
           $ git submodule update --init
           $ ./install.sh
 

--- a/integrations/docker/images/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32/Dockerfile
@@ -10,7 +10,7 @@ RUN set -x \
     && : # last line
 
 RUN set -x \
-    && git clone --recursive -b v4.4 https://github.com/espressif/esp-idf.git /tmp/esp-idf \
+    && git clone --recursive -b v4.4.1 https://github.com/espressif/esp-idf.git /tmp/esp-idf \
     && : # last line
 
 FROM connectedhomeip/chip-build:${VERSION}

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.65 Added zap tool into vscode image
+0.5.66 Version bump reason: Update ESP-IDF to v4.4.1 release


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* CHIP uses ESP-IDF v4.4.  [ESP-IDF v4.4.1](https://github.com/espressif/esp-idf/releases/tag/v4.4.1) is released,  so need to update to use that.

#### Change overview
* Update the documentation to use v4.4.1 release tag
* Update docker to use v4.4.1

#### Testing
* Compilation of esp32/all-clusters-app with ESP32 and ESP32-C3
* Commissioning and cluster control with ESP32 and ESP32-C3
