### PR TITLE
Quick-fix running out of CASE sessions

### DIFF
--- a/src/transport/PairingSession.cpp
+++ b/src/transport/PairingSession.cpp
@@ -34,15 +34,24 @@ CHIP_ERROR PairingSession::AllocateSecureSession(SessionManager & sessionManager
 
 CHIP_ERROR PairingSession::ActivateSecureSession(const Transport::PeerAddress & peerAddress)
 {
-    Transport::SecureSession * secureSession = mSecureSessionHolder->AsSecureSession();
+    // TODO(17568): Replace with proper expiry logic. This current method makes sure there
+    // are not multiple sessions established, until eventual exhaustion of the resources
+    // for CASE sessions. Current method is quick fix for #17698, cannot remain.
+    mSessionManager->ExpireAllPairingsForPeerExceptPending(GetPeer());
 
+    // Prepare SecureSession fields, including key derivation, first, before activation
+    Transport::SecureSession * secureSession = mSecureSessionHolder->AsSecureSession();
+    ReturnErrorOnFailure(DeriveSecureSession(secureSession->GetCryptoContext()));
     uint16_t peerSessionId = GetPeerSessionId();
+    secureSession->SetPeerAddress(peerAddress);
+    secureSession->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(LocalSessionMessageCounter::kInitialSyncValue);
+
+    // Call Activate last, otherwise errors on anything after would lead to
+    // a partially valid session.
+    secureSession->Activate(GetSecureSessionType(), GetPeer(), GetPeerCATs(), peerSessionId, mRemoteMRPConfig);
+
     ChipLogDetail(Inet, "New secure session created for device " ChipLogFormatScopedNodeId ", LSID:%d PSID:%d!",
                   ChipLogValueScopedNodeId(GetPeer()), secureSession->GetLocalSessionId(), peerSessionId);
-    secureSession->Activate(GetSecureSessionType(), GetPeer(), GetPeerCATs(), peerSessionId, mRemoteMRPConfig);
-    secureSession->SetPeerAddress(peerAddress);
-    ReturnErrorOnFailure(DeriveSecureSession(secureSession->GetCryptoContext()));
-    secureSession->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(LocalSessionMessageCounter::kInitialSyncValue);
 
     return CHIP_NO_ERROR;
 }

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -363,7 +363,7 @@ void SessionManager::ExpireAllPairings(const ScopedNodeId & node)
 void SessionManager::ExpireAllPairingsForPeerExceptPending(const ScopedNodeId & node)
 {
     mSecureSessions.ForEachSession([&](auto session) {
-        if ((session->GetPeer() == node) && (session->GetSecureSessionType() != SecureSession::Type::kPending))
+        if ((session->GetPeer() == node) && (session->GetSecureSessionType() == SecureSession::Type::kCASE))
         {
             ChipLogDetail(Inet, "Expired/released previous local session ID %u for peer " ChipLogFormatScopedNodeId,
                           static_cast<unsigned>(session->GetLocalSessionId()), ChipLogValueScopedNodeId(session->GetPeer()));

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -365,7 +365,8 @@ void SessionManager::ExpireAllPairingsForPeerExceptPending(const ScopedNodeId & 
     mSecureSessions.ForEachSession([&](auto session) {
         if ((session->GetPeer() == node) && (session->GetSecureSessionType() != SecureSession::Type::kPending))
         {
-            ChipLogDetail(Inet, "Expired/released previous local session ID %u for peer " ChipLogFormatScopedNodeId, static_cast<unsigned>(session->GetLocalSessionId()), ChipLogValueScopedNodeId(session->GetPeer()));
+            ChipLogDetail(Inet, "Expired/released previous local session ID %u for peer " ChipLogFormatScopedNodeId,
+                          static_cast<unsigned>(session->GetLocalSessionId()), ChipLogValueScopedNodeId(session->GetPeer()));
             mSecureSessions.ReleaseSession(session);
         }
         return Loop::Continue;

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -360,6 +360,18 @@ void SessionManager::ExpireAllPairings(const ScopedNodeId & node)
     });
 }
 
+void SessionManager::ExpireAllPairingsForPeerExceptPending(const ScopedNodeId & node)
+{
+    mSecureSessions.ForEachSession([&](auto session) {
+        if ((session->GetPeer() == node) && (session->GetSecureSessionType() != SecureSession::Type::kPending))
+        {
+            ChipLogDetail(Inet, "Expired/released previous local session ID %u for peer " ChipLogFormatScopedNodeId, static_cast<unsigned>(session->GetLocalSessionId()), ChipLogValueScopedNodeId(session->GetPeer()));
+            mSecureSessions.ReleaseSession(session);
+        }
+        return Loop::Continue;
+    });
+}
+
 void SessionManager::ExpireAllPairingsForFabric(FabricIndex fabric)
 {
     ChipLogDetail(Inet, "Expiring all connections for fabric %d!!", fabric);

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -173,6 +173,7 @@ public:
 
     void ExpirePairing(const SessionHandle & session);
     void ExpireAllPairings(const ScopedNodeId & node);
+    void ExpireAllPairingsForPeerExceptPending(const ScopedNodeId & node);
     void ExpireAllPairingsForFabric(FabricIndex fabric);
     void ExpireAllPASEPairings();
 


### PR DESCRIPTION
#### Problem
- From #17422 onwards, "previous" CASE sessions were not expired
  in terms of the session cache if sessions were constantly
  re-established.
- A root cause solution will be to solve #17568, but in the meantime,
  cert testing started failing after N (where N is session manager
  pool size) runs.

Fixes #17698

#### Change overview
This PR cleans-up the previous sessions from same node (duplicate sessions
that should not happen). This is a bit unclean but will do to unblock
testing since it was good enough before, and the better method is not
yet implemented.

This PR also adds logging when this happens.

#### Testing

- Unit tests pass
- Cert tests pass
- Manual run of N > 16
  `for i in {1..18}; do ./out/debug/standalone/chip-tool basic read vendor-name 115566 0 ; done`
  does not fail as before.
