### PR TITLE
Add ModeSelectCluster's CurrentMode attribute to Scene.

### DIFF
--- a/src/app/clusters/scenes/scenes.cpp
+++ b/src/app/clusters/scenes/scenes.cpp
@@ -594,9 +594,8 @@ EmberAfStatus emberAfScenesClusterStoreCurrentSceneCallback(chip::FabricIndex fa
 #endif
 #ifdef ZCL_USING_MODE_SELECT_CLUSTER_SERVER
     entry.hasCurrentModeValue =
-        readServerAttribute(endpoint, ZCL_MODE_SELECT_CLUSTER_ID, ZCL_CURRENT_MODE_ATTRIBUTE_ID,
-                            "currentMode", (uint8_t *) &entry.currentModeValue,
-                            sizeof(entry.currentModeValue));
+        readServerAttribute(endpoint, ZCL_MODE_SELECT_CLUSTER_ID, ZCL_CURRENT_MODE_ATTRIBUTE_ID, "currentMode",
+                            (uint8_t *) &entry.currentModeValue, sizeof(entry.currentModeValue));
 #endif
 
     // When creating a new entry, the name is set to the null string (i.e., the
@@ -752,8 +751,7 @@ EmberAfStatus emberAfScenesClusterRecallSavedSceneCallback(chip::FabricIndex fab
 #ifdef ZCL_USING_MODE_SELECT_CLUSTER_SERVER
             if (entry.hasCurrentModeValue)
             {
-                writeServerAttribute(endpoint, ZCL_MODE_SELECT_CLUSTER_ID,
-                                     ZCL_MODE_SELECT_CLUSTER_ID, "CurrentMode",
+                writeServerAttribute(endpoint, ZCL_MODE_SELECT_CLUSTER_ID, ZCL_MODE_SELECT_CLUSTER_ID, "CurrentMode",
                                      (uint8_t *) &entry.currentModeValue, ZCL_INT8U_ATTRIBUTE_TYPE);
             }
 #endif
@@ -1058,7 +1056,6 @@ bool emberAfPluginScenesServerParseAddScene(
             // extensions are added in this cluster, more logic will be needed here.
             entry.hasCurrentModeValue = true;
             entry.currentModeValue = emberAfGetInt8u(extensionFieldSets, extensionFieldSetsIndex, extensionFieldSetsLen);
-
 
 #endif
 #endif // if 0 disabling all the code.

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -807,6 +807,10 @@ typedef struct
     bool hasTargetPositionTiltPercent100thsValue;
     uint16_t targetPositionTiltPercent100thsValue;
 #endif
+#ifdef ZCL_USING_MODE_SELECT_CLUSTER_SERVER
+    bool hasCurrentModeValue;
+    uint8_t currentModeValue;
+#endif
 } EmberAfSceneTableEntry;
 
 #if !defined(EMBER_AF_PLUGIN_MESSAGING_CLIENT)


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:

* Fixes #11745

#### Change overview
* Add Mode Select Cluster's CurrentMode attribute to the EmberAfSceneTableEntry. 
* Add code in src/app/clusters/scenes/scenes.cpp to support the above attribute. 

#### Testing
How was this tested? (at least one bullet point required)
* If no testing is required, why not?
Test could not be performed as Scenes Cluster is not implemented properly yet. 