### PR TITLE
Handle response errors during commissioning

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -377,7 +377,9 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
                                  "Failed device attestation. Device vendor and/or product ID do not match the IDs expected. "
                                  "Verify DAC certificate chain and certification declaration to ensure spec rules followed.");
                 }
-            } else if (report.Is<CommissionErrorInfo>()) {
+            }
+            else if (report.Is<CommissionErrorInfo>())
+            {
                 completionStatus.commissioningError = MakeOptional(report.Get<CommissionErrorInfo>().commissioningError);
             }
         }

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -363,9 +363,9 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
     {
         completionStatus.failedStage = MakeOptional(report.stageCompleted);
         ChipLogError(Controller, "Failed to perform commissioning step %d", static_cast<int>(report.stageCompleted));
-        if (report.stageCompleted == CommissioningStage::kAttestationVerification)
+        if (report.Is<AdditionalErrorInfo>())
         {
-            if (report.Is<AdditionalErrorInfo>())
+            if (report.stageCompleted == CommissioningStage::kAttestationVerification)
             {
                 completionStatus.attestationResult = MakeOptional(report.Get<AdditionalErrorInfo>().attestationResult);
                 if ((report.Get<AdditionalErrorInfo>().attestationResult ==
@@ -378,10 +378,10 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
                                  "Verify DAC certificate chain and certification declaration to ensure spec rules followed.");
                 }
             }
-            else if (report.Is<CommissionErrorInfo>())
-            {
-                completionStatus.commissioningError = MakeOptional(report.Get<CommissionErrorInfo>().commissioningError);
-            }
+        }
+        else if (report.Is<CommissionErrorInfo>())
+        {
+            completionStatus.commissioningError = MakeOptional(report.Get<CommissionErrorInfo>().commissioningError);
         }
     }
     else

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -377,6 +377,8 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
                                  "Failed device attestation. Device vendor and/or product ID do not match the IDs expected. "
                                  "Verify DAC certificate chain and certification declaration to ensure spec rules followed.");
                 }
+            } else if (report.Is<CommissionErrorInfo>()) {
+                completionStatus.commissioningError = MakeOptional(report.Get<CommissionErrorInfo>().commissioningError);
             }
         }
     }

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -379,9 +379,14 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
                 }
             }
         }
-        else if (report.Is<CommissionErrorInfo>())
+        else if (report.Is<CommissioningErrorInfo>())
         {
-            completionStatus.commissioningError = MakeOptional(report.Get<CommissionErrorInfo>().commissioningError);
+            completionStatus.commissioningError = MakeOptional(report.Get<CommissioningErrorInfo>().commissioningError);
+        }
+        else if (report.Is<NetworkCommissioningStatusInfo>())
+        {
+            completionStatus.networkCommissioningStatus =
+                MakeOptional(report.Get<NetworkCommissioningStatusInfo>().networkCommissioningStatus);
         }
     }
     else

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1487,6 +1487,8 @@ void DeviceCommissioner::CommissioningStageComplete(CHIP_ERROR err, Commissionin
 
     if (mPairingDelegate != nullptr)
     {
+        // TODO github issue mentions that the intent it to plumb result to PairingDelegate, but over
+        // chat it was mentioned to plumb event to AutoCommisioner. Need to double check which.
         mPairingDelegate->OnCommissioningStatusUpdate(PeerId(GetCompressedFabricId(), nodeId), mCommissioningStage, err);
     }
     if (mCommissioningDelegate == nullptr)
@@ -1724,13 +1726,47 @@ void DeviceCommissioner::OnDone()
     CommissioningStageComplete(return_err, report);
 }
 
