### PR TITLE
Fix raspi startup of tv-casting-app

### DIFF
--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -679,15 +679,18 @@ LinuxCommissionableDataProvider gCommissionableDataProvider;
 int main(int argc, char * argv[])
 {
 #if defined(ENABLE_CHIP_SHELL)
-    Engine::Root().Init();
     std::thread shellThread([]() { Engine::Root().RunMainLoop(); });
-    Shell::RegisterCastingCommands();
 #endif
 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     SuccessOrExit(err = chip::Platform::MemoryInit());
     SuccessOrExit(err = chip::DeviceLayer::PlatformMgr().InitChipStack());
+
+#if defined(ENABLE_CHIP_SHELL)
+    Engine::Root().Init();
+    Shell::RegisterCastingCommands();
+#endif
 
     // Init the commissionable data provider based on command line options
     // to handle custom verifiers, discriminators, etc.

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -678,19 +678,15 @@ LinuxCommissionableDataProvider gCommissionableDataProvider;
 
 int main(int argc, char * argv[])
 {
-#if defined(ENABLE_CHIP_SHELL)
-    std::thread shellThread([]() { Engine::Root().RunMainLoop(); });
-#endif
-
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    SuccessOrExit(err = chip::Platform::MemoryInit());
-    SuccessOrExit(err = chip::DeviceLayer::PlatformMgr().InitChipStack());
+    VerifyOrDie(CHIP_NO_ERROR == chip::Platform::MemoryInit());
+    VerifyOrDie(CHIP_NO_ERROR == chip::DeviceLayer::PlatformMgr().InitChipStack());
 
 #if defined(ENABLE_CHIP_SHELL)
     Engine::Root().Init();
+    std::thread shellThread([]() { Engine::Root().RunMainLoop(); });
     Shell::RegisterCastingCommands();
 #endif
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Init the commissionable data provider based on command line options
     // to handle custom verifiers, discriminators, etc.


### PR DESCRIPTION
#### Problem
* tv-casting-app start crashes on raspi

#### Change overview
Make sure to call Platform::MemoryInit() before any alloc

#### Testing
* Fix verified by Chaitanya on raspi
