### PR TITLE
Remove incorrect comments in WriteHandler.

### DIFF
--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -306,9 +306,6 @@ CHIP_ERROR WriteHandler::ProcessAttributeDataIBs(TLV::TLVReader & aAttributeData
         err = element.GetPath(&attributePath);
         SuccessOrExit(err);
 
-        // We are using the feature that the parser won't touch the value if the field does not exist, since all fields in the
-        // cluster info will be invalid / wildcard, it is safe ignore CHIP_END_OF_TLV directly.
-
         err = attributePath.GetEndpoint(&(dataAttributePath.mEndpointId));
         SuccessOrExit(err);
 
@@ -423,9 +420,6 @@ CHIP_ERROR WriteHandler::ProcessGroupAttributeDataIBs(TLV::TLVReader & aAttribut
 
         err = element.GetPath(&attributePath);
         SuccessOrExit(err);
-
-        // We are using the feature that the parser won't touch the value if the field does not exist, since all fields in the
-        // cluster info will be invalid / wildcard, it is safe to ignore CHIP_END_OF_TLV.
 
         err = attributePath.GetCluster(&(dataAttributePath.mClusterId));
         SuccessOrExit(err);


### PR DESCRIPTION
We're not parsing into a "cluster info" and we are not ignoring
CHIP_END_OF_TLV.  The comments simply do not match the code.

#### Problem
See above.

#### Change overview
See above.

#### Testing
No behavior changes.