### PR TITLE
Add composed device to the bridge app example.

### DIFF
--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -183,3 +183,45 @@ void DeviceSwitch::HandleDeviceChange(Device * device, Device::Changed_t changeM
         mChanged_CB(this, (DeviceSwitch::Changed_t) changeMask);
     }
 }
+
+void ComposedDevice::HandleDeviceChange(Device * device, Device::Changed_t changeMask)
+{
+    if (mChanged_CB)
+    {
+        mChanged_CB(this, (ComposedDevice::Changed_t) changeMask);
+    }
+}
+
+void DevicePowerSource::HandleDeviceChange(Device * device, Device::Changed_t changeMask)
+{
+    if (mChanged_CB)
+    {
+        mChanged_CB(this, (DevicePowerSource::Changed_t) changeMask);
+    }
+}
+
+void DevicePowerSource::SetBatChargeLevel(uint8_t aBatChargeLevel)
+{
+    bool changed;
+
+    changed         = aBatChargeLevel != mBatChargeLevel;
+    mBatChargeLevel = aBatChargeLevel;
+
+    if ((changed) && (mChanged_CB))
+    {
+        mChanged_CB(this, kChanged_BatLevel);
+    }
+}
+
+void DevicePowerSource::SetDescription(std::string aDescription)
+{
+    bool changed;
+
+    changed      = aDescription != mDescription;
+    mDescription = aDescription;
+
+    if ((changed) && (mChanged_CB))
+    {
+        mChanged_CB(this, kChanged_Description);
+    }
+}

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -119,3 +119,55 @@ private:
     uint32_t mFeatureMap;
     DeviceCallback_fn mChanged_CB;
 };
+
+class ComposedDevice : public Device
+{
+public:
+    ComposedDevice(const char * szDeviceName, const char * szLocation) : Device(szDeviceName, szLocation){};
+
+    using DeviceCallback_fn = std::function<void(ComposedDevice *, ComposedDevice::Changed_t)>;
+
+    void SetChangeCallback(DeviceCallback_fn aChanged_CB);
+
+private:
+    void HandleDeviceChange(Device * device, Device::Changed_t changeMask);
+
+private:
+    DeviceCallback_fn mChanged_CB;
+};
+
+class DevicePowerSource : public Device
+{
+public:
+    enum Changed_t
+    {
+        kChanged_BatLevel    = kChanged_Last << 1,
+        kChanged_Description = kChanged_Last << 2,
+    } Changed;
+
+    DevicePowerSource(const char * szDeviceName, const char * szLocation, uint32_t aFeatureMap) :
+        Device(szDeviceName, szLocation), mFeatureMap(aFeatureMap){};
+
+    using DeviceCallback_fn = std::function<void(DevicePowerSource *, DevicePowerSource::Changed_t)>;
+    void SetChangeCallback(DeviceCallback_fn aChanged_CB) { mChanged_CB = aChanged_CB; }
+
+    void SetBatChargeLevel(uint8_t aBatChargeLevel);
+    void SetDescription(std::string aDescription);
+
+    inline uint32_t GetFeatureMap() { return mFeatureMap; };
+    inline uint8_t GetBatChargeLevel() { return mBatChargeLevel; };
+    inline uint8_t GetOrder() { return mOrder; };
+    inline uint8_t GetStatus() { return mStatus; };
+    inline std::string GetDescription() { return mDescription; };
+
+private:
+    void HandleDeviceChange(Device * device, Device::Changed_t changeMask);
+
+private:
+    uint8_t mBatChargeLevel  = 0;
+    uint8_t mOrder           = 0;
+    uint8_t mStatus          = 0;
+    std::string mDescription = "Primary Battery";
+    uint32_t mFeatureMap;
+    DeviceCallback_fn mChanged_CB;
+};

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -416,8 +416,8 @@ void HandleDevicePowerSourceStatusChanged(DevicePowerSource * dev, DevicePowerSo
     {
         uint8_t batChargeLevel = dev->GetBatChargeLevel();
         MatterReportingAttributeChangeCallback(dev->GetEndpointId(), PowerSource::Id,
-                                               PowerSource::Attributes::BatteryChargeLevel::Id, CLUSTER_MASK_SERVER,
-                                               ZCL_INT8U_ATTRIBUTE_TYPE, &batChargeLevel);
+                                               PowerSource::Attributes::BatteryChargeLevel::Id, ZCL_INT8U_ATTRIBUTE_TYPE,
+                                               &batChargeLevel);
     }
 
     if (itemChangedMask & DevicePowerSource::kChanged_Description)

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -567,12 +567,12 @@ EmberAfStatus HandleReadPowerSourceAttribute(DevicePowerSource * dev, chip::Attr
     }
     else if ((attributeId == PowerSource::Attributes::ClusterRevision::Id) && (maxReadLength == 2))
     {
-        auto rev = ZCL_POWER_SOURCE_CLUSTER_REVISION;
+        uint16_t rev = ZCL_POWER_SOURCE_CLUSTER_REVISION;
         memcpy(buffer, &rev, sizeof(rev));
     }
     else if ((attributeId == PowerSource::Attributes::FeatureMap::Id) && (maxReadLength == 4))
     {
-        auto featureMap = dev->GetFeatureMap();
+        uint32_t featureMap = dev->GetFeatureMap();
         memcpy(buffer, &featureMap, sizeof(featureMap));
     }
     else

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 
+#include <AppMain.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/PlatformManager.h>
 
