### PR TITLE
deduplicate the concrete paths intersected with the other wildcard paths in server

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -29,10 +29,8 @@
 
 #include <lib/core/CHIPTLVUtilities.hpp>
 
-#include <app-common/zap-generated/att-storage.h>
-
-extern uint16_t emberAfGetServerAttributeIndexByAttributeId(chip::EndpointId endpoint, chip::ClusterId cluster,
-                                                            chip::AttributeId attributeId);
+extern bool emberAfContainsAttribute(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
+                                     bool asServer);
 
 namespace chip {
 namespace app {
@@ -868,8 +866,7 @@ void InteractionModelEngine::RemoveDuplicateConcreteAttributePath(ObjectList<Att
         bool duplicate = false;
         // skip all wildcard paths and invalid concrete attribute
         if (path1->mValue.HasAttributeWildcard() ||
-            emberAfGetServerAttributeIndexByAttributeId(path1->mValue.mEndpointId, path1->mValue.mClusterId,
-                                                        path1->mValue.mAttributeId) == UINT16_MAX)
+            !emberAfContainsAttribute(path1->mValue.mEndpointId, path1->mValue.mClusterId, path1->mValue.mAttributeId, true))
         {
             prev  = path1;
             path1 = path1->mpNext;
@@ -909,7 +906,7 @@ void InteractionModelEngine::RemoveDuplicateConcreteAttributePath(ObjectList<Att
         {
             prev->mpNext = path1->mpNext;
             mAttributePathPool.ReleaseObject(path1);
-            path1 = path1->mpNext;
+            path1 = prev->mpNext;
         }
     }
 }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -24,9 +24,15 @@
  */
 
 #include "InteractionModelEngine.h"
+
 #include <cinttypes>
 
 #include <lib/core/CHIPTLVUtilities.hpp>
+
+#include <app-common/zap-generated/att-storage.h>
+
+extern uint16_t emberAfGetServerAttributeIndexByAttributeId(chip::EndpointId endpoint, chip::ClusterId cluster,
+                                                            chip::AttributeId attributeId);
 
 namespace chip {
 namespace app {
@@ -860,8 +866,10 @@ void InteractionModelEngine::RemoveDuplicateConcreteAttributePath(ObjectList<Att
     while (path1 != nullptr)
     {
         bool duplicate = false;
-        // skip all wildcard paths
-        if (path1->mValue.HasAttributeWildcard())
+        // skip all wildcard paths and invalid concrete attribute
+        if (path1->mValue.HasAttributeWildcard() ||
+            emberAfGetServerAttributeIndexByAttributeId(path1->mValue.mEndpointId, path1->mValue.mClusterId,
+                                                        path1->mValue.mAttributeId) == UINT16_MAX)
         {
             prev  = path1;
             path1 = path1->mpNext;

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -157,9 +157,9 @@ public:
     CHIP_ERROR PushFrontAttributePathList(ObjectList<AttributePathParams> *& aAttributePathList,
                                           AttributePathParams & aAttributePath);
 
-    // If the path indicates an attribute that is also referenced by one of all wildcard paths in the request,
-    // the path SHALL be removed.
-    void RemoveDuplicateConcreteAttribute(ObjectList<AttributePathParams> *& aAttributePaths);
+    // If a concrete path indicates an attribute that is also referenced by a wildcard path in the request,
+    // the path SHALL be removed from the list.
+    void RemoveDuplicateConcreteAttributePath(ObjectList<AttributePathParams> *& aAttributePaths);
 
     void ReleaseEventPathList(ObjectList<EventPathParams> *& aEventPathList);
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -157,6 +157,10 @@ public:
     CHIP_ERROR PushFrontAttributePathList(ObjectList<AttributePathParams> *& aAttributePathList,
                                           AttributePathParams & aAttributePath);
 
+    // If the path indicates an attribute that is also referenced by one of all wildcard paths in the request,
+    // the path SHALL be removed.
+    void RemoveDuplicateConcreteAttribute(ObjectList<AttributePathParams> *& aAttributePaths);
+
     void ReleaseEventPathList(ObjectList<EventPathParams> *& aEventPathList);
 
     CHIP_ERROR PushFrontEventPathParamsList(ObjectList<EventPathParams> *& aEventPathList, EventPathParams & aEventPath);

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -473,7 +473,7 @@ CHIP_ERROR ReadHandler::ProcessAttributePathList(AttributePathIBs::Parser & aAtt
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)
     {
-        InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttribute(mpAttributePathList);
+        InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttributePath(mpAttributePathList);
         mAttributePathExpandIterator = AttributePathExpandIterator(mpAttributePathList);
         err                          = CHIP_NO_ERROR;
     }

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -473,6 +473,7 @@ CHIP_ERROR ReadHandler::ProcessAttributePathList(AttributePathIBs::Parser & aAtt
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)
     {
+        InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttribute(mpAttributePathList);
         mAttributePathExpandIterator = AttributePathExpandIterator(mpAttributePathList);
         err                          = CHIP_NO_ERROR;
     }

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -24,6 +24,8 @@
 
 #include <app/InteractionModelEngine.h>
 #include <app/tests/AppTestContext.h>
+#include <app/util/mock/Constants.h>
+#include <app/util/mock/Functions.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPTLV.h>
 #include <lib/core/CHIPTLVDebug.hpp>
@@ -109,17 +111,17 @@ void TestInteractionModelEngine::TestRemoveDuplicateConcreteAttribute(nlTestSuit
     AttributePathParams attributePathParams3;
 
     // Three concrete paths, no duplicates
-    attributePathParams1.mEndpointId  = 1;
-    attributePathParams1.mClusterId   = 1;
-    attributePathParams1.mAttributeId = 1;
+    attributePathParams1.mEndpointId  = Test::kMockEndpoint3;
+    attributePathParams1.mClusterId   = Test::MockClusterId(2);
+    attributePathParams1.mAttributeId = Test::MockAttributeId(1);
 
-    attributePathParams2.mEndpointId  = 2;
-    attributePathParams2.mClusterId   = 1;
-    attributePathParams2.mAttributeId = 1;
+    attributePathParams2.mEndpointId  = Test::kMockEndpoint3;
+    attributePathParams2.mClusterId   = Test::MockClusterId(2);
+    attributePathParams2.mAttributeId = Test::MockAttributeId(2);
 
-    attributePathParams3.mEndpointId  = 3;
-    attributePathParams3.mClusterId   = 1;
-    attributePathParams3.mAttributeId = 1;
+    attributePathParams3.mEndpointId  = Test::kMockEndpoint3;
+    attributePathParams3.mClusterId   = Test::MockClusterId(2);
+    attributePathParams3.mAttributeId = Test::MockAttributeId(3);
 
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams1);
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams2);
@@ -129,16 +131,16 @@ void TestInteractionModelEngine::TestRemoveDuplicateConcreteAttribute(nlTestSuit
     InteractionModelEngine::GetInstance()->ReleaseAttributePathList(attributePathParamsList);
 
     attributePathParams1.mEndpointId  = kInvalidEndpointId;
-    attributePathParams1.mClusterId   = 1;
-    attributePathParams1.mAttributeId = 1;
+    attributePathParams1.mClusterId   = kInvalidClusterId;
+    attributePathParams1.mAttributeId = kInvalidAttributeId;
 
-    attributePathParams2.mEndpointId  = 2;
-    attributePathParams2.mClusterId   = 1;
-    attributePathParams2.mAttributeId = 1;
+    attributePathParams2.mEndpointId  = Test::kMockEndpoint3;
+    attributePathParams2.mClusterId   = Test::MockClusterId(2);
+    attributePathParams2.mAttributeId = Test::MockAttributeId(2);
 
-    attributePathParams3.mEndpointId  = 3;
-    attributePathParams3.mClusterId   = 1;
-    attributePathParams3.mAttributeId = 1;
+    attributePathParams3.mEndpointId  = Test::kMockEndpoint3;
+    attributePathParams3.mClusterId   = Test::MockClusterId(2);
+    attributePathParams3.mAttributeId = Test::MockAttributeId(3);
 
     // 1st path is wildcard endpoint, 2nd, 3rd paths are concrete paths, the concrete ones would be removed.
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams1);
@@ -164,17 +166,17 @@ void TestInteractionModelEngine::TestRemoveDuplicateConcreteAttribute(nlTestSuit
     NL_TEST_ASSERT(apSuite, GetAttributePathListLength(attributePathParamsList) == 1);
     InteractionModelEngine::GetInstance()->ReleaseAttributePathList(attributePathParamsList);
 
-    attributePathParams1.mEndpointId  = 1;
-    attributePathParams1.mClusterId   = 1;
+    attributePathParams1.mEndpointId  = Test::kMockEndpoint3;
+    attributePathParams1.mClusterId   = Test::MockClusterId(2);
     attributePathParams1.mAttributeId = kInvalidAttributeId;
 
-    attributePathParams2.mEndpointId  = 1;
-    attributePathParams2.mClusterId   = 2;
-    attributePathParams2.mAttributeId = 1;
+    attributePathParams2.mEndpointId  = Test::kMockEndpoint2;
+    attributePathParams2.mClusterId   = Test::MockClusterId(2);
+    attributePathParams2.mAttributeId = Test::MockAttributeId(2);
 
-    attributePathParams3.mEndpointId  = 1;
-    attributePathParams3.mClusterId   = 2;
-    attributePathParams3.mAttributeId = 2;
+    attributePathParams3.mEndpointId  = Test::kMockEndpoint2;
+    attributePathParams3.mClusterId   = Test::MockClusterId(2);
+    attributePathParams3.mAttributeId = Test::MockAttributeId(3);
 
     // 1st is wildcard one, but not intersect with the latter two concrete paths, so the paths in total are 3 finally
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams1);
@@ -188,13 +190,13 @@ void TestInteractionModelEngine::TestRemoveDuplicateConcreteAttribute(nlTestSuit
     attributePathParams1.mClusterId   = kInvalidClusterId;
     attributePathParams1.mAttributeId = kInvalidAttributeId;
 
-    attributePathParams2.mEndpointId  = 1;
+    attributePathParams2.mEndpointId  = Test::kMockEndpoint3;
     attributePathParams2.mClusterId   = kInvalidClusterId;
     attributePathParams2.mAttributeId = kInvalidAttributeId;
 
     attributePathParams3.mEndpointId  = kInvalidEndpointId;
     attributePathParams3.mClusterId   = kInvalidClusterId;
-    attributePathParams3.mAttributeId = 1;
+    attributePathParams3.mAttributeId = Test::MockAttributeId(3);
 
     // Wildcards cannot be deduplicated.
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams1);
@@ -202,6 +204,21 @@ void TestInteractionModelEngine::TestRemoveDuplicateConcreteAttribute(nlTestSuit
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams3);
     InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttributePath(attributePathParamsList);
     NL_TEST_ASSERT(apSuite, GetAttributePathListLength(attributePathParamsList) == 3);
+    InteractionModelEngine::GetInstance()->ReleaseAttributePathList(attributePathParamsList);
+
+    attributePathParams1.mEndpointId  = kInvalidEndpointId;
+    attributePathParams1.mClusterId   = Test::MockClusterId(2);
+    attributePathParams1.mAttributeId = Test::MockAttributeId(10);
+
+    attributePathParams2.mEndpointId  = Test::kMockEndpoint3;
+    attributePathParams2.mClusterId   = Test::MockClusterId(2);
+    attributePathParams2.mAttributeId = Test::MockAttributeId(10);
+
+    // 1st path is wildcard endpoint, 2nd path is invalid attribute
+    InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams1);
+    InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams2);
+    InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttributePath(attributePathParamsList);
+    NL_TEST_ASSERT(apSuite, GetAttributePathListLength(attributePathParamsList) == 2);
     InteractionModelEngine::GetInstance()->ReleaseAttributePathList(attributePathParamsList);
 }
 

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -124,7 +124,7 @@ void TestInteractionModelEngine::TestRemoveDuplicateConcreteAttribute(nlTestSuit
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams1);
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams2);
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams3);
-    InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttribute(attributePathParamsList);
+    InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttributePath(attributePathParamsList);
     NL_TEST_ASSERT(apSuite, GetAttributePathListLength(attributePathParamsList) == 3);
     InteractionModelEngine::GetInstance()->ReleaseAttributePathList(attributePathParamsList);
 
@@ -144,7 +144,7 @@ void TestInteractionModelEngine::TestRemoveDuplicateConcreteAttribute(nlTestSuit
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams1);
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams2);
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams3);
-    InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttribute(attributePathParamsList);
+    InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttributePath(attributePathParamsList);
     NL_TEST_ASSERT(apSuite, GetAttributePathListLength(attributePathParamsList) == 1);
     InteractionModelEngine::GetInstance()->ReleaseAttributePathList(attributePathParamsList);
 
