### PR TITLE
Updated ASN1Reader::GetInteger() Implementation to Fix Clang tidy Error

### DIFF
--- a/src/lib/asn1/ASN1Reader.cpp
+++ b/src/lib/asn1/ASN1Reader.cpp
@@ -30,10 +30,13 @@
 #include <stdlib.h>
 
 #include <lib/asn1/ASN1.h>
+#include <lib/core/CHIPEncoding.h>
 #include <lib/support/SafeInt.h>
 
 namespace chip {
 namespace ASN1 {
+
+using namespace chip::Encoding;
 
 void ASN1Reader::Init(const uint8_t * buf, size_t len)
 {
@@ -142,23 +145,24 @@ bool ASN1Reader::IsContained() const
 
 CHIP_ERROR ASN1Reader::GetInteger(int64_t & val)
 {
+    uint8_t encodedVal[sizeof(int64_t)] = { 0 };
+    size_t valPaddingLen                = sizeof(int64_t) - ValueLen;
+
     ReturnErrorCodeIf(Value == nullptr, ASN1_ERROR_INVALID_STATE);
     ReturnErrorCodeIf(ValueLen < 1, ASN1_ERROR_INVALID_ENCODING);
     ReturnErrorCodeIf(ValueLen > sizeof(int64_t), ASN1_ERROR_VALUE_OVERFLOW);
     ReturnErrorCodeIf(mElemStart + mHeadLen + ValueLen > mContainerEnd, ASN1_ERROR_UNDERRUN);
 
-    // NOLINTBEGIN(clang-analyzer-core.UndefinedBinaryOperatorResult)
-    //
-    // TODO: clang-tidy says that if val is -1, then (val << 8) is not defined.
-    //       added above supression to keep clang-tidy validating the rest of the files, however
-    //       this complain likely needs fixing.
-    const uint8_t * p = Value;
-    val               = ((*p & 0x80) == 0) ? 0 : -1;
-    for (uint32_t i = ValueLen; i > 0; i--, p++)
+    if ((*Value & 0x80) == 0x80)
     {
-        val = (val << 8) | *p;
+        for (size_t i = 0; i < valPaddingLen; i++)
+        {
+            encodedVal[i] = 0xFF;
+        }
     }
-    // NOLINTEND(clang-analyzer-core.UndefinedBinaryOperatorResult)
+    memcpy(&encodedVal[valPaddingLen], Value, ValueLen);
+
+    val = static_cast<int64_t>(BigEndian::Get64(encodedVal));
 
     return CHIP_NO_ERROR;
 }

--- a/src/lib/asn1/ASN1Writer.cpp
+++ b/src/lib/asn1/ASN1Writer.cpp
@@ -75,7 +75,7 @@ size_t ASN1Writer::GetLengthWritten() const
 
 CHIP_ERROR ASN1Writer::PutInteger(int64_t val)
 {
-    uint8_t encodedVal[8];
+    uint8_t encodedVal[sizeof(int64_t)];
     uint8_t valStart, valLen;
 
     BigEndian::Put64(encodedVal, static_cast<uint64_t>(val));


### PR DESCRIPTION
#### Problem
The Clang tidy clang-analyzer-core.UndefinedBinaryOperatorResult
check was enabled in PR #17649.

#### Change overview
The original ASN1Reader::GetInteger() was correct but to silent the error
the implementation was update. I hope it is now also more user readable

#### Testing
existing tests