### PR TITLE
[ESP32] Handling Wifi-diagnostic events at esp32 side

### DIFF
--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -24,10 +24,10 @@
 
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/DiagnosticDataProvider.h>
 #include <platform/ESP32/ESP32Utils.h>
 #include <platform/ESP32/NetworkCommissioningDriver.h>
 #include <platform/internal/BLEManager.h>
-#include <platform/DiagnosticDataProvider.h>
 
 #include "esp_event.h"
 #include "esp_netif.h"
@@ -666,8 +666,9 @@ void ConnectivityManagerImpl::OnStationConnected()
 
     if (delegate)
     {
-        delegate->OnConnectionStatusChanged(static_cast<uint8_t>(chip::app::Clusters::WiFiNetworkDiagnostics::WiFiConnectionStatus::kConnected));
-    }       
+        delegate->OnConnectionStatusChanged(
+            chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::WiFiConnectionStatus::kConnected));
+    }
 
     UpdateInternetConnectivityState();
 }
@@ -682,64 +683,69 @@ void ConnectivityManagerImpl::OnStationDisconnected()
     event.WiFiConnectivityChange.Result = kConnectivity_Lost;
     PlatformMgr().PostEventOrDie(&event);
     WiFiDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetWiFiDiagnosticsDelegate();
-    uint16_t reason = NetworkCommissioning::ESPWiFiDriver::GetInstance().GetLastDisconnectReason();
-    uint8_t associationFailureCause = static_cast<uint8_t>(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kUnknown);
+    uint16_t reason                    = NetworkCommissioning::ESPWiFiDriver::GetInstance().GetLastDisconnectReason();
+    uint8_t associationFailureCause =
+        chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kUnknown);
 
     switch (reason)
-     {
-     case WIFI_REASON_ASSOC_TOOMANY: 
-     case WIFI_REASON_NOT_ASSOCED: 
-     case WIFI_REASON_ASSOC_NOT_AUTHED:
-     case WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT:
-     case WIFI_REASON_GROUP_CIPHER_INVALID:
-     case WIFI_REASON_UNSUPP_RSN_IE_VERSION:
-     case WIFI_REASON_AKMP_INVALID:
-     case WIFI_REASON_CIPHER_SUITE_REJECTED: 
-     case WIFI_REASON_PAIRWISE_CIPHER_INVALID: 
-         associationFailureCause = static_cast<uint8_t>(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kAssociationFailed);
-         if (delegate)
-         {
-             delegate->OnAssociationFailureDetected(associationFailureCause, reason);
-         }
+    {
+    case WIFI_REASON_ASSOC_TOOMANY:
+    case WIFI_REASON_NOT_ASSOCED:
+    case WIFI_REASON_ASSOC_NOT_AUTHED:
+    case WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT:
+    case WIFI_REASON_GROUP_CIPHER_INVALID:
+    case WIFI_REASON_UNSUPP_RSN_IE_VERSION:
+    case WIFI_REASON_AKMP_INVALID:
+    case WIFI_REASON_CIPHER_SUITE_REJECTED:
+    case WIFI_REASON_PAIRWISE_CIPHER_INVALID:
+        associationFailureCause =
+            chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kAssociationFailed);
+        if (delegate)
+        {
+            delegate->OnAssociationFailureDetected(associationFailureCause, reason);
+        }
         break;
-     case WIFI_REASON_NOT_AUTHED:
-     case WIFI_REASON_MIC_FAILURE: 
-     case WIFI_REASON_IE_IN_4WAY_DIFFERS: 
-     case WIFI_REASON_INVALID_RSN_IE_CAP:
-     case WIFI_REASON_INVALID_PMKID:
-     case WIFI_REASON_802_1X_AUTH_FAILED:
-         associationFailureCause = static_cast<uint8_t>(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kAuthenticationFailed);
-         if (delegate)
-         {
-             delegate->OnAssociationFailureDetected(associationFailureCause, reason);
-         }
-         break;
-     case WIFI_REASON_NO_AP_FOUND:
-         associationFailureCause = static_cast<uint8_t>(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kSsidNotFound);
-         if (delegate)
-         {
-             delegate->OnAssociationFailureDetected(associationFailureCause, reason);
-         }
-     case WIFI_REASON_BEACON_TIMEOUT:
-     case WIFI_REASON_AUTH_EXPIRE:
-     case WIFI_REASON_AUTH_LEAVE:
-     case WIFI_REASON_ASSOC_LEAVE: 
-     case WIFI_REASON_ASSOC_EXPIRE:
-         break;
+    case WIFI_REASON_NOT_AUTHED:
+    case WIFI_REASON_MIC_FAILURE:
+    case WIFI_REASON_IE_IN_4WAY_DIFFERS:
+    case WIFI_REASON_INVALID_RSN_IE_CAP:
+    case WIFI_REASON_INVALID_PMKID:
+    case WIFI_REASON_802_1X_AUTH_FAILED:
+        associationFailureCause =
+            chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kAuthenticationFailed);
+        if (delegate)
+        {
+            delegate->OnAssociationFailureDetected(associationFailureCause, reason);
+        }
+        break;
+    case WIFI_REASON_NO_AP_FOUND:
+        associationFailureCause =
+            chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kSsidNotFound);
+        if (delegate)
+        {
+            delegate->OnAssociationFailureDetected(associationFailureCause, reason);
+        }
+    case WIFI_REASON_BEACON_TIMEOUT:
+    case WIFI_REASON_AUTH_EXPIRE:
+    case WIFI_REASON_AUTH_LEAVE:
+    case WIFI_REASON_ASSOC_LEAVE:
+    case WIFI_REASON_ASSOC_EXPIRE:
+        break;
 
-     default:
-         if (delegate)
-         {
-             delegate->OnAssociationFailureDetected(associationFailureCause, reason);
-         }
-         break;
+    default:
+        if (delegate)
+        {
+            delegate->OnAssociationFailureDetected(associationFailureCause, reason);
+        }
+        break;
     }
 
     if (delegate)
     {
         delegate->OnDisconnectionDetected(reason);
-        delegate->OnConnectionStatusChanged(static_cast<uint8_t>(chip::app::Clusters::WiFiNetworkDiagnostics::WiFiConnectionStatus::kNotConnected));
-    }       
+        delegate->OnConnectionStatusChanged(
+            chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::WiFiConnectionStatus::kNotConnected));
+    }
 
     UpdateInternetConnectivityState();
 }


### PR DESCRIPTION
#### Problem
* [TE 8] General Diagnostics - 3.1.3. [TC-GENDIAG-2.1] Event functionality test with server as DUT - Chip tool does not show any data in response
* No response recieved for read-event commands

#### Change overview
* calld the functions in class WiFiDiagnosticsDelegate after wifi events were detected

#### Testing
* Tested Event functionality with server as DUT using chip-tool
