### PR TITLE
[Inet] Fix Interface Address Iterator OpenThread

### DIFF
--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -57,6 +57,10 @@
 #include <net/net_if.h>
 #endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
 
+#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
+#include <inet/UDPEndPointImplOpenThread.h>
+#endif
+
 #include <stdio.h>
 #include <string.h>
 
@@ -105,15 +109,41 @@ bool InterfaceIterator::Next()
     // TODO : Cleanup #17346
     return false;
 }
+
+InterfaceAddressIterator::InterfaceAddressIterator()
+{
+    mNetifAddrList = nullptr;
+    mCurAddr       = nullptr;
+}
+
 bool InterfaceAddressIterator::HasCurrent()
 {
-    return mIntfIter.HasCurrent();
+    return (mNetifAddrList != nullptr) ? (mCurAddr != nullptr) : Next();
 }
 
 bool InterfaceAddressIterator::Next()
 {
-    // TODO : Cleanup #17346
-    return false;
+    if (mNetifAddrList == nullptr)
+    {
+        mNetifAddrList = otIp6GetUnicastAddresses(Inet::globalOtInstance);
+
+        if (mNetifAddrList == nullptr)
+        {
+            return false;
+        }
+        mCurAddr = const_cast<otNetifAddress *>(mNetifAddrList);
+    }
+    else if (mCurAddr != nullptr)
+    {
+        mCurAddr = mCurAddr->mNext;
+    }
+
+    if (mCurAddr == nullptr)
+    {
+        return false;
+    }
+
+    return true;
 }
 CHIP_ERROR InterfaceAddressIterator::GetAddress(IPAddress & outIPAddress)
 {
@@ -122,7 +152,7 @@ CHIP_ERROR InterfaceAddressIterator::GetAddress(IPAddress & outIPAddress)
         return CHIP_ERROR_SENTINEL;
     }
 
-    outIPAddress = IPAddress((*(mAddrInfoList[mCurAddrIndex].mAddress)));
+    outIPAddress = IPAddress(mCurAddr->mAddress);
     return CHIP_NO_ERROR;
 }
 

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -126,24 +126,14 @@ bool InterfaceAddressIterator::Next()
     if (mNetifAddrList == nullptr)
     {
         mNetifAddrList = otIp6GetUnicastAddresses(Inet::globalOtInstance);
-
-        if (mNetifAddrList == nullptr)
-        {
-            return false;
-        }
-        mCurAddr = const_cast<otNetifAddress *>(mNetifAddrList);
+        mCurAddr       = mNetifAddrList;
     }
     else if (mCurAddr != nullptr)
     {
         mCurAddr = mCurAddr->mNext;
     }
 
-    if (mCurAddr == nullptr)
-    {
-        return false;
-    }
-
-    return true;
+    return (mCurAddr != nullptr);
 }
 CHIP_ERROR InterfaceAddressIterator::GetAddress(IPAddress & outIPAddress)
 {

--- a/src/inet/InetInterface.h
+++ b/src/inet/InetInterface.h
@@ -540,15 +540,13 @@ private:
     int mCurAddrIndex   = -1;
 #endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
 #if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
-    otIp6AddressInfo * mAddrInfoList;
-    int mCurAddrIndex;
-    InterfaceIterator mIntfIter;
+    const otNetifAddress * mNetifAddrList;
+    otNetifAddress * mCurAddr;
 #endif // #if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 };
 
 #if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 inline InterfaceIterator::InterfaceIterator(void) {}
-inline InterfaceAddressIterator::InterfaceAddressIterator(void) {}
 inline InterfaceIterator::~InterfaceIterator()               = default;
 inline InterfaceAddressIterator::~InterfaceAddressIterator() = default;
 inline bool InterfaceIterator::HasCurrent(void)

--- a/src/inet/InetInterface.h
+++ b/src/inet/InetInterface.h
@@ -541,7 +541,7 @@ private:
 #endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
 #if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
     const otNetifAddress * mNetifAddrList;
-    otNetifAddress * mCurAddr;
+    const otNetifAddress * mCurAddr;
 #endif // #if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 };
 

--- a/src/inet/UDPEndPointImplOpenThread.cpp
+++ b/src/inet/UDPEndPointImplOpenThread.cpp
@@ -30,6 +30,8 @@
 namespace chip {
 namespace Inet {
 
+otInstance * globalOtInstance;
+
 void UDPEndPointImplOT::handleUdpReceive(void * aContext, otMessage * aMessage, const otMessageInfo * aMessageInfo)
 {
     UDPEndPointImplOT * ep = static_cast<UDPEndPointImplOT *>(aContext);
@@ -168,6 +170,12 @@ void UDPEndPointImplOT::HandleDataReceived(System::PacketBufferHandle && msg)
             }
         }
     }
+}
+
+void UDPEndPointImplOT::SetNativeParams(void * params)
+{
+    mOTInstance      = static_cast<otInstance *>(params);
+    globalOtInstance = mOTInstance;
 }
 
 CHIP_ERROR UDPEndPointImplOT::SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback)

--- a/src/inet/UDPEndPointImplOpenThread.h
+++ b/src/inet/UDPEndPointImplOpenThread.h
@@ -32,6 +32,8 @@
 namespace chip {
 namespace Inet {
 
+extern otInstance * globalOtInstance;
+
 class UDPEndPointImplOT : public UDPEndPoint, public EndPointStateOpenThread
 {
 public:
@@ -44,7 +46,7 @@ public:
     uint16_t GetBoundPort() const override;
     void Free() override;
     void HandleDataReceived(System::PacketBufferHandle && msg);
-    inline void SetNativeParams(void * params) { mOTInstance = static_cast<otInstance *>(params); }
+    void SetNativeParams(void * params);
     CHIP_ERROR SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback) override;
     CHIP_ERROR BindInterfaceImpl(IPAddressType addressType, InterfaceId interfaceId) override;
 


### PR DESCRIPTION
#### Problem
Inet Interface Address Iterator was hardcoded with uninitialized array, causing an hardfault when used.

#### Change overview
Implement the missing portion of the Inet layer for the native OpenThread implementation.

#### Testing
EFR32 platform.
