### PR TITLE
Fix output name of qpg_executable OTA

### DIFF
--- a/third_party/qpg_sdk/qpg_executable.gni
+++ b/third_party/qpg_sdk/qpg_executable.gni
@@ -14,9 +14,11 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
+import("//build_overrides/pigweed.gni")
 
 import("${build_root}/toolchain/flashable_executable.gni")
 import("${chip_root}/src/platform/device.gni")
+import("${dir_pw_build}/python_action.gni")
 import("qpg_sdk.gni")
 
 # Run the generator script that takes a .HEX file and adds the OTA header to it.
@@ -41,7 +43,7 @@ template("gen_ota_header") {
                            "data_deps",
                          ])
 
-  action(target_name) {
+  pw_python_action(target_name) {
     outputs = [ ota_header_script_name ]
 
     args = ota_header_options
@@ -94,8 +96,10 @@ template("qpg_executable") {
 
   # If OTA requestor is enabled, generate OTA image from HEX
   if (chip_enable_ota_requestor) {
+    ota_image_name = invoker.output_name + ".ota"
+
     gen_ota_header("$executable_target_name.ota") {
-      ota_header_script_name = "${root_out_dir}/${executable_target_name}.ota"
+      ota_header_script_name = "${root_out_dir}/${ota_image_name}"
       out_dir = rebase_path(root_out_dir, root_build_dir)
       ota_header_generator = "${qpg_sdk_root}/Tools/ota/generate_ota_img.py"
 


### PR DESCRIPTION
#### Problem

This always builds because it uses the wrong filename:

```
ninja: Entering directory `out/debug'
ninja explain: output build.ninja older than most recent input ../../third_party/connectedhomeip/third_party/qpg_sdk/qpg_executable.gni (1651007143800012937 vs 1651007267243517127)
[0/1] Regenerating ninja files
ninja explain: output lock_app.out.ota doesn't exist
ninja explain: lock_app.out.ota is dirty
[1/2] ACTION //:lock_app.out.ota(//third_party/connectedhomeip/build/toolchain/arm_gcc:arm_gcc)
```

#### Change overview

Fix the filename (and squelch the output).

#### Testing

(cd ./examples/lock-app/qpg; gn gen out/debug; ninja -C out/debug)
