### PR TITLE
fix: IM server initialization without parameters

### DIFF
--- a/examples/chef/esp32/main/main.cpp
+++ b/examples/chef/esp32/main/main.cpp
@@ -161,9 +161,7 @@ void printQRCode()
 void InitServer(intptr_t)
 {
     // Start IM server
-    static chip::CommonCaseDeviceServerInitParams initParams;
-    (void) initParams.InitializeStaticResourcesBeforeServerInit();
-    chip::Server::GetInstance().Init(initParams);
+    chip::Server::GetInstance().Init();
 
     // Device Attestation & Onboarding codes
     chip::Credentials::SetDeviceAttestationCredentialsProvider(chip::Credentials::Examples::GetExampleDACProvider());


### PR DESCRIPTION

#### Problem
ESP32 build broken during backport to interop_testing_2022_01_01

#### Change overview
IM server is now initialized w/o parameters

#### Testing
Tested on local macOS build `./chef.py -bz -d lighting-app -t esp32 -p 0x8000`