### PR TITLE
[ESP32] Update lighting-app with spake2p dependency for generation of factory partition

### DIFF
--- a/examples/lighting-app/esp32/README.md
+++ b/examples/lighting-app/esp32/README.md
@@ -84,6 +84,66 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
         or
         $ idf.py --preview set-target esp32h2
 
+-   Using ESP32 Factory Data Provider (Optional)
+
+    By default this application uses test-mode CommissionableDataProvider and
+    Example DeviceAttestationCredentialsProvider.
+
+    Enable config option `CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER` to use
+    ESP32 specific implementation of CommissionableDataProvider and
+    DeviceAttestationCredentialsProvider.
+
+    ESP32 implementation reads factory data from nvs partition, chip-factory
+    data must be flashed into the configure nvs partition. Factory partition can
+    be configured using `CONFIG_CHIP_FACTORY_NAMESPACE_PARTITION_LABEL` option,
+    default is "nvs".
+
+    `scripts/tools/generate_esp32_chip_factory_bin.py` script generates the
+    chip-factory NVS image `partition.bin`.
+
+    Script has dependency on
+    [spake2p](https://github.com/project-chip/connectedhomeip/tree/master/src/tools/spake2p)
+    for generating spake2p parameters.
+
+    Build spake2p:
+
+    ```
+    cd path/to/connectedhomeip
+    gn gen out/host
+    ninja -C out/host
+    cd -
+    ```
+
+    Add spake2p to \$PATH environment variable
+
+    ```
+    export PATH=$PATH:path/to/connectedhomeip/out/host
+    ```
+
+    Below mentioned command generates the nvs image with test DAC with
+    VID:0xFFF2 and PID:8001
+
+    ```
+    cd third_party/connectedhomeip/scripts/tools
+
+    ./generate_esp32_chip_factory_bin.py -d 3434 -p 99663300 \
+                                        --dac-cert ../../credentials/test/attestation/Chip-Test-DAC-FFF2-8001-0008-Cert.der \
+                                        --dac-key ../../credentials/test/attestation/Chip-Test-DAC-FFF2-8001-0008-Key.der \
+                                        --pai-cert ../../credentials/test/attestation/Chip-Test-PAI-FFF2-8001-Cert.der \
+                                        --cd ../../credentials/test/certification-declaration/Chip-Test-CD-FFF2-8001.der
+    cd -
+    ```
+
+    This project uses VID:0xFFF1 and PID:0x8000, if you are planning to use the
+    above command as is please change the VID/PID using menuconfig options.
+
+    Use the following command to flash the NVS image. `0x9000` is default
+    address for `nvs` partition.
+
+    ```
+    esptool.py -p <port> write_flash 0x9000 third_party/connectedhomeip/scripts/tools/partition.bin
+    ```
+
 -   To build the demo application.
 
         $ idf.py build
@@ -111,69 +171,6 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
 
         $ idf.py -p /dev/tty.SLAB_USBtoUART monitor
 
-## Using ESP32 Factory Data Provider
-
-This application uses test-mode CommissionableDataProvider and Example
-DeviceAttestationCredentialsProvider.
-
-Enabled config option `CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER` to use ESP32
-specific implementation of CommissionableDataProvider and
-DeviceAttestationCredentialsProvider.
-
-ESP32 implementation reads factory data from nvs partition, chip-factory data
-must be flashed into the configure nvs partition. Factory partition can be
-configured using CONFIG_CHIP_FACTORY_NAMESPACE_PARTITION_LABEL option, default
-is "nvs".
-
-`scripts/tools/generate_esp32_chip_factory_bin.py` script generates the
-chip-factory NVS image `partition.bin`.
-
-Script has dependency on
-[spake2p](https://github.com/project-chip/connectedhomeip/tree/master/src/tools/spake2p)
-for generating spake2p parameters.
-
-Build spake2p as follows
-
-```
-cd path/to/connectedhomeip
-gn gen out/host
-ninja -C out/host
-cd -
-```
-
-Add spake2p to \$PATH environment variable
-
-```
-export PATH=$PATH:path/to/connectedhomeip/out/host
-```
-
-Below mentioned command generates the nvs image with test DAC with VID:0xFFF2
-and PID:8001
-
-```
-cd third_party/connectedhomeip/scripts/tools
-
-./generate_esp32_chip_factory_bin.py -d 3434 -p 99663300 \
-                                    --dac-cert ../../credentials/test/attestation/Chip-Test-DAC-FFF2-8001-0008-Cert.der \
-                                    --dac-key ../../credentials/test/attestation/Chip-Test-DAC-FFF2-8001-0008-Key.der \
-                                    --pai-cert ../../credentials/test/attestation/Chip-Test-PAI-FFF2-8001-Cert.der \
-                                    --cd ../../credentials/test/certification-declaration/Chip-Test-CD-FFF2-8001.der
-cd -
-```
-
-This project uses VID:0xFFF1 and PID:0x8000, if you are planning to use the
-above command as is please change the VID/PID using menuconfig options.
-
-Use the following command to flash the NVS image. `0x9000` is default address
-for `nvs` partition.
-
-```
-esptool.py -p <port> write_flash 0x9000 third_party/connectedhomeip/scripts/tools/partition.bin
-```
-
-NOTE: Please commission the device using above specified discriminator and
-passcode
-
 ## Commissioning over BLE using chip-tool
 
 -   Please build the standalone chip-tool as described [here](../../chip-tool)
@@ -192,6 +189,9 @@ passcode
 -   Commissioning the Thread Lighting device(ESP32H2)
 
          $ ./out/debug/chip-tool pairing ble-thread 12345 hex:<operational-dataset> 20202021 3840
+
+    NOTE: If using ESP32 factory data provider then commission the device using
+    discriminator and passcode provided while building the factory NVS binary.
 
 ## Cluster Control
 

--- a/examples/lighting-app/esp32/README.md
+++ b/examples/lighting-app/esp32/README.md
@@ -128,6 +128,25 @@ is "nvs".
 `scripts/tools/generate_esp32_chip_factory_bin.py` script generates the
 chip-factory NVS image `partition.bin`.
 
+Script has dependency on
+[spake2p](https://github.com/project-chip/connectedhomeip/tree/master/src/tools/spake2p)
+for generating spake2p parameters.
+
+Build spake2p as follows
+
+```
+cd path/to/connectedhomeip
+gn gen out/host
+ninja -C out/host
+cd -
+```
+
+Add spake2p to \$PATH environment variable
+
+```
+export PATH=$PATH:path/to/connectedhomeip/out/host
+```
+
 Below mentioned command generates the nvs image with test DAC with VID:0xFFF2
 and PID:8001
 


### PR DESCRIPTION
#### Problem
* Lighting app readme file do not contain step to build spake2p and add its path to $PATH environment variable

#### Change overview
* Updated readme

#### Testing
* Documentation update, no tests required