### PR TITLE
Allow size optimization in "debug" builds

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -174,10 +174,15 @@ config("optimize_zero") {
   ldflags = cflags
 }
 
+config("optimize_debug") {
+  cflags = [ "-O${optimize_debug_level}" ]
+  ldflags = cflags
+}
+
 config("optimize_default") {
   if (is_debug) {
     if (optimize_debug) {
-      configs = [ "$dir_pw_build:optimize_debugging" ]
+      configs = [ ":optimize_debug" ]
     } else {
       configs = [ ":optimize_zero" ]
     }

--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -23,6 +23,9 @@ declare_args() {
   optimize_debug =
       current_os == "freertos" || current_os == "zephyr" || current_os == "mbed"
 
+  # Optimization level for debug. Only has an effect if optimize_debug is true.
+  optimize_debug_level = "g"
+
   # Symbol level for debugging.
   symbol_level = 2
 

--- a/config/qpg/chip-gn/args.gni
+++ b/config/qpg/chip-gn/args.gni
@@ -18,7 +18,9 @@ qpg_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_device_platform = "qpg"
 
-is_debug = false
+optimize_debug_level = "s"
+lwip_debug = false
+
 chip_enable_openthread = true
 chip_config_network_layer_ble = true
 chip_inet_config_enable_ipv4 = false

--- a/examples/all-clusters-app/cc13x2x7_26x2x7/args.gni
+++ b/examples/all-clusters-app/cc13x2x7_26x2x7/args.gni
@@ -23,7 +23,8 @@ ti_simplelink_board = "LP_CC2652R7"
 
 # Size Optimizations
 # use -Os instead of -Og, LWIP release build
-is_debug = false
+optimize_debug_level = "s"
+lwip_debug = false
 
 #optimize_for_size=true
 chip_enable_ota_requestor = true
@@ -32,7 +33,7 @@ chip_enable_ota_requestor = true
 chip_openthread_ftd = false
 
 # Disable CHIP Logging
-#chip_progress_logging = false
+chip_progress_logging = false
 
 # Dsiable verbose logs for all-clusters app to save Flash
 chip_detail_logging = false

--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -54,10 +54,9 @@ namespace {
 TaskHandle_t sAppTaskHandle;
 QueueHandle_t sAppEventQueue;
 
-bool sIsThreadProvisioned     = false;
-bool sIsThreadEnabled         = false;
-bool sHaveBLEConnections      = false;
-bool sHaveServiceConnectivity = false;
+bool sIsThreadProvisioned = false;
+bool sIsThreadEnabled     = false;
+bool sHaveBLEConnections  = false;
 
 uint8_t sAppEventQueueBuffer[APP_EVENT_QUEUE_SIZE * sizeof(AppEvent)];
 

--- a/examples/lock-app/cc13x2x7_26x2x7/args.gni
+++ b/examples/lock-app/cc13x2x7_26x2x7/args.gni
@@ -23,7 +23,8 @@ ti_simplelink_board = "LP_CC2652R7"
 
 # Size Optimizations
 # use -Os instead of -Og, LWIP release build
-is_debug = false
+optimize_debug_level = "s"
+lwip_debug = false
 
 chip_enable_ota_requestor = true
 

--- a/examples/persistent-storage/cc13x2x7_26x2x7/args.gni
+++ b/examples/persistent-storage/cc13x2x7_26x2x7/args.gni
@@ -22,7 +22,8 @@ ti_simplelink_sysconfig_target =
 ti_simplelink_board = "LP_CC2652R7"
 
 # use -Os instead of -Og
-#is_debug = false
+#optimize_debug_level = "s"
+#lwip_debug = false
 
 # BLE options
 chip_config_network_layer_ble = true

--- a/examples/persistent-storage/qpg/args.gni
+++ b/examples/persistent-storage/qpg/args.gni
@@ -21,6 +21,8 @@ chip_openthread_ftd = false
 chip_system_config_use_open_thread_inet_endpoints = false
 chip_with_lwip = true
 
+lwip_debug = false
+
 declare_args() {
   # Disable lock tracking, since our FreeRTOS configuration does not set
   # INCLUDE_xSemaphoreGetMutexHolder

--- a/examples/persistent-storage/qpg/main.cpp
+++ b/examples/persistent-storage/qpg/main.cpp
@@ -34,8 +34,6 @@
 
 #define LOG_MODULE_ID 1
 
-static TaskHandle_t sTestTaskHandle;
-
 StackType_t appStack[APP_TASK_STACK_SIZE / sizeof(StackType_t)];
 StaticTask_t appTaskStruct;
 

--- a/examples/pump-app/cc13x2x7_26x2x7/args.gni
+++ b/examples/pump-app/cc13x2x7_26x2x7/args.gni
@@ -23,7 +23,8 @@ ti_simplelink_board = "LP_CC2652R7"
 
 # Size Optimizations
 # use -Os instead of -Og, LWIP release build
-is_debug = false
+optimize_debug_level = "s"
+lwip_debug = false
 
 chip_enable_ota_requestor = true
 

--- a/examples/pump-controller-app/cc13x2x7_26x2x7/args.gni
+++ b/examples/pump-controller-app/cc13x2x7_26x2x7/args.gni
@@ -23,7 +23,8 @@ ti_simplelink_board = "LP_CC2652R7"
 
 # Size Optimizations
 # use -Os instead of -Og, LWIP release build
-is_debug = false
+optimize_debug_level = "s"
+lwip_debug = false
 
 chip_enable_ota_requestor = true
 

--- a/src/lwip/BUILD.gn
+++ b/src/lwip/BUILD.gn
@@ -65,7 +65,7 @@ buildconfig_header("lwip_buildconfig") {
 
   defines = [ "HAVE_LWIP_UDP_BIND_NETIF=1" ]
   if (lwip_platform != "external") {
-    if (is_debug) {
+    if (lwip_debug) {
       # Automatically enable LWIP_DEBUG for internal is_debug builds.
       defines += [ "LWIP_DEBUG=1" ]
     }

--- a/src/platform/CYW30739/args.gni
+++ b/src/platform/CYW30739/args.gni
@@ -44,7 +44,8 @@ chip_system_config_locking = "none"
 chip_system_config_use_lwip = true
 chip_system_config_use_sockets = false
 
-is_debug = false
+optimize_debug_level = "s"
+lwip_debug = false
 default_configs_optimize = [ "$dir_pw_build:optimize_size" ]
 
 chip_build_tests = false

--- a/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
@@ -67,7 +67,6 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     // Initialize the generic implementation base class.
     err = Internal::GenericConfigurationManagerImpl<CC13X2_26X2Config>::Init();
 
-exit:
     return err;
 }
 

--- a/src/platform/cc13x2_26x2/OTAImageProcessorImpl.cpp
+++ b/src/platform/cc13x2_26x2/OTAImageProcessorImpl.cpp
@@ -99,20 +99,6 @@ static bool readExtFlashImgHeader(NVS_Handle handle, imgFixedHdr_t * header)
     return (status == NVS_STATUS_SUCCESS);
 }
 
-static bool eraseExtFlashHeader(NVS_Handle handle)
-{
-    int_fast16_t status;
-    NVS_Attrs regionAttrs;
-    unsigned int sectors;
-
-    NVS_getAttrs(handle, &regionAttrs);
-    /* calculate the number of sectors to erase */
-    sectors = (sizeof(imgFixedHdr_t) + (regionAttrs.sectorSize - 1)) / regionAttrs.sectorSize;
-    status  = NVS_erase(handle, IMG_START, sectors * regionAttrs.sectorSize);
-
-    return (status == NVS_STATUS_SUCCESS);
-}
-
 /* makes room for the new block if needed */
 static bool writeExtFlashImgPages(NVS_Handle handle, size_t bytesWritten, MutableByteSpan block)
 {

--- a/src/platform/qpg/args.gni
+++ b/src/platform/qpg/args.gni
@@ -35,7 +35,8 @@ chip_detail_logging = false
 chip_automation_logging = false
 
 # Use -Os
-is_debug = false
+optimize_debug_level = "s"
+lwip_debug = false
 
 chip_build_tests = false
 


### PR DESCRIPTION
#### Problem

Some platforms have forced release builds because otherwise they don't
fit in flash. Currently assertions and optimization level are coupled
into a single is_debug argument.

#### Change overview

Decouple these in the hope that it enables at least some of these
platforms to develop with debug asserts enabled.

Remove some dead code as builds debug enable -Wunused.

#### Testing

build_examples for the affected platforms + CI
