### PR TITLE
Clang tidy enable clang-analyzer-core.UndefinedBinaryOperatorResult

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,7 +23,6 @@ Checks: >
   -bugprone-signed-char-misuse,
   -bugprone-copy-constructor-init,
   -clang-analyzer-core.CallAndMessage,
-  -clang-analyzer-core.UndefinedBinaryOperatorResult,
   -clang-analyzer-core.NullDereference,
   -clang-analyzer-optin.cplusplus.UninitializedObject,
   -clang-analyzer-core.uninitialized.Branch,

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -1984,11 +1984,11 @@ void TestSubjectsTargets(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, accessControl.CreateEntry(&index, entry) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, int(index) == 2);
 
-    FabricIndex fabricIndex;
-    Privilege privilege;
-    AuthMode authMode;
-    size_t count;
-    NodeId subject;
+    FabricIndex fabricIndex = 0;
+    Privilege privilege     = Privilege::kView;
+    AuthMode authMode       = AuthMode::kNone;
+    size_t count            = 0;
+    NodeId subject          = kUndefinedNodeId;
     Target target;
 
     NL_TEST_ASSERT(inSuite, accessControl.ReadEntry(0, entry) == CHIP_NO_ERROR);

--- a/src/app/tests/TestClusterStateCache.cpp
+++ b/src/app/tests/TestClusterStateCache.cpp
@@ -313,7 +313,7 @@ private:
         case AttributeInstruction::kAttributeA: {
             ChipLogProgress(DataManagement, "\t\t -- Validating A");
 
-            Clusters::TestCluster::Attributes::Int16u::TypeInfo::DecodableType v;
+            Clusters::TestCluster::Attributes::Int16u::TypeInfo::DecodableType v = 0;
             err = cache->Get<Clusters::TestCluster::Attributes::Int16u::TypeInfo>(path, v);
             if (err == CHIP_ERROR_IM_STATUS_CODE_RECEIVED)
             {

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -517,7 +517,7 @@ int8_t emberAfCompareValues(const uint8_t * val1, const uint8_t * val2, uint16_t
 {
     if (len == 0)
     {
-        // no length means nothing to compare.
+        // no length means nothing to compare.  Shouldn't even happen, since len is sizeof(some-integer-type).
         return 0;
     }
     uint8_t i, j, k;

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -437,23 +437,23 @@ EmberStatus emberAfSendDefaultResponse(const EmberAfClusterCommand * cmd, EmberA
 
 void emberAfCopyInt16u(uint8_t * data, uint16_t index, uint16_t x)
 {
-    data[index]     = (uint8_t) (((x)) & 0xFF);
-    data[index + 1] = (uint8_t) (((x) >> 8) & 0xFF);
+    data[index]     = (uint8_t)(((x)) & 0xFF);
+    data[index + 1] = (uint8_t)(((x) >> 8) & 0xFF);
 }
 
 void emberAfCopyInt24u(uint8_t * data, uint16_t index, uint32_t x)
 {
-    data[index]     = (uint8_t) (((x)) & 0xFF);
-    data[index + 1] = (uint8_t) (((x) >> 8) & 0xFF);
-    data[index + 2] = (uint8_t) (((x) >> 16) & 0xFF);
+    data[index]     = (uint8_t)(((x)) & 0xFF);
+    data[index + 1] = (uint8_t)(((x) >> 8) & 0xFF);
+    data[index + 2] = (uint8_t)(((x) >> 16) & 0xFF);
 }
 
 void emberAfCopyInt32u(uint8_t * data, uint16_t index, uint32_t x)
 {
-    data[index]     = (uint8_t) (((x)) & 0xFF);
-    data[index + 1] = (uint8_t) (((x) >> 8) & 0xFF);
-    data[index + 2] = (uint8_t) (((x) >> 16) & 0xFF);
-    data[index + 3] = (uint8_t) (((x) >> 24) & 0xFF);
+    data[index]     = (uint8_t)(((x)) & 0xFF);
+    data[index + 1] = (uint8_t)(((x) >> 8) & 0xFF);
+    data[index + 2] = (uint8_t)(((x) >> 16) & 0xFF);
+    data[index + 3] = (uint8_t)(((x) >> 24) & 0xFF);
 }
 
 void emberAfCopyString(uint8_t * dest, const uint8_t * src, size_t size)

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -437,23 +437,23 @@ EmberStatus emberAfSendDefaultResponse(const EmberAfClusterCommand * cmd, EmberA
 
 void emberAfCopyInt16u(uint8_t * data, uint16_t index, uint16_t x)
 {
-    data[index]     = (uint8_t)(((x)) & 0xFF);
-    data[index + 1] = (uint8_t)(((x) >> 8) & 0xFF);
+    data[index]     = (uint8_t) (((x)) & 0xFF);
+    data[index + 1] = (uint8_t) (((x) >> 8) & 0xFF);
 }
 
 void emberAfCopyInt24u(uint8_t * data, uint16_t index, uint32_t x)
 {
-    data[index]     = (uint8_t)(((x)) & 0xFF);
-    data[index + 1] = (uint8_t)(((x) >> 8) & 0xFF);
-    data[index + 2] = (uint8_t)(((x) >> 16) & 0xFF);
+    data[index]     = (uint8_t) (((x)) & 0xFF);
+    data[index + 1] = (uint8_t) (((x) >> 8) & 0xFF);
+    data[index + 2] = (uint8_t) (((x) >> 16) & 0xFF);
 }
 
 void emberAfCopyInt32u(uint8_t * data, uint16_t index, uint32_t x)
 {
-    data[index]     = (uint8_t)(((x)) & 0xFF);
-    data[index + 1] = (uint8_t)(((x) >> 8) & 0xFF);
-    data[index + 2] = (uint8_t)(((x) >> 16) & 0xFF);
-    data[index + 3] = (uint8_t)(((x) >> 24) & 0xFF);
+    data[index]     = (uint8_t) (((x)) & 0xFF);
+    data[index + 1] = (uint8_t) (((x) >> 8) & 0xFF);
+    data[index + 2] = (uint8_t) (((x) >> 16) & 0xFF);
+    data[index + 3] = (uint8_t) (((x) >> 24) & 0xFF);
 }
 
 void emberAfCopyString(uint8_t * dest, const uint8_t * src, size_t size)
@@ -515,6 +515,11 @@ void emberAfCopyLongString(uint8_t * dest, const uint8_t * src, size_t size)
 // default value of NULL is treated as all zeroes.
 int8_t emberAfCompareValues(const uint8_t * val1, const uint8_t * val2, uint16_t len, bool signedNumber)
 {
+    if (len == 0)
+    {
+        // no length means nothing to compare.
+        return 0;
+    }
     uint8_t i, j, k;
     if (signedNumber)
     { // signed number comparison

--- a/src/lib/asn1/ASN1Reader.cpp
+++ b/src/lib/asn1/ASN1Reader.cpp
@@ -147,12 +147,18 @@ CHIP_ERROR ASN1Reader::GetInteger(int64_t & val)
     ReturnErrorCodeIf(ValueLen > sizeof(int64_t), ASN1_ERROR_VALUE_OVERFLOW);
     ReturnErrorCodeIf(mElemStart + mHeadLen + ValueLen > mContainerEnd, ASN1_ERROR_UNDERRUN);
 
+    // NOLINTBEGIN(clang-analyzer-core.UndefinedBinaryOperatorResult)
+    //
+    // TODO: clang-tidy says that if val is -1, then (val << 8) is not defined.
+    //       added above supression to keep clang-tidy validating the rest of the files, however
+    //       this complain likely needs fixing.
     const uint8_t * p = Value;
     val               = ((*p & 0x80) == 0) ? 0 : -1;
     for (uint32_t i = ValueLen; i > 0; i--, p++)
     {
         val = (val << 8) | *p;
     }
+    // NOLINTEND(clang-analyzer-core.UndefinedBinaryOperatorResult)
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Problem
Let clang-tidy find more potential problems with our code

#### Change overview
Enable clang-tidy check
Fix potential problem in ember code (seems valid - trying to compare 0-sized values)
Add TODO on ASN1 code which I am unsure about

#### Testing
Ran clang-tidy locally.