### PR TITLE
Remove duplicate declarations of build variables

### DIFF
--- a/config/tizen/chip-gn/args.gni
+++ b/config/tizen/chip-gn/args.gni
@@ -14,11 +14,6 @@
 
 import("//build_overrides/chip.gni")
 
-declare_args() {
-  # Location of the Tizen SDK.
-  tizen_sdk_root = ""
-}
-
 chip_device_platform = "tizen"
 
 chip_build_tests = false

--- a/examples/light-switch-app/efr32/args.gni
+++ b/examples/light-switch-app/efr32/args.gni
@@ -18,9 +18,7 @@ import("${chip_root}/src/platform/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
-declare_args() {
-  chip_enable_ota_requestor = true
-}
+chip_enable_ota_requestor = true
 
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"

--- a/examples/lighting-app/bouffalolab/bl602/args.gni
+++ b/examples/lighting-app/bouffalolab/bl602/args.gni
@@ -21,8 +21,7 @@ pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"
 
 chip_enable_openthread = false
-declare_args() {
-  # Disable lock tracking, since our FreeRTOS configuration does not set
-  # INCLUDE_xSemaphoreGetMutexHolder
-  chip_stack_lock_tracking = "none"
-}
+
+# Disable lock tracking, since our FreeRTOS configuration does not set
+# INCLUDE_xSemaphoreGetMutexHolder
+chip_stack_lock_tracking = "none"

--- a/examples/lighting-app/efr32/args.gni
+++ b/examples/lighting-app/efr32/args.gni
@@ -18,9 +18,7 @@ import("${chip_root}/src/platform/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
-declare_args() {
-  chip_enable_ota_requestor = true
-}
+chip_enable_ota_requestor = true
 
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"

--- a/examples/lighting-app/nxp/k32w/k32w0/args.gni
+++ b/examples/lighting-app/nxp/k32w/k32w0/args.gni
@@ -18,8 +18,6 @@ import("${chip_root}/examples/platform/nxp/k32w/k32w0/args.gni")
 # SDK target. This is overridden to add our SDK app_config.h & defines.
 k32w0_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
-declare_args() {
-  chip_enable_ota_requestor = true
-  chip_stack_lock_tracking = "fatal"
-  chip_enable_ble = true
-}
+chip_enable_ota_requestor = true
+chip_stack_lock_tracking = "fatal"
+chip_enable_ble = true

--- a/examples/lighting-app/qpg/args.gni
+++ b/examples/lighting-app/qpg/args.gni
@@ -18,14 +18,12 @@ import("${chip_root}/examples/platform/qpg/args.gni")
 
 qpg_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
-declare_args() {
-  chip_enable_ota_requestor = true
-  chip_openthread_ftd = true
+chip_enable_ota_requestor = true
+chip_openthread_ftd = true
 
-  # Disable lock tracking, since our FreeRTOS configuration does not set
-  # INCLUDE_xSemaphoreGetMutexHolder
-  chip_stack_lock_tracking = "none"
-}
+# Disable lock tracking, since our FreeRTOS configuration does not set
+# INCLUDE_xSemaphoreGetMutexHolder
+chip_stack_lock_tracking = "none"
 
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"

--- a/examples/lock-app/efr32/args.gni
+++ b/examples/lock-app/efr32/args.gni
@@ -18,9 +18,7 @@ import("${chip_root}/src/platform/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
-declare_args() {
-  chip_enable_ota_requestor = true
-}
+chip_enable_ota_requestor = true
 
 chip_enable_openthread = true
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"

--- a/examples/lock-app/nxp/k32w/k32w0/args.gni
+++ b/examples/lock-app/nxp/k32w/k32w0/args.gni
@@ -18,7 +18,5 @@ import("${chip_root}/examples/platform/nxp/k32w/k32w0/args.gni")
 # SDK target. This is overridden to add our SDK app_config.h & defines.
 k32w0_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
-declare_args() {
-  chip_stack_lock_tracking = "fatal"
-  chip_enable_ble = true
-}
+chip_stack_lock_tracking = "fatal"
+chip_enable_ble = true

--- a/examples/lock-app/qpg/args.gni
+++ b/examples/lock-app/qpg/args.gni
@@ -18,14 +18,12 @@ import("${chip_root}/examples/platform/qpg/args.gni")
 
 qpg_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
-declare_args() {
-  chip_enable_ota_requestor = true
-  chip_openthread_ftd = false
+chip_enable_ota_requestor = true
+chip_openthread_ftd = false
 
-  # Disable lock tracking, since our FreeRTOS configuration does not set
-  # INCLUDE_xSemaphoreGetMutexHolder
-  chip_stack_lock_tracking = "none"
-}
+# Disable lock tracking, since our FreeRTOS configuration does not set
+# INCLUDE_xSemaphoreGetMutexHolder
+chip_stack_lock_tracking = "none"
 
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"

--- a/examples/ota-requestor-app/cyw30739/args.gni
+++ b/examples/ota-requestor-app/cyw30739/args.gni
@@ -23,6 +23,4 @@ chip_openthread_ftd = true
 chip_progress_logging = false
 chip_error_logging = false
 
-declare_args() {
-  chip_enable_ota_requestor = true
-}
+chip_enable_ota_requestor = true

--- a/examples/ota-requestor-app/efr32/args.gni
+++ b/examples/ota-requestor-app/efr32/args.gni
@@ -27,6 +27,4 @@ chip_openthread_ftd = false
 # Example will not be maintained in the long term and will be depraceted now that OTA is beeing intagrated into our examples
 chip_stack_lock_tracking = "None"
 
-declare_args() {
-  chip_enable_ota_requestor = true
-}
+chip_enable_ota_requestor = true

--- a/examples/ota-requestor-app/linux/args.gni
+++ b/examples/ota-requestor-app/linux/args.gni
@@ -24,6 +24,4 @@ chip_project_config_include_dirs =
     [ "${chip_root}/examples/ota-requestor-app/linux/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 
-declare_args() {
-  chip_enable_ota_requestor = true
-}
+chip_enable_ota_requestor = true

--- a/examples/ota-requestor-app/p6/args.gni
+++ b/examples/ota-requestor-app/p6/args.gni
@@ -16,9 +16,7 @@ import("//build_overrides/chip.gni")
 import("//build_overrides/pigweed.gni")
 import("${chip_root}/src/platform/P6/args.gni")
 
-declare_args() {
-  chip_enable_ota_requestor = true
-}
+chip_enable_ota_requestor = true
 
 p6_target_project =
     get_label_info(":ota_requestor_app_sdk_sources", "label_no_toolchain")

--- a/examples/persistent-storage/qpg/args.gni
+++ b/examples/persistent-storage/qpg/args.gni
@@ -23,8 +23,6 @@ chip_with_lwip = true
 
 lwip_debug = false
 
-declare_args() {
-  # Disable lock tracking, since our FreeRTOS configuration does not set
-  # INCLUDE_xSemaphoreGetMutexHolder
-  chip_stack_lock_tracking = "none"
-}
+# Disable lock tracking, since our FreeRTOS configuration does not set
+# INCLUDE_xSemaphoreGetMutexHolder
+chip_stack_lock_tracking = "none"

--- a/examples/shell/nxp/k32w/k32w0/args.gni
+++ b/examples/shell/nxp/k32w/k32w0/args.gni
@@ -19,6 +19,4 @@ import("${chip_root}/src/platform/nxp/k32w/k32w0/args.gni")
 
 k32w0_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
-declare_args() {
-  chip_enable_ble = true
-}
+chip_enable_ble = true

--- a/examples/window-app/efr32/args.gni
+++ b/examples/window-app/efr32/args.gni
@@ -18,10 +18,8 @@ import("${chip_root}/src/platform/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
-declare_args() {
-  # TODO fix me
-  chip_enable_ota_requestor = false
-}
+# TODO fix me
+chip_enable_ota_requestor = false
 
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"


### PR DESCRIPTION
#### Problem

Each argument should be declared in exactly one build file. The args.gni
files are for setting arguments, not declaring them. 

Using declare_args() in these files doesn't do anything except for
suppress "unused argument" diagnostics, which isn't desirable (those
diagnostics are already opt-in).

#### Change overview
 
Remove errant declare_args() from args.gni files.

#### Testing

CI