### PR TITLE
[EFR32 light-app] Use the stored on off attribute state to initialize led state

### DIFF
--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -279,8 +279,6 @@ CHIP_ERROR AppTask::Init()
     sLightLED.Init(LIGHT_LED);
     sLightLED.Set(LightMgr().IsLightOn());
 
-    chip::DeviceLayer::PlatformMgr().ScheduleWork(UpdateClusterState, reinterpret_cast<intptr_t>(nullptr));
-
     ConfigurationMgr().LogDeviceConfig();
 
 // Print setup info on LCD if available

--- a/examples/lighting-app/efr32/src/LightingManager.cpp
+++ b/examples/lighting-app/efr32/src/LightingManager.cpp
@@ -23,6 +23,11 @@
 #include "AppTask.h"
 #include <FreeRTOS.h>
 
+#include <app/clusters/on-off-server/on-off-server.h>
+
+using namespace chip;
+using namespace ::chip::DeviceLayer;
+
 LightingManager LightingManager::sLight;
 
 TimerHandle_t sLightTimer;
@@ -43,7 +48,13 @@ CHIP_ERROR LightingManager::Init()
         return APP_ERROR_CREATE_TIMER_FAILED;
     }
 
-    mState                 = kState_OffCompleted;
+    bool currentLedState;
+    // read current on/off value on endpoint one.
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
+    OnOffServer::Instance().getOnOffValue(1, &currentLedState);
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+
+    mState                 = currentLedState ? kState_OnCompleted : kState_OffCompleted;
     mAutoTurnOffTimerArmed = false;
     mAutoTurnOff           = false;
     mAutoTurnOffDuration   = 0;

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -86,6 +86,20 @@ bool OnOffServer::HasFeature(chip::EndpointId endpoint, OnOffFeature feature)
     return success ? ((featureMap & to_underlying(feature)) != 0) : false;
 }
 
+EmberAfStatus OnOffServer::getOnOffValue(chip::EndpointId endpoint, bool * currentOnOffValue)
+{
+    // read current on/off value
+    EmberAfStatus status = Attributes::OnOff::Get(endpoint, currentOnOffValue);
+    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    {
+        emberAfOnOffClusterPrintln("ERR: reading on/off %x", status);
+    }
+
+    emberAfOnOffClusterPrintln("On/Off ep%d value: %d", endpoint, *currentOnOffValue);
+
+    return status;
+}
+
 /** @brief On/off Cluster Set Value
  *
  * This function is called when the on/off value needs to be set, either through

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -58,6 +58,7 @@ public:
     bool OnWithTimedOffCommand(const chip::app::ConcreteCommandPath & commandPath,
                                const chip::app::Clusters::OnOff::Commands::OnWithTimedOff::DecodableType & commandData);
     void updateOnOffTimeCommand(chip::EndpointId endpoint);
+    EmberAfStatus getOnOffValue(chip::EndpointId endpoint, bool * currentOnOffValue);
     EmberAfStatus setOnOffValue(chip::EndpointId endpoint, uint8_t command, bool initiatedByLevelChange);
     EmberAfStatus getOnOffValueForStartUp(chip::EndpointId endpoint, bool & onOffValueForStartUp);
 


### PR DESCRIPTION
#### Problem
At Lighting-app's init, the led and linked on-off attribute is force initialized off

#### Change overview
The on-off attribute value is stored in nvm for a little while now for the lighting app. 
Use this stored value to initialize the lighting manager/led state. 

#### Testing
Tested on EFR32 platform.
- Toggle led with Chip-tool command or push-button. 
- Reboot board. 
- Confirm led state matches the state before the reboot. 