### PR TITLE
Add a config variable for disabling platform KVS.

### DIFF
--- a/examples/chip-tool-darwin/.gn
+++ b/examples/chip-tool-darwin/.gn
@@ -22,4 +22,6 @@ check_system_includes = true
 
 default_args = {
   import("//args.gni")
+
+  chip_disable_platform_kvs = true
 }

--- a/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.mm
+++ b/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.mm
@@ -43,7 +43,6 @@ CHIP_ERROR CHIPCommandBridge::Run()
     auto params = [[MatterControllerFactoryParams alloc] initWithStorage:storage];
     params.port = @(kListenPort);
     params.startServer = YES;
-    params.kvsPath = @("/tmp/chip_kvs_darwin");
 
     if ([factory startup:params] == NO) {
         ChipLogError(chipTool, "Controller factory startup failed");

--- a/src/darwin/Framework/CHIP/MatterControllerFactory.h
+++ b/src/darwin/Framework/CHIP/MatterControllerFactory.h
@@ -56,11 +56,6 @@ NS_ASSUME_NONNULL_BEGIN
  * connections.  Defaults to NO.
  */
 @property (nonatomic) BOOL startServer;
-/*
- * Path to a file to use for backing our KVS storage.  This should not
- * be used, generally; it will be removed soon.  Defaults to nil.
- */
-@property (strong, nonatomic, nullable) NSString * kvsPath;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithStorage:(id<CHIPPersistentStorageDelegate>)storageDelegate;

--- a/src/darwin/Framework/CHIP/MatterControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MatterControllerFactory.mm
@@ -41,7 +41,6 @@ static NSString * const kErrorPersistentStorageInit = @"Init failure while creat
 static NSString * const kErrorAttestationTrustStoreInit = @"Init failure while creating the attestation trust store";
 static NSString * const kInfoFactoryShutdown = @"Shutting down the Matter controller factory";
 static NSString * const kErrorGroupProviderInit = @"Init failure while initializing group data provider";
-static NSString * const kErrorKVSInit = @"Init Key Value Store failure";
 static NSString * const kErrorControllersInit = @"Init controllers array failure";
 static NSString * const kErrorControllerFactoryInit = @"Init failure while initializing controller factory";
 
@@ -178,15 +177,6 @@ static NSString * const kErrorControllerFactoryInit = @"Init failure while initi
         }
 
         [CHIPControllerAccessControl init];
-
-        if (startupParams.kvsPath != nil) {
-            // TODO: We should stop needing a KeyValueStoreManager on the client side, then remove this code.
-            CHIP_ERROR errorCode = DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init([startupParams.kvsPath UTF8String]);
-            if (errorCode != CHIP_NO_ERROR) {
-                CHIP_LOG_ERROR("Error: %@", kErrorKVSInit);
-                return;
-            }
-        }
 
         _persistentStorageDelegateBridge = new CHIPPersistentStorageDelegateBridge(startupParams.storageDelegate);
         if (_persistentStorageDelegateBridge == nil) {
@@ -468,7 +458,6 @@ static NSString * const kErrorControllerFactoryInit = @"Init failure while initi
     _paaCerts = nil;
     _port = nil;
     _startServer = NO;
-    _kvsPath = nil;
 
     return self;
 }

