### PR TITLE
[YAML] Update the tests to use ReadClient/WriteClient/CommandSender directly instead of Invoke

### DIFF
--- a/examples/chip-tool-darwin/commands/tests/TestCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/tests/TestCommandBridge.h
@@ -57,10 +57,10 @@ public:
 
     virtual void NextTest() = 0;
 
-    void Exit(std::string message) override
+    void Exit(std::string message, CHIP_ERROR err = CHIP_ERROR_INTERNAL) override
     {
         ChipLogError(chipTool, " ***** Test Failure: %s\n", message.c_str());
-        SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+        SetCommandExitStatus(err);
     }
 
     /////////// GlobalCommands Interface /////////

--- a/examples/chip-tool-darwin/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool-darwin/templates/tests/partials/test_cluster.zapt
@@ -1,4 +1,4 @@
-{{#chip_tests tests}}
+{{#chip_tests tests useSynthesizeWaitForReport=true}}
 class {{filename}}: public TestCommandBridge
 {
   public:

--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -84,6 +84,7 @@ static_library("chip-tool-utils") {
     "${chip_root}/src/app/tests/suites/commands/commissioner",
     "${chip_root}/src/app/tests/suites/commands/delay",
     "${chip_root}/src/app/tests/suites/commands/discovery",
+    "${chip_root}/src/app/tests/suites/commands/interaction_model",
     "${chip_root}/src/app/tests/suites/commands/log",
     "${chip_root}/src/app/tests/suites/commands/system",
     "${chip_root}/src/app/tests/suites/pics",

--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -66,18 +66,42 @@ void TestCommand::OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHI
     LogErrorOnFailure(command->ContinueOnChipMainThread(error));
 }
 
-void TestCommand::Exit(std::string message)
+void TestCommand::ExitAsync(intptr_t context)
 {
-    ChipLogError(chipTool, " ***** Test Failure: %s\n", message.c_str());
-    SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+    auto testCommand = reinterpret_cast<TestCommand *>(context);
+    testCommand->InteractionModel::Shutdown();
+    testCommand->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
 }
 
-void TestCommand::ThrowFailureResponse(CHIP_ERROR error)
+void TestCommand::Exit(std::string message, CHIP_ERROR err)
 {
-    Exit(std::string("Expecting success response but got a failure response: ") + chip::ErrorStr(error));
+    mContinueProcessing = false;
+
+    LogEnd(err);
+
+    if (CHIP_NO_ERROR == err)
+    {
+        InteractionModel::Shutdown();
+        SetCommandExitStatus(err);
+    }
+    else
+    {
+        chip::DeviceLayer::PlatformMgr().ScheduleWork(ExitAsync, reinterpret_cast<intptr_t>(this));
+    }
 }
 
-void TestCommand::ThrowSuccessResponse()
+CHIP_ERROR TestCommand::ContinueOnChipMainThread(CHIP_ERROR err)
 {
-    Exit("Expecting failure response but got a success response");
+    if (mContinueProcessing == false)
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    if (CHIP_NO_ERROR == err)
+    {
+        return WaitForMs(0);
+    }
+
+    Exit(chip::ErrorStr(err), err);
+    return CHIP_NO_ERROR;
 }

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -22,6 +22,7 @@
 #include <app/tests/suites/commands/commissioner/CommissionerCommands.h>
 #include <app/tests/suites/commands/delay/DelayCommands.h>
 #include <app/tests/suites/commands/discovery/DiscoveryCommands.h>
+#include <app/tests/suites/commands/interaction_model/InteractionModel.h>
 #include <app/tests/suites/commands/log/LogCommands.h>
 #include <app/tests/suites/commands/system/SystemCommands.h>
 #include <app/tests/suites/include/ConstraintsChecker.h>
@@ -40,7 +41,8 @@ class TestCommand : public CHIPCommand,
                     public CommissionerCommands,
                     public DiscoveryCommands,
                     public SystemCommands,
-                    public DelayCommands
+                    public DelayCommands,
+                    public InteractionModel
 {
 public:
     TestCommand(const char * commandName, CredentialIssuerCommands * credsIssuerConfig) :
@@ -62,7 +64,9 @@ protected:
     CHIP_ERROR WaitForCommissionee(chip::NodeId nodeId) override;
     void OnWaitForMs() override { NextTest(); };
 
-    std::map<std::string, ChipDevice *> mDevices;
+    /////////// Interaction Model Interface /////////
+    chip::DeviceProxy * GetDevice(const char * identity) override { return mDevices[identity]; }
+    void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override{};
 
     static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
@@ -102,4 +106,5 @@ protected:
     chip::Optional<uint64_t> mDelayInMs;
     chip::Optional<char *> mPICSFilePath;
     chip::Optional<uint16_t> mTimeout;
+    std::map<std::string, ChipDevice *> mDevices;
 };

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -27,13 +27,14 @@
 #include <app/tests/suites/commands/system/SystemCommands.h>
 #include <app/tests/suites/include/ConstraintsChecker.h>
 #include <app/tests/suites/include/PICSChecker.h>
+#include <app/tests/suites/include/TestRunner.h>
 #include <app/tests/suites/include/ValueChecker.h>
-#include <lib/support/UnitTestUtils.h>
 #include <zap-generated/tests/CHIPClustersTest.h>
 
 constexpr uint16_t kTimeoutInSeconds = 90;
 
-class TestCommand : public CHIPCommand,
+class TestCommand : public TestRunner,
+                    public CHIPCommand,
                     public ValueChecker,
                     public ConstraintsChecker,
                     public PICSChecker,
@@ -45,9 +46,9 @@ class TestCommand : public CHIPCommand,
                     public InteractionModel
 {
 public:
-    TestCommand(const char * commandName, CredentialIssuerCommands * credsIssuerConfig) :
-        CHIPCommand(commandName, credsIssuerConfig), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
-        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
+    TestCommand(const char * commandName, uint16_t testsCount, CredentialIssuerCommands * credsIssuerConfig) :
+        TestRunner(commandName, testsCount), CHIPCommand(commandName, credsIssuerConfig),
+        mOnDeviceConnectedCallback(OnDeviceConnectedFn, this), mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
     {
         AddArgument("delayInMs", 0, UINT64_MAX, &mDelayInMs);
         AddArgument("PICS", &mPICSFilePath);
@@ -57,7 +58,6 @@ public:
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    virtual void NextTest() = 0;
 
 protected:
     /////////// DelayCommands Interface /////////
@@ -71,21 +71,12 @@ protected:
     static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 
-    CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) override
-    {
-        if (CHIP_NO_ERROR == err)
-        {
-            return WaitForMs(0);
-        }
-        Exit(chip::ErrorStr(err));
-        return CHIP_NO_ERROR;
-    }
+    CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) override;
 
     chip::Controller::DeviceCommissioner & GetCurrentCommissioner() override { return CurrentCommissioner(); };
 
-    void Exit(std::string message) override;
-    void ThrowFailureResponse(CHIP_ERROR error);
-    void ThrowSuccessResponse();
+    static void ExitAsync(intptr_t context);
+    void Exit(std::string message, CHIP_ERROR err = CHIP_ERROR_INTERNAL) override;
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
@@ -96,15 +87,14 @@ protected:
             status.mStatus == chip::Protocols::InteractionModel::Status::UnsupportedCommand;
     }
 
-    void Wait()
-    {
-        if (mDelayInMs.HasValue())
-        {
-            chip::test_utils::SleepMillis(mDelayInMs.Value());
-        }
-    };
-    chip::Optional<uint64_t> mDelayInMs;
     chip::Optional<char *> mPICSFilePath;
     chip::Optional<uint16_t> mTimeout;
     std::map<std::string, ChipDevice *> mDevices;
+
+    // When set to false, prevents interaction model events from affecting the current test status.
+    // This flag exists because if an error happens while processing a response the allocated
+    // command client/sender (ReadClient/WriteClient/CommandSender) can not be deallocated
+    // as it still used by the stack afterward. So a task is scheduled to run to close the
+    // test suite as soon as possible, and pending events are ignored in between.
+    bool mContinueProcessing = true;
 };

--- a/examples/chip-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_cluster.zapt
@@ -1,11 +1,11 @@
 {{#chip_tests tests}}
 class {{filename}}Suite: public TestCommand
 {
-  public:
+public:
     {{#if ../credsIssuerConfigArg}}
-    {{filename}}Suite(CredentialIssuerCommands * credsIssuerConfig): TestCommand("{{filename}}", credsIssuerConfig), mTestIndex(0)
+    {{filename}}Suite(CredentialIssuerCommands * credsIssuerConfig): TestCommand("{{filename}}", {{totalTests}}, credsIssuerConfig)
     {{else}}
-    {{filename}}Suite(): TestCommand("{{filename}}"), mTestIndex(0)
+    {{filename}}Suite(): TestCommand("{{filename}}", {{totalTests}})
     {{/if}}
     {
         {{#chip_tests_config}}
@@ -22,66 +22,29 @@ class {{filename}}Suite: public TestCommand
         {{>teardownSaveAs}}
     }
 
-    /////////// TestCommand Interface /////////
-    void NextTest() override
-    {
-      CHIP_ERROR err = CHIP_NO_ERROR;
-
-      if (0 == mTestIndex)
-      {
-          ChipLogProgress(chipTool, " **** Test Start: {{filename}}\n");
-      }
-
-      if (mTestCount == mTestIndex)
-      {
-          ChipLogProgress(chipTool, " **** Test Complete: {{filename}}\n");
-          SetCommandExitStatus(CHIP_NO_ERROR);
-          return;
-      }
-
-      Wait();
-
-      // Ensure we increment mTestIndex before we start running the relevant
-      // command.  That way if we lose the timeslice after we send the message
-      // but before our function call returns, we won't end up with an
-      // incorrect mTestIndex value observed when we get the response.
-      switch (mTestIndex++)
-      {
-        {{#chip_tests_items}}
-        case {{index}}:
-          ChipLogProgress(chipTool, " ***** Test Step {{index}} : {{label}}\n");
-          {{#if PICS}}
-          if (ShouldSkip("{{PICS}}"))
-          {
-              NextTest();
-              return;
-          }
-          {{/if}}
-          err = Test{{asUpperCamelCase label}}_{{index}}();
-          break;
-        {{/chip_tests_items}}
-      }
-
-      if (CHIP_NO_ERROR != err)
-      {
-          ChipLogError(chipTool, " ***** Test Failure: %s\n", chip::ErrorStr(err));
-          SetCommandExitStatus(err);
-      }
-    }
-
   {{#if ../needsWaitDuration}}
   chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(mTimeout.ValueOr({{chip_tests_config_get_default_value "timeout"}})); }
   {{/if}}
 
-  private:
-    std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = {{totalTests}};
-
+private:
     {{#chip_tests_config}}
     chip::Optional<{{chipType}}> m{{asUpperCamelCase name}};
     {{/chip_tests_config}}
 
     {{>setupSaveAs}}
+
+    chip::EndpointId GetEndpoint(chip::EndpointId endpoint)
+    {
+        {{#if (chip_tests_config_has "endpoint")}}
+        return mEndpoint.HasValue() ? mEndpoint.Value() : endpoint;
+        {{else}}
+        return endpoint;
+        {{/if}}
+    }
+
+    //
+    // Tests methods
+    //
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
@@ -90,15 +53,11 @@ class {{filename}}Suite: public TestCommand
         switch (mTestIndex - 1)
         {
         {{#chip_tests_items}}
-        {{!
-            This check can be removed once the cluster APIs have been converted from Invoke to
-            ReadClient/WriteClient/CommandSender
-        }}
-        {{~#if (isTestOnlyCluster cluster)~}}
+        {{#unless isWait}}
         case {{index}}:
             {{>test_step_response}}
             break;
-        {{/if~}}
+        {{/unless}}
         {{/chip_tests_items}}
         default:
             LogErrorOnFailure(ContinueOnChipMainThread(CHIP_ERROR_INVALID_ARGUMENT));
@@ -110,294 +69,19 @@ class {{filename}}Suite: public TestCommand
         }
     }
 
-    {{! Helper around zapTypeToDecodableClusterObjectType that lets us set the
-        array/nullable/etc context appropriately.}}
-    {{~#*inline "subscribeResponseDataArgument"~}}
-      {{zapTypeToDecodableClusterObjectType type ns=cluster isArgument=true}} value
-    {{~/inline~}}
-    {{~#*inline "subscribeResponseArguments"~}}
-    {{> subscribeResponseDataArgument type=attr.type isArray=attr.isArray isNullable=attr.isNullable}}
-    {{~/inline~}}
-
-    {{~#*inline "subscribeDataCallback"}}
-    mTest_{{parent.filename}}_{{attribute}}_Reported
-    {{/inline}}
-    {{#*inline "subscribeDataCallbackType"}}
-    Test_{{parent.filename}}_{{attribute}}_ReportCallback
-    {{/inline}}
-    {{#chip_tests_items}}
-    {{#if allocateSubscribeDataCallback}}
-    typedef void (*{{> subscribeDataCallbackType}})(void * context, {{> subscribeResponseArguments attr=attributeObject}});
-    {{> subscribeDataCallbackType}} {{> subscribeDataCallback}} = nullptr;
-    {{/if}}
-    {{/chip_tests_items}}
-
-    {{#*inline "failureResponse"}}OnFailureResponse_{{index}}{{/inline}}
-    {{#*inline "successResponse"}}OnSuccessResponse_{{index}}{{/inline}}
-    {{#*inline "subscriptionEstablished"}}OnSubscriptionEstablishedResponse_{{index}}{{/inline}}
-    {{#*inline "doneResponse"}}OnDoneResponse_{{index}}{{/inline}}
-
-    {{#*inline "staticFailureResponse"}}OnFailureCallback_{{index}}{{/inline}}
-    {{#*inline "staticSuccessResponse"}}OnSuccessCallback_{{index}}{{/inline}}
-    {{#*inline "staticSubscriptionEstablished"}}OnSubscriptionEstablished_{{index}}{{/inline}}
-    {{#*inline "staticDoneResponse"}}OnDoneCallback_{{index}}{{/inline}}
-
-    {{#*inline "successArguments"}}{{#chip_tests_item_response_parameters}}{{#first}}{{#if ../leadingComma}}, {{/if}}{{/first}} {{zapTypeToDecodableClusterObjectType type ns=parent.cluster isArgument=true}} {{asLowerCamelCase name}}{{#not_last}}, {{/not_last}}{{/chip_tests_item_response_parameters}}{{/inline}}
-    {{! TODO: Temporary if cascade until everything is converted to the new status setup }}
-    {{#*inline "failureArguments"}}{{#if leadingComma}}, {{/if}}CHIP_ERROR error{{/inline}}
-    {{#*inline "staticSuccessArguments"}}void * context{{> successArguments leadingComma=true}}{{/inline}}
-    {{#*inline "staticFailureArguments"}}void * context{{> failureArguments leadingComma=true}}{{/inline}}
-    {{#*inline "staticDoneArguments"}}void * context{{/inline}}
-    {{#*inline "doneArguments"}}{{/inline}}
-
-    {{#*inline "staticSubscriptionEstablishedArguments"}}void * context{{/inline}}
-    {{#*inline "subscriptionEstablishedArguments"}}{{/inline}}
-
-    {{#chip_tests_items}}
-    {{#unless (isTestOnlyCluster cluster)}}
-    {{#unless isWait}}
-    {{#unless isCommand}}
-    {{#if isWriteAttribute}}
-      {{#if isGroupCommand}}
-      static void {{>staticDoneResponse}}({{>staticDoneArguments}})
-      {
-          (static_cast<{{filename}}Suite *>(context))->{{> doneResponse }}();
-      }
-      {{/if}}
-    {{/if}}
-
-    static void {{>staticFailureResponse}}({{>staticFailureArguments}})
+    CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
-        (static_cast<{{filename}}Suite *>(context))->{{>failureResponse}}(error);
+        using namespace chip::app::Clusters;
+        switch (testIndex)
+        {
+        {{#chip_tests_items}}
+        case {{index}}: {
+            {{>test_step}}
+        }
+        {{/chip_tests_items}}
+        }
+        return CHIP_NO_ERROR;
     }
-
-    static void {{>staticSuccessResponse}}({{> staticSuccessArguments}})
-    {
-        (static_cast<{{filename}}Suite *>(context))->{{>successResponse}}({{#chip_tests_item_response_parameters}}{{#not_first}}, {{/not_first}}{{asLowerCamelCase name}}{{/chip_tests_item_response_parameters}});
-    }
-
-    {{#if isSubscribe}}
-    static void {{> staticSubscriptionEstablished}}({{> staticSubscriptionEstablishedArguments}})
-    {
-        (static_cast<{{filename}}Suite *>(context))->{{> subscriptionEstablished}}();
-    }
-    {{/if}}
-
-    {{#if isWaitForReport}}
-    bool mReceivedReport_{{index}} = false;
-    {{/if}}
-
-    {{/unless}}
-    {{/unless}}
-    {{/unless}}
-    {{/chip_tests_items}}
-
-    //
-    // Tests methods
-    //
-
-    {{#chip_tests_items}}
-    {{#*inline "testCommand"}}Test{{asUpperCamelCase label}}_{{index}}{{/inline}}
-    {{#if (isTestOnlyCluster cluster)}}
-    CHIP_ERROR {{>testCommand}}()
-    {
-        SetIdentity(kIdentity{{asUpperCamelCase identity}});
-        return {{command}}({{#chip_tests_item_parameters}}{{#not_first}},{{/not_first}}
-          {{#*inline "defaultValue"}}{{asTypedLiteral (chip_tests_config_get_default_value definedValue) (chip_tests_config_get_type definedValue)}}{{/inline}}
-          {{~#if (chip_tests_config_has definedValue)~}}
-          m{{asUpperCamelCase definedValue}}.HasValue() ? m{{asUpperCamelCase definedValue}}.Value() : {{~#if (isString type)}}chip::CharSpan::fromCharString("{{>defaultValue}}"){{else}}{{>defaultValue}}{{/if~}}
-          {{~else if (isString type)}}"{{definedValue}}"
-          {{else}}{{definedValue}}
-          {{~/if~}}
-          {{/chip_tests_item_parameters}});
-    }
-    {{else if isWait}}
-    CHIP_ERROR {{>testCommand}}()
-    {
-      const chip::EndpointId endpoint = {{#if (chip_tests_config_has "endpoint")}}mEndpoint.HasValue() ? mEndpoint.Value() : {{/if}}{{endpoint}};
-      ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: {{cluster}} {{#if isAttribute}}Attribute: {{attribute}}{{else}}Command: {{wait}}{{/if}}] {{label}}", endpoint);
-      {{#*inline "waitForTypeName"}}{{#if isAttribute}}Attribute{{else}}Command{{/if}}{{/inline}}
-      {{#*inline "waitForTypeId"}}chip::app::Clusters::{{asUpperCamelCase cluster}}::{{#if isAttribute}}Attributes::{{asUpperCamelCase attribute}}{{else}}Commands::{{asUpperCamelCase wait}}{{/if}}::Id{{/inline}}
-      ClearAttributeAndCommandPaths();
-      m{{>waitForTypeName}}Path = chip::app::Concrete{{>waitForTypeName}}Path(endpoint, chip::app::Clusters::{{asUpperCamelCase cluster}}::Id, {{>waitForTypeId}});
-      return CHIP_NO_ERROR;
-    }
-    {{else}}
-
-    {{#*inline "device"}}mDevices[kIdentity{{asUpperCamelCase identity}}]{{/inline}}
-    CHIP_ERROR {{>testCommand}}()
-    {
-        {{#if isGroupCommand}}
-        const chip::GroupId groupId = {{groupId}};
-        {{else}}
-        const chip::EndpointId endpoint = {{#if (chip_tests_config_has "endpoint")}}mEndpoint.HasValue() ? mEndpoint.Value() : {{/if}}{{endpoint}};
-        {{/if}}
-
-        {{~#*inline "maybeTimedInteractionTimeout"}}
-          {{#if timedInteractionTimeoutMs}}
-          , {{timedInteractionTimeoutMs}}
-          {{else if commandObject.mustUseTimedInvoke}}
-          , chip::NullOptional
-          {{else if attributeObject.mustUseTimedWrite}}
-          , chip::NullOptional
-          {{/if}}
-        {{/inline~}}
-
-        {{~#*inline "maybeWait"}}
-          {{#if busyWaitMs}}
-          using namespace chip::System::Clock::Literals;
-          BusyWaitFor({{busyWaitMs}}_ms);
-          {{/if}}
-        {{/inline~}}
-
-        {{#if isCommand}}
-        using RequestType = chip::app::Clusters::{{asUpperCamelCase cluster}}::Commands::{{asUpperCamelCase command}}::Type;
-
-        {{#if (chip_tests_item_has_list)}} ListFreer listFreer;{{/if}}
-        RequestType request;
-        {{#chip_tests_item_parameters}}
-        {{>commandValue ns=parent.cluster container=(concat "request." (asLowerCamelCase label)) definedValue=definedValue depth=0}}
-        {{/chip_tests_item_parameters}}
-
-        auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<{{filename}}Suite *>(context))->{{>successResponse}}({{#chip_tests_item_response_parameters}}{{#not_first}}, {{/not_first}}data.{{asLowerCamelCase name}}{{/chip_tests_item_response_parameters}});
-        };
-
-        auto failure = [](void * context, CHIP_ERROR error) {
-            (static_cast<{{filename}}Suite *>(context))->{{>failureResponse}}(error);
-        };
-
-        {{#if isGroupCommand}}
-        auto done = [](void * context) {
-            (static_cast<{{filename}}Suite *>(context))->OnDoneResponse_{{index}}();
-        };
-        {{/if}}
-
-        ReturnErrorOnFailure(chip::Controller::{{#if isGroupCommand}}InvokeGroupCommand{{else}}InvokeCommand{{/if}}({{>device}}, this, success, failure, {{#if isGroupCommand}}done,{{/if}}
-          {{#if isGroupCommand}}groupId{{else}}endpoint{{/if}},
-          request
-          {{> maybeTimedInteractionTimeout }}
-          ));
-        {{> maybeWait }}
-        {{else}}
-        chip::Controller::{{asUpperCamelCase cluster}}ClusterTest cluster;
-        {{#unless isGroupCommand}}
-        cluster.Associate({{>device}}, endpoint);
-        {{/unless}}
-
-        {{#if (chip_tests_item_has_list)}} ListFreer listFreer;{{/if}}
-        {{#chip_tests_item_parameters}}
-        {{zapTypeToEncodableClusterObjectType type ns=parent.cluster}} {{asLowerCamelCase name}}Argument;
-        {{>commandValue ns=parent.cluster container=(concat (asLowerCamelCase name) "Argument") definedValue=definedValue depth=0}}
-        {{/chip_tests_item_parameters}}
-
-        {{#if isWriteAttribute}}
-        {{#if isGroupCommand}}
-          ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::{{asUpperCamelCase cluster}}::Attributes::{{asUpperCamelCase attribute}}::TypeInfo>(groupId, {{>device}}->GetSecureSession().Value()->GetFabricIndex(), {{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument, {{/chip_tests_item_parameters}}this, {{>staticSuccessResponse}}, {{>staticFailureResponse}}
-            {{~> maybeTimedInteractionTimeout ~}}
-            , {{>staticDoneResponse}}
-            ));
-          {{> maybeWait }}
-        {{else}}
-          ReturnErrorOnFailure(cluster.WriteAttribute<chip::app::Clusters::{{asUpperCamelCase cluster}}::Attributes::{{asUpperCamelCase attribute}}::TypeInfo>({{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument, {{/chip_tests_item_parameters}}this, {{>staticSuccessResponse}}, {{>staticFailureResponse}}
-            {{~> maybeTimedInteractionTimeout ~}}
-            ));
-          {{> maybeWait }}
-        {{/if}}
-        {{else if isReadEvent}}
-          ReturnErrorOnFailure(cluster.ReadEvent<{{zapTypeToDecodableClusterObjectType event ns=cluster isArgument=true}}>(this, {{>staticSuccessResponse}}, {{>staticFailureResponse}}));
-        {{else if isSubscribeEvent}}
-          ReturnErrorOnFailure(cluster.SubscribeEvent<{{zapTypeToDecodableClusterObjectType event ns=cluster isArgument=true}}>(this, {{>staticSuccessResponse}}, {{>staticFailureResponse}}, minIntervalArgument, maxIntervalArgument, {{>staticSubscriptionEstablished}}));
-        {{else if isReadAttribute}}
-          ReturnErrorOnFailure(cluster.ReadAttribute<chip::app::Clusters::{{asUpperCamelCase cluster}}::Attributes::{{asUpperCamelCase attribute}}::TypeInfo>({{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument, {{/chip_tests_item_parameters}}this, {{>staticSuccessResponse}}, {{>staticFailureResponse}}, {{fabricFiltered}}));
-        {{else if isSubscribeAttribute}}
-          ReturnErrorOnFailure(cluster.SubscribeAttribute<chip::app::Clusters::{{asUpperCamelCase cluster}}::Attributes::{{asUpperCamelCase attribute}}::TypeInfo>(this, {{>staticSuccessResponse}}, {{>staticFailureResponse}}, minIntervalArgument, maxIntervalArgument, {{>staticSubscriptionEstablished}}, {{fabricFiltered}}));
-        {{else if isWaitForReport}}
-          {{> subscribeDataCallback}} = {{> staticSuccessResponse}};
-        {{else}}
-          UNEXPECTED COMMAND: {{>commandName}}
-        {{/if}}
-        {{/if}}
-        {{#if async}}
-          return WaitForMs(0);
-        {{else}}
-          return CHIP_NO_ERROR;
-        {{/if}}
-    }
-
-    void {{>failureResponse}}({{>failureArguments}})
-    {
-        chip::app::StatusIB status(error);
-        {{#if response.error}}
-          {{#if optional}}
-          if (status.mStatus == chip::Protocols::InteractionModel::Status::UnsupportedAttribute){
-            {{#unless async}}NextTest();{{/unless}}
-          } else {
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), {{response.error}}));
-            {{#unless async}}NextTest();{{/unless}}
-          }
-          {{else}}
-          VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), {{response.error}}));
-          {{#unless async}}NextTest();{{/unless}}
-          {{/if}}
-        {{else}}
-          {{#if optional}}(status.mStatus == chip::Protocols::InteractionModel::Status::UnsupportedAttribute) ? NextTest() : {{/if}}ThrowFailureResponse(error);
-        {{/if}}
-    }
-
-    {{#if isSubscribe}}
-    void {{>successResponse}}({{> subscribeResponseArguments attr=attributeObject}})
-    {
-        {{#if response.error}}
-          ThrowSuccessResponse();
-        {{else if response.errorWrongValue}}
-          ThrowSuccessResponse();
-        {{else}}
-          if ({{> subscribeDataCallback}}) {
-              auto callback = {{> subscribeDataCallback}};
-              {{> subscribeDataCallback}} = nullptr;
-              callback(this, value);
-          }
-       {{/if}}
-    }
-
-    void {{>subscriptionEstablished}}({{> subscriptionEstablishedArguments}})
-    {
-        {{#if hasWaitForReport}}
-          VerifyOrReturn(mReceivedReport_{{waitForReport.index}}, Exit("Initial report not received!"));
-        {{/if}}
-        {{#unless async}}NextTest();{{/unless}}
-    }
-    {{else}}
-    void {{>successResponse}}({{>successArguments}})
-    {
-        {{~#if response.error}}
-          ThrowSuccessResponse();
-        {{else if response.errorWrongValue}}
-          ThrowSuccessResponse();
-        {{else}}
-          {{#if isWaitForReport}}
-          mReceivedReport_{{index}} = true;
-          {{/if}}
-          {{#chip_tests_item_response_parameters}}
-            {{>maybeCheckExpectedValue}}
-            {{>maybeCheckExpectedConstraints}}
-            {{>maybeSaveAs}}
-          {{/chip_tests_item_response_parameters}}
-        {{#unless async}}NextTest();{{/unless}}
-        {{/if}}
-    }
-    {{/if}}
-
-    {{#if isGroupCommand}}
-    void {{>doneResponse}}({{>doneArguments}})
-    {
-      NextTest();
-    }
-    {{/if}}
-
-    {{/if}}
-    {{/chip_tests_items}}
 };
 
 {{/chip_tests}}

--- a/examples/chip-tool/templates/tests/partials/test_step.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_step.zapt
@@ -1,0 +1,111 @@
+{{~#*inline "clusterName"}}{{asUpperCamelCase cluster}}{{/inline~}}
+
+{{~#*inline "maybePICS"}}
+{{#if PICS}}
+    VerifyOrdo(!ShouldSkip("{{PICS}}"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+{{/if}}
+{{/inline~}}
+
+{{~#*inline "maybePrepareArguments"}}
+{{#unless isWait}}
+{{#if (isTestOnlyCluster cluster)}}
+    SetIdentity({{>kIdentity}});
+{{else if hasSpecificArguments}}
+    {{#if (chip_tests_item_has_list)}}ListFreer listFreer;{{/if~}}
+    {{asEncodableType}} value;
+    {{#chip_tests_item_parameters}}
+        {{>commandValue ns=parent.cluster container=(asPropertyValue dontUnwrapValue=true) definedValue=definedValue depth=0}}
+    {{/chip_tests_item_parameters}}
+{{/if}}
+{{/unless}}
+{{/inline~}}
+
+{{~#*inline "testOnlyClusterArguments"}}
+{{#chip_tests_item_parameters}}{{#not_first}},{{/not_first}}
+    {{#*inline "defaultValue"}}{{asTypedLiteral (chip_tests_config_get_default_value definedValue) (chip_tests_config_get_type definedValue)}}{{/inline}}
+    {{~#if (chip_tests_config_has definedValue)~}}
+        m{{asUpperCamelCase definedValue}}.HasValue() ? m{{asUpperCamelCase definedValue}}.Value() : {{~#if (isString type)}}chip::CharSpan::fromCharString("{{>defaultValue}}"){{else}}{{>defaultValue}}{{/if~}}
+    {{~else if (isString type)}}
+        "{{definedValue}}"
+    {{else}}
+        {{definedValue}}
+    {{~/if~}}
+{{/chip_tests_item_parameters}}
+{{/inline~}}
+
+
+{{~#*inline "maybeFabricFiltered"}}
+{{#unless isWait}}
+{{#unless fabricFiltered}}
+    , false
+{{/unless}}
+{{/unless}}
+{{/inline~}}
+
+{{~#*inline "maybeTimedInteractionTimeout"}}
+{{#if timedInteractionTimeoutMs}}
+    , chip::Optional<uint16_t>({{timedInteractionTimeoutMs}})
+{{else if commandObject.mustUseTimedInvoke}}
+    , chip::NullOptional
+{{else if attributeObject.mustUseTimedWrite}}
+    , chip::NullOptional
+{{/if}}
+{{/inline~}}
+
+{{~#*inline "kIdentity"}}kIdentity{{asUpperCamelCase identity}}{{/inline~}}
+{{~#*inline "groupId"}}{{groupId}}{{/inline~}}
+{{~#*inline "endpointId"}}GetEndpoint({{endpoint}}){{/inline~}}
+{{~#*inline "clusterId"}}{{>clusterName}}::Id{{/inline~}}
+{{~#*inline "attributeId"}}{{>clusterName}}::Attributes::{{asUpperCamelCase attribute}}::Id{{/inline~}}
+{{~#*inline "eventId"}}{{>clusterName}}::Events::{{asUpperCamelCase event}}::Id{{/inline~}}
+{{~#*inline "commandId"}}{{>clusterName}}::Commands::{{asUpperCamelCase command}}::Id{{/inline~}}
+
+{{~#*inline "attributeArguments"}}{{>kIdentity}}, {{>endpointId}}, {{>clusterId}}, {{>attributeId}}{{/inline~}}
+{{~#*inline "eventArguments"}}{{>kIdentity}}, {{>endpointId}}, {{>clusterId}}, {{>eventId}}{{/inline~}}
+{{~#*inline "commandArguments"}}{{>kIdentity}}, {{>endpointId}}, {{>clusterId}}, {{>commandId}}{{/inline~}}
+{{~#*inline "waitAttributeArguments"}}{{>endpointId}}, {{>clusterId}}, {{>attributeId}}{{/inline~}}
+{{~#*inline "waitEventArguments"}}{{>endpointId}}, {{>clusterId}}, {{>eventId}}{{/inline~}}
+{{~#*inline "waitCommandArguments"}}{{>endpointId}}, {{>clusterId}}, {{>commandId}}{{/inline~}}
+{{~#*inline "groupAttributeArguments"}}{{>kIdentity}}, {{>groupId}}, {{>clusterId}}, {{>attributeId}}{{/inline~}}
+{{~#*inline "groupCommandArguments"}}{{>kIdentity}}, {{>groupId}}, {{>clusterId}}, {{>commandId}}{{/inline~}}
+
+{{~#*inline "waitArguments"}}
+{{#if isAttribute}}
+  {{>waitAttributeArguments}}
+{{else if isEvent}}
+  {{>endpointId}}, {{>clusterId}}, {{>eventId}}
+{{else}}
+  {{>waitCommandArguments}}
+{{/if}}
+{{/inline~}}
+
+{{~#*inline "arguments"}}
+{{#if (isTestOnlyCluster cluster)}}{{>testOnlyClusterArguments}}
+{{else if isWait}}                 {{>waitArguments}}
+{{else if isReadAttribute}}        {{>attributeArguments}}{{>maybeFabricFiltered~}}
+{{else if isSubscribeAttribute}}   {{>attributeArguments}}, {{minInterval}}, {{maxInterval}}{{>maybeFabricFiltered~}}
+{{else if isWriteGroupAttribute}}  {{>groupAttributeArguments}}, value{{>maybeTimedInteractionTimeout~}}
+{{else if isWriteAttribute}}       {{>attributeArguments}}, value{{>maybeTimedInteractionTimeout~}}
+{{else if isReadEvent}}            {{>eventArguments}}{{>maybeFabricFiltered}}
+{{else if isSubscribeEvent}}       {{>eventArguments}}, {{minInterval}}, {{maxInterval}}{{>maybeFabricFiltered~}}
+{{else if isGroupCommand}}         {{>groupCommandArguments}}, value{{>maybeTimedInteractionTimeout~}}
+{{else if isCommand}}              {{>commandArguments}}, value{{>maybeTimedInteractionTimeout~}}
+{{/if}}
+{{/inline~}}
+
+{{~#*inline "maybeBusyWait"}}
+{{#if busyWaitMs}}
+    ReturnErrorOnFailure({{commandName}}({{>arguments}}));
+
+    using namespace chip::System::Clock::Literals;
+    return BusyWaitFor({{busyWaitMs}}_ms);
+{{else}}
+    return {{commandName}}({{>arguments}});
+{{/if}}
+{{/inline~}}
+
+{{! --- Test Step Content --}}
+LogStep({{index}}, "{{label}}");
+{{>maybePICS}}
+{{>maybePrepareArguments}}
+{{>maybeBusyWait}}

--- a/examples/chip-tool/templates/tests/templates.json
+++ b/examples/chip-tool/templates/tests/templates.json
@@ -22,6 +22,10 @@
             "path": "partials/test_cluster.zapt"
         },
         {
+            "name": "test_step",
+            "path": "partials/test_step.zapt"
+        },
+        {
             "name": "test_step_response",
             "path": "partials/test_step_response.zapt"
         },

--- a/examples/placeholder/linux/include/TestCommand.h
+++ b/examples/placeholder/linux/include/TestCommand.h
@@ -28,6 +28,7 @@
 #include <app/tests/suites/commands/log/LogCommands.h>
 #include <app/tests/suites/include/ConstraintsChecker.h>
 #include <app/tests/suites/include/PICSChecker.h>
+#include <app/tests/suites/include/TestRunner.h>
 #include <app/tests/suites/include/ValueChecker.h>
 
 #include <app-common/zap-generated/ids/Attributes.h>
@@ -38,7 +39,8 @@ constexpr const char kIdentityAlpha[] = "";
 constexpr const char kIdentityBeta[]  = "";
 constexpr const char kIdentityGamma[] = "";
 
-class TestCommand : public PICSChecker,
+class TestCommand : public TestRunner,
+                    public PICSChecker,
                     public LogCommands,
                     public DiscoveryCommands,
                     public DelayCommands,
@@ -46,10 +48,10 @@ class TestCommand : public PICSChecker,
                     public ConstraintsChecker
 {
 public:
-    TestCommand(const char * commandName) : mCommandPath(0, 0, 0), mAttributePath(0, 0, 0) {}
+    TestCommand(const char * commandName, uint16_t testsCount) :
+        TestRunner(commandName, testsCount), mCommandPath(0, 0, 0), mAttributePath(0, 0, 0)
+    {}
     virtual ~TestCommand() {}
-
-    virtual void NextTest() = 0;
 
     void SetCommandExitStatus(CHIP_ERROR status)
     {
@@ -77,15 +79,15 @@ public:
         }
         else
         {
-            Exit(chip::ErrorStr(err));
+            Exit(chip::ErrorStr(err), err);
         }
         return CHIP_NO_ERROR;
     }
 
-    void Exit(std::string message) override
+    void Exit(std::string message, CHIP_ERROR err) override
     {
-        ChipLogError(chipTool, " ***** Test Failure: %s\n", message.c_str());
-        SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+        LogEnd(err);
+        SetCommandExitStatus(err);
     }
 
     static void ScheduleNextTest(intptr_t context)
@@ -139,12 +141,27 @@ public:
 
     std::atomic_bool isRunning{ true };
 
+    CHIP_ERROR WaitAttribute(chip::EndpointId endpointId, chip::ClusterId clusterId, chip::AttributeId attributeId)
+    {
+        ClearAttributeAndCommandPaths();
+        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: %d, Attribute: %d]", endpointId, clusterId, attributeId);
+        mAttributePath = chip::app::ConcreteAttributePath(endpointId, clusterId, attributeId);
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR WaitCommand(chip::EndpointId endpointId, chip::ClusterId clusterId, chip::CommandId commandId)
+    {
+        ClearAttributeAndCommandPaths();
+        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: %d, Command: %d]", endpointId, clusterId, commandId);
+        mCommandPath = chip::app::ConcreteCommandPath(endpointId, clusterId, commandId);
+        return CHIP_NO_ERROR;
+    }
+
 protected:
     chip::app::ConcreteCommandPath mCommandPath;
     chip::app::ConcreteAttributePath mAttributePath;
     chip::Optional<chip::EndpointId> mEndpointId;
     void SetIdentity(const char * name){};
-    void Wait(){};
 
     /////////// DelayCommands Interface /////////
     void OnWaitForMs() override { NextTest(); }

--- a/examples/placeholder/templates/templates.json
+++ b/examples/placeholder/templates/templates.json
@@ -22,6 +22,10 @@
             "path": "../../../examples/chip-tool/templates/tests/partials/test_cluster.zapt"
         },
         {
+            "name": "test_step",
+            "path": "../../../examples/chip-tool/templates/tests/partials/test_step.zapt"
+        },
+        {
             "name": "test_step_response",
             "path": "../../../examples/chip-tool/templates/tests/partials/test_step_response.zapt"
         },

--- a/src/app/ChunkedWriteCallback.cpp
+++ b/src/app/ChunkedWriteCallback.cpp
@@ -69,6 +69,9 @@ void ChunkedWriteCallback::OnDone(WriteClient * apWriteClient)
         callback->OnResponse(apWriteClient, mProcessingAttributePath.Value(), mAttributeStatus);
     }
 
+    mProcessingAttributePath = NullOptional;
+    mAttributeStatus         = StatusIB();
+
     callback->OnDone(apWriteClient);
 }
 

--- a/src/app/tests/suites/commands/interaction_model/BUILD.gn
+++ b/src/app/tests/suites/commands/interaction_model/BUILD.gn
@@ -1,0 +1,32 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+static_library("interaction_model") {
+  output_name = "libInteractionModel"
+
+  sources = [
+    "InteractionModel.cpp",
+    "InteractionModel.h",
+  ]
+
+  cflags = [ "-Wconversion" ]
+
+  public_deps = [
+    "${chip_root}/src/app",
+    "${chip_root}/src/lib/support",
+  ]
+}

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
@@ -1,0 +1,245 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "InteractionModel.h"
+
+using namespace chip;
+using namespace chip::app;
+
+CHIP_ERROR InteractionModel::ReadAttribute(const char * identity, EndpointId endpointId, ClusterId clusterId,
+                                           AttributeId attributeId, bool fabricFiltered)
+{
+    DeviceProxy * device = GetDevice(identity);
+    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    AttributePathParams attributePathParams[1];
+    if (endpointId != kInvalidEndpointId)
+    {
+        attributePathParams[0].mEndpointId = endpointId;
+    }
+
+    if (clusterId != kInvalidClusterId)
+    {
+        attributePathParams[0].mClusterId = clusterId;
+    }
+
+    if (attributeId != kInvalidAttributeId)
+    {
+        attributePathParams[0].mAttributeId = attributeId;
+    }
+
+    ReadPrepareParams params(device->GetSecureSession().Value());
+    params.mpEventPathParamsList        = nullptr;
+    params.mEventPathParamsListSize     = 0;
+    params.mpAttributePathParamsList    = attributePathParams;
+    params.mAttributePathParamsListSize = 1;
+    params.mIsFabricFiltered            = fabricFiltered;
+
+    mReadClient = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
+                                               mBufferedReadAdapter, ReadClient::InteractionType::Read);
+    return mReadClient->SendRequest(params);
+}
+
+CHIP_ERROR InteractionModel::ReadEvent(const char * identity, EndpointId endpointId, ClusterId clusterId, EventId eventId,
+                                       bool fabricFiltered)
+{
+    DeviceProxy * device = GetDevice(identity);
+    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    EventPathParams eventPathParams[1];
+    if (endpointId != kInvalidEndpointId)
+    {
+        eventPathParams[0].mEndpointId = endpointId;
+    }
+
+    if (clusterId != kInvalidClusterId)
+    {
+        eventPathParams[0].mClusterId = clusterId;
+    }
+
+    if (eventId != kInvalidEventId)
+    {
+        eventPathParams[0].mEventId = eventId;
+    }
+
+    ReadPrepareParams params(device->GetSecureSession().Value());
+    params.mpEventPathParamsList        = eventPathParams;
+    params.mEventPathParamsListSize     = 1;
+    params.mpAttributePathParamsList    = nullptr;
+    params.mAttributePathParamsListSize = 0;
+    params.mIsFabricFiltered            = fabricFiltered;
+
+    // TODO: Add data version supports
+    mReadClient = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
+                                               mBufferedReadAdapter, ReadClient::InteractionType::Read);
+    VerifyOrReturnError(mReadClient != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    return mReadClient->SendRequest(params);
+}
+
+CHIP_ERROR InteractionModel::SubscribeAttribute(const char * identity, EndpointId endpointId, ClusterId clusterId,
+                                                AttributeId attributeId, uint16_t minInterval, uint16_t maxInterval,
+                                                bool fabricFiltered)
+{
+    DeviceProxy * device = GetDevice(identity);
+    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    AttributePathParams attributePathParams[1];
+    if (endpointId != kInvalidEndpointId)
+    {
+        attributePathParams[0].mEndpointId = endpointId;
+    }
+
+    if (clusterId != kInvalidClusterId)
+    {
+        attributePathParams[0].mClusterId = clusterId;
+    }
+
+    if (attributeId != kInvalidAttributeId)
+    {
+        attributePathParams[0].mAttributeId = attributeId;
+    }
+
+    ReadPrepareParams params(device->GetSecureSession().Value());
+    params.mpEventPathParamsList        = nullptr;
+    params.mEventPathParamsListSize     = 0;
+    params.mpAttributePathParamsList    = attributePathParams;
+    params.mAttributePathParamsListSize = 1;
+    params.mMinIntervalFloorSeconds     = minInterval;
+    params.mMaxIntervalCeilingSeconds   = maxInterval;
+    params.mIsFabricFiltered            = fabricFiltered;
+
+    mSubscribeClient = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
+                                                    mBufferedReadAdapter, ReadClient::InteractionType::Subscribe);
+    VerifyOrReturnError(mSubscribeClient != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    return mSubscribeClient->SendRequest(params);
+}
+
+CHIP_ERROR InteractionModel::SubscribeEvent(const char * identity, EndpointId endpointId, ClusterId clusterId, EventId eventId,
+                                            uint16_t minInterval, uint16_t maxInterval, bool fabricFiltered)
+{
+    DeviceProxy * device = GetDevice(identity);
+    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    EventPathParams eventPathParams[1];
+
+    if (endpointId != kInvalidEndpointId)
+    {
+        eventPathParams[0].mEndpointId = endpointId;
+    }
+
+    if (clusterId != kInvalidClusterId)
+    {
+        eventPathParams[0].mClusterId = clusterId;
+    }
+
+    if (eventId != kInvalidEventId)
+    {
+        eventPathParams[0].mEventId = eventId;
+    }
+
+    ReadPrepareParams params(device->GetSecureSession().Value());
+    params.mpEventPathParamsList        = eventPathParams;
+    params.mEventPathParamsListSize     = 1;
+    params.mpAttributePathParamsList    = nullptr;
+    params.mAttributePathParamsListSize = 0;
+    params.mMinIntervalFloorSeconds     = minInterval;
+    params.mMaxIntervalCeilingSeconds   = maxInterval;
+    params.mIsFabricFiltered            = fabricFiltered;
+
+    mSubscribeClient = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
+                                                    mBufferedReadAdapter, ReadClient::InteractionType::Subscribe);
+    VerifyOrReturnError(mSubscribeClient != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    return mSubscribeClient->SendRequest(params);
+}
+
+void InteractionModel::Shutdown()
+{
+    mReadClient.reset();
+    mSubscribeClient.reset();
+    mWriteClient.reset();
+    mCommandSender.reset();
+}
+
+/////////// ReadClient Callback Interface /////////
+void InteractionModel::OnAttributeData(const ConcreteDataAttributePath & path, TLV::TLVReader * data, const StatusIB & status)
+{
+    OnResponse(status, data);
+}
+
+void InteractionModel::OnEventData(const EventHeader & eventHeader, TLV::TLVReader * data, const StatusIB * status)
+{
+    OnResponse(status == nullptr ? StatusIB() : *status, data);
+}
+
+void InteractionModel::OnError(CHIP_ERROR error)
+{
+    StatusIB status(error);
+    OnResponse(status, nullptr);
+}
+
+void InteractionModel::OnDone()
+{
+    mReadClient.reset();
+    // TODO: Close the subscribe client
+    ContinueOnChipMainThread(CHIP_NO_ERROR);
+}
+
+void InteractionModel::OnSubscriptionEstablished(uint64_t subscriptionId)
+{
+    ContinueOnChipMainThread(CHIP_NO_ERROR);
+}
+
+/////////// WriteClient Callback Interface /////////
+void InteractionModel::OnResponse(const WriteClient * client, const ConcreteDataAttributePath & path, StatusIB status)
+{
+    OnResponse(status, nullptr);
+}
+
+void InteractionModel::OnError(const WriteClient * client, CHIP_ERROR error)
+{
+    StatusIB status(error);
+    OnResponse(status, nullptr);
+}
+
+void InteractionModel::OnDone(WriteClient * client)
+{
+    mWriteClient.reset();
+    ContinueOnChipMainThread(CHIP_NO_ERROR);
+}
+
+/////////// CommandSender Callback Interface /////////
+void InteractionModel::OnResponse(CommandSender * client, const ConcreteCommandPath & path, const StatusIB & status,
+                                  TLV::TLVReader * data)
+{
+    OnResponse(status, data);
+}
+
+void InteractionModel::OnError(const CommandSender * client, CHIP_ERROR error)
+{
+    StatusIB status(error);
+    OnResponse(status, nullptr);
+}
+
+void InteractionModel::OnDone(CommandSender * client)
+{
+    mCommandSender.reset();
+    ContinueOnChipMainThread(CHIP_NO_ERROR);
+}

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.h
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.h
@@ -1,0 +1,192 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include <app/BufferedReadCallback.h>
+#include <app/ChunkedWriteCallback.h>
+#include <app/CommandSender.h>
+#include <app/DeviceProxy.h>
+#include <app/ReadClient.h>
+#include <app/WriteClient.h>
+#include <lib/support/CodeUtils.h>
+
+class InteractionModel : public chip::app::ReadClient::Callback,
+                         public chip::app::WriteClient::Callback,
+                         public chip::app::CommandSender::Callback
+{
+public:
+    InteractionModel() : mBufferedReadAdapter(*this), mChunkedWriteCallback(this){};
+    virtual ~InteractionModel(){};
+
+    virtual void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) = 0;
+    virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err)                              = 0;
+    virtual chip::DeviceProxy * GetDevice(const char * identity)                             = 0;
+
+    CHIP_ERROR ReadAttribute(const char * identity, chip::EndpointId endpointId, chip::ClusterId clusterId,
+                             chip::AttributeId attributeId, bool fabricFiltered = true);
+
+    CHIP_ERROR SubscribeAttribute(const char * identity, chip::EndpointId endpointId, chip::ClusterId clusterId,
+                                  chip::AttributeId attributeId, uint16_t minInterval, uint16_t maxInterval,
+                                  bool fabricFiltered = true);
+
+    CHIP_ERROR ReadEvent(const char * identity, chip::EndpointId endpointId, chip::ClusterId clusterId, chip::EventId eventId,
+                         bool fabricFiltered = true);
+
+    CHIP_ERROR SubscribeEvent(const char * identity, chip::EndpointId endpointId, chip::ClusterId clusterId, chip::EventId eventId,
+                              uint16_t minInterval, uint16_t maxInterval, bool fabricFiltered = true);
+
+    CHIP_ERROR WaitForReport() { return CHIP_NO_ERROR; }
+
+    template <class T>
+    CHIP_ERROR WriteAttribute(const char * identity, chip::EndpointId endpointId, chip::ClusterId clusterId,
+                              chip::AttributeId attributeId, const T & value,
+                              chip::Optional<uint16_t> timedInteractionTimeoutMs = chip::NullOptional)
+    {
+        chip::DeviceProxy * device = GetDevice(identity);
+        VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+        chip::app::AttributePathParams attributePathParams;
+        if (endpointId != chip::kInvalidEndpointId)
+        {
+            attributePathParams.mEndpointId = endpointId;
+        }
+
+        if (clusterId != chip::kInvalidClusterId)
+        {
+            attributePathParams.mClusterId = clusterId;
+        }
+
+        if (attributeId != chip::kInvalidAttributeId)
+        {
+            attributePathParams.mAttributeId = attributeId;
+        }
+
+        mWriteClient = std::make_unique<chip::app::WriteClient>(device->GetExchangeManager(), &mChunkedWriteCallback,
+                                                                timedInteractionTimeoutMs);
+        VerifyOrReturnError(mWriteClient != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        // TODO: Add data version supports
+        chip::Optional<chip::DataVersion> dataVersion = chip::NullOptional;
+        ReturnErrorOnFailure(mWriteClient->EncodeAttribute(attributePathParams, value, dataVersion));
+        return mWriteClient->SendWriteRequest(device->GetSecureSession().Value());
+    }
+
+    template <class T>
+    CHIP_ERROR WriteGroupAttribute(const char * identity, chip::GroupId groupId, chip::ClusterId clusterId,
+                                   chip::AttributeId attributeId, const T & value,
+                                   chip::Optional<uint16_t> timedInteractionTimeoutMs = chip::NullOptional)
+    {
+        chip::DeviceProxy * device = GetDevice(identity);
+        VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+        chip::app::AttributePathParams attributePathParams;
+
+        if (clusterId != chip::kInvalidClusterId)
+        {
+            attributePathParams.mClusterId = clusterId;
+        }
+
+        if (attributeId != chip::kInvalidAttributeId)
+        {
+            attributePathParams.mAttributeId = attributeId;
+        }
+
+        mWriteClient = std::make_unique<chip::app::WriteClient>(device->GetExchangeManager(), &mChunkedWriteCallback,
+                                                                timedInteractionTimeoutMs);
+        VerifyOrReturnError(mWriteClient != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        // TODO: Add data version supports
+        chip::Optional<chip::DataVersion> dataVersion = chip::NullOptional;
+        ReturnErrorOnFailure(mWriteClient->EncodeAttribute(attributePathParams, value, dataVersion));
+
+        chip::FabricIndex fabricIndex = device->GetSecureSession().Value()->GetFabricIndex();
+        chip::Transport::OutgoingGroupSession session(groupId, fabricIndex);
+        return mWriteClient->SendWriteRequest(chip::SessionHandle(session));
+    }
+
+    template <class T>
+    CHIP_ERROR SendCommand(const char * identity, chip::EndpointId endpointId, chip::ClusterId clusterId, chip::CommandId commandId,
+                           const T & value, chip::Optional<uint16_t> timedInteractionTimeoutMs = chip::NullOptional)
+    {
+        chip::DeviceProxy * device = GetDevice(identity);
+        VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+        chip::app::CommandPathParams commandPath = { endpointId, 0 /* groupId */, clusterId, commandId,
+                                                     (chip::app::CommandPathFlags::kEndpointIdValid) };
+        mCommandSender =
+            std::make_unique<chip::app::CommandSender>(this, device->GetExchangeManager(), timedInteractionTimeoutMs.HasValue());
+        VerifyOrReturnError(mCommandSender != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        ReturnErrorOnFailure(mCommandSender->AddRequestDataNoTimedCheck(commandPath, value, timedInteractionTimeoutMs));
+        return mCommandSender->SendCommandRequest(device->GetSecureSession().Value());
+    }
+
+    template <class T>
+    CHIP_ERROR SendGroupCommand(const char * identity, chip::GroupId groupId, chip::ClusterId clusterId, chip::CommandId commandId,
+                                const T & value, chip::Optional<uint16_t> timedInteractionTimeoutMs = chip::NullOptional)
+    {
+        chip::DeviceProxy * device = GetDevice(identity);
+        VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+        chip::app::CommandPathParams commandPath = { 0 /* endpoint */, groupId, clusterId, commandId,
+                                                     (chip::app::CommandPathFlags::kGroupIdValid) };
+
+        mCommandSender =
+            std::make_unique<chip::app::CommandSender>(this, device->GetExchangeManager(), timedInteractionTimeoutMs.HasValue());
+        VerifyOrReturnError(mCommandSender != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        chip::FabricIndex fabricIndex = device->GetSecureSession().Value()->GetFabricIndex();
+        chip::Transport::OutgoingGroupSession session(groupId, fabricIndex);
+        ReturnErrorOnFailure(mCommandSender->AddRequestDataNoTimedCheck(commandPath, value, timedInteractionTimeoutMs));
+        return mCommandSender->SendGroupCommandRequest(chip::SessionHandle(session));
+    }
+
+    void Shutdown();
+
+    /////////// ReadClient Callback Interface /////////
+    void OnAttributeData(const chip::app::ConcreteDataAttributePath & path, chip::TLV::TLVReader * data,
+                         const chip::app::StatusIB & status) override;
+    void OnEventData(const chip::app::EventHeader & eventHeader, chip::TLV::TLVReader * data,
+                     const chip::app::StatusIB * status) override;
+    void OnError(CHIP_ERROR error) override;
+    void OnDone() override;
+    void OnSubscriptionEstablished(uint64_t subscriptionId) override;
+
+    /////////// WriteClient Callback Interface /////////
+    void OnResponse(const chip::app::WriteClient * client, const chip::app::ConcreteDataAttributePath & path,
+                    chip::app::StatusIB status) override;
+    void OnError(const chip::app::WriteClient * client, CHIP_ERROR error) override;
+    void OnDone(chip::app::WriteClient * client) override;
+
+    /////////// CommandSender Callback Interface /////////
+    void OnResponse(chip::app::CommandSender * client, const chip::app::ConcreteCommandPath & path,
+                    const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override;
+    void OnError(const chip::app::CommandSender * client, CHIP_ERROR error) override;
+    void OnDone(chip::app::CommandSender * client) override;
+
+protected:
+    std::unique_ptr<chip::app::ReadClient> mReadClient;
+    // TODO: Add multiple subscriptions at the same time supports
+    std::unique_ptr<chip::app::ReadClient> mSubscribeClient;
+    std::unique_ptr<chip::app::WriteClient> mWriteClient;
+    std::unique_ptr<chip::app::CommandSender> mCommandSender;
+
+    chip::app::BufferedReadCallback mBufferedReadAdapter;
+    chip::app::ChunkedWriteCallback mChunkedWriteCallback;
+};

--- a/src/app/tests/suites/include/ConstraintsChecker.h
+++ b/src/app/tests/suites/include/ConstraintsChecker.h
@@ -30,7 +30,7 @@ public:
     virtual ~ConstraintsChecker(){};
 
 protected:
-    virtual void Exit(std::string message) = 0;
+    virtual void Exit(std::string message, CHIP_ERROR err = CHIP_ERROR_INTERNAL) = 0;
 
     bool CheckConstraintType(const char * itemName, const char * current, const char * expected)
     {

--- a/src/app/tests/suites/include/TestRunner.h
+++ b/src/app/tests/suites/include/TestRunner.h
@@ -1,0 +1,88 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include <lib/support/UnitTestUtils.h>
+
+class TestRunner
+{
+public:
+    TestRunner(const char * name, uint16_t testCount) : mTestName(name), mTestCount(testCount), mTestIndex(0) {}
+    virtual ~TestRunner(){};
+
+    void LogStart() { ChipLogProgress(chipTool, " ***** Test Start : %s\n", mTestName); }
+
+    void LogStep(uint32_t stepNumber, const char * stepName)
+    {
+        ChipLogProgress(chipTool, " ***** Test Step %u : %s\n", stepNumber, stepName);
+    }
+
+    void LogEnd(CHIP_ERROR err)
+    {
+        if (CHIP_NO_ERROR == err)
+        {
+            ChipLogProgress(chipTool, " **** Test Complete: %s\n", mTestName);
+        }
+        else
+        {
+            ChipLogError(chipTool, " ***** Test Failure: %s\n", mTestName);
+        }
+    }
+
+    virtual CHIP_ERROR DoTestStep(uint16_t testIndex)                            = 0;
+    virtual void Exit(std::string message, CHIP_ERROR err = CHIP_ERROR_INTERNAL) = 0;
+
+    void NextTest()
+    {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        if (0 == mTestIndex)
+        {
+            LogStart();
+        }
+
+        if (mTestCount == mTestIndex)
+        {
+            LogEnd(CHIP_NO_ERROR);
+            Exit(mTestName, CHIP_NO_ERROR);
+            return;
+        }
+
+        if (mDelayInMs.HasValue())
+        {
+            chip::test_utils::SleepMillis(mDelayInMs.Value());
+        }
+
+        // Ensure we increment mTestIndex before we start running the relevant
+        // command.  That way if we lose the timeslice after we send the message
+        // but before our function call returns, we won't end up with an
+        // incorrect mTestIndex value observed when we get the response.
+        DoTestStep(mTestIndex++);
+        if (CHIP_NO_ERROR != err)
+        {
+            Exit(chip::ErrorStr(err));
+        }
+    }
+
+protected:
+    const char * mTestName;
+    const uint16_t mTestCount;
+    std::atomic_uint16_t mTestIndex;
+    chip::Optional<uint64_t> mDelayInMs;
+};

--- a/src/app/tests/suites/include/ValueChecker.h
+++ b/src/app/tests/suites/include/ValueChecker.h
@@ -30,7 +30,7 @@ public:
     virtual ~ValueChecker(){};
 
 protected:
-    virtual void Exit(std::string message) = 0;
+    virtual void Exit(std::string message, CHIP_ERROR err = CHIP_ERROR_INTERNAL) = 0;
 
     bool CheckDecodeValue(CHIP_ERROR error)
     {

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -88,30 +88,36 @@ function setDefaultTypeForWaitCommand(test)
   const type = test[kWaitCommandName];
   switch (type) {
   case 'readEvent':
+    test.commandName = 'WaitEvent';
     test.isEvent     = true;
     test.isReadEvent = true;
     break;
   case 'subscribeEvent':
+    test.commandName      = 'WaitEvent';
     test.isEvent          = true;
     test.isSubscribe      = true;
     test.isSubscribeEvent = true;
     break;
   case 'readAttribute':
+    test.commandName     = 'WaitAttribute';
     test.isAttribute     = true;
     test.isReadAttribute = true;
     break;
   case 'writeAttribute':
+    test.commandName      = 'WaitAttribute';
     test.isAttribute      = true;
     test.isWriteAttribute = true;
     break;
   case 'subscribeAttribute':
+    test.commandName          = 'WaitAttribute';
     test.isAttribute          = true;
     test.isSubscribe          = true;
     test.isSubscribeAttribute = true;
     break;
   default:
-    test.isCommand = true;
-    test.command   = test.wait
+    test.commandName = 'WaitCommand';
+    test.isCommand   = true;
+    test.command     = test.wait
     break;
   }
 
@@ -123,20 +129,20 @@ function setDefaultTypeForCommand(test)
   const type = test[kCommandName];
   switch (type) {
   case 'readEvent':
-    test.commandName = 'Read';
+    test.commandName = 'ReadEvent';
     test.isEvent     = true;
     test.isReadEvent = true;
     break;
 
   case 'subscribeEvent':
-    test.commandName      = 'Subscribe';
+    test.commandName      = 'SubscribeEvent';
     test.isEvent          = true;
     test.isSubscribe      = true;
     test.isSubscribeEvent = true;
     break;
 
   case 'readAttribute':
-    test.commandName     = 'Read';
+    test.commandName     = 'ReadAttribute';
     test.isAttribute     = true;
     test.isReadAttribute = true;
     if (!(kFabricFiltered in test)) {
@@ -145,17 +151,19 @@ function setDefaultTypeForCommand(test)
     break;
 
   case 'writeAttribute':
-    test.commandName      = 'Write';
+    test.commandName      = 'WriteAttribute';
     test.isAttribute      = true;
     test.isWriteAttribute = true;
     if ((kGroupId in test)) {
-      test.isGroupCommand = true;
-      test.groupId        = parseInt(test[kGroupId], 10);
+      test.isGroupCommand        = true;
+      test.isWriteGroupAttribute = true;
+      test.commandName           = 'WriteGroupAttribute';
+      test.groupId               = parseInt(test[kGroupId], 10);
     }
     break;
 
   case 'subscribeAttribute':
-    test.commandName          = 'Subscribe';
+    test.commandName          = 'SubscribeAttribute';
     test.isAttribute          = true;
     test.isSubscribe          = true;
     test.isSubscribeAttribute = true;
@@ -165,16 +173,17 @@ function setDefaultTypeForCommand(test)
     break;
 
   case 'waitForReport':
-    test.commandName     = 'Report';
+    test.commandName     = 'WaitForReport';
     test.isAttribute     = true;
     test.isWaitForReport = true;
     break;
 
   default:
-    test.commandName = test.command;
+    test.commandName = isTestOnlyCluster(test.cluster) ? test.command : 'SendCommand';
     test.isCommand   = true;
     if ((kGroupId in test)) {
       test.isGroupCommand = true;
+      test.commandName    = 'SendGroupCommand';
       test.groupId        = parseInt(test[kGroupId], 10);
     }
     break;
@@ -331,11 +340,11 @@ function setDefaults(test, defaultConfig)
   const defaultEndpointId   = kEndpointName in defaultConfig ? defaultConfig[kEndpointName] : null;
   const defaultDisabled     = false;
 
-  setDefaultType(test);
   setDefault(test, kIdentityName, defaultIdentityName);
   setDefault(test, kClusterName, defaultClusterName);
   setDefault(test, kEndpointName, defaultEndpointId);
   setDefault(test, kDisabledName, defaultDisabled);
+  setDefaultType(test);
   setDefaultPICS(test);
   setDefaultArguments(test);
   setDefaultResponse(test);

--- a/src/darwin/Framework/CHIP/templates/tests/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/tests/partials/test_cluster.zapt
@@ -1,4 +1,4 @@
-{{#chip_tests tests}}
+{{#chip_tests tests useSynthesizeWaitForReport=true}}
 {{#chip_tests_items}}
 {{#if async}}
 bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase command}}_Fulfilled = false;

--- a/zzz_generated/placeholder/app1/zap-generated/test/Commands.h
+++ b/zzz_generated/placeholder/app1/zap-generated/test/Commands.h
@@ -24,7 +24,7 @@
 class Test_TC_DM_1_3_SimulatedSuite : public TestCommand
 {
 public:
-    Test_TC_DM_1_3_SimulatedSuite() : TestCommand("Test_TC_DM_1_3_Simulated"), mTestIndex(0)
+    Test_TC_DM_1_3_SimulatedSuite() : TestCommand("Test_TC_DM_1_3_Simulated", 21)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
@@ -34,132 +34,17 @@ public:
 
     ~Test_TC_DM_1_3_SimulatedSuite() {}
 
-    /////////// TestCommand Interface /////////
-    void NextTest() override
-    {
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        if (0 == mTestIndex)
-        {
-            ChipLogProgress(chipTool, " **** Test Start: Test_TC_DM_1_3_Simulated\n");
-        }
-
-        if (mTestCount == mTestIndex)
-        {
-            ChipLogProgress(chipTool, " **** Test Complete: Test_TC_DM_1_3_Simulated\n");
-            SetCommandExitStatus(CHIP_NO_ERROR);
-            return;
-        }
-
-        Wait();
-
-        // Ensure we increment mTestIndex before we start running the relevant
-        // command.  That way if we lose the timeslice after we send the message
-        // but before our function call returns, we won't end up with an
-        // incorrect mTestIndex value observed when we get the response.
-        switch (mTestIndex++)
-        {
-        case 0:
-            ChipLogProgress(chipTool, " ***** Test Step 0 : Wait for the device to be commissioned\n");
-            err = TestWaitForTheDeviceToBeCommissioned_0();
-            break;
-        case 1:
-            ChipLogProgress(chipTool, " ***** Test Step 1 : Log OnOff Test Startup\n");
-            err = TestLogOnOffTestStartup_1();
-            break;
-        case 2:
-            ChipLogProgress(chipTool, " ***** Test Step 2 : Query Data Model Revision\n");
-            err = TestQueryDataModelRevision_2();
-            break;
-        case 3:
-            ChipLogProgress(chipTool, " ***** Test Step 3 : Query Vendor Name\n");
-            err = TestQueryVendorName_3();
-            break;
-        case 4:
-            ChipLogProgress(chipTool, " ***** Test Step 4 : Query VendorID\n");
-            err = TestQueryVendorID_4();
-            break;
-        case 5:
-            ChipLogProgress(chipTool, " ***** Test Step 5 : Query Product Name\n");
-            err = TestQueryProductName_5();
-            break;
-        case 6:
-            ChipLogProgress(chipTool, " ***** Test Step 6 : Query ProductID\n");
-            err = TestQueryProductID_6();
-            break;
-        case 7:
-            ChipLogProgress(chipTool, " ***** Test Step 7 : Query Node Label\n");
-            err = TestQueryNodeLabel_7();
-            break;
-        case 8:
-            ChipLogProgress(chipTool, " ***** Test Step 8 : Query User Location\n");
-            err = TestQueryUserLocation_8();
-            break;
-        case 9:
-            ChipLogProgress(chipTool, " ***** Test Step 9 : Query HardwareVersion\n");
-            err = TestQueryHardwareVersion_9();
-            break;
-        case 10:
-            ChipLogProgress(chipTool, " ***** Test Step 10 : Query HardwareVersionString\n");
-            err = TestQueryHardwareVersionString_10();
-            break;
-        case 11:
-            ChipLogProgress(chipTool, " ***** Test Step 11 : Query SoftwareVersion\n");
-            err = TestQuerySoftwareVersion_11();
-            break;
-        case 12:
-            ChipLogProgress(chipTool, " ***** Test Step 12 : Query SoftwareVersionString\n");
-            err = TestQuerySoftwareVersionString_12();
-            break;
-        case 13:
-            ChipLogProgress(chipTool, " ***** Test Step 13 : Query ManufacturingDate\n");
-            err = TestQueryManufacturingDate_13();
-            break;
-        case 14:
-            ChipLogProgress(chipTool, " ***** Test Step 14 : Query PartNumber\n");
-            err = TestQueryPartNumber_14();
-            break;
-        case 15:
-            ChipLogProgress(chipTool, " ***** Test Step 15 : Query ProductURL\n");
-            err = TestQueryProductURL_15();
-            break;
-        case 16:
-            ChipLogProgress(chipTool, " ***** Test Step 16 : Query ProductLabel\n");
-            err = TestQueryProductLabel_16();
-            break;
-        case 17:
-            ChipLogProgress(chipTool, " ***** Test Step 17 : Query SerialNumber\n");
-            err = TestQuerySerialNumber_17();
-            break;
-        case 18:
-            ChipLogProgress(chipTool, " ***** Test Step 18 : Query LocalConfigDisabled\n");
-            err = TestQueryLocalConfigDisabled_18();
-            break;
-        case 19:
-            ChipLogProgress(chipTool, " ***** Test Step 19 : Query Reachable\n");
-            err = TestQueryReachable_19();
-            break;
-        case 20:
-            ChipLogProgress(chipTool, " ***** Test Step 20 : Query UniqueID\n");
-            err = TestQueryUniqueID_20();
-            break;
-        }
-
-        if (CHIP_NO_ERROR != err)
-        {
-            ChipLogError(chipTool, " ***** Test Failure: %s\n", chip::ErrorStr(err));
-            SetCommandExitStatus(err);
-        }
-    }
-
 private:
-    std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 21;
-
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
     chip::Optional<uint16_t> mTimeout;
+
+    chip::EndpointId GetEndpoint(chip::EndpointId endpoint) { return mEndpoint.HasValue() ? mEndpoint.Value() : endpoint; }
+
+    //
+    // Tests methods
+    //
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
@@ -185,232 +70,98 @@ private:
         }
     }
 
-    //
-    // Tests methods
-    //
-
-    CHIP_ERROR TestWaitForTheDeviceToBeCommissioned_0()
+    CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
-        SetIdentity(kIdentityAlpha);
-        return WaitForCommissioning();
-    }
-
-    CHIP_ERROR TestLogOnOffTestStartup_1()
-    {
-        SetIdentity(kIdentityAlpha);
-        return Log("*** Basic Cluster Tests Ready");
-    }
-
-    CHIP_ERROR TestQueryDataModelRevision_2()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: DataModelRevision] Query Data Model Revision",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::DataModelRevision::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryVendorName_3()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: VendorName] Query Vendor Name", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::VendorName::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryVendorID_4()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: VendorID] Query VendorID", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::VendorID::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryProductName_5()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: ProductName] Query Product Name", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::ProductName::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryProductID_6()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: ProductID] Query ProductID", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::ProductID::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryNodeLabel_7()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: NodeLabel] Query Node Label", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::NodeLabel::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryUserLocation_8()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: Location] Query User Location", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::Location::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryHardwareVersion_9()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: HardwareVersion] Query HardwareVersion", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::HardwareVersion::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryHardwareVersionString_10()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: HardwareVersionString] Query HardwareVersionString",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::HardwareVersionString::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQuerySoftwareVersion_11()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: SoftwareVersion] Query SoftwareVersion", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::SoftwareVersion::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQuerySoftwareVersionString_12()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: SoftwareVersionString] Query SoftwareVersionString",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::SoftwareVersionString::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryManufacturingDate_13()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: ManufacturingDate] Query ManufacturingDate", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::ManufacturingDate::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryPartNumber_14()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: PartNumber] Query PartNumber", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::PartNumber::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryProductURL_15()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: ProductURL] Query ProductURL", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::ProductURL::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryProductLabel_16()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: ProductLabel] Query ProductLabel", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::ProductLabel::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQuerySerialNumber_17()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: SerialNumber] Query SerialNumber", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::SerialNumber::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryLocalConfigDisabled_18()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: LocalConfigDisabled] Query LocalConfigDisabled",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::LocalConfigDisabled::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryReachable_19()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: Reachable] Query Reachable", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::Reachable::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryUniqueID_20()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: UniqueID] Query UniqueID", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::UniqueID::Id);
+        using namespace chip::app::Clusters;
+        switch (testIndex)
+        {
+        case 0: {
+            LogStep(0, "Wait for the device to be commissioned");
+            SetIdentity(kIdentityAlpha);
+            return WaitForCommissioning();
+        }
+        case 1: {
+            LogStep(1, "Log OnOff Test Startup");
+            SetIdentity(kIdentityAlpha);
+            return Log("*** Basic Cluster Tests Ready");
+        }
+        case 2: {
+            LogStep(2, "Query Data Model Revision");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::DataModelRevision::Id);
+        }
+        case 3: {
+            LogStep(3, "Query Vendor Name");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::VendorName::Id);
+        }
+        case 4: {
+            LogStep(4, "Query VendorID");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::VendorID::Id);
+        }
+        case 5: {
+            LogStep(5, "Query Product Name");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::ProductName::Id);
+        }
+        case 6: {
+            LogStep(6, "Query ProductID");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::ProductID::Id);
+        }
+        case 7: {
+            LogStep(7, "Query Node Label");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id);
+        }
+        case 8: {
+            LogStep(8, "Query User Location");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::Location::Id);
+        }
+        case 9: {
+            LogStep(9, "Query HardwareVersion");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::HardwareVersion::Id);
+        }
+        case 10: {
+            LogStep(10, "Query HardwareVersionString");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::HardwareVersionString::Id);
+        }
+        case 11: {
+            LogStep(11, "Query SoftwareVersion");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::SoftwareVersion::Id);
+        }
+        case 12: {
+            LogStep(12, "Query SoftwareVersionString");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::SoftwareVersionString::Id);
+        }
+        case 13: {
+            LogStep(13, "Query ManufacturingDate");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::ManufacturingDate::Id);
+        }
+        case 14: {
+            LogStep(14, "Query PartNumber");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::PartNumber::Id);
+        }
+        case 15: {
+            LogStep(15, "Query ProductURL");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::ProductURL::Id);
+        }
+        case 16: {
+            LogStep(16, "Query ProductLabel");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::ProductLabel::Id);
+        }
+        case 17: {
+            LogStep(17, "Query SerialNumber");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::SerialNumber::Id);
+        }
+        case 18: {
+            LogStep(18, "Query LocalConfigDisabled");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::LocalConfigDisabled::Id);
+        }
+        case 19: {
+            LogStep(19, "Query Reachable");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::Reachable::Id);
+        }
+        case 20: {
+            LogStep(20, "Query UniqueID");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::UniqueID::Id);
+        }
+        }
         return CHIP_NO_ERROR;
     }
 };
@@ -418,7 +169,7 @@ private:
 class Test_TC_DM_3_3_SimulatedSuite : public TestCommand
 {
 public:
-    Test_TC_DM_3_3_SimulatedSuite() : TestCommand("Test_TC_DM_3_3_Simulated"), mTestIndex(0)
+    Test_TC_DM_3_3_SimulatedSuite() : TestCommand("Test_TC_DM_3_3_Simulated", 6)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
@@ -428,87 +179,17 @@ public:
 
     ~Test_TC_DM_3_3_SimulatedSuite() {}
 
-    /////////// TestCommand Interface /////////
-    void NextTest() override
-    {
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        if (0 == mTestIndex)
-        {
-            ChipLogProgress(chipTool, " **** Test Start: Test_TC_DM_3_3_Simulated\n");
-        }
-
-        if (mTestCount == mTestIndex)
-        {
-            ChipLogProgress(chipTool, " **** Test Complete: Test_TC_DM_3_3_Simulated\n");
-            SetCommandExitStatus(CHIP_NO_ERROR);
-            return;
-        }
-
-        Wait();
-
-        // Ensure we increment mTestIndex before we start running the relevant
-        // command.  That way if we lose the timeslice after we send the message
-        // but before our function call returns, we won't end up with an
-        // incorrect mTestIndex value observed when we get the response.
-        switch (mTestIndex++)
-        {
-        case 0:
-            ChipLogProgress(chipTool, " ***** Test Step 0 : Wait for the device to be commissioned\n");
-            err = TestWaitForTheDeviceToBeCommissioned_0();
-            break;
-        case 1:
-            ChipLogProgress(chipTool, " ***** Test Step 1 : Wait for Scan Network Command\n");
-            err = TestWaitForScanNetworkCommand_1();
-            break;
-        case 2:
-            ChipLogProgress(chipTool, " ***** Test Step 2 : Wait for Add Wifi Network Command\n");
-            if (ShouldSkip("WIFI"))
-            {
-                NextTest();
-                return;
-            }
-            err = TestWaitForAddWifiNetworkCommand_2();
-            break;
-        case 3:
-            ChipLogProgress(chipTool, " ***** Test Step 3 : Wait for Update Thread Network Command\n");
-            if (ShouldSkip("THREAD"))
-            {
-                NextTest();
-                return;
-            }
-            err = TestWaitForUpdateThreadNetworkCommand_3();
-            break;
-        case 4:
-            ChipLogProgress(chipTool, " ***** Test Step 4 : Wait for Enable Network Command\n");
-            err = TestWaitForEnableNetworkCommand_4();
-            break;
-        case 5:
-            ChipLogProgress(chipTool, " ***** Test Step 5 : Wait for Remove Network Command\n");
-            if (ShouldSkip("WIFI | THREAD"))
-            {
-                NextTest();
-                return;
-            }
-            err = TestWaitForRemoveNetworkCommand_5();
-            break;
-        }
-
-        if (CHIP_NO_ERROR != err)
-        {
-            ChipLogError(chipTool, " ***** Test Failure: %s\n", chip::ErrorStr(err));
-            SetCommandExitStatus(err);
-        }
-    }
-
 private:
-    std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 6;
-
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
     chip::Optional<uint16_t> mTimeout;
+
+    chip::EndpointId GetEndpoint(chip::EndpointId endpoint) { return mEndpoint.HasValue() ? mEndpoint.Value() : endpoint; }
+
+    //
+    // Tests methods
+    //
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
@@ -530,82 +211,42 @@ private:
         }
     }
 
-    //
-    // Tests methods
-    //
-
-    CHIP_ERROR TestWaitForTheDeviceToBeCommissioned_0()
+    CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
-        SetIdentity(kIdentityAlpha);
-        return WaitForCommissioning();
-    }
-
-    CHIP_ERROR TestWaitForScanNetworkCommand_1()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool,
-                     "[Endpoint: 0x%08x Cluster: Network Commissioning Command: ScanNetworks] Wait for Scan Network Command",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath = chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::NetworkCommissioning::Id,
-                                                      chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworks::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForAddWifiNetworkCommand_2()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(
-            chipTool,
-            "[Endpoint: 0x%08x Cluster: Network Commissioning Command: AddOrUpdateWiFiNetwork] Wait for Add Wifi Network Command",
-            endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath =
-            chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::NetworkCommissioning::Id,
-                                           chip::app::Clusters::NetworkCommissioning::Commands::AddOrUpdateWiFiNetwork::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForUpdateThreadNetworkCommand_3()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool,
-                     "[Endpoint: 0x%08x Cluster: Network Commissioning Command: AddOrUpdateThreadNetwork] Wait for Update Thread "
-                     "Network Command",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath =
-            chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::NetworkCommissioning::Id,
-                                           chip::app::Clusters::NetworkCommissioning::Commands::AddOrUpdateThreadNetwork::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForEnableNetworkCommand_4()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool,
-                     "[Endpoint: 0x%08x Cluster: Network Commissioning Command: ConnectNetwork] Wait for Enable Network Command",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath = chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::NetworkCommissioning::Id,
-                                                      chip::app::Clusters::NetworkCommissioning::Commands::ConnectNetwork::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForRemoveNetworkCommand_5()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool,
-                     "[Endpoint: 0x%08x Cluster: Network Commissioning Command: RemoveNetwork] Wait for Remove Network Command",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath = chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::NetworkCommissioning::Id,
-                                                      chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetwork::Id);
+        using namespace chip::app::Clusters;
+        switch (testIndex)
+        {
+        case 0: {
+            LogStep(0, "Wait for the device to be commissioned");
+            SetIdentity(kIdentityAlpha);
+            return WaitForCommissioning();
+        }
+        case 1: {
+            LogStep(1, "Wait for Scan Network Command");
+            return WaitCommand(GetEndpoint(0), NetworkCommissioning::Id, NetworkCommissioning::Commands::ScanNetworks::Id);
+        }
+        case 2: {
+            LogStep(2, "Wait for Add Wifi Network Command");
+            VerifyOrdo(!ShouldSkip("WIFI"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            return WaitCommand(GetEndpoint(0), NetworkCommissioning::Id,
+                               NetworkCommissioning::Commands::AddOrUpdateWiFiNetwork::Id);
+        }
+        case 3: {
+            LogStep(3, "Wait for Update Thread Network Command");
+            VerifyOrdo(!ShouldSkip("THREAD"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            return WaitCommand(GetEndpoint(0), NetworkCommissioning::Id,
+                               NetworkCommissioning::Commands::AddOrUpdateThreadNetwork::Id);
+        }
+        case 4: {
+            LogStep(4, "Wait for Enable Network Command");
+            return WaitCommand(GetEndpoint(0), NetworkCommissioning::Id, NetworkCommissioning::Commands::ConnectNetwork::Id);
+        }
+        case 5: {
+            LogStep(5, "Wait for Remove Network Command");
+            VerifyOrdo(!ShouldSkip("WIFI | THREAD"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            return WaitCommand(GetEndpoint(0), NetworkCommissioning::Id, NetworkCommissioning::Commands::RemoveNetwork::Id);
+        }
+        }
         return CHIP_NO_ERROR;
     }
 };
@@ -613,7 +254,7 @@ private:
 class Test_TC_DM_2_3_SimulatedSuite : public TestCommand
 {
 public:
-    Test_TC_DM_2_3_SimulatedSuite() : TestCommand("Test_TC_DM_2_3_Simulated"), mTestIndex(0)
+    Test_TC_DM_2_3_SimulatedSuite() : TestCommand("Test_TC_DM_2_3_Simulated", 10)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
@@ -623,88 +264,17 @@ public:
 
     ~Test_TC_DM_2_3_SimulatedSuite() {}
 
-    /////////// TestCommand Interface /////////
-    void NextTest() override
-    {
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        if (0 == mTestIndex)
-        {
-            ChipLogProgress(chipTool, " **** Test Start: Test_TC_DM_2_3_Simulated\n");
-        }
-
-        if (mTestCount == mTestIndex)
-        {
-            ChipLogProgress(chipTool, " **** Test Complete: Test_TC_DM_2_3_Simulated\n");
-            SetCommandExitStatus(CHIP_NO_ERROR);
-            return;
-        }
-
-        Wait();
-
-        // Ensure we increment mTestIndex before we start running the relevant
-        // command.  That way if we lose the timeslice after we send the message
-        // but before our function call returns, we won't end up with an
-        // incorrect mTestIndex value observed when we get the response.
-        switch (mTestIndex++)
-        {
-        case 0:
-            ChipLogProgress(chipTool, " ***** Test Step 0 : Wait for Arm Fail Safe\n");
-            err = TestWaitForArmFailSafe_0();
-            break;
-        case 1:
-            ChipLogProgress(chipTool, " ***** Test Step 1 : Wait for Set Regulatory Config\n");
-            err = TestWaitForSetRegulatoryConfig_1();
-            break;
-        case 2:
-            ChipLogProgress(chipTool, " ***** Test Step 2 : Wait for Attestation Certificate Chain Request\n");
-            err = TestWaitForAttestationCertificateChainRequest_2();
-            break;
-        case 3:
-            ChipLogProgress(chipTool, " ***** Test Step 3 : Wait for Attestation Certificate Chain Request\n");
-            err = TestWaitForAttestationCertificateChainRequest_3();
-            break;
-        case 4:
-            ChipLogProgress(chipTool, " ***** Test Step 4 : Wait for Attestation Request\n");
-            err = TestWaitForAttestationRequest_4();
-            break;
-        case 5:
-            ChipLogProgress(chipTool, " ***** Test Step 5 : Wait for CSR Request\n");
-            err = TestWaitForCsrRequest_5();
-            break;
-        case 6:
-            ChipLogProgress(chipTool, " ***** Test Step 6 : Wait for Add Trusted Root Certificate Request\n");
-            err = TestWaitForAddTrustedRootCertificateRequest_6();
-            break;
-        case 7:
-            ChipLogProgress(chipTool, " ***** Test Step 7 : Wait for Add Op NOC\n");
-            err = TestWaitForAddOpNoc_7();
-            break;
-        case 8:
-            ChipLogProgress(chipTool, " ***** Test Step 8 : Wait for Commissioning Complete\n");
-            err = TestWaitForCommissioningComplete_8();
-            break;
-        case 9:
-            ChipLogProgress(chipTool, " ***** Test Step 9 : Wait 3000ms\n");
-            err = TestWait3000ms_9();
-            break;
-        }
-
-        if (CHIP_NO_ERROR != err)
-        {
-            ChipLogError(chipTool, " ***** Test Failure: %s\n", chip::ErrorStr(err));
-            SetCommandExitStatus(err);
-        }
-    }
-
 private:
-    std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 10;
-
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
     chip::Optional<uint16_t> mTimeout;
+
+    chip::EndpointId GetEndpoint(chip::EndpointId endpoint) { return mEndpoint.HasValue() ? mEndpoint.Value() : endpoint; }
+
+    //
+    // Tests methods
+    //
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
@@ -726,137 +296,58 @@ private:
         }
     }
 
-    //
-    // Tests methods
-    //
-
-    CHIP_ERROR TestWaitForArmFailSafe_0()
+    CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: General Commissioning Command: ArmFailSafe] Wait for Arm Fail Safe",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath = chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::GeneralCommissioning::Id,
-                                                      chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafe::Id);
+        using namespace chip::app::Clusters;
+        switch (testIndex)
+        {
+        case 0: {
+            LogStep(0, "Wait for Arm Fail Safe");
+            return WaitCommand(GetEndpoint(0), GeneralCommissioning::Id, GeneralCommissioning::Commands::ArmFailSafe::Id);
+        }
+        case 1: {
+            LogStep(1, "Wait for Set Regulatory Config");
+            return WaitCommand(GetEndpoint(0), GeneralCommissioning::Id, GeneralCommissioning::Commands::SetRegulatoryConfig::Id);
+        }
+        case 2: {
+            LogStep(2, "Wait for Attestation Certificate Chain Request");
+            return WaitCommand(GetEndpoint(0), OperationalCredentials::Id,
+                               OperationalCredentials::Commands::CertificateChainRequest::Id);
+        }
+        case 3: {
+            LogStep(3, "Wait for Attestation Certificate Chain Request");
+            return WaitCommand(GetEndpoint(0), OperationalCredentials::Id,
+                               OperationalCredentials::Commands::CertificateChainRequest::Id);
+        }
+        case 4: {
+            LogStep(4, "Wait for Attestation Request");
+            return WaitCommand(GetEndpoint(0), OperationalCredentials::Id,
+                               OperationalCredentials::Commands::AttestationRequest::Id);
+        }
+        case 5: {
+            LogStep(5, "Wait for CSR Request");
+            return WaitCommand(GetEndpoint(0), OperationalCredentials::Id, OperationalCredentials::Commands::CSRRequest::Id);
+        }
+        case 6: {
+            LogStep(6, "Wait for Add Trusted Root Certificate Request");
+            return WaitCommand(GetEndpoint(0), OperationalCredentials::Id,
+                               OperationalCredentials::Commands::AddTrustedRootCertificate::Id);
+        }
+        case 7: {
+            LogStep(7, "Wait for Add Op NOC");
+            return WaitCommand(GetEndpoint(0), OperationalCredentials::Id, OperationalCredentials::Commands::AddNOC::Id);
+        }
+        case 8: {
+            LogStep(8, "Wait for Commissioning Complete");
+            return WaitCommand(GetEndpoint(0), GeneralCommissioning::Id, GeneralCommissioning::Commands::CommissioningComplete::Id);
+        }
+        case 9: {
+            LogStep(9, "Wait 3000ms");
+            SetIdentity(kIdentityAlpha);
+            return WaitForMs(3000);
+        }
+        }
         return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForSetRegulatoryConfig_1()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(
-            chipTool,
-            "[Endpoint: 0x%08x Cluster: General Commissioning Command: SetRegulatoryConfig] Wait for Set Regulatory Config",
-            endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath = chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::GeneralCommissioning::Id,
-                                                      chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForAttestationCertificateChainRequest_2()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool,
-                     "[Endpoint: 0x%08x Cluster: Operational Credentials Command: CertificateChainRequest] Wait for Attestation "
-                     "Certificate Chain Request",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath =
-            chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::OperationalCredentials::Id,
-                                           chip::app::Clusters::OperationalCredentials::Commands::CertificateChainRequest::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForAttestationCertificateChainRequest_3()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool,
-                     "[Endpoint: 0x%08x Cluster: Operational Credentials Command: CertificateChainRequest] Wait for Attestation "
-                     "Certificate Chain Request",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath =
-            chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::OperationalCredentials::Id,
-                                           chip::app::Clusters::OperationalCredentials::Commands::CertificateChainRequest::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForAttestationRequest_4()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool,
-                     "[Endpoint: 0x%08x Cluster: Operational Credentials Command: AttestationRequest] Wait for Attestation Request",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath =
-            chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::OperationalCredentials::Id,
-                                           chip::app::Clusters::OperationalCredentials::Commands::AttestationRequest::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForCsrRequest_5()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Operational Credentials Command: CSRRequest] Wait for CSR Request",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath = chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::OperationalCredentials::Id,
-                                                      chip::app::Clusters::OperationalCredentials::Commands::CSRRequest::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForAddTrustedRootCertificateRequest_6()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool,
-                     "[Endpoint: 0x%08x Cluster: Operational Credentials Command: AddTrustedRootCertificate] Wait for Add Trusted "
-                     "Root Certificate Request",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath =
-            chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::OperationalCredentials::Id,
-                                           chip::app::Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForAddOpNoc_7()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Operational Credentials Command: AddNOC] Wait for Add Op NOC", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath = chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::OperationalCredentials::Id,
-                                                      chip::app::Clusters::OperationalCredentials::Commands::AddNOC::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForCommissioningComplete_8()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(
-            chipTool,
-            "[Endpoint: 0x%08x Cluster: General Commissioning Command: CommissioningComplete] Wait for Commissioning Complete",
-            endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath =
-            chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::GeneralCommissioning::Id,
-                                           chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWait3000ms_9()
-    {
-        SetIdentity(kIdentityAlpha);
-        return WaitForMs(3000);
     }
 };
 

--- a/zzz_generated/placeholder/app2/zap-generated/test/Commands.h
+++ b/zzz_generated/placeholder/app2/zap-generated/test/Commands.h
@@ -24,7 +24,7 @@
 class Test_TC_DM_1_3_SimulatedSuite : public TestCommand
 {
 public:
-    Test_TC_DM_1_3_SimulatedSuite() : TestCommand("Test_TC_DM_1_3_Simulated"), mTestIndex(0)
+    Test_TC_DM_1_3_SimulatedSuite() : TestCommand("Test_TC_DM_1_3_Simulated", 21)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
@@ -34,132 +34,17 @@ public:
 
     ~Test_TC_DM_1_3_SimulatedSuite() {}
 
-    /////////// TestCommand Interface /////////
-    void NextTest() override
-    {
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        if (0 == mTestIndex)
-        {
-            ChipLogProgress(chipTool, " **** Test Start: Test_TC_DM_1_3_Simulated\n");
-        }
-
-        if (mTestCount == mTestIndex)
-        {
-            ChipLogProgress(chipTool, " **** Test Complete: Test_TC_DM_1_3_Simulated\n");
-            SetCommandExitStatus(CHIP_NO_ERROR);
-            return;
-        }
-
-        Wait();
-
-        // Ensure we increment mTestIndex before we start running the relevant
-        // command.  That way if we lose the timeslice after we send the message
-        // but before our function call returns, we won't end up with an
-        // incorrect mTestIndex value observed when we get the response.
-        switch (mTestIndex++)
-        {
-        case 0:
-            ChipLogProgress(chipTool, " ***** Test Step 0 : Wait for the device to be commissioned\n");
-            err = TestWaitForTheDeviceToBeCommissioned_0();
-            break;
-        case 1:
-            ChipLogProgress(chipTool, " ***** Test Step 1 : Log OnOff Test Startup\n");
-            err = TestLogOnOffTestStartup_1();
-            break;
-        case 2:
-            ChipLogProgress(chipTool, " ***** Test Step 2 : Query Data Model Revision\n");
-            err = TestQueryDataModelRevision_2();
-            break;
-        case 3:
-            ChipLogProgress(chipTool, " ***** Test Step 3 : Query Vendor Name\n");
-            err = TestQueryVendorName_3();
-            break;
-        case 4:
-            ChipLogProgress(chipTool, " ***** Test Step 4 : Query VendorID\n");
-            err = TestQueryVendorID_4();
-            break;
-        case 5:
-            ChipLogProgress(chipTool, " ***** Test Step 5 : Query Product Name\n");
-            err = TestQueryProductName_5();
-            break;
-        case 6:
-            ChipLogProgress(chipTool, " ***** Test Step 6 : Query ProductID\n");
-            err = TestQueryProductID_6();
-            break;
-        case 7:
-            ChipLogProgress(chipTool, " ***** Test Step 7 : Query Node Label\n");
-            err = TestQueryNodeLabel_7();
-            break;
-        case 8:
-            ChipLogProgress(chipTool, " ***** Test Step 8 : Query User Location\n");
-            err = TestQueryUserLocation_8();
-            break;
-        case 9:
-            ChipLogProgress(chipTool, " ***** Test Step 9 : Query HardwareVersion\n");
-            err = TestQueryHardwareVersion_9();
-            break;
-        case 10:
-            ChipLogProgress(chipTool, " ***** Test Step 10 : Query HardwareVersionString\n");
-            err = TestQueryHardwareVersionString_10();
-            break;
-        case 11:
-            ChipLogProgress(chipTool, " ***** Test Step 11 : Query SoftwareVersion\n");
-            err = TestQuerySoftwareVersion_11();
-            break;
-        case 12:
-            ChipLogProgress(chipTool, " ***** Test Step 12 : Query SoftwareVersionString\n");
-            err = TestQuerySoftwareVersionString_12();
-            break;
-        case 13:
-            ChipLogProgress(chipTool, " ***** Test Step 13 : Query ManufacturingDate\n");
-            err = TestQueryManufacturingDate_13();
-            break;
-        case 14:
-            ChipLogProgress(chipTool, " ***** Test Step 14 : Query PartNumber\n");
-            err = TestQueryPartNumber_14();
-            break;
-        case 15:
-            ChipLogProgress(chipTool, " ***** Test Step 15 : Query ProductURL\n");
-            err = TestQueryProductURL_15();
-            break;
-        case 16:
-            ChipLogProgress(chipTool, " ***** Test Step 16 : Query ProductLabel\n");
-            err = TestQueryProductLabel_16();
-            break;
-        case 17:
-            ChipLogProgress(chipTool, " ***** Test Step 17 : Query SerialNumber\n");
-            err = TestQuerySerialNumber_17();
-            break;
-        case 18:
-            ChipLogProgress(chipTool, " ***** Test Step 18 : Query LocalConfigDisabled\n");
-            err = TestQueryLocalConfigDisabled_18();
-            break;
-        case 19:
-            ChipLogProgress(chipTool, " ***** Test Step 19 : Query Reachable\n");
-            err = TestQueryReachable_19();
-            break;
-        case 20:
-            ChipLogProgress(chipTool, " ***** Test Step 20 : Query UniqueID\n");
-            err = TestQueryUniqueID_20();
-            break;
-        }
-
-        if (CHIP_NO_ERROR != err)
-        {
-            ChipLogError(chipTool, " ***** Test Failure: %s\n", chip::ErrorStr(err));
-            SetCommandExitStatus(err);
-        }
-    }
-
 private:
-    std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 21;
-
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
     chip::Optional<uint16_t> mTimeout;
+
+    chip::EndpointId GetEndpoint(chip::EndpointId endpoint) { return mEndpoint.HasValue() ? mEndpoint.Value() : endpoint; }
+
+    //
+    // Tests methods
+    //
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
@@ -185,232 +70,98 @@ private:
         }
     }
 
-    //
-    // Tests methods
-    //
-
-    CHIP_ERROR TestWaitForTheDeviceToBeCommissioned_0()
+    CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
-        SetIdentity(kIdentityAlpha);
-        return WaitForCommissioning();
-    }
-
-    CHIP_ERROR TestLogOnOffTestStartup_1()
-    {
-        SetIdentity(kIdentityAlpha);
-        return Log("*** Basic Cluster Tests Ready");
-    }
-
-    CHIP_ERROR TestQueryDataModelRevision_2()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: DataModelRevision] Query Data Model Revision",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::DataModelRevision::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryVendorName_3()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: VendorName] Query Vendor Name", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::VendorName::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryVendorID_4()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: VendorID] Query VendorID", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::VendorID::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryProductName_5()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: ProductName] Query Product Name", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::ProductName::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryProductID_6()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: ProductID] Query ProductID", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::ProductID::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryNodeLabel_7()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: NodeLabel] Query Node Label", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::NodeLabel::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryUserLocation_8()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: Location] Query User Location", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::Location::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryHardwareVersion_9()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: HardwareVersion] Query HardwareVersion", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::HardwareVersion::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryHardwareVersionString_10()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: HardwareVersionString] Query HardwareVersionString",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::HardwareVersionString::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQuerySoftwareVersion_11()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: SoftwareVersion] Query SoftwareVersion", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::SoftwareVersion::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQuerySoftwareVersionString_12()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: SoftwareVersionString] Query SoftwareVersionString",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::SoftwareVersionString::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryManufacturingDate_13()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: ManufacturingDate] Query ManufacturingDate", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::ManufacturingDate::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryPartNumber_14()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: PartNumber] Query PartNumber", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::PartNumber::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryProductURL_15()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: ProductURL] Query ProductURL", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::ProductURL::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryProductLabel_16()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: ProductLabel] Query ProductLabel", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::ProductLabel::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQuerySerialNumber_17()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: SerialNumber] Query SerialNumber", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::SerialNumber::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryLocalConfigDisabled_18()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: LocalConfigDisabled] Query LocalConfigDisabled",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::LocalConfigDisabled::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryReachable_19()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: Reachable] Query Reachable", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::Reachable::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestQueryUniqueID_20()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Basic Attribute: UniqueID] Query UniqueID", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mAttributePath = chip::app::ConcreteAttributePath(endpoint, chip::app::Clusters::Basic::Id,
-                                                          chip::app::Clusters::Basic::Attributes::UniqueID::Id);
+        using namespace chip::app::Clusters;
+        switch (testIndex)
+        {
+        case 0: {
+            LogStep(0, "Wait for the device to be commissioned");
+            SetIdentity(kIdentityAlpha);
+            return WaitForCommissioning();
+        }
+        case 1: {
+            LogStep(1, "Log OnOff Test Startup");
+            SetIdentity(kIdentityAlpha);
+            return Log("*** Basic Cluster Tests Ready");
+        }
+        case 2: {
+            LogStep(2, "Query Data Model Revision");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::DataModelRevision::Id);
+        }
+        case 3: {
+            LogStep(3, "Query Vendor Name");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::VendorName::Id);
+        }
+        case 4: {
+            LogStep(4, "Query VendorID");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::VendorID::Id);
+        }
+        case 5: {
+            LogStep(5, "Query Product Name");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::ProductName::Id);
+        }
+        case 6: {
+            LogStep(6, "Query ProductID");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::ProductID::Id);
+        }
+        case 7: {
+            LogStep(7, "Query Node Label");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id);
+        }
+        case 8: {
+            LogStep(8, "Query User Location");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::Location::Id);
+        }
+        case 9: {
+            LogStep(9, "Query HardwareVersion");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::HardwareVersion::Id);
+        }
+        case 10: {
+            LogStep(10, "Query HardwareVersionString");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::HardwareVersionString::Id);
+        }
+        case 11: {
+            LogStep(11, "Query SoftwareVersion");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::SoftwareVersion::Id);
+        }
+        case 12: {
+            LogStep(12, "Query SoftwareVersionString");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::SoftwareVersionString::Id);
+        }
+        case 13: {
+            LogStep(13, "Query ManufacturingDate");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::ManufacturingDate::Id);
+        }
+        case 14: {
+            LogStep(14, "Query PartNumber");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::PartNumber::Id);
+        }
+        case 15: {
+            LogStep(15, "Query ProductURL");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::ProductURL::Id);
+        }
+        case 16: {
+            LogStep(16, "Query ProductLabel");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::ProductLabel::Id);
+        }
+        case 17: {
+            LogStep(17, "Query SerialNumber");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::SerialNumber::Id);
+        }
+        case 18: {
+            LogStep(18, "Query LocalConfigDisabled");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::LocalConfigDisabled::Id);
+        }
+        case 19: {
+            LogStep(19, "Query Reachable");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::Reachable::Id);
+        }
+        case 20: {
+            LogStep(20, "Query UniqueID");
+            return WaitAttribute(GetEndpoint(0), Basic::Id, Basic::Attributes::UniqueID::Id);
+        }
+        }
         return CHIP_NO_ERROR;
     }
 };
@@ -418,7 +169,7 @@ private:
 class Test_TC_DM_3_3_SimulatedSuite : public TestCommand
 {
 public:
-    Test_TC_DM_3_3_SimulatedSuite() : TestCommand("Test_TC_DM_3_3_Simulated"), mTestIndex(0)
+    Test_TC_DM_3_3_SimulatedSuite() : TestCommand("Test_TC_DM_3_3_Simulated", 6)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
@@ -428,87 +179,17 @@ public:
 
     ~Test_TC_DM_3_3_SimulatedSuite() {}
 
-    /////////// TestCommand Interface /////////
-    void NextTest() override
-    {
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        if (0 == mTestIndex)
-        {
-            ChipLogProgress(chipTool, " **** Test Start: Test_TC_DM_3_3_Simulated\n");
-        }
-
-        if (mTestCount == mTestIndex)
-        {
-            ChipLogProgress(chipTool, " **** Test Complete: Test_TC_DM_3_3_Simulated\n");
-            SetCommandExitStatus(CHIP_NO_ERROR);
-            return;
-        }
-
-        Wait();
-
-        // Ensure we increment mTestIndex before we start running the relevant
-        // command.  That way if we lose the timeslice after we send the message
-        // but before our function call returns, we won't end up with an
-        // incorrect mTestIndex value observed when we get the response.
-        switch (mTestIndex++)
-        {
-        case 0:
-            ChipLogProgress(chipTool, " ***** Test Step 0 : Wait for the device to be commissioned\n");
-            err = TestWaitForTheDeviceToBeCommissioned_0();
-            break;
-        case 1:
-            ChipLogProgress(chipTool, " ***** Test Step 1 : Wait for Scan Network Command\n");
-            err = TestWaitForScanNetworkCommand_1();
-            break;
-        case 2:
-            ChipLogProgress(chipTool, " ***** Test Step 2 : Wait for Add Wifi Network Command\n");
-            if (ShouldSkip("WIFI"))
-            {
-                NextTest();
-                return;
-            }
-            err = TestWaitForAddWifiNetworkCommand_2();
-            break;
-        case 3:
-            ChipLogProgress(chipTool, " ***** Test Step 3 : Wait for Update Thread Network Command\n");
-            if (ShouldSkip("THREAD"))
-            {
-                NextTest();
-                return;
-            }
-            err = TestWaitForUpdateThreadNetworkCommand_3();
-            break;
-        case 4:
-            ChipLogProgress(chipTool, " ***** Test Step 4 : Wait for Enable Network Command\n");
-            err = TestWaitForEnableNetworkCommand_4();
-            break;
-        case 5:
-            ChipLogProgress(chipTool, " ***** Test Step 5 : Wait for Remove Network Command\n");
-            if (ShouldSkip("WIFI | THREAD"))
-            {
-                NextTest();
-                return;
-            }
-            err = TestWaitForRemoveNetworkCommand_5();
-            break;
-        }
-
-        if (CHIP_NO_ERROR != err)
-        {
-            ChipLogError(chipTool, " ***** Test Failure: %s\n", chip::ErrorStr(err));
-            SetCommandExitStatus(err);
-        }
-    }
-
 private:
-    std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 6;
-
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
     chip::Optional<uint16_t> mTimeout;
+
+    chip::EndpointId GetEndpoint(chip::EndpointId endpoint) { return mEndpoint.HasValue() ? mEndpoint.Value() : endpoint; }
+
+    //
+    // Tests methods
+    //
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
@@ -530,82 +211,42 @@ private:
         }
     }
 
-    //
-    // Tests methods
-    //
-
-    CHIP_ERROR TestWaitForTheDeviceToBeCommissioned_0()
+    CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
-        SetIdentity(kIdentityAlpha);
-        return WaitForCommissioning();
-    }
-
-    CHIP_ERROR TestWaitForScanNetworkCommand_1()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool,
-                     "[Endpoint: 0x%08x Cluster: Network Commissioning Command: ScanNetworks] Wait for Scan Network Command",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath = chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::NetworkCommissioning::Id,
-                                                      chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworks::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForAddWifiNetworkCommand_2()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(
-            chipTool,
-            "[Endpoint: 0x%08x Cluster: Network Commissioning Command: AddOrUpdateWiFiNetwork] Wait for Add Wifi Network Command",
-            endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath =
-            chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::NetworkCommissioning::Id,
-                                           chip::app::Clusters::NetworkCommissioning::Commands::AddOrUpdateWiFiNetwork::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForUpdateThreadNetworkCommand_3()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool,
-                     "[Endpoint: 0x%08x Cluster: Network Commissioning Command: AddOrUpdateThreadNetwork] Wait for Update Thread "
-                     "Network Command",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath =
-            chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::NetworkCommissioning::Id,
-                                           chip::app::Clusters::NetworkCommissioning::Commands::AddOrUpdateThreadNetwork::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForEnableNetworkCommand_4()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool,
-                     "[Endpoint: 0x%08x Cluster: Network Commissioning Command: ConnectNetwork] Wait for Enable Network Command",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath = chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::NetworkCommissioning::Id,
-                                                      chip::app::Clusters::NetworkCommissioning::Commands::ConnectNetwork::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForRemoveNetworkCommand_5()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool,
-                     "[Endpoint: 0x%08x Cluster: Network Commissioning Command: RemoveNetwork] Wait for Remove Network Command",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath = chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::NetworkCommissioning::Id,
-                                                      chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetwork::Id);
+        using namespace chip::app::Clusters;
+        switch (testIndex)
+        {
+        case 0: {
+            LogStep(0, "Wait for the device to be commissioned");
+            SetIdentity(kIdentityAlpha);
+            return WaitForCommissioning();
+        }
+        case 1: {
+            LogStep(1, "Wait for Scan Network Command");
+            return WaitCommand(GetEndpoint(0), NetworkCommissioning::Id, NetworkCommissioning::Commands::ScanNetworks::Id);
+        }
+        case 2: {
+            LogStep(2, "Wait for Add Wifi Network Command");
+            VerifyOrdo(!ShouldSkip("WIFI"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            return WaitCommand(GetEndpoint(0), NetworkCommissioning::Id,
+                               NetworkCommissioning::Commands::AddOrUpdateWiFiNetwork::Id);
+        }
+        case 3: {
+            LogStep(3, "Wait for Update Thread Network Command");
+            VerifyOrdo(!ShouldSkip("THREAD"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            return WaitCommand(GetEndpoint(0), NetworkCommissioning::Id,
+                               NetworkCommissioning::Commands::AddOrUpdateThreadNetwork::Id);
+        }
+        case 4: {
+            LogStep(4, "Wait for Enable Network Command");
+            return WaitCommand(GetEndpoint(0), NetworkCommissioning::Id, NetworkCommissioning::Commands::ConnectNetwork::Id);
+        }
+        case 5: {
+            LogStep(5, "Wait for Remove Network Command");
+            VerifyOrdo(!ShouldSkip("WIFI | THREAD"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            return WaitCommand(GetEndpoint(0), NetworkCommissioning::Id, NetworkCommissioning::Commands::RemoveNetwork::Id);
+        }
+        }
         return CHIP_NO_ERROR;
     }
 };
@@ -613,7 +254,7 @@ private:
 class Test_TC_DM_2_3_SimulatedSuite : public TestCommand
 {
 public:
-    Test_TC_DM_2_3_SimulatedSuite() : TestCommand("Test_TC_DM_2_3_Simulated"), mTestIndex(0)
+    Test_TC_DM_2_3_SimulatedSuite() : TestCommand("Test_TC_DM_2_3_Simulated", 10)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
@@ -623,88 +264,17 @@ public:
 
     ~Test_TC_DM_2_3_SimulatedSuite() {}
 
-    /////////// TestCommand Interface /////////
-    void NextTest() override
-    {
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        if (0 == mTestIndex)
-        {
-            ChipLogProgress(chipTool, " **** Test Start: Test_TC_DM_2_3_Simulated\n");
-        }
-
-        if (mTestCount == mTestIndex)
-        {
-            ChipLogProgress(chipTool, " **** Test Complete: Test_TC_DM_2_3_Simulated\n");
-            SetCommandExitStatus(CHIP_NO_ERROR);
-            return;
-        }
-
-        Wait();
-
-        // Ensure we increment mTestIndex before we start running the relevant
-        // command.  That way if we lose the timeslice after we send the message
-        // but before our function call returns, we won't end up with an
-        // incorrect mTestIndex value observed when we get the response.
-        switch (mTestIndex++)
-        {
-        case 0:
-            ChipLogProgress(chipTool, " ***** Test Step 0 : Wait for Arm Fail Safe\n");
-            err = TestWaitForArmFailSafe_0();
-            break;
-        case 1:
-            ChipLogProgress(chipTool, " ***** Test Step 1 : Wait for Set Regulatory Config\n");
-            err = TestWaitForSetRegulatoryConfig_1();
-            break;
-        case 2:
-            ChipLogProgress(chipTool, " ***** Test Step 2 : Wait for Attestation Certificate Chain Request\n");
-            err = TestWaitForAttestationCertificateChainRequest_2();
-            break;
-        case 3:
-            ChipLogProgress(chipTool, " ***** Test Step 3 : Wait for Attestation Certificate Chain Request\n");
-            err = TestWaitForAttestationCertificateChainRequest_3();
-            break;
-        case 4:
-            ChipLogProgress(chipTool, " ***** Test Step 4 : Wait for Attestation Request\n");
-            err = TestWaitForAttestationRequest_4();
-            break;
-        case 5:
-            ChipLogProgress(chipTool, " ***** Test Step 5 : Wait for CSR Request\n");
-            err = TestWaitForCsrRequest_5();
-            break;
-        case 6:
-            ChipLogProgress(chipTool, " ***** Test Step 6 : Wait for Add Trusted Root Certificate Request\n");
-            err = TestWaitForAddTrustedRootCertificateRequest_6();
-            break;
-        case 7:
-            ChipLogProgress(chipTool, " ***** Test Step 7 : Wait for Add Op NOC\n");
-            err = TestWaitForAddOpNoc_7();
-            break;
-        case 8:
-            ChipLogProgress(chipTool, " ***** Test Step 8 : Wait for Commissioning Complete\n");
-            err = TestWaitForCommissioningComplete_8();
-            break;
-        case 9:
-            ChipLogProgress(chipTool, " ***** Test Step 9 : Wait 3000ms\n");
-            err = TestWait3000ms_9();
-            break;
-        }
-
-        if (CHIP_NO_ERROR != err)
-        {
-            ChipLogError(chipTool, " ***** Test Failure: %s\n", chip::ErrorStr(err));
-            SetCommandExitStatus(err);
-        }
-    }
-
 private:
-    std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 10;
-
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
     chip::Optional<uint16_t> mTimeout;
+
+    chip::EndpointId GetEndpoint(chip::EndpointId endpoint) { return mEndpoint.HasValue() ? mEndpoint.Value() : endpoint; }
+
+    //
+    // Tests methods
+    //
 
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
     {
@@ -726,137 +296,58 @@ private:
         }
     }
 
-    //
-    // Tests methods
-    //
-
-    CHIP_ERROR TestWaitForArmFailSafe_0()
+    CHIP_ERROR DoTestStep(uint16_t testIndex) override
     {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: General Commissioning Command: ArmFailSafe] Wait for Arm Fail Safe",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath = chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::GeneralCommissioning::Id,
-                                                      chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafe::Id);
+        using namespace chip::app::Clusters;
+        switch (testIndex)
+        {
+        case 0: {
+            LogStep(0, "Wait for Arm Fail Safe");
+            return WaitCommand(GetEndpoint(0), GeneralCommissioning::Id, GeneralCommissioning::Commands::ArmFailSafe::Id);
+        }
+        case 1: {
+            LogStep(1, "Wait for Set Regulatory Config");
+            return WaitCommand(GetEndpoint(0), GeneralCommissioning::Id, GeneralCommissioning::Commands::SetRegulatoryConfig::Id);
+        }
+        case 2: {
+            LogStep(2, "Wait for Attestation Certificate Chain Request");
+            return WaitCommand(GetEndpoint(0), OperationalCredentials::Id,
+                               OperationalCredentials::Commands::CertificateChainRequest::Id);
+        }
+        case 3: {
+            LogStep(3, "Wait for Attestation Certificate Chain Request");
+            return WaitCommand(GetEndpoint(0), OperationalCredentials::Id,
+                               OperationalCredentials::Commands::CertificateChainRequest::Id);
+        }
+        case 4: {
+            LogStep(4, "Wait for Attestation Request");
+            return WaitCommand(GetEndpoint(0), OperationalCredentials::Id,
+                               OperationalCredentials::Commands::AttestationRequest::Id);
+        }
+        case 5: {
+            LogStep(5, "Wait for CSR Request");
+            return WaitCommand(GetEndpoint(0), OperationalCredentials::Id, OperationalCredentials::Commands::CSRRequest::Id);
+        }
+        case 6: {
+            LogStep(6, "Wait for Add Trusted Root Certificate Request");
+            return WaitCommand(GetEndpoint(0), OperationalCredentials::Id,
+                               OperationalCredentials::Commands::AddTrustedRootCertificate::Id);
+        }
+        case 7: {
+            LogStep(7, "Wait for Add Op NOC");
+            return WaitCommand(GetEndpoint(0), OperationalCredentials::Id, OperationalCredentials::Commands::AddNOC::Id);
+        }
+        case 8: {
+            LogStep(8, "Wait for Commissioning Complete");
+            return WaitCommand(GetEndpoint(0), GeneralCommissioning::Id, GeneralCommissioning::Commands::CommissioningComplete::Id);
+        }
+        case 9: {
+            LogStep(9, "Wait 3000ms");
+            SetIdentity(kIdentityAlpha);
+            return WaitForMs(3000);
+        }
+        }
         return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForSetRegulatoryConfig_1()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(
-            chipTool,
-            "[Endpoint: 0x%08x Cluster: General Commissioning Command: SetRegulatoryConfig] Wait for Set Regulatory Config",
-            endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath = chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::GeneralCommissioning::Id,
-                                                      chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForAttestationCertificateChainRequest_2()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool,
-                     "[Endpoint: 0x%08x Cluster: Operational Credentials Command: CertificateChainRequest] Wait for Attestation "
-                     "Certificate Chain Request",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath =
-            chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::OperationalCredentials::Id,
-                                           chip::app::Clusters::OperationalCredentials::Commands::CertificateChainRequest::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForAttestationCertificateChainRequest_3()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool,
-                     "[Endpoint: 0x%08x Cluster: Operational Credentials Command: CertificateChainRequest] Wait for Attestation "
-                     "Certificate Chain Request",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath =
-            chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::OperationalCredentials::Id,
-                                           chip::app::Clusters::OperationalCredentials::Commands::CertificateChainRequest::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForAttestationRequest_4()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool,
-                     "[Endpoint: 0x%08x Cluster: Operational Credentials Command: AttestationRequest] Wait for Attestation Request",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath =
-            chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::OperationalCredentials::Id,
-                                           chip::app::Clusters::OperationalCredentials::Commands::AttestationRequest::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForCsrRequest_5()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Operational Credentials Command: CSRRequest] Wait for CSR Request",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath = chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::OperationalCredentials::Id,
-                                                      chip::app::Clusters::OperationalCredentials::Commands::CSRRequest::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForAddTrustedRootCertificateRequest_6()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool,
-                     "[Endpoint: 0x%08x Cluster: Operational Credentials Command: AddTrustedRootCertificate] Wait for Add Trusted "
-                     "Root Certificate Request",
-                     endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath =
-            chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::OperationalCredentials::Id,
-                                           chip::app::Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForAddOpNoc_7()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(chipTool, "[Endpoint: 0x%08x Cluster: Operational Credentials Command: AddNOC] Wait for Add Op NOC", endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath = chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::OperationalCredentials::Id,
-                                                      chip::app::Clusters::OperationalCredentials::Commands::AddNOC::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForCommissioningComplete_8()
-    {
-        const chip::EndpointId endpoint = mEndpoint.HasValue() ? mEndpoint.Value() : 0;
-        ChipLogError(
-            chipTool,
-            "[Endpoint: 0x%08x Cluster: General Commissioning Command: CommissioningComplete] Wait for Commissioning Complete",
-            endpoint);
-
-        ClearAttributeAndCommandPaths();
-        mCommandPath =
-            chip::app::ConcreteCommandPath(endpoint, chip::app::Clusters::GeneralCommissioning::Id,
-                                           chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Id);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWait3000ms_9()
-    {
-        SetIdentity(kIdentityAlpha);
-        return WaitForMs(3000);
     }
 };
 


### PR DESCRIPTION
#### Problem

The YAML generated code uses Invoke which makes it hard to extend the framework to supports things such as events or wildcards that may generates multiple responses.
Furthermore,using the Invoke API has a cost at generation time and at build time.

The former because we generate a lot of specific code. On my machine it takes ~100 seconds to generate the YAML tests while with this PR is takes "only" 30 seconds. This is the root cause for some of the node memory issues that has popped up recently.

The latter because "Invoke" is relying heavily on cpp template and std::function which has a build time/link time cost. This PR relies a less on that which should makes it easier to build on stuff like a RPI and which is also must faster.

#### Change overview
 * Add a interaction model backend in `src/app/tests/suites/commands/interaction_model`
 * Update `examples/chip-tool/templates/tests/` so they make use of this module

#### Testing
I have tested it locally by running the whole test suite. The only thing that is failing on my Mac is `TestGroupMessaging` which is not activated by default on Mac. I tried to makes it based on the current code that exists in `chip-tool` for groups though - so I will see if CI is happy with it.