### PR TITLE
[YAML] Fix some discovery tests thare are using notValue improperly and add a codegen check to make sure it does not happens again 

### DIFF
--- a/src/app/tests/suites/TestDiscovery.yaml
+++ b/src/app/tests/suites/TestDiscovery.yaml
@@ -269,7 +269,8 @@ tests:
       response:
           values:
               - name: "pairingHint"
-                notValue: 0
+                constraints:
+                    notValue: 0
 
     - label: "Optional TXT key for pairing instructions (PI)"
       PICS: PI_KEY

--- a/src/app/tests/suites/certification/Test_TC_SC_4_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_4_2.yaml
@@ -233,7 +233,8 @@ tests:
       response:
           values:
               - name: "pairingHint"
-                notValue: 0
+                constraints:
+                    notValue: 0
 
     - label: "Optional TXT key for pairing instructions (PI)"
       PICS: PI_KEY
@@ -457,7 +458,8 @@ tests:
       response:
           values:
               - name: "pairingHint"
-                notValue: 0
+                constraints:
+                    notValue: 0
 
     - label: "Optional TXT key for pairing instructions (PI)"
       disabled: true

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -249,6 +249,19 @@ function setDefaultResponse(test)
   const defaultResponseValues = [];
   setDefault(test[kResponseName], kValuesName, defaultResponseValues);
 
+  // Ensure only valid keywords are used for response values.
+  const values = test[kResponseName][kValuesName];
+  for (let i = 0; i < values.length; i++) {
+    for (let key in values[i]) {
+      if (key == "name" || key == "value" || key == kConstraintsName || key == kSaveAsName) {
+        continue;
+      }
+
+      const errorStr = `Unknown key "${key}"`;
+      throwError(test, errorStr);
+    }
+  }
+
   const defaultResponseConstraints = {};
   setDefault(test[kResponseName], kConstraintsName, defaultResponseConstraints);
 


### PR DESCRIPTION
#### Problem

Some discovery tests does not use `notValue` at the right place. It needs to be under a `constraints` section.

#### Change overview
 * Add the missing section
 * Add a check in the JS parser to make sure it does not happens again
 * Update generated code
