### PR TITLE
Enable more clang tidy checks, fix a memory leak found by tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,8 +41,6 @@ Checks: >
   -clang-analyzer-core.NonNullParamChecker,
   -clang-analyzer-nullability.NullPassedToNonnull,
   -clang-analyzer-unix.Malloc,
-  -clang-analyzer-valist.Unterminated,
-  -clang-analyzer-cplusplus.NewDeleteLeaks,
   -clang-diagnostic-implicit-int-conversion
 WarningsAsErrors: '*'
 HeaderFilterRegex: '(src|examples|zzz_generated|credentials).*(?<!third_party.*repo)'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -35,7 +35,6 @@ Checks: >
   -clang-analyzer-security.insecureAPI.strcpy,
   -clang-analyzer-nullability.NullablePassedToNonnull,
   -clang-analyzer-optin.performance.Padding,
-  -clang-analyzer-security.insecureAPI.bzero,
   -clang-analyzer-unix.cstring.NullArg,
   -clang-analyzer-security.insecureAPI.rand,
   -clang-analyzer-core.NonNullParamChecker,

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -611,7 +611,10 @@ void ThreadStackManagerImpl::_OnNetworkScanFinished(GAsyncResult * res)
         std::unique_ptr<GVariantIter, GVariantIterDeleter> iter;
         g_variant_get(scan_result.get(), "a(tstayqqyyyybb)", &MakeUniquePointerReceiver(iter).Get());
         if (!iter)
+        {
+            delete scanResult;
             return;
+        }
 
         guint64 ext_address;
         const gchar * network_name;

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -340,9 +340,15 @@ void LayerImplSelect::PrepareEvents()
     Clock::ToTimeval(sleepTime, mNextTimeout);
 
     mMaxFd = -1;
+
+    // NOLINTBEGIN(clang-analyzer-security.insecureAPI.bzero)
+    //
+    // NOTE: darwin uses bzero to clear out FD sets. This is not a security concern.
     FD_ZERO(&mSelected.mReadSet);
     FD_ZERO(&mSelected.mWriteSet);
     FD_ZERO(&mSelected.mErrorSet);
+    // NOLINTEND(clang-analyzer-security.insecureAPI.bzero)
+
     for (auto & w : mSocketWatchPool)
     {
         if (w.mFD != kInvalidFd)

--- a/src/system/tests/TestSystemWakeEvent.cpp
+++ b/src/system/tests/TestSystemWakeEvent.cpp
@@ -75,9 +75,14 @@ struct TestContext
 
     int SelectWakeEvent(timeval timeout = {})
     {
+        // NOLINTBEGIN(clang-analyzer-security.insecureAPI.bzero)
+        //
+        // NOTE: darwin uses bzero to clear out FD sets. This is not a security concern.
         FD_ZERO(&mReadSet);
         FD_ZERO(&mWriteSet);
         FD_ZERO(&mErrorSet);
+        // NOLINTEND(clang-analyzer-security.insecureAPI.bzero)
+
         FD_SET(WakeEventTest::GetReadFD(mWakeEvent), &mReadSet);
         return select(WakeEventTest::GetReadFD(mWakeEvent) + 1, &mReadSet, &mWriteSet, &mErrorSet, &timeout);
     }


### PR DESCRIPTION
#### Problem
Clang tidy checks are useful. Enable more of them.

#### Change overview
Enables more checks.
Checks found a bug. Fix it.

#### Testing
Ran clang-tidy locally on the compile database of chip-tool. Expect CI to run more of them.