### PR TITLE
Remove bluez from third_party

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,11 +40,6 @@
 	url = https://github.com/openthread/ot-br-posix.git
 	branch  = main
 	platforms = linux
-[submodule "bluez"]
-	path = third_party/bluez/repo
-	url = https://github.com/bluez/bluez.git
-	branch  = master
-	platforms = linux
 [submodule "cirque"]
 	path = third_party/cirque/repo
 	url = https://github.com/openweave/cirque.git

--- a/docs/guides/python_chip_controller_advanced_usage.md
+++ b/docs/guides/python_chip_controller_advanced_usage.md
@@ -26,22 +26,24 @@ interfaces working as Bluetooth LE central and peripheral, respectively.
     sudo apt-get update
     sudo apt-get install libtool m4 automake autotools-dev libudev-dev libical-dev libreadline-dev
 
-    cd third_party/bluez/repo
+    git clone https://github.com/bluez/bluez.git
+
+    cd bluez
     ./bootstrap
-    third_party/bluez/repo/configure --prefix=/usr --mandir=/usr/share/man --sysconfdir=/etc --localstatedir=/var --enable-experimental --with-systemdsystemunitdir=/lib/systemd/system --with-systemduserunitdir=/usr/lib/systemd --enable-deprecated --enable-testing --enable-tools
+    ./configure --prefix=/usr --mandir=/usr/share/man --sysconfdir=/etc --localstatedir=/var --enable-experimental --with-systemdsystemunitdir=/lib/systemd/system --with-systemduserunitdir=/usr/lib/systemd --enable-deprecated --enable-testing --enable-tools
     make
     ```
 
 2. Run bluetoothd:
 
     ```
-    sudo third_party/bluez/repo/src/bluetoothd --experimental --debug &
+    sudo ./src/bluetoothd --experimental --debug &
     ```
 
 3. Bring up two virtual Bluetooth LE interfaces:
 
     ```
-    sudo third_party/bluez/repo/emulator/btvirt -L -l2
+    sudo ./emulator/btvirt -L -l2
     ```
 
     You can find the virtual interface by running `hciconfig` command:


### PR DESCRIPTION
#### Problem

This is not used in any builds or tests but is referenced from some
documentation. Dependencies only referenced from documentation
cannot be tested automatically (even for compilation).

#### Change overview

Point the documentation directly at the upstream repository and
remove the submodule.

#### Testing

CI.