### PR TITLE
PLATFORM_PREFERRED_ARCH is deprecated, stop using it.

### DIFF
--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -60,8 +60,14 @@ for define in "${defines[@]}"; do
 done
 target_defines=[${target_defines:1}]
 
+read -r -a archs <<<"$ARCHS"
+
+# We need to pick some arg for our target_cflags and target_cpu bits.
+# Just take the first one.
+declare first_arch="${archs[0]}"
+
 declare target_cpu=
-case $PLATFORM_PREFERRED_ARCH in
+case $first_arch in
     i386)
         target_cpu=x86
         ;;
@@ -79,9 +85,7 @@ case $PLATFORM_PREFERRED_ARCH in
         ;;
 esac
 
-declare target_cflags='"-target","'"$PLATFORM_PREFERRED_ARCH"'-'"$LLVM_TARGET_TRIPLE_VENDOR"'-'"$LLVM_TARGET_TRIPLE_OS_VERSION"'"'
-
-read -r -a archs <<<"$ARCHS"
+declare target_cflags='"-target","'"$first_arch"'-'"$LLVM_TARGET_TRIPLE_VENDOR"'-'"$LLVM_TARGET_TRIPLE_OS_VERSION"'"'
 
 for arch in "${archs[@]}"; do
     target_cflags+=',"-arch","'"$arch"'"'
@@ -155,7 +159,7 @@ find_in_ancestors() {
     # put build intermediates in TEMP_DIR
     cd "$TEMP_DIR"
 
-    # gnerate and build
+    # generate and build
     gn --root="$CHIP_ROOT" gen --check out --args="${args[*]}"
     ninja -v -C out
 )


### PR DESCRIPTION
Sadly, we need _some_ arch for the xcode build connector for the
target_cpu and target_cflags settings, so just take the first one in
ARCHS.

#### Problem
PLATFORM_PREFERRED_ARCH will go away.

#### Change overview
For now, use ARCHS[0] instead, until we figure out what we actually want to do when ARCHS has multiple things in it.

#### Testing
Ran xcodebuild locally.