--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -96,6 +96,7 @@ declare -a args=(
     'chip_crypto="mbedtls"'
     'chip_build_tools=false'
     'chip_build_tests=false'
+    'chip_disable_platform_kvs=true'
     'target_cpu="'"$target_cpu"'"'
     'target_defines='"$target_defines"
     'target_cflags=['"$target_cflags"']'

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -108,6 +108,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
       "CHIP_STACK_LOCK_TRACKING_ERROR_FATAL=${chip_stack_lock_tracking_fatal}",
       "CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING=${chip_enable_additional_data_advertising}",
       "CHIP_DEVICE_CONFIG_RUN_AS_ROOT=${chip_device_config_run_as_root}",
+      "CHIP_DISABLE_PLATFORM_KVS=${chip_disable_platform_kvs}",
     ]
 
     if (chip_device_platform == "linux" || chip_device_platform == "darwin" ||

--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -55,8 +55,6 @@ static_library("Darwin") {
     "DnssdImpl.cpp",
     "DnssdImpl.h",
     "InetPlatformConfig.h",
-    "KeyValueStoreManagerImpl.h",
-    "KeyValueStoreManagerImpl.mm",
     "Logging.cpp",
     "MdnsError.cpp",
     "MdnsError.h",
@@ -67,6 +65,13 @@ static_library("Darwin") {
     "SystemPlatformConfig.h",
     "SystemTimeSupport.cpp",
   ]
+
+  if (chip_disable_platform_kvs == false) {
+    sources += [
+      "KeyValueStoreManagerImpl.h",
+      "KeyValueStoreManagerImpl.mm",
+    ]
+  }
 
   deps = [
     "${chip_root}/src/lib/dnssd:platform_header",

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -151,6 +151,9 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
 
 CHIP_ERROR ConfigurationManagerImpl::Init()
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_NO_ERROR;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     // Initialize the generic implementation base class.
     ReturnErrorOnFailure(Internal::GenericConfigurationManagerImpl<PosixConfig>::Init());
 
@@ -199,6 +202,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     }
 
     return CHIP_NO_ERROR;
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
@@ -232,56 +236,99 @@ void ConfigurationManagerImpl::InitiateFactoryReset()
 
 CHIP_ERROR ConfigurationManagerImpl::GetVendorId(uint16_t & vendorId)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return ReadConfigValue(PosixConfig::kConfigKey_VendorId, vendorId);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetProductId(uint16_t & productId)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return ReadConfigValue(PosixConfig::kConfigKey_ProductId, productId);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreVendorId(uint16_t vendorId)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return WriteConfigValue(PosixConfig::kConfigKey_VendorId, vendorId);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreProductId(uint16_t productId)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return WriteConfigValue(PosixConfig::kConfigKey_ProductId, productId);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return ReadConfigValue(PosixConfig::kCounterKey_RebootCount, rebootCount);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreRebootCount(uint32_t rebootCount)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return WriteConfigValue(PosixConfig::kCounterKey_RebootCount, rebootCount);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return ReadConfigValue(PosixConfig::kCounterKey_TotalOperationalHours, totalOperationalHours);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreTotalOperationalHours(uint32_t totalOperationalHours)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return WriteConfigValue(PosixConfig::kCounterKey_TotalOperationalHours, totalOperationalHours);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetBootReason(uint32_t & bootReason)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return ReadConfigValue(PosixConfig::kCounterKey_BootReason, bootReason);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreBootReason(uint32_t bootReason)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return WriteConfigValue(PosixConfig::kCounterKey_BootReason, bootReason);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetRegulatoryLocation(uint8_t & location)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     uint32_t value = 0;
 
     CHIP_ERROR err = ReadConfigValue(PosixConfig::kConfigKey_RegulatoryLocation, value);
@@ -293,10 +340,14 @@ CHIP_ERROR ConfigurationManagerImpl::GetRegulatoryLocation(uint8_t & location)
     }
 
     return err;
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetLocationCapability(uint8_t & location)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     uint32_t value = 0;
 
     CHIP_ERROR err = ReadConfigValue(PosixConfig::kConfigKey_LocationCapability, value);
@@ -308,10 +359,14 @@ CHIP_ERROR ConfigurationManagerImpl::GetLocationCapability(uint8_t & location)
     }
 
     return err;
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     PosixConfig::Key configKey{ PosixConfig::kConfigNamespace_ChipCounters, key };
 
     CHIP_ERROR err = ReadConfigValue(configKey, value);
