### PR TITLE
Update git version for doxygen dockerfile

### DIFF
--- a/integrations/docker/images/chip-build-doxygen/Dockerfile
+++ b/integrations/docker/images/chip-build-doxygen/Dockerfile
@@ -4,4 +4,4 @@ RUN apk --no-cache add \
   doxygen=1.9.2-r1 \
   graphviz=2.49.3-r0 \
   bash=5.1.16-r0 \
-  git=2.34.1-r0
+  git=2.34.2-r0

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.66 Version bump reason: Update ESP-IDF to v4.4.1 release
+0.5.67 Version bump reason: update git version in Doxygen image


### PR DESCRIPTION
#### Problem
Alpine updated git to 2.34.2 (instead of 2.34.1) and this keeps getting CI errors even though our docker file has not changed in ages (this is why our local builds keep succeeding - they use cached layers)

#### Change overview
Change git package version

#### Testing
Manually ran apk to find the correct version of git. CI will validate that doxygen image builds in a clean environment.