### PR TITLE
use the build_examples tool in CI for imx

### DIFF
--- a/.github/workflows/examples-linux-imx.yaml
+++ b/.github/workflows/examples-linux-imx.yaml
@@ -55,3 +55,24 @@ jobs:
               run: |
                   ./scripts/examples/imxlinux_example.sh \
                   examples/chip-tool examples/chip-tool/out/aarch64
+            - name: Build thermostat
+              timeout-minutes: 30
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --target imx-thermostat build \
+                     "
+            - name: Build all-cluster
+              timeout-minutes: 30
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                         --target imx-all-clusters-app build \
+                     "
+            - name: Build ota-provider-app
+              timeout-minutes: 30
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                         --target imx-ota-provider-app build
+                     "


### PR DESCRIPTION
the build_examples tool is used in CI for imx devices to verify this
tool automatically during development.