### PR TITLE
Linux: add support for GetClock_RealTimeMS

### DIFF
--- a/src/platform/Linux/SystemTimeSupport.cpp
+++ b/src/platform/Linux/SystemTimeSupport.cpp
@@ -72,23 +72,13 @@ CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
 
 CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Clock::Milliseconds64 & aCurTime)
 {
-    struct timeval tv;
-    if (gettimeofday(&tv, nullptr) != 0)
+    Clock::Microseconds64 curTimeUs;
+    CHIP_ERROR err = GetClock_RealTime(curTimeUs);
+    if (err == CHIP_NO_ERROR)
     {
-        return CHIP_ERROR_POSIX(errno);
+        aCurTime = std::chrono::duration_cast<Clock::Milliseconds64>(curTimeUs);
     }
-    if (tv.tv_sec < CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD)
-    {
-        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
-    }
-    if (tv.tv_usec < 0)
-    {
-        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
-    }
-    static_assert(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD >= 0, "We might be letting through negative tv_sec values!");
-    aCurTime =
-        Clock::Milliseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000)) + (static_cast<uint64_t>(tv.tv_usec) / 1000));
-    return CHIP_NO_ERROR;
+    return err;
 }
 
 CHIP_ERROR ClockImpl::SetClock_RealTime(Clock::Microseconds64 aNewCurTime)

--- a/src/platform/Linux/SystemTimeSupport.cpp
+++ b/src/platform/Linux/SystemTimeSupport.cpp
@@ -52,17 +52,64 @@ Milliseconds64 ClockImpl::GetMonotonicMilliseconds64()
 
 CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    struct timeval tv;
+    if (gettimeofday(&tv, nullptr) != 0)
+    {
+        return CHIP_ERROR_POSIX(errno);
+    }
+    if (tv.tv_sec < CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD)
+    {
+        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
+    }
+    if (tv.tv_usec < 0)
+    {
+        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
+    }
+    static_assert(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD >= 0, "We might be letting through negative tv_sec values!");
+    aCurTime = Clock::Microseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000000)) + static_cast<uint64_t>(tv.tv_usec));
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Clock::Milliseconds64 & aCurTime)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    struct timeval tv;
+    if (gettimeofday(&tv, nullptr) != 0)
+    {
+        return CHIP_ERROR_POSIX(errno);
+    }
+    if (tv.tv_sec < CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD)
+    {
+        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
+    }
+    if (tv.tv_usec < 0)
+    {
+        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
+    }
+    static_assert(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD >= 0, "We might be letting through negative tv_sec values!");
+    aCurTime =
+        Clock::Milliseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000)) + (static_cast<uint64_t>(tv.tv_usec) / 1000));
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ClockImpl::SetClock_RealTime(Clock::Microseconds64 aNewCurTime)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    struct timeval tv;
+    tv.tv_sec  = static_cast<time_t>(aNewCurTime.count() / UINT64_C(1000000));
+    tv.tv_usec = static_cast<long>(aNewCurTime.count() % UINT64_C(1000000));
+    if (settimeofday(&tv, nullptr) != 0)
+    {
+        return (errno == EPERM) ? CHIP_ERROR_ACCESS_DENIED : CHIP_ERROR_POSIX(errno);
+    }
+#if CHIP_PROGRESS_LOGGING
+    {
+        const time_t timep = tv.tv_sec;
+        struct tm calendar;
+        localtime_r(&timep, &calendar);
+        ChipLogProgress(DeviceLayer, "Real time clock set to %ld (%04d/%02d/%02d %02d:%02d:%02d UTC)", tv.tv_sec, calendar.tm_year,
+                        calendar.tm_mon, calendar.tm_mday, calendar.tm_hour, calendar.tm_min, calendar.tm_sec);
+    }
+#endif // CHIP_PROGRESS_LOGGING
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Clock


### PR DESCRIPTION
#### Problem
Linux does not implement GetClock_RealTimeMS and GetClock_RealTime. This leads to various modules not functioning as they are meant to and the runtime warning "The device does not support GetClock_RealTimeMS() API. This will eventually result in CASE session setup failures."

#### Change overview
Add support for GetClock_RealTimeMS and the rest of unimplemented system time functions.
Fixes #17615 

#### Testing
* tested manually on Raspberry Pi using chip-tool pairing commands. Pairings are successful and the warnings are gone.
* does not affect non-Linux platforms