### PR TITLE
[CI] Add all supported test suites applications to the AppRegister

### DIFF
--- a/scripts/tests/chiptest/accessories.py
+++ b/scripts/tests/chiptest/accessories.py
@@ -49,6 +49,9 @@ class AppsRegister:
     def removeAll(self):
         self.__accessories = {}
 
+    def get(self, name):
+        return self.__accessories[name]
+
     def kill(self, name):
         accessory = self.__accessories[name]
         if accessory:
@@ -73,13 +76,10 @@ class AppsRegister:
             return accessory.stop()
         return False
 
-    def reboot(self, name, args):
+    def reboot(self, name):
         accessory = self.__accessories[name]
         if accessory:
-            # The args param comes directly from the sys.argv[1:] of Reboot.py and should contain a list of strings in
-            # key-value pair, e.g. [option1, value1, option2, value2, ...]
-            options = self.__createCommandLineOptions(args)
-            return accessory.stop() and accessory.start(options)
+            return accessory.stop() and accessory.start()
         return False
 
     def factoryResetAll(self):

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -36,16 +36,20 @@ class App:
         self.runner = runner
         self.command = command
         self.cv_stopped = threading.Condition()
-        self.stopped = False
+        self.stopped = True
         self.lastLogIndex = 0
-        self.kvs = '/tmp/chip_kvs'
+        self.kvsPathSet = {'/tmp/chip_kvs'}
+        self.options = None
 
     def start(self, options=None):
         if not self.process:
+            # Cache command line options to be used for reboots
+            if options:
+                self.options = options
             # Make sure to assign self.process before we do any operations that
             # might fail, so attempts to kill us on failure actually work.
             self.process, self.outpipe, errpipe = self.__startServer(
-                self.runner, self.command, options)
+                self.runner, self.command)
             self.waitForAnyAdvertisement()
             self.__updateSetUpCode()
             with self.cv_stopped:
@@ -67,8 +71,9 @@ class App:
         return False
 
     def factoryReset(self):
-        if os.path.exists(self.kvs):
-            os.unlink(self.kvs)
+        for kvs in self.kvsPathSet:
+            if os.path.exists(kvs):
+                os.unlink(kvs)
         return True
 
     def waitForAnyAdvertisement(self):
@@ -90,6 +95,10 @@ class App:
 
     def wait(self, timeout=None):
         while True:
+            # If the App was never started, wait cannot be called on the process
+            if self.process == None:
+                time.sleep(0.1)
+                continue
             code = self.process.wait(timeout)
             with self.cv_stopped:
                 if not self.stopped:
@@ -100,18 +109,18 @@ class App:
                 while self.stopped:
                     self.cv_stopped.wait()
 
-    def __startServer(self, runner, command, options):
+    def __startServer(self, runner, command):
         app_cmd = command + ['--interface-id', str(-1)]
 
-        if not options:
+        if not self.options:
             logging.debug('Executing application under test with default args')
         else:
             logging.debug('Executing application under test with the following args:')
-            for key, value in options.items():
+            for key, value in self.options.items():
                 logging.debug('   %s: %s' % (key, value))
                 app_cmd = app_cmd + [key, value]
                 if key == '--KVS':
-                    self.kvs = value
+                    self.kvsPathSet.add(value)
         return runner.RunSubprocess(app_cmd, name='APP ', wait=False)
 
     def __waitFor(self, waitForString, server_process, outpipe):
@@ -153,6 +162,9 @@ class ApplicationPaths:
     all_clusters_app: typing.List[str]
     lock_app: typing.List[str]
     tv_app: typing.List[str]
+
+    def items(self):
+        return [self.chip_tool, self.all_clusters_app, self.lock_app, self.tv_app]
 
 
 @dataclass
@@ -208,14 +220,33 @@ class TestDefinition:
 
         try:
             if self.target == TestTarget.ALL_CLUSTERS:
-                app_cmd = paths.all_clusters_app
+                target_app = paths.all_clusters_app
             elif self.target == TestTarget.TV:
-                app_cmd = paths.tv_app
+                target_app = paths.tv_app
             elif self.target == TestTarget.LOCK:
-                app_cmd = paths.lock_app
+                target_app = paths.lock_app
             else:
                 raise Exception("Unknown test target - "
                                 "don't know which application to run")
+
+            for path in paths.items():
+                # Do not add chip-tool to the register
+                if path == paths.chip_tool:
+                    continue
+
+                # For the app indicated by self.target, give it the 'default' key to add to the register
+                if path == target_app:
+                    key = 'default'
+                else:
+                    key = os.path.basename(path[-1])
+
+                app = App(runner, path)
+                # Add the App to the register immediately, so if it fails during
+                # start() we will be able to clean things up properly.
+                apps_register.add(key, app)
+                # Remove server application storage (factory reset),
+                # so it will be commissionable again.
+                app.factoryReset()
 
             tool_cmd = paths.chip_tool
 
@@ -230,19 +261,13 @@ class TestDefinition:
                 if os.path.exists(f):
                     os.unlink(f)
 
-            app = App(runner, app_cmd)
-            # Add the App to the register immediately, so if it fails during
-            # start() we will be able to clean things up properly.
-            apps_register.add("default", app)
-            # Remove server application storage (factory reset),
-            # so it will be commissionable again.
-            app.factoryReset()
+            # Only start and pair the default app
+            app = apps_register.get('default')
             app.start()
             pairing_cmd = tool_cmd + ['pairing', 'qrcode', TEST_NODE_ID, app.setupCode]
             if sys.platform != 'darwin':
                 pairing_cmd.append('--paa-trust-store-path')
                 pairing_cmd.append(DEVELOPMENT_PAA_LIST)
-
             runner.RunSubprocess(pairing_cmd,
                                  name='PAIR', dependencies=[apps_register])
 

--- a/src/app/tests/suites/TestArmFailSafe.yaml
+++ b/src/app/tests/suites/TestArmFailSafe.yaml
@@ -17,21 +17,11 @@ name: ArmFailSafe Tests
 config:
     nodeId: 0x12344321
     endpoint: 0
-    discriminator:
-        type: INT16U
-        defaultValue: 3840
-    payload:
-        type: CHAR_STRING
-        defaultValue: "MT:-24J0AFN00KA0648G00" # This value needs to be generated automatically
 
 tests:
     - label: "Reboot target device"
       cluster: "SystemCommands"
       command: "Reboot"
-      arguments:
-          values:
-              - name: "discriminator"
-                value: discriminator
 
     - label: "Wait for the alpha device to be retrieved "
       cluster: "DelayCommands"

--- a/src/app/tests/suites/TestDiscovery.yaml
+++ b/src/app/tests/suites/TestDiscovery.yaml
@@ -31,9 +31,15 @@ config:
         defaultValue: 5
 
 tests:
-    - label: "Reboot target device"
+    - label: "Stop target device"
       cluster: "SystemCommands"
-      command: "Reboot"
+      command: "Stop"
+
+    - label:
+          "Start target device with the provided discriminator for basic
+          commissioning advertisement"
+      cluster: "SystemCommands"
+      command: "Start"
       arguments:
           values:
               - name: "discriminator"
@@ -291,9 +297,15 @@ tests:
                 constraints:
                     minValue: 1
 
-    - label: "Reboot target device"
+    - label: "Stop target device"
       cluster: "SystemCommands"
-      command: "Reboot"
+      command: "Stop"
+
+    - label:
+          "Start target device with the provided discriminator for basic
+          commissioning advertisement"
+      cluster: "SystemCommands"
+      command: "Start"
       arguments:
           values:
               - name: "discriminator"

--- a/src/app/tests/suites/TestModeSelectCluster.yaml
+++ b/src/app/tests/suites/TestModeSelectCluster.yaml
@@ -18,9 +18,6 @@ config:
     nodeId: 0x12344321
     cluster: "Mode Select"
     endpoint: 1
-    discriminator:
-        type: INT16U
-        defaultValue: 3840
 
 tests:
     - label: "Wait for the commissioned device to be retrieved"
@@ -190,10 +187,6 @@ tests:
     - label: "Reboot target device"
       cluster: "SystemCommands"
       command: "Reboot"
-      arguments:
-          values:
-              - name: "discriminator"
-                value: discriminator
 
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
@@ -220,10 +213,6 @@ tests:
     - label: "Reboot target device"
       cluster: "SystemCommands"
       command: "Reboot"
-      arguments:
-          values:
-              - name: "discriminator"
-                value: discriminator
 
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"

--- a/src/app/tests/suites/TestMultiAdmin.yaml
+++ b/src/app/tests/suites/TestMultiAdmin.yaml
@@ -34,9 +34,15 @@ config:
         defaultValue: "MT:-24J0AFN00KA0648G00" # This value needs to be generated automatically
 
 tests:
-    - label: "Reboot target device"
+    - label: "Stop target device"
       cluster: "SystemCommands"
-      command: "Reboot"
+      command: "Stop"
+
+    - label:
+          "Start target device with the provided discriminator for basic
+          commissioning advertisement"
+      cluster: "SystemCommands"
+      command: "Start"
       arguments:
           values:
               - name: "discriminator"

--- a/src/app/tests/suites/TestSystemCommands.yaml
+++ b/src/app/tests/suites/TestSystemCommands.yaml
@@ -18,6 +18,9 @@ config:
     nodeId: 0x12344321
     cluster: "SystemCommands"
     endpoint: 0
+    payload:
+        type: CHAR_STRING
+        defaultValue: "MT:-24J0IX4122-.548G00" # This value needs to be generated
 
 tests:
     - label: "Wait for the commissioned device to be retrieved"
@@ -28,27 +31,33 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
-    - label: "Stop the accessory"
+    - label: "Stop the default accessory"
       command: "Stop"
 
-    - label: "Start the accessory with no command line options"
+    - label: "Start the default accessory with no command line options"
       command: "Start"
 
-    - label: "Stop the accessory"
+    - label: "Stop the default accessory by key"
       command: "Stop"
+      arguments:
+          values:
+              - name: "registerKey"
+                value: "default"
 
-    - label: "Start the accessory with only discriminator command line option"
+    - label:
+          "Start the default accessory with discriminator command line option"
       command: "Start"
       arguments:
           values:
               - name: "discriminator"
                 value: 1111
 
-    - label: "Stop the accessory"
+    - label: "Stop the default accessory"
       command: "Stop"
 
     - label:
-          "Start the accessory with discriminator and port command line option"
+          "Start the default accessory with discriminator and port command line
+          options"
       command: "Start"
       arguments:
           values:
@@ -57,10 +66,10 @@ tests:
               - name: "port"
                 value: 5560
 
-    - label: "Stop the accessory"
+    - label: "Stop the default accessory"
       command: "Stop"
 
-    - label: "Start the accessory with all command line options"
+    - label: "Start the default accessory with all command line options"
       command: "Start"
       arguments:
           values:
@@ -69,38 +78,107 @@ tests:
               - name: "port"
                 value: 5560
               - name: "kvs"
-                value: "/tmp/chip_kvs_test"
+                value: "/tmp/chip_kvs_default"
 
-    - label: "Reboot the accessory with no command line options"
-      command: "Reboot"
+    - label: "Stop the default accessory"
+      command: "Stop"
 
-    - label: "Reboot the accessory with only discriminator command line option"
-      command: "Reboot"
+    - label: "Start the default accessory by key with all command line options"
+      command: "Start"
       arguments:
           values:
               - name: "discriminator"
-                value: 2222
-
-    - label:
-          "Reboot the accessory with discriminator and port command line option"
-      command: "Reboot"
-      arguments:
-          values:
-              - name: "discriminator"
-                value: 2222
+                value: 1111
               - name: "port"
-                value: 5565
-
-    - label: "Reboot the accessory with all command line options"
-      command: "Reboot"
-      arguments:
-          values:
-              - name: "discriminator"
-                value: 2222
-              - name: "port"
-                value: 5565
+                value: 5560
               - name: "kvs"
-                value: "/tmp/chip_kvs_test"
+                value: "/tmp/chip_kvs_default"
+              - name: "registerKey"
+                value: "default"
 
-    - label: "Factory Reset the accessory"
+    - label: "Start a second accessory with all command line options"
+      command: "Start"
+      arguments:
+          values:
+              - name: "discriminator"
+                value: 50
+              - name: "port"
+                value: 5561
+              - name: "kvs"
+                value: "/tmp/chip_kvs_lock"
+              - name: "registerKey"
+                value: "chip-lock-app"
+
+    - label: "Commission second accessory from alpha"
+      identity: "alpha"
+      cluster: "CommissionerCommands"
+      command: "PairWithQRCode"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: 0xDEADBEEF
+              - name: "payload"
+                value: payload
+
+    - label: "Wait for the second commissioned device to be retrieved for alpha"
+      identity: "alpha"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: 0xDEADBEEF
+
+    - label: "Stop the second accessory"
+      command: "Stop"
+      arguments:
+          values:
+              - name: "registerKey"
+                value: "chip-lock-app"
+
+    - label: "Start a second accessory with different KVS"
+      command: "Start"
+      arguments:
+          values:
+              - name: "discriminator"
+                value: 50
+              - name: "port"
+                value: 5561
+              - name: "kvs"
+                value: "/tmp/chip_kvs_lock2"
+              - name: "registerKey"
+                value: "chip-lock-app"
+
+    - label: "Reboot the default accessory"
+      command: "Reboot"
+
+    - label: "Reboot the default accessory by key"
+      command: "Reboot"
+      arguments:
+          values:
+              - name: "registerKey"
+                value: "default"
+
+    - label: "Reboot the second accessory"
+      command: "Reboot"
+      arguments:
+          values:
+              - name: "registerKey"
+                value: "chip-lock-app"
+
+    - label: "Factory Reset the default accessory"
       command: "FactoryReset"
+
+    - label: "Factory Reset the default accessory by key"
+      command: "FactoryReset"
+      arguments:
+          values:
+              - name: "registerKey"
+                value: "default"
+
+    - label: "Factory Reset the second accessory"
+      command: "FactoryReset"
+      arguments:
+          values:
+              - name: "registerKey"
+                value: "chip-lock-app"

--- a/src/app/tests/suites/TestUserLabelCluster.yaml
+++ b/src/app/tests/suites/TestUserLabelCluster.yaml
@@ -18,9 +18,6 @@ config:
     nodeId: 0x12344321
     cluster: "User Label"
     endpoint: 0
-    discriminator:
-        type: INT16U
-        defaultValue: 3840
 
 tests:
     - label: "Wait for the commissioned device to be retrieved"
@@ -58,10 +55,6 @@ tests:
     - label: "Reboot target device"
       cluster: "SystemCommands"
       command: "Reboot"
-      arguments:
-          values:
-              - name: "discriminator"
-                value: discriminator
 
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"

--- a/src/app/tests/suites/certification/Test_TC_MF_1_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MF_1_3.yaml
@@ -28,9 +28,15 @@ config:
         defaultValue: "MT:0000000000I31506010" # This value needs to be generated automatically
 
 tests:
-    - label: "Reboot target device"
+    - label: "Stop target device"
       cluster: "SystemCommands"
-      command: "Reboot"
+      command: "Stop"
+
+    - label:
+          "Start target device with the provided discriminator for basic
+          commissioning advertisement"
+      cluster: "SystemCommands"
+      command: "Start"
       arguments:
           values:
               - name: "discriminator"
@@ -55,7 +61,7 @@ tests:
               - name: "PAKEVerifier"
                 value: "\x06\xc7\x56\xdf\xfc\xd7\x22\x65\x34\x52\xa1\x2d\xcd\x94\x5d\x8c\x54\xda\x2b\x0f\x3c\xbd\x1b\x4d\xc3\xf1\xad\xb2\x23\xae\xb2\x6b\x04\x7c\xd2\x4c\x96\x86\x6f\x97\x9b\x1d\x83\xec\x50\xe2\xb4\xae\x30\xcd\xf2\xfd\xb3\x2b\xd8\xa2\x11\xb8\x37\xdc\x94\xed\xcd\x56\xf4\xd1\x43\x77\x19\x10\x76\xbf\xc5\x9d\x99\xb7\xdd\x30\x53\xef\xd6\xf0\x2c\x44\x34\xf2\xbd\xd2\x7a\xa4\xf9\xce\xa7\x0d\x73\x8e\x4c"
               - name: "discriminator"
-                value: 3840
+                value: discriminator
               - name: "iterations"
                 value: 1000
               - name: "salt"

