### PR TITLE
Remove some unnecessary nullable annotations.

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
@@ -35,8 +35,8 @@ public:
     CHIP_ERROR SyncDeleteKeyValue(const char * key) override;
 
 private:
-    _Nullable id<CHIPPersistentStorageDelegate> mDelegate;
-    _Nullable dispatch_queue_t mWorkQueue;
+    id<CHIPPersistentStorageDelegate> mDelegate;
+    dispatch_queue_t mWorkQueue;
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -53,8 +53,8 @@ std::string Base64ToString(const std::string & b64Value)
 
 CHIPPersistentStorageDelegateBridge::CHIPPersistentStorageDelegateBridge(id<CHIPPersistentStorageDelegate> delegate)
     : mDelegate(delegate)
+    , mWorkQueue(dispatch_queue_create("com.zigbee.chip.framework.storage.workqueue", DISPATCH_QUEUE_SERIAL))
 {
-    mWorkQueue = dispatch_queue_create("com.zigbee.chip.framework.storage.workqueue", DISPATCH_QUEUE_SERIAL);
 }
 
 CHIPPersistentStorageDelegateBridge::~CHIPPersistentStorageDelegateBridge(void) {}


### PR DESCRIPTION
Just need to initialize things in the initializer list instead of
default-constructing them as nil and then initializing them.

#### Problem
See above.

#### Change overview
See above.

#### Testing
No behavior changes, still passes clang-tidy lints.