@@ -40,7 +41,6 @@
 
 #include "CommissionableInit.h"
 #include "Device.h"
-#include "Options.h"
 #include <app/server/Server.h>
 
 #include <cassert>
@@ -65,9 +65,6 @@ EndpointId gCurrentEndpointId;
 EndpointId gFirstDynamicEndpointId;
 Device * gDevices[CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT];
 
-// To hold SPAKE2+ verifier, discriminator, passcode
-LinuxCommissionableDataProvider gCommissionableDataProvider;
-
 // ENDPOINT DEFINITIONS:
 // =================================================================================
 //
@@ -91,6 +88,8 @@ LinuxCommissionableDataProvider gCommissionableDataProvider;
 #define DEVICE_TYPE_ROOT_NODE 0x0016
 // (taken from chip-devices.xml)
 #define DEVICE_TYPE_BRIDGE 0x000e
+// (taken from chip-devices.xml)
+#define DEVICE_TYPE_POWER_SOURCE 0x0011
 
 // Device Version for dynamic endpoints:
 #define DEVICE_VERSION_DEFAULT 1
@@ -200,6 +199,44 @@ DECLARE_DYNAMIC_ENDPOINT(bridgedSwitchEndpoint, bridgedSwitchClusters);
 DataVersion gSwitch1DataVersions[ArraySize(bridgedSwitchClusters)];
 DataVersion gSwitch2DataVersions[ArraySize(bridgedSwitchClusters)];
 
