### PR TITLE
Set up a network commissioning cluster in linux lock-app.

### DIFF
--- a/examples/lock-app/linux/main.cpp
+++ b/examples/lock-app/linux/main.cpp
@@ -24,39 +24,38 @@ using namespace chip;
 using namespace chip::app;
 
 namespace {
-#ifdef HAVE_NETWORK_COMMISSIONING_DRIVER
-#undef HAVE_NETWORK_COMMISSIONING_DRIVER
-#endif // HAVE_NETWORK_COMMISSIONING_DRIVER
-
 // We support either thread or wi-fi commissioning, not both.  Prefer thread if
 // both are available.
 #if CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_THREAD
-
-#define HAVE_NETWORK_COMMISSIONING_DRIVER 1
 DeviceLayer::NetworkCommissioning::LinuxThreadDriver sNetworkCommissioningDriver;
-
-#else // CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_THREAD
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-
-#define HAVE_NETWORK_COMMISSIONING_DRIVER 1
-DeviceLayer::NetworkCommissioning::LinuxWiFiDriver sNetworkCommissioningDriver;
-
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
-
-#endif // CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_THREAD
-
-#if HAVE_NETWORK_COMMISSIONING_DRIVER
 Clusters::NetworkCommissioning::Instance sNetworkCommissioningInstance(0, &sNetworkCommissioningDriver);
-#endif // HAVE_NETWORK_COMMISSIONING_DRIVER
+
+void InitNetworkCommissioning()
+{
+    sNetworkCommissioningInstance.Init();
+}
+
+#elif CHIP_DEVICE_CONFIG_ENABLE_WPA
+
+DeviceLayer::NetworkCommissioning::LinuxWiFiDriver sNetworkCommissioningDriver;
+Clusters::NetworkCommissioning::Instance sNetworkCommissioningInstance(0, &sNetworkCommissioningDriver);
+
+void InitNetworkCommissioning()
+{
+    sNetworkCommissioningInstance.Init();
+}
+
+#else // !CHIP_DEVICE_CONFIG_ENABLE_WPA && !(CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_THREAD)
+
+void InitNetworkCommissioning() {}
+
+#endif // (CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_THREAD) || CHIP_DEVICE_CONFIG_ENABLE_WPA
 
 } // anonymous namespace
 
 void ApplicationInit()
 {
-#if HAVE_NETWORK_COMMISSIONING_DRIVER
-    sNetworkCommissioningInstance.Init();
-#endif // HAVE_NETWORK_COMMISSIONING_DRIVER
+    InitNetworkCommissioning();
 }
 
 int main(int argc, char * argv[])

--- a/examples/lock-app/linux/main.cpp
+++ b/examples/lock-app/linux/main.cpp
@@ -17,8 +17,47 @@
  */
 
 #include "AppMain.h"
+#include <app/clusters/network-commissioning/network-commissioning.h>
+#include <platform/Linux/NetworkCommissioningDriver.h>
 
-void ApplicationInit() {}
+using namespace chip;
+using namespace chip::app;
+
+namespace {
+#ifdef HAVE_NETWORK_COMMISSIONING_DRIVER
+#undef HAVE_NETWORK_COMMISSIONING_DRIVER
+#endif // HAVE_NETWORK_COMMISSIONING_DRIVER
+
+// We support either thread or wi-fi commissioning, not both.  Prefer thread if
+// both are available.
+#if CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_THREAD
+
+#define HAVE_NETWORK_COMMISSIONING_DRIVER 1
+DeviceLayer::NetworkCommissioning::LinuxThreadDriver sNetworkCommissioningDriver;
+
+#else // CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_THREAD
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+
+#define HAVE_NETWORK_COMMISSIONING_DRIVER 1
+DeviceLayer::NetworkCommissioning::LinuxWiFiDriver sNetworkCommissioningDriver;
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
+
+#endif // CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_THREAD
+
+#if HAVE_NETWORK_COMMISSIONING_DRIVER
+Clusters::NetworkCommissioning::Instance sNetworkCommissioningInstance(0, &sNetworkCommissioningDriver);
+#endif // HAVE_NETWORK_COMMISSIONING_DRIVER
+
+} // anonymous namespace
+
+void ApplicationInit()
+{
+#if HAVE_NETWORK_COMMISSIONING_DRIVER
+    sNetworkCommissioningInstance.Init();
+#endif // HAVE_NETWORK_COMMISSIONING_DRIVER
+}
 
 int main(int argc, char * argv[])
 {


### PR DESCRIPTION
If we have thread or wifi, use them to set up a network commissioning
cluster.

#### Problem
Linux lock-app does not support any sort of commissioning other than onnetwork.

#### Change overview
Use Thread if compiled with that.  If not, use Wi-Fi if compiled with that.

#### Testing
Going to find someone who can test this on a Raspberry Pi.