### PR TITLE
Fix build on NRFConnect.

### DIFF
--- a/src/lib/dnssd/Advertiser_ImplNone.cpp
+++ b/src/lib/dnssd/Advertiser_ImplNone.cpp
@@ -58,9 +58,15 @@ public:
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
-    CHIP_ERROR GetCommissionableInstanceName(char * instanceName, size_t maxLength) override
+    CHIP_ERROR GetCommissionableInstanceName(char * instanceName, size_t maxLength) const override
     {
         ChipLogError(Discovery, "DNS-SD advertising not available. DNS-SD GetCommissionableInstanceName not available.");
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+
+    CHIP_ERROR UpdateCommissionableInstanceName() override
+    {
+        ChipLogError(Discovery, "DNS-SD advertising not available. Can't update DNS-SD commissionable instance name.");
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 };


### PR DESCRIPTION
Looks like that has started using Advertiser_ImplNone.

#### Problem
NRFConnect using Advertiser_ImplNone, which does not compile.

#### Change overview
Make it compile.

#### Testing
No good way to test apart from CI.