### PR TITLE
Clang tidy uninitialized.Branch

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,7 +26,6 @@ Checks: >
   -clang-analyzer-core.UndefinedBinaryOperatorResult,
   -clang-analyzer-core.NullDereference,
   -clang-analyzer-optin.cplusplus.UninitializedObject,
-  -clang-analyzer-core.uninitialized.Branch,
   -clang-analyzer-optin.performance,
   -clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker,
   -clang-analyzer-deadcode.DeadStores,

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -576,7 +576,7 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, b
             (attributeCluster != nullptr) ? &reader : GetAttributeAccessOverride(aPath.mEndpointId, aPath.mClusterId);
         if (attributeOverride)
         {
-            bool triedEncode;
+            bool triedEncode = false;
             ReturnErrorOnFailure(ReadViaAccessInterface(aSubjectDescriptor.fabricIndex, aIsFabricFiltered, aPath, aAttributeReports,
                                                         apEncoderState, attributeOverride, &triedEncode));
             ReturnErrorCodeIf(triedEncode, CHIP_NO_ERROR);

--- a/src/lib/core/Optional.h
+++ b/src/lib/core/Optional.h
@@ -50,6 +50,7 @@ public:
 
     ~Optional()
     {
+        // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch): mData is set when mHasValue
         if (mHasValue)
         {
             mValue.mData.~T();


### PR DESCRIPTION
#### Problem
Enable more clang-tidy checks to make sure our code is safe.

#### Change overview
enable clang-tidy check for uninitialized values used for branching.
Fixes one instance of this.

#### Testing
Ran clang-tidy locally on chip-tool on linux. CI will run more (specifically darwin code as well)