--- a/src/app/tests/suites/certification/Test_TC_MF_1_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MF_1_4.yaml
@@ -28,9 +28,15 @@ config:
         defaultValue: "MT:-24J0AFN00KA0648G00" # This value needs to be generated automatically
 
 tests:
-    - label: "Reboot target device"
+    - label: "Stop target device"
       cluster: "SystemCommands"
-      command: "Reboot"
+      command: "Stop"
+
+    - label:
+          "Start target device with the provided discriminator for basic
+          commissioning advertisement"
+      cluster: "SystemCommands"
+      command: "Start"
       arguments:
           values:
               - name: "discriminator"

--- a/src/app/tests/suites/certification/Test_TC_MF_1_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MF_1_6.yaml
@@ -37,9 +37,15 @@ config:
         defaultValue: "MT:-24J0AFN00KA0648G00" # This value needs to be generated automatically
 
 tests:
-    - label: "Reboot target device"
+    - label: "Stop target device"
       cluster: "SystemCommands"
-      command: "Reboot"
+      command: "Stop"
+
+    - label:
+          "Start target device with the provided discriminator for basic
+          commissioning advertisement"
+      cluster: "SystemCommands"
+      command: "Start"
       arguments:
           values:
               - name: "discriminator"

--- a/src/app/tests/suites/certification/Test_TC_OO_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OO_2_4.yaml
@@ -18,9 +18,6 @@ config:
     nodeId: 0x12344321
     cluster: "On/Off"
     endpoint: 1
-    discriminator:
-        type: INT16U
-        defaultValue: 3840
 
 tests:
     - label: "Wait for the commissioned device to be retrieved"
@@ -50,10 +47,6 @@ tests:
       cluster: "SystemCommands"
       endpoint: 0
       command: "Reboot"
-      arguments:
-          values:
-              - name: "discriminator"
-                value: discriminator
 
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
@@ -82,10 +75,6 @@ tests:
       cluster: "SystemCommands"
       endpoint: 0
       command: "Reboot"
-      arguments:
-          values:
-              - name: "discriminator"
-                value: discriminator
 
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
@@ -114,10 +103,6 @@ tests:
       cluster: "SystemCommands"
       endpoint: 0
       command: "Reboot"
-      arguments:
-          values:
-              - name: "discriminator"
-                value: discriminator
 
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
@@ -140,10 +125,6 @@ tests:
       cluster: "SystemCommands"
       endpoint: 0
       command: "Reboot"
-      arguments:
-          values:
-              - name: "discriminator"
-                value: discriminator
 
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
@@ -172,10 +153,6 @@ tests:
       cluster: "SystemCommands"
       endpoint: 0
       command: "Reboot"
-      arguments:
-          values:
-              - name: "discriminator"
-                value: discriminator
 
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"
@@ -201,10 +178,6 @@ tests:
       cluster: "SystemCommands"
       endpoint: 0
       command: "Reboot"
-      arguments:
-          values:
-              - name: "discriminator"
-                value: discriminator
 
     - label: "Wait for the commissioned device to be retrieved"
       cluster: "DelayCommands"

--- a/src/app/tests/suites/certification/Test_TC_SC_4_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_SC_4_2.yaml
@@ -34,9 +34,15 @@ config:
         defaultValue: 5
 
 tests:
-    - label: "Reboot target device"
+    - label: "Stop target device"
       cluster: "SystemCommands"
-      command: "Reboot"
+      command: "Stop"
+
+    - label:
+          "Start target device with the provided discriminator for basic
+          commissioning advertisement"
+      cluster: "SystemCommands"
+      command: "Start"
       arguments:
           values:
               - name: "discriminator"
@@ -256,9 +262,15 @@ tests:
                     minValue: 1
 
     # The testplan needs TH needs to be Rebooted so below steps disabled for now
-    - label: "Reboot target device"
+    - label: "Stop target device"
       cluster: "SystemCommands"
-      command: "Reboot"
+      command: "Stop"
+
+    - label:
+          "Start target device with the provided discriminator for basic
+          commissioning advertisement"
+      cluster: "SystemCommands"
+      command: "Start"
       arguments:
           values:
               - name: "discriminator"

--- a/src/app/tests/suites/certification/Test_TC_WNCV_4_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_4_5.yaml
@@ -21,9 +21,6 @@ config:
     nodeId: 0x12344321
     cluster: "Window Covering"
     endpoint: 1
-    discriminator:
-        type: INT16U
-        defaultValue: 3840
 
 tests:
     ################ Init Phase #############
@@ -132,10 +129,6 @@ tests:
       cluster: "SystemCommands"
       endpoint: 0
       command: "Reboot"
-      arguments:
-          values:
-              - name: "discriminator"
-                value: discriminator
 
     ### DUT GoesOff
     - label: "3d: Wait for the commissioned device to be retrieved"

--- a/src/app/tests/suites/commands/system/SystemCommands.cpp
+++ b/src/app/tests/suites/commands/system/SystemCommands.cpp
@@ -30,43 +30,47 @@ const char * getScriptsFolder()
 
 constexpr size_t kCommandMaxLen = 256;
 
-CHIP_ERROR SystemCommands::Start(uint16_t discriminator, uint16_t port, const char * kvs)
+CHIP_ERROR SystemCommands::Start(uint16_t discriminator, uint16_t port, const char * kvs, const char * registerKey)
 {
     const char * scriptDir            = getScriptsFolder();
     constexpr const char * scriptName = "Start.py";
 
     char command[kCommandMaxLen];
-    ReturnErrorOnFailure(CreateCommonCommandArgs(command, sizeof(command), scriptDir, scriptName, discriminator, port, kvs));
+    ReturnErrorOnFailure(
+        CreateCommonCommandArgs(command, sizeof(command), scriptDir, scriptName, registerKey, discriminator, port, kvs));
     return RunInternal(command);
 }
 
-CHIP_ERROR SystemCommands::Stop()
+CHIP_ERROR SystemCommands::Stop(const char * registerKey)
 {
     const char * scriptDir            = getScriptsFolder();
     constexpr const char * scriptName = "Stop.py";
 
     char command[128];
-    VerifyOrReturnError(snprintf(command, sizeof(command), "%s%s", scriptDir, scriptName) >= 0, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(snprintf(command, sizeof(command), "%s%s %s", scriptDir, scriptName, registerKey) >= 0,
+                        CHIP_ERROR_INTERNAL);
     return RunInternal(command);
 }
 
-CHIP_ERROR SystemCommands::Reboot(uint16_t discriminator, uint16_t port, const char * kvs)
+CHIP_ERROR SystemCommands::Reboot(const char * registerKey)
 {
     const char * scriptDir            = getScriptsFolder();
     constexpr const char * scriptName = "Reboot.py";
 
-    char command[kCommandMaxLen];
-    ReturnErrorOnFailure(CreateCommonCommandArgs(command, sizeof(command), scriptDir, scriptName, discriminator, port, kvs));
+    char command[128];
+    VerifyOrReturnError(snprintf(command, sizeof(command), "%s%s %s", scriptDir, scriptName, registerKey) >= 0,
+                        CHIP_ERROR_INTERNAL);
     return RunInternal(command);
 }
 
-CHIP_ERROR SystemCommands::FactoryReset()
+CHIP_ERROR SystemCommands::FactoryReset(const char * registerKey)
 {
     const char * scriptDir            = getScriptsFolder();
     constexpr const char * scriptName = "FactoryReset.py";
 
     char command[128];
-    VerifyOrReturnError(snprintf(command, sizeof(command), "%s%s", scriptDir, scriptName) >= 0, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(snprintf(command, sizeof(command), "%s%s %s", scriptDir, scriptName, registerKey) >= 0,
+                        CHIP_ERROR_INTERNAL);
     return RunInternal(command);
 }
 
@@ -77,11 +81,16 @@ CHIP_ERROR SystemCommands::RunInternal(const char * command)
 }
 
 CHIP_ERROR SystemCommands::CreateCommonCommandArgs(char * commandBuffer, size_t commandBufferSize, const char * scriptDir,
-                                                   const char * scriptName, uint16_t discriminator, uint16_t port, const char * kvs)
+                                                   const char * scriptName, const char * registerKey, uint16_t discriminator,
+                                                   uint16_t port, const char * kvs)
 {
+    VerifyOrReturnError(registerKey != nullptr, CHIP_ERROR_INVALID_KEY_ID);
+
     chip::StringBuilder<kCommandMaxLen> builder;
     builder.Add(scriptDir);
     builder.Add(scriptName);
+    builder.Add(" ");
+    builder.Add(registerKey);
 
     // Add any applicable optional command line options
     if (discriminator != 0xFFFF)

--- a/src/app/tests/suites/commands/system/SystemCommands.h
+++ b/src/app/tests/suites/commands/system/SystemCommands.h
@@ -28,13 +28,15 @@ public:
 
     virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) = 0;
 
-    CHIP_ERROR Start(uint16_t discriminator = 0xFFFF, uint16_t port = CHIP_PORT, const char * kvs = nullptr);
-    CHIP_ERROR Stop();
-    CHIP_ERROR Reboot(uint16_t discriminator = 0xFFFF, uint16_t port = CHIP_PORT, const char * kvs = nullptr);
-    CHIP_ERROR FactoryReset();
+    CHIP_ERROR Start(uint16_t discriminator = 0xFFFF, uint16_t port = CHIP_PORT, const char * kvs = nullptr,
+                     const char * registerKey = "default");
+    CHIP_ERROR Stop(const char * registerKey = "default");
+    CHIP_ERROR Reboot(const char * registerKey = "default");
+    CHIP_ERROR FactoryReset(const char * registerKey = "default");
 
 private:
     CHIP_ERROR RunInternal(const char * command);
     CHIP_ERROR CreateCommonCommandArgs(char * commandBuffer, size_t commandBufferSize, const char * scriptDir,
-                                       const char * scriptName, uint16_t discriminator, uint16_t port, const char * kvs);
+                                       const char * scriptName, const char * registerKey, uint16_t discriminator, uint16_t port,
+                                       const char * kvs);
 };

--- a/src/app/tests/suites/commands/system/scripts/FactoryReset.py
+++ b/src/app/tests/suites/commands/system/scripts/FactoryReset.py
@@ -23,5 +23,6 @@ PORT = 9000
 if sys.platform == 'linux':
     IP = '10.10.10.5'
 
+# sys.argv[1] contains the key to the apps register
 with xmlrpc.client.ServerProxy('http://' + IP + ':' + str(PORT) + '/', allow_none=True) as proxy:
-    proxy.factoryReset('default')
+    proxy.factoryReset(sys.argv[1])

--- a/src/app/tests/suites/commands/system/scripts/Reboot.py
+++ b/src/app/tests/suites/commands/system/scripts/Reboot.py
@@ -23,7 +23,6 @@ PORT = 9000
 if sys.platform == 'linux':
     IP = '10.10.10.5'
 
-# Passing in sys.argv[1:] gets rid of the script name with the remaining values in the list as
-# key-value pairs, e.g. [option1, value1, option2, value2, ...]
+# sys.argv[1] contains the key to the apps register
 with xmlrpc.client.ServerProxy('http://' + IP + ':' + str(PORT) + '/', allow_none=True) as proxy:
-    proxy.reboot('default', sys.argv[1:])
+    proxy.reboot(sys.argv[1])

--- a/src/app/tests/suites/commands/system/scripts/Start.py
+++ b/src/app/tests/suites/commands/system/scripts/Start.py
@@ -23,7 +23,7 @@ PORT = 9000
 if sys.platform == 'linux':
     IP = '10.10.10.5'
 
-# Passing in sys.argv[1:] gets rid of the script name with the remaining values in the list as
-# key-value pairs, e.g. [option1, value1, option2, value2, ...]
+# Passing in sys.argv[2:] gets rid of the script name and key to the apps register. The remaining
+# values in the list are key-value pairs, e.g. [option1, value1, option2, value2, ...]
 with xmlrpc.client.ServerProxy('http://' + IP + ':' + str(PORT) + '/', allow_none=True) as proxy:
-    proxy.start('default', sys.argv[1:])
+    proxy.start(sys.argv[1], sys.argv[2:])

--- a/src/app/tests/suites/commands/system/scripts/Stop.py
+++ b/src/app/tests/suites/commands/system/scripts/Stop.py
@@ -23,5 +23,6 @@ PORT = 9000
 if sys.platform == 'linux':
     IP = '10.10.10.5'
 
+# sys.argv[1] contains the key to the apps register
 with xmlrpc.client.ServerProxy('http://' + IP + ':' + str(PORT) + '/', allow_none=True) as proxy:
-    proxy.stop('default')
+    proxy.stop(sys.argv[1])

--- a/src/app/zap-templates/common/simulated-clusters/clusters/SystemCommands.js
+++ b/src/app/zap-templates/common/simulated-clusters/clusters/SystemCommands.js
@@ -28,29 +28,26 @@ const Start = {
   name : 'Start',
   arguments : [
     { 'name' : 'discriminator', type : 'INT16U', isOptional : true }, { 'name' : 'port', type : 'INT16U', isOptional : true },
-    { 'name' : 'kvs', type : 'CHAR_STRING', isOptional : true }
+    { 'name' : 'kvs', type : 'CHAR_STRING', isOptional : true }, { 'name' : 'registerKey', type : 'CHAR_STRING', isOptional : true }
   ],
   response : { arguments : [] }
 };
 
 const Stop = {
   name : 'Stop',
-  arguments : [],
+  arguments : [ { 'name' : 'registerKey', type : 'CHAR_STRING', isOptional : true } ],
   response : { arguments : [] }
 };
 
 const Reboot = {
   name : 'Reboot',
-  arguments : [
-    { 'name' : 'discriminator', type : 'INT16U', isOptional : true }, { 'name' : 'port', type : 'INT16U', isOptional : true },
-    { 'name' : 'kvs', type : 'CHAR_STRING', isOptional : true }
-  ],
+  arguments : [ { 'name' : 'registerKey', type : 'CHAR_STRING', isOptional : true } ],
   response : { arguments : [] }
 };
 
 const FactoryReset = {
   name : 'FactoryReset',
-  arguments : [],
+  arguments : [ { 'name' : 'registerKey', type : 'CHAR_STRING', isOptional : true } ],
   response : { arguments : [] }
 };
 