@@ -320,82 +375,143 @@ CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform:
         err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     }
     return err;
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     PosixConfig::Key configKey{ PosixConfig::kConfigNamespace_ChipCounters, key };
     return WriteConfigValue(configKey, value);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return PosixConfig::ReadConfigValue(key, val);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint16_t & val)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return PosixConfig::ReadConfigValue(key, val);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint32_t & val)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return PosixConfig::ReadConfigValue(key, val);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, uint64_t & val)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return PosixConfig::ReadConfigValue(key, val);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return PosixConfig::ReadConfigValueStr(key, buf, bufSize, outLen);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return PosixConfig::ReadConfigValueBin(key, buf, bufSize, outLen);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, bool val)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return PosixConfig::WriteConfigValue(key, val);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint16_t val)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return PosixConfig::WriteConfigValue(key, val);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint32_t val)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return PosixConfig::WriteConfigValue(key, val);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValue(Key key, uint64_t val)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return PosixConfig::WriteConfigValue(key, val);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return PosixConfig::WriteConfigValueStr(key, str);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return PosixConfig::WriteConfigValueStr(key, str, strLen);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     return PosixConfig::WriteConfigValueBin(key, data, dataLen);
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 void ConfigurationManagerImpl::RunConfigUnitTest(void)
 {
+#if CHIP_DISABLE_PLATFORM_KVS
+    return;
+#else  // CHIP_DISABLE_PLATFORM_KVS
     PosixConfig::RunConfigUnitTest();
+#endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
 } // namespace DeviceLayer

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -43,8 +43,10 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     CHIP_ERROR err;
 
     // Initialize the configuration system.
+#if !CHIP_DISABLE_PLATFORM_KVS
     err = Internal::PosixConfig::Init();
     SuccessOrExit(err);
+#endif // CHIP_DISABLE_PLATFORM_KVS
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
     SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
     SetDeviceInfoProvider(&DeviceInfoProviderImpl::GetDefaultInstance());

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -83,6 +83,7 @@ const PosixConfig::Key PosixConfig::kCounterKey_TotalOperationalHours = { kConfi
                                                                           "total-operational-hours" };
 const PosixConfig::Key PosixConfig::kConfigKey_UniqueId               = { kConfigNamespace_ChipConfig, "unique-id" };
 
+#if !CHIP_DISABLE_PLATFORM_KVS
 // Prefix used for NVS keys that contain Chip group encryption keys.
 const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";
 
@@ -210,6 +211,8 @@ exit:
 }
 
 void PosixConfig::RunConfigUnitTest() {}
+
+#endif // CHIP_DISABLE_PLATFORM_KVS
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/Darwin/PosixConfig.h
+++ b/src/platform/Darwin/PosixConfig.h
@@ -88,6 +88,7 @@ public:
 
     static const char kGroupKeyNamePrefix[];
 
+#if !CHIP_DISABLE_PLATFORM_KVS
     static CHIP_ERROR Init(void);
 
     // Config value accessors.
@@ -114,11 +115,7 @@ protected:
     // NVS Namespace helper functions.
     static CHIP_ERROR EnsureNamespace(const char * ns);
     static CHIP_ERROR ClearNamespace(const char * ns);
-
-private:
-    // TODO: This is temporary until Darwin implements a proper ReadConfigValue
-    static uint16_t mPosixSetupDiscriminator;
-    static char mPosixCountryCode[2 + 1];
+#endif // CHIP_DISABLE_PLATFORM_KVS
 };
 
 struct PosixConfig::Key

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -143,6 +143,15 @@ if (chip_device_platform != "external") {
   }
 }
 
+declare_args() {
+  # If true, disables KVS implementation for the platform.  May not be
+  # supported on all platforms.
+  chip_disable_platform_kvs = false
+}
+
+assert(chip_disable_platform_kvs == false || chip_device_platform == "darwin",
+       "Can only disable KVS on some platforms")
+
 if (_chip_device_layer != "none" && chip_device_platform != "external") {
   chip_ble_platform_config_include =
       "<platform/" + _chip_device_layer + "/BlePlatformConfig.h>"


### PR DESCRIPTION
Implement support for doing that on Darwin, and enable that support
when building the Darwin framework, via either Xcode or
chip-tool-darwin.

#### Problem
Darwin framework can't actually have a "platform" KVS impl.  Everything needs to go through the storage delegate.

#### Change overview
Disable the platform KVS on Darwin when building the framework.  This should have no impact on anything, because the things that use KVS are either not compiled or not called in the Darwin framework.

#### Testing
CI will verify chip-tool-darwin still works.  Verified that iOS CHIPTool can commission things and talk to them.