### PR TITLE
Bump git from ubutun3.3 to ubuntu3.4 as ubuntu:focal repository got u…

### DIFF
--- a/integrations/docker/ci-only-images/chip-cirque-device-base/Dockerfile
+++ b/integrations/docker/ci-only-images/chip-cirque-device-base/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
   ca-certificates=20210119~20.04.2 \
   dhcpcd5=7.1.0-2build1 \
   gdb=9.2-0ubuntu1~20.04.1 \
-  git=1:2.25.1-1ubuntu3.3 \
+  git=1:2.25.1-1ubuntu3.4 \
   iproute2=5.5.0-1ubuntu1 \
   libavahi-client3=0.7-4ubuntu7.1 \
   libcairo2-dev=1.16.0-4ubuntu1 \


### PR DESCRIPTION
…pdated

#### Problem
Cirque fails

#### Change overview
Update docker file version.

#### Testing
CI will validate. Got new version by using `apt-cache show git` after pulling the latest ubuntu:focal image.