### PR TITLE
Fix error reporting in chip-tool.

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -77,7 +77,7 @@ void TestCommand::Exit(std::string message, CHIP_ERROR err)
 {
     mContinueProcessing = false;
 
-    LogEnd(err);
+    LogEnd(message, err);
 
     if (CHIP_NO_ERROR == err)
     {

--- a/examples/placeholder/linux/include/TestCommand.h
+++ b/examples/placeholder/linux/include/TestCommand.h
@@ -86,7 +86,7 @@ public:
 
     void Exit(std::string message, CHIP_ERROR err) override
     {
-        LogEnd(err);
+        LogEnd(message, err);
         SetCommandExitStatus(err);
     }
 

--- a/src/app/tests/suites/include/TestRunner.h
+++ b/src/app/tests/suites/include/TestRunner.h
@@ -33,15 +33,15 @@ public:
         ChipLogProgress(chipTool, " ***** Test Step %u : %s\n", stepNumber, stepName);
     }
 
-    void LogEnd(CHIP_ERROR err)
+    void LogEnd(std::string message, CHIP_ERROR err)
     {
         if (CHIP_NO_ERROR == err)
         {
-            ChipLogProgress(chipTool, " **** Test Complete: %s\n", mTestName);
+            ChipLogProgress(chipTool, " **** Test Complete: %s\n", message.c_str());
         }
         else
         {
-            ChipLogError(chipTool, " ***** Test Failure: %s\n", mTestName);
+            ChipLogError(chipTool, " ***** Test Failure: %s\n", message.c_str());
         }
     }
 
@@ -59,7 +59,6 @@ public:
 
         if (mTestCount == mTestIndex)
         {
-            LogEnd(CHIP_NO_ERROR);
             Exit(mTestName, CHIP_NO_ERROR);
             return;
         }


### PR DESCRIPTION
The actual error message got lost in #17628.

#### Problem
Get error messages like:
```
2022-04-26 11:42:30.391 ERROR   11:42:30.251 - TEST OUT  : [1650987750251] [5754:35283414] CHIP: [TOO]  ***** Test Failure: TestGeneralCommissioning
```

#### Change overview
Make it be more like:
```
2022-04-26 11:57:18.930 ERROR   11:57:18.781 - TEST OUT  : [1650988638781] [9251:35303705] CHIP: [TOO]  ***** Test Failure: breadcrumb value mismatch: expected 25 but got 0
```

#### Testing
Ran a failing test, looked at the error message.