### PR TITLE
[Yaml] Add TestEvents.yaml

### DIFF
--- a/examples/chip-tool-darwin/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool-darwin/templates/tests/partials/test_cluster.zapt
@@ -84,11 +84,13 @@ class {{filename}}: public TestCommandBridge
     {{#if async}}
     bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase command}}_Fulfilled = false;
     {{/if}}
+    {{#chip_tests_item_responses}}
     {{#chip_tests_item_response_parameters}}
     {{#if saveAs}}
     {{asObjectiveCType type ../cluster}} {{saveAs}};
     {{/if}}
     {{/chip_tests_item_response_parameters}}
+    {{/chip_tests_item_responses}}
 
     {{~#*inline "subscribeDataCallback"}}
     test_{{parent.filename}}_{{attribute}}_Reported
@@ -172,11 +174,9 @@ class {{filename}}: public TestCommandBridge
             }
             {{/if}}
 
-            {{#if response.error}}
-              VerifyOrReturn(CheckValue("status", err, {{response.error}}));
-              NextTest();
-            {{else if response.errorWrongValue}}
-              VerifyOrReturn(CheckConstraintNotValue("status", err, 0));
+            {{#chip_tests_item_responses}}
+            {{#if error}}
+              VerifyOrReturn(CheckValue("status", err, {{error}}));
               NextTest();
             {{else}}
               VerifyOrReturn(CheckValue("status", err, 0));
@@ -235,7 +235,7 @@ class {{filename}}: public TestCommandBridge
         {{#unless async}}
         NextTest();
         {{else}}
-        testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase command}}_Fulfilled = true;
+        testSendCluster{{parent.filename}}_{{asTestIndex ../index}}_{{asUpperCamelCase command}}_Fulfilled = true;
         {{/unless}}
         {{else}}
           {{! We're a subscription }}
@@ -246,6 +246,7 @@ class {{filename}}: public TestCommandBridge
           }
         {{/unless}}
         {{/if}}
+        {{/chip_tests_item_responses}}
     }{{#unless isWaitForReport}}]{{/unless}};
 
     {{/if}}

--- a/examples/chip-tool/templates/tests/partials/saveAs/setupSaveAs.zapt
+++ b/examples/chip-tool/templates/tests/partials/saveAs/setupSaveAs.zapt
@@ -1,4 +1,5 @@
 {{#chip_tests_items}}
+    {{#chip_tests_item_responses}}
     {{#chip_tests_item_response_parameters}}
     {{#if saveAs}}
         {{~#if (isString type)}}
@@ -7,4 +8,5 @@
         {{zapTypeToDecodableClusterObjectType type ns=../cluster}} {{saveAs}};
     {{/if}}
     {{/chip_tests_item_response_parameters}}
+    {{/chip_tests_item_responses}}
 {{/chip_tests_items}}

--- a/examples/chip-tool/templates/tests/partials/saveAs/teardownSaveAs.zapt
+++ b/examples/chip-tool/templates/tests/partials/saveAs/teardownSaveAs.zapt
@@ -1,4 +1,5 @@
 {{#chip_tests_items}}
+    {{#chip_tests_item_responses}}
     {{#chip_tests_item_response_parameters}}
     {{#if saveAs}}
         {{#if (isString type)}}
@@ -10,4 +11,5 @@
         {{/if}}
     {{/if}}
     {{/chip_tests_item_response_parameters}}
+    {{/chip_tests_item_responses}}
 {{/chip_tests_items}}

--- a/examples/chip-tool/templates/tests/partials/test_step.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_step.zapt
@@ -6,6 +6,12 @@
 {{/if}}
 {{/inline~}}
 
+{{~#*inline "maybeSetupSubStepCount"}}
+{{#if expectMultipleResponses}}
+    mTestSubStepCount = {{response.length}};
+{{/if}}
+{{/inline~}}
+
 {{~#*inline "maybePrepareArguments"}}
 {{#unless isWait}}
 {{#if (isTestOnlyCluster cluster)}}
@@ -107,5 +113,6 @@
 {{! --- Test Step Content --}}
 LogStep({{index}}, "{{label}}");
 {{>maybePICS}}
+{{>maybeSetupSubStepCount}}
 {{>maybePrepareArguments}}
 {{>maybeBusyWait}}

--- a/examples/chip-tool/templates/tests/partials/test_step_response.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_step_response.zapt
@@ -1,13 +1,18 @@
-{{~#*inline "maybeCheckClusterError"}}
-{{#if response.clusterError}}
-    VerifyOrReturn(CheckValue("clusterStatus", status.mClusterStatus.HasValue(), true));
-    VerifyOrReturn(CheckValue("clusterStatus", status.mClusterStatus.Value(), {{response.clusterError}}));
+{{#if expectMultipleResponses}}
+switch(mTestSubStepIndex)
+{
 {{/if}}
-{{/inline~}}
-
+{{#chip_tests_item_responses}}
 {{~#*inline "maybeContinueWithoutWaitingOnDone"}}
     {{~#if isWaitForReport}}shouldContinue = true;{{/if~}}
     {{~#if (isTestOnlyCluster cluster)}}shouldContinue = true;{{/if~}}
+{{/inline~}}
+
+{{~#*inline "maybeCheckClusterError"}}
+{{#if clusterError}}
+    VerifyOrReturn(CheckValue("clusterStatus", status.mClusterStatus.HasValue(), true));
+    VerifyOrReturn(CheckValue("clusterStatus", status.mClusterStatus.Value(), {{clusterError}}));
+{{/if}}
 {{/inline~}}
 
 {{~#*inline "maybeReturnOnUnsupported"}}
@@ -21,12 +26,15 @@
 {{/inline~}}
 
 {{! --- Test Step Response Content --}}
-{{#if response.error}}
-    VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), {{response.error}}));
+{{#if ../expectMultipleResponses}}
+  case {{index}}:
+{{/if}}
+{{#if error}}
+    VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), {{error}}));
     {{>maybeCheckClusterError}}
 {{else}}
     {{>maybeReturnOnUnsupported}}
-    VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), {{response.error}}));
+    VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), {{error}}));
     {{#if hasSpecificResponse}}
     {
         {{asDecodableType}} value;
@@ -40,3 +48,14 @@
     {{/if}}
 {{/if}}
 {{>maybeContinueWithoutWaitingOnDone}}
+{{#if ../expectMultipleResponses}}
+  mTestSubStepIndex++;
+  break;
+{{/if}}
+{{/chip_tests_item_responses}}
+{{#if expectMultipleResponses}}
+  default:
+    LogErrorOnFailure(ContinueOnChipMainThread(CHIP_ERROR_INVALID_ARGUMENT));
+    break;
+}
+{{/if}}

--- a/examples/chip-tool/templates/tests/tests.js
+++ b/examples/chip-tool/templates/tests/tests.js
@@ -536,6 +536,7 @@ function getTests()
     'TestClusterComplexTypes',
     'TestConstraints',
     'TestDelayCommands',
+    'TestEvents',
     'TestDiscovery',
     'TestLogCommands',
     'TestSaveAs',

--- a/src/app/tests/suites/TestEvents.yaml
+++ b/src/app/tests/suites/TestEvents.yaml
@@ -1,0 +1,87 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Events Tests
+
+config:
+    nodeId: 0x12344321
+    cluster: "Test Cluster"
+    endpoint: 1
+
+tests:
+    - label: "Wait for the commissioned device to be retrieved"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
+
+    - label: "Check there is no event on the target endpoint"
+      command: "readEvent"
+      event: "TestEvent"
+      response:
+          value: {}
+
+    - label: "Check reading events from an invalid endpoint"
+      command: "readEvent"
+      event: "TestEvent"
+      endpoint: 0
+      response:
+          value: {}
+
+    - label: "Generate an event on the accessory"
+      command: "TestEmitTestEventRequest"
+      arguments:
+          values:
+              - name: "arg1"
+                value: 1
+              - name: "arg2"
+                value: 2
+              - name: "arg3"
+                value: true
+      response:
+          values:
+              - name: "value"
+                saveAs: eventNumber
+
+    - label: "Read the event back"
+      command: "readEvent"
+      event: "TestEvent"
+      response:
+          value: { arg1: 1, arg2: 2, arg3: true }
+
+    - label: "Generate a second event on the accessory"
+      command: "TestEmitTestEventRequest"
+      arguments:
+          values:
+              - name: "arg1"
+                value: 3
+              - name: "arg2"
+                value: 4
+              - name: "arg3"
+                value: false
+      response:
+          values:
+              - name: "value"
+                value: eventNumber + 1
+
+    - label: "Read the event back"
+      command: "readEvent"
+      event: "TestEvent"
+      response:
+          - values:
+                - value: { arg1: 1, arg2: 2, arg3: true }
+          - values:
+                - value: { arg1: 3, arg2: 4, arg3: false }

--- a/src/app/tests/suites/certification/Test_TC_MC_6_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_6_4.yaml
@@ -65,7 +65,7 @@ tests:
       response:
           values:
               - name: "returnValue"
-              - value: 0
+                value: 0
 
     - label: "log a command"
       cluster: "LogCommands"
@@ -94,7 +94,7 @@ tests:
       response:
           values:
               - name: "returnValue"
-              - value: 0
+                value: 0
 
     - label: "log a command"
       cluster: "LogCommands"
@@ -142,7 +142,7 @@ tests:
       response:
           values:
               - name: "returnValue"
-              - value: 0
+                value: 0
 
     - label: "log a command"
       cluster: "LogCommands"
@@ -165,7 +165,7 @@ tests:
       response:
           values:
               - name: "returnValue"
-              - value: 0
+                value: 0
 
     - label: "log a command"
       cluster: "LogCommands"

--- a/src/app/tests/suites/include/TestRunner.h
+++ b/src/app/tests/suites/include/TestRunner.h
@@ -50,7 +50,12 @@ public:
 
     void NextTest()
     {
-        CHIP_ERROR err = CHIP_NO_ERROR;
+        if (mTestSubStepIndex != mTestSubStepCount)
+        {
+            Exit(mTestName, CHIP_ERROR_INVALID_ARGUMENT);
+        }
+        mTestSubStepIndex = 0;
+        mTestSubStepCount = 0;
 
         if (0 == mTestIndex)
         {
@@ -72,7 +77,7 @@ public:
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
         // incorrect mTestIndex value observed when we get the response.
-        DoTestStep(mTestIndex++);
+        auto err = DoTestStep(mTestIndex++);
         if (CHIP_NO_ERROR != err)
         {
             Exit(chip::ErrorStr(err));
@@ -84,4 +89,7 @@ protected:
     const uint16_t mTestCount;
     std::atomic_uint16_t mTestIndex;
     chip::Optional<uint64_t> mDelayInMs;
+
+    uint16_t mTestSubStepIndex = 0;
+    uint16_t mTestSubStepCount = 0;
 };

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -247,90 +247,128 @@ function ensureValidError(response, errorName)
 
 function setDefaultResponse(test, useSynthesizeWaitForReport)
 {
+  // Some of the tests does not have any command defined.
+  if (!test.command || test.isWait) {
+    setDefault(test, kResponseName, []);
+    return;
+  }
+
   const defaultResponse = {};
   setDefault(test, kResponseName, defaultResponse);
 
-  const hasResponseError = (kResponseErrorName in test[kResponseName]);
+  // There is different syntax for expressing the expected response, but in the
+  // end it needs to be converted to an array of responses.
+  if (kResponseName in test && !Array.isArray(test[kResponseName])) {
+    let testValues = {};
 
-  const defaultResponseError = 0;
-  setDefault(test[kResponseName], kResponseErrorName, defaultResponseError);
+    const response = test[kResponseName];
 
-  const defaultResponseValues = [];
-  setDefault(test[kResponseName], kValuesName, defaultResponseValues);
-
-  // Ensure only valid keywords are used for response values.
-  const values = test[kResponseName][kValuesName];
-  for (let i = 0; i < values.length; i++) {
-    for (let key in values[i]) {
-      if (key == "name" || key == "value" || key == kConstraintsName || key == kSaveAsName) {
-        continue;
+    if (kValuesName in response) {
+      testValues[kValuesName] = response[kValuesName];
+    } else if ('value' in response || kConstraintsName in response || kSaveAsName in response) {
+      let obj = {};
+      if ('value' in response) {
+        obj['value'] = response['value'];
       }
 
-      const errorStr = `Unknown key "${key}"`;
-      throwError(test, errorStr);
-    }
-  }
+      if (kConstraintsName in response) {
+        obj[kConstraintsName] = response[kConstraintsName];
+      }
 
-  const defaultResponseConstraints = {};
-  setDefault(test[kResponseName], kConstraintsName, defaultResponseConstraints);
+      if (kSaveAsName in response) {
+        obj[kSaveAsName] = response[kSaveAsName];
+      }
 
-  const defaultResponseSaveAs = '';
-  setDefault(test[kResponseName], kSaveAsName, defaultResponseSaveAs);
-
-  const hasResponseValue              = 'value' in test[kResponseName];
-  const hasResponseConstraints        = 'constraints' in test[kResponseName] && Object.keys(test[kResponseName].constraints).length;
-  const hasResponseValueOrConstraints = hasResponseValue || hasResponseConstraints;
-
-  if (test.isCommand && hasResponseValueOrConstraints) {
-    const errorStr = 'Test has a "value" or a "constraints" defined.\n' +
-        '\n' +
-        'Command should explicitly use the response argument name. Example: \n' +
-        '- label: "Send Test Specific Command"\n' +
-        '  command: "testSpecific"\n' +
-        '  response: \n' +
-        '    values: \n' +
-        '      - name: "returnValue"\n' +
-        '      - value: 7\n';
-    throwError(test, errorStr);
-  }
-
-  ensureValidError(test[kResponseName], kResponseErrorName);
-
-  // Step that waits for a particular event does not requires constraints nor expected values.
-  if (test.isWait) {
-    return;
-  }
-
-  if (!test.isAttribute && !test.isEvent) {
-    return;
-  }
-
-  if (test.isWriteAttribute || (useSynthesizeWaitForReport && test.isSubscribe)) {
-    if (hasResponseValueOrConstraints) {
-      const errorStr = 'Test has a "value" or a "constraints" defined.';
-      throwError(test, errorStr);
+      testValues[kValuesName] = [ obj ];
+    } else {
+      testValues[kValuesName] = [];
     }
 
-    return;
+    if (kResponseErrorName in response) {
+      testValues[kResponseErrorName] = response[kResponseErrorName];
+    }
+
+    if ('clusterError' in response) {
+      testValues['clusterError'] = response['clusterError'];
+    }
+
+    test[kResponseName] = [ testValues ];
   }
 
-  if (!hasResponseValueOrConstraints && !hasResponseError) {
-    console.log(test);
-    console.log(test[kResponseName]);
-    const errorStr = 'Test does not have a "value" or a "constraints" defined and is not expecting an error.';
-    throwError(test, errorStr);
+  // Ensure only valid keywords are used for response values.
+  test[kResponseName].forEach(response => {
+    const values = response[kValuesName];
+    for (let i = 0; i < values.length; i++) {
+      for (let key in values[i]) {
+        if (key == "name" || key == "value" || key == kConstraintsName || key == kSaveAsName) {
+          continue;
+        }
+
+        const errorStr = `Unknown key "${key}" in "${JSON.stringify(values)}"`;
+        throwError(test, errorStr);
+      }
+    }
+  });
+
+  let responseType = '';
+  if (test.isCommand) {
+    responseType = 'command';
+  } else if (test.isAttribute) {
+    responseType = 'attribute';
+  } else if (test.isEvent) {
+    responseType = 'event';
+  } else {
+    const errorStr = 'Unknown response type';
+    throwError(response, errorStr);
   }
 
-  if (hasResponseValueOrConstraints) {
-    const name             = test.isAttribute ? test.attribute : test.event;
-    const response         = test[kResponseName];
-    const responseValue    = hasResponseValue ? { value : response.value } : null;
-    const constraintsValue = hasResponseConstraints ? { constraints : response.constraints } : null;
+  const defaultName = test[responseType];
 
-    response.values.push({ name, saveAs : response.saveAs, ...responseValue, ...constraintsValue });
-  }
+  test[kResponseName].forEach(response => {
+    const hasResponseError = (kResponseErrorName in response);
 
-  delete test[kResponseName].value;
+    const defaultResponseError = 0;
+    setDefault(response, kResponseErrorName, defaultResponseError);
+    ensureValidError(response, kResponseErrorName);
+
+    const values = response[kValuesName];
+    values.forEach(expectedValue => {
+      const hasResponseValue       = 'value' in expectedValue;
+      const hasResponseConstraints = (kConstraintsName in expectedValue) && !!Object.keys(expectedValue.constraints).length;
+      const hasResponseSaveAs      = (kSaveAsName in expectedValue);
+
+      if (test.isWriteAttribute || (useSynthesizeWaitForReport && test.isSubscribe)) {
+        if (hasResponseValue || hasResponseConstraints) {
+          const errorStr = 'Test has a "value" or a "constraints" defined.';
+          throwError(test, errorStr);
+        }
+      }
+
+      if (test.isCommand && !('name' in expectedValue)) {
+        const errorStr = 'Test value does not have a named argument.\n' +
+            '\n' +
+            'Command should explicitly use the response argument name. Example: \n' +
+            '- label: "Send Test Specific Command"\n' +
+            '  command: "testSpecific"\n' +
+            '  response: \n' +
+            '    values: \n' +
+            '      - name: "returnValue"\n' +
+            '      - value: 7\n';
+        throwError(test, errorStr);
+      }
+
+      setDefault(expectedValue, 'name', defaultName);
+    });
+
+    test.expectMultipleResponses = test[kResponseName].length > 1;
+
+    setDefault(response, kCommandName, test.command);
+    setDefault(response, responseType, test[responseType]);
+    setDefault(response, kClusterName, test.cluster);
+    setDefault(response, 'optional', test.optional || false);
+    setDefault(response, 'async', test.async || false);
+    setDefaultType(response);
+  });
 }
 
 function setDefaults(test, defaultConfig, useSynthesizeWaitForReport)
@@ -496,6 +534,26 @@ function chip_tests_pics(options)
   return templateUtil.collectBlocks(PICS.getAll(), options, this);
 }
 
+async function configureTestItem(item)
+{
+  if (item.isCommand) {
+    let command               = await assertCommandOrAttributeOrEvent(item);
+    item.commandObject        = command;
+    item.hasSpecificArguments = true;
+    item.hasSpecificResponse  = command.hasSpecificResponse || false;
+  } else if (item.isAttribute) {
+    let attr                  = await assertCommandOrAttributeOrEvent(item);
+    item.attributeObject      = attr;
+    item.hasSpecificArguments = item.isWriteAttribute || false;
+    item.hasSpecificResponse  = item.isReadAttribute || item.isSubscribeAttribute || item.isWaitForReport || false;
+  } else if (item.isEvent) {
+    let evt                   = await assertCommandOrAttributeOrEvent(item);
+    item.eventObject          = evt;
+    item.hasSpecificArguments = false;
+    item.hasSpecificResponse  = true;
+  }
+}
+
 async function chip_tests(list, options)
 {
   // Set a global on our items so assertCommandOrAttributeOrEvent can work.
@@ -508,22 +566,12 @@ async function chip_tests(list, options)
   tests         = await Promise.all(tests.map(async function(test) {
     test.tests = await Promise.all(test.tests.map(async function(item) {
       item.global = global;
-      if (item.isCommand) {
-        let command               = await assertCommandOrAttributeOrEvent(item);
-        item.commandObject        = command;
-        item.hasSpecificArguments = true;
-        item.hasSpecificResponse  = command.hasSpecificResponse;
-      } else if (item.isAttribute) {
-        let attr                  = await assertCommandOrAttributeOrEvent(item);
-        item.attributeObject      = attr;
-        item.hasSpecificArguments = item.isWriteAttribute;
-        item.hasSpecificResponse  = item.isReadAttribute || item.isSubscribeAttribute || item.isWaitForReport;
-      } else if (item.isEvent) {
-        let evt                   = await assertCommandOrAttributeOrEvent(item);
-        item.eventObject          = evt;
-        item.hasSpecificArguments = false;
-        item.hasSpecificResponse  = true;
+      await configureTestItem(item);
+
+      if (kResponseName in item) {
+        await Promise.all(item[kResponseName].map(response => configureTestItem(response)));
       }
+
       return item;
     }));
 
@@ -708,9 +756,14 @@ function chip_tests_item_parameters(options)
   return asBlocks.call(this, promise, options);
 }
 
+function chip_tests_item_responses(options)
+{
+  return templateUtil.collectBlocks(this[kResponseName], options, this);
+}
+
 function chip_tests_item_response_parameters(options)
 {
-  const responseValues = this.response.values.slice();
+  const responseValues = this.values.slice();
 
   const promise = assertCommandOrAttributeOrEvent(this).then(item => {
     if (this.isWriteAttribute) {
@@ -831,6 +884,7 @@ exports.chip_tests                          = chip_tests;
 exports.chip_tests_items                    = chip_tests_items;
 exports.chip_tests_item_has_list            = chip_tests_item_has_list;
 exports.chip_tests_item_parameters          = chip_tests_item_parameters;
+exports.chip_tests_item_responses           = chip_tests_item_responses;
 exports.chip_tests_item_response_parameters = chip_tests_item_response_parameters;
 exports.chip_tests_pics                     = chip_tests_pics;
 exports.chip_tests_config                   = chip_tests_config;

--- a/src/app/zap-templates/common/variables/Variables.js
+++ b/src/app/zap-templates/common/variables/Variables.js
@@ -109,17 +109,19 @@ async function extractVariablesFromTests(context, suite)
 {
   let variables = {};
   suite.tests.forEach(test => {
-    test.response.values.filter(value => value.saveAs).forEach(saveAsValue => {
-      const key = saveAsValue.saveAs;
-      if (key in variables) {
-        throwError(test, `Variable with name: ${key} is already registered.`);
-      }
+    test.response.forEach(response => {
+      response.values.filter(value => value.saveAs).forEach(saveAsValue => {
+        const key = saveAsValue.saveAs;
+        if (key in variables) {
+          throwError(test, `Variable with name: ${key} is already registered.`);
+        }
 
-      if (!test.isCommand && !test.isAttribute) {
-        throwError(test, `Variable support for step ${test} is not supported. Only commands and attributes are supported.`);
-      }
+        if (!test.isCommand && !test.isAttribute) {
+          throwError(test, `Variable support for step ${test} is not supported. Only commands and attributes are supported.`);
+        }
 
-      variables[key] = { test, name : saveAsValue.name };
+        variables[key] = { test, name : saveAsValue.name };
+      });
     });
   });
 

--- a/src/darwin/Framework/CHIP/templates/tests/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/tests/partials/test_cluster.zapt
@@ -3,11 +3,13 @@
 {{#if async}}
 bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase command}}_Fulfilled = false;
 {{/if}}
+{{#chip_tests_item_responses}}
 {{#chip_tests_item_response_parameters}}
 {{#if saveAs}}
 {{asObjectiveCType type ../cluster}} {{saveAs}};
 {{/if}}
 {{/chip_tests_item_response_parameters}}
+{{/chip_tests_item_responses}}
 
 {{~#*inline "subscribeDataCallback"}}
 test_{{parent.filename}}_{{attribute}}_Reported
@@ -86,7 +88,8 @@ ResponseHandler {{> subscribeDataCallback}} = nil;
     {{/chip_tests_item_parameters}}
     [cluster writeAttribute{{asUpperCamelCase attribute}}WithValue:{{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument{{/chip_tests_item_parameters}} completionHandler:^(NSError * _Nullable err) {
     {{/if}}
-        NSLog(@"{{label}} Error: %@", err);
+        {{#chip_tests_item_responses}}
+        NSLog(@"{{../label}} Error: %@", err);
 
         {{#if optional}}
         if (err.domain == MatterInteractionErrorDomain && err.code == MatterInteractionErrorCodeUnsupportedAttribute) {
@@ -95,8 +98,8 @@ ResponseHandler {{> subscribeDataCallback}} = nil;
         }
         {{/if}}
 
-        {{#if response.error}}
-          XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], {{response.error}});
+        {{#if error}}
+          XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], {{error}});
           [expectation fulfill];
         {{else}}
         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
@@ -211,7 +214,7 @@ ResponseHandler {{> subscribeDataCallback}} = nil;
         {{#unless async}}
         [expectation fulfill];
         {{else}}
-        testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase command}}_Fulfilled = true;
+        testSendCluster{{parent.filename}}_{{asTestIndex ../index}}_{{asUpperCamelCase command}}_Fulfilled = true;
         {{/unless}}
         {{else}}
           {{! We're a subscription }}
@@ -222,6 +225,7 @@ ResponseHandler {{> subscribeDataCallback}} = nil;
           }
         {{/unless}}
         {{/if}}
+        {{/chip_tests_item_responses}}
     }{{#unless isWaitForReport}}]{{/unless}};
 
 {{/if}}


### PR DESCRIPTION
#### Problem

There is no YAML test for events.

#### Change overview
 * Add `TestEvents.yaml`
 * Update the YAML backend so it can supports multiple responses

Unrelated cleanup: 
 * Removed `if response.errorWrongValue` case in the darwin template has it is unused now
 * Replace `DoTestStep(mTestIndex++);` by `auto err = DoTestStep(mTestIndex++);` as the returned `CHIP_ERROR` was ignored...

#### Testing
`./scripts/tests/run_test_suite.py --chip-tool out/debug/standalone/chip-tool --target TestEvents --log-level debug run --iterations 1 --all-clusters-app out/debug/standalone/chip-all-clusters-app --lock-app out/debug/standalone/chip-lock-app --tv-app out/debug/standalone/chip-tv-app`