@@ -152,7 +152,7 @@ void TestInteractionModelEngine::TestRemoveDuplicateConcreteAttribute(nlTestSuit
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams2);
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams1);
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams3);
-    InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttribute(attributePathParamsList);
+    InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttributePath(attributePathParamsList);
     NL_TEST_ASSERT(apSuite, GetAttributePathListLength(attributePathParamsList) == 1);
     InteractionModelEngine::GetInstance()->ReleaseAttributePathList(attributePathParamsList);
 
@@ -160,7 +160,7 @@ void TestInteractionModelEngine::TestRemoveDuplicateConcreteAttribute(nlTestSuit
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams2);
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams3);
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams1);
-    InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttribute(attributePathParamsList);
+    InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttributePath(attributePathParamsList);
     NL_TEST_ASSERT(apSuite, GetAttributePathListLength(attributePathParamsList) == 1);
     InteractionModelEngine::GetInstance()->ReleaseAttributePathList(attributePathParamsList);
 
@@ -180,7 +180,7 @@ void TestInteractionModelEngine::TestRemoveDuplicateConcreteAttribute(nlTestSuit
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams1);
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams2);
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams3);
-    InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttribute(attributePathParamsList);
+    InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttributePath(attributePathParamsList);
     NL_TEST_ASSERT(apSuite, GetAttributePathListLength(attributePathParamsList) == 3);
     InteractionModelEngine::GetInstance()->ReleaseAttributePathList(attributePathParamsList);
 
