### PR TITLE
Configure dependabot for pigweed updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "third_party/pigweed/repo"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
#### Problem

We should ship up to date versions of all dependencies.

#### Change overview

Automate the gitmodules update via dependabot. Start with pigweed (if it
goes well, other repositories can follow).

#### Testing

Tested in a fork.