### PR TITLE
Removed dacProvider parameter from ChipLinuxAppMainLoop

### DIFF
--- a/examples/all-clusters-app/linux/main.cpp
+++ b/examples/all-clusters-app/linux/main.cpp
@@ -25,6 +25,7 @@ int main(int argc, char * argv[])
     VerifyOrDie(ChipLinuxAppInit(argc, argv, AppOptions::GetOptions()) == 0);
     VerifyOrDie(InitBindingHandlers() == CHIP_NO_ERROR);
 
-    ChipLinuxAppMainLoop(AppOptions::GetDACProvider());
+    LinuxDeviceOptions::GetInstance().dacProvider = AppOptions::GetDACProvider();
+    ChipLinuxAppMainLoop();
     return 0;
 }

--- a/examples/placeholder/linux/main.cpp
+++ b/examples/placeholder/linux/main.cpp
@@ -32,6 +32,7 @@ int main(int argc, char * argv[])
         test->NextTest();
     }
 
-    ChipLinuxAppMainLoop(AppOptions::GetDACProvider());
+    LinuxDeviceOptions::GetInstance().dacProvider = AppOptions::GetDACProvider();
+    ChipLinuxAppMainLoop();
     return 0;
 }

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -27,10 +27,10 @@
 #include <lib/core/NodeId.h>
 #include <lib/support/logging/CHIPLogging.h>
 
+#include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/GroupDataProviderImpl.h>
 #include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
 
 #include <lib/support/CHIPMem.h>
 #include <lib/support/ScopedBuffer.h>
@@ -389,7 +389,7 @@ exit:
     return 0;
 }
 
-void ChipLinuxAppMainLoop(DeviceAttestationCredentialsProvider * dacProvider)
+void ChipLinuxAppMainLoop()
 {
     static chip::CommonCaseDeviceServerInitParams initParams;
     VerifyOrDie(initParams.InitializeStaticResourcesBeforeServerInit() == CHIP_NO_ERROR);
@@ -422,7 +422,7 @@ void ChipLinuxAppMainLoop(DeviceAttestationCredentialsProvider * dacProvider)
     PrintOnboardingCodes(LinuxDeviceOptions::GetInstance().payload);
 
     // Initialize device attestation config
-    SetDeviceAttestationCredentialsProvider(dacProvider == nullptr ? Examples::GetExampleDACProvider() : dacProvider);
+    SetDeviceAttestationCredentialsProvider(LinuxDeviceOptions::GetInstance().dacProvider);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
     ChipLogProgress(AppServer, "Starting commissioner");

--- a/examples/platform/linux/AppMain.h
+++ b/examples/platform/linux/AppMain.h
@@ -20,7 +20,6 @@
 
 #include <controller/CHIPDeviceController.h>
 #include <controller/CommissionerDiscoveryController.h>
-#include <credentials/DeviceAttestationCredsProvider.h>
 #include <lib/core/CHIPError.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/PlatformManager.h>
@@ -29,7 +28,7 @@
 #include "Options.h"
 
 int ChipLinuxAppInit(int argc, char ** argv, chip::ArgParser::OptionSet * customOptions = nullptr);
-void ChipLinuxAppMainLoop(chip::Credentials::DeviceAttestationCredentialsProvider * dacProvider = nullptr);
+void ChipLinuxAppMainLoop();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -28,6 +28,8 @@
 #include <lib/core/CHIPError.h>
 #include <lib/support/Base64.h>
 
+#include <credentials/examples/DeviceAttestationCredsExample.h>
+
 using namespace chip;
 using namespace chip::ArgParser;
 
@@ -413,5 +415,9 @@ CHIP_ERROR ParseArguments(int argc, char * argv[], OptionSet * customOptions)
 
 LinuxDeviceOptions & LinuxDeviceOptions::GetInstance()
 {
+    if (gDeviceOptions.dacProvider == nullptr)
+    {
+        gDeviceOptions.dacProvider = chip::Credentials::Examples::GetExampleDACProvider();
+    }
     return gDeviceOptions;
 }

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -34,6 +34,8 @@
 #include <lib/support/CHIPArgParser.hpp>
 #include <setup_payload/SetupPayload.h>
 
+#include <credentials/DeviceAttestationCredsProvider.h>
+
 struct LinuxDeviceOptions
 {
     chip::SetupPayload payload;
@@ -53,6 +55,7 @@ struct LinuxDeviceOptions
     chip::Inet::InterfaceId interfaceId = chip::Inet::InterfaceId::Null();
     bool traceStreamToLogEnabled        = false;
     chip::Optional<std::string> traceStreamFilename;
+    chip::Credentials::DeviceAttestationCredentialsProvider * dacProvider = nullptr;
 
     static LinuxDeviceOptions & GetInstance();
 };


### PR DESCRIPTION
#### Problem
* dacProvider is passed as an arguement to ChipLinuxAppMainLoop method, instead of being a part of LinuxDeviceOptions

#### Change overview
* Removed dacProvider parameter from ChipLinuxAppMainLoop method.
* Added dacProvider member variable to LinuxDeviceOptions - This will be used by the main function to overload the desired dacProvider.
* If no dacProvider is provided, LinuxDeviceOptions will default to the Example DAC Provider.

#### Testing
* Matter Unit Tests
* Tested Commissioning flow (chip-tool vs chip-all-clusters-app)