### PR TITLE
Remove some unused keys from platform manager configs.

### DIFF
--- a/src/platform/Ameba/AmebaConfig.cpp
+++ b/src/platform/Ameba/AmebaConfig.cpp
@@ -42,21 +42,20 @@ namespace Internal {
 // *** CAUTION ***: Changing the names or namespaces of these values will *break* existing devices.
 
 // NVS namespaces used to store device configuration information.
-const char AmebaConfig::kConfigNamespace_ChipFactory[]          = "chip-factory";
-const char AmebaConfig::kConfigNamespace_ChipConfig[]           = "chip-config";
-const char AmebaConfig::kConfigNamespace_ChipCounters[]         = "chip-counters";
-const char AmebaConfig::kConfigNamespace_ChipFabric1[]          = "chip-fabric-1";
-const char AmebaConfig::kConfigNamespace_ChipFabric2[]          = "chip-fabric-2";
-const char AmebaConfig::kConfigNamespace_ChipFabric3[]          = "chip-fabric-3";
-const char AmebaConfig::kConfigNamespace_ChipFabric4[]          = "chip-fabric-4";
-const char AmebaConfig::kConfigNamespace_ChipFabric5[]          = "chip-fabric-5";
-const char AmebaConfig::kConfigNamespace_ChipACL[]              = "chip-acl";
-const char AmebaConfig::kConfigNamespace_ChipGroupMsgCounters[] = "chip-groupmsgcounters";
-const char AmebaConfig::kConfigNamespace_ChipAttributes[]       = "chip-attributes";
-const char AmebaConfig::kConfigNamespace_ChipBindingTable[]     = "chip-bindingtable";
-const char AmebaConfig::kConfigNamespace_ChipOTA[]              = "chip-ota";
-const char AmebaConfig::kConfigNamespace_ChipDNS[]              = "chip-dns";
-const char AmebaConfig::kConfigNamespace_ChipOthers[]           = "chip-others";
+const char AmebaConfig::kConfigNamespace_ChipFactory[]      = "chip-factory";
+const char AmebaConfig::kConfigNamespace_ChipConfig[]       = "chip-config";
+const char AmebaConfig::kConfigNamespace_ChipCounters[]     = "chip-counters";
+const char AmebaConfig::kConfigNamespace_ChipFabric1[]      = "chip-fabric-1";
+const char AmebaConfig::kConfigNamespace_ChipFabric2[]      = "chip-fabric-2";
+const char AmebaConfig::kConfigNamespace_ChipFabric3[]      = "chip-fabric-3";
+const char AmebaConfig::kConfigNamespace_ChipFabric4[]      = "chip-fabric-4";
+const char AmebaConfig::kConfigNamespace_ChipFabric5[]      = "chip-fabric-5";
+const char AmebaConfig::kConfigNamespace_ChipACL[]          = "chip-acl";
+const char AmebaConfig::kConfigNamespace_ChipAttributes[]   = "chip-attributes";
+const char AmebaConfig::kConfigNamespace_ChipBindingTable[] = "chip-bindingtable";
+const char AmebaConfig::kConfigNamespace_ChipOTA[]          = "chip-ota";
+const char AmebaConfig::kConfigNamespace_ChipDNS[]          = "chip-dns";
+const char AmebaConfig::kConfigNamespace_ChipOthers[]       = "chip-others";
 
 // Keys stored in the chip-factory namespace
 const AmebaConfig::Key AmebaConfig::kConfigKey_SerialNum             = { kConfigNamespace_ChipFactory, "serial-num" };
@@ -74,11 +73,9 @@ const AmebaConfig::Key AmebaConfig::kConfigKey_Spake2pVerifier       = { kConfig
 const AmebaConfig::Key AmebaConfig::kConfigKey_UniqueId              = { kConfigNamespace_ChipFactory, "uniqueId" };
 
 // Keys stored in the chip-config namespace
-const AmebaConfig::Key AmebaConfig::kConfigKey_FabricId                    = { kConfigNamespace_ChipConfig, "fabric-id" };
 const AmebaConfig::Key AmebaConfig::kConfigKey_ServiceConfig               = { kConfigNamespace_ChipConfig, "service-config" };
 const AmebaConfig::Key AmebaConfig::kConfigKey_PairedAccountId             = { kConfigNamespace_ChipConfig, "account-id" };
 const AmebaConfig::Key AmebaConfig::kConfigKey_ServiceId                   = { kConfigNamespace_ChipConfig, "service-id" };
-const AmebaConfig::Key AmebaConfig::kConfigKey_GroupKeyIndex               = { kConfigNamespace_ChipConfig, "group-key-index" };
 const AmebaConfig::Key AmebaConfig::kConfigKey_LastUsedEpochKeyId          = { kConfigNamespace_ChipConfig, "last-ek-id" };
 const AmebaConfig::Key AmebaConfig::kConfigKey_FailSafeArmed               = { kConfigNamespace_ChipConfig, "fail-safe-armed" };
 const AmebaConfig::Key AmebaConfig::kConfigKey_WiFiStationSecType          = { kConfigNamespace_ChipConfig, "sta-sec-type" };

--- a/src/platform/Ameba/AmebaConfig.h
+++ b/src/platform/Ameba/AmebaConfig.h
@@ -46,7 +46,6 @@ public:
     static const char kConfigNamespace_ChipFabric4[];
     static const char kConfigNamespace_ChipFabric5[];
     static const char kConfigNamespace_ChipACL[];
-    static const char kConfigNamespace_ChipGroupMsgCounters[];
     static const char kConfigNamespace_ChipAttributes[];
     static const char kConfigNamespace_ChipBindingTable[];
     static const char kConfigNamespace_ChipOTA[];
@@ -62,12 +61,9 @@ public:
     static const Key kConfigKey_HardwareVersion;
     static const Key kConfigKey_ManufacturingDate;
     static const Key kConfigKey_SetupPinCode;
-    static const Key kConfigKey_FabricId;
     static const Key kConfigKey_ServiceConfig;
     static const Key kConfigKey_PairedAccountId;
     static const Key kConfigKey_ServiceId;
-    static const Key kConfigKey_FabricSecret;
-    static const Key kConfigKey_GroupKeyIndex;
     static const Key kConfigKey_LastUsedEpochKeyId;
     static const Key kConfigKey_FailSafeArmed;
     static const Key kConfigKey_WiFiStationSecType;
@@ -89,8 +85,6 @@ public:
     static const Key kCounterKey_UpTime;
     static const Key kCounterKey_TotalOperationalHours;
     static const Key kCounterKey_BootReason;
-
-    static const char kGroupKeyNamePrefix[];
 
     // Config value accessors.
     static CHIP_ERROR ReadConfigValue(Key key, bool & val);

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -67,8 +67,6 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     SuccessOrExit(err);
     err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipACL);
     SuccessOrExit(err);
-    err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipGroupMsgCounters);
-    SuccessOrExit(err);
     err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipAttributes);
     SuccessOrExit(err);
     err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipBindingTable);

--- a/src/platform/CYW30739/CYW30739Config.h
+++ b/src/platform/CYW30739/CYW30739Config.h
@@ -54,11 +54,9 @@ public:
     static constexpr Key kConfigKey_Spake2pSalt           = 9;
     static constexpr Key kConfigKey_Spake2pVerifier       = 10;
     // CHIP Config Keys
-    static constexpr Key kConfigKey_FabricId           = 8;
     static constexpr Key kConfigKey_ServiceConfig      = 9;
     static constexpr Key kConfigKey_PairedAccountId    = 10;
     static constexpr Key kConfigKey_ServiceId          = 11;
-    static constexpr Key kConfigKey_FabricSecret       = 12;
     static constexpr Key kConfigKey_LastUsedEpochKeyId = 13;
     static constexpr Key kConfigKey_FailSafeArmed      = 14;
     static constexpr Key kConfigKey_GroupKey           = 15;

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -61,12 +61,9 @@ const PosixConfig::Key PosixConfig::kConfigKey_VendorId              = { kConfig
 const PosixConfig::Key PosixConfig::kConfigKey_ProductId             = { kConfigNamespace_ChipFactory, "product-id" };
 
 // Keys stored in the Chip-config namespace
-const PosixConfig::Key PosixConfig::kConfigKey_FabricId           = { kConfigNamespace_ChipConfig, "fabric-id" };
 const PosixConfig::Key PosixConfig::kConfigKey_ServiceConfig      = { kConfigNamespace_ChipConfig, "service-config" };
 const PosixConfig::Key PosixConfig::kConfigKey_PairedAccountId    = { kConfigNamespace_ChipConfig, "account-id" };
 const PosixConfig::Key PosixConfig::kConfigKey_ServiceId          = { kConfigNamespace_ChipConfig, "service-id" };
-const PosixConfig::Key PosixConfig::kConfigKey_FabricSecret       = { kConfigNamespace_ChipConfig, "fabric-secret" };
-const PosixConfig::Key PosixConfig::kConfigKey_GroupKeyIndex      = { kConfigNamespace_ChipConfig, "group-key-index" };
 const PosixConfig::Key PosixConfig::kConfigKey_LastUsedEpochKeyId = { kConfigNamespace_ChipConfig, "last-ek-id" };
 const PosixConfig::Key PosixConfig::kConfigKey_FailSafeArmed      = { kConfigNamespace_ChipConfig, "fail-safe-armed" };
 const PosixConfig::Key PosixConfig::kConfigKey_WiFiStationSecType = { kConfigNamespace_ChipConfig, "sta-sec-type" };
@@ -84,9 +81,6 @@ const PosixConfig::Key PosixConfig::kCounterKey_TotalOperationalHours = { kConfi
 const PosixConfig::Key PosixConfig::kConfigKey_UniqueId               = { kConfigNamespace_ChipConfig, "unique-id" };
 
 #if !CHIP_DISABLE_PLATFORM_KVS
-// Prefix used for NVS keys that contain Chip group encryption keys.
-const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";
-
 CHIP_ERROR PosixConfig::Init()
 {
     return PersistedStorage::KeyValueStoreMgrImpl().Init(CHIP_CONFIG_KVS_PATH);

--- a/src/platform/Darwin/PosixConfig.h
+++ b/src/platform/Darwin/PosixConfig.h
@@ -61,12 +61,9 @@ public:
     static const Key kConfigKey_HardwareVersion;
     static const Key kConfigKey_ManufacturingDate;
     static const Key kConfigKey_SetupPinCode;
-    static const Key kConfigKey_FabricId;
     static const Key kConfigKey_ServiceConfig;
     static const Key kConfigKey_PairedAccountId;
     static const Key kConfigKey_ServiceId;
-    static const Key kConfigKey_FabricSecret;
-    static const Key kConfigKey_GroupKeyIndex;
     static const Key kConfigKey_LastUsedEpochKeyId;
     static const Key kConfigKey_FailSafeArmed;
     static const Key kConfigKey_WiFiStationSecType;
@@ -85,8 +82,6 @@ public:
     static const Key kCounterKey_RebootCount;
     static const Key kCounterKey_BootReason;
     static const Key kCounterKey_UpTime;
-
-    static const char kGroupKeyNamePrefix[];
 
 #if !CHIP_DISABLE_PLATFORM_KVS
     static CHIP_ERROR Init(void);

--- a/src/platform/EFR32/EFR32Config.h
+++ b/src/platform/EFR32/EFR32Config.h
@@ -101,11 +101,9 @@ public:
     static constexpr Key kConfigKey_Spake2pSalt           = EFR32ConfigKey(kMatterFactory_KeyBase, 0x09);
     static constexpr Key kConfigKey_Spake2pVerifier       = EFR32ConfigKey(kMatterFactory_KeyBase, 0x0A);
     // Matter Config Keys
-    static constexpr Key kConfigKey_FabricId           = EFR32ConfigKey(kMatterConfig_KeyBase, 0x00);
     static constexpr Key kConfigKey_ServiceConfig      = EFR32ConfigKey(kMatterConfig_KeyBase, 0x01);
     static constexpr Key kConfigKey_PairedAccountId    = EFR32ConfigKey(kMatterConfig_KeyBase, 0x02);
     static constexpr Key kConfigKey_ServiceId          = EFR32ConfigKey(kMatterConfig_KeyBase, 0x03);
-    static constexpr Key kConfigKey_FabricSecret       = EFR32ConfigKey(kMatterConfig_KeyBase, 0x04);
     static constexpr Key kConfigKey_LastUsedEpochKeyId = EFR32ConfigKey(kMatterConfig_KeyBase, 0x05);
     static constexpr Key kConfigKey_FailSafeArmed      = EFR32ConfigKey(kMatterConfig_KeyBase, 0x06);
     static constexpr Key kConfigKey_GroupKey           = EFR32ConfigKey(kMatterConfig_KeyBase, 0x07);

--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -69,11 +69,9 @@ const ESP32Config::Key ESP32Config::kConfigKey_PAICert               = { kConfig
 const ESP32Config::Key ESP32Config::kConfigKey_CertDeclaration       = { kConfigNamespace_ChipFactory, "cert-dclrn" };
 
 // Keys stored in the chip-config namespace
-const ESP32Config::Key ESP32Config::kConfigKey_FabricId           = { kConfigNamespace_ChipConfig, "fabric-id" };
 const ESP32Config::Key ESP32Config::kConfigKey_ServiceConfig      = { kConfigNamespace_ChipConfig, "service-config" };
 const ESP32Config::Key ESP32Config::kConfigKey_PairedAccountId    = { kConfigNamespace_ChipConfig, "account-id" };
 const ESP32Config::Key ESP32Config::kConfigKey_ServiceId          = { kConfigNamespace_ChipConfig, "service-id" };
-const ESP32Config::Key ESP32Config::kConfigKey_GroupKeyIndex      = { kConfigNamespace_ChipConfig, "group-key-index" };
 const ESP32Config::Key ESP32Config::kConfigKey_LastUsedEpochKeyId = { kConfigNamespace_ChipConfig, "last-ek-id" };
 const ESP32Config::Key ESP32Config::kConfigKey_FailSafeArmed      = { kConfigNamespace_ChipConfig, "fail-safe-armed" };
 const ESP32Config::Key ESP32Config::kConfigKey_WiFiStationSecType = { kConfigNamespace_ChipConfig, "sta-sec-type" };
@@ -86,9 +84,6 @@ const ESP32Config::Key ESP32Config::kConfigKey_UniqueId           = { kConfigNam
 const ESP32Config::Key ESP32Config::kCounterKey_RebootCount           = { kConfigNamespace_ChipCounters, "reboot-count" };
 const ESP32Config::Key ESP32Config::kCounterKey_UpTime                = { kConfigNamespace_ChipCounters, "up-time" };
 const ESP32Config::Key ESP32Config::kCounterKey_TotalOperationalHours = { kConfigNamespace_ChipCounters, "total-hours" };
-
-// Prefix used for NVS keys that contain Chip group encryption keys.
-const char ESP32Config::kGroupKeyNamePrefix[] = "gk-";
 
 const char * ESP32Config::GetPartitionLabelByNamespace(const char * ns)
 {

--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -60,12 +60,9 @@ public:
     static const Key kConfigKey_HardwareVersion;
     static const Key kConfigKey_ManufacturingDate;
     static const Key kConfigKey_SetupPinCode;
-    static const Key kConfigKey_FabricId;
     static const Key kConfigKey_ServiceConfig;
     static const Key kConfigKey_PairedAccountId;
     static const Key kConfigKey_ServiceId;
-    static const Key kConfigKey_FabricSecret;
-    static const Key kConfigKey_GroupKeyIndex;
     static const Key kConfigKey_LastUsedEpochKeyId;
     static const Key kConfigKey_FailSafeArmed;
     static const Key kConfigKey_WiFiStationSecType;
@@ -86,8 +83,6 @@ public:
     static const Key kCounterKey_RebootCount;
     static const Key kCounterKey_UpTime;
     static const Key kCounterKey_TotalOperationalHours;
-
-    static const char kGroupKeyNamePrefix[];
 
     // Config value accessors.
     static CHIP_ERROR ReadConfigValue(Key key, bool & val);

--- a/src/platform/Linux/PosixConfig.cpp
+++ b/src/platform/Linux/PosixConfig.cpp
@@ -64,12 +64,9 @@ const PosixConfig::Key PosixConfig::kConfigKey_VendorId              = { kConfig
 const PosixConfig::Key PosixConfig::kConfigKey_ProductId             = { kConfigNamespace_ChipFactory, "product-id" };
 
 // Keys stored in the Chip-config namespace
-const PosixConfig::Key PosixConfig::kConfigKey_FabricId           = { kConfigNamespace_ChipConfig, "fabric-id" };
 const PosixConfig::Key PosixConfig::kConfigKey_ServiceConfig      = { kConfigNamespace_ChipConfig, "service-config" };
 const PosixConfig::Key PosixConfig::kConfigKey_PairedAccountId    = { kConfigNamespace_ChipConfig, "account-id" };
 const PosixConfig::Key PosixConfig::kConfigKey_ServiceId          = { kConfigNamespace_ChipConfig, "service-id" };
-const PosixConfig::Key PosixConfig::kConfigKey_FabricSecret       = { kConfigNamespace_ChipConfig, "fabric-secret" };
-const PosixConfig::Key PosixConfig::kConfigKey_GroupKeyIndex      = { kConfigNamespace_ChipConfig, "group-key-index" };
 const PosixConfig::Key PosixConfig::kConfigKey_LastUsedEpochKeyId = { kConfigNamespace_ChipConfig, "last-ek-id" };
 const PosixConfig::Key PosixConfig::kConfigKey_FailSafeArmed      = { kConfigNamespace_ChipConfig, "fail-safe-armed" };
 const PosixConfig::Key PosixConfig::kConfigKey_WiFiStationSecType = { kConfigNamespace_ChipConfig, "sta-sec-type" };
@@ -85,9 +82,6 @@ const PosixConfig::Key PosixConfig::kCounterKey_UpTime                = { kConfi
 const PosixConfig::Key PosixConfig::kCounterKey_TotalOperationalHours = { kConfigNamespace_ChipCounters,
                                                                           "total-operational-hours" };
 const PosixConfig::Key PosixConfig::kCounterKey_BootReason            = { kConfigNamespace_ChipCounters, "boot-reason" };
-
-// Prefix used for NVS keys that contain Chip group encryption keys.
-const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";
 
 ChipLinuxStorage * PosixConfig::GetStorageForNamespace(Key key)
 {

--- a/src/platform/Linux/PosixConfig.h
+++ b/src/platform/Linux/PosixConfig.h
@@ -63,12 +63,9 @@ public:
     static const Key kConfigKey_HardwareVersion;
     static const Key kConfigKey_ManufacturingDate;
     static const Key kConfigKey_SetupPinCode;
-    static const Key kConfigKey_FabricId;
     static const Key kConfigKey_ServiceConfig;
     static const Key kConfigKey_PairedAccountId;
     static const Key kConfigKey_ServiceId;
-    static const Key kConfigKey_FabricSecret;
-    static const Key kConfigKey_GroupKeyIndex;
     static const Key kConfigKey_LastUsedEpochKeyId;
     static const Key kConfigKey_FailSafeArmed;
     static const Key kConfigKey_WiFiStationSecType;
@@ -87,8 +84,6 @@ public:
     static const Key kCounterKey_UpTime;
     static const Key kCounterKey_TotalOperationalHours;
     static const Key kCounterKey_BootReason;
-
-    static const char kGroupKeyNamePrefix[];
 
     static CHIP_ERROR Init();
 

--- a/src/platform/P6/P6Config.cpp
+++ b/src/platform/P6/P6Config.cpp
@@ -63,11 +63,9 @@ const P6Config::Key P6Config::kConfigKey_Spake2pSalt           = { kConfigNamesp
 const P6Config::Key P6Config::kConfigKey_Spake2pVerifier       = { kConfigNamespace_ChipFactory, "verifier" };
 
 // Keys stored in the chip-config namespace
-const P6Config::Key P6Config::kConfigKey_FabricId           = { kConfigNamespace_ChipConfig, "fabric-id" };
 const P6Config::Key P6Config::kConfigKey_ServiceConfig      = { kConfigNamespace_ChipConfig, "service-config" };
 const P6Config::Key P6Config::kConfigKey_PairedAccountId    = { kConfigNamespace_ChipConfig, "account-id" };
 const P6Config::Key P6Config::kConfigKey_ServiceId          = { kConfigNamespace_ChipConfig, "service-id" };
-const P6Config::Key P6Config::kConfigKey_GroupKeyIndex      = { kConfigNamespace_ChipConfig, "group-key-index" };
 const P6Config::Key P6Config::kConfigKey_LastUsedEpochKeyId = { kConfigNamespace_ChipConfig, "last-ek-id" };
 const P6Config::Key P6Config::kConfigKey_FailSafeArmed      = { kConfigNamespace_ChipConfig, "fail-safe-armed" };
 const P6Config::Key P6Config::kConfigKey_WiFiStationSecType = { kConfigNamespace_ChipConfig, "sta-sec-type" };
@@ -84,9 +82,6 @@ const P6Config::Key P6Config::kConfigKey_UniqueId           = { kConfigNamespace
 const P6Config::Key P6Config::kCounterKey_RebootCount           = { kConfigNamespace_ChipCounters, "reboot-count" };
 const P6Config::Key P6Config::kCounterKey_UpTime                = { kConfigNamespace_ChipCounters, "up-time" };
 const P6Config::Key P6Config::kCounterKey_TotalOperationalHours = { kConfigNamespace_ChipCounters, "total-hours" };
-
-// Prefix used for keys that contain Chip group encryption keys.
-const char P6Config::kGroupKeyNamePrefix[] = "gk-";
 
 CHIP_ERROR P6Config::ReadConfigValue(Key key, bool & val)
 {
@@ -219,11 +214,10 @@ bool P6Config::ConfigValueExists(Key key)
 CHIP_ERROR P6Config::FactoryResetConfig(void)
 {
     CHIP_ERROR err            = CHIP_NO_ERROR;
-    const Key * config_keys[] = { &kConfigKey_FabricId,       &kConfigKey_ServiceConfig,      &kConfigKey_PairedAccountId,
-                                  &kConfigKey_ServiceId,      &kConfigKey_GroupKeyIndex,      &kConfigKey_LastUsedEpochKeyId,
-                                  &kConfigKey_FailSafeArmed,  &kConfigKey_WiFiStationSecType, &kConfigKey_WiFiSSID,
-                                  &kConfigKey_WiFiPassword,   &kConfigKey_WiFiSecurity,       &kConfigKey_WiFiMode,
-                                  &kConfigKey_SoftwareVersion };
+    const Key * config_keys[] = { &kConfigKey_ServiceConfig,      &kConfigKey_PairedAccountId, &kConfigKey_ServiceId,
+                                  &kConfigKey_LastUsedEpochKeyId, &kConfigKey_FailSafeArmed,   &kConfigKey_WiFiStationSecType,
+                                  &kConfigKey_WiFiSSID,           &kConfigKey_WiFiPassword,    &kConfigKey_WiFiSecurity,
+                                  &kConfigKey_WiFiMode,           &kConfigKey_SoftwareVersion };
 
     for (uint32_t i = 0; i < (sizeof(config_keys) / sizeof(config_keys[0])); i++)
     {

--- a/src/platform/P6/P6Config.h
+++ b/src/platform/P6/P6Config.h
@@ -64,12 +64,9 @@ public:
     static const Key kConfigKey_HardwareVersion;
     static const Key kConfigKey_ManufacturingDate;
     static const Key kConfigKey_SetupPinCode;
-    static const Key kConfigKey_FabricId;
     static const Key kConfigKey_ServiceConfig;
     static const Key kConfigKey_PairedAccountId;
     static const Key kConfigKey_ServiceId;
-    static const Key kConfigKey_FabricSecret;
-    static const Key kConfigKey_GroupKeyIndex;
     static const Key kConfigKey_LastUsedEpochKeyId;
     static const Key kConfigKey_FailSafeArmed;
     static const Key kConfigKey_WiFiStationSecType;
@@ -89,8 +86,6 @@ public:
     static const Key kCounterKey_RebootCount;
     static const Key kCounterKey_UpTime;
     static const Key kCounterKey_TotalOperationalHours;
-
-    static const char kGroupKeyNamePrefix[];
 
     // Config value accessors.
     static CHIP_ERROR ReadConfigValue(Key key, bool & val);

--- a/src/platform/Tizen/PosixConfig.cpp
+++ b/src/platform/Tizen/PosixConfig.cpp
@@ -60,12 +60,9 @@ const PosixConfig::Key PosixConfig::kConfigKey_VendorId              = { kConfig
 const PosixConfig::Key PosixConfig::kConfigKey_ProductId             = { kConfigNamespace_ChipFactory, "product-id" };
 
 // Keys stored in the Chip-config namespace
-const PosixConfig::Key PosixConfig::kConfigKey_FabricId           = { kConfigNamespace_ChipConfig, "fabric-id" };
 const PosixConfig::Key PosixConfig::kConfigKey_ServiceConfig      = { kConfigNamespace_ChipConfig, "service-config" };
 const PosixConfig::Key PosixConfig::kConfigKey_PairedAccountId    = { kConfigNamespace_ChipConfig, "account-id" };
 const PosixConfig::Key PosixConfig::kConfigKey_ServiceId          = { kConfigNamespace_ChipConfig, "service-id" };
-const PosixConfig::Key PosixConfig::kConfigKey_FabricSecret       = { kConfigNamespace_ChipConfig, "fabric-secret" };
-const PosixConfig::Key PosixConfig::kConfigKey_GroupKeyIndex      = { kConfigNamespace_ChipConfig, "group-key-index" };
 const PosixConfig::Key PosixConfig::kConfigKey_LastUsedEpochKeyId = { kConfigNamespace_ChipConfig, "last-ek-id" };
 const PosixConfig::Key PosixConfig::kConfigKey_FailSafeArmed      = { kConfigNamespace_ChipConfig, "fail-safe-armed" };
 const PosixConfig::Key PosixConfig::kConfigKey_WiFiStationSecType = { kConfigNamespace_ChipConfig, "sta-sec-type" };
@@ -73,9 +70,6 @@ const PosixConfig::Key PosixConfig::kConfigKey_RegulatoryLocation = { kConfigNam
 const PosixConfig::Key PosixConfig::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
 const PosixConfig::Key PosixConfig::kConfigKey_Breadcrumb         = { kConfigNamespace_ChipConfig, "breadcrumb" };
 const PosixConfig::Key PosixConfig::kConfigKey_UniqueId           = { kConfigNamespace_ChipConfig, "unique-id" };
-
-// Prefix used for NVS keys that contain Chip group encryption keys.
-const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";
 
 CHIP_ERROR PosixConfig::Init()
 {

--- a/src/platform/Tizen/PosixConfig.h
+++ b/src/platform/Tizen/PosixConfig.h
@@ -61,12 +61,9 @@ public:
     static const Key kConfigKey_HardwareVersion;
     static const Key kConfigKey_ManufacturingDate;
     static const Key kConfigKey_SetupPinCode;
-    static const Key kConfigKey_FabricId;
     static const Key kConfigKey_ServiceConfig;
     static const Key kConfigKey_PairedAccountId;
     static const Key kConfigKey_ServiceId;
-    static const Key kConfigKey_FabricSecret;
-    static const Key kConfigKey_GroupKeyIndex;
     static const Key kConfigKey_LastUsedEpochKeyId;
     static const Key kConfigKey_FailSafeArmed;
     static const Key kConfigKey_WiFiStationSecType;
@@ -79,8 +76,6 @@ public:
     static const Key kConfigKey_Spake2pVerifier;
     static const Key kConfigKey_VendorId;
     static const Key kConfigKey_ProductId;
-
-    static const char kGroupKeyNamePrefix[];
 
     static CHIP_ERROR Init(void);
 

--- a/src/platform/Zephyr/ZephyrConfig.cpp
+++ b/src/platform/Zephyr/ZephyrConfig.cpp
@@ -63,12 +63,9 @@ const ZephyrConfig::Key ZephyrConfig::kConfigKey_Spake2pSalt           = CONFIG_
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_Spake2pVerifier       = CONFIG_KEY(NAMESPACE_FACTORY "verifier");
 // Keys stored in the chip config namespace
 // NOTE: update sAllResettableConfigKeys definition when adding a new entry below
-const ZephyrConfig::Key ZephyrConfig::kConfigKey_FabricId           = CONFIG_KEY(NAMESPACE_CONFIG "fabric-id");
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_ServiceConfig      = CONFIG_KEY(NAMESPACE_CONFIG "service-config");
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_PairedAccountId    = CONFIG_KEY(NAMESPACE_CONFIG "account-id");
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_ServiceId          = CONFIG_KEY(NAMESPACE_CONFIG "service-id");
-const ZephyrConfig::Key ZephyrConfig::kConfigKey_FabricSecret       = CONFIG_KEY(NAMESPACE_CONFIG "fabric-secret");
-const ZephyrConfig::Key ZephyrConfig::kConfigKey_GroupKeyIndex      = CONFIG_KEY(NAMESPACE_CONFIG "group-key-index");
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_LastUsedEpochKeyId = CONFIG_KEY(NAMESPACE_CONFIG "last-ek-id");
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_FailSafeArmed      = CONFIG_KEY(NAMESPACE_CONFIG "fail-safe-armed");
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_RegulatoryLocation = CONFIG_KEY(NAMESPACE_CONFIG "regulatory-location");
@@ -84,12 +81,10 @@ const ZephyrConfig::Key ZephyrConfig::kCounterKey_TotalOperationalHours = CONFIG
 namespace {
 
 constexpr const char * sAllResettableConfigKeys[] = {
-    ZephyrConfig::kConfigKey_FabricId,           ZephyrConfig::kConfigKey_ServiceConfig,
-    ZephyrConfig::kConfigKey_PairedAccountId,    ZephyrConfig::kConfigKey_ServiceId,
-    ZephyrConfig::kConfigKey_FabricSecret,       ZephyrConfig::kConfigKey_GroupKeyIndex,
-    ZephyrConfig::kConfigKey_LastUsedEpochKeyId, ZephyrConfig::kConfigKey_FailSafeArmed,
-    ZephyrConfig::kConfigKey_RegulatoryLocation, ZephyrConfig::kConfigKey_CountryCode,
-    ZephyrConfig::kConfigKey_Breadcrumb,
+    ZephyrConfig::kConfigKey_ServiceConfig, ZephyrConfig::kConfigKey_PairedAccountId,
+    ZephyrConfig::kConfigKey_ServiceId,     ZephyrConfig::kConfigKey_LastUsedEpochKeyId,
+    ZephyrConfig::kConfigKey_FailSafeArmed, ZephyrConfig::kConfigKey_RegulatoryLocation,
+    ZephyrConfig::kConfigKey_CountryCode,   ZephyrConfig::kConfigKey_Breadcrumb,
 };
 
 // Data structure to be passed as a parameter of Zephyr's settings_load_subtree_direct() function

--- a/src/platform/Zephyr/ZephyrConfig.h
+++ b/src/platform/Zephyr/ZephyrConfig.h
@@ -53,12 +53,9 @@ public:
     static const Key kConfigKey_ManufacturingDate;
     static const Key kConfigKey_SetupPinCode;
     static const Key kConfigKey_SetupDiscriminator;
-    static const Key kConfigKey_FabricId;
     static const Key kConfigKey_ServiceConfig;
     static const Key kConfigKey_PairedAccountId;
     static const Key kConfigKey_ServiceId;
-    static const Key kConfigKey_FabricSecret;
-    static const Key kConfigKey_GroupKeyIndex;
     static const Key kConfigKey_LastUsedEpochKeyId;
     static const Key kConfigKey_FailSafeArmed;
     static const Key kConfigKey_RegulatoryLocation;

--- a/src/platform/android/AndroidConfig.cpp
+++ b/src/platform/android/AndroidConfig.cpp
@@ -82,21 +82,15 @@ const AndroidConfig::Key AndroidConfig::kConfigKey_Spake2pSalt           = { kCo
 const AndroidConfig::Key AndroidConfig::kConfigKey_Spake2pVerifier       = { kConfigNamespace_ChipFactory, "verifier" };
 
 // Keys stored in the Chip-config namespace
-const AndroidConfig::Key AndroidConfig::kConfigKey_FabricId           = { kConfigNamespace_ChipConfig, "fabric-id" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_ServiceConfig      = { kConfigNamespace_ChipConfig, "service-config" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_PairedAccountId    = { kConfigNamespace_ChipConfig, "account-id" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_ServiceId          = { kConfigNamespace_ChipConfig, "service-id" };
-const AndroidConfig::Key AndroidConfig::kConfigKey_FabricSecret       = { kConfigNamespace_ChipConfig, "fabric-secret" };
-const AndroidConfig::Key AndroidConfig::kConfigKey_GroupKeyIndex      = { kConfigNamespace_ChipConfig, "group-key-index" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_LastUsedEpochKeyId = { kConfigNamespace_ChipConfig, "last-ek-id" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_FailSafeArmed      = { kConfigNamespace_ChipConfig, "fail-safe-armed" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_WiFiStationSecType = { kConfigNamespace_ChipConfig, "sta-sec-type" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_RegulatoryLocation = { kConfigNamespace_ChipConfig, "regulatory-location" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
 const AndroidConfig::Key AndroidConfig::kConfigKey_Breadcrumb         = { kConfigNamespace_ChipConfig, "breadcrumb" };
-
-// Prefix used for NVS keys that contain Chip group encryption keys.
-const char AndroidConfig::kGroupKeyNamePrefix[] = "gk-";
 
 void AndroidConfig::InitializeWithObject(jobject managerObject)
 {

--- a/src/platform/android/AndroidConfig.h
+++ b/src/platform/android/AndroidConfig.h
@@ -62,12 +62,9 @@ public:
     static const Key kConfigKey_HardwareVersionString;
     static const Key kConfigKey_ManufacturingDate;
     static const Key kConfigKey_SetupPinCode;
-    static const Key kConfigKey_FabricId;
     static const Key kConfigKey_ServiceConfig;
     static const Key kConfigKey_PairedAccountId;
     static const Key kConfigKey_ServiceId;
-    static const Key kConfigKey_FabricSecret;
-    static const Key kConfigKey_GroupKeyIndex;
     static const Key kConfigKey_LastUsedEpochKeyId;
     static const Key kConfigKey_FailSafeArmed;
     static const Key kConfigKey_WiFiStationSecType;
@@ -88,8 +85,6 @@ public:
     static const Key kConfigKey_Spake2pIterationCount;
     static const Key kConfigKey_Spake2pSalt;
     static const Key kConfigKey_Spake2pVerifier;
-
-    static const char kGroupKeyNamePrefix[];
 
     static CHIP_ERROR Init();
 

--- a/src/platform/android/java/chip/platform/ConfigurationManager.java
+++ b/src/platform/android/java/chip/platform/ConfigurationManager.java
@@ -50,21 +50,15 @@ public interface ConfigurationManager {
   String kConfigKey_Spake2pVerifier = "verifier";
 
   // Keys stored in the Chip-config namespace
-  String kConfigKey_FabricId = "fabric-id";
   String kConfigKey_ServiceConfig = "service-config";
   String kConfigKey_PairedAccountId = "account-id";
   String kConfigKey_ServiceId = "service-id";
-  String kConfigKey_FabricSecret = "fabric-secret";
-  String kConfigKey_GroupKeyIndex = "group-key-index";
   String kConfigKey_LastUsedEpochKeyId = "last-ek-id";
   String kConfigKey_FailSafeArmed = "fail-safe-armed";
   String kConfigKey_WiFiStationSecType = "sta-sec-type";
   String kConfigKey_RegulatoryLocation = "regulatory-location";
   String kConfigKey_CountryCode = "country-code";
   String kConfigKey_Breadcrumb = "breadcrumb";
-
-  // Prefix used for NVS keys that contain Chip group encryption keys.
-  String kGroupKeyNamePrefix = "gk-";
 
   long readConfigValueLong(String namespace, String name) throws AndroidChipPlatformException;
 

--- a/src/platform/bouffalolab/BL602/BL602Config.cpp
+++ b/src/platform/bouffalolab/BL602/BL602Config.cpp
@@ -57,11 +57,9 @@ const BL602Config::Key BL602Config::kConfigKey_Spake2pSalt           = { "salt" 
 const BL602Config::Key BL602Config::kConfigKey_Spake2pVerifier       = { "verifier" };
 
 // Keys stored in the chip-config namespace
-const BL602Config::Key BL602Config::kConfigKey_FabricId                    = { "fabric-id" };
 const BL602Config::Key BL602Config::kConfigKey_ServiceConfig               = { "service-config" };
 const BL602Config::Key BL602Config::kConfigKey_PairedAccountId             = { "account-id" };
 const BL602Config::Key BL602Config::kConfigKey_ServiceId                   = { "service-id" };
-const BL602Config::Key BL602Config::kConfigKey_GroupKeyIndex               = { "group-key-index" };
 const BL602Config::Key BL602Config::kConfigKey_LastUsedEpochKeyId          = { "last-ek-id" };
 const BL602Config::Key BL602Config::kConfigKey_FailSafeArmed               = { "fail-safe-armed" };
 const BL602Config::Key BL602Config::kConfigKey_WiFiStationSecType          = { "sta-sec-type" };
@@ -73,9 +71,6 @@ const BL602Config::Key BL602Config::kConfigKey_RegulatoryLocation          = { "
 const BL602Config::Key BL602Config::kConfigKey_CountryCode                 = { "country-code" };
 const BL602Config::Key BL602Config::kConfigKey_Breadcrumb                  = { "breadcrumb" };
 const BL602Config::Key BL602Config::kConfigKey_UniqueId                    = { "unique-id" };
-
-// Prefix used for Easyflash keys that contain Chip group encryption keys.
-const char BL602Config::kGroupKeyNamePrefix[] = "gk-";
 
 CHIP_ERROR BL602Config::Init()
 {

--- a/src/platform/bouffalolab/BL602/BL602Config.h
+++ b/src/platform/bouffalolab/BL602/BL602Config.h
@@ -63,12 +63,9 @@ public:
     static const Key kConfigKey_HardwareVersion;
     static const Key kConfigKey_ManufacturingDate;
     static const Key kConfigKey_SetupPinCode;
-    static const Key kConfigKey_FabricId;
     static const Key kConfigKey_ServiceConfig;
     static const Key kConfigKey_PairedAccountId;
     static const Key kConfigKey_ServiceId;
-    static const Key kConfigKey_FabricSecret;
-    static const Key kConfigKey_GroupKeyIndex;
     static const Key kConfigKey_LastUsedEpochKeyId;
     static const Key kConfigKey_FailSafeArmed;
     static const Key kConfigKey_WiFiStationSecType;
@@ -84,8 +81,6 @@ public:
     static const Key kConfigKey_Spake2pIterationCount;
     static const Key kConfigKey_Spake2pSalt;
     static const Key kConfigKey_Spake2pVerifier;
-
-    static const char kGroupKeyNamePrefix[];
 
     static CHIP_ERROR Init(void);
 

--- a/src/platform/cc13x2_26x2/CC13X2_26X2Config.cpp
+++ b/src/platform/cc13x2_26x2/CC13X2_26X2Config.cpp
@@ -69,18 +69,12 @@ const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_Spake2pVerifier      
                                                                                  .itemID   = 0x000c } };
 
 // Keys stored in the Chip-config namespace
-const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_FabricId           = { { .systemID = kCC13X2_26X2ChipConfig_Sysid,
-                                                                          .itemID   = 0x0011 } };
 const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_ServiceConfig      = { { .systemID = kCC13X2_26X2ChipConfig_Sysid,
                                                                                .itemID   = 0x0012 } };
 const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_PairedAccountId    = { { .systemID = kCC13X2_26X2ChipConfig_Sysid,
                                                                                  .itemID   = 0x0013 } };
 const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_ServiceId          = { { .systemID = kCC13X2_26X2ChipConfig_Sysid,
                                                                            .itemID   = 0x0014 } };
-const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_FabricSecret       = { { .systemID = kCC13X2_26X2ChipConfig_Sysid,
-                                                                              .itemID   = 0x0015 } };
-const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_GroupKeyIndex      = { { .systemID = kCC13X2_26X2ChipConfig_Sysid,
-                                                                               .itemID   = 0x0016 } };
 const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_LastUsedEpochKeyId = { { .systemID = kCC13X2_26X2ChipConfig_Sysid,
                                                                                     .itemID   = 0x0017 } };
 const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_FailSafeArmed      = { { .systemID = kCC13X2_26X2ChipConfig_Sysid,

--- a/src/platform/cc13x2_26x2/CC13X2_26X2Config.h
+++ b/src/platform/cc13x2_26x2/CC13X2_26X2Config.h
@@ -55,12 +55,9 @@ public:
     static const Key kConfigKey_ManufacturingDate;
     static const Key kConfigKey_SetupPinCode;
     static const Key kConfigKey_SetupDiscriminator;
-    static const Key kConfigKey_FabricId;
     static const Key kConfigKey_ServiceConfig;
     static const Key kConfigKey_PairedAccountId;
     static const Key kConfigKey_ServiceId;
-    static const Key kConfigKey_FabricSecret;
-    static const Key kConfigKey_GroupKeyIndex;
     static const Key kConfigKey_LastUsedEpochKeyId;
     static const Key kConfigKey_FailSafeArmed;
     static const Key kConfigKey_WiFiStationSecType;

--- a/src/platform/mbed/MbedConfig.cpp
+++ b/src/platform/mbed/MbedConfig.cpp
@@ -75,11 +75,9 @@ const MbedConfig::Key MbedConfig::kConfigKey_Spake2pSalt           = { FACTORY_K
 const MbedConfig::Key MbedConfig::kConfigKey_Spake2pVerifier       = { FACTORY_KEY("verifier") };
 
 // Keys stored in the chip-config namespace
-const MbedConfig::Key MbedConfig::kConfigKey_FabricId           = { CONFIG_KEY("fabric-id") };
 const MbedConfig::Key MbedConfig::kConfigKey_ServiceConfig      = { CONFIG_KEY("service-config") };
 const MbedConfig::Key MbedConfig::kConfigKey_PairedAccountId    = { CONFIG_KEY("account-id") };
 const MbedConfig::Key MbedConfig::kConfigKey_ServiceId          = { CONFIG_KEY("service-id") };
-const MbedConfig::Key MbedConfig::kConfigKey_GroupKeyIndex      = { CONFIG_KEY("group-key-index") };
 const MbedConfig::Key MbedConfig::kConfigKey_LastUsedEpochKeyId = { CONFIG_KEY("last-ek-id") };
 const MbedConfig::Key MbedConfig::kConfigKey_FailSafeArmed      = { CONFIG_KEY("fail-safe-armed") };
 const MbedConfig::Key MbedConfig::kConfigKey_WiFiStationSecType = { CONFIG_KEY("sta-sec-type") };

--- a/src/platform/mbed/MbedConfig.h
+++ b/src/platform/mbed/MbedConfig.h
@@ -60,12 +60,9 @@ public:
     static const Key kConfigKey_HardwareVersion;
     static const Key kConfigKey_ManufacturingDate;
     static const Key kConfigKey_SetupPinCode;
-    static const Key kConfigKey_FabricId;
     static const Key kConfigKey_ServiceConfig;
     static const Key kConfigKey_PairedAccountId;
     static const Key kConfigKey_ServiceId;
-    static const Key kConfigKey_FabricSecret;
-    static const Key kConfigKey_GroupKeyIndex;
     static const Key kConfigKey_LastUsedEpochKeyId;
     static const Key kConfigKey_FailSafeArmed;
     static const Key kConfigKey_WiFiStationSecType;

--- a/src/platform/nxp/k32w/k32w0/K32W0Config.h
+++ b/src/platform/nxp/k32w/k32w0/K32W0Config.h
@@ -80,11 +80,9 @@ public:
     static constexpr Key kConfigKey_Spake2pVerifier       = K32WConfigKey(kPDMId_ChipFactory, 0x0B);
 
     // CHIP Config Keys
-    static constexpr Key kConfigKey_FabricId           = K32WConfigKey(kPDMId_ChipConfig, 0x00);
     static constexpr Key kConfigKey_ServiceConfig      = K32WConfigKey(kPDMId_ChipConfig, 0x01);
     static constexpr Key kConfigKey_PairedAccountId    = K32WConfigKey(kPDMId_ChipConfig, 0x02);
     static constexpr Key kConfigKey_ServiceId          = K32WConfigKey(kPDMId_ChipConfig, 0x03);
-    static constexpr Key kConfigKey_FabricSecret       = K32WConfigKey(kPDMId_ChipConfig, 0x04);
     static constexpr Key kConfigKey_LastUsedEpochKeyId = K32WConfigKey(kPDMId_ChipConfig, 0x05);
     static constexpr Key kConfigKey_FailSafeArmed      = K32WConfigKey(kPDMId_ChipConfig, 0x06);
     static constexpr Key kConfigKey_RegulatoryLocation = K32WConfigKey(kPDMId_ChipConfig, 0x07);

--- a/src/platform/qpg/qpgConfig.h
+++ b/src/platform/qpg/qpgConfig.h
@@ -76,11 +76,9 @@ public:
     static constexpr Key kConfigKey_Spake2pSalt           = QorvoConfigKey(kFileId_ChipFactory, 0x09);
     static constexpr Key kConfigKey_Spake2pVerifier       = QorvoConfigKey(kFileId_ChipFactory, 0x0A);
 
-    static constexpr Key kConfigKey_FabricId           = QorvoConfigKey(kFileId_ChipConfig, 0x00);
     static constexpr Key kConfigKey_ServiceConfig      = QorvoConfigKey(kFileId_ChipConfig, 0x01);
     static constexpr Key kConfigKey_PairedAccountId    = QorvoConfigKey(kFileId_ChipConfig, 0x02);
     static constexpr Key kConfigKey_ServiceId          = QorvoConfigKey(kFileId_ChipConfig, 0x03);
-    static constexpr Key kConfigKey_FabricSecret       = QorvoConfigKey(kFileId_ChipConfig, 0x04);
     static constexpr Key kConfigKey_LastUsedEpochKeyId = QorvoConfigKey(kFileId_ChipConfig, 0x05);
     static constexpr Key kConfigKey_FailSafeArmed      = QorvoConfigKey(kFileId_ChipConfig, 0x06);
     static constexpr Key kConfigKey_GroupKey           = QorvoConfigKey(kFileId_ChipConfig, 0x07);
@@ -100,7 +98,7 @@ public:
     // Set key id limits for each group.
     static constexpr Key kMinConfigKey_ChipFactory = kConfigKey_SerialNum;
     static constexpr Key kMaxConfigKey_ChipFactory = kConfigKey_Spake2pVerifier;
-    static constexpr Key kMinConfigKey_ChipConfig  = kConfigKey_FabricId;
+    static constexpr Key kMinConfigKey_ChipConfig  = kConfigKey_ServiceConfig;
     static constexpr Key kMaxConfigKey_ChipConfig  = kConfigKey_GroupKeyMax;
     static constexpr Key kMinConfigKey_ChipCounter = kConfigKey_CounterKeyBase;
     static constexpr Key kMaxConfigKey_ChipCounter = kConfigKey_CounterKeyMax; // Allows 32 Counters to be created.


### PR DESCRIPTION
#### Problem
Lots of unused keys in platform manager configs.

#### Change overview
Remove some (not all yet).

#### Testing
Tree should compile, since they are unused.