### PR TITLE
[Darwin] Pass the correct type to the register callback

### DIFF
--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -39,6 +39,17 @@ std::string GetHostNameWithoutDomain(const char * hostnameWithDomain)
     return hostname;
 }
 
+std::string GetFullTypeWithoutSubTypes(std::string fullType)
+{
+    size_t position = fullType.find(",");
+    if (position != std::string::npos)
+    {
+        fullType.erase(position);
+    }
+
+    return fullType;
+}
+
 void GetTextEntries(DnssdService & service, const unsigned char * data, uint16_t len)
 {
     uint16_t recordCount   = TXTRecordGetCount(len, data);
@@ -246,7 +257,7 @@ RegisterContext::RegisterContext(const char * sType, DnssdPublishCallback cb, vo
     context  = cbContext;
     callback = cb;
 
-    Platform::CopyString(mType, sType);
+    mType = sType;
 }
 
 void RegisterContext::DispatchFailure(DNSServiceErrorType err)
@@ -258,7 +269,8 @@ void RegisterContext::DispatchFailure(DNSServiceErrorType err)
 
 void RegisterContext::DispatchSuccess()
 {
-    callback(context, mType, CHIP_NO_ERROR);
+    std::string typeWithoutSubTypes = GetFullTypeWithoutSubTypes(mType);
+    callback(context, typeWithoutSubTypes.c_str(), CHIP_NO_ERROR);
 }
 
 BrowseContext::BrowseContext(void * cbContext, DnssdBrowseCallback cb, DnssdServiceProtocol cbContextProtocol)

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -91,7 +91,7 @@ private:
 struct RegisterContext : public GenericContext
 {
     DnssdPublishCallback callback;
-    char mType[kDnssdTypeMaxSize + 1];
+    std::string mType;
 
     RegisterContext(const char * sType, DnssdPublishCallback cb, void * cbContext);
     virtual ~RegisterContext() {}
@@ -99,7 +99,7 @@ struct RegisterContext : public GenericContext
     void DispatchFailure(DNSServiceErrorType err) override;
     void DispatchSuccess() override;
 
-    bool matches(const char * sType) { return (strcmp(mType, sType) == 0); }
+    bool matches(const char * sType) { return mType.compare(sType) == 0; }
 };
 
 struct BrowseContext : public GenericContext


### PR DESCRIPTION
#### Problem

Followup of https://github.com/project-chip/connectedhomeip/pull/17333 where the type that is passed to the register callback has wrongly been changed.

The logs now shows: ` mDNS service published: _matter` where it used to show ` mDNS service published: _matter._tcp`

#### Change overview
Pass the correct type around.

#### Testing
The accessory application now shows ` mDNS service published: _matter._tcp` properly.