### PR TITLE
Use CHIP memory allocator instead of native malloc for watermark stat…

### DIFF
--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -507,11 +507,11 @@ static void backport_if_freenameindex(struct if_nameindex * inArray)
     {
         if (inArray[i].if_name != NULL)
         {
-            free(inArray[i].if_name);
+            MemoryFree(inArray[i].if_name);
         }
     }
 
-    free(inArray);
+    MemoryFree(inArray);
 }
 
 static struct if_nameindex * backport_if_nameindex(void)

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -30,6 +30,7 @@
 #include <inet/InetInterface.h>
 
 #include <inet/IPPrefix.h>
+#include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DLLUtil.h>
@@ -542,7 +543,7 @@ static struct if_nameindex * backport_if_nameindex(void)
         lastIntfName = addrIter->ifa_name;
     }
 
-    tmpval = (struct if_nameindex *) malloc((numIntf + 1) * sizeof(struct if_nameindex));
+    tmpval = (struct if_nameindex *) MemoryAlloc((numIntf + 1) * sizeof(struct if_nameindex));
     VerifyOrExit(tmpval != NULL, );
     memset(tmpval, 0, (numIntf + 1) * sizeof(struct if_nameindex));
 
@@ -574,7 +575,7 @@ static struct if_nameindex * backport_if_nameindex(void)
         }
     }
 
-    retval = (struct if_nameindex *) malloc((maxIntfNum + 1) * sizeof(struct if_nameindex));
+    retval = (struct if_nameindex *) MemoryAlloc((maxIntfNum + 1) * sizeof(struct if_nameindex));
     VerifyOrExit(retval != NULL, );
     memset(retval, 0, (maxIntfNum + 1) * sizeof(struct if_nameindex));
 
@@ -614,7 +615,7 @@ static struct if_nameindex * backport_if_nameindex(void)
 exit:
     if (tmpval != NULL)
     {
-        free(tmpval);
+        MemoryFree(tmpval);
     }
 
     if (addrList != NULL)

--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -43,7 +43,7 @@ extern "C" void pw_tokenizer_HandleEncodedMessageWithPayload(uintptr_t levels, c
 {
     uint8_t log_category = levels >> 8 & 0xFF;
     uint8_t log_module   = levels & 0xFF;
-    char * buffer        = (char *) MemoryAlloc(2 * size_bytes + 1);
+    char * buffer        = (char *) chip::Platform::MemoryAlloc(2 * size_bytes + 1);
 
     if (buffer)
     {
@@ -53,7 +53,7 @@ extern "C" void pw_tokenizer_HandleEncodedMessageWithPayload(uintptr_t levels, c
         }
         buffer[2 * size_bytes] = '\0';
         chip::Logging::Log(log_module, log_category, "%s", buffer);
-        MemoryFree(buffer);
+        chip::Platform::MemoryFree(buffer);
     }
 }
 

--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -26,6 +26,7 @@
 #include "CHIPLogging.h"
 
 #include <lib/core/CHIPCore.h>
+#include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DLLUtil.h>
 #include <lib/support/Span.h>
@@ -42,7 +43,7 @@ extern "C" void pw_tokenizer_HandleEncodedMessageWithPayload(uintptr_t levels, c
 {
     uint8_t log_category = levels >> 8 & 0xFF;
     uint8_t log_module   = levels & 0xFF;
-    char * buffer        = (char *) malloc(2 * size_bytes + 1);
+    char * buffer        = (char *) MemoryAlloc(2 * size_bytes + 1);
 
     if (buffer)
     {
@@ -52,7 +53,7 @@ extern "C" void pw_tokenizer_HandleEncodedMessageWithPayload(uintptr_t levels, c
         }
         buffer[2 * size_bytes] = '\0';
         chip::Logging::Log(log_module, log_category, "%s", buffer);
-        free(buffer);
+        MemoryFree(buffer);
     }
 }
 


### PR DESCRIPTION
…istics

#### Problem
What is being fixed?  Examples:
* We should always use CHIP memory allocator instead of native malloc to allocate memory within CHIP stack. This will help on watermark statistic.

#### Change overview
Use CHIP memory allocator instead of native malloc to allocate memory 

#### Testing
How was this tested? (at least one bullet point required)
* No logic change, regression is covered by CI