+// ---------------------------------------------------------------------------
+//
+// POWER SOURCE ENDPOINT: contains the following clusters:
+//   - Power Source
+//   - Descriptor
+//   - Bridged Device Basic
+
+DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(powerSourceAttrs)
+DECLARE_DYNAMIC_ATTRIBUTE(ZCL_POWER_SOURCE_BAT_CHARGE_LEVEL_ATTRIBUTE_ID, ENUM8, 1, 0),
+    DECLARE_DYNAMIC_ATTRIBUTE(ZCL_POWER_SOURCE_ORDER_ATTRIBUTE_ID, INT8U, 1, 0),
+    DECLARE_DYNAMIC_ATTRIBUTE(ZCL_POWER_SOURCE_STATUS_ATTRIBUTE_ID, ENUM8, 1, 0),
+    DECLARE_DYNAMIC_ATTRIBUTE(ZCL_POWER_SOURCE_DESCRIPTION_ATTRIBUTE_ID, CHAR_STRING, 32, 0), DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
+
+DECLARE_DYNAMIC_CLUSTER_LIST_BEGIN(bridgedPowerSourceClusters)
+DECLARE_DYNAMIC_CLUSTER(ZCL_DESCRIPTOR_CLUSTER_ID, descriptorAttrs, nullptr, nullptr),
+    DECLARE_DYNAMIC_CLUSTER(ZCL_BRIDGED_DEVICE_BASIC_CLUSTER_ID, bridgedDeviceBasicAttrs, nullptr, nullptr),
+    DECLARE_DYNAMIC_CLUSTER(ZCL_POWER_SOURCE_CLUSTER_ID, powerSourceAttrs, nullptr, nullptr), DECLARE_DYNAMIC_CLUSTER_LIST_END;
+
+DECLARE_DYNAMIC_ENDPOINT(bridgedPowerSourceEndpoint, bridgedPowerSourceClusters);
+
+// ---------------------------------------------------------------------------
+//
+// COMPOSED DEVICE ENDPOINT: contains the following clusters:
+//   - Descriptor
+//   - Bridged Device Basic
+
+// Composed Device Configuration
+DECLARE_DYNAMIC_CLUSTER_LIST_BEGIN(bridgedComposedDeviceClusters)
+DECLARE_DYNAMIC_CLUSTER(ZCL_DESCRIPTOR_CLUSTER_ID, descriptorAttrs, nullptr, nullptr),
+    DECLARE_DYNAMIC_CLUSTER(ZCL_BRIDGED_DEVICE_BASIC_CLUSTER_ID, bridgedDeviceBasicAttrs, nullptr, nullptr),
+    DECLARE_DYNAMIC_CLUSTER_LIST_END;
+
+DECLARE_DYNAMIC_ENDPOINT(bridgedComposedDeviceEndpoint, bridgedComposedDeviceClusters);
+DataVersion gComposedDeviceDataVersions[ArraySize(bridgedComposedDeviceClusters)];
+DataVersion gComposedSwitch1DataVersions[ArraySize(bridgedSwitchClusters)];
+DataVersion gComposedSwitch2DataVersions[ArraySize(bridgedSwitchClusters)];
+DataVersion gComposedPowerSourceDataVersions[ArraySize(bridgedPowerSourceClusters)];
+
 } // namespace
 
 // REVISION DEFINITIONS:
@@ -210,11 +247,12 @@ DataVersion gSwitch2DataVersions[ArraySize(bridgedSwitchClusters)];
 #define ZCL_FIXED_LABEL_CLUSTER_REVISION (1u)
 #define ZCL_ON_OFF_CLUSTER_REVISION (4u)
 #define ZCL_SWITCH_CLUSTER_REVISION (1u)
+#define ZCL_POWER_SOURCE_CLUSTER_REVISION (1u)
 
 // ---------------------------------------------------------------------------
 
 int AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, const Span<const EmberAfDeviceType> & deviceTypeList,
