### PR TITLE
Fix nrfconnect compilation errors

### DIFF
--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -357,7 +357,7 @@ true''')
             queueCommand(f"cd {paths['rootSampleFolder']}/nrfconnect")
             if options.doClean:
                 # queueCommand(f"rm -rf {paths['rootSampleFolder']}/nrfconnect/build")
-                queueCommand(f"west build -b nrf52840dk_nrf52840 -c")
+                queueCommand(f"west build -b nrf52840dk_nrf52840 -p always")
             else:
                 queueCommand(f"west build -b nrf52840dk_nrf52840")
         elif options.buildTarget == "linux":

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -357,7 +357,7 @@ true''')
             queueCommand(f"cd {paths['rootSampleFolder']}/nrfconnect")
             if options.doClean:
                 # queueCommand(f"rm -rf {paths['rootSampleFolder']}/nrfconnect/build")
-                queueCommand(f"west build -b nrf52840dk_nrf52840")
+                queueCommand(f"west build -b nrf52840dk_nrf52840 -c")
             else:
                 queueCommand(f"west build -b nrf52840dk_nrf52840")
         elif options.buildTarget == "linux":
@@ -403,7 +403,7 @@ true''')
         elif options.buildTarget == "nrfconnect":
             queueCommand(f"cd {paths['rootSampleFolder']}/nrfconnect")
             if options.doErase:
-                queueCommand("rm -rf build")
+                queueCommand("west flash --erase")
             else:
                 queueCommand("west flash")
 

--- a/examples/chef/nrfconnect/CMakeLists.txt
+++ b/examples/chef/nrfconnect/CMakeLists.txt
@@ -25,7 +25,7 @@ include(${CHEF}/project_include.cmake)
 
 get_filename_component(GEN_DIR ${CHEF}/out/${SAMPLE_NAME}/zap-generated REALPATH)
 
-set(CONF_FILE prj.conf)
+set(CONF_FILE ${CHIP_ROOT}/config/nrfconnect/app/sample-defaults.conf prj.conf)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CHIP_CFLAGS "${CHIP_CFLAGS} -DCHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID=${CONFIG_DEVICE_PRODUCT_ID}")

--- a/examples/chef/nrfconnect/Kconfig
+++ b/examples/chef/nrfconnect/Kconfig
@@ -15,6 +15,7 @@
 #
 mainmenu "Matter nRF Connect Chef Example Application"
 
-rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
-rsource "../../../config/nrfconnect/chip-module/Kconfig.features"
+#rsource "../../../config/nrfconnect/chip-module/Kconfig.defaults"
+#rsource "../../../config/nrfconnect/chip-module/Kconfig.features"
+rsource "../../../config/nrfconnect/chip-module/Kconfig"
 source "Kconfig.zephyr"

--- a/examples/chef/nrfconnect/main.cpp
+++ b/examples/chef/nrfconnect/main.cpp
@@ -87,9 +87,7 @@ CHIP_ERROR main()
     chip::app::DnssdServer::Instance().SetExtendedDiscoveryTimeoutSecs(kExtDiscoveryTimeoutSecs);
 
     // Start IM server
-    static chip::CommonCaseDeviceServerInitParams initParams;
-    (void) initParams.InitializeStaticResourcesBeforeServerInit();
-    ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
+    ReturnErrorOnFailure(chip::Server::GetInstance().Init());
 
     chip::DeviceLayer::ConfigurationMgr().LogDeviceConfig();
 

--- a/examples/chef/nrfconnect/prj.conf
+++ b/examples/chef/nrfconnect/prj.conf
@@ -46,9 +46,6 @@ CONFIG_RESET_ON_FATAL_ERROR=n
 # Disable Matter OTA DFU
 CONFIG_CHIP_OTA_REQUESTOR=n
 
-# Disable QSPI NOR
-CONFIG_CHIP_QSPI_NOR=n
-
 # CHIP configuration
 CONFIG_CHIP_PROJECT_CONFIG="CHIPProjectConfig.h"
 # 32773 == 0x8005 (example lighting-app)


### PR DESCRIPTION
Problem
Nrfconnect build broken during backport to interop_testing_2022_01_01

Change overview
- IM server is now initialized w/o parameters
- Changes in KConfig
- Corrected the command to flash and erase

Testing
Tested on local gLinux build ./chef.py -bz -d lighting-app -t nrfconnect