### PR TITLE
tv-casting-app/android: Open commissioning window through JNI in a new fragment

### DIFF
--- a/examples/tv-casting-app/android/App/app/build.gradle
+++ b/examples/tv-casting-app/android/App/app/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     testImplementation 'junit:junit:4.+'
     testImplementation 'org.mockito:mockito-core:3.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
@@ -1,0 +1,95 @@
+package com.chip.casting.app;
+
+import android.content.Context;
+import android.net.nsd.NsdManager;
+import android.net.wifi.WifiManager;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import com.chip.casting.dnssd.CommissionerDiscoveryListener;
+import com.chip.casting.util.GlobalCastingConstants;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/** A {@link Fragment} to discover commissioners on the network */
+public class CommissionerDiscoveryFragment extends Fragment {
+
+  public CommissionerDiscoveryFragment() {}
+
+  /**
+   * Use this factory method to create a new instance of this fragment using the provided
+   * parameters.
+   *
+   * @return A new instance of fragment CommissionerDiscoveryFragment.
+   */
+  public static CommissionerDiscoveryFragment newInstance() {
+    return new CommissionerDiscoveryFragment();
+  }
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    startCommissionerDiscovery();
+  }
+
+  @Override
+  public View onCreateView(
+      LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    // Inflate the layout for this fragment
+    return inflater.inflate(R.layout.fragment_commissioner_discovery, container, false);
+  }
+
+  @Override
+  public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+    Button manualCommissioningButton = getView().findViewById(R.id.manualCommissioningButton);
+    Callback callback = (Callback) this.getActivity();
+    manualCommissioningButton.setOnClickListener(
+        new View.OnClickListener() {
+          @Override
+          public void onClick(View v) {
+            callback.handleManualCommissioningButtonClicked();
+          }
+        });
+  }
+
+  private void startCommissionerDiscovery() {
+    WifiManager wifi = (WifiManager) this.getContext().getSystemService(Context.WIFI_SERVICE);
+    WifiManager.MulticastLock multicastLock = wifi.createMulticastLock("multicastLock");
+    multicastLock.setReferenceCounted(true);
+    multicastLock.acquire();
+
+    CastingContext castingContext = new CastingContext(this.getActivity());
+    NsdManager.DiscoveryListener commissionerDiscoveryListener =
+        new CommissionerDiscoveryListener(castingContext);
+
+    NsdManager nsdManager = castingContext.getNsdManager();
+    nsdManager.discoverServices(
+        GlobalCastingConstants.CommissionerServiceType,
+        NsdManager.PROTOCOL_DNS_SD,
+        commissionerDiscoveryListener);
+
+    // Stop discovery after specified timeout
+    Executors.newSingleThreadScheduledExecutor()
+        .schedule(
+            new Runnable() {
+              @Override
+              public void run() {
+                nsdManager.stopServiceDiscovery(commissionerDiscoveryListener);
+                multicastLock.release();
+              }
+            },
+            10,
+            TimeUnit.SECONDS);
+  }
+
+  /** Interface for notifying the host. */
+  interface Callback {
+    /** Notifies listener of Skip to manual Commissioning Button click. */
+    void handleManualCommissioningButtonClicked();
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissioningFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissioningFragment.java
@@ -1,0 +1,68 @@
+package com.chip.casting.app;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import com.chip.casting.TvCastingApp;
+import com.chip.casting.dnssd.CommissionerDiscoveryListener;
+import com.chip.casting.util.GlobalCastingConstants;
+
+/** A {@link Fragment} to get the TV Casting App commissioned. */
+public class CommissioningFragment extends Fragment {
+  private static final String TAG = CommissionerDiscoveryListener.class.getSimpleName();
+
+  private final TvCastingApp tvCastingApp;
+
+  public CommissioningFragment(TvCastingApp tvCastingApp) {
+    this.tvCastingApp = tvCastingApp;
+  }
+
+  /**
+   * Use this factory method to create a new instance of this fragment using the provided
+   * parameters.
+   *
+   * @param tvCastingApp TV Casting App (JNI)
+   * @return A new instance of fragment CommissioningFragment.
+   */
+  // TODO: Rename and change types and number of parameters
+  public static CommissioningFragment newInstance(TvCastingApp tvCastingApp) {
+    return new CommissioningFragment(tvCastingApp);
+  }
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+  }
+
+  @Override
+  public View onCreateView(
+      LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    // Inflate the layout for this fragment
+    return inflater.inflate(R.layout.fragment_commissioning, container, false);
+  }
+
+  @Override
+  public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+    boolean status =
+        tvCastingApp.openBasicCommissioningWindow(
+            GlobalCastingConstants.CommissioningWindowDurationSecs);
+    Log.d(
+        TAG,
+        "CommissioningFragment.onViewCreated tvCastingApp.openBasicCommissioningWindow returned "
+            + status);
+    TextView commissioningWindowStatusView = getView().findViewById(R.id.commissioningWindowStatus);
+    TextView onboardingPayloadView = getView().findViewById(R.id.onboardingPayload);
+    if (status == true) {
+      commissioningWindowStatusView.setText("Commissioning window opened!");
+      onboardingPayloadView.setText("Onboarding Pin: " + GlobalCastingConstants.SetupPasscode);
+    } else {
+      commissioningWindowStatusView.setText("Commissioning window could not be opened!");
+    }
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
@@ -1,61 +1,84 @@
 package com.chip.casting.app;
 
 import android.content.Context;
-import android.net.nsd.NsdManager;
-import android.net.wifi.WifiManager;
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentTransaction;
+import chip.appserver.ChipAppServer;
+import chip.platform.AndroidBleManager;
+import chip.platform.AndroidChipPlatform;
+import chip.platform.ChipMdnsCallbackImpl;
+import chip.platform.DiagnosticDataProviderImpl;
+import chip.platform.NsdManagerServiceResolver;
+import chip.platform.PreferencesConfigurationManager;
+import chip.platform.PreferencesKeyValueStoreManager;
+import com.chip.casting.DACProviderStub;
 import com.chip.casting.TvCastingApp;
-import com.chip.casting.dnssd.CommissionerDiscoveryListener;
 import com.chip.casting.util.GlobalCastingConstants;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends AppCompatActivity
+    implements CommissionerDiscoveryFragment.Callback {
+
+  private ChipAppServer chipAppServer;
+  private TvCastingApp tvCastingApp;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
-    startCommissionerDiscovery();
 
-    testJni();
+    initJni();
+
+    Fragment fragment = CommissionerDiscoveryFragment.newInstance();
+    getSupportFragmentManager()
+        .beginTransaction()
+        .add(R.id.main_fragment_container, fragment, fragment.getClass().getSimpleName())
+        .commit();
   }
 
-  private void startCommissionerDiscovery() {
-    WifiManager wifi = (WifiManager) getApplicationContext().getSystemService(Context.WIFI_SERVICE);
-    WifiManager.MulticastLock multicastLock = wifi.createMulticastLock("multicastLock");
-    multicastLock.setReferenceCounted(true);
-    multicastLock.acquire();
-
-    CastingContext castingContext = new CastingContext(this);
-    NsdManager.DiscoveryListener commissionerDiscoveryListener =
-        new CommissionerDiscoveryListener(castingContext);
-
-    NsdManager nsdManager = castingContext.getNsdManager();
-    nsdManager.discoverServices(
-        GlobalCastingConstants.CommissionerServiceType,
-        NsdManager.PROTOCOL_DNS_SD,
-        commissionerDiscoveryListener);
-
-    // Stop discovery after specified timeout
-    Executors.newSingleThreadScheduledExecutor()
-        .schedule(
-            new Runnable() {
-              @Override
-              public void run() {
-                nsdManager.stopServiceDiscovery(commissionerDiscoveryListener);
-                multicastLock.release();
-              }
-            },
-            10,
-            TimeUnit.SECONDS);
+  @Override
+  public void handleManualCommissioningButtonClicked() {
+    showFragment(CommissioningFragment.newInstance(tvCastingApp));
   }
 
-  /** TBD: Temp dummy function for testing */
-  private void testJni() {
-    TvCastingApp tvCastingApp =
-        new TvCastingApp((app, clusterId, endpoint) -> app.doSomethingInCpp(endpoint));
-    tvCastingApp.doSomethingInCpp(0);
+  private void initJni() {
+    tvCastingApp =
+        new TvCastingApp((app, clusterId, duration) -> app.openBasicCommissioningWindow(duration));
+
+    tvCastingApp.setDACProvider(new DACProviderStub());
+    Context applicationContext = this.getApplicationContext();
+    AndroidChipPlatform chipPlatform =
+        new AndroidChipPlatform(
+            new AndroidBleManager(),
+            new PreferencesKeyValueStoreManager(applicationContext),
+            new PreferencesConfigurationManager(applicationContext),
+            new NsdManagerServiceResolver(applicationContext),
+            new ChipMdnsCallbackImpl(),
+            new DiagnosticDataProviderImpl(applicationContext));
+
+    chipPlatform.updateCommissionableDataProviderData(
+        null, null, 0, GlobalCastingConstants.SetupPasscode, GlobalCastingConstants.Discriminator);
+
+    chipAppServer = new ChipAppServer();
+    chipAppServer.startApp();
+  }
+
+  private void showFragment(Fragment fragment, boolean showOnBack) {
+    System.out.println(
+        "showFragment called with " + fragment.getClass().getSimpleName() + " and " + showOnBack);
+    FragmentTransaction fragmentTransaction =
+        getSupportFragmentManager()
+            .beginTransaction()
+            .replace(R.id.main_fragment_container, fragment, fragment.getClass().getSimpleName());
+    if (showOnBack) {
+      fragmentTransaction.addToBackStack(null);
+    }
+
+    fragmentTransaction.commit();
+  }
+
+  private void showFragment(Fragment fragment) {
+    showFragment(fragment, true);
   }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/util/GlobalCastingConstants.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/util/GlobalCastingConstants.java
@@ -2,4 +2,7 @@ package com.chip.casting.util;
 
 public class GlobalCastingConstants {
   public static final String CommissionerServiceType = "_matterd._udp.";
+  public static final int CommissioningWindowDurationSecs = 3 * 60;
+  public static int SetupPasscode = 20202021;
+  public static int Discriminator = 0xF00;
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/DACProvider.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/DACProvider.java
@@ -1,0 +1,32 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.chip.casting;
+
+public interface DACProvider {
+  byte[] GetCertificationDeclaration();
+
+  byte[] GetFirmwareInformation();
+
+  byte[] GetDeviceAttestationCert();
+
+  byte[] GetProductAttestationIntermediateCert();
+
+  byte[] GetDeviceAttestationCertPrivateKey();
+
+  byte[] GetDeviceAttestationCertPublicKeyKey();
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/DACProviderStub.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/DACProviderStub.java
@@ -1,0 +1,57 @@
+package com.chip.casting;
+
+import android.util.Base64;
+
+public class DACProviderStub implements DACProvider {
+
+  private String kDevelopmentDAC_Cert_FFF1_8001 =
+      "MIIB5zCCAY6gAwIBAgIIac3xDenlTtEwCgYIKoZIzj0EAwIwPTElMCMGA1UEAwwcTWF0dGVyIERldiBQQUkgMHhGRkYxIG5vIFBJRDEUMBIGCisGAQQBgqJ8AgEMBEZGRjEwIBcNMjIwMjA1MDAwMDAwWhgPOTk5OTEyMzEyMzU5NTlaMFMxJTAjBgNVBAMMHE1hdHRlciBEZXYgREFDIDB4RkZGMS8weDgwMDExFDASBgorBgEEAYKifAIBDARGRkYxMRQwEgYKKwYBBAGConwCAgwEODAwMTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABEY6xpNCkQoOVYj8b/Vrtj5i7M7LFI99TrA+5VJgFBV2fRalxmP3k+SRIyYLgpenzX58/HsxaznZjpDSk3dzjoKjYDBeMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgeAMB0GA1UdDgQWBBSI3eezADgpMs/3NMBGJIEPRBaKbzAfBgNVHSMEGDAWgBRjVA5H9kscONE4hKRi0WwZXY/7PDAKBggqhkjOPQQDAgNHADBEAiABJ6J7S0RhDuL83E0reIVWNmC8D3bxchntagjfsrPBzQIga1ngr0Xz6yqFuRnTVzFSjGAoxBUjlUXhCOTlTnCXE1M=";
+
+  private String kDevelopmentDAC_PrivateKey_FFF1_8001 =
+      "qrYAroroqrfXNifCF7fCBHCcppRq9fL3UwgzpStE+/8=";
+
+  private String kDevelopmentDAC_PublicKey_FFF1_8001 =
+      "BEY6xpNCkQoOVYj8b/Vrtj5i7M7LFI99TrA+5VJgFBV2fRalxmP3k+SRIyYLgpenzX58/HsxaznZjpDSk3dzjoI=";
+
+  private String KPAI_FFF1_8000_Cert_Array =
+      "MIIByzCCAXGgAwIBAgIIVq2CIq2UW2QwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMjAyMDUwMDAwMDBaGA85OTk5MTIzMTIzNTk1OVowPTElMCMGA1UEAwwcTWF0dGVyIERldiBQQUkgMHhGRkYxIG5vIFBJRDEUMBIGCisGAQQBgqJ8AgEMBEZGRjEwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARBmpMVwhc+DIyHbQPM/JRIUmR/f+xeUIL0BZko7KiUxZQVEwmsYx5MsDOSr2hLC6+35ls7gWLC9Sv5MbjneqqCo2YwZDASBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUY1QOR/ZLHDjROISkYtFsGV2P+zwwHwYDVR0jBBgwFoAUav0idx9RH+y/FkGXZxDc3DGhcX4wCgYIKoZIzj0EAwIDSAAwRQIhALLvJ/Sa6bUPuR7qyUxNC9u415KcbLiPrOUpNo0SBUwMAiBlXckrhr2QmIKmxiF3uCXX0F7b58Ivn+pxIg5+pwP4kQ==";
+
+  /**
+   * format_version = 1 vendor_id = 0xFFF1 product_id_array = [ 0x8000,0x8001...0x8063]
+   * device_type_id = 0x1234 certificate_id = "ZIG20141ZB330001-24" security_level = 0
+   * security_information = 0 version_number = 0x2694 certification_type = 0 dac_origin_vendor_id is
+   * not present dac_origin_product_id is not present
+   */
+  private String kCertificationDeclaration =
+      "MIICGQYJKoZIhvcNAQcCoIICCjCCAgYCAQMxDTALBglghkgBZQMEAgEwggFxBgkqhkiG9w0BBwGgggFiBIIBXhUkAAElAfH/NgIFAIAFAYAFAoAFA4AFBIAFBYAFBoAFB4AFCIAFCYAFCoAFC4AFDIAFDYAFDoAFD4AFEIAFEYAFEoAFE4AFFIAFFYAFFoAFF4AFGIAFGYAFGoAFG4AFHIAFHYAFHoAFH4AFIIAFIYAFIoAFI4AFJIAFJYAFJoAFJ4AFKIAFKYAFKoAFK4AFLIAFLYAFLoAFL4AFMIAFMYAFMoAFM4AFNIAFNYAFNoAFN4AFOIAFOYAFOoAFO4AFPIAFPYAFPoAFP4AFQIAFQYAFQoAFQ4AFRIAFRYAFRoAFR4AFSIAFSYAFSoAFS4AFTIAFTYAFToAFT4AFUIAFUYAFUoAFU4AFVIAFVYAFVoAFV4AFWIAFWYAFWoAFW4AFXIAFXYAFXoAFX4AFYIAFYYAFYoAFY4AYJAMWLAQTWklHMjAxNDJaQjMzMDAwMy0yNCQFACQGACUHlCYkCAAYMX0wewIBA4AUYvqCM1ms+qmWPhz6FArd9QTzcWAwCwYJYIZIAWUDBAIBMAoGCCqGSM49BAMCBEcwRQIgJOXR9Hp9ew0gaibvaZt8l1e3LUaQid4xkuZ4x0Xn9gwCIQD4qi+nEfy3m5fjl87aZnuuRk4r0//fw8zteqjKX0wafA==";
+
+  @Override
+  public byte[] GetCertificationDeclaration() {
+    return Base64.decode(kCertificationDeclaration, Base64.DEFAULT);
+  }
+
+  @Override
+  public byte[] GetFirmwareInformation() {
+    return new byte[0];
+  }
+
+  @Override
+  public byte[] GetDeviceAttestationCert() {
+    return Base64.decode(kDevelopmentDAC_Cert_FFF1_8001, Base64.DEFAULT);
+  }
+
+  @Override
+  public byte[] GetProductAttestationIntermediateCert() {
+    return Base64.decode(KPAI_FFF1_8000_Cert_Array, Base64.DEFAULT);
+  }
+
+  @Override
+  public byte[] GetDeviceAttestationCertPrivateKey() {
+    return Base64.decode(kDevelopmentDAC_PrivateKey_FFF1_8001, Base64.DEFAULT);
+  }
+
+  @Override
+  public byte[] GetDeviceAttestationCertPublicKeyKey() {
+    return Base64.decode(kDevelopmentDAC_PublicKey_FFF1_8001, Base64.DEFAULT);
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -37,8 +37,10 @@ public class TvCastingApp {
 
   public native void nativeInit();
 
+  public native void setDACProvider(DACProvider provider);
+
   /** TBD: Temp dummy function for testing */
-  public native void doSomethingInCpp(int endpoint);
+  public native boolean openBasicCommissioningWindow(int duration);
 
   static {
     System.loadLibrary("TvCastingApp");

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/JNIDACProvider.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/JNIDACProvider.cpp
@@ -1,0 +1,172 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "JNIDACProvider.h"
+#include "lib/support/logging/CHIPLogging.h"
+#include <credentials/CHIPCert.h>
+#include <crypto/CHIPCryptoPAL.h>
+#include <cstdlib>
+#include <jni.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/CHIPJNIError.h>
+#include <lib/support/JniReferences.h>
+#include <lib/support/JniTypeWrappers.h>
+#include <lib/support/Span.h>
+
+using namespace chip;
+
+JNIDACProvider::JNIDACProvider(jobject provider)
+{
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for JNIDACProvider"));
+
+    mJNIDACProviderObject = env->NewGlobalRef(provider);
+    VerifyOrReturn(mJNIDACProviderObject != nullptr, ChipLogError(Zcl, "Failed to NewGlobalRef JNIDACProvider"));
+
+    jclass JNIDACProviderClass = env->GetObjectClass(provider);
+    VerifyOrReturn(JNIDACProviderClass != nullptr, ChipLogError(Zcl, "Failed to get JNIDACProvider Java class"));
+
+    mGetCertificationDeclarationMethod = env->GetMethodID(JNIDACProviderClass, "GetCertificationDeclaration", "()[B");
+    if (mGetCertificationDeclarationMethod == nullptr)
+    {
+        ChipLogError(Zcl, "Failed to access JNIDACProvider 'GetCertificationDeclaration' method");
+        env->ExceptionClear();
+    }
+
+    mGetFirmwareInformationMethod = env->GetMethodID(JNIDACProviderClass, "GetFirmwareInformation", "()[B");
+    if (mGetFirmwareInformationMethod == nullptr)
+    {
+        ChipLogError(Zcl, "Failed to access JNIDACProvider 'GetFirmwareInformation' method");
+        env->ExceptionClear();
+    }
+
+    mGetDeviceAttestationCertMethod = env->GetMethodID(JNIDACProviderClass, "GetDeviceAttestationCert", "()[B");
+    if (mGetDeviceAttestationCertMethod == nullptr)
+    {
+        ChipLogError(Zcl, "Failed to access JNIDACProvider 'GetDeviceAttestationCert' method");
+        env->ExceptionClear();
+    }
+
+    mGetProductAttestationIntermediateCertMethod =
+        env->GetMethodID(JNIDACProviderClass, "GetProductAttestationIntermediateCert", "()[B");
+    if (mGetProductAttestationIntermediateCertMethod == nullptr)
+    {
+        ChipLogError(Zcl, "Failed to access JNIDACProvider 'GetProductAttestationIntermediateCert' method");
+        env->ExceptionClear();
+    }
+
+    mGetDeviceAttestationCertPrivateKeyMethod = env->GetMethodID(JNIDACProviderClass, "GetDeviceAttestationCertPrivateKey", "()[B");
+    if (mGetDeviceAttestationCertPrivateKeyMethod == nullptr)
+    {
+        ChipLogError(Zcl, "Failed to access JNIDACProvider 'GetDeviceAttestationCertPrivateKey' method");
+        env->ExceptionClear();
+    }
+
+    mGetDeviceAttestationCertPublicKeyKeyMethod =
+        env->GetMethodID(JNIDACProviderClass, "GetDeviceAttestationCertPublicKeyKey", "()[B");
+    if (mGetDeviceAttestationCertPublicKeyKeyMethod == nullptr)
+    {
+        ChipLogError(Zcl, "Failed to access JNIDACProvider 'GetDeviceAttestationCertPublicKeyKey' method");
+        env->ExceptionClear();
+    }
+}
+
+CHIP_ERROR JNIDACProvider::GetJavaByteByMethod(jmethodID method, MutableByteSpan & out_buffer)
+{
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturnLogError(mJNIDACProviderObject != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnLogError(method != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnLogError(env != nullptr, CHIP_JNI_ERROR_NO_ENV);
+
+    jbyteArray outArray = (jbyteArray) env->CallObjectMethod(mJNIDACProviderObject, method);
+    if (env->ExceptionCheck())
+    {
+        ChipLogError(Zcl, "Java exception in get Method");
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    if (outArray == nullptr || env->GetArrayLength(outArray) <= 0)
+    {
+        out_buffer.reduce_size(0);
+        return CHIP_NO_ERROR;
+    }
+
+    JniByteArray JniOutArray(env, outArray);
+    return CopySpanToMutableSpan(JniOutArray.byteSpan(), out_buffer);
+}
+
+CHIP_ERROR JNIDACProvider::GetCertificationDeclaration(MutableByteSpan & out_cd_buffer)
+{
+    ChipLogProgress(Zcl, "Received GetCertificationDeclaration");
+    return GetJavaByteByMethod(mGetCertificationDeclarationMethod, out_cd_buffer);
+}
+
+CHIP_ERROR JNIDACProvider::GetFirmwareInformation(MutableByteSpan & out_firmware_info_buffer)
+{
+    ChipLogProgress(Zcl, "Received GetFirmwareInformation");
+    return GetJavaByteByMethod(mGetFirmwareInformationMethod, out_firmware_info_buffer);
+}
+
+CHIP_ERROR JNIDACProvider::GetDeviceAttestationCert(MutableByteSpan & out_dac_buffer)
+{
+    ChipLogProgress(Zcl, "Received GetDeviceAttestationCert");
+    return GetJavaByteByMethod(mGetDeviceAttestationCertMethod, out_dac_buffer);
+}
+
+CHIP_ERROR JNIDACProvider::GetProductAttestationIntermediateCert(MutableByteSpan & out_pai_buffer)
+{
+    ChipLogProgress(Zcl, "Received GetProductAttestationIntermediateCert");
+    return GetJavaByteByMethod(mGetProductAttestationIntermediateCertMethod, out_pai_buffer);
+}
+
+// TODO: This should be moved to a method of P256Keypair
+CHIP_ERROR LoadKeypairFromRaw(ByteSpan private_key, ByteSpan public_key, Crypto::P256Keypair & keypair)
+{
+    Crypto::P256SerializedKeypair serialized_keypair;
+    ReturnErrorOnFailure(serialized_keypair.SetLength(private_key.size() + public_key.size()));
+    memcpy(serialized_keypair.Bytes(), public_key.data(), public_key.size());
+    memcpy(serialized_keypair.Bytes() + public_key.size(), private_key.data(), private_key.size());
+    return keypair.Deserialize(serialized_keypair);
+}
+
+CHIP_ERROR JNIDACProvider::SignWithDeviceAttestationKey(const ByteSpan & digest_to_sign, MutableByteSpan & out_signature_buffer)
+{
+    ChipLogProgress(Zcl, "Received SignWithDeviceAttestationKey");
+    Crypto::P256ECDSASignature signature;
+    Crypto::P256Keypair keypair;
+
+    VerifyOrReturnError(IsSpanUsable(out_signature_buffer), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(IsSpanUsable(digest_to_sign), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_signature_buffer.size() >= signature.Capacity(), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    uint8_t privateKeyBuf[Crypto::kP256_PrivateKey_Length];
+    MutableByteSpan privateKeyBufSpan(privateKeyBuf);
+    ReturnErrorOnFailure(GetJavaByteByMethod(mGetDeviceAttestationCertPrivateKeyMethod, privateKeyBufSpan));
+
+    uint8_t publicKeyBuf[Crypto::kP256_PublicKey_Length];
+    MutableByteSpan publicKeyBufSpan(publicKeyBuf);
+    ReturnErrorOnFailure(GetJavaByteByMethod(mGetDeviceAttestationCertPublicKeyKeyMethod, publicKeyBufSpan));
+
+    // In a non-exemplary implementation, the public key is not needed here. It is used here merely because
+    // Crypto::P256Keypair is only (currently) constructable from raw keys if both private/public keys are present.
+    ReturnErrorOnFailure(LoadKeypairFromRaw(privateKeyBufSpan, publicKeyBufSpan, keypair));
+    ReturnErrorOnFailure(keypair.ECDSA_sign_hash(digest_to_sign.data(), digest_to_sign.size(), signature));
+
+    return CopySpanToMutableSpan(ByteSpan{ signature.ConstBytes(), signature.Length() }, out_signature_buffer);
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/JNIDACProvider.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/JNIDACProvider.h
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include "lib/support/logging/CHIPLogging.h"
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <jni.h>
+
+class JNIDACProvider : public chip::Credentials::DeviceAttestationCredentialsProvider
+{
+public:
+    JNIDACProvider(jobject provider);
+    CHIP_ERROR GetCertificationDeclaration(chip::MutableByteSpan & out_cd_buffer) override;
+    CHIP_ERROR GetFirmwareInformation(chip::MutableByteSpan & out_firmware_info_buffer) override;
+    CHIP_ERROR GetDeviceAttestationCert(chip::MutableByteSpan & out_dac_buffer) override;
+    CHIP_ERROR GetProductAttestationIntermediateCert(chip::MutableByteSpan & out_pai_buffer) override;
+    CHIP_ERROR SignWithDeviceAttestationKey(const chip::ByteSpan & digest_to_sign,
+                                            chip::MutableByteSpan & out_signature_buffer) override;
+
+private:
+    CHIP_ERROR GetJavaByteByMethod(jmethodID method, chip::MutableByteSpan & out_buffer);
+    jobject mJNIDACProviderObject                          = nullptr;
+    jmethodID mGetCertificationDeclarationMethod           = nullptr;
+    jmethodID mGetFirmwareInformationMethod                = nullptr;
+    jmethodID mGetDeviceAttestationCertMethod              = nullptr;
+    jmethodID mGetProductAttestationIntermediateCertMethod = nullptr;
+    jmethodID mGetDeviceAttestationCertPrivateKeyMethod    = nullptr;
+    jmethodID mGetDeviceAttestationCertPublicKeyKeyMethod  = nullptr;
+};

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/activity_main.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/activity_main.xml
@@ -6,11 +6,9 @@
     android:layout_height="match_parent"
     tools:context="MainActivity">
 
-    <LinearLayout
-        android:id="@+id/castingCommissioners"
-        android:layout_width="409dp"
-        android:layout_height="729dp"
-        android:orientation="vertical"
-        tools:layout_editor_absoluteX="1dp"
-        tools:layout_editor_absoluteY="1dp"></LinearLayout>
+    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/main_fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_commissioner_discovery.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_commissioner_discovery.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".CommissionerDiscoveryFragment">
+
+    <LinearLayout
+        android:id="@+id/castingCommissioners"
+        android:layout_width="409dp"
+        android:layout_height="729dp"
+        android:orientation="vertical"
+        tools:layout_editor_absoluteX="1dp"
+        tools:layout_editor_absoluteY="1dp">
+
+        <Button
+            android:id="@+id/manualCommissioningButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Skip to manual commissioning >>" />
+    </LinearLayout>
+
+
+</FrameLayout>

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_commissioning.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_commissioning.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".CommissioningFragment">
+
+    <TextView
+        android:id="@+id/commissioningWindowStatus"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="24sp"/>
+
+    <TextView
+        android:id="@+id/onboardingPayload"
+        android:layout_below="@id/commissioningWindowStatus"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="24sp"/>
+
+</RelativeLayout>

--- a/examples/tv-casting-app/android/BUILD.gn
+++ b/examples/tv-casting-app/android/BUILD.gn
@@ -24,6 +24,8 @@ shared_library("jni") {
 
   sources = [
     "${chip_root}/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h",
+    "App/app/src/main/jni/cpp/JNIDACProvider.cpp",
+    "App/app/src/main/jni/cpp/JNIDACProvider.h",
     "App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp",
   ]
 
@@ -55,6 +57,8 @@ android_library("java") {
   ]
 
   sources = [
+    "App/app/src/main/jni/com/chip/casting/DACProvider.java",
+    "App/app/src/main/jni/com/chip/casting/DACProviderStub.java",
     "App/app/src/main/jni/com/chip/casting/TvCastingApp.java",
     "App/app/src/main/jni/com/chip/casting/TvCastingAppCallback.java",
   ]


### PR DESCRIPTION
#### Problem
* The android tv-casting-app does not support opening a commissioning window to get commissioned (See https://github.com/project-chip/connectedhomeip/issues/14557)
* All functionality was implemented in the MainActivity

#### Change overview
* Modularize the app's UI using fragments (added CommissionerDiscoveryFragment and CommissioningFragment)
* Initialize the Matter SDK and casting app through JNI
* Added UI controls (skip to manual commissioning button) and status views to open a commissioning window in order to get the app commissioned
* Also, includes DACProvider stub
* *TBD: In future PR, will refactor/break-down tv-casting-app/linux/main.cpp so it be used via this android app to do UDC that would precede opening this commissioning window and send TV Control commands*

#### Testing
How was this tested? (at least one bullet point required)
* Tested on a physical android phone and checked that the fragment transitions work, the JNI layer gets initialized and a commissioning window is successfully opened (when "Skip to manual commissioning button" is clicked)

| <img src="https://user-images.githubusercontent.com/31142146/164784201-98ff7469-dea2-4eb0-ad83-52077063dd68.jpg" width="281" height="500"> | <img src="https://user-images.githubusercontent.com/31142146/164784205-b5012558-4c05-4dce-b3fc-0addf02164f6.jpg" width="281" height="500"> |

