### PR TITLE
[Linux] Implement Ethernet network driver

### DIFF
--- a/examples/all-clusters-app/linux/main-common.cpp
+++ b/examples/all-clusters-app/linux/main-common.cpp
@@ -107,10 +107,13 @@ NetworkCommissioning::LinuxWiFiDriver sLinuxWiFiDriver;
 Clusters::NetworkCommissioning::Instance sWiFiNetworkCommissioningInstance(kNetworkCommissioningEndpointSecondary,
                                                                            &sLinuxWiFiDriver);
 #endif
-#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
-
+NetworkCommissioning::LinuxEthernetDriver sLinuxEthernetDriver;
+Clusters::NetworkCommissioning::Instance sEthernetNetworkCommissioningInstance(kNetworkCommissioningEndpointMain,
+                                                                               &sLinuxEthernetDriver);
+#else  // CHIP_DEVICE_LAYER_TARGET_LINUX
 Clusters::NetworkCommissioning::NullNetworkDriver sNullNetworkDriver;
 Clusters::NetworkCommissioning::Instance sNullNetworkCommissioningInstance(kNetworkCommissioningEndpointMain, &sNullNetworkDriver);
+#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
 } // namespace
 
 void ApplicationInit()
@@ -166,8 +169,12 @@ void ApplicationInit()
     else
 #endif // CHIP_DEVICE_LAYER_TARGET_LINUX
     {
+#if CHIP_DEVICE_LAYER_TARGET_LINUX
+        sEthernetNetworkCommissioningInstance.Init();
+#else
         // Use NullNetworkCommissioningInstance to disable the network commissioning functions.
         sNullNetworkCommissioningInstance.Init();
+#endif
     }
 }
 

--- a/src/platform/Linux/BUILD.gn
+++ b/src/platform/Linux/BUILD.gn
@@ -64,6 +64,7 @@ static_library("Linux") {
     "KeyValueStoreManagerImpl.h",
     "Logging.cpp",
     "NetworkCommissioningDriver.h",
+    "NetworkCommissioningEthernetDriver.cpp",
     "NetworkCommissioningThreadDriver.cpp",
     "NetworkCommissioningWiFiDriver.cpp",
     "PlatformManagerImpl.cpp",

--- a/src/platform/Linux/NetworkCommissioningDriver.h
+++ b/src/platform/Linux/NetworkCommissioningDriver.h
@@ -156,6 +156,38 @@ private:
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
+class LinuxEthernetDriver final : public EthernetDriver
+{
+public:
+    struct EthernetNetworkIterator final : public NetworkIterator
+    {
+        EthernetNetworkIterator() = default;
+        size_t Count() override { return interfaceNameLen > 0 ? 1 : 0; }
+        bool Next(Network & item) override
+        {
+            if (exhausted)
+            {
+                return false;
+            }
+            exhausted = true;
+            memcpy(item.networkID, interfaceName, interfaceNameLen);
+            item.networkIDLen = interfaceNameLen;
+            item.connected    = true;
+            return true;
+        }
+        void Release() override { delete this; }
+        ~EthernetNetworkIterator() override = default;
+
+        // Public, but cannot be accessed via NetworkIterator interface.
+        uint8_t interfaceName[kMaxNetworkIDLen];
+        uint8_t interfaceNameLen = 0;
+        bool exhausted           = false;
+    };
+
+    uint8_t GetMaxNetworks() override { return 1; };
+    NetworkIterator * GetNetworks() override;
+};
+
 } // namespace NetworkCommissioning
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Linux/NetworkCommissioningEthernetDriver.cpp
+++ b/src/platform/Linux/NetworkCommissioningEthernetDriver.cpp
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/support/SafePointerCast.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/Linux/ConnectivityUtils.h>
+#include <platform/Linux/NetworkCommissioningDriver.h>
+
+#include <limits>
+#include <string>
+#include <vector>
+
+using namespace chip::DeviceLayer::Internal;
+
+namespace chip {
+namespace DeviceLayer {
+namespace NetworkCommissioning {
+
+NetworkIterator * LinuxEthernetDriver::GetNetworks()
+{
+    auto ret = new EthernetNetworkIterator();
+    ConnectivityUtils::GetEthInterfaceName(SafePointerCast<char *>(ret->interfaceName), sizeof(ret->interfaceName));
+    ret->interfaceNameLen = strnlen(SafePointerCast<char *>(ret->interfaceName), sizeof(ret->interfaceName));
+    return ret;
+}
+
+} // namespace NetworkCommissioning
+} // namespace DeviceLayer
+} // namespace chip


### PR DESCRIPTION
#### Problem
Fixes #17535 

#### Change overview
Implemented a EthernetDriver for Linux

#### Testing
```
In [1]: devCtrl.CommissionIP(b"127.0.0.1", 20202021, 123123)
Established CASE with Device
Commissioning complete
Out[1]: True

In [2]: await devCtrl.ReadAttribute(nodeid=123123, attributes=[(0, Clusters.NetworkCommissioning)])
Out[2]: 
{
│   0: {
│   │   <class 'chip.clusters.Objects.NetworkCommissioning'>: {
│   │   │   <class 'chip.clusters.Attribute.DataVersion'>: 352360043,
│   │   │   <class 'chip.clusters.Objects.NetworkCommissioning.Attributes.MaxNetworks'>: 1,
│   │   │   <class 'chip.clusters.Objects.NetworkCommissioning.Attributes.Networks'>: [
│   │   │   │   NetworkInfo(
│   │   │   │   │   networkID=b'eno1',
│   │   │   │   │   connected=True
│   │   │   │   )
│   │   │   ],
│   │   │   <class 'chip.clusters.Objects.NetworkCommissioning.Attributes.ScanMaxTimeSeconds'>: 0,
│   │   │   <class 'chip.clusters.Objects.NetworkCommissioning.Attributes.ConnectMaxTimeSeconds'>: 0,
│   │   │   <class 'chip.clusters.Objects.NetworkCommissioning.Attributes.InterfaceEnabled'>: True,
│   │   │   <class 'chip.clusters.Objects.NetworkCommissioning.Attributes.LastNetworkingStatus'>: Null,
│   │   │   <class 'chip.clusters.Objects.NetworkCommissioning.Attributes.LastNetworkID'>: Null,
│   │   │   <class 'chip.clusters.Objects.NetworkCommissioning.Attributes.LastConnectErrorValue'>: Null,
│   │   │   <class 'chip.clusters.Objects.NetworkCommissioning.Attributes.FeatureMap'>: 4,
│   │   │   <class 'chip.clusters.Objects.NetworkCommissioning.Attributes.ClusterRevision'>: 1,
│   │   │   <class 'chip.clusters.Objects.NetworkCommissioning.Attributes.GeneratedCommandList'>: [],
│   │   │   <class 'chip.clusters.Objects.NetworkCommissioning.Attributes.AcceptedCommandList'>: [],
│   │   │   <class 'chip.clusters.Objects.NetworkCommissioning.Attributes.AttributeList'>: [
│   │   │   │   0,
│   │   │   │   1,
│   │   │   │   2,
│   │   │   │   3,
│   │   │   │   4,
│   │   │   │   5,
│   │   │   │   6,
│   │   │   │   7,
│   │   │   │   65528,
│   │   │   │   65529,
│   │   │   │   65531,
│   │   │   │   65532,
│   │   │   │   65533
│   │   │   ]
│   │   }
│   }
}
```