-                      const Span<DataVersion> & dataVersionStorage)
+                      const Span<DataVersion> & dataVersionStorage, chip::EndpointId parentEndpointId = chip::kInvalidEndpointId)
 {
     uint8_t index = 0;
     while (index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
@@ -226,7 +264,8 @@ int AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, const Span<const E
             while (1)
             {
                 dev->SetEndpointId(gCurrentEndpointId);
-                ret = emberAfSetDynamicEndpoint(index, gCurrentEndpointId, ep, dataVersionStorage, deviceTypeList);
+                ret =
+                    emberAfSetDynamicEndpoint(index, gCurrentEndpointId, ep, dataVersionStorage, deviceTypeList, parentEndpointId);
                 if (ret == EMBER_ZCL_STATUS_SUCCESS)
                 {
                     ChipLogProgress(DeviceLayer, "Added device %s to dynamic endpoint %d (index=%d)", dev->GetName(),
@@ -364,6 +403,29 @@ void HandleDeviceSwitchStatusChanged(DeviceSwitch * dev, DeviceSwitch::Changed_t
     }
 }
 
+void HandleDevicePowerSourceStatusChanged(DevicePowerSource * dev, DevicePowerSource::Changed_t itemChangedMask)
+{
+    using namespace app::Clusters;
+    if (itemChangedMask &
+        (DevicePowerSource::kChanged_Reachable | DevicePowerSource::kChanged_Name | DevicePowerSource::kChanged_Location))
+    {
+        HandleDeviceStatusChanged(static_cast<Device *>(dev), (Device::Changed_t) itemChangedMask);
+    }
+
+    if (itemChangedMask & DevicePowerSource::kChanged_BatLevel)
+    {
+        uint8_t batChargeLevel = dev->GetBatChargeLevel();
+        MatterReportingAttributeChangeCallback(dev->GetEndpointId(), PowerSource::Id,
+                                               PowerSource::Attributes::BatteryChargeLevel::Id, CLUSTER_MASK_SERVER,
+                                               ZCL_INT8U_ATTRIBUTE_TYPE, &batChargeLevel);
+    }
+
+    if (itemChangedMask & DevicePowerSource::kChanged_Description)
+    {
+        MatterReportingAttributeChangeCallback(dev->GetEndpointId(), PowerSource::Id, PowerSource::Attributes::Description::Id);
+    }
+}
+
 EmberAfStatus HandleReadBridgedDeviceBasicAttribute(Device * dev, chip::AttributeId attributeId, uint8_t * buffer,
                                                     uint16_t maxReadLength)
 {
@@ -375,10 +437,8 @@ EmberAfStatus HandleReadBridgedDeviceBasicAttribute(Device * dev, chip::Attribut
     }
     else if ((attributeId == ZCL_NODE_LABEL_ATTRIBUTE_ID) && (maxReadLength == 32))
     {
-        uint8_t bufferMemory[254];
-        MutableByteSpan zclString(bufferMemory);
-        MakeZclCharString(zclString, dev->GetName());
-        buffer = zclString.data();
+        MutableByteSpan zclNameSpan(buffer, maxReadLength);
+        MakeZclCharString(zclNameSpan, dev->GetName());
     }
     else if ((attributeId == ZCL_CLUSTER_REVISION_SERVER_ATTRIBUTE_ID) && (maxReadLength == 2))
     {
@@ -484,6 +544,45 @@ EmberAfStatus HandleReadSwitchAttribute(DeviceSwitch * dev, chip::AttributeId at
     return EMBER_ZCL_STATUS_SUCCESS;
 }
 
+EmberAfStatus HandleReadPowerSourceAttribute(DevicePowerSource * dev, chip::AttributeId attributeId, uint8_t * buffer,
+                                             uint16_t maxReadLength)
+{
+    using namespace app::Clusters;
+    if ((attributeId == PowerSource::Attributes::BatteryChargeLevel::Id) && (maxReadLength == 1))
+    {
+        *buffer = dev->GetBatChargeLevel();
+    }
+    else if ((attributeId == PowerSource::Attributes::Order::Id) && (maxReadLength == 1))
+    {
+        *buffer = dev->GetOrder();
+    }
+    else if ((attributeId == PowerSource::Attributes::Status::Id) && (maxReadLength == 1))
+    {
+        *buffer = dev->GetStatus();
+    }
+    else if ((attributeId == PowerSource::Attributes::Description::Id) && (maxReadLength == 32))
+    {
+        MutableByteSpan zclDescpitionSpan(buffer, maxReadLength);
+        MakeZclCharString(zclDescpitionSpan, dev->GetDescription().c_str());
+    }
+    else if ((attributeId == PowerSource::Attributes::ClusterRevision::Id) && (maxReadLength == 2))
+    {
+        auto rev = ZCL_POWER_SOURCE_CLUSTER_REVISION;
+        memcpy(buffer, &rev, sizeof(rev));
+    }
+    else if ((attributeId == PowerSource::Attributes::FeatureMap::Id) && (maxReadLength == 4))
+    {
+        auto featureMap = dev->GetFeatureMap();
+        memcpy(buffer, &featureMap, sizeof(featureMap));
+    }
+    else
+    {
+        return EMBER_ZCL_STATUS_FAILURE;
+    }
+
+    return EMBER_ZCL_STATUS_SUCCESS;
+}
+
 EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
                                                    const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer,
                                                    uint16_t maxReadLength)
@@ -513,6 +612,11 @@ EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterI
             ret =
                 HandleReadSwitchAttribute(static_cast<DeviceSwitch *>(dev), attributeMetadata->attributeId, buffer, maxReadLength);
         }
+        else if (clusterId == chip::app::Clusters::PowerSource::Id)
+        {
+            ret = HandleReadPowerSourceAttribute(static_cast<DevicePowerSource *>(dev), attributeMetadata->attributeId, buffer,
+                                                 maxReadLength);
+        }
     }
 
     return ret;
@@ -540,65 +644,6 @@ EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, Cluster
     return ret;
 }
 
-namespace {
-void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
-{
-    (void) arg;
-    if (event->Type == chip::DeviceLayer::DeviceEventType::kCHIPoBLEConnectionEstablished)
-    {
-        ChipLogProgress(DeviceLayer, "Receive kCHIPoBLEConnectionEstablished");
-    }
-}
-
-CHIP_ERROR PrintQRCodeContent()
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    // If we do not have a discriminator, generate one
-    chip::SetupPayload payload;
-    uint32_t setUpPINCode;
-    uint16_t setUpDiscriminator;
-    uint16_t vendorId;
-    uint16_t productId;
-    std::string result;
-
-    err = GetCommissionableDataProvider()->GetSetupPasscode(setUpPINCode);
-    SuccessOrExit(err);
-
-    err = GetCommissionableDataProvider()->GetSetupDiscriminator(setUpDiscriminator);
-    SuccessOrExit(err);
-
-    err = ConfigurationMgr().GetVendorId(vendorId);
-    SuccessOrExit(err);
-
-    err = ConfigurationMgr().GetProductId(productId);
-    SuccessOrExit(err);
-
-    payload.version       = 0;
-    payload.vendorID      = vendorId;
-    payload.productID     = productId;
-    payload.setUpPINCode  = setUpPINCode;
-    payload.discriminator = setUpDiscriminator;
-
-    // Wrap it so SuccessOrExit can work
-    {
-        chip::QRCodeSetupPayloadGenerator generator(payload);
-        err = generator.payloadBase38Representation(result);
-        SuccessOrExit(err);
-    }
-
-    std::cout << "SetupPINCode: [" << setUpPINCode << "]" << std::endl;
-    // There might be whitespace in setup QRCode, add brackets to make it clearer.
-    std::cout << "SetupQRCode:  [" << result << "]" << std::endl;
-
-exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        std::cerr << "Failed to generate QR Code: " << ErrorStr(err) << std::endl;
-    }
-    return err;
-}
-} // namespace
-
 void ApplicationInit() {}
 
 const EmberAfDeviceType gBridgedRootDeviceTypes[] = { { DEVICE_TYPE_ROOT_NODE, DEVICE_VERSION_DEFAULT },
@@ -610,10 +655,14 @@ const EmberAfDeviceType gBridgedOnOffDeviceTypes[] = { { DEVICE_TYPE_LO_ON_OFF_L
 const EmberAfDeviceType gBridgedSwitchDeviceTypes[] = { { DEVICE_TYPE_LO_ON_OFF_LIGHT_SWITCH, DEVICE_VERSION_DEFAULT },
                                                         { DEVICE_TYPE_BRIDGED_NODE, DEVICE_VERSION_DEFAULT } };
 
+const EmberAfDeviceType gBridgedComposedDeviceTypes[] = { { DEVICE_TYPE_BRIDGED_NODE, DEVICE_VERSION_DEFAULT } };
+
+const EmberAfDeviceType gComposedSwitchDeviceTypes[] = { { DEVICE_TYPE_LO_ON_OFF_LIGHT_SWITCH, DEVICE_VERSION_DEFAULT } };
+
+const EmberAfDeviceType gComposedPowerSourceDeviceTypes[] = { { DEVICE_TYPE_POWER_SOURCE, DEVICE_VERSION_DEFAULT } };
+
 int main(int argc, char * argv[])
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
     // Clear out the device database
     memset(gDevices, 0, sizeof(gDevices));
 
@@ -648,37 +697,29 @@ int main(int argc, char * argv[])
     Switch1.SetReachable(true);
     Switch2.SetReachable(true);
 
-    // Initialize CHIP
+    // Define composed device with two switches
+    ComposedDevice ComposedDevice("Composed Switcher", "Bedroom");
+    DeviceSwitch ComposedSwitch1("Composed Switch 1", "Bedroom", EMBER_AF_SWITCH_FEATURE_LATCHING_SWITCH);
+    DeviceSwitch ComposedSwitch2("Composed Switch 2", "Bedroom",
+                                 EMBER_AF_SWITCH_FEATURE_MOMENTARY_SWITCH | EMBER_AF_SWITCH_FEATURE_MOMENTARY_SWITCH_RELEASE |
+                                     EMBER_AF_SWITCH_FEATURE_MOMENTARY_SWITCH_LONG_PRESS |
+                                     EMBER_AF_SWITCH_FEATURE_MOMENTARY_SWITCH_MULTI_PRESS);
+    DevicePowerSource ComposedPowerSource("Composed Power Source", "Bedroom", EMBER_AF_POWER_SOURCE_FEATURE_BATTERY);
 
-    err = chip::Platform::MemoryInit();
-    SuccessOrExit(err);
+    ComposedSwitch1.SetChangeCallback(&HandleDeviceSwitchStatusChanged);
+    ComposedSwitch2.SetChangeCallback(&HandleDeviceSwitchStatusChanged);
+    ComposedPowerSource.SetChangeCallback(&HandleDevicePowerSourceStatusChanged);
 
-    err = ParseArguments(argc, argv);
-    SuccessOrExit(err);
+    ComposedDevice.SetReachable(true);
+    ComposedSwitch1.SetReachable(true);
+    ComposedSwitch2.SetReachable(true);
+    ComposedPowerSource.SetReachable(true);
+    ComposedPowerSource.SetBatChargeLevel(58);
 
-    err = chip::DeviceLayer::PlatformMgr().InitChipStack();
-    SuccessOrExit(err);
-
-    // Init the commissionable data provider based on command line options
-    // to handle custom verifiers, discriminators, etc.
-    err = chip::examples::InitCommissionableDataProvider(gCommissionableDataProvider, LinuxDeviceOptions::GetInstance());
-    SuccessOrExit(err);
-    DeviceLayer::SetCommissionableDataProvider(&gCommissionableDataProvider);
-
-    err = chip::examples::InitConfigurationManager(reinterpret_cast<ConfigurationManagerImpl &>(ConfigurationMgr()),
-                                                   LinuxDeviceOptions::GetInstance());
-    SuccessOrExit(err);
-
-    err = PrintQRCodeContent();
-    SuccessOrExit(err);
-
-    chip::DeviceLayer::PlatformMgrImpl().AddEventHandler(EventHandler, 0);
-
-#if CONFIG_NETWORK_LAYER_BLE
-    chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(nullptr); // Use default device name (CHIP-XXXX)
-    chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(LinuxDeviceOptions::GetInstance().mBleDevice, false);
-    chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(true);
-#endif
+    if (ChipLinuxAppInit(argc, argv) != 0)
+    {
+        return -1;
+    }
 
     // Init Data Model and CHIP App Server
     static chip::CommonCaseDeviceServerInitParams initParams;
@@ -736,16 +777,20 @@ int main(int argc, char * argv[])
     AddDeviceEndpoint(&Switch2, &bridgedSwitchEndpoint, Span<const EmberAfDeviceType>(gBridgedSwitchDeviceTypes),
                       Span<DataVersion>(gSwitch2DataVersions));
 
+    // Add composed Device with two buttons and a power source
+    AddDeviceEndpoint(&ComposedDevice, &bridgedComposedDeviceEndpoint, Span<const EmberAfDeviceType>(gBridgedComposedDeviceTypes),
+                      Span<DataVersion>(gComposedDeviceDataVersions));
+    AddDeviceEndpoint(&ComposedSwitch1, &bridgedSwitchEndpoint, Span<const EmberAfDeviceType>(gComposedSwitchDeviceTypes),
+                      Span<DataVersion>(gComposedSwitch1DataVersions), ComposedDevice.GetEndpointId());
+    AddDeviceEndpoint(&ComposedSwitch2, &bridgedSwitchEndpoint, Span<const EmberAfDeviceType>(gComposedSwitchDeviceTypes),
+                      Span<DataVersion>(gComposedSwitch2DataVersions), ComposedDevice.GetEndpointId());
+    AddDeviceEndpoint(&ComposedPowerSource, &bridgedPowerSourceEndpoint,
+                      Span<const EmberAfDeviceType>(gComposedPowerSourceDeviceTypes),
+                      Span<DataVersion>(gComposedPowerSourceDataVersions), ComposedDevice.GetEndpointId());
+
     // Run CHIP
 
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
 
-exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        std::cerr << "Failed to run Linux Bridge App: " << ErrorStr(err) << std::endl;
-        // End the program with non zero error code to indicate a error.
-        return 1;
-    }
     return 0;
 }


### PR DESCRIPTION
#### Problem
* Bridge app don't reflect composed device wich support added recently.

#### Change overview
* Add composed device consist from two switch endpoints and power source endpoint. 
* (Outdated) ~Fix crash at the bridge app start.~
* Use common CHIP initialization from 'platform/linux' module.




