### PR TITLE
Use async loopback transport for all tests

### DIFF
--- a/src/app/tests/AppTestContext.h
+++ b/src/app/tests/AppTestContext.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <messaging/tests/MessagingContext.h>
-#include <transport/raw/tests/NetworkTestHelpers.h>
 
 namespace chip {
 namespace Test {
@@ -25,14 +24,11 @@ namespace Test {
  * @brief The context of test cases for messaging layer. It wil initialize network layer and system layer, and create
  *        two secure sessions, connected with each other. Exchanges can be created for each secure session.
  */
-class AppContext : public LoopbackMessagingContext<>
+class AppContext : public LoopbackMessagingContext
 {
-    typedef LoopbackMessagingContext<> Super;
+    typedef LoopbackMessagingContext Super;
 
 public:
-    // Disallow initialization as a sync loopback context.
-    static void Initialize(void *) = delete;
-
     /// Initialize the underlying layers.
     CHIP_ERROR Init() override;
 

--- a/src/app/tests/TestBufferedReadCallback.cpp
+++ b/src/app/tests/TestBufferedReadCallback.cpp
@@ -609,7 +609,7 @@ nlTestSuite theSuite =
 {
     "TestBufferedReadCallback",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 

--- a/src/app/tests/TestClusterStateCache.cpp
+++ b/src/app/tests/TestClusterStateCache.cpp
@@ -625,7 +625,7 @@ nlTestSuite theSuite =
 {
     "TestClusterStateCache",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -677,7 +677,6 @@ void TestCommandInteraction::TestCommandHandlerWithProcessReceivedEmptyDataMsg(n
             chip::isCommandDispatched = false;
             GenerateInvokeRequest(apSuite, apContext, commandDatabuf, false /*aNeedCommandData*/, messageIsTimed);
             err = commandHandler.ProcessInvokeRequest(std::move(commandDatabuf), transactionIsTimed);
-            ctx.DrainAndServiceIO();
             NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
             NL_TEST_ASSERT(apSuite, chip::isCommandDispatched == (messageIsTimed == transactionIsTimed));
         }

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -677,6 +677,7 @@ void TestCommandInteraction::TestCommandHandlerWithProcessReceivedEmptyDataMsg(n
             chip::isCommandDispatched = false;
             GenerateInvokeRequest(apSuite, apContext, commandDatabuf, false /*aNeedCommandData*/, messageIsTimed);
             err = commandHandler.ProcessInvokeRequest(std::move(commandDatabuf), transactionIsTimed);
+            ctx.DrainAndServiceIO();
             NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
             NL_TEST_ASSERT(apSuite, chip::isCommandDispatched == (messageIsTimed == transactionIsTimed));
         }
@@ -924,7 +925,7 @@ nlTestSuite sSuite =
 {
     "TestCommandInteraction",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/app/tests/TestEventLogging.cpp
+++ b/src/app/tests/TestEventLogging.cpp
@@ -61,9 +61,9 @@ static chip::app::CircularEventBuffer gCircularEventBuffer[3];
 class TestContext : public chip::Test::AppContext
 {
 public:
-    static int InitializeAsync(void * context)
+    static int Initialize(void * context)
     {
-        if (AppContext::InitializeAsync(context) != SUCCESS)
+        if (AppContext::Initialize(context) != SUCCESS)
             return FAILURE;
 
         auto * ctx = static_cast<TestContext *>(context);
@@ -302,7 +302,7 @@ nlTestSuite sSuite =
 {
     "EventLogging",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/app/tests/TestEventOverflow.cpp
+++ b/src/app/tests/TestEventOverflow.cpp
@@ -53,9 +53,9 @@ static chip::app::CircularEventBuffer gCircularEventBuffer[3];
 class TestContext : public chip::Test::AppContext
 {
 public:
-    static int InitializeAsync(void * context)
+    static int Initialize(void * context)
     {
-        if (AppContext::InitializeAsync(context) != SUCCESS)
+        if (AppContext::Initialize(context) != SUCCESS)
             return FAILURE;
 
         auto * ctx = static_cast<TestContext *>(context);
@@ -176,7 +176,7 @@ nlTestSuite sSuite =
 {
     "TestEventOverflow",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -113,7 +113,7 @@ nlTestSuite sSuite =
 {
     "TestInteractionModelEngine",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -64,11 +64,9 @@ chip::DataVersion kTestDataVersion2     = 5;
 class TestContext : public chip::Test::AppContext
 {
 public:
-    static int Initialize(void * context) = delete;
-
-    static int InitializeAsync(void * context)
+    static int Initialize(void * context)
     {
-        if (AppContext::InitializeAsync(context) != SUCCESS)
+        if (AppContext::Initialize(context) != SUCCESS)
             return FAILURE;
 
         auto * ctx = static_cast<TestContext *>(context);
@@ -105,7 +103,6 @@ private:
 };
 
 TestContext sContext;
-auto & sLoopback = sContext.GetLoopback();
 
 class TestEventGenerator : public chip::app::EventLoggingDelegate
 {
@@ -2609,7 +2606,7 @@ nlTestSuite sSuite =
 {
     "TestReadInteraction",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -195,7 +195,7 @@ nlTestSuite sSuite =
 {
     "TestReportingEngine",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/app/tests/TestTimedHandler.cpp
+++ b/src/app/tests/TestTimedHandler.cpp
@@ -258,7 +258,7 @@ nlTestSuite sSuite =
 {
     "TestTimedHandler",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -290,7 +290,6 @@ void TestWriteInteraction::TestWriteHandler(nlTestSuite * apSuite, void * apCont
     //    a synchronous model, the exchange is still open, and the status response is sent to the WriteHandler.
     // 5. WriteHandler::OnMessageReceived is invoked, and it correctly asserts.
     //
-    ctx.EnableAsyncDispatch();
 
     constexpr bool allBooleans[] = { true, false };
     for (auto messageIsTimed : allBooleans)
@@ -335,8 +334,6 @@ void TestWriteInteraction::TestWriteHandler(nlTestSuite * apSuite, void * apCont
             NL_TEST_ASSERT(apSuite, rm->TestGetCountRetransTable() == 0);
         }
     }
-
-    ctx.DisableAsyncDispatch();
 }
 
 const EmberAfAttributeMetadata * GetAttributeMetadata(const ConcreteAttributePath & aConcreteClusterPath)
@@ -490,7 +487,7 @@ int Test_Setup(void * inContext)
 {
     VerifyOrReturnError(CHIP_NO_ERROR == chip::Platform::MemoryInit(), FAILURE);
 
-    VerifyOrReturnError(TestContext::InitializeAsync(inContext) == SUCCESS, FAILURE);
+    VerifyOrReturnError(TestContext::Initialize(inContext) == SUCCESS, FAILURE);
 
     TestContext & ctx = *static_cast<TestContext *>(inContext);
     gTestStorage.ClearStorage();

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -276,21 +276,6 @@ void TestWriteInteraction::TestWriteHandler(nlTestSuite * apSuite, void * apCont
 
     TestContext & ctx = *static_cast<TestContext *>(apContext);
 
-    //
-    // We have to enable async dispatch here to ensure that the exchange
-    // gets correctly closed out in the test below. Otherwise, the following happens:
-    //
-    // 1. WriteHandler generates a response upon OnWriteRequest being called.
-    // 2. Since there is no matching active client-side exchange for that request, the IM engine
-    //    handles it incorrectly and treats it like an unsolicited message.
-    // 3. It is invalid to receive a WriteResponse as an unsolicited message so it correctly sends back
-    //    a StatusResponse containing an error to that message.
-    // 4. Without unwinding the existing call stack, a response is received on the same exchange that the handler
-    //    generated a WriteResponse on. This exchange should have been closed in a normal execution model, but in
-    //    a synchronous model, the exchange is still open, and the status response is sent to the WriteHandler.
-    // 5. WriteHandler::OnMessageReceived is invoked, and it correctly asserts.
-    //
-
     constexpr bool allBooleans[] = { true, false };
     for (auto messageIsTimed : allBooleans)
     {
@@ -327,7 +312,6 @@ void TestWriteInteraction::TestWriteHandler(nlTestSuite * apSuite, void * apCont
                 NL_TEST_ASSERT(apSuite, status == Status::UnsupportedAccess);
             }
 
-            ctx.DrainAndServiceIO();
             ctx.DrainAndServiceIO();
 
             Messaging::ReliableMessageMgr * rm = ctx.GetExchangeManager().GetReliableMessageMgr();

--- a/src/controller/tests/TestEventCaching.cpp
+++ b/src/controller/tests/TestEventCaching.cpp
@@ -54,9 +54,9 @@ static chip::app::CircularEventBuffer gCircularEventBuffer[3];
 class TestContext : public chip::Test::AppContext
 {
 public:
-    static int InitializeAsync(void * context)
+    static int Initialize(void * context)
     {
-        if (AppContext::InitializeAsync(context) != SUCCESS)
+        if (AppContext::Initialize(context) != SUCCESS)
             return FAILURE;
 
         auto * ctx = static_cast<TestContext *>(context);
@@ -454,7 +454,7 @@ nlTestSuite sSuite =
 {
     "TestEventCaching",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/controller/tests/TestEventChunking.cpp
+++ b/src/controller/tests/TestEventChunking.cpp
@@ -54,9 +54,9 @@ static chip::app::CircularEventBuffer gCircularEventBuffer[3];
 class TestContext : public chip::Test::AppContext
 {
 public:
-    static int InitializeAsync(void * context)
+    static int Initialize(void * context)
     {
-        if (AppContext::InitializeAsync(context) != SUCCESS)
+        if (AppContext::Initialize(context) != SUCCESS)
             return FAILURE;
 
         auto * ctx = static_cast<TestContext *>(context);
@@ -534,7 +534,7 @@ nlTestSuite sSuite =
 {
     "TestEventChunking",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/controller/tests/TestReadChunking.cpp
+++ b/src/controller/tests/TestReadChunking.cpp
@@ -908,7 +908,7 @@ nlTestSuite sSuite =
 {
     "TestReadChunking",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/controller/tests/TestServerCommandDispatch.cpp
+++ b/src/controller/tests/TestServerCommandDispatch.cpp
@@ -184,8 +184,6 @@ void TestCommandInteraction::TestNoHandler(nlTestSuite * apSuite, void * apConte
 
     responseDirective = kSendDataResponse;
 
-    ctx.EnableAsyncDispatch();
-
     chip::Controller::InvokeCommandRequest(&ctx.GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                            onFailureCb);
 
@@ -402,7 +400,7 @@ nlTestSuite sSuite =
 {
     "TestCommands",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -727,7 +727,7 @@ nlTestSuite sSuite =
 {
     "TestWriteChunking",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/controller/tests/data_model/TestCommands.cpp
+++ b/src/controller/tests/data_model/TestCommands.cpp
@@ -450,7 +450,7 @@ nlTestSuite sSuite =
 {
     "TestCommands",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -1490,7 +1490,7 @@ nlTestSuite sSuite =
 {
     "TestRead",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/controller/tests/data_model/TestWrite.cpp
+++ b/src/controller/tests/data_model/TestWrite.cpp
@@ -384,7 +384,7 @@ nlTestSuite sSuite =
 {
     "TestWrite",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -424,25 +424,10 @@ CHIP_ERROR ExchangeContext::HandleMessage(uint32_t messageCounter, const Payload
     // layer has completed its work on the ExchangeContext.
     ExchangeHandle ref(*this);
 
-    // Keep track of whether we're nested under an outer HandleMessage
-    // invocation.
-    bool alreadyHandlingMessage = mFlags.Has(Flags::kFlagHandlingMessage);
-    mFlags.Set(Flags::kFlagHandlingMessage);
-
     bool isStandaloneAck = payloadHeader.HasMessageType(Protocols::SecureChannel::MsgType::StandaloneAck);
     bool isDuplicate     = msgFlags.Has(MessageFlagValues::kDuplicateMessage);
 
     auto deferred = MakeDefer([&]() {
-        // The alreadyHandlingMessage check is effectively a workaround for the fact that SendMessage() is not calling
-        // MessageHandled() yet and will go away when we fix that.
-        if (alreadyHandlingMessage)
-        {
-            // Don't close if there's an outer HandleMessage invocation.  It'll deal with the closing.
-            return;
-        }
-        // We are the outermost HandleMessage invocation.  We're not handling a message anymore.
-        mFlags.Clear(Flags::kFlagHandlingMessage);
-
         // Duplicates and standalone acks are not application-level messages, so they should generally not lead to any state
         // changes.  The one exception to that is that if we have a null mDelegate then our lifetime is not application-defined,
         // since we don't interact with the application at that point.  That can happen when we are already closed (in which case

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -198,9 +198,6 @@ protected:
         /// When set, signifies that this exchange is waiting for a call to SendMessage.
         kFlagWillSendMessage = (1u << 8),
 
-        /// When set, signifies that we are currently in the middle of HandleMessage.
-        kFlagHandlingMessage = (1u << 9),
-
         /// When set, we have had Close() or Abort() called on us already.
         kFlagClosed = (1u << 10),
 

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -199,10 +199,10 @@ protected:
         kFlagWillSendMessage = (1u << 8),
 
         /// When set, we have had Close() or Abort() called on us already.
-        kFlagClosed = (1u << 10),
+        kFlagClosed = (1u << 9),
 
         /// When set, signifies that the exchange is requesting Sleepy End Device fast-polling mode.
-        kFlagFastPollingMode = (1u << 11),
+        kFlagFastPollingMode = (1u << 10),
     };
 
     BitFlags<Flags> mFlags; // Internal state flags

--- a/src/messaging/tests/BUILD.gn
+++ b/src/messaging/tests/BUILD.gn
@@ -35,7 +35,7 @@ static_library("helpers") {
     "${chip_root}/src/messaging",
     "${chip_root}/src/protocols",
     "${chip_root}/src/transport",
-    "${chip_root}/src/transport/raw/tests:helpers",
+    "${chip_root}/src/transport/tests:helpers",
     "${nlio_root}:nlio",
   ]
 }

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -24,7 +24,7 @@
 #include <system/SystemClock.h>
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
-#include <transport/raw/tests/NetworkTestHelpers.h>
+#include <transport/tests/LoopbackTransportManager.h>
 
 #include <nlunit-test.h>
 
@@ -158,8 +158,8 @@ private:
     Optional<Transport::OutgoingGroupSession> mSessionBobToFriends;
 };
 
-template <typename Transport = LoopbackTransport>
-class LoopbackMessagingContext : public MessagingContext
+// LoopbackMessagingContext enriches MessagingContext with a async loopback transport
+class LoopbackMessagingContext : public LoopbackTransportManager, public MessagingContext
 {
 public:
     virtual ~LoopbackMessagingContext() {}
@@ -168,9 +168,8 @@ public:
     virtual CHIP_ERROR Init()
     {
         ReturnErrorOnFailure(chip::Platform::MemoryInit());
-        ReturnErrorOnFailure(mIOContext.Init());
-        ReturnErrorOnFailure(mTransportManager.Init("LOOPBACK"));
-        ReturnErrorOnFailure(MessagingContext::Init(&mTransportManager, &mIOContext));
+        ReturnErrorOnFailure(LoopbackTransportManager::Init());
+        ReturnErrorOnFailure(MessagingContext::Init(&GetTransportMgr(), &GetIOContext()));
         return CHIP_NO_ERROR;
     }
 
@@ -178,7 +177,7 @@ public:
     virtual CHIP_ERROR Shutdown()
     {
         ReturnErrorOnFailure(MessagingContext::Shutdown());
-        ReturnErrorOnFailure(mIOContext.Shutdown());
+        ReturnErrorOnFailure(LoopbackTransportManager::Shutdown());
         chip::Platform::MemoryShutdown();
         return CHIP_NO_ERROR;
     }
@@ -191,111 +190,13 @@ public:
         return ctx->Init() == CHIP_NO_ERROR ? SUCCESS : FAILURE;
     }
 
-    static int InitializeAsync(void * context)
-    {
-        auto * ctx = static_cast<LoopbackMessagingContext *>(context);
-
-        VerifyOrReturnError(ctx->Init() == CHIP_NO_ERROR, FAILURE);
-        ctx->EnableAsyncDispatch();
-
-        return SUCCESS;
-    }
-
     static int Finalize(void * context)
     {
         auto * ctx = static_cast<LoopbackMessagingContext *>(context);
         return ctx->Shutdown() == CHIP_NO_ERROR ? SUCCESS : FAILURE;
     }
 
-    Transport & GetLoopback() { return mTransportManager.GetTransport().template GetImplAtIndex<0>(); }
-
-    TransportMgrBase & GetTransportMgr() { return mTransportManager; }
-
-    IOContext & GetIOContext() { return mIOContext; }
-
-    /*
-     * For unit-tests that simulate end-to-end transmission and reception of messages in loopback mode,
-     * this mode better replicates a real-functioning stack that correctly handles the processing
-     * of a transmitted message as an asynchronous, bottom half handler dispatched after the current execution context has
-     completed.
-     * This is achieved using SystemLayer::ScheduleWork.
-
-     * This should be used in conjunction with the DrainAndServiceIO function below to correctly service and drain the event queue.
-     *
-     */
-    void EnableAsyncDispatch()
-    {
-        auto & impl = GetLoopback();
-        impl.EnableAsyncDispatch(&mIOContext.GetSystemLayer());
-    }
-
-    /*
-     * Reset the dispatch back to a model that synchronously dispatches received messages up the stack.
-     *
-     * NOTE: This results in highly atypical/complex call stacks that are not representative of what happens on real
-     * devices and can cause subtle and complex bugs to either appear or get masked in the system. Where possible, please
-     * use this sparingly!
-     *
-     */
-    void DisableAsyncDispatch()
-    {
-        auto & impl = GetLoopback();
-        impl.DisableAsyncDispatch();
-    }
-
-    /*
-     * This drives the servicing of events using the embedded IOContext while there are pending
-     * messages in the loopback transport's pending message queue. This should run to completion
-     * in well-behaved logic (i.e there isn't an indefinite ping-pong of messages transmitted back
-     * and forth).
-     *
-     * Consequently, this is guarded with a user-provided timeout to ensure we don't have unit-tests that stall
-     * in CI due to bugs in the code that is being tested.
-     *
-     * This DOES NOT ensure that all pending events are serviced to completion
-     * (i.e timers, any ScheduleWork calls), but does:
-     *
-     * 1) Guarantee that every call will make some progress on ready-to-run
-     *    things, by calling DriveIO at least once.
-     * 2) Try to ensure that any ScheduleWork calls that happend directly as a
-     *    result of message reception, and any messages those async tasks send,
-     *    get handled before DrainAndServiceIO returns.
-     */
-    void DrainAndServiceIO(System::Clock::Timeout maxWait = chip::System::Clock::Seconds16(5))
-    {
-        auto & impl                        = GetLoopback();
-        System::Clock::Timestamp startTime = System::SystemClock().GetMonotonicTimestamp();
-
-        while (true)
-        {
-            bool hadPendingMessages = impl.HasPendingMessages();
-            while (impl.HasPendingMessages())
-            {
-                mIOContext.DriveIO();
-                if ((System::SystemClock().GetMonotonicTimestamp() - startTime) >= maxWait)
-                {
-                    return;
-                }
-            }
-            // Processing those messages might have queued some run-ASAP async
-            // work.  Make sure to process that too, in case it generates
-            // response messages.
-            mIOContext.DriveIO();
-            if (!hadPendingMessages && !impl.HasPendingMessages())
-            {
-                // We're not making any progress on messages.  Just stop.
-                break;
-            }
-            // No need to check our timer here: either impl.HasPendingMessages()
-            // is true and we will check it next iteration, or it's false and we
-            // will either stop on the next iteration or it will become true and
-            // we will check the timer then.
-        }
-    }
-
-private:
-    TransportMgr<Transport> mTransportManager;
-    Test::IOContext mIOContext;
+    using LoopbackTransportManager::GetSystemLayer;
 };
 
 } // namespace Test

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -158,7 +158,7 @@ private:
     Optional<Transport::OutgoingGroupSession> mSessionBobToFriends;
 };
 
-// LoopbackMessagingContext enriches MessagingContext with a async loopback transport
+// LoopbackMessagingContext enriches MessagingContext with an async loopback transport
 class LoopbackMessagingContext : public LoopbackTransportManager, public MessagingContext
 {
 public:

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -34,7 +34,6 @@
 #include <protocols/Protocols.h>
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
-#include <transport/raw/tests/NetworkTestHelpers.h>
 
 #include <nlbyteorder.h>
 #include <nlunit-test.h>
@@ -49,7 +48,7 @@ using namespace chip::Inet;
 using namespace chip::Transport;
 using namespace chip::Messaging;
 
-using TestContext = Test::LoopbackMessagingContext<>;
+using TestContext = Test::LoopbackMessagingContext;
 
 enum : uint8_t
 {
@@ -251,7 +250,7 @@ nlTestSuite sSuite =
 {
     "Test-CHIP-ExchangeManager",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -44,7 +44,6 @@
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
 #include <messaging/tests/MessagingContext.h>
-#include <transport/raw/tests/NetworkTestHelpers.h>
 
 namespace {
 
@@ -55,7 +54,7 @@ using namespace chip::Messaging;
 using namespace chip::Protocols;
 using namespace chip::System::Clock::Literals;
 
-using TestContext = Test::LoopbackMessagingContext<>;
+using TestContext = Test::LoopbackMessagingContext;
 
 TestContext sContext;
 
@@ -1587,7 +1586,7 @@ nlTestSuite sSuite =
 {
     "Test-CHIP-ReliableMessageProtocol",
     &sTests[0],
-    TestContext::InitializeAsync,
+    TestContext::Initialize,
     TestContext::Finalize,
     InitializeTestCase,
 };

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -37,7 +37,6 @@
 #include <protocols/secure_channel/CASEServer.h>
 #include <protocols/secure_channel/CASESession.h>
 #include <stdarg.h>
-#include <transport/raw/tests/NetworkTestHelpers.h>
 
 #include "credentials/tests/CHIPCert_test_vectors.h"
 
@@ -51,7 +50,7 @@ using namespace chip::Transport;
 using namespace chip::Messaging;
 using namespace chip::Protocols;
 
-using TestContext = Test::LoopbackMessagingContext<>;
+using TestContext = Test::LoopbackMessagingContext;
 
 namespace {
 TestContext sContext;
@@ -654,7 +653,6 @@ CHIP_ERROR CASETestSecurePairingSetup(void * inContext)
 
     ctx.ConfigInitializeNodes(false);
     ReturnErrorOnFailure(ctx.Init());
-    ctx.EnableAsyncDispatch();
 
     gCommissionerFabrics.Init(&gCommissionerStorageDelegate);
     gDeviceFabrics.Init(&gDeviceStorageDelegate);

--- a/src/protocols/secure_channel/tests/TestMessageCounterManager.cpp
+++ b/src/protocols/secure_channel/tests/TestMessageCounterManager.cpp
@@ -33,7 +33,6 @@
 #include <protocols/echo/Echo.h>
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
-#include <transport/raw/tests/NetworkTestHelpers.h>
 
 #include <nlbyteorder.h>
 #include <nlunit-test.h>
@@ -48,12 +47,8 @@ using namespace chip::Transport;
 using namespace chip::Messaging;
 using namespace chip::Protocols;
 
-using TestContext = chip::Test::MessagingContext;
-
+using TestContext = chip::Test::LoopbackMessagingContext;
 TestContext sContext;
-
-TransportMgr<Test::LoopbackTransport> gTransportMgr;
-chip::Test::IOContext gIOContext;
 
 const char PAYLOAD[] = "Hello!";
 
@@ -152,13 +147,8 @@ nlTestSuite sSuite =
  */
 int Initialize(void * aContext)
 {
-    // Initialize System memory and resources
-    VerifyOrReturnError(chip::Platform::MemoryInit() == CHIP_NO_ERROR, FAILURE);
-    VerifyOrReturnError(gIOContext.Init(&sSuite) == CHIP_NO_ERROR, FAILURE);
-    VerifyOrReturnError(gTransportMgr.Init("LOOPBACK") == CHIP_NO_ERROR, FAILURE);
-
     auto * ctx = static_cast<TestContext *>(aContext);
-    VerifyOrReturnError(ctx->Init(&sSuite, &gTransportMgr, &gIOContext) == CHIP_NO_ERROR, FAILURE);
+    VerifyOrReturnError(ctx->Init(&sSuite) == CHIP_NO_ERROR, FAILURE);
 
     return SUCCESS;
 }
@@ -169,8 +159,6 @@ int Initialize(void * aContext)
 int Finalize(void * aContext)
 {
     CHIP_ERROR err = reinterpret_cast<TestContext *>(aContext)->Shutdown();
-    gIOContext.Shutdown();
-    chip::Platform::MemoryShutdown();
     return (err == CHIP_NO_ERROR) ? SUCCESS : FAILURE;
 }
 

--- a/src/transport/raw/tests/NetworkTestHelpers.h
+++ b/src/transport/raw/tests/NetworkTestHelpers.h
@@ -74,6 +74,7 @@ public:
     void InitLoopbackTransport(System::Layer * systemLayer) { mSystemLayer = systemLayer; }
     void ShutdownLoopbackTransport()
     {
+        // TODO: remove these after #17624 (Ensure tests drain all message in loopback transport) being fixed
         // Packets are allocated from platform memory, we should release them before Platform::MemoryShutdown
         while (!mPendingMessageQueue.empty())
             mPendingMessageQueue.pop();

--- a/src/transport/raw/tests/NetworkTestHelpers.h
+++ b/src/transport/raw/tests/NetworkTestHelpers.h
@@ -61,34 +61,29 @@ private:
     Inet::EndPointManager<Inet::UDPEndPoint> * mUDPEndPointManager = nullptr;
 };
 
+class LoopbackTransportDelegate
+{
+public:
+    virtual ~LoopbackTransportDelegate() {}
+    virtual void OnMessageDropped() {}
+};
+
 class LoopbackTransport : public Transport::Base
 {
 public:
+    void InitLoopbackTransport(System::Layer * systemLayer) { mSystemLayer = systemLayer; }
+    void ShutdownLoopbackTransport()
+    {
+        while (!mPendingMessageQueue.empty())
+            mPendingMessageQueue.pop();
+    }
+
     /// Transports are required to have a constructor that takes exactly one argument
     CHIP_ERROR Init(const char *) { return CHIP_NO_ERROR; }
 
-    /*
-     * For unit-tests that simulate end-to-end transmission and reception of messages in loopback mode,
-     * this mode better replicates a real-functioning stack that correctly handles the processing
-     * of a transmitted message as an asynchronous, bottom half handler dispatched after the current execution context has
-     * completed. This is achieved using SystemLayer::ScheduleWork.
-     */
-    void EnableAsyncDispatch(System::Layer * aSystemLayer)
-    {
-        mSystemLayer          = aSystemLayer;
-        mAsyncMessageDispatch = true;
-    }
-
-    /*
-     * Reset the dispatch back to a model that synchronously dispatches received messages up the stack.
-     *
-     * NOTE: This results in highly atypical/complex call stacks that are not representative of what happens on real
-     * devices and can cause subtle and complex bugs to either appear or get masked in the system. Where possible, please
-     * use this sparingly!
-     */
-    void DisableAsyncDispatch() { mAsyncMessageDispatch = false; }
-
     bool HasPendingMessages() { return !mPendingMessageQueue.empty(); }
+
+    void SetLoopbackTransportDelegate(LoopbackTransportDelegate * delegate) { mDelegate = delegate; }
 
     static void OnMessageReceived(System::Layer * aSystemLayer, void * aAppState)
     {
@@ -110,22 +105,15 @@ public:
         if (mNumMessagesToDrop == 0)
         {
             System::PacketBufferHandle receivedMessage = msgBuf.CloneData();
-
-            if (mAsyncMessageDispatch)
-            {
-                mPendingMessageQueue.push(PendingMessageItem(address, std::move(receivedMessage)));
-                mSystemLayer->ScheduleWork(OnMessageReceived, this);
-            }
-            else
-            {
-                HandleMessageReceived(address, std::move(receivedMessage));
-            }
+            mPendingMessageQueue.push(PendingMessageItem(address, std::move(receivedMessage)));
+            mSystemLayer->ScheduleWork(OnMessageReceived, this);
         }
         else
         {
             mNumMessagesToDrop--;
             mDroppedMessageCount++;
-            MessageDropped();
+            if (mDelegate != nullptr)
+                mDelegate->OnMessageDropped();
         }
 
         return CHIP_NO_ERROR;
@@ -151,17 +139,14 @@ public:
         System::PacketBufferHandle mPendingMessage;
     };
 
-    // Hook for subclasses to perform custom logic on message drops.
-    virtual void MessageDropped() {}
-
     System::Layer * mSystemLayer = nullptr;
-    bool mAsyncMessageDispatch   = false;
     std::queue<PendingMessageItem> mPendingMessageQueue;
     Transport::PeerAddress mTxAddress;
-    uint32_t mNumMessagesToDrop   = 0;
-    uint32_t mDroppedMessageCount = 0;
-    uint32_t mSentMessageCount    = 0;
-    CHIP_ERROR mMessageSendError  = CHIP_NO_ERROR;
+    uint32_t mNumMessagesToDrop           = 0;
+    uint32_t mDroppedMessageCount         = 0;
+    uint32_t mSentMessageCount            = 0;
+    CHIP_ERROR mMessageSendError          = CHIP_NO_ERROR;
+    LoopbackTransportDelegate * mDelegate = nullptr;
 };
 
 } // namespace Test

--- a/src/transport/raw/tests/NetworkTestHelpers.h
+++ b/src/transport/raw/tests/NetworkTestHelpers.h
@@ -36,8 +36,6 @@ namespace Test {
 class IOContext
 {
 public:
-    IOContext() {}
-
     /// Initialize the underlying layers and test suite pointer
     CHIP_ERROR Init();
 
@@ -65,6 +63,8 @@ class LoopbackTransportDelegate
 {
 public:
     virtual ~LoopbackTransportDelegate() {}
+
+    // Called by the loopback transport when it drops a message due to a nonzero mNumMessagesToDrop.
     virtual void OnMessageDropped() {}
 };
 
@@ -74,6 +74,7 @@ public:
     void InitLoopbackTransport(System::Layer * systemLayer) { mSystemLayer = systemLayer; }
     void ShutdownLoopbackTransport()
     {
+        // Packets are allocated from platform memory, we should release them before Platform::MemoryShutdown
         while (!mPendingMessageQueue.empty())
             mPendingMessageQueue.pop();
     }

--- a/src/transport/tests/BUILD.gn
+++ b/src/transport/tests/BUILD.gn
@@ -19,6 +19,21 @@ import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
 
+static_library("helpers") {
+  output_name = "libTestTransportHelpers"
+  output_dir = "${root_out_dir}/lib"
+
+  sources = [ "LoopbackTransportManager.h" ]
+
+  cflags = [ "-Wconversion" ]
+
+  public_deps = [
+    "${chip_root}/src/transport:transport",
+    "${chip_root}/src/transport/raw",
+    "${chip_root}/src/transport/raw/tests:helpers",
+  ]
+}
+
 chip_test_suite("tests") {
   output_name = "libTransportLayerTests"
 
@@ -41,7 +56,7 @@ chip_test_suite("tests") {
     "${chip_root}/src/lib/support",
     "${chip_root}/src/protocols",
     "${chip_root}/src/transport",
-    "${chip_root}/src/transport/raw/tests:helpers",
+    "${chip_root}/src/transport/tests:helpers",
     "${nlio_root}:nlio",
     "${nlunit_test_root}:nlunit-test",
   ]

--- a/src/transport/tests/BUILD.gn
+++ b/src/transport/tests/BUILD.gn
@@ -19,13 +19,8 @@ import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
 
-static_library("helpers") {
-  output_name = "libTestTransportHelpers"
-  output_dir = "${root_out_dir}/lib"
-
+source_set("helpers") {
   sources = [ "LoopbackTransportManager.h" ]
-
-  cflags = [ "-Wconversion" ]
 
   public_deps = [
     "${chip_root}/src/transport:transport",

--- a/src/transport/tests/LoopbackTransportManager.h
+++ b/src/transport/tests/LoopbackTransportManager.h
@@ -1,0 +1,107 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <lib/support/CodeUtils.h>
+#include <transport/TransportMgr.h>
+#include <transport/raw/tests/NetworkTestHelpers.h>
+
+namespace chip {
+namespace Test {
+
+class LoopbackTransportManager
+{
+public:
+    /// Initialize the underlying layers.
+    CHIP_ERROR Init()
+    {
+        ReturnErrorOnFailure(mIOContext.Init());
+        GetLoopback().InitLoopbackTransport(&mIOContext.GetSystemLayer());
+        ReturnErrorOnFailure(mTransportManager.Init("LOOPBACK"));
+        return CHIP_NO_ERROR;
+    }
+
+    // Shutdown all layers, finalize operations
+    CHIP_ERROR Shutdown()
+    {
+        GetLoopback().ShutdownLoopbackTransport();
+        ReturnErrorOnFailure(mIOContext.Shutdown());
+        return CHIP_NO_ERROR;
+    }
+
+    System::Layer & GetSystemLayer() { return mIOContext.GetSystemLayer(); }
+    LoopbackTransport & GetLoopback() { return mTransportManager.GetTransport().template GetImplAtIndex<0>(); }
+    TransportMgrBase & GetTransportMgr() { return mTransportManager; }
+    IOContext & GetIOContext() { return mIOContext; }
+
+    /*
+     * This drives the servicing of events using the embedded IOContext while there are pending
+     * messages in the loopback transport's pending message queue. This should run to completion
+     * in well-behaved logic (i.e there isn't an indefinite ping-pong of messages transmitted back
+     * and forth).
+     *
+     * Consequently, this is guarded with a user-provided timeout to ensure we don't have unit-tests that stall
+     * in CI due to bugs in the code that is being tested.
+     *
+     * This DOES NOT ensure that all pending events are serviced to completion
+     * (i.e timers, any ScheduleWork calls), but does:
+     *
+     * 1) Guarantee that every call will make some progress on ready-to-run
+     *    things, by calling DriveIO at least once.
+     * 2) Try to ensure that any ScheduleWork calls that happend directly as a
+     *    result of message reception, and any messages those async tasks send,
+     *    get handled before DrainAndServiceIO returns.
+     */
+    void DrainAndServiceIO(System::Clock::Timeout maxWait = chip::System::Clock::Seconds16(5))
+    {
+        auto & impl                        = GetLoopback();
+        System::Clock::Timestamp startTime = System::SystemClock().GetMonotonicTimestamp();
+
+        while (true)
+        {
+            bool hadPendingMessages = impl.HasPendingMessages();
+            while (impl.HasPendingMessages())
+            {
+                mIOContext.DriveIO();
+                if ((System::SystemClock().GetMonotonicTimestamp() - startTime) >= maxWait)
+                {
+                    return;
+                }
+            }
+            // Processing those messages might have queued some run-ASAP async
+            // work.  Make sure to process that too, in case it generates
+            // response messages.
+            mIOContext.DriveIO();
+            if (!hadPendingMessages && !impl.HasPendingMessages())
+            {
+                // We're not making any progress on messages.  Just stop.
+                break;
+            }
+            // No need to check our timer here: either impl.HasPendingMessages()
+            // is true and we will check it next iteration, or it's false and we
+            // will either stop on the next iteration or it will become true and
+            // we will check the timer then.
+        }
+    }
+
+private:
+    TransportMgr<LoopbackTransport> mTransportManager;
+    Test::IOContext mIOContext;
+};
+
+} // namespace Test
+} // namespace chip

--- a/src/transport/tests/LoopbackTransportManager.h
+++ b/src/transport/tests/LoopbackTransportManager.h
@@ -99,8 +99,8 @@ public:
     }
 
 private:
-    TransportMgr<LoopbackTransport> mTransportManager;
     Test::IOContext mIOContext;
+    TransportMgr<LoopbackTransport> mTransportManager;
 };
 
 } // namespace Test


### PR DESCRIPTION
#### Problem
The sync loopback transport is tricky, error prone

#### Change overview
Convert all test-cases use async loopback transport

* `TestContext::Initialize` uses async loopback by default, `InitializeAsync` is not needed any more
* Extract `LoopbackTransportManager` class from `LoopbackMessagingContext`
  * `LoopbackTransportManager` is a combo of `TransportMgr<LoopbackTransport>`, `Test::IOContext`
* Add `DrainAndServiceIO` to tests when needed (surprisingly there is only a few places it is needed)
* In `ExchangeContext::HandleMessage`, remove alreadyHandlingMessage logic

This is test-only changes.

Follow ups:
- [ ] In `ExchangeMessageDispatch::SendMessage`, do not allocate a retrans entry until we start the retransmition.
- [x] #17624

#### Testing
Passed unit-tests