### PR TITLE
Create CHIPAttestationTrustStoreBridge when we know we have PAA certs.

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPAttestationTrustStoreBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPAttestationTrustStoreBridge.h
@@ -22,15 +22,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 class CHIPAttestationTrustStoreBridge : public chip::Credentials::AttestationTrustStore {
 public:
+    CHIPAttestationTrustStoreBridge(NSArray<NSData *> * paaCerts)
+        : mPaaCerts(paaCerts)
+    {
+    }
     ~CHIPAttestationTrustStoreBridge() {};
-
-    void Init(NSArray<NSData *> * paaCerts);
 
     CHIP_ERROR GetProductAttestationAuthorityCert(
         const chip::ByteSpan & skid, chip::MutableByteSpan & outPaaDerBuffer) const override;
 
 private:
-    NSArray<NSData *> * _Nullable mPaaCerts;
+    NSArray<NSData *> * mPaaCerts;
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPAttestationTrustStoreBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPAttestationTrustStoreBridge.mm
@@ -19,8 +19,6 @@
 
 static chip::ByteSpan asByteSpan(NSData * value) { return chip::ByteSpan(static_cast<const uint8_t *>(value.bytes), value.length); }
 
-void CHIPAttestationTrustStoreBridge::Init(NSArray<NSData *> * paaCerts) { mPaaCerts = paaCerts; }
-
 CHIP_ERROR CHIPAttestationTrustStoreBridge::GetProductAttestationAuthorityCert(
     const chip::ByteSpan & skid, chip::MutableByteSpan & outPaaDerBuffer) const
 {

--- a/src/darwin/Framework/CHIP/MatterControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MatterControllerFactory.mm
@@ -87,11 +87,6 @@ static NSString * const kErrorControllerFactoryInit = @"Init failure while initi
         return nil;
     }
 
-    _attestationTrustStoreBridge = new CHIPAttestationTrustStoreBridge();
-    if ([self checkForInitError:(_attestationTrustStoreBridge != nullptr) logMsg:kErrorAttestationTrustStoreInit]) {
-        return nil;
-    }
-
     _groupStorageDelegate = new chip::TestPersistentStorageDelegate();
     if ([self checkForInitError:(_groupStorageDelegate != nullptr) logMsg:kErrorGroupProviderInit]) {
         return nil;
@@ -119,7 +114,8 @@ static NSString * const kErrorControllerFactoryInit = @"Init failure while initi
 
 - (void)dealloc
 {
-    [self cleanupOwnedObjects];
+    [self shutdown];
+    [self cleanupInitObjects];
 }
 
 - (BOOL)checkForInitError:(BOOL)condition logMsg:(NSString *)logMsg
@@ -130,12 +126,12 @@ static NSString * const kErrorControllerFactoryInit = @"Init failure while initi
 
     CHIP_LOG_ERROR("Error: %@", logMsg);
 
-    [self cleanupOwnedObjects];
+    [self cleanupInitObjects];
 
     return YES;
 }
 
-- (void)cleanupOwnedObjects
+- (void)cleanupInitObjects
 {
     _controllers = nil;
 
@@ -150,6 +146,11 @@ static NSString * const kErrorControllerFactoryInit = @"Init failure while initi
         _groupStorageDelegate = nullptr;
     }
 
+    Platform::MemoryShutdown();
+}
+
+- (void)cleanupStartupObjects
+{
     if (_attestationTrustStoreBridge) {
         delete _attestationTrustStoreBridge;
         _attestationTrustStoreBridge = nullptr;
@@ -159,8 +160,6 @@ static NSString * const kErrorControllerFactoryInit = @"Init failure while initi
         delete _persistentStorageDelegateBridge;
         _persistentStorageDelegateBridge = nullptr;
     }
-
-    Platform::MemoryShutdown();
 }
 
 - (BOOL)startup:(MatterControllerFactoryParams *)startupParams
@@ -196,7 +195,11 @@ static NSString * const kErrorControllerFactoryInit = @"Init failure while initi
 
         // Initialize device attestation verifier
         if (startupParams.paaCerts) {
-            _attestationTrustStoreBridge->Init(startupParams.paaCerts);
+            _attestationTrustStoreBridge = new CHIPAttestationTrustStoreBridge(startupParams.paaCerts);
+            if (_attestationTrustStoreBridge == nullptr) {
+                CHIP_LOG_ERROR("Error: %@", kErrorAttestationTrustStoreInit);
+                return;
+            }
             chip::Credentials::SetDeviceAttestationVerifier(chip::Credentials::GetDefaultDACVerifier(_attestationTrustStoreBridge));
         } else {
             // TODO: Replace testingRootStore with a AttestationTrustStore that has the necessary official PAA roots available
@@ -226,6 +229,10 @@ static NSString * const kErrorControllerFactoryInit = @"Init failure while initi
     // Make sure to stop the event loop again before returning, so we are not running it while we don't have any controllers.
     DeviceLayer::PlatformMgrImpl().StopEventLoopTask();
 
+    if (![self isRunning]) {
+        [self cleanupStartupObjects];
+    }
+
     return [self isRunning];
 }
 
@@ -242,13 +249,10 @@ static NSString * const kErrorControllerFactoryInit = @"Init failure while initi
     CHIP_LOG_DEBUG("%@", kInfoFactoryShutdown);
     _controllerFactory->Shutdown();
 
-    if (_persistentStorageDelegateBridge) {
-        delete _persistentStorageDelegateBridge;
-        _persistentStorageDelegateBridge = nullptr;
-    }
+    [self cleanupStartupObjects];
 
-    // NOTE: we do not call cleanupOwnedObjects because we can be restarted, and
-    // that does not re-create the owned objects that we create inside init.
+    // NOTE: we do not call cleanupInitObjects because we can be restarted, and
+    // that does not re-create the objects that we create inside init.
     // Maybe we should be creating them in startup?
 
     _isRunning = NO;


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/17746

#### Problem
We end up with a field marked nullable that should never be nil.

#### Change overview
Initialize it in the constructor so it's never nil.  This requires creating the containing object somewhat later.

#### Testing
Should compile and pass clang-tidy.