### PR TITLE
[modeselect] Fix ChangeToMode error code

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
@@ -62,7 +62,7 @@ EmberAfStatus StaticSupportedModesManager::getModeOptionByMode(unsigned short en
         }
     }
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "Cannot find the mode %u", mode);
-    return EMBER_ZCL_STATUS_INVALID_VALUE;
+    return EMBER_ZCL_STATUS_INVALID_COMMAND;
 }
 
 const ModeSelect::SupportedModesManager * ModeSelect::getSupportedModesManager()

--- a/examples/placeholder/linux/static-supported-modes-manager.cpp
+++ b/examples/placeholder/linux/static-supported-modes-manager.cpp
@@ -62,7 +62,7 @@ EmberAfStatus StaticSupportedModesManager::getModeOptionByMode(unsigned short en
         }
     }
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "Cannot find the mode %u", mode);
-    return EMBER_ZCL_STATUS_INVALID_VALUE;
+    return EMBER_ZCL_STATUS_INVALID_COMMAND;
 }
 
 const ModeSelect::SupportedModesManager * ModeSelect::getSupportedModesManager()

--- a/src/app/tests/suites/TestModeSelectCluster.yaml
+++ b/src/app/tests/suites/TestModeSelectCluster.yaml
@@ -96,7 +96,7 @@ tests:
               - name: "NewMode"
                 value: 2
       response:
-          error: CONSTRAINT_ERROR
+          error: INVALID_COMMAND
 
     - label: "Toggle OnOff"
       cluster: "On/Off"
@@ -118,7 +118,7 @@ tests:
       arguments:
           value: 2
       response:
-          error: CONSTRAINT_ERROR
+          error: INVALID_COMMAND
 
     - label: "Change OnMode"
       command: "writeAttribute"
@@ -153,7 +153,7 @@ tests:
       arguments:
           value: 2
       response:
-          error: CONSTRAINT_ERROR
+          error: INVALID_COMMAND
 
     - label: "Change to Supported StartUp Mode"
       command: "writeAttribute"


### PR DESCRIPTION
#### Problem
`ChangeToMode` run with an unsupported mode returns CONSTRAINT_ERROR instead of INVALID_COMMAND (as defined
in the spec).

#### Change overview
Return the correct error code.
Fixes #17493

#### Testing
Tested using nRF Connect all-clusters-app.