@@ -192,15 +192,15 @@ void TestInteractionModelEngine::TestRemoveDuplicateConcreteAttribute(nlTestSuit
     attributePathParams2.mClusterId   = kInvalidClusterId;
     attributePathParams2.mAttributeId = kInvalidAttributeId;
 
-    attributePathParams3.mEndpointId  = 1;
-    attributePathParams3.mClusterId   = 2;
-    attributePathParams3.mAttributeId = kInvalidAttributeId;
+    attributePathParams3.mEndpointId  = kInvalidEndpointId;
+    attributePathParams3.mClusterId   = kInvalidClusterId;
+    attributePathParams3.mAttributeId = 1;
 
     // Wildcards cannot be deduplicated.
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams1);
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams2);
     InteractionModelEngine::GetInstance()->PushFrontAttributePathList(attributePathParamsList, attributePathParams3);
-    InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttribute(attributePathParamsList);
+    InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttributePath(attributePathParamsList);
     NL_TEST_ASSERT(apSuite, GetAttributePathListLength(attributePathParamsList) == 3);
     InteractionModelEngine::GetInstance()->ReleaseAttributePathList(attributePathParamsList);
 }

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -650,6 +650,10 @@ EmberAfStatus emAfReadOrWriteAttribute(EmberAfAttributeSearchRecord * attRecord,
             // Dynamic endpoints are external and don't factor into storage size
             if (!isDynamicEndpoint)
             {
+                if (emAfEndpoints[ep].endpointType == nullptr)
+                {
+                    return EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE;
+                }
                 attributeOffsetIndex = static_cast<uint16_t>(attributeOffsetIndex + emAfEndpoints[ep].endpointType->endpointSize);
             }
         }

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -164,6 +164,11 @@ uint16_t emberAfGetServerAttributeIndexByAttributeId(chip::EndpointId endpoint, 
     return UINT16_MAX;
 }
 
+bool emberAfContainsAttribute(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId, bool asServer)
+{
+    return !(emberAfGetServerAttributeIndexByAttributeId(endpoint, clusterId, attributeId) == UINT16_MAX);
+}
+
 chip::EndpointId emberAfEndpointFromIndex(uint16_t index)
 {
     VerifyOrDie(index < ArraySize(endpoints));

--- a/src/darwin/Framework/CHIP/CHIPIMDispatch.mm
+++ b/src/darwin/Framework/CHIP/CHIPIMDispatch.mm
@@ -272,6 +272,11 @@ uint16_t emberAfGetServerAttributeIndexByAttributeId(EndpointId endpoint, Cluste
     return UINT16_MAX;
 }
 
+bool emberAfContainsAttribute(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId, bool asServer)
+{
+    return false;
+}
+
 uint8_t emberAfClusterCount(EndpointId endpoint, bool server)
 {
     if (endpoint == kSupportedEndpoint && server) {


### PR DESCRIPTION
#### Problem
* Fix https://github.com/project-chip/connectedhomeip/issues/17486

#### Change overview
Add function to deduplicate the concrete paths intersected with the current wildcard paths when processing the attribute paths in request

#### Testing
Add unit test to cover it.
