### PR TITLE
Repair run_oad_tool.py in sub-toolchain

### DIFF
--- a/third_party/ti_simplelink_sdk/run_oad_tool.py
+++ b/third_party/ti_simplelink_sdk/run_oad_tool.py
@@ -10,6 +10,7 @@ Run with:
     python run_oad_tool.py <path to TI SimpleLinkSdk> <root out dir> <exe base name> <pem file> <bim hexfile>
 """
 
+import os
 import sys
 import subprocess
 import json
@@ -35,13 +36,13 @@ proc_call += [
     'ccs',
     root_out_dir,
     '7',
-    '-hex1', hex_file,
+    '-hex1', os.path.relpath(hex_file, root_out_dir),
     '-k', pem_file,
     '-o', sys.argv[3]
 ]
 
 # run oad_tool to fill in the header
-subprocess.call(proc_call)
+subprocess.check_call(proc_call)
 
 # merge binary executable with bim hex file
 ota_image = intelhex.IntelHex()


### PR DESCRIPTION

#### Problem

This tool requires a path relative to its first argument in the -hex1
argument. It works fine in the default toolchain because in that case
the output directory is ".".

```
[1812682] Failed to execute script oad_image_tool
Traceback (most recent call last):
  File "oad_image_tool.py", line 542, in <module>
  File "oad_image_tool.py", line 343, in main
  File "oad_image_tool.py", line 171, in createAppStackBinfile
  File "intelhex/__init__.py", line 1029, in hex2bin
  File "intelhex/__init__.py", line 90, in __init__
  File "intelhex/__init__.py", line 199, in loadhex
FileNotFoundError: [Errno 2] No such file or directory: 'cc13x2x7_26x2x7_all_clusters_app/cc13x2x7_26x2x7_all_clusters_app/chip-LP_CC2652R7-all-clusters-example.hex'
Traceback (most recent call last):
  File "/ssd/src/connectedhomeip2/out/debug/../../third_party/ti_simplelink_sdk/run_oad_tool.py", line 48, in <module>
    ota_image.fromfile(oad_bin_file, format='bin')
  File "/home/spang/connectedhomeip2/.environment/pigweed-venv/lib/python3.9/site-packages/intelhex/__init__.py", line 251, in loadfile
    self.loadbin(fobj)
  File "/home/spang/connectedhomeip2/.environment/pigweed-venv/lib/python3.9/site-packages/intelhex/__init__.py", line 229, in loadbin
    f = open(fobj, "rb")
FileNotFoundError: [Errno 2] No such file or directory: 'cc13x2x7_26x2x7_all_clusters_app/chip-LP_CC2652R7-all-clusters-example.bin'
ninja: build stopped: subcommand failed.
```

#### Change overview

Use relpath to pass the correct directory.

Also use check_call() so as not to keep going after a failure to
generate the bin file.

#### Testing

gn_build.sh