--- a/zzz_generated/chip-tool-darwin/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool-darwin/zap-generated/test/Commands.h
@@ -31962,62 +31962,67 @@ public:
         // incorrect mTestIndex value observed when we get the response.
         switch (mTestIndex++) {
         case 0:
-            ChipLogProgress(chipTool, " ***** Test Step 0 : Reboot target device\n");
-            err = TestRebootTargetDevice_0();
+            ChipLogProgress(chipTool, " ***** Test Step 0 : Stop target device\n");
+            err = TestStopTargetDevice_0();
             break;
         case 1:
-            ChipLogProgress(chipTool, " ***** Test Step 1 : TH_CR1 starts a commissioning process with DUT_CE\n");
-            err = TestThCr1StartsACommissioningProcessWithDutCe_1();
+            ChipLogProgress(chipTool,
+                " ***** Test Step 1 : Start target device with the provided discriminator for basic commissioning advertisement\n");
+            err = TestStartTargetDeviceWithTheProvidedDiscriminatorForBasicCommissioningAdvertisement_1();
             break;
         case 2:
-            ChipLogProgress(chipTool, " ***** Test Step 2 : TH_CR1 opens a commissioning window on DUT_CE\n");
-            err = TestThCr1OpensACommissioningWindowOnDutCe_2();
+            ChipLogProgress(chipTool, " ***** Test Step 2 : TH_CR1 starts a commissioning process with DUT_CE\n");
+            err = TestThCr1StartsACommissioningProcessWithDutCe_2();
             break;
         case 3:
-            ChipLogProgress(chipTool,
-                " ***** Test Step 3 : TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
-            err = TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_3();
+            ChipLogProgress(chipTool, " ***** Test Step 3 : TH_CR1 opens a commissioning window on DUT_CE\n");
+            err = TestThCr1OpensACommissioningWindowOnDutCe_3();
             break;
         case 4:
             ChipLogProgress(chipTool,
-                " ***** Test Step 4 : TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
-            err = TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_4();
+                " ***** Test Step 4 : TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
+            err = TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_4();
             break;
         case 5:
-            ChipLogProgress(chipTool, " ***** Test Step 5 : Commission from beta\n");
-            err = TestCommissionFromBeta_5();
+            ChipLogProgress(chipTool,
+                " ***** Test Step 5 : TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
+            err = TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_5();
             break;
         case 6:
-            ChipLogProgress(chipTool, " ***** Test Step 6 : TH_CR2 starts a commissioning process with DUT_CE\n");
-            err = TestThCr2StartsACommissioningProcessWithDutCe_6();
+            ChipLogProgress(chipTool, " ***** Test Step 6 : Commission from beta\n");
+            err = TestCommissionFromBeta_6();
             break;
         case 7:
-            ChipLogProgress(chipTool, " ***** Test Step 7 : Query fabrics list\n");
-            err = TestQueryFabricsList_7();
+            ChipLogProgress(chipTool, " ***** Test Step 7 : TH_CR2 starts a commissioning process with DUT_CE\n");
+            err = TestThCr2StartsACommissioningProcessWithDutCe_7();
             break;
         case 8:
             ChipLogProgress(chipTool, " ***** Test Step 8 : Query fabrics list\n");
             err = TestQueryFabricsList_8();
             break;
         case 9:
-            ChipLogProgress(chipTool,
-                " ***** Test Step 9 : TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
-            err = TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_9();
+            ChipLogProgress(chipTool, " ***** Test Step 9 : Query fabrics list\n");
+            err = TestQueryFabricsList_9();
             break;
         case 10:
             ChipLogProgress(chipTool,
-                " ***** Test Step 10 : TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
-            err = TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_10();
+                " ***** Test Step 10 : TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
+            err = TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_10();
             break;
         case 11:
             ChipLogProgress(chipTool,
-                " ***** Test Step 11 : TH_CR2 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
-            err = TestThCr2WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_11();
+                " ***** Test Step 11 : TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
+            err = TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_11();
             break;
         case 12:
             ChipLogProgress(chipTool,
-                " ***** Test Step 12 : TH_CR2 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
-            err = TestThCr2ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_12();
+                " ***** Test Step 12 : TH_CR2 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
+            err = TestThCr2WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_12();
+            break;
+        case 13:
+            ChipLogProgress(chipTool,
+                " ***** Test Step 13 : TH_CR2 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
+            err = TestThCr2ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_13();
             break;
         }
 
@@ -32069,6 +32074,9 @@ public:
         case 12:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
+        case 13:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
         }
 
         // Go on to the next test.
@@ -32082,7 +32090,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 13;
+    const uint16_t mTestCount = 14;
 
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::NodeId> mNodeId2;
@@ -32091,21 +32099,28 @@ private:
     chip::Optional<chip::CharSpan> mPayload;
     chip::Optional<uint16_t> mTimeout;
 
-    CHIP_ERROR TestRebootTargetDevice_0()
+    CHIP_ERROR TestStopTargetDevice_0()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Stop();
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1StartsACommissioningProcessWithDutCe_1()
+    CHIP_ERROR TestStartTargetDeviceWithTheProvidedDiscriminatorForBasicCommissioningAdvertisement_1()
+    {
+        SetIdentity("alpha");
+        Start(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR TestThCr1StartsACommissioningProcessWithDutCe_2()
     {
         SetIdentity("alpha");
         WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1OpensACommissioningWindowOnDutCe_2()
+    CHIP_ERROR TestThCr1OpensACommissioningWindowOnDutCe_3()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -32137,7 +32152,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_3()
+    CHIP_ERROR TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_4()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -32160,7 +32175,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_4()
+    CHIP_ERROR TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_5()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -32185,7 +32200,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestCommissionFromBeta_5()
+    CHIP_ERROR TestCommissionFromBeta_6()
     {
         SetIdentity("beta");
         PairWithQRCode(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL,
@@ -32193,14 +32208,14 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr2StartsACommissioningProcessWithDutCe_6()
+    CHIP_ERROR TestThCr2StartsACommissioningProcessWithDutCe_7()
     {
         SetIdentity("beta");
         WaitForCommissionee(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL);
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestQueryFabricsList_7()
+    CHIP_ERROR TestQueryFabricsList_8()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -32231,7 +32246,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestQueryFabricsList_8()
+    CHIP_ERROR TestQueryFabricsList_9()
     {
         SetIdentity("beta");
         CHIPDevice * device = GetConnectedDevice();
@@ -32264,7 +32279,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_9()
+    CHIP_ERROR TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_10()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -32287,7 +32302,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_10()
+    CHIP_ERROR TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_11()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -32312,7 +32327,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr2WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_11()
+    CHIP_ERROR TestThCr2WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_12()
     {
         SetIdentity("beta");
         CHIPDevice * device = GetConnectedDevice();
@@ -32335,7 +32350,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr2ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_12()
+    CHIP_ERROR TestThCr2ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_13()
     {
         SetIdentity("beta");
         CHIPDevice * device = GetConnectedDevice();
@@ -32402,62 +32417,67 @@ public:
         // incorrect mTestIndex value observed when we get the response.
         switch (mTestIndex++) {
         case 0:
-            ChipLogProgress(chipTool, " ***** Test Step 0 : Reboot target device\n");
-            err = TestRebootTargetDevice_0();
+            ChipLogProgress(chipTool, " ***** Test Step 0 : Stop target device\n");
+            err = TestStopTargetDevice_0();
             break;
         case 1:
-            ChipLogProgress(chipTool, " ***** Test Step 1 : TH_CR1 starts a commissioning process with DUT_CE\n");
-            err = TestThCr1StartsACommissioningProcessWithDutCe_1();
+            ChipLogProgress(chipTool,
+                " ***** Test Step 1 : Start target device with the provided discriminator for basic commissioning advertisement\n");
+            err = TestStartTargetDeviceWithTheProvidedDiscriminatorForBasicCommissioningAdvertisement_1();
             break;
         case 2:
-            ChipLogProgress(chipTool, " ***** Test Step 2 : TH_CR1 opens a commissioning window on DUT_CE\n");
-            err = TestThCr1OpensACommissioningWindowOnDutCe_2();
+            ChipLogProgress(chipTool, " ***** Test Step 2 : TH_CR1 starts a commissioning process with DUT_CE\n");
+            err = TestThCr1StartsACommissioningProcessWithDutCe_2();
             break;
         case 3:
-            ChipLogProgress(chipTool,
-                " ***** Test Step 3 : TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
-            err = TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_3();
+            ChipLogProgress(chipTool, " ***** Test Step 3 : TH_CR1 opens a commissioning window on DUT_CE\n");
+            err = TestThCr1OpensACommissioningWindowOnDutCe_3();
             break;
         case 4:
             ChipLogProgress(chipTool,
-                " ***** Test Step 4 : TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
-            err = TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_4();
+                " ***** Test Step 4 : TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
+            err = TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_4();
             break;
         case 5:
-            ChipLogProgress(chipTool, " ***** Test Step 5 : Commission from beta\n");
-            err = TestCommissionFromBeta_5();
+            ChipLogProgress(chipTool,
+                " ***** Test Step 5 : TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
+            err = TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_5();
             break;
         case 6:
-            ChipLogProgress(chipTool, " ***** Test Step 6 : TH_CR2 starts a commissioning process with DUT_CE\n");
-            err = TestThCr2StartsACommissioningProcessWithDutCe_6();
+            ChipLogProgress(chipTool, " ***** Test Step 6 : Commission from beta\n");
+            err = TestCommissionFromBeta_6();
             break;
         case 7:
-            ChipLogProgress(chipTool, " ***** Test Step 7 : Query fabrics list\n");
-            err = TestQueryFabricsList_7();
+            ChipLogProgress(chipTool, " ***** Test Step 7 : TH_CR2 starts a commissioning process with DUT_CE\n");
+            err = TestThCr2StartsACommissioningProcessWithDutCe_7();
             break;
         case 8:
             ChipLogProgress(chipTool, " ***** Test Step 8 : Query fabrics list\n");
             err = TestQueryFabricsList_8();
             break;
         case 9:
-            ChipLogProgress(chipTool,
-                " ***** Test Step 9 : TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
-            err = TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_9();
+            ChipLogProgress(chipTool, " ***** Test Step 9 : Query fabrics list\n");
+            err = TestQueryFabricsList_9();
             break;
         case 10:
             ChipLogProgress(chipTool,
-                " ***** Test Step 10 : TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
-            err = TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_10();
+                " ***** Test Step 10 : TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
+            err = TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_10();
             break;
         case 11:
             ChipLogProgress(chipTool,
-                " ***** Test Step 11 : TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
-            err = TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_11();
+                " ***** Test Step 11 : TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
+            err = TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_11();
             break;
         case 12:
             ChipLogProgress(chipTool,
-                " ***** Test Step 12 : TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
-            err = TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_12();
+                " ***** Test Step 12 : TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
+            err = TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_12();
+            break;
+        case 13:
+            ChipLogProgress(chipTool,
+                " ***** Test Step 13 : TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE\n");
+            err = TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_13();
             break;
         }
 
@@ -32509,6 +32529,9 @@ public:
         case 12:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
+        case 13:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
         }
 
         // Go on to the next test.
@@ -32522,7 +32545,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 13;
+    const uint16_t mTestCount = 14;
 
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::NodeId> mNodeId2;
@@ -32531,21 +32554,28 @@ private:
     chip::Optional<chip::CharSpan> mPayload;
     chip::Optional<uint16_t> mTimeout;
 
-    CHIP_ERROR TestRebootTargetDevice_0()
+    CHIP_ERROR TestStopTargetDevice_0()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Stop();
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1StartsACommissioningProcessWithDutCe_1()
+    CHIP_ERROR TestStartTargetDeviceWithTheProvidedDiscriminatorForBasicCommissioningAdvertisement_1()
+    {
+        SetIdentity("alpha");
+        Start(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR TestThCr1StartsACommissioningProcessWithDutCe_2()
     {
         SetIdentity("alpha");
         WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1OpensACommissioningWindowOnDutCe_2()
+    CHIP_ERROR TestThCr1OpensACommissioningWindowOnDutCe_3()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -32568,7 +32598,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_3()
+    CHIP_ERROR TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_4()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -32591,7 +32621,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_4()
+    CHIP_ERROR TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_5()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -32611,7 +32641,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestCommissionFromBeta_5()
+    CHIP_ERROR TestCommissionFromBeta_6()
     {
         SetIdentity("beta");
         PairWithQRCode(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL,
@@ -32619,14 +32649,14 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr2StartsACommissioningProcessWithDutCe_6()
+    CHIP_ERROR TestThCr2StartsACommissioningProcessWithDutCe_7()
     {
         SetIdentity("beta");
         WaitForCommissionee(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL);
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestQueryFabricsList_7()
+    CHIP_ERROR TestQueryFabricsList_8()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -32657,7 +32687,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestQueryFabricsList_8()
+    CHIP_ERROR TestQueryFabricsList_9()
     {
         SetIdentity("beta");
         CHIPDevice * device = GetConnectedDevice();
@@ -32688,7 +32718,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_9()
+    CHIP_ERROR TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_10()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -32711,7 +32741,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_10()
+    CHIP_ERROR TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_11()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -32731,7 +32761,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_11()
+    CHIP_ERROR TestThCr1WritesTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_12()
     {
         SetIdentity("beta");
         CHIPDevice * device = GetConnectedDevice();
@@ -32754,7 +32784,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_12()
+    CHIP_ERROR TestThCr1ReadsTheBasicInformationClustersNodeLabelMandatoryAttributeOfDutCe_13()
     {
         SetIdentity("beta");
         CHIPDevice * device = GetConnectedDevice();
@@ -32964,7 +32994,7 @@ private:
     CHIP_ERROR TestRebootTargetDevice_0()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Reboot();
         return CHIP_NO_ERROR;
     }
 
@@ -33250,20 +33280,21 @@ public:
         // incorrect mTestIndex value observed when we get the response.
         switch (mTestIndex++) {
         case 0:
-            ChipLogProgress(chipTool, " ***** Test Step 0 : Reboot target device\n");
-            err = TestRebootTargetDevice_0();
+            ChipLogProgress(chipTool, " ***** Test Step 0 : Stop target device\n");
+            err = TestStopTargetDevice_0();
             break;
         case 1:
-            ChipLogProgress(chipTool, " ***** Test Step 1 : TH_CR1 starts a commissioning process with DUT_CE\n");
-            err = TestThCr1StartsACommissioningProcessWithDutCe_1();
+            ChipLogProgress(chipTool,
+                " ***** Test Step 1 : Start target device with the provided discriminator for basic commissioning advertisement\n");
+            err = TestStartTargetDeviceWithTheProvidedDiscriminatorForBasicCommissioningAdvertisement_1();
             break;
         case 2:
-            ChipLogProgress(chipTool, " ***** Test Step 2 : TH_CR1 opens a commissioning window on DUT_CE\n");
-            err = TestThCr1OpensACommissioningWindowOnDutCe_2();
+            ChipLogProgress(chipTool, " ***** Test Step 2 : TH_CR1 starts a commissioning process with DUT_CE\n");
+            err = TestThCr1StartsACommissioningProcessWithDutCe_2();
             break;
         case 3:
-            ChipLogProgress(chipTool, " ***** Test Step 3 : Wait for PIXIT_COMM_WIN(180) + 10\n");
-            err = TestWaitForPixitCommWin18010_3();
+            ChipLogProgress(chipTool, " ***** Test Step 3 : TH_CR1 opens a commissioning window on DUT_CE\n");
+            err = TestThCr1OpensACommissioningWindowOnDutCe_3();
             break;
         case 4:
             ChipLogProgress(chipTool, " ***** Test Step 4 : Wait for PIXIT_COMM_WIN(180) + 10\n");
@@ -33278,48 +33309,52 @@ public:
             err = TestWaitForPixitCommWin18010_6();
             break;
         case 7:
-            ChipLogProgress(chipTool, " ***** Test Step 7 : Commission from beta\n");
-            err = TestCommissionFromBeta_7();
+            ChipLogProgress(chipTool, " ***** Test Step 7 : Wait for PIXIT_COMM_WIN(180) + 10\n");
+            err = TestWaitForPixitCommWin18010_7();
             break;
         case 8:
-            ChipLogProgress(chipTool, " ***** Test Step 8 : TH_CR1 opens a commissioning window on DUT_CE\n");
-            err = TestThCr1OpensACommissioningWindowOnDutCe_8();
+            ChipLogProgress(chipTool, " ***** Test Step 8 : Commission from beta\n");
+            err = TestCommissionFromBeta_8();
             break;
         case 9:
-            ChipLogProgress(chipTool, " ***** Test Step 9 : TH_CR1 revokes the commissioning window on DUT_CE\n");
-            err = TestThCr1RevokesTheCommissioningWindowOnDutCe_9();
+            ChipLogProgress(chipTool, " ***** Test Step 9 : TH_CR1 opens a commissioning window on DUT_CE\n");
+            err = TestThCr1OpensACommissioningWindowOnDutCe_9();
             break;
         case 10:
-            ChipLogProgress(chipTool, " ***** Test Step 10 : Commission from beta\n");
-            err = TestCommissionFromBeta_10();
+            ChipLogProgress(chipTool, " ***** Test Step 10 : TH_CR1 revokes the commissioning window on DUT_CE\n");
+            err = TestThCr1RevokesTheCommissioningWindowOnDutCe_10();
             break;
         case 11:
-            ChipLogProgress(chipTool, " ***** Test Step 11 : TH_CR1 revokes the commissioning window on DUT_CE\n");
-            err = TestThCr1RevokesTheCommissioningWindowOnDutCe_11();
+            ChipLogProgress(chipTool, " ***** Test Step 11 : Commission from beta\n");
+            err = TestCommissionFromBeta_11();
             break;
         case 12:
-            ChipLogProgress(chipTool, " ***** Test Step 12 : TH_CR1 writes the mandatory attribute NodeLabel of DUT_CE\n");
-            err = TestThCr1WritesTheMandatoryAttributeNodeLabelOfDutCe_12();
+            ChipLogProgress(chipTool, " ***** Test Step 12 : TH_CR1 revokes the commissioning window on DUT_CE\n");
+            err = TestThCr1RevokesTheCommissioningWindowOnDutCe_12();
             break;
         case 13:
-            ChipLogProgress(chipTool, " ***** Test Step 13 : TH_CR1 read the mandatory attribute NodeLabel of DUT_CE\n");
-            err = TestThCr1ReadTheMandatoryAttributeNodeLabelOfDutCe_13();
+            ChipLogProgress(chipTool, " ***** Test Step 13 : TH_CR1 writes the mandatory attribute NodeLabel of DUT_CE\n");
+            err = TestThCr1WritesTheMandatoryAttributeNodeLabelOfDutCe_13();
             break;
         case 14:
-            ChipLogProgress(chipTool, " ***** Test Step 14 : TH_CR1 opens a commissioning window on DUT_CE\n");
-            err = TestThCr1OpensACommissioningWindowOnDutCe_14();
+            ChipLogProgress(chipTool, " ***** Test Step 14 : TH_CR1 read the mandatory attribute NodeLabel of DUT_CE\n");
+            err = TestThCr1ReadTheMandatoryAttributeNodeLabelOfDutCe_14();
             break;
         case 15:
-            ChipLogProgress(chipTool, " ***** Test Step 15 : Commission from beta\n");
-            err = TestCommissionFromBeta_15();
+            ChipLogProgress(chipTool, " ***** Test Step 15 : TH_CR1 opens a commissioning window on DUT_CE\n");
+            err = TestThCr1OpensACommissioningWindowOnDutCe_15();
             break;
         case 16:
-            ChipLogProgress(chipTool, " ***** Test Step 16 : TH_CR2 starts a commissioning process on DUT_CE\n");
-            err = TestThCr2StartsACommissioningProcessOnDutCe_16();
+            ChipLogProgress(chipTool, " ***** Test Step 16 : Commission from beta\n");
+            err = TestCommissionFromBeta_16();
             break;
         case 17:
-            ChipLogProgress(chipTool, " ***** Test Step 17 : TH_CR3 starts a commissioning process with DUT_CE\n");
-            err = TestThCr3StartsACommissioningProcessWithDutCe_17();
+            ChipLogProgress(chipTool, " ***** Test Step 17 : TH_CR2 starts a commissioning process on DUT_CE\n");
+            err = TestThCr2StartsACommissioningProcessOnDutCe_17();
+            break;
+        case 18:
+            ChipLogProgress(chipTool, " ***** Test Step 18 : TH_CR3 starts a commissioning process with DUT_CE\n");
+            err = TestThCr3StartsACommissioningProcessWithDutCe_18();
             break;
         }
 
@@ -33354,22 +33389,22 @@ public:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 7:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 8:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             break;
         case 9:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 10:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 11:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             break;
         case 12:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             break;
         case 13:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -33384,6 +33419,9 @@ public:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 17:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 18:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             break;
         }
@@ -33396,7 +33434,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 18;
+    const uint16_t mTestCount = 19;
 
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<uint16_t> mTimeout;
@@ -33407,21 +33445,28 @@ private:
     chip::Optional<uint16_t> mDiscriminator;
     chip::Optional<chip::CharSpan> mPayload;
 
-    CHIP_ERROR TestRebootTargetDevice_0()
+    CHIP_ERROR TestStopTargetDevice_0()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Stop();
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1StartsACommissioningProcessWithDutCe_1()
+    CHIP_ERROR TestStartTargetDeviceWithTheProvidedDiscriminatorForBasicCommissioningAdvertisement_1()
+    {
+        SetIdentity("alpha");
+        Start(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR TestThCr1StartsACommissioningProcessWithDutCe_2()
     {
         SetIdentity("alpha");
         WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1OpensACommissioningWindowOnDutCe_2()
+    CHIP_ERROR TestThCr1OpensACommissioningWindowOnDutCe_3()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -33441,13 +33486,6 @@ private:
                                           NextTest();
                                       }];
 
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR TestWaitForPixitCommWin18010_3()
-    {
-        SetIdentity("alpha");
-        WaitForMs(54000);
         return CHIP_NO_ERROR;
     }
 
@@ -33468,11 +33506,18 @@ private:
     CHIP_ERROR TestWaitForPixitCommWin18010_6()
     {
         SetIdentity("alpha");
+        WaitForMs(54000);
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR TestWaitForPixitCommWin18010_7()
+    {
+        SetIdentity("alpha");
         WaitForMs(28000);
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestCommissionFromBeta_7()
+    CHIP_ERROR TestCommissionFromBeta_8()
     {
         SetIdentity("beta");
         PairWithQRCode(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL,
@@ -33480,7 +33525,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1OpensACommissioningWindowOnDutCe_8()
+    CHIP_ERROR TestThCr1OpensACommissioningWindowOnDutCe_9()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -33503,7 +33548,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1RevokesTheCommissioningWindowOnDutCe_9()
+    CHIP_ERROR TestThCr1RevokesTheCommissioningWindowOnDutCe_10()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -33523,7 +33568,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestCommissionFromBeta_10()
+    CHIP_ERROR TestCommissionFromBeta_11()
     {
         SetIdentity("beta");
         PairWithQRCode(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL,
@@ -33531,7 +33576,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1RevokesTheCommissioningWindowOnDutCe_11()
+    CHIP_ERROR TestThCr1RevokesTheCommissioningWindowOnDutCe_12()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -33550,7 +33595,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1WritesTheMandatoryAttributeNodeLabelOfDutCe_12()
+    CHIP_ERROR TestThCr1WritesTheMandatoryAttributeNodeLabelOfDutCe_13()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -33571,7 +33616,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1ReadTheMandatoryAttributeNodeLabelOfDutCe_13()
+    CHIP_ERROR TestThCr1ReadTheMandatoryAttributeNodeLabelOfDutCe_14()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -33594,7 +33639,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr1OpensACommissioningWindowOnDutCe_14()
+    CHIP_ERROR TestThCr1OpensACommissioningWindowOnDutCe_15()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -33617,7 +33662,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestCommissionFromBeta_15()
+    CHIP_ERROR TestCommissionFromBeta_16()
     {
         SetIdentity("beta");
         PairWithQRCode(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL,
@@ -33625,14 +33670,14 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr2StartsACommissioningProcessOnDutCe_16()
+    CHIP_ERROR TestThCr2StartsACommissioningProcessOnDutCe_17()
     {
         SetIdentity("beta");
         WaitForCommissionee(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL);
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestThCr3StartsACommissioningProcessWithDutCe_17()
+    CHIP_ERROR TestThCr3StartsACommissioningProcessWithDutCe_18()
     {
         SetIdentity("gamma");
         PairWithQRCode(mNodeId3.HasValue() ? mNodeId3.Value() : 12586990ULL,
@@ -33886,7 +33931,7 @@ private:
     CHIP_ERROR TestRebootTargetDevice_0()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Reboot();
         return CHIP_NO_ERROR;
     }
 
@@ -37791,7 +37836,6 @@ public:
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
-        AddArgument("discriminator", 0, UINT16_MAX, &mDiscriminator);
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }
     // NOLINTEND(clang-analyzer-nullability.NullPassedToNonnull)
@@ -38031,7 +38075,6 @@ private:
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
-    chip::Optional<uint16_t> mDiscriminator;
     chip::Optional<uint16_t> mTimeout;
 
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
@@ -38107,7 +38150,7 @@ private:
     CHIP_ERROR TestPowerOffDut_4()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Reboot();
         return CHIP_NO_ERROR;
     }
 
@@ -38165,7 +38208,7 @@ private:
     CHIP_ERROR TestPowerOffDut_8()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Reboot();
         return CHIP_NO_ERROR;
     }
 
@@ -38223,7 +38266,7 @@ private:
     CHIP_ERROR TestPowerOffDut_12()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Reboot();
         return CHIP_NO_ERROR;
     }
 
@@ -38260,7 +38303,7 @@ private:
     CHIP_ERROR TestPowerOffDut_15()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Reboot();
         return CHIP_NO_ERROR;
     }
 
@@ -38318,7 +38361,7 @@ private:
     CHIP_ERROR TestPowerOffDut_19()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Reboot();
         return CHIP_NO_ERROR;
     }
 
@@ -38373,7 +38416,7 @@ private:
     CHIP_ERROR TestPowerOffDut_23()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Reboot();
         return CHIP_NO_ERROR;
     }
 
@@ -60364,7 +60407,6 @@ public:
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
-        AddArgument("discriminator", 0, UINT16_MAX, &mDiscriminator);
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }
     // NOLINTEND(clang-analyzer-nullability.NullPassedToNonnull)
@@ -60560,7 +60602,6 @@ private:
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
-    chip::Optional<uint16_t> mDiscriminator;
     chip::Optional<uint16_t> mTimeout;
 
     CHIP_ERROR Test0aWaitForTheCommissionedDeviceToBeRetrieved_0()
@@ -60753,7 +60794,7 @@ private:
     CHIP_ERROR Test3cRebootRestartTheDut_12()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Reboot();
         return CHIP_NO_ERROR;
     }
 
@@ -86004,7 +86045,6 @@ public:
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
-        AddArgument("discriminator", 0, UINT16_MAX, &mDiscriminator);
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }
     // NOLINTEND(clang-analyzer-nullability.NullPassedToNonnull)
@@ -86287,7 +86327,6 @@ private:
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
-    chip::Optional<uint16_t> mDiscriminator;
     chip::Optional<uint16_t> mTimeout;
 
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
@@ -86838,7 +86877,7 @@ private:
     CHIP_ERROR TestRebootTargetDevice_25()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Reboot();
         return CHIP_NO_ERROR;
     }
 
@@ -86896,7 +86935,7 @@ private:
     CHIP_ERROR TestRebootTargetDevice_29()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Reboot();
         return CHIP_NO_ERROR;
     }
 
@@ -87532,7 +87571,6 @@ public:
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
-        AddArgument("discriminator", 0, UINT16_MAX, &mDiscriminator);
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }
     // NOLINTEND(clang-analyzer-nullability.NullPassedToNonnull)
@@ -87639,7 +87677,6 @@ private:
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
-    chip::Optional<uint16_t> mDiscriminator;
     chip::Optional<uint16_t> mTimeout;
 
     CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
@@ -87739,7 +87776,7 @@ private:
     CHIP_ERROR TestRebootTargetDevice_4()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Reboot();
         return CHIP_NO_ERROR;
     }
 
@@ -87794,8 +87831,6 @@ public:
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
-        AddArgument("discriminator", 0, UINT16_MAX, &mDiscriminator);
-        AddArgument("payload", &mPayload);
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }
     // NOLINTEND(clang-analyzer-nullability.NullPassedToNonnull)
@@ -87887,14 +87922,12 @@ private:
 
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::EndpointId> mEndpoint;
-    chip::Optional<uint16_t> mDiscriminator;
-    chip::Optional<chip::CharSpan> mPayload;
     chip::Optional<uint16_t> mTimeout;
 
     CHIP_ERROR TestRebootTargetDevice_0()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Reboot();
         return CHIP_NO_ERROR;
     }
 
@@ -88033,72 +88066,77 @@ public:
         // incorrect mTestIndex value observed when we get the response.
         switch (mTestIndex++) {
         case 0:
-            ChipLogProgress(chipTool, " ***** Test Step 0 : Reboot target device\n");
-            err = TestRebootTargetDevice_0();
+            ChipLogProgress(chipTool, " ***** Test Step 0 : Stop target device\n");
+            err = TestStopTargetDevice_0();
             break;
         case 1:
-            ChipLogProgress(chipTool, " ***** Test Step 1 : Wait for the commissioned device to be retrieved for alpha\n");
-            err = TestWaitForTheCommissionedDeviceToBeRetrievedForAlpha_1();
+            ChipLogProgress(chipTool,
+                " ***** Test Step 1 : Start target device with the provided discriminator for basic commissioning advertisement\n");
+            err = TestStartTargetDeviceWithTheProvidedDiscriminatorForBasicCommissioningAdvertisement_1();
             break;
         case 2:
-            ChipLogProgress(chipTool, " ***** Test Step 2 : Commission from alpha when the commissioning window is not opened\n");
-            err = TestCommissionFromAlphaWhenTheCommissioningWindowIsNotOpened_2();
+            ChipLogProgress(chipTool, " ***** Test Step 2 : Wait for the commissioned device to be retrieved for alpha\n");
+            err = TestWaitForTheCommissionedDeviceToBeRetrievedForAlpha_2();
             break;
         case 3:
-            ChipLogProgress(chipTool, " ***** Test Step 3 : Open Commissioning Window from alpha\n");
-            err = TestOpenCommissioningWindowFromAlpha_3();
+            ChipLogProgress(chipTool, " ***** Test Step 3 : Commission from alpha when the commissioning window is not opened\n");
+            err = TestCommissionFromAlphaWhenTheCommissioningWindowIsNotOpened_3();
             break;
         case 4:
-            ChipLogProgress(chipTool, " ***** Test Step 4 : Commission from alpha again\n");
-            err = TestCommissionFromAlphaAgain_4();
+            ChipLogProgress(chipTool, " ***** Test Step 4 : Open Commissioning Window from alpha\n");
+            err = TestOpenCommissioningWindowFromAlpha_4();
             break;
         case 5:
-            ChipLogProgress(chipTool, " ***** Test Step 5 : Check that we just have the one fabric and did not add a new one\n");
-            err = TestCheckThatWeJustHaveTheOneFabricAndDidNotAddANewOne_5();
+            ChipLogProgress(chipTool, " ***** Test Step 5 : Commission from alpha again\n");
+            err = TestCommissionFromAlphaAgain_5();
             break;
         case 6:
-            ChipLogProgress(chipTool, " ***** Test Step 6 : Close Commissioning Window after failed commissioning\n");
-            err = TestCloseCommissioningWindowAfterFailedCommissioning_6();
+            ChipLogProgress(chipTool, " ***** Test Step 6 : Check that we just have the one fabric and did not add a new one\n");
+            err = TestCheckThatWeJustHaveTheOneFabricAndDidNotAddANewOne_6();
             break;
         case 7:
-            ChipLogProgress(chipTool, " ***** Test Step 7 : Open Commissioning Window from alpha again\n");
-            err = TestOpenCommissioningWindowFromAlphaAgain_7();
+            ChipLogProgress(chipTool, " ***** Test Step 7 : Close Commissioning Window after failed commissioning\n");
+            err = TestCloseCommissioningWindowAfterFailedCommissioning_7();
             break;
         case 8:
-            ChipLogProgress(chipTool, " ***** Test Step 8 : Commission from beta\n");
-            err = TestCommissionFromBeta_8();
+            ChipLogProgress(chipTool, " ***** Test Step 8 : Open Commissioning Window from alpha again\n");
+            err = TestOpenCommissioningWindowFromAlphaAgain_8();
             break;
         case 9:
-            ChipLogProgress(chipTool, " ***** Test Step 9 : Wait for the commissioned device to be retrieved for beta\n");
-            err = TestWaitForTheCommissionedDeviceToBeRetrievedForBeta_9();
+            ChipLogProgress(chipTool, " ***** Test Step 9 : Commission from beta\n");
+            err = TestCommissionFromBeta_9();
             break;
         case 10:
-            ChipLogProgress(chipTool, " ***** Test Step 10 : Open Commissioning Window from beta\n");
-            err = TestOpenCommissioningWindowFromBeta_10();
+            ChipLogProgress(chipTool, " ***** Test Step 10 : Wait for the commissioned device to be retrieved for beta\n");
+            err = TestWaitForTheCommissionedDeviceToBeRetrievedForBeta_10();
             break;
         case 11:
-            ChipLogProgress(chipTool, " ***** Test Step 11 : Commission from gamma\n");
-            err = TestCommissionFromGamma_11();
+            ChipLogProgress(chipTool, " ***** Test Step 11 : Open Commissioning Window from beta\n");
+            err = TestOpenCommissioningWindowFromBeta_11();
             break;
         case 12:
-            ChipLogProgress(chipTool, " ***** Test Step 12 : Wait for the commissioned device to be retrieved for gamma\n");
-            err = TestWaitForTheCommissionedDeviceToBeRetrievedForGamma_12();
+            ChipLogProgress(chipTool, " ***** Test Step 12 : Commission from gamma\n");
+            err = TestCommissionFromGamma_12();
             break;
         case 13:
-            ChipLogProgress(chipTool, " ***** Test Step 13 : read the mandatory attribute: NodeLabel from alpha\n");
-            err = TestReadTheMandatoryAttributeNodeLabelFromAlpha_13();
+            ChipLogProgress(chipTool, " ***** Test Step 13 : Wait for the commissioned device to be retrieved for gamma\n");
+            err = TestWaitForTheCommissionedDeviceToBeRetrievedForGamma_13();
             break;
         case 14:
-            ChipLogProgress(chipTool, " ***** Test Step 14 : write the mandatory attribute NodeLabel from beta\n");
-            err = TestWriteTheMandatoryAttributeNodeLabelFromBeta_14();
+            ChipLogProgress(chipTool, " ***** Test Step 14 : read the mandatory attribute: NodeLabel from alpha\n");
+            err = TestReadTheMandatoryAttributeNodeLabelFromAlpha_14();
             break;
         case 15:
-            ChipLogProgress(chipTool, " ***** Test Step 15 : read the mandatory attribute: NodeLabel from gamma\n");
-            err = TestReadTheMandatoryAttributeNodeLabelFromGamma_15();
+            ChipLogProgress(chipTool, " ***** Test Step 15 : write the mandatory attribute NodeLabel from beta\n");
+            err = TestWriteTheMandatoryAttributeNodeLabelFromBeta_15();
             break;
         case 16:
-            ChipLogProgress(chipTool, " ***** Test Step 16 : write the mandatory attribute NodeLabel back to default\n");
-            err = TestWriteTheMandatoryAttributeNodeLabelBackToDefault_16();
+            ChipLogProgress(chipTool, " ***** Test Step 16 : read the mandatory attribute: NodeLabel from gamma\n");
+            err = TestReadTheMandatoryAttributeNodeLabelFromGamma_16();
+            break;
+        case 17:
+            ChipLogProgress(chipTool, " ***** Test Step 17 : write the mandatory attribute NodeLabel back to default\n");
+            err = TestWriteTheMandatoryAttributeNodeLabelBackToDefault_17();
             break;
         }
 
@@ -88118,18 +88156,18 @@ public:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 2:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
-            break;
-        case 3:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
+        case 3:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            break;
         case 4:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 5:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             VerifyOrReturn(CheckValue("clusterStatus present", status.mClusterStatus.HasValue(), true));
             VerifyOrReturn(CheckValue("clusterStatus value", status.mClusterStatus.Value(), 9));
-            break;
-        case 5:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 6:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -88164,6 +88202,9 @@ public:
         case 16:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
+        case 17:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
         }
 
         // Go on to the next test.
@@ -88177,7 +88218,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 17;
+    const uint16_t mTestCount = 18;
 
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::NodeId> mNodeIdForDuplicateCommissioning;
@@ -88188,21 +88229,28 @@ private:
     chip::Optional<chip::CharSpan> mPayload;
     chip::Optional<uint16_t> mTimeout;
 
-    CHIP_ERROR TestRebootTargetDevice_0()
+    CHIP_ERROR TestStopTargetDevice_0()
     {
         SetIdentity("alpha");
-        Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        Stop();
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrievedForAlpha_1()
+    CHIP_ERROR TestStartTargetDeviceWithTheProvidedDiscriminatorForBasicCommissioningAdvertisement_1()
+    {
+        SetIdentity("alpha");
+        Start(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrievedForAlpha_2()
     {
         SetIdentity("alpha");
         WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestCommissionFromAlphaWhenTheCommissioningWindowIsNotOpened_2()
+    CHIP_ERROR TestCommissionFromAlphaWhenTheCommissioningWindowIsNotOpened_3()
     {
         SetIdentity("alpha");
         PairWithQRCode(mNodeIdForDuplicateCommissioning.HasValue() ? mNodeIdForDuplicateCommissioning.Value() : 17ULL,
@@ -88210,7 +88258,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestOpenCommissioningWindowFromAlpha_3()
+    CHIP_ERROR TestOpenCommissioningWindowFromAlpha_4()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -88233,7 +88281,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestCommissionFromAlphaAgain_4()
+    CHIP_ERROR TestCommissionFromAlphaAgain_5()
     {
         SetIdentity("alpha");
         PairWithQRCode(mNodeIdForDuplicateCommissioning.HasValue() ? mNodeIdForDuplicateCommissioning.Value() : 17ULL,
@@ -88241,7 +88289,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestCheckThatWeJustHaveTheOneFabricAndDidNotAddANewOne_5()
+    CHIP_ERROR TestCheckThatWeJustHaveTheOneFabricAndDidNotAddANewOne_6()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -88269,7 +88317,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestCloseCommissioningWindowAfterFailedCommissioning_6()
+    CHIP_ERROR TestCloseCommissioningWindowAfterFailedCommissioning_7()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -88289,7 +88337,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestOpenCommissioningWindowFromAlphaAgain_7()
+    CHIP_ERROR TestOpenCommissioningWindowFromAlphaAgain_8()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -88312,7 +88360,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestCommissionFromBeta_8()
+    CHIP_ERROR TestCommissionFromBeta_9()
     {
         SetIdentity("beta");
         PairWithQRCode(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL,
@@ -88320,14 +88368,14 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrievedForBeta_9()
+    CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrievedForBeta_10()
     {
         SetIdentity("beta");
         WaitForCommissionee(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL);
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestOpenCommissioningWindowFromBeta_10()
+    CHIP_ERROR TestOpenCommissioningWindowFromBeta_11()
     {
         SetIdentity("beta");
         CHIPDevice * device = GetConnectedDevice();
@@ -88350,7 +88398,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestCommissionFromGamma_11()
+    CHIP_ERROR TestCommissionFromGamma_12()
     {
         SetIdentity("gamma");
         PairWithQRCode(mNodeId3.HasValue() ? mNodeId3.Value() : 12586990ULL,
@@ -88358,7 +88406,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrievedForGamma_12()
+    CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrievedForGamma_13()
     {
         SetIdentity("gamma");
         WaitForCommissionee(mNodeId3.HasValue() ? mNodeId3.Value() : 12586990ULL);
@@ -88366,7 +88414,7 @@ private:
     }
     NSString * _Nonnull readFromAlpha;
 
-    CHIP_ERROR TestReadTheMandatoryAttributeNodeLabelFromAlpha_13()
+    CHIP_ERROR TestReadTheMandatoryAttributeNodeLabelFromAlpha_14()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();
@@ -88392,7 +88440,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestWriteTheMandatoryAttributeNodeLabelFromBeta_14()
+    CHIP_ERROR TestWriteTheMandatoryAttributeNodeLabelFromBeta_15()
     {
         SetIdentity("beta");
         CHIPDevice * device = GetConnectedDevice();
@@ -88413,7 +88461,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestReadTheMandatoryAttributeNodeLabelFromGamma_15()
+    CHIP_ERROR TestReadTheMandatoryAttributeNodeLabelFromGamma_16()
     {
         SetIdentity("gamma");
         CHIPDevice * device = GetConnectedDevice();
@@ -88435,7 +88483,7 @@ private:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR TestWriteTheMandatoryAttributeNodeLabelBackToDefault_16()
+    CHIP_ERROR TestWriteTheMandatoryAttributeNodeLabelBackToDefault_17()
     {
         SetIdentity("alpha");
         CHIPDevice * device = GetConnectedDevice();

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -17427,7 +17427,7 @@ private:
 class Test_TC_MF_1_3Suite : public TestCommand
 {
 public:
-    Test_TC_MF_1_3Suite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MF_1_3", 13, credsIssuerConfig)
+    Test_TC_MF_1_3Suite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MF_1_3", 14, credsIssuerConfig)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("nodeId2", 0, UINT64_MAX, &mNodeId2);
@@ -17474,11 +17474,15 @@ private:
             break;
         case 2:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
             break;
         case 3:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 4:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 5:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::CharSpan value;
@@ -17488,15 +17492,15 @@ private:
                 VerifyOrReturn(CheckConstraintMaxLength("value", value.size(), 32));
             }
             break;
-        case 5:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            shouldContinue = true;
-            break;
         case 6:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             shouldContinue = true;
             break;
         case 7:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 8:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::DecodableList<
@@ -17512,7 +17516,7 @@ private:
                 VerifyOrReturn(CheckConstraintType("value", "", "list"));
             }
             break;
-        case 8:
+        case 9:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::DecodableList<
@@ -17530,10 +17534,10 @@ private:
                 VerifyOrReturn(CheckConstraintType("value", "", "list"));
             }
             break;
-        case 9:
+        case 10:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 10:
+        case 11:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::CharSpan value;
@@ -17543,10 +17547,10 @@ private:
                 VerifyOrReturn(CheckConstraintMaxLength("value", value.size(), 32));
             }
             break;
-        case 11:
+        case 12:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 12:
+        case 13:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::CharSpan value;
@@ -17572,17 +17576,22 @@ private:
         switch (testIndex)
         {
         case 0: {
-            LogStep(0, "Reboot target device");
+            LogStep(0, "Stop target device");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Stop();
         }
         case 1: {
-            LogStep(1, "TH_CR1 starts a commissioning process with DUT_CE");
+            LogStep(1, "Start target device with the provided discriminator for basic commissioning advertisement");
+            SetIdentity(kIdentityAlpha);
+            return Start(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        }
+        case 2: {
+            LogStep(2, "TH_CR1 starts a commissioning process with DUT_CE");
             SetIdentity(kIdentityAlpha);
             return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
         }
-        case 2: {
-            LogStep(2, "TH_CR1 opens a commissioning window on DUT_CE");
+        case 3: {
+            LogStep(3, "TH_CR1 opens a commissioning window on DUT_CE");
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Type value;
             value.commissioningTimeout = 180U;
             value.PAKEVerifier         = chip::ByteSpan(
@@ -17591,63 +17600,63 @@ private:
                                              "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
                                              "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
                 97);
-            value.discriminator = 3840U;
+            value.discriminator = mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U;
             value.iterations    = 1000UL;
             value.salt = chip::ByteSpan(chip::Uint8::from_const_char("SPAKE2P Key Saltgarbage: not in length on purpose"), 16);
             return SendCommand(kIdentityAlpha, GetEndpoint(0), AdministratorCommissioning::Id,
                                AdministratorCommissioning::Commands::OpenCommissioningWindow::Id, value,
                                chip::Optional<uint16_t>(10000));
         }
-        case 3: {
-            LogStep(3, "TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
+        case 4: {
+            LogStep(4, "TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
             chip::CharSpan value;
             value = chip::Span<const char>("chiptestgarbage: not in length on purpose", 8);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id, value);
         }
-        case 4: {
-            LogStep(4, "TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
+        case 5: {
+            LogStep(5, "TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id);
         }
-        case 5: {
-            LogStep(5, "Commission from beta");
+        case 6: {
+            LogStep(6, "Commission from beta");
             SetIdentity(kIdentityBeta);
             return PairWithQRCode(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL,
                                   mPayload.HasValue() ? mPayload.Value()
                                                       : chip::CharSpan::fromCharString("MT:0000000000I31506010"));
         }
-        case 6: {
-            LogStep(6, "TH_CR2 starts a commissioning process with DUT_CE");
+        case 7: {
+            LogStep(7, "TH_CR2 starts a commissioning process with DUT_CE");
             SetIdentity(kIdentityBeta);
             return WaitForCommissionee(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL);
         }
-        case 7: {
-            LogStep(7, "Query fabrics list");
+        case 8: {
+            LogStep(8, "Query fabrics list");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(0), OperationalCredentials::Id,
                                  OperationalCredentials::Attributes::Fabrics::Id);
         }
-        case 8: {
-            LogStep(8, "Query fabrics list");
+        case 9: {
+            LogStep(9, "Query fabrics list");
             return ReadAttribute(kIdentityBeta, GetEndpoint(0), OperationalCredentials::Id,
                                  OperationalCredentials::Attributes::Fabrics::Id, false);
         }
-        case 9: {
-            LogStep(9, "TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
+        case 10: {
+            LogStep(10, "TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
             chip::CharSpan value;
             value = chip::Span<const char>("chiptest1garbage: not in length on purpose", 9);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id, value);
         }
-        case 10: {
-            LogStep(10, "TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
+        case 11: {
+            LogStep(11, "TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id);
         }
-        case 11: {
-            LogStep(11, "TH_CR2 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
+        case 12: {
+            LogStep(12, "TH_CR2 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
             chip::CharSpan value;
             value = chip::Span<const char>("chiptest2garbage: not in length on purpose", 9);
             return WriteAttribute(kIdentityBeta, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id, value);
         }
-        case 12: {
-            LogStep(12, "TH_CR2 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
+        case 13: {
+            LogStep(13, "TH_CR2 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
             return ReadAttribute(kIdentityBeta, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id);
         }
         }
@@ -17658,7 +17667,7 @@ private:
 class Test_TC_MF_1_4Suite : public TestCommand
 {
 public:
-    Test_TC_MF_1_4Suite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MF_1_4", 13, credsIssuerConfig)
+    Test_TC_MF_1_4Suite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MF_1_4", 14, credsIssuerConfig)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("nodeId2", 0, UINT64_MAX, &mNodeId2);
@@ -17705,11 +17714,15 @@ private:
             break;
         case 2:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
             break;
         case 3:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 4:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 5:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::CharSpan value;
@@ -17718,29 +17731,13 @@ private:
                 VerifyOrReturn(CheckConstraintMaxLength("value", value.size(), 32));
             }
             break;
-        case 5:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            shouldContinue = true;
-            break;
         case 6:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             shouldContinue = true;
             break;
         case 7:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::DataModel::DecodableList<
-                    chip::app::Clusters::OperationalCredentials::Structs::FabricDescriptor::DecodableType>
-                    value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                {
-                    auto iter_0 = value.begin();
-                    VerifyOrReturn(CheckNextListItemDecodes<decltype(value)>("fabrics", iter_0, 0));
-                    VerifyOrReturn(CheckValueAsString("fabrics[0].label", iter_0.GetValue().label, chip::CharSpan("", 0)));
-                    VerifyOrReturn(CheckNoMoreListItems<decltype(value)>("fabrics", iter_0, 1));
-                }
-                VerifyOrReturn(CheckConstraintType("value", "", "list"));
-            }
+            shouldContinue = true;
             break;
         case 8:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -17760,8 +17757,24 @@ private:
             break;
         case 9:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::DecodableList<
+                    chip::app::Clusters::OperationalCredentials::Structs::FabricDescriptor::DecodableType>
+                    value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                {
+                    auto iter_0 = value.begin();
+                    VerifyOrReturn(CheckNextListItemDecodes<decltype(value)>("fabrics", iter_0, 0));
+                    VerifyOrReturn(CheckValueAsString("fabrics[0].label", iter_0.GetValue().label, chip::CharSpan("", 0)));
+                    VerifyOrReturn(CheckNoMoreListItems<decltype(value)>("fabrics", iter_0, 1));
+                }
+                VerifyOrReturn(CheckConstraintType("value", "", "list"));
+            }
             break;
         case 10:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 11:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::CharSpan value;
@@ -17770,10 +17783,10 @@ private:
                 VerifyOrReturn(CheckConstraintMaxLength("value", value.size(), 32));
             }
             break;
-        case 11:
+        case 12:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 12:
+        case 13:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::CharSpan value;
@@ -17798,73 +17811,78 @@ private:
         switch (testIndex)
         {
         case 0: {
-            LogStep(0, "Reboot target device");
+            LogStep(0, "Stop target device");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Stop();
         }
         case 1: {
-            LogStep(1, "TH_CR1 starts a commissioning process with DUT_CE");
+            LogStep(1, "Start target device with the provided discriminator for basic commissioning advertisement");
+            SetIdentity(kIdentityAlpha);
+            return Start(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        }
+        case 2: {
+            LogStep(2, "TH_CR1 starts a commissioning process with DUT_CE");
             SetIdentity(kIdentityAlpha);
             return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
         }
-        case 2: {
-            LogStep(2, "TH_CR1 opens a commissioning window on DUT_CE");
+        case 3: {
+            LogStep(3, "TH_CR1 opens a commissioning window on DUT_CE");
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type value;
             value.commissioningTimeout = 180U;
             return SendCommand(kIdentityAlpha, GetEndpoint(0), AdministratorCommissioning::Id,
                                AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id, value,
                                chip::Optional<uint16_t>(10000));
         }
-        case 3: {
-            LogStep(3, "TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
+        case 4: {
+            LogStep(4, "TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
             chip::CharSpan value;
             value = chip::Span<const char>("chiptestgarbage: not in length on purpose", 8);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id, value);
         }
-        case 4: {
-            LogStep(4, "TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
+        case 5: {
+            LogStep(5, "TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id);
         }
-        case 5: {
-            LogStep(5, "Commission from beta");
+        case 6: {
+            LogStep(6, "Commission from beta");
             SetIdentity(kIdentityBeta);
             return PairWithQRCode(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL,
                                   mPayload.HasValue() ? mPayload.Value()
                                                       : chip::CharSpan::fromCharString("MT:-24J0AFN00KA0648G00"));
         }
-        case 6: {
-            LogStep(6, "TH_CR2 starts a commissioning process with DUT_CE");
+        case 7: {
+            LogStep(7, "TH_CR2 starts a commissioning process with DUT_CE");
             SetIdentity(kIdentityBeta);
             return WaitForCommissionee(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL);
         }
-        case 7: {
-            LogStep(7, "Query fabrics list");
+        case 8: {
+            LogStep(8, "Query fabrics list");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(0), OperationalCredentials::Id,
                                  OperationalCredentials::Attributes::Fabrics::Id);
         }
-        case 8: {
-            LogStep(8, "Query fabrics list");
+        case 9: {
+            LogStep(9, "Query fabrics list");
             return ReadAttribute(kIdentityBeta, GetEndpoint(0), OperationalCredentials::Id,
                                  OperationalCredentials::Attributes::Fabrics::Id);
         }
-        case 9: {
-            LogStep(9, "TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
+        case 10: {
+            LogStep(10, "TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
             chip::CharSpan value;
             value = chip::Span<const char>("chiptestgarbage: not in length on purpose", 8);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id, value);
         }
-        case 10: {
-            LogStep(10, "TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
+        case 11: {
+            LogStep(11, "TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id);
         }
-        case 11: {
-            LogStep(11, "TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
+        case 12: {
+            LogStep(12, "TH_CR1 writes the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
             chip::CharSpan value;
             value = chip::Span<const char>("chiptestgarbage: not in length on purpose", 8);
             return WriteAttribute(kIdentityBeta, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id, value);
         }
-        case 12: {
-            LogStep(12, "TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
+        case 13: {
+            LogStep(13, "TH_CR1 reads the Basic Information Clusters NodeLabel mandatory attribute of DUT_CE");
             return ReadAttribute(kIdentityBeta, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id);
         }
         }
@@ -17993,7 +18011,7 @@ private:
         case 0: {
             LogStep(0, "Reboot target device");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Reboot();
         }
         case 1: {
             LogStep(1, "TH_CR1 starts a commissioning process with DUT_CE");
@@ -18124,7 +18142,7 @@ private:
 class Test_TC_MF_1_6Suite : public TestCommand
 {
 public:
-    Test_TC_MF_1_6Suite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MF_1_6", 18, credsIssuerConfig)
+    Test_TC_MF_1_6Suite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_MF_1_6", 19, credsIssuerConfig)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
@@ -18172,10 +18190,10 @@ private:
             break;
         case 2:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
             break;
         case 3:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            shouldContinue = true;
             break;
         case 4:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -18190,26 +18208,30 @@ private:
             shouldContinue = true;
             break;
         case 7:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             shouldContinue = true;
             break;
         case 8:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            shouldContinue = true;
             break;
         case 9:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 10:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
-            shouldContinue = true;
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 11:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            shouldContinue = true;
             break;
         case 12:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             break;
         case 13:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 14:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::CharSpan value;
@@ -18217,18 +18239,18 @@ private:
                 VerifyOrReturn(CheckValueAsString("nodeLabel", value, chip::CharSpan("chiptest", 8)));
             }
             break;
-        case 14:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
         case 15:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            shouldContinue = true;
             break;
         case 16:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             shouldContinue = true;
             break;
         case 17:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 18:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             shouldContinue = true;
             break;
@@ -18248,27 +18270,27 @@ private:
         switch (testIndex)
         {
         case 0: {
-            LogStep(0, "Reboot target device");
+            LogStep(0, "Stop target device");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Stop();
         }
         case 1: {
-            LogStep(1, "TH_CR1 starts a commissioning process with DUT_CE");
+            LogStep(1, "Start target device with the provided discriminator for basic commissioning advertisement");
+            SetIdentity(kIdentityAlpha);
+            return Start(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        }
+        case 2: {
+            LogStep(2, "TH_CR1 starts a commissioning process with DUT_CE");
             SetIdentity(kIdentityAlpha);
             return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
         }
-        case 2: {
-            LogStep(2, "TH_CR1 opens a commissioning window on DUT_CE");
+        case 3: {
+            LogStep(3, "TH_CR1 opens a commissioning window on DUT_CE");
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type value;
             value.commissioningTimeout = 180U;
             return SendCommand(kIdentityAlpha, GetEndpoint(0), AdministratorCommissioning::Id,
                                AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id, value,
                                chip::Optional<uint16_t>(10000));
-        }
-        case 3: {
-            LogStep(3, "Wait for PIXIT_COMM_WIN(180) + 10");
-            SetIdentity(kIdentityAlpha);
-            return WaitForMs(54000);
         }
         case 4: {
             LogStep(4, "Wait for PIXIT_COMM_WIN(180) + 10");
@@ -18283,76 +18305,81 @@ private:
         case 6: {
             LogStep(6, "Wait for PIXIT_COMM_WIN(180) + 10");
             SetIdentity(kIdentityAlpha);
-            return WaitForMs(28000);
+            return WaitForMs(54000);
         }
         case 7: {
-            LogStep(7, "Commission from beta");
+            LogStep(7, "Wait for PIXIT_COMM_WIN(180) + 10");
+            SetIdentity(kIdentityAlpha);
+            return WaitForMs(28000);
+        }
+        case 8: {
+            LogStep(8, "Commission from beta");
             SetIdentity(kIdentityBeta);
             return PairWithQRCode(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL,
                                   mPayload.HasValue() ? mPayload.Value()
                                                       : chip::CharSpan::fromCharString("MT:-24J0AFN00KA0648G00"));
         }
-        case 8: {
-            LogStep(8, "TH_CR1 opens a commissioning window on DUT_CE");
+        case 9: {
+            LogStep(9, "TH_CR1 opens a commissioning window on DUT_CE");
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type value;
             value.commissioningTimeout = 180U;
             return SendCommand(kIdentityAlpha, GetEndpoint(0), AdministratorCommissioning::Id,
                                AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id, value,
                                chip::Optional<uint16_t>(10000));
         }
-        case 9: {
-            LogStep(9, "TH_CR1 revokes the commissioning window on DUT_CE");
+        case 10: {
+            LogStep(10, "TH_CR1 revokes the commissioning window on DUT_CE");
             chip::app::Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Type value;
             return SendCommand(kIdentityAlpha, GetEndpoint(0), AdministratorCommissioning::Id,
                                AdministratorCommissioning::Commands::RevokeCommissioning::Id, value,
                                chip::Optional<uint16_t>(10000));
         }
-        case 10: {
-            LogStep(10, "Commission from beta");
+        case 11: {
+            LogStep(11, "Commission from beta");
             SetIdentity(kIdentityBeta);
             return PairWithQRCode(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL,
                                   mPayload.HasValue() ? mPayload.Value()
                                                       : chip::CharSpan::fromCharString("MT:-24J0AFN00KA0648G00"));
         }
-        case 11: {
-            LogStep(11, "TH_CR1 revokes the commissioning window on DUT_CE");
+        case 12: {
+            LogStep(12, "TH_CR1 revokes the commissioning window on DUT_CE");
             chip::app::Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Type value;
             return SendCommand(kIdentityAlpha, GetEndpoint(0), AdministratorCommissioning::Id,
                                AdministratorCommissioning::Commands::RevokeCommissioning::Id, value,
                                chip::Optional<uint16_t>(10000));
         }
-        case 12: {
-            LogStep(12, "TH_CR1 writes the mandatory attribute NodeLabel of DUT_CE");
+        case 13: {
+            LogStep(13, "TH_CR1 writes the mandatory attribute NodeLabel of DUT_CE");
             chip::CharSpan value;
             value = chip::Span<const char>("chiptestgarbage: not in length on purpose", 8);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id, value);
         }
-        case 13: {
-            LogStep(13, "TH_CR1 read the mandatory attribute NodeLabel of DUT_CE");
+        case 14: {
+            LogStep(14, "TH_CR1 read the mandatory attribute NodeLabel of DUT_CE");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id);
         }
-        case 14: {
-            LogStep(14, "TH_CR1 opens a commissioning window on DUT_CE");
+        case 15: {
+            LogStep(15, "TH_CR1 opens a commissioning window on DUT_CE");
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type value;
             value.commissioningTimeout = 180U;
             return SendCommand(kIdentityAlpha, GetEndpoint(0), AdministratorCommissioning::Id,
                                AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id, value,
                                chip::Optional<uint16_t>(10000));
         }
-        case 15: {
-            LogStep(15, "Commission from beta");
+        case 16: {
+            LogStep(16, "Commission from beta");
             SetIdentity(kIdentityBeta);
             return PairWithQRCode(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL,
                                   mPayload.HasValue() ? mPayload.Value()
                                                       : chip::CharSpan::fromCharString("MT:-24J0AFN00KA0648G00"));
         }
-        case 16: {
-            LogStep(16, "TH_CR2 starts a commissioning process on DUT_CE");
+        case 17: {
+            LogStep(17, "TH_CR2 starts a commissioning process on DUT_CE");
             SetIdentity(kIdentityBeta);
             return WaitForCommissionee(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL);
         }
-        case 17: {
-            LogStep(17, "TH_CR3 starts a commissioning process with DUT_CE");
+        case 18: {
+            LogStep(18, "TH_CR3 starts a commissioning process with DUT_CE");
             SetIdentity(kIdentityGamma);
             return PairWithQRCode(mNodeId3.HasValue() ? mNodeId3.Value() : 12586990ULL,
                                   mPayload.HasValue() ? mPayload.Value()
@@ -18542,7 +18569,7 @@ private:
         case 0: {
             LogStep(0, "Reboot target device");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Reboot();
         }
         case 1: {
             LogStep(1, "TH_CR1 starts a commissioning process with DUT_CE");
@@ -20378,7 +20405,6 @@ public:
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
-        AddArgument("discriminator", 0, UINT16_MAX, &mDiscriminator);
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }
 
@@ -20393,7 +20419,6 @@ private:
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
-    chip::Optional<uint16_t> mDiscriminator;
     chip::Optional<uint16_t> mTimeout;
 
     chip::EndpointId GetEndpoint(chip::EndpointId endpoint) { return mEndpoint.HasValue() ? mEndpoint.Value() : endpoint; }
@@ -20574,7 +20599,7 @@ private:
         case 4: {
             LogStep(4, "Power off DUT");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Reboot();
         }
         case 5: {
             LogStep(5, "Wait for the commissioned device to be retrieved");
@@ -20595,7 +20620,7 @@ private:
         case 8: {
             LogStep(8, "Power off DUT");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Reboot();
         }
         case 9: {
             LogStep(9, "Wait for the commissioned device to be retrieved");
@@ -20616,7 +20641,7 @@ private:
         case 12: {
             LogStep(12, "Power off DUT");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Reboot();
         }
         case 13: {
             LogStep(13, "Wait for the commissioned device to be retrieved");
@@ -20630,7 +20655,7 @@ private:
         case 15: {
             LogStep(15, "Power off DUT");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Reboot();
         }
         case 16: {
             LogStep(16, "Wait for the commissioned device to be retrieved");
@@ -20650,7 +20675,7 @@ private:
         case 19: {
             LogStep(19, "Power off DUT");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Reboot();
         }
         case 20: {
             LogStep(20, "Wait for the commissioned device to be retrieved");
@@ -20669,7 +20694,7 @@ private:
         case 23: {
             LogStep(23, "Power off DUT");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Reboot();
         }
         case 24: {
             LogStep(24, "Wait for the commissioned device to be retrieved");
@@ -23547,7 +23572,7 @@ private:
 class Test_TC_SC_4_2Suite : public TestCommand
 {
 public:
-    Test_TC_SC_4_2Suite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_SC_4_2", 21, credsIssuerConfig)
+    Test_TC_SC_4_2Suite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_SC_4_2", 23, credsIssuerConfig)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
@@ -23608,8 +23633,12 @@ private:
             break;
         case 2:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
             break;
         case 3:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 4:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -23626,14 +23655,6 @@ private:
                 deviceInstanceNameBeforeReboot1Buffer = static_cast<char *>(chip::Platform::MemoryAlloc(value.instanceName.size()));
                 memcpy(deviceInstanceNameBeforeReboot1Buffer, value.instanceName.data(), value.instanceName.size());
                 deviceInstanceNameBeforeReboot1 = chip::CharSpan(deviceInstanceNameBeforeReboot1Buffer, value.instanceName.size());
-            }
-            shouldContinue = true;
-            break;
-        case 4:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
             }
             shouldContinue = true;
             break;
@@ -23666,12 +23687,20 @@ private:
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+            }
+            shouldContinue = true;
+            break;
+        case 9:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
 
                 VerifyOrReturn(CheckValue("vendorId", value.vendorId, mVendorId.HasValue() ? mVendorId.Value() : 65521U));
             }
             shouldContinue = true;
             break;
-        case 9:
+        case 10:
             if (IsUnsupported(status.mStatus))
             {
                 shouldContinue = true;
@@ -23686,7 +23715,7 @@ private:
             }
             shouldContinue = true;
             break;
-        case 10:
+        case 11:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -23698,7 +23727,7 @@ private:
             }
             shouldContinue = true;
             break;
-        case 11:
+        case 12:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -23710,7 +23739,7 @@ private:
             }
             shouldContinue = true;
             break;
-        case 12:
+        case 13:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -23720,7 +23749,7 @@ private:
             }
             shouldContinue = true;
             break;
-        case 13:
+        case 14:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -23730,7 +23759,7 @@ private:
             }
             shouldContinue = true;
             break;
-        case 14:
+        case 15:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -23740,7 +23769,7 @@ private:
             }
             shouldContinue = true;
             break;
-        case 15:
+        case 16:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -23750,7 +23779,7 @@ private:
             }
             shouldContinue = true;
             break;
-        case 16:
+        case 17:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -23760,7 +23789,7 @@ private:
             }
             shouldContinue = true;
             break;
-        case 17:
+        case 18:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -23770,15 +23799,19 @@ private:
             }
             shouldContinue = true;
             break;
-        case 18:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            shouldContinue = true;
-            break;
         case 19:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             shouldContinue = true;
             break;
         case 20:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 21:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 22:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             shouldContinue = true;
             break;
@@ -23798,17 +23831,22 @@ private:
         switch (testIndex)
         {
         case 0: {
-            LogStep(0, "Reboot target device");
+            LogStep(0, "Stop target device");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Stop();
         }
         case 1: {
-            LogStep(1, "Wait for the commissioned device to be retrieved");
+            LogStep(1, "Start target device with the provided discriminator for basic commissioning advertisement");
+            SetIdentity(kIdentityAlpha);
+            return Start(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        }
+        case 2: {
+            LogStep(2, "Wait for the commissioned device to be retrieved");
             SetIdentity(kIdentityAlpha);
             return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
         }
-        case 2: {
-            LogStep(2,
+        case 3: {
+            LogStep(3,
                     "TH is put in Commissioning Mode using Open Basic Commissioning Window command and starts advertising "
                     "Commissionable Node Discovery service using DNS-SD");
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type value;
@@ -23817,37 +23855,31 @@ private:
                                AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id, value,
                                chip::Optional<uint16_t>(10000));
         }
-        case 3: {
-            LogStep(3, "Check Instance Name");
+        case 4: {
+            LogStep(4, "Check Instance Name");
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
-        case 4: {
-            LogStep(4, "Check Long Discriminator _L");
+        case 5: {
+            LogStep(5, "Check Long Discriminator _L");
             SetIdentity(kIdentityAlpha);
             return FindCommissionableByLongDiscriminator(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
         }
-        case 5: {
-            LogStep(5, "Check Short Discriminator (_S)");
+        case 6: {
+            LogStep(6, "Check Short Discriminator (_S)");
             SetIdentity(kIdentityAlpha);
             return FindCommissionableByShortDiscriminator(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
         }
-        case 6: {
-            LogStep(6, "Check Vendor ID (_V)");
+        case 7: {
+            LogStep(7, "Check Vendor ID (_V)");
             VerifyOrdo(!ShouldSkip("VENDOR_SUBTYPE"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             SetIdentity(kIdentityAlpha);
             return FindCommissionableByVendorId(mVendorId.HasValue() ? mVendorId.Value() : 65521U);
         }
-        case 7: {
-            LogStep(7, "Check Commissioning Mode (_CM)");
+        case 8: {
+            LogStep(8, "Check Commissioning Mode (_CM)");
             SetIdentity(kIdentityAlpha);
             return FindCommissionableByCommissioningMode();
-        }
-        case 8: {
-            LogStep(8, "TXT key for Vendor ID and Product ID (VP)");
-            VerifyOrdo(!ShouldSkip("VP_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
-            SetIdentity(kIdentityAlpha);
-            return FindCommissionable();
         }
         case 9: {
             LogStep(9, "TXT key for Vendor ID and Product ID (VP)");
@@ -23856,63 +23888,74 @@ private:
             return FindCommissionable();
         }
         case 10: {
-            LogStep(10, "Optional TXT key for MRP Retry Interval Idle (CRI)");
-            VerifyOrdo(!ShouldSkip("CRI_COMM_DISCOVERY_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            LogStep(10, "TXT key for Vendor ID and Product ID (VP)");
+            VerifyOrdo(!ShouldSkip("VP_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
         case 11: {
-            LogStep(11, "Optional TXT key for MRP Retry Interval Active (CRA)");
-            VerifyOrdo(!ShouldSkip("CRA_COMM_DISCOVERY_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            LogStep(11, "Optional TXT key for MRP Retry Interval Idle (CRI)");
+            VerifyOrdo(!ShouldSkip("CRI_COMM_DISCOVERY_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
         case 12: {
-            LogStep(12, "TXT key for commissioning mode (CM)");
+            LogStep(12, "Optional TXT key for MRP Retry Interval Active (CRA)");
+            VerifyOrdo(!ShouldSkip("CRA_COMM_DISCOVERY_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
         case 13: {
-            LogStep(13, "Optional TXT key for device name (DN)");
-            VerifyOrdo(!ShouldSkip("DN_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            LogStep(13, "TXT key for commissioning mode (CM)");
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
         case 14: {
-            LogStep(14, "Optional TXT key for rotating device identifier (RI)");
-            VerifyOrdo(!ShouldSkip("RI_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            LogStep(14, "Optional TXT key for device name (DN)");
+            VerifyOrdo(!ShouldSkip("DN_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
         case 15: {
-            LogStep(15, "Optional TXT key for pairing hint (PH)");
-            VerifyOrdo(!ShouldSkip("PH_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            LogStep(15, "Optional TXT key for rotating device identifier (RI)");
+            VerifyOrdo(!ShouldSkip("RI_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
         case 16: {
-            LogStep(16, "Optional TXT key for pairing instructions (PI)");
-            VerifyOrdo(!ShouldSkip("PI_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            LogStep(16, "Optional TXT key for pairing hint (PH)");
+            VerifyOrdo(!ShouldSkip("PH_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
         case 17: {
-            LogStep(17, "Check IPs");
+            LogStep(17, "Optional TXT key for pairing instructions (PI)");
+            VerifyOrdo(!ShouldSkip("PI_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
         case 18: {
-            LogStep(18, "Reboot target device");
+            LogStep(18, "Check IPs");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return FindCommissionable();
         }
         case 19: {
-            LogStep(19, "Log commands");
+            LogStep(19, "Stop target device");
+            SetIdentity(kIdentityAlpha);
+            return Stop();
+        }
+        case 20: {
+            LogStep(20, "Start target device with the provided discriminator for basic commissioning advertisement");
+            SetIdentity(kIdentityAlpha);
+            return Start(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        }
+        case 21: {
+            LogStep(21, "Log commands");
             SetIdentity(kIdentityAlpha);
             return Log("TH adds an unknown key/value pair in the advertised data");
         }
-        case 20: {
-            LogStep(20, "Log commands");
+        case 22: {
+            LogStep(22, "Log commands");
             SetIdentity(kIdentityAlpha);
             return Log("Scan for DNS-SD commissioner advertisements from TH");
         }
@@ -31776,7 +31819,6 @@ public:
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
-        AddArgument("discriminator", 0, UINT16_MAX, &mDiscriminator);
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }
 
@@ -31791,7 +31833,6 @@ private:
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
-    chip::Optional<uint16_t> mDiscriminator;
     chip::Optional<uint16_t> mTimeout;
 
     chip::app::DataModel::Nullable<chip::Percent100ths> attrCurrentPositionLiftPercent100ths;
@@ -31996,7 +32037,7 @@ private:
         case 12: {
             LogStep(12, "3c: reboot/restart the DUT");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Reboot();
         }
         case 13: {
             LogStep(13, "3d: Wait for the commissioned device to be retrieved");
@@ -41421,7 +41462,7 @@ private:
 class TestDiscoverySuite : public TestCommand
 {
 public:
-    TestDiscoverySuite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestDiscovery", 25, credsIssuerConfig)
+    TestDiscoverySuite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestDiscovery", 27, credsIssuerConfig)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
@@ -41479,15 +41520,19 @@ private:
             shouldContinue = true;
             break;
         case 2:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_COMMAND));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
             break;
         case 3:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_COMMAND));
             break;
         case 4:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_COMMAND));
             break;
         case 5:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 6:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -41504,14 +41549,6 @@ private:
                 deviceInstanceNameBeforeRebootBuffer = static_cast<char *>(chip::Platform::MemoryAlloc(value.instanceName.size()));
                 memcpy(deviceInstanceNameBeforeRebootBuffer, value.instanceName.data(), value.instanceName.size());
                 deviceInstanceNameBeforeReboot = chip::CharSpan(deviceInstanceNameBeforeRebootBuffer, value.instanceName.size());
-            }
-            shouldContinue = true;
-            break;
-        case 6:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
             }
             shouldContinue = true;
             break;
@@ -41544,11 +41581,6 @@ private:
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-
-                VerifyOrReturn(CheckValue("longDiscriminator", value.longDiscriminator,
-                                          mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U));
-                VerifyOrReturn(CheckConstraintMinValue("value.longDiscriminator", value.longDiscriminator, 0U));
-                VerifyOrReturn(CheckConstraintMaxValue("value.longDiscriminator", value.longDiscriminator, 4096U));
             }
             shouldContinue = true;
             break;
@@ -41558,11 +41590,24 @@ private:
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
 
-                VerifyOrReturn(CheckValue("vendorId", value.vendorId, mVendorId.HasValue() ? mVendorId.Value() : 65521U));
+                VerifyOrReturn(CheckValue("longDiscriminator", value.longDiscriminator,
+                                          mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U));
+                VerifyOrReturn(CheckConstraintMinValue("value.longDiscriminator", value.longDiscriminator, 0U));
+                VerifyOrReturn(CheckConstraintMaxValue("value.longDiscriminator", value.longDiscriminator, 4096U));
             }
             shouldContinue = true;
             break;
         case 12:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+
+                VerifyOrReturn(CheckValue("vendorId", value.vendorId, mVendorId.HasValue() ? mVendorId.Value() : 65521U));
+            }
+            shouldContinue = true;
+            break;
+        case 13:
             if (IsUnsupported(status.mStatus))
             {
                 shouldContinue = true;
@@ -41577,7 +41622,7 @@ private:
             }
             shouldContinue = true;
             break;
-        case 13:
+        case 14:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -41589,7 +41634,7 @@ private:
             }
             shouldContinue = true;
             break;
-        case 14:
+        case 15:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -41601,7 +41646,7 @@ private:
             }
             shouldContinue = true;
             break;
-        case 15:
+        case 16:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -41611,7 +41656,7 @@ private:
             }
             shouldContinue = true;
             break;
-        case 16:
+        case 17:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -41621,7 +41666,7 @@ private:
             }
             shouldContinue = true;
             break;
-        case 17:
+        case 18:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -41631,7 +41676,7 @@ private:
             }
             shouldContinue = true;
             break;
-        case 18:
+        case 19:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -41641,7 +41686,7 @@ private:
             }
             shouldContinue = true;
             break;
-        case 19:
+        case 20:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -41651,7 +41696,7 @@ private:
             }
             shouldContinue = true;
             break;
-        case 20:
+        case 21:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -41661,18 +41706,22 @@ private:
             }
             shouldContinue = true;
             break;
-        case 21:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            shouldContinue = true;
-            break;
         case 22:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             shouldContinue = true;
             break;
         case 23:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
             break;
         case 24:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 25:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 26:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::DiscoveryCommands::Commands::DiscoveryCommandResponse::DecodableType value;
@@ -41702,73 +41751,72 @@ private:
         switch (testIndex)
         {
         case 0: {
-            LogStep(0, "Reboot target device");
+            LogStep(0, "Stop target device");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Stop();
         }
         case 1: {
-            LogStep(1, "Wait for the commissioned device to be retrieved");
+            LogStep(1, "Start target device with the provided discriminator for basic commissioning advertisement");
+            SetIdentity(kIdentityAlpha);
+            return Start(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        }
+        case 2: {
+            LogStep(2, "Wait for the commissioned device to be retrieved");
             SetIdentity(kIdentityAlpha);
             return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
         }
-        case 2: {
-            LogStep(2, "Open Commissioning Window with too-short timeout");
+        case 3: {
+            LogStep(3, "Open Commissioning Window with too-short timeout");
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type value;
             value.commissioningTimeout = 120U;
             return SendCommand(kIdentityAlpha, GetEndpoint(0), AdministratorCommissioning::Id,
                                AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id, value,
                                chip::Optional<uint16_t>(10000));
         }
-        case 3: {
-            LogStep(3, "Open Commissioning Window with too-long timeout");
+        case 4: {
+            LogStep(4, "Open Commissioning Window with too-long timeout");
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type value;
             value.commissioningTimeout = 1000U;
             return SendCommand(kIdentityAlpha, GetEndpoint(0), AdministratorCommissioning::Id,
                                AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id, value,
                                chip::Optional<uint16_t>(10000));
         }
-        case 4: {
-            LogStep(4, "Open Commissioning Window");
+        case 5: {
+            LogStep(5, "Open Commissioning Window");
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type value;
             value.commissioningTimeout = 180U;
             return SendCommand(kIdentityAlpha, GetEndpoint(0), AdministratorCommissioning::Id,
                                AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id, value,
                                chip::Optional<uint16_t>(10000));
         }
-        case 5: {
-            LogStep(5, "Check Instance Name");
+        case 6: {
+            LogStep(6, "Check Instance Name");
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
-        case 6: {
-            LogStep(6, "Check Long Discriminator _L");
+        case 7: {
+            LogStep(7, "Check Long Discriminator _L");
             SetIdentity(kIdentityAlpha);
             return FindCommissionableByLongDiscriminator(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
         }
-        case 7: {
-            LogStep(7, "Check Short Discriminator (_S)");
+        case 8: {
+            LogStep(8, "Check Short Discriminator (_S)");
             SetIdentity(kIdentityAlpha);
             return FindCommissionableByShortDiscriminator(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
         }
-        case 8: {
-            LogStep(8, "Check Commissioning Mode (_CM)");
+        case 9: {
+            LogStep(9, "Check Commissioning Mode (_CM)");
             SetIdentity(kIdentityAlpha);
             return FindCommissionableByCommissioningMode();
         }
-        case 9: {
-            LogStep(9, "Check Vendor ID (_V)");
+        case 10: {
+            LogStep(10, "Check Vendor ID (_V)");
             VerifyOrdo(!ShouldSkip("VENDOR_SUBTYPE"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             SetIdentity(kIdentityAlpha);
             return FindCommissionableByVendorId(mVendorId.HasValue() ? mVendorId.Value() : 65521U);
         }
-        case 10: {
-            LogStep(10, "TXT key for discriminator (D)");
-            SetIdentity(kIdentityAlpha);
-            return FindCommissionable();
-        }
         case 11: {
-            LogStep(11, "TXT key for Vendor ID and Product ID (VP)");
-            VerifyOrdo(!ShouldSkip("VP_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            LogStep(11, "TXT key for discriminator (D)");
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
@@ -41779,71 +41827,82 @@ private:
             return FindCommissionable();
         }
         case 13: {
-            LogStep(13, "Optional TXT key for MRP Retry Interval Idle (CRI)");
-            VerifyOrdo(!ShouldSkip("CRI_COMM_DISCOVERY_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            LogStep(13, "TXT key for Vendor ID and Product ID (VP)");
+            VerifyOrdo(!ShouldSkip("VP_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
         case 14: {
-            LogStep(14, "Optional TXT key for MRP Retry Interval Active (CRA)");
-            VerifyOrdo(!ShouldSkip("CRA_COMM_DISCOVERY_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            LogStep(14, "Optional TXT key for MRP Retry Interval Idle (CRI)");
+            VerifyOrdo(!ShouldSkip("CRI_COMM_DISCOVERY_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
         case 15: {
-            LogStep(15, "TXT key for commissioning mode (CM)");
+            LogStep(15, "Optional TXT key for MRP Retry Interval Active (CRA)");
+            VerifyOrdo(!ShouldSkip("CRA_COMM_DISCOVERY_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
         case 16: {
-            LogStep(16, "Optional TXT key for device name (DN)");
-            VerifyOrdo(!ShouldSkip("DN_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            LogStep(16, "TXT key for commissioning mode (CM)");
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
         case 17: {
-            LogStep(17, "Optional TXT key for rotating device identifier (RI)");
-            VerifyOrdo(!ShouldSkip("RI_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            LogStep(17, "Optional TXT key for device name (DN)");
+            VerifyOrdo(!ShouldSkip("DN_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
         case 18: {
-            LogStep(18, "Optional TXT key for pairing hint (PH)");
-            VerifyOrdo(!ShouldSkip("PH_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            LogStep(18, "Optional TXT key for rotating device identifier (RI)");
+            VerifyOrdo(!ShouldSkip("RI_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
         case 19: {
-            LogStep(19, "Optional TXT key for pairing instructions (PI)");
-            VerifyOrdo(!ShouldSkip("PI_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
+            LogStep(19, "Optional TXT key for pairing hint (PH)");
+            VerifyOrdo(!ShouldSkip("PH_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
         case 20: {
-            LogStep(20, "Check IPs");
+            LogStep(20, "Optional TXT key for pairing instructions (PI)");
+            VerifyOrdo(!ShouldSkip("PI_KEY"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
         case 21: {
-            LogStep(21, "Reboot target device");
+            LogStep(21, "Check IPs");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return FindCommissionable();
         }
         case 22: {
-            LogStep(22, "Wait for the commissioned device to be retrieved");
+            LogStep(22, "Stop target device");
+            SetIdentity(kIdentityAlpha);
+            return Stop();
+        }
+        case 23: {
+            LogStep(23, "Start target device with the provided discriminator for basic commissioning advertisement");
+            SetIdentity(kIdentityAlpha);
+            return Start(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        }
+        case 24: {
+            LogStep(24, "Wait for the commissioned device to be retrieved");
             SetIdentity(kIdentityAlpha);
             return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
         }
-        case 23: {
-            LogStep(23, "Open Commissioning Window");
+        case 25: {
+            LogStep(25, "Open Commissioning Window");
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type value;
             value.commissioningTimeout = 180U;
             return SendCommand(kIdentityAlpha, GetEndpoint(0), AdministratorCommissioning::Id,
                                AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id, value,
                                chip::Optional<uint16_t>(10000));
         }
-        case 24: {
-            LogStep(24, "Check Instance Name");
+        case 26: {
+            LogStep(26, "Check Instance Name");
             SetIdentity(kIdentityAlpha);
             return FindCommissionable();
         }
@@ -44624,7 +44683,6 @@ public:
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
-        AddArgument("discriminator", 0, UINT16_MAX, &mDiscriminator);
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }
 
@@ -44639,7 +44697,6 @@ private:
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
-    chip::Optional<uint16_t> mDiscriminator;
     chip::Optional<uint16_t> mTimeout;
 
     uint8_t currentModeBeforeToggle;
@@ -44997,7 +45054,7 @@ private:
         case 25: {
             LogStep(25, "Reboot target device");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Reboot();
         }
         case 26: {
             LogStep(26, "Wait for the commissioned device to be retrieved");
@@ -45017,7 +45074,7 @@ private:
         case 29: {
             LogStep(29, "Reboot target device");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Reboot();
         }
         case 30: {
             LogStep(30, "Wait for the commissioned device to be retrieved");
@@ -45147,11 +45204,12 @@ private:
 class TestSystemCommandsSuite : public TestCommand
 {
 public:
-    TestSystemCommandsSuite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestSystemCommands", 14, credsIssuerConfig)
+    TestSystemCommandsSuite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestSystemCommands", 22, credsIssuerConfig)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
+        AddArgument("payload", &mPayload);
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }
 
@@ -45166,6 +45224,7 @@ private:
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
+    chip::Optional<chip::CharSpan> mPayload;
     chip::Optional<uint16_t> mTimeout;
 
     chip::EndpointId GetEndpoint(chip::EndpointId endpoint) { return mEndpoint.HasValue() ? mEndpoint.Value() : endpoint; }
@@ -45236,6 +45295,38 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             shouldContinue = true;
             break;
+        case 14:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 15:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 16:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 17:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 18:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 19:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 20:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 21:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
         default:
             LogErrorOnFailure(ContinueOnChipMainThread(CHIP_ERROR_INVALID_ARGUMENT));
         }
@@ -45257,69 +45348,110 @@ private:
             return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
         }
         case 1: {
-            LogStep(1, "Stop the accessory");
+            LogStep(1, "Stop the default accessory");
             SetIdentity(kIdentityAlpha);
             return Stop();
         }
         case 2: {
-            LogStep(2, "Start the accessory with no command line options");
+            LogStep(2, "Start the default accessory with no command line options");
             SetIdentity(kIdentityAlpha);
             return Start();
         }
         case 3: {
-            LogStep(3, "Stop the accessory");
+            LogStep(3, "Stop the default accessory by key");
             SetIdentity(kIdentityAlpha);
-            return Stop();
+            return Stop("default");
         }
         case 4: {
-            LogStep(4, "Start the accessory with only discriminator command line option");
+            LogStep(4, "Start the default accessory with discriminator command line option");
             SetIdentity(kIdentityAlpha);
             return Start(1111);
         }
         case 5: {
-            LogStep(5, "Stop the accessory");
+            LogStep(5, "Stop the default accessory");
             SetIdentity(kIdentityAlpha);
             return Stop();
         }
         case 6: {
-            LogStep(6, "Start the accessory with discriminator and port command line option");
+            LogStep(6, "Start the default accessory with discriminator and port command line options");
             SetIdentity(kIdentityAlpha);
             return Start(1111, 5560);
         }
         case 7: {
-            LogStep(7, "Stop the accessory");
+            LogStep(7, "Stop the default accessory");
             SetIdentity(kIdentityAlpha);
             return Stop();
         }
         case 8: {
-            LogStep(8, "Start the accessory with all command line options");
+            LogStep(8, "Start the default accessory with all command line options");
             SetIdentity(kIdentityAlpha);
-            return Start(1111, 5560, "/tmp/chip_kvs_test");
+            return Start(1111, 5560, "/tmp/chip_kvs_default");
         }
         case 9: {
-            LogStep(9, "Reboot the accessory with no command line options");
+            LogStep(9, "Stop the default accessory");
+            SetIdentity(kIdentityAlpha);
+            return Stop();
+        }
+        case 10: {
+            LogStep(10, "Start the default accessory by key with all command line options");
+            SetIdentity(kIdentityAlpha);
+            return Start(1111, 5560, "/tmp/chip_kvs_default", "default");
+        }
+        case 11: {
+            LogStep(11, "Start a second accessory with all command line options");
+            SetIdentity(kIdentityAlpha);
+            return Start(50, 5561, "/tmp/chip_kvs_lock", "chip-lock-app");
+        }
+        case 12: {
+            LogStep(12, "Commission second accessory from alpha");
+            SetIdentity(kIdentityAlpha);
+            return PairWithQRCode(
+                3735928559, mPayload.HasValue() ? mPayload.Value() : chip::CharSpan::fromCharString("MT:-24J0IX4122-.548G00"));
+        }
+        case 13: {
+            LogStep(13, "Wait for the second commissioned device to be retrieved for alpha");
+            SetIdentity(kIdentityAlpha);
+            return WaitForCommissionee(3735928559);
+        }
+        case 14: {
+            LogStep(14, "Stop the second accessory");
+            SetIdentity(kIdentityAlpha);
+            return Stop("chip-lock-app");
+        }
+        case 15: {
+            LogStep(15, "Start a second accessory with different KVS");
+            SetIdentity(kIdentityAlpha);
+            return Start(50, 5561, "/tmp/chip_kvs_lock2", "chip-lock-app");
+        }
+        case 16: {
+            LogStep(16, "Reboot the default accessory");
             SetIdentity(kIdentityAlpha);
             return Reboot();
         }
-        case 10: {
-            LogStep(10, "Reboot the accessory with only discriminator command line option");
+        case 17: {
+            LogStep(17, "Reboot the default accessory by key");
             SetIdentity(kIdentityAlpha);
-            return Reboot(2222);
+            return Reboot("default");
         }
-        case 11: {
-            LogStep(11, "Reboot the accessory with discriminator and port command line option");
+        case 18: {
+            LogStep(18, "Reboot the second accessory");
             SetIdentity(kIdentityAlpha);
-            return Reboot(2222, 5565);
+            return Reboot("chip-lock-app");
         }
-        case 12: {
-            LogStep(12, "Reboot the accessory with all command line options");
-            SetIdentity(kIdentityAlpha);
-            return Reboot(2222, 5565, "/tmp/chip_kvs_test");
-        }
-        case 13: {
-            LogStep(13, "Factory Reset the accessory");
+        case 19: {
+            LogStep(19, "Factory Reset the default accessory");
             SetIdentity(kIdentityAlpha);
             return FactoryReset();
+        }
+        case 20: {
+            LogStep(20, "Factory Reset the default accessory by key");
+            SetIdentity(kIdentityAlpha);
+            return FactoryReset("default");
+        }
+        case 21: {
+            LogStep(21, "Factory Reset the second accessory");
+            SetIdentity(kIdentityAlpha);
+            return FactoryReset("chip-lock-app");
         }
         }
         return CHIP_NO_ERROR;
@@ -45600,7 +45732,6 @@ public:
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
-        AddArgument("discriminator", 0, UINT16_MAX, &mDiscriminator);
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }
 
@@ -45615,7 +45746,6 @@ private:
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::CharSpan> mCluster;
     chip::Optional<chip::EndpointId> mEndpoint;
-    chip::Optional<uint16_t> mDiscriminator;
     chip::Optional<uint16_t> mTimeout;
 
     chip::EndpointId GetEndpoint(chip::EndpointId endpoint) { return mEndpoint.HasValue() ? mEndpoint.Value() : endpoint; }
@@ -45746,7 +45876,7 @@ private:
         case 4: {
             LogStep(4, "Reboot target device");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Reboot();
         }
         case 5: {
             LogStep(5, "Wait for the commissioned device to be retrieved");
@@ -45769,8 +45899,6 @@ public:
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
-        AddArgument("discriminator", 0, UINT16_MAX, &mDiscriminator);
-        AddArgument("payload", &mPayload);
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }
 
@@ -45784,8 +45912,6 @@ public:
 private:
     chip::Optional<chip::NodeId> mNodeId;
     chip::Optional<chip::EndpointId> mEndpoint;
-    chip::Optional<uint16_t> mDiscriminator;
-    chip::Optional<chip::CharSpan> mPayload;
     chip::Optional<uint16_t> mTimeout;
 
     chip::EndpointId GetEndpoint(chip::EndpointId endpoint) { return mEndpoint.HasValue() ? mEndpoint.Value() : endpoint; }
@@ -45858,7 +45984,7 @@ private:
         case 0: {
             LogStep(0, "Reboot target device");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Reboot();
         }
         case 1: {
             LogStep(1, "Wait for the alpha device to be retrieved ");
@@ -45890,7 +46016,7 @@ private:
 class TestMultiAdminSuite : public TestCommand
 {
 public:
-    TestMultiAdminSuite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestMultiAdmin", 17, credsIssuerConfig)
+    TestMultiAdminSuite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestMultiAdmin", 18, credsIssuerConfig)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("nodeIdForDuplicateCommissioning", 0, UINT64_MAX, &mNodeIdForDuplicateCommissioning);
@@ -45950,19 +46076,23 @@ private:
             shouldContinue = true;
             break;
         case 2:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             shouldContinue = true;
             break;
         case 3:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            shouldContinue = true;
             break;
         case 4:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 5:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             VerifyOrReturn(CheckValue("clusterStatus", status.mClusterStatus.HasValue(), true));
             VerifyOrReturn(CheckValue("clusterStatus", status.mClusterStatus.Value(), 9));
             shouldContinue = true;
             break;
-        case 5:
+        case 6:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::DecodableList<
@@ -45976,15 +46106,11 @@ private:
                 }
             }
             break;
-        case 6:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
         case 7:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 8:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            shouldContinue = true;
             break;
         case 9:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -45992,16 +46118,20 @@ private:
             break;
         case 10:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
             break;
         case 11:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            shouldContinue = true;
             break;
         case 12:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             shouldContinue = true;
             break;
         case 13:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 14:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::CharSpan value;
@@ -46017,10 +46147,10 @@ private:
                 readFromAlpha = chip::CharSpan(readFromAlphaBuffer, value.size());
             }
             break;
-        case 14:
+        case 15:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 15:
+        case 16:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::CharSpan value;
@@ -46028,7 +46158,7 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, readFromAlpha));
             }
             break;
-        case 16:
+        case 17:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         default:
@@ -46047,105 +46177,110 @@ private:
         switch (testIndex)
         {
         case 0: {
-            LogStep(0, "Reboot target device");
+            LogStep(0, "Stop target device");
             SetIdentity(kIdentityAlpha);
-            return Reboot(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+            return Stop();
         }
         case 1: {
-            LogStep(1, "Wait for the commissioned device to be retrieved for alpha");
+            LogStep(1, "Start target device with the provided discriminator for basic commissioning advertisement");
+            SetIdentity(kIdentityAlpha);
+            return Start(mDiscriminator.HasValue() ? mDiscriminator.Value() : 3840U);
+        }
+        case 2: {
+            LogStep(2, "Wait for the commissioned device to be retrieved for alpha");
             SetIdentity(kIdentityAlpha);
             return WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
         }
-        case 2: {
-            LogStep(2, "Commission from alpha when the commissioning window is not opened");
+        case 3: {
+            LogStep(3, "Commission from alpha when the commissioning window is not opened");
             SetIdentity(kIdentityAlpha);
             return PairWithQRCode(mNodeIdForDuplicateCommissioning.HasValue() ? mNodeIdForDuplicateCommissioning.Value() : 17ULL,
                                   mPayload.HasValue() ? mPayload.Value()
                                                       : chip::CharSpan::fromCharString("MT:-24J0AFN00KA0648G00"));
         }
-        case 3: {
-            LogStep(3, "Open Commissioning Window from alpha");
+        case 4: {
+            LogStep(4, "Open Commissioning Window from alpha");
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type value;
             value.commissioningTimeout = 180U;
             return SendCommand(kIdentityAlpha, GetEndpoint(0), AdministratorCommissioning::Id,
                                AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id, value,
                                chip::Optional<uint16_t>(10000));
         }
-        case 4: {
-            LogStep(4, "Commission from alpha again");
+        case 5: {
+            LogStep(5, "Commission from alpha again");
             SetIdentity(kIdentityAlpha);
             return PairWithQRCode(mNodeIdForDuplicateCommissioning.HasValue() ? mNodeIdForDuplicateCommissioning.Value() : 17ULL,
                                   mPayload.HasValue() ? mPayload.Value()
                                                       : chip::CharSpan::fromCharString("MT:-24J0AFN00KA0648G00"));
         }
-        case 5: {
-            LogStep(5, "Check that we just have the one fabric and did not add a new one");
+        case 6: {
+            LogStep(6, "Check that we just have the one fabric and did not add a new one");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(0), OperationalCredentials::Id,
                                  OperationalCredentials::Attributes::Fabrics::Id, false);
         }
-        case 6: {
-            LogStep(6, "Close Commissioning Window after failed commissioning");
+        case 7: {
+            LogStep(7, "Close Commissioning Window after failed commissioning");
             chip::app::Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Type value;
             return SendCommand(kIdentityAlpha, GetEndpoint(0), AdministratorCommissioning::Id,
                                AdministratorCommissioning::Commands::RevokeCommissioning::Id, value,
                                chip::Optional<uint16_t>(10000));
         }
-        case 7: {
-            LogStep(7, "Open Commissioning Window from alpha again");
+        case 8: {
+            LogStep(8, "Open Commissioning Window from alpha again");
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type value;
             value.commissioningTimeout = 180U;
             return SendCommand(kIdentityAlpha, GetEndpoint(0), AdministratorCommissioning::Id,
                                AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id, value,
                                chip::Optional<uint16_t>(10000));
         }
-        case 8: {
-            LogStep(8, "Commission from beta");
+        case 9: {
+            LogStep(9, "Commission from beta");
             SetIdentity(kIdentityBeta);
             return PairWithQRCode(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL,
                                   mPayload.HasValue() ? mPayload.Value()
                                                       : chip::CharSpan::fromCharString("MT:-24J0AFN00KA0648G00"));
         }
-        case 9: {
-            LogStep(9, "Wait for the commissioned device to be retrieved for beta");
+        case 10: {
+            LogStep(10, "Wait for the commissioned device to be retrieved for beta");
             SetIdentity(kIdentityBeta);
             return WaitForCommissionee(mNodeId2.HasValue() ? mNodeId2.Value() : 51966ULL);
         }
-        case 10: {
-            LogStep(10, "Open Commissioning Window from beta");
+        case 11: {
+            LogStep(11, "Open Commissioning Window from beta");
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type value;
             value.commissioningTimeout = 180U;
             return SendCommand(kIdentityBeta, GetEndpoint(0), AdministratorCommissioning::Id,
                                AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id, value,
                                chip::Optional<uint16_t>(10000));
         }
-        case 11: {
-            LogStep(11, "Commission from gamma");
+        case 12: {
+            LogStep(12, "Commission from gamma");
             SetIdentity(kIdentityGamma);
             return PairWithQRCode(mNodeId3.HasValue() ? mNodeId3.Value() : 12586990ULL,
                                   mPayload.HasValue() ? mPayload.Value()
                                                       : chip::CharSpan::fromCharString("MT:-24J0AFN00KA0648G00"));
         }
-        case 12: {
-            LogStep(12, "Wait for the commissioned device to be retrieved for gamma");
+        case 13: {
+            LogStep(13, "Wait for the commissioned device to be retrieved for gamma");
             SetIdentity(kIdentityGamma);
             return WaitForCommissionee(mNodeId3.HasValue() ? mNodeId3.Value() : 12586990ULL);
         }
-        case 13: {
-            LogStep(13, "read the mandatory attribute: NodeLabel from alpha");
+        case 14: {
+            LogStep(14, "read the mandatory attribute: NodeLabel from alpha");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id);
         }
-        case 14: {
-            LogStep(14, "write the mandatory attribute NodeLabel from beta");
+        case 15: {
+            LogStep(15, "write the mandatory attribute NodeLabel from beta");
             chip::CharSpan value;
             value = chip::Span<const char>("written from betagarbage: not in length on purpose", 17);
             return WriteAttribute(kIdentityBeta, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id, value);
         }
-        case 15: {
-            LogStep(15, "read the mandatory attribute: NodeLabel from gamma");
+        case 16: {
+            LogStep(16, "read the mandatory attribute: NodeLabel from gamma");
             return ReadAttribute(kIdentityGamma, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id);
         }
-        case 16: {
-            LogStep(16, "write the mandatory attribute NodeLabel back to default");
+        case 17: {
+            LogStep(17, "write the mandatory attribute NodeLabel back to default");
             chip::CharSpan value;
             value = readFromAlpha;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(0), Basic::Id, Basic::Attributes::NodeLabel::Id, value);


### PR DESCRIPTION
#### Problem
Currently, the test suites only starts one application for testing. Any tests that require more than one application running cannot be added.

#### Change overview
- Add all applications supported to the apps register
- Any pre-added apps can be launched using the SystemCommands cluster Start command in yaml files
- Add a `register_key` to the SystemCommands cluster which is to be used to Start/Stop/Reboot/FactoryReset any application that had been added to the apps register
- Update all tests that use the `SystemCommands` cluster commands to pass in the required `register_key` argument
- Make `SystemCommands::Reboot` signify a true reboot- use the same command line options the application was last started with
- With the `Reboot` redefinition, any tests that require a specific discriminator for basic commissioning advertisement must do an explicit `Stop` followed by `Start` with the appropriate discriminator. `Reboot` is only used when the test genuinely just wants to reboot a device.

#### Testing
- Added extra test cases to TestSystemCommands to start/commission/stop a second application
