### PR TITLE
Use enum class for CASESession::State

### DIFF
--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -162,7 +162,7 @@ public:
     void Clear();
 
 private:
-    enum State : uint8_t
+    enum class State : uint8_t
     {
         kInitialized      = 0,
         kSentSigma1       = 1,


### PR DESCRIPTION
#### Problem
enum class should be preferred over enum

#### Change overview
Use enum class for CASESession::State

#### Testing
Passed unit-tests