### PR TITLE
Improve clang-tidy script output to not be noisy

### DIFF
--- a/scripts/run-clang-tidy-on-compile-commands.py
+++ b/scripts/run-clang-tidy-on-compile-commands.py
@@ -132,13 +132,14 @@ class ClangTidyEntry:
                 # Most (all?) of our files do contain errors in system-heades so lines like these
                 # are expected:
                 #
+                # ```
                 # 59 warnings generated.
                 # Suppressed 59 warnings (59 in non-user code).
                 # Use -header-filter=.* to display errors from all non-system headers.
                 # Use -system-headers to display errors from system headers as well.
+                # ```
                 #
-                # We ignore output from that file
-
+                # The list below ignores those expected output lines.
                 skip_strings = [
                     "warnings generated",
                     "in non-user code",

--- a/scripts/run-clang-tidy-on-compile-commands.py
+++ b/scripts/run-clang-tidy-on-compile-commands.py
@@ -129,7 +129,7 @@ class ClangTidyEntry:
                 logging.info("TIDY %s: %s", self.file, output.decode("utf-8"))
 
             if err:
-                # Most (all?) of our files do contain errors in system-heades so lines like these
+                # Most (all?) of our files do contain errors in system-headers so lines like these
                 # are expected:
                 #
                 # ```

--- a/scripts/run-clang-tidy-on-compile-commands.py
+++ b/scripts/run-clang-tidy-on-compile-commands.py
@@ -134,7 +134,7 @@ class ClangTidyEntry:
                 #
                 # 59 warnings generated.
                 # Suppressed 59 warnings (59 in non-user code).
-                # Use -header-filter=.* to display errors from all non-system headers. 
+                # Use -header-filter=.* to display errors from all non-system headers.
                 # Use -system-headers to display errors from system headers as well.
                 #
                 # We ignore output from that file
@@ -146,7 +146,6 @@ class ClangTidyEntry:
                     "Use -system-headers to display errors from system headers as well.",
                 ]
 
-
                 for l in err.decode('utf-8').split('\n'):
                     l = l.strip()
 
@@ -154,10 +153,9 @@ class ClangTidyEntry:
                         continue
 
                     if not l:
-                        continue # no empty lines
+                        continue  # no empty lines
 
                     logging.warning('TIDY %s: %s', self.file, l)
-
 
             if proc.returncode != 0:
                 if proc.returncode < 0:

--- a/scripts/run-clang-tidy-on-compile-commands.py
+++ b/scripts/run-clang-tidy-on-compile-commands.py
@@ -307,11 +307,12 @@ class ClangTidyRunner:
             task_queue.put(e)
         task_queue.join()
 
-        logging.info("Successfully processed %d paths", self.state.successes)
-        logging.info("Failed to process %d paths", self.state.failures)
+        logging.info("Successfully processed %d path(s)", self.state.successes)
+        logging.warning("Failed to process %d path(s)", self.state.failures)
         if self.state.failures:
+            logging.warning("The following paths failed clang-tidy checks:")
             for name in self.state.failed_files:
-                logging.warning("Failure reported for %s", name)
+                logging.warning("  - %s", name)
 
         return self.state.failures == 0
 

--- a/scripts/run-clang-tidy-on-compile-commands.py
+++ b/scripts/run-clang-tidy-on-compile-commands.py
@@ -336,8 +336,8 @@ class ClangTidyRunner:
         task_queue.join()
 
         logging.info("Successfully processed %d path(s)", self.state.successes)
-        logging.warning("Failed to process %d path(s)", self.state.failures)
         if self.state.failures:
+            logging.warning("Failed to process %d path(s)", self.state.failures)
             logging.warning("The following paths failed clang-tidy checks:")
             for name in self.state.failed_files:
                 logging.warning("  - %s", name)

--- a/scripts/run-clang-tidy-on-compile-commands.py
+++ b/scripts/run-clang-tidy-on-compile-commands.py
@@ -134,18 +134,27 @@ class ClangTidyEntry:
                 #
                 # 59 warnings generated.
                 # Suppressed 59 warnings (59 in non-user code).
-                # Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
+                # Use -header-filter=.* to display errors from all non-system headers. 
+                # Use -system-headers to display errors from system headers as well.
                 #
                 # We ignore output from that file
+
+                skip_strings = [
+                    "warnings generated",
+                    "in non-user code",
+                    "Use -header-filter=.* to display errors from all non-system headers.",
+                    "Use -system-headers to display errors from system headers as well.",
+                ]
+
+
                 for l in err.decode('utf-8').split('\n'):
-                    if 'warnings generated.' in l:
+                    l = l.strip()
+
+                    if any(map(lambda s: s in l, skip_strings)):
                         continue
 
-                    if 'in non-user code' in l:
-                        continue
-
-                    if 'use -system-headers to display errors' in l:
-                        continue
+                    if not l:
+                        continue # no empty lines
 
                     logging.warning('TIDY %s: %s', self.file, l)
 


### PR DESCRIPTION
#### Problem
Clang-tidy warns of all system header warnings, drowning real failures in massive output amount.

#### Change overview
Filter out 'expected' noisy output, to keep only relevant info (failures)

#### Testing
Manually ran locally. CI should show nicer output as well.