### PR TITLE
Support network commissioning attributes for P6

### DIFF
--- a/src/platform/P6/ConnectivityManagerImpl.cpp
+++ b/src/platform/P6/ConnectivityManagerImpl.cpp
@@ -280,6 +280,7 @@ void ConnectivityManagerImpl::wlan_event_cb(cy_wcm_event_t event, cy_wcm_event_d
     case CY_WCM_EVENT_DISCONNECTED:
         ChipLogProgress(DeviceLayer, "CY_WCM_EVENT_DISCONNECTED");
         ConnectivityMgrImpl().ChangeWiFiStationState(kWiFiStationState_Disconnecting);
+        NetworkCommissioning::P6WiFiDriver::GetInstance().SetLastDisconnectReason(WLC_E_SUP_DEAUTH);
         break;
     case CY_WCM_EVENT_IP_CHANGED:
         ChipLogProgress(DeviceLayer, "CY_WCM_EVENT_IP_CHANGED");
@@ -323,6 +324,7 @@ void ConnectivityManagerImpl::ChangeWiFiStationState(WiFiStationState newState)
         ChipLogProgress(DeviceLayer, "WiFi station state change: %s -> %s", WiFiStationStateToStr(mWiFiStationState),
                         WiFiStationStateToStr(newState));
         mWiFiStationState = newState;
+        SystemLayer().ScheduleLambda([]() { NetworkCommissioning::P6WiFiDriver::GetInstance().OnNetworkStatusChange(); });
     }
 }
 

--- a/src/platform/P6/NetworkCommissioningDriver.h
+++ b/src/platform/P6/NetworkCommissioningDriver.h
@@ -118,6 +118,11 @@ public:
 
     void OnConnectWiFiNetwork();
     void OnScanWiFiNetworkDone();
+    void OnNetworkStatusChange();
+
+    CHIP_ERROR SetLastDisconnectReason(int32_t reason);
+    int32_t GetLastDisconnectReason();
+
     static P6WiFiDriver & GetInstance()
     {
         static P6WiFiDriver instance;
@@ -133,6 +138,8 @@ private:
     WiFiNetwork mStagingNetwork;
     ScanCallback * mpScanCallback;
     ConnectCallback * mpConnectCallback;
+    NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
+    int32_t mLastDisconnectedReason;
 };
 
 } // namespace NetworkCommissioning

--- a/src/platform/P6/P6Utils.cpp
+++ b/src/platform/P6/P6Utils.cpp
@@ -102,6 +102,12 @@ CHIP_ERROR P6Utils::IsAPEnabled(bool & apEnabled)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR P6Utils::IsStationEnabled(bool & staEnabled)
+{
+    staEnabled = (WiFiMode == WIFI_MODE_STA || WiFiMode == WIFI_MODE_APSTA);
+    return CHIP_NO_ERROR;
+}
+
 bool P6Utils::IsStationProvisioned(void)
 {
     wifi_config_t stationConfig;

--- a/src/platform/P6/P6Utils.h
+++ b/src/platform/P6/P6Utils.h
@@ -23,6 +23,7 @@
 #include "whd_wlioctl.h"
 #include <cy_wcm.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <whd_events_int.h>
 
 typedef struct
 {
@@ -190,6 +191,7 @@ class P6Utils
 {
 public:
     static CHIP_ERROR IsAPEnabled(bool & apEnabled);
+    static CHIP_ERROR IsStationEnabled(bool & staEnabled);
     static bool IsStationProvisioned(void);
     static CHIP_ERROR IsStationConnected(bool & connected);
     static CHIP_ERROR StartWiFiLayer(void);


### PR DESCRIPTION
#### Problem
Add support for below attributes of network commissioning cluster P6 Platform

LastNetworkingStatus
LastNetworkID
LastConnectErrorValue

#### Change overview
Add Support for above attributes of network commissioning cluster

#### Testing
Manually tested all the attributes of network commissioning cluster

Fixes https://github.com/project-chip/connectedhomeip/issues/15700 For Infineon P6