+// TODO if we want to branch out the Commissioning Error to a specific chip error this will be
+// moved to the top and likely is better as a map lookup (which I would look for suggestions).
+CHIP_ERROR ConvertCommissioningErrorToChipError(GeneralCommissioning::CommissioningError commissioningError) {
+    switch (commissioningError)
+    {
+    case GeneralCommissioning::CommissioningError::kOk:
+        return CHIP_NO_ERROR;
+        break;
+    case GeneralCommissioning::CommissioningError::kValueOutsideRange:
+        return CHIP_ERROR_INVALID_ARGUMENT;  //  TODO figure out more appropriate error.
+        break;
+    case GeneralCommissioning::CommissioningError::kInvalidAuthentication:
+        return CHIP_ERROR_INVALID_ARGUMENT;  //  TODO figure out more appropriate error.
+        break;
+    case GeneralCommissioning::CommissioningError::kNoFailSafe:
+        return CHIP_ERROR_INVALID_ARGUMENT;  //  TODO figure out more appropriate error.
+        break;
+    case GeneralCommissioning::CommissioningError::kBusyWithOtherAdmin:
+        return CHIP_ERROR_INVALID_ARGUMENT;  //  TODO figure out more appropriate error.
+        break;
+    default:
+        break;
+    }
+    return CHIP_ERROR_INVALID_ARGUMENT;  //  TODO figure out more appropriate error.
+}
+
 void DeviceCommissioner::OnArmFailSafe(void * context,
                                        const GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType & data)
 {
-    // TODO: Use errorCode
-    ChipLogProgress(Controller, "Received ArmFailSafe response");
+    // TODO: Figure out if ther is a better way other than static_cast.
+    ChipLogProgress(Controller, "Received ArmFailSafe response errorCode=%u", static_cast<uint8_t>(data.errorCode));
+
+    CommissioningDelegate::CommissioningReport report;
+    if (data.errorCode != GeneralCommissioning::CommissioningError::kOk) {
+      report.Set<CommissionErrorInfo>(data.errorCode);
+    }
+
+    // TODO: do we actually want to look this up or is it okay to just use CHIP_ERROR_INTERNAL instead of this mapping
+    CHIP_ERROR retVal = ConvertCommissioningErrorToChipError(data.errorCode);
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
-    commissioner->CommissioningStageComplete(CHIP_NO_ERROR);
+    commissioner->CommissioningStageComplete(retVal, report);
 }
 
 void DeviceCommissioner::OnSetRegulatoryConfigResponse(

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1730,7 +1730,6 @@ void DeviceCommissioner::OnArmFailSafe(void * context,
     CommissioningDelegate::CommissioningReport report;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    // TODO: Figure out if ther is a better way other than static_cast.
     ChipLogProgress(Controller, "Received ArmFailSafe response errorCode=%u", static_cast<uint8_t>(data.errorCode));
     if (data.errorCode != GeneralCommissioning::CommissioningError::kOk)
     {
@@ -1748,7 +1747,6 @@ void DeviceCommissioner::OnSetRegulatoryConfigResponse(
     CommissioningDelegate::CommissioningReport report;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    // TODO: Figure out if ther is a better way other than static_cast.
     ChipLogProgress(Controller, "Received SetRegulatoryConfig response errorCode=%u", static_cast<uint8_t>(data.errorCode));
     if (data.errorCode != GeneralCommissioning::CommissioningError::kOk)
     {
@@ -1765,7 +1763,6 @@ void DeviceCommissioner::OnNetworkConfigResponse(void * context,
     CommissioningDelegate::CommissioningReport report;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    // TODO: Figure out if ther is a better way other than static_cast.
     ChipLogProgress(Controller, "Received NetworkConfig response, networkingStatus=%u",
                     static_cast<uint8_t>(data.networkingStatus));
     if (data.networkingStatus != NetworkCommissioning::NetworkCommissioningStatus::kSuccess)
@@ -1783,7 +1780,6 @@ void DeviceCommissioner::OnConnectNetworkResponse(
     CommissioningDelegate::CommissioningReport report;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    // TODO: Figure out if ther is a better way other than static_cast.
     ChipLogProgress(Controller, "Received ConnectNetwork response, networkingStatus=%u",
                     static_cast<uint8_t>(data.networkingStatus));
     if (data.networkingStatus != NetworkCommissioning::NetworkCommissioningStatus::kSuccess)
@@ -1801,7 +1797,6 @@ void DeviceCommissioner::OnCommissioningCompleteResponse(
     CommissioningDelegate::CommissioningReport report;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    // TODO: Figure out if ther is a better way other than static_cast.
     ChipLogProgress(Controller, "Received CommissioningComplete response, errorCode=%u", static_cast<uint8_t>(data.errorCode));
     if (data.errorCode != GeneralCommissioning::CommissioningError::kOk)
     {

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1472,7 +1472,7 @@ void DeviceCommissioner::SendCommissioningCompleteCallbacks(NodeId nodeId, const
     }
     else
     {
-        // TODO: We should propogate errors commissioningError networkCommissioningStatus errors from completionStatus.
+        // TODO: We should propogate detailed error information (commissioningError, networkCommissioningStatus) from completionStatus.
         mPairingDelegate->OnCommissioningFailure(peerId, completionStatus.err, completionStatus.failedStage.ValueOr(kError),
                                                  completionStatus.attestationResult);
     }
@@ -1731,7 +1731,7 @@ void DeviceCommissioner::OnArmFailSafe(void * context,
     CommissioningDelegate::CommissioningReport report;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ChipLogProgress(Controller, "Received ArmFailSafe response errorCode=%u", static_cast<uint8_t>(data.errorCode));
+    ChipLogProgress(Controller, "Received ArmFailSafe response errorCode=%u", to_underlying(data.errorCode));
     if (data.errorCode != GeneralCommissioning::CommissioningError::kOk)
     {
         err = CHIP_ERROR_INTERNAL;
@@ -1748,7 +1748,7 @@ void DeviceCommissioner::OnSetRegulatoryConfigResponse(
     CommissioningDelegate::CommissioningReport report;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ChipLogProgress(Controller, "Received SetRegulatoryConfig response errorCode=%u", static_cast<uint8_t>(data.errorCode));
+    ChipLogProgress(Controller, "Received SetRegulatoryConfig response errorCode=%u", to_underlying(data.errorCode));
     if (data.errorCode != GeneralCommissioning::CommissioningError::kOk)
     {
         err = CHIP_ERROR_INTERNAL;
@@ -1765,7 +1765,7 @@ void DeviceCommissioner::OnNetworkConfigResponse(void * context,
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     ChipLogProgress(Controller, "Received NetworkConfig response, networkingStatus=%u",
-                    static_cast<uint8_t>(data.networkingStatus));
+                    to_underlying(data.networkingStatus));
     if (data.networkingStatus != NetworkCommissioning::NetworkCommissioningStatus::kSuccess)
     {
         err = CHIP_ERROR_INTERNAL;
@@ -1782,7 +1782,7 @@ void DeviceCommissioner::OnConnectNetworkResponse(
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     ChipLogProgress(Controller, "Received ConnectNetwork response, networkingStatus=%u",
-                    static_cast<uint8_t>(data.networkingStatus));
+                    to_underlying(data.networkingStatus));
     if (data.networkingStatus != NetworkCommissioning::NetworkCommissioningStatus::kSuccess)
     {
         err = CHIP_ERROR_INTERNAL;
@@ -1798,7 +1798,7 @@ void DeviceCommissioner::OnCommissioningCompleteResponse(
     CommissioningDelegate::CommissioningReport report;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ChipLogProgress(Controller, "Received CommissioningComplete response, errorCode=%u", static_cast<uint8_t>(data.errorCode));
+    ChipLogProgress(Controller, "Received CommissioningComplete response, errorCode=%u", to_underlying(data.errorCode));
     if (data.errorCode != GeneralCommissioning::CommissioningError::kOk)
     {
         err = CHIP_ERROR_INTERNAL;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -753,7 +753,7 @@ DeviceCommissioner::ContinueCommissioningAfterDeviceAttestationFailure(DevicePro
                      to_underlying(attestationResult));
 
         CommissioningDelegate::CommissioningReport report;
-        report.Set<AdditionalErrorInfo>(attestationResult);
+        report.Set<AttestationErrorInfo>(attestationResult);
         CommissioningStageComplete(CHIP_ERROR_INTERNAL, report);
     }
     else
@@ -931,7 +931,7 @@ void DeviceCommissioner::OnDeviceAttestationInformationVerification(void * conte
     if (result != AttestationVerificationResult::kSuccess)
     {
         CommissioningDelegate::CommissioningReport report;
-        report.Set<AdditionalErrorInfo>(result);
+        report.Set<AttestationErrorInfo>(result);
         if (result == AttestationVerificationResult::kNotImplemented)
         {
             ChipLogError(Controller,
@@ -992,7 +992,7 @@ void DeviceCommissioner::OnArmFailSafeExtendedForFailedDeviceAttestation(
     {
         ChipLogProgress(Controller, "Device attestation failed and no delegate set, failing commissioning");
         CommissioningDelegate::CommissioningReport report;
-        report.Set<AdditionalErrorInfo>(commissioner->mAttestationResult);
+        report.Set<AttestationErrorInfo>(commissioner->mAttestationResult);
         commissioner->CommissioningStageComplete(CHIP_ERROR_INTERNAL, report);
     }
 }
@@ -1003,7 +1003,7 @@ void DeviceCommissioner::OnFailedToExtendedArmFailSafeFailedDeviceAttestation(vo
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
 
     CommissioningDelegate::CommissioningReport report;
-    report.Set<AdditionalErrorInfo>(commissioner->mAttestationResult);
+    report.Set<AttestationErrorInfo>(commissioner->mAttestationResult);
     commissioner->CommissioningStageComplete(CHIP_ERROR_INTERNAL, report);
 }
 
@@ -1472,6 +1472,7 @@ void DeviceCommissioner::SendCommissioningCompleteCallbacks(NodeId nodeId, const
     }
     else
     {
+        // TODO: We should propogate errors commissioningError networkCommissioningStatus errors from completionStatus.
         mPairingDelegate->OnCommissioningFailure(peerId, completionStatus.err, completionStatus.failedStage.ValueOr(kError),
                                                  completionStatus.attestationResult);
     }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1487,8 +1487,6 @@ void DeviceCommissioner::CommissioningStageComplete(CHIP_ERROR err, Commissionin
 
     if (mPairingDelegate != nullptr)
     {
-        // TODO github issue mentions that the intent it to plumb result to PairingDelegate, but over
-        // chat it was mentioned to plumb event to AutoCommisioner. Need to double check which.
         mPairingDelegate->OnCommissioningStatusUpdate(PeerId(GetCompressedFabricId(), nodeId), mCommissioningStage, err);
     }
     if (mCommissioningDelegate == nullptr)
@@ -1737,7 +1735,7 @@ void DeviceCommissioner::OnArmFailSafe(void * context,
     if (data.errorCode != GeneralCommissioning::CommissioningError::kOk)
     {
         err = CHIP_ERROR_INTERNAL;
-        report.Set<CommissionErrorInfo>(data.errorCode);
+        report.Set<CommissioningErrorInfo>(data.errorCode);
     }
 
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
@@ -1747,37 +1745,71 @@ void DeviceCommissioner::OnArmFailSafe(void * context,
 void DeviceCommissioner::OnSetRegulatoryConfigResponse(
     void * context, const GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType & data)
 {
-    // TODO: Use errorCode
-    ChipLogProgress(Controller, "Received SetRegulatoryConfig response");
+    CommissioningDelegate::CommissioningReport report;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // TODO: Figure out if ther is a better way other than static_cast.
+    ChipLogProgress(Controller, "Received SetRegulatoryConfig response errorCode=%u", static_cast<uint8_t>(data.errorCode));
+    if (data.errorCode != GeneralCommissioning::CommissioningError::kOk)
+    {
+        err = CHIP_ERROR_INTERNAL;
+        report.Set<CommissioningErrorInfo>(data.errorCode);
+    }
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
-    commissioner->CommissioningStageComplete(CHIP_NO_ERROR);
+    commissioner->CommissioningStageComplete(err, report);
 }
 
 void DeviceCommissioner::OnNetworkConfigResponse(void * context,
                                                  const NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType & data)
 {
-    // TODO: Use networkingStatus
-    ChipLogProgress(Controller, "Received NetworkConfig response");
+    CommissioningDelegate::CommissioningReport report;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // TODO: Figure out if ther is a better way other than static_cast.
+    ChipLogProgress(Controller, "Received NetworkConfig response, networkingStatus=%u",
+                    static_cast<uint8_t>(data.networkingStatus));
+    if (data.networkingStatus != NetworkCommissioning::NetworkCommissioningStatus::kSuccess)
+    {
+        err = CHIP_ERROR_INTERNAL;
+        report.Set<NetworkCommissioningStatusInfo>(data.networkingStatus);
+    }
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
-    commissioner->CommissioningStageComplete(CHIP_NO_ERROR);
+    commissioner->CommissioningStageComplete(err, report);
 }
 
 void DeviceCommissioner::OnConnectNetworkResponse(
     void * context, const NetworkCommissioning::Commands::ConnectNetworkResponse::DecodableType & data)
 {
-    // TODO: Use networkingStatus
-    ChipLogProgress(Controller, "Received ConnectNetwork response");
+    CommissioningDelegate::CommissioningReport report;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // TODO: Figure out if ther is a better way other than static_cast.
+    ChipLogProgress(Controller, "Received ConnectNetwork response, networkingStatus=%u",
+                    static_cast<uint8_t>(data.networkingStatus));
+    if (data.networkingStatus != NetworkCommissioning::NetworkCommissioningStatus::kSuccess)
+    {
+        err = CHIP_ERROR_INTERNAL;
+        report.Set<NetworkCommissioningStatusInfo>(data.networkingStatus);
+    }
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
-    commissioner->CommissioningStageComplete(CHIP_NO_ERROR);
+    commissioner->CommissioningStageComplete(err, report);
 }
 
 void DeviceCommissioner::OnCommissioningCompleteResponse(
     void * context, const GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType & data)
 {
-    // TODO: Use errorCode
-    ChipLogProgress(Controller, "Received CommissioningComplete response");
+    CommissioningDelegate::CommissioningReport report;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // TODO: Figure out if ther is a better way other than static_cast.
+    ChipLogProgress(Controller, "Received CommissioningComplete response, errorCode=%u", static_cast<uint8_t>(data.errorCode));
+    if (data.errorCode != GeneralCommissioning::CommissioningError::kOk)
+    {
+        err = CHIP_ERROR_INTERNAL;
+        report.Set<CommissioningErrorInfo>(data.errorCode);
+    }
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
-    commissioner->CommissioningStageComplete(CHIP_NO_ERROR);
+    commissioner->CommissioningStageComplete(err, report);
 }
 
 void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, CommissioningStage step, CommissioningParameters & params,

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1472,7 +1472,8 @@ void DeviceCommissioner::SendCommissioningCompleteCallbacks(NodeId nodeId, const
     }
     else
     {
-        // TODO: We should propogate detailed error information (commissioningError, networkCommissioningStatus) from completionStatus.
+        // TODO: We should propogate detailed error information (commissioningError, networkCommissioningStatus) from
+        // completionStatus.
         mPairingDelegate->OnCommissioningFailure(peerId, completionStatus.err, completionStatus.failedStage.ValueOr(kError),
                                                  completionStatus.attestationResult);
     }
@@ -1764,8 +1765,7 @@ void DeviceCommissioner::OnNetworkConfigResponse(void * context,
     CommissioningDelegate::CommissioningReport report;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ChipLogProgress(Controller, "Received NetworkConfig response, networkingStatus=%u",
-                    to_underlying(data.networkingStatus));
+    ChipLogProgress(Controller, "Received NetworkConfig response, networkingStatus=%u", to_underlying(data.networkingStatus));
     if (data.networkingStatus != NetworkCommissioning::NetworkCommissioningStatus::kSuccess)
     {
         err = CHIP_ERROR_INTERNAL;
@@ -1781,8 +1781,7 @@ void DeviceCommissioner::OnConnectNetworkResponse(
     CommissioningDelegate::CommissioningReport report;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ChipLogProgress(Controller, "Received ConnectNetwork response, networkingStatus=%u",
-                    to_underlying(data.networkingStatus));
+    ChipLogProgress(Controller, "Received ConnectNetwork response, networkingStatus=%u", to_underlying(data.networkingStatus));
     if (data.networkingStatus != NetworkCommissioning::NetworkCommissioningStatus::kSuccess)
     {
         err = CHIP_ERROR_INTERNAL;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1728,28 +1728,29 @@ void DeviceCommissioner::OnDone()
 
 // TODO if we want to branch out the Commissioning Error to a specific chip error this will be
 // moved to the top and likely is better as a map lookup (which I would look for suggestions).
-CHIP_ERROR ConvertCommissioningErrorToChipError(GeneralCommissioning::CommissioningError commissioningError) {
+CHIP_ERROR ConvertCommissioningErrorToChipError(GeneralCommissioning::CommissioningError commissioningError)
+{
     switch (commissioningError)
     {
     case GeneralCommissioning::CommissioningError::kOk:
         return CHIP_NO_ERROR;
         break;
     case GeneralCommissioning::CommissioningError::kValueOutsideRange:
-        return CHIP_ERROR_INVALID_ARGUMENT;  //  TODO figure out more appropriate error.
+        return CHIP_ERROR_INVALID_ARGUMENT; //  TODO figure out more appropriate error.
         break;
     case GeneralCommissioning::CommissioningError::kInvalidAuthentication:
-        return CHIP_ERROR_INVALID_ARGUMENT;  //  TODO figure out more appropriate error.
+        return CHIP_ERROR_INVALID_ARGUMENT; //  TODO figure out more appropriate error.
         break;
     case GeneralCommissioning::CommissioningError::kNoFailSafe:
-        return CHIP_ERROR_INVALID_ARGUMENT;  //  TODO figure out more appropriate error.
+        return CHIP_ERROR_INVALID_ARGUMENT; //  TODO figure out more appropriate error.
         break;
     case GeneralCommissioning::CommissioningError::kBusyWithOtherAdmin:
-        return CHIP_ERROR_INVALID_ARGUMENT;  //  TODO figure out more appropriate error.
+        return CHIP_ERROR_INVALID_ARGUMENT; //  TODO figure out more appropriate error.
         break;
     default:
         break;
     }
-    return CHIP_ERROR_INVALID_ARGUMENT;  //  TODO figure out more appropriate error.
+    return CHIP_ERROR_INVALID_ARGUMENT; //  TODO figure out more appropriate error.
 }
 
 void DeviceCommissioner::OnArmFailSafe(void * context,
@@ -1759,12 +1760,13 @@ void DeviceCommissioner::OnArmFailSafe(void * context,
     ChipLogProgress(Controller, "Received ArmFailSafe response errorCode=%u", static_cast<uint8_t>(data.errorCode));
 
     CommissioningDelegate::CommissioningReport report;
-    if (data.errorCode != GeneralCommissioning::CommissioningError::kOk) {
-      report.Set<CommissionErrorInfo>(data.errorCode);
+    if (data.errorCode != GeneralCommissioning::CommissioningError::kOk)
+    {
+        report.Set<CommissionErrorInfo>(data.errorCode);
     }
 
     // TODO: do we actually want to look this up or is it okay to just use CHIP_ERROR_INTERNAL instead of this mapping
-    CHIP_ERROR retVal = ConvertCommissioningErrorToChipError(data.errorCode);
+    CHIP_ERROR retVal                 = ConvertCommissioningErrorToChipError(data.errorCode);
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
     commissioner->CommissioningStageComplete(retVal, report);
 }

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -455,10 +455,18 @@ struct AdditionalErrorInfo
     Credentials::AttestationVerificationResult attestationResult;
 };
 
-struct CommissionErrorInfo
+struct CommissioningErrorInfo
 {
-    CommissionErrorInfo(app::Clusters::GeneralCommissioning::CommissioningError result) : commissioningError(result) {}
+    CommissioningErrorInfo(app::Clusters::GeneralCommissioning::CommissioningError result) : commissioningError(result) {}
     app::Clusters::GeneralCommissioning::CommissioningError commissioningError;
+};
+
+struct NetworkCommissioningStatusInfo
+{
+    NetworkCommissioningStatusInfo(app::Clusters::NetworkCommissioning::NetworkCommissioningStatus result) :
+        networkCommissioningStatus(result)
+    {}
+    app::Clusters::NetworkCommissioning::NetworkCommissioningStatus networkCommissioningStatus;
 };
 
 class CommissioningDelegate
@@ -467,8 +475,8 @@ public:
     virtual ~CommissioningDelegate(){};
     /* CommissioningReport is returned after each commissioning step is completed. The reports for each step are:
      * kReadCommissioningInfo - ReadCommissioningInfo
-     * kArmFailsafe: CommissionErrorInfo if there is an error
-     * kConfigRegulatory: none
+     * kArmFailsafe: CommissioningErrorInfo if there is an error
+     * kConfigRegulatory: CommissioningErrorInfo if there is an error
      * kSendPAICertificateRequest: RequestedCertificate
      * kSendDACCertificateRequest: RequestedCertificate
      * kSendAttestationRequest: AttestationResponse
@@ -477,16 +485,17 @@ public:
      * kGenerateNOCChain: NocChain
      * kSendTrustedRootCert: None
      * kSendNOC: none
-     * kWiFiNetworkSetup: none
+     * kWiFiNetworkSetup: NetworkCommissioningStatusInfo if there is an error
      * kThreadNetworkSetup: none
-     * kWiFiNetworkEnable: none
+     * kWiFiNetworkEnable: NetworkCommissioningStatusInfo if there is an error
      * kThreadNetworkEnable: none
      * kFindOperational: OperationalNodeFoundData
-     * kSendComplete: none
+     * kSendComplete: CommissioningErrorInfo if there is an error
      * kCleanup: none
      */
-    struct CommissioningReport : Variant<RequestedCertificate, AttestationResponse, CSRResponse, NocChain, OperationalNodeFoundData,
-                                         ReadCommissioningInfo, AdditionalErrorInfo, CommissionErrorInfo>
+    struct CommissioningReport
+        : Variant<RequestedCertificate, AttestationResponse, CSRResponse, NocChain, OperationalNodeFoundData, ReadCommissioningInfo,
+                  AdditionalErrorInfo, CommissioningErrorInfo, NetworkCommissioningStatusInfo>
     {
         CommissioningReport() : stageCompleted(CommissioningStage::kError) {}
         CommissioningStage stageCompleted;

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -74,6 +74,8 @@ struct CompletionStatus
     CHIP_ERROR err;
     Optional<CommissioningStage> failedStage;
     Optional<Credentials::AttestationVerificationResult> attestationResult;
+    Optional<app::Clusters::GeneralCommissioning::CommissioningError> commissioningError;
+    Optional<app::Clusters::NetworkCommissioning::NetworkCommissioningStatus> networkCommissioningStatus;
 };
 
 constexpr uint16_t kDefaultFailsafeTimeout = 60;
@@ -453,13 +455,19 @@ struct AdditionalErrorInfo
     Credentials::AttestationVerificationResult attestationResult;
 };
 
+struct CommissionErrorInfo
+{
+    CommissionErrorInfo(app::Clusters::GeneralCommissioning::CommissioningError result) : commissioningError(result) {}
+    app::Clusters::GeneralCommissioning::CommissioningError commissioningError;
+};
+
 class CommissioningDelegate
 {
 public:
     virtual ~CommissioningDelegate(){};
     /* CommissioningReport is returned after each commissioning step is completed. The reports for each step are:
      * kReadCommissioningInfo - ReadCommissioningInfo
-     * kArmFailsafe: none
+     * kArmFailsafe: CommissionErrorInfo if there is an error
      * kConfigRegulatory: none
      * kSendPAICertificateRequest: RequestedCertificate
      * kSendDACCertificateRequest: RequestedCertificate
@@ -478,7 +486,7 @@ public:
      * kCleanup: none
      */
     struct CommissioningReport : Variant<RequestedCertificate, AttestationResponse, CSRResponse, NocChain, OperationalNodeFoundData,
-                                         ReadCommissioningInfo, AdditionalErrorInfo>
+                                         ReadCommissioningInfo, AdditionalErrorInfo, CommissionErrorInfo>
     {
         CommissioningReport() : stageCompleted(CommissioningStage::kError) {}
         CommissioningStage stageCompleted;

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -486,9 +486,9 @@ public:
      * kSendTrustedRootCert: None
      * kSendNOC: none
      * kWiFiNetworkSetup: NetworkCommissioningStatusInfo if there is an error
-     * kThreadNetworkSetup: none
+     * kThreadNetworkSetup: NetworkCommissioningStatusInfo if there is an error
      * kWiFiNetworkEnable: NetworkCommissioningStatusInfo if there is an error
-     * kThreadNetworkEnable: none
+     * kThreadNetworkEnable: NetworkCommissioningStatusInfo if there is an error
      * kFindOperational: OperationalNodeFoundData
      * kSendComplete: CommissioningErrorInfo if there is an error
      * kCleanup: none

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -449,9 +449,9 @@ struct ReadCommissioningInfo
     GeneralCommissioningInfo general;
 };
 
-struct AdditionalErrorInfo
+struct AttestationErrorInfo
 {
-    AdditionalErrorInfo(Credentials::AttestationVerificationResult result) : attestationResult(result) {}
+    AttestationErrorInfo(Credentials::AttestationVerificationResult result) : attestationResult(result) {}
     Credentials::AttestationVerificationResult attestationResult;
 };
 
@@ -480,7 +480,7 @@ public:
      * kSendPAICertificateRequest: RequestedCertificate
      * kSendDACCertificateRequest: RequestedCertificate
      * kSendAttestationRequest: AttestationResponse
-     * kAttestationVerification: AdditionalErrorInfo if there is an error
+     * kAttestationVerification: AttestationErrorInfo if there is an error
      * kSendOpCertSigningRequest: CSRResponse
      * kGenerateNOCChain: NocChain
      * kSendTrustedRootCert: None
@@ -495,7 +495,7 @@ public:
      */
     struct CommissioningReport
         : Variant<RequestedCertificate, AttestationResponse, CSRResponse, NocChain, OperationalNodeFoundData, ReadCommissioningInfo,
-                  AdditionalErrorInfo, CommissioningErrorInfo, NetworkCommissioningStatusInfo>
+                  AttestationErrorInfo, CommissioningErrorInfo, NetworkCommissioningStatusInfo>
     {
         CommissioningReport() : stageCompleted(CommissioningStage::kError) {}
         CommissioningStage stageCompleted;


### PR DESCRIPTION
#### Problem
Fixes #17526
The DeviceCommissioner sends reports back to the CommissioningDelegate with statuses from each of the steps. However, on several of these steps, we ignore the actual return codes from the device and just assume that if the command was sent, it was successful. There are TODOs in the code to report these errors properly, but it was never done.

#### Change overview
* If status in response from devices during commissioning is an error, indicate to while calling `CommissioningStageComplete`. Done for:
  * OnArmFailSafe response
  * OnSetRegulatoryConfigResponse
  * OnNetworkConfigResponse
  * OnConnectNetworkResponse
  * OnCommissioningCompleteResponse
* Propagate error to `AutoCommissioner`

#### Testing
* Manually tested hard-coding response errors device to report errors using `src/controller/python/test/test_scripts/commissioning_test.py`. This verified:
  * OnArmFailSafe response
  * OnSetRegulatoryConfigResponse
  * OnCommissioningCompleteResponse
* Used `chip-tool` to commission M5Stack
  * OnNetworkConfigResponse - Code running on device was hardcoded to send error
  * OnConnectNetworkResponse - Device was provided incorrect network credentials