### PR TITLE
Renaming Status Enum in xml and regening

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -661,7 +661,7 @@ server cluster ColorControl = 768 {
 }
 
 server cluster ContentLauncher = 1290 {
-  enum ContentLauncherStatusEnum : ENUM8 {
+  enum ContentLaunchStatusEnum : ENUM8 {
     kSuccess = 0;
     kUrlNotAvailable = 1;
     kAuthFailed = 2;

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -128,7 +128,7 @@ server cluster ApplicationBasic = 1293 {
 }
 
 server cluster ApplicationLauncher = 1292 {
-  enum StatusEnum : ENUM8 {
+  enum ApplicationLauncherStatusEnum : ENUM8 {
     kSuccess = 0;
     kAppNotAvailable = 1;
     kSystemBusy = 2;
@@ -339,14 +339,14 @@ server cluster BridgedActions = 37 {
 }
 
 server cluster Channel = 1284 {
-  enum LineupInfoTypeEnum : ENUM8 {
-    kMso = 0;
-  }
-
-  enum StatusEnum : ENUM8 {
+  enum ChannelStatusEnum : ENUM8 {
     kSuccess = 0;
     kMultipleMatches = 1;
     kNoMatches = 2;
+  }
+
+  enum LineupInfoTypeEnum : ENUM8 {
+    kMso = 0;
   }
 
   bitmap ChannelFeature : BITMAP32 {
@@ -661,6 +661,12 @@ server cluster ColorControl = 768 {
 }
 
 server cluster ContentLauncher = 1290 {
+  enum ContentLauncherStatusEnum : ENUM8 {
+    kSuccess = 0;
+    kUrlNotAvailable = 1;
+    kAuthFailed = 2;
+  }
+
   enum MetricTypeEnum : ENUM8 {
     kPixels = 0;
     kPercentage = 1;
@@ -680,12 +686,6 @@ server cluster ContentLauncher = 1290 {
     kSport = 10;
     kSportsTeam = 11;
     kType = 12;
-  }
-
-  enum StatusEnum : ENUM8 {
-    kSuccess = 0;
-    kUrlNotAvailable = 1;
-    kAuthFailed = 2;
   }
 
   bitmap ContentLauncherFeature : BITMAP32 {
@@ -1910,7 +1910,7 @@ server cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum StatusEnum : ENUM8 {
+  enum KeypadInputStatusEnum : ENUM8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;
@@ -2057,20 +2057,20 @@ server cluster MediaInput = 1287 {
 }
 
 server cluster MediaPlayback = 1286 {
-  enum PlaybackStateEnum : ENUM8 {
-    kPlaying = 0;
-    kPaused = 1;
-    kNotPlaying = 2;
-    kBuffering = 3;
-  }
-
-  enum StatusEnum : ENUM8 {
+  enum MediaPlaybackStatusEnum : ENUM8 {
     kSuccess = 0;
     kInvalidStateForCommand = 1;
     kNotAllowed = 2;
     kNotActive = 3;
     kSpeedOutOfRange = 4;
     kSeekOutOfRange = 5;
+  }
+
+  enum PlaybackStateEnum : ENUM8 {
+    kPlaying = 0;
+    kPaused = 1;
+    kNotPlaying = 2;
+    kBuffering = 3;
   }
 
   readonly attribute PlaybackStateEnum currentState = 0;
@@ -2925,7 +2925,7 @@ server cluster Switch = 59 {
 }
 
 server cluster TargetNavigator = 1285 {
-  enum StatusEnum : ENUM8 {
+  enum TargetNavigatorStatusEnum : ENUM8 {
     kSuccess = 0;
     kTargetNotFound = 1;
     kNotAllowed = 2;

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -327,6 +327,12 @@ server cluster ColorControl = 768 {
 }
 
 client cluster ContentLauncher = 1290 {
+  enum ContentLauncherStatusEnum : ENUM8 {
+    kSuccess = 0;
+    kUrlNotAvailable = 1;
+    kAuthFailed = 2;
+  }
+
   enum MetricTypeEnum : ENUM8 {
     kPixels = 0;
     kPercentage = 1;
@@ -346,12 +352,6 @@ client cluster ContentLauncher = 1290 {
     kSport = 10;
     kSportsTeam = 11;
     kType = 12;
-  }
-
-  enum StatusEnum : ENUM8 {
-    kSuccess = 0;
-    kUrlNotAvailable = 1;
-    kAuthFailed = 2;
   }
 
   bitmap ContentLauncherFeature : BITMAP32 {
@@ -420,7 +420,7 @@ client cluster ContentLauncher = 1290 {
   }
 
   response struct LaunchResponse = 2 {
-    StatusEnum status = 0;
+    ContentLauncherStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 
@@ -429,6 +429,12 @@ client cluster ContentLauncher = 1290 {
 }
 
 server cluster ContentLauncher = 1290 {
+  enum ContentLauncherStatusEnum : ENUM8 {
+    kSuccess = 0;
+    kUrlNotAvailable = 1;
+    kAuthFailed = 2;
+  }
+
   enum MetricTypeEnum : ENUM8 {
     kPixels = 0;
     kPercentage = 1;
@@ -448,12 +454,6 @@ server cluster ContentLauncher = 1290 {
     kSport = 10;
     kSportsTeam = 11;
     kType = 12;
-  }
-
-  enum StatusEnum : ENUM8 {
-    kSuccess = 0;
-    kUrlNotAvailable = 1;
-    kAuthFailed = 2;
   }
 
   bitmap ContentLauncherFeature : BITMAP32 {
@@ -522,7 +522,7 @@ server cluster ContentLauncher = 1290 {
   }
 
   response struct LaunchResponse = 2 {
-    StatusEnum status = 0;
+    ContentLauncherStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 
@@ -976,7 +976,7 @@ client cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum StatusEnum : ENUM8 {
+  enum KeypadInputStatusEnum : ENUM8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;
@@ -998,7 +998,7 @@ client cluster KeypadInput = 1289 {
   }
 
   response struct SendKeyResponse = 1 {
-    StatusEnum status = 0;
+    KeypadInputStatusEnum status = 0;
   }
 
   command SendKey(SendKeyRequest): SendKeyResponse = 0;
@@ -1094,7 +1094,7 @@ server cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum StatusEnum : ENUM8 {
+  enum KeypadInputStatusEnum : ENUM8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;
@@ -1116,7 +1116,7 @@ server cluster KeypadInput = 1289 {
   }
 
   response struct SendKeyResponse = 1 {
-    StatusEnum status = 0;
+    KeypadInputStatusEnum status = 0;
   }
 
   command SendKey(SendKeyRequest): SendKeyResponse = 0;
@@ -2148,7 +2148,7 @@ server cluster Switch = 59 {
 }
 
 client cluster TargetNavigator = 1285 {
-  enum StatusEnum : ENUM8 {
+  enum TargetNavigatorStatusEnum : ENUM8 {
     kSuccess = 0;
     kTargetNotFound = 1;
     kNotAllowed = 2;
@@ -2172,7 +2172,7 @@ client cluster TargetNavigator = 1285 {
   }
 
   response struct NavigateTargetResponse = 1 {
-    StatusEnum status = 0;
+    TargetNavigatorStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 
@@ -2180,7 +2180,7 @@ client cluster TargetNavigator = 1285 {
 }
 
 server cluster TargetNavigator = 1285 {
-  enum StatusEnum : ENUM8 {
+  enum TargetNavigatorStatusEnum : ENUM8 {
     kSuccess = 0;
     kTargetNotFound = 1;
     kNotAllowed = 2;
@@ -2204,7 +2204,7 @@ server cluster TargetNavigator = 1285 {
   }
 
   response struct NavigateTargetResponse = 1 {
-    StatusEnum status = 0;
+    TargetNavigatorStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -327,7 +327,7 @@ server cluster ColorControl = 768 {
 }
 
 client cluster ContentLauncher = 1290 {
-  enum ContentLauncherStatusEnum : ENUM8 {
+  enum ContentLaunchStatusEnum : ENUM8 {
     kSuccess = 0;
     kUrlNotAvailable = 1;
     kAuthFailed = 2;
@@ -420,7 +420,7 @@ client cluster ContentLauncher = 1290 {
   }
 
   response struct LaunchResponse = 2 {
-    ContentLauncherStatusEnum status = 0;
+    ContentLaunchStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 
@@ -429,7 +429,7 @@ client cluster ContentLauncher = 1290 {
 }
 
 server cluster ContentLauncher = 1290 {
-  enum ContentLauncherStatusEnum : ENUM8 {
+  enum ContentLaunchStatusEnum : ENUM8 {
     kSuccess = 0;
     kUrlNotAvailable = 1;
     kAuthFailed = 2;
@@ -522,7 +522,7 @@ server cluster ContentLauncher = 1290 {
   }
 
   response struct LaunchResponse = 2 {
-    ContentLauncherStatusEnum status = 0;
+    ContentLaunchStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -327,6 +327,12 @@ server cluster ColorControl = 768 {
 }
 
 client cluster ContentLauncher = 1290 {
+  enum ContentLauncherStatusEnum : ENUM8 {
+    kSuccess = 0;
+    kUrlNotAvailable = 1;
+    kAuthFailed = 2;
+  }
+
   enum MetricTypeEnum : ENUM8 {
     kPixels = 0;
     kPercentage = 1;
@@ -346,12 +352,6 @@ client cluster ContentLauncher = 1290 {
     kSport = 10;
     kSportsTeam = 11;
     kType = 12;
-  }
-
-  enum StatusEnum : ENUM8 {
-    kSuccess = 0;
-    kUrlNotAvailable = 1;
-    kAuthFailed = 2;
   }
 
   bitmap ContentLauncherFeature : BITMAP32 {
@@ -420,7 +420,7 @@ client cluster ContentLauncher = 1290 {
   }
 
   response struct LaunchResponse = 2 {
-    StatusEnum status = 0;
+    ContentLauncherStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 
@@ -429,6 +429,12 @@ client cluster ContentLauncher = 1290 {
 }
 
 server cluster ContentLauncher = 1290 {
+  enum ContentLauncherStatusEnum : ENUM8 {
+    kSuccess = 0;
+    kUrlNotAvailable = 1;
+    kAuthFailed = 2;
+  }
+
   enum MetricTypeEnum : ENUM8 {
     kPixels = 0;
     kPercentage = 1;
@@ -448,12 +454,6 @@ server cluster ContentLauncher = 1290 {
     kSport = 10;
     kSportsTeam = 11;
     kType = 12;
-  }
-
-  enum StatusEnum : ENUM8 {
-    kSuccess = 0;
-    kUrlNotAvailable = 1;
-    kAuthFailed = 2;
   }
 
   bitmap ContentLauncherFeature : BITMAP32 {
@@ -522,7 +522,7 @@ server cluster ContentLauncher = 1290 {
   }
 
   response struct LaunchResponse = 2 {
-    StatusEnum status = 0;
+    ContentLauncherStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 
@@ -976,7 +976,7 @@ client cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum StatusEnum : ENUM8 {
+  enum KeypadInputStatusEnum : ENUM8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;
@@ -998,7 +998,7 @@ client cluster KeypadInput = 1289 {
   }
 
   response struct SendKeyResponse = 1 {
-    StatusEnum status = 0;
+    KeypadInputStatusEnum status = 0;
   }
 
   command SendKey(SendKeyRequest): SendKeyResponse = 0;
@@ -1094,7 +1094,7 @@ server cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum StatusEnum : ENUM8 {
+  enum KeypadInputStatusEnum : ENUM8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;
@@ -1116,7 +1116,7 @@ server cluster KeypadInput = 1289 {
   }
 
   response struct SendKeyResponse = 1 {
-    StatusEnum status = 0;
+    KeypadInputStatusEnum status = 0;
   }
 
   command SendKey(SendKeyRequest): SendKeyResponse = 0;
@@ -2148,7 +2148,7 @@ server cluster Switch = 59 {
 }
 
 client cluster TargetNavigator = 1285 {
-  enum StatusEnum : ENUM8 {
+  enum TargetNavigatorStatusEnum : ENUM8 {
     kSuccess = 0;
     kTargetNotFound = 1;
     kNotAllowed = 2;
@@ -2172,7 +2172,7 @@ client cluster TargetNavigator = 1285 {
   }
 
   response struct NavigateTargetResponse = 1 {
-    StatusEnum status = 0;
+    TargetNavigatorStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 
@@ -2180,7 +2180,7 @@ client cluster TargetNavigator = 1285 {
 }
 
 server cluster TargetNavigator = 1285 {
-  enum StatusEnum : ENUM8 {
+  enum TargetNavigatorStatusEnum : ENUM8 {
     kSuccess = 0;
     kTargetNotFound = 1;
     kNotAllowed = 2;
@@ -2204,7 +2204,7 @@ server cluster TargetNavigator = 1285 {
   }
 
   response struct NavigateTargetResponse = 1 {
-    StatusEnum status = 0;
+    TargetNavigatorStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -327,7 +327,7 @@ server cluster ColorControl = 768 {
 }
 
 client cluster ContentLauncher = 1290 {
-  enum ContentLauncherStatusEnum : ENUM8 {
+  enum ContentLaunchStatusEnum : ENUM8 {
     kSuccess = 0;
     kUrlNotAvailable = 1;
     kAuthFailed = 2;
@@ -420,7 +420,7 @@ client cluster ContentLauncher = 1290 {
   }
 
   response struct LaunchResponse = 2 {
-    ContentLauncherStatusEnum status = 0;
+    ContentLaunchStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 
@@ -429,7 +429,7 @@ client cluster ContentLauncher = 1290 {
 }
 
 server cluster ContentLauncher = 1290 {
-  enum ContentLauncherStatusEnum : ENUM8 {
+  enum ContentLaunchStatusEnum : ENUM8 {
     kSuccess = 0;
     kUrlNotAvailable = 1;
     kAuthFailed = 2;
@@ -522,7 +522,7 @@ server cluster ContentLauncher = 1290 {
   }
 
   response struct LaunchResponse = 2 {
-    ContentLauncherStatusEnum status = 0;
+    ContentLaunchStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 

--- a/examples/tv-app/android/include/application-launcher/ApplicationLauncherManager.cpp
+++ b/examples/tv-app/android/include/application-launcher/ApplicationLauncherManager.cpp
@@ -45,7 +45,7 @@ void ApplicationLauncherManager::HandleLaunchApp(CommandResponseHelper<LauncherR
     LauncherResponseType response;
     const char * buf = "data";
     response.data    = ByteSpan(from_const_char(buf), strlen(buf));
-    response.status  = StatusEnum::kSuccess;
+    response.status  = ApplicationLauncherStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -58,7 +58,7 @@ void ApplicationLauncherManager::HandleStopApp(CommandResponseHelper<LauncherRes
     LauncherResponseType response;
     const char * buf = "data";
     response.data    = ByteSpan(from_const_char(buf), strlen(buf));
-    response.status  = StatusEnum::kSuccess;
+    response.status  = ApplicationLauncherStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -71,6 +71,6 @@ void ApplicationLauncherManager::HandleHideApp(CommandResponseHelper<LauncherRes
     LauncherResponseType response;
     const char * buf = "data";
     response.data    = ByteSpan(from_const_char(buf), strlen(buf));
-    response.status  = StatusEnum::kSuccess;
+    response.status  = ApplicationLauncherStatusEnum::kSuccess;
     helper.Success(response);
 }

--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
@@ -40,7 +40,7 @@ void AppContentLauncherManager::HandleLaunchContent(CommandResponseHelper<Launch
     LaunchResponseType response;
     // TODO: Insert code here
     response.data   = chip::MakeOptional(CharSpan::fromCharString("exampleData"));
-    response.status = ContentLauncher::StatusEnum::kSuccess;
+    response.status = ContentLauncher::ContentLaunchStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -55,7 +55,7 @@ void AppContentLauncherManager::HandleLaunchUrl(CommandResponseHelper<LaunchResp
     // TODO: Insert code here
     LaunchResponseType response;
     response.data   = chip::MakeOptional(CharSpan::fromCharString("exampleData"));
-    response.status = ContentLauncher::StatusEnum::kSuccess;
+    response.status = ContentLauncher::ContentLaunchStatusEnum::kSuccess;
     helper.Success(response);
 }
 

--- a/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
@@ -56,13 +56,13 @@ void TargetNavigatorManager::HandleNavigateTarget(CommandResponseHelper<Navigate
     if (target == kNoCurrentTarget || target > mTargets.size())
     {
         response.data   = chip::MakeOptional(CharSpan::fromCharString("error"));
-        response.status = StatusEnum::kTargetNotFound;
+        response.status = TargetNavigatorStatusEnum::kTargetNotFound;
         helper.Success(response);
         return;
     }
     mCurrentTarget = static_cast<uint8_t>(target);
 
     response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
-    response.status = StatusEnum::kSuccess;
+    response.status = TargetNavigatorStatusEnum::kSuccess;
     helper.Success(response);
 }

--- a/examples/tv-app/android/java/ChannelManager.cpp
+++ b/examples/tv-app/android/java/ChannelManager.cpp
@@ -284,7 +284,7 @@ void ChannelManager::HandleChangeChannel(CommandResponseHelper<ChangeChannelResp
 
         jfieldID getStatusField = env->GetFieldID(channelClass, "status", "I");
         jint jstatus            = env->GetIntField(channelObject, getStatusField);
-        response.status         = static_cast<app::Clusters::Channel::StatusEnum>(jstatus);
+        response.status         = static_cast<app::Clusters::Channel::ChannelStatusEnum>(jstatus);
 
         jfieldID getNameField = env->GetFieldID(channelClass, "name", "Ljava/lang/String;");
         jstring jname         = static_cast<jstring>(env->GetObjectField(channelObject, getNameField));

--- a/examples/tv-app/android/java/ContentLauncherManager.cpp
+++ b/examples/tv-app/android/java/ContentLauncherManager.cpp
@@ -85,7 +85,7 @@ void ContentLauncherManager::HandleLaunchContent(CommandResponseHelper<LaunchRes
         jstring jdataStr = (jstring) env->GetObjectField(resp, dataFid);
         JniUtfString dataStr(env, jdataStr);
 
-        response.status = static_cast<chip::app::Clusters::ContentLauncher::StatusEnum>(status);
+        response.status = static_cast<chip::app::Clusters::ContentLauncher::ContentLaunchStatusEnum>(status);
         response.data   = chip::Optional<CharSpan>(dataStr.charSpan());
 
         err = helper.Success(response);
@@ -140,7 +140,7 @@ void ContentLauncherManager::HandleLaunchUrl(CommandResponseHelper<LaunchRespons
         jstring jdataStr = (jstring) env->GetObjectField(resp, dataFid);
         JniUtfString dataStr(env, jdataStr);
 
-        response.status = static_cast<chip::app::Clusters::ContentLauncher::StatusEnum>(status);
+        response.status = static_cast<chip::app::Clusters::ContentLauncher::ContentLaunchStatusEnum>(status);
         response.data   = chip::Optional<CharSpan>(dataStr.charSpan());
 
         err = helper.Success(response);

--- a/examples/tv-app/android/java/KeypadInputManager.cpp
+++ b/examples/tv-app/android/java/KeypadInputManager.cpp
@@ -59,11 +59,11 @@ void KeypadInputManager::HandleSendKey(CommandResponseHelper<SendKeyResponseType
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kInvalidKeyInCurrentState;
+        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kInvalidKeyInCurrentState;
     }
     else
     {
-        response.status = static_cast<chip::app::Clusters::KeypadInput::StatusEnum>(ret);
+        response.status = static_cast<chip::app::Clusters::KeypadInput::KeypadInputStatusEnum>(ret);
     }
     helper.Success(response);
 }

--- a/examples/tv-app/android/java/MediaPlaybackManager.cpp
+++ b/examples/tv-app/android/java/MediaPlaybackManager.cpp
@@ -243,14 +243,14 @@ Commands::PlaybackResponse::Type MediaPlaybackManager::HandleMediaRequest(MediaP
         ChipLogError(AppServer, "Java exception in MediaPlaybackManager::Request %d", mediaPlaybackRequest);
         env->ExceptionDescribe();
         env->ExceptionClear();
-        response.status = StatusEnum::kInvalidStateForCommand;
+        response.status = MediaPlaybackStatusEnum::kInvalidStateForCommand;
     }
-    response.status = static_cast<StatusEnum>(ret);
+    response.status = static_cast<MediaPlaybackStatusEnum>(ret);
 
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        response.status = StatusEnum::kInvalidStateForCommand;
+        response.status = MediaPlaybackStatusEnum::kInvalidStateForCommand;
         ChipLogError(Zcl, "MediaPlaybackManager::HandleMediaRequest status error: %s", err.AsString());
     }
 

--- a/examples/tv-app/linux/include/application-launcher/ApplicationLauncherManager.cpp
+++ b/examples/tv-app/linux/include/application-launcher/ApplicationLauncherManager.cpp
@@ -45,7 +45,7 @@ void ApplicationLauncherManager::HandleLaunchApp(CommandResponseHelper<LauncherR
     LauncherResponseType response;
     const char * buf = "data";
     response.data    = ByteSpan(from_const_char(buf), strlen(buf));
-    response.status  = StatusEnum::kSuccess;
+    response.status  = ApplicationLauncherStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -58,7 +58,7 @@ void ApplicationLauncherManager::HandleStopApp(CommandResponseHelper<LauncherRes
     LauncherResponseType response;
     const char * buf = "data";
     response.data    = ByteSpan(from_const_char(buf), strlen(buf));
-    response.status  = StatusEnum::kSuccess;
+    response.status  = ApplicationLauncherStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -71,6 +71,6 @@ void ApplicationLauncherManager::HandleHideApp(CommandResponseHelper<LauncherRes
     LauncherResponseType response;
     const char * buf = "data";
     response.data    = ByteSpan(from_const_char(buf), strlen(buf));
-    response.status  = StatusEnum::kSuccess;
+    response.status  = ApplicationLauncherStatusEnum::kSuccess;
     helper.Success(response);
 }

--- a/examples/tv-app/linux/include/channel/ChannelManager.cpp
+++ b/examples/tv-app/linux/include/channel/ChannelManager.cpp
@@ -122,18 +122,18 @@ void ChannelManager::HandleChangeChannel(CommandResponseHelper<ChangeChannelResp
     // Error: Found multiple matches
     if (matchedChannels.size() > 1)
     {
-        response.status = chip::app::Clusters::Channel::StatusEnum::kMultipleMatches;
+        response.status = chip::app::Clusters::Channel::ChannelStatusEnum::kMultipleMatches;
         helper.Success(response);
     }
     else if (matchedChannels.size() == 0)
     {
         // Error: Found no match
-        response.status = chip::app::Clusters::Channel::StatusEnum::kNoMatches;
+        response.status = chip::app::Clusters::Channel::ChannelStatusEnum::kNoMatches;
         helper.Success(response);
     }
     else
     {
-        response.status      = chip::app::Clusters::Channel::StatusEnum::kSuccess;
+        response.status      = chip::app::Clusters::Channel::ChannelStatusEnum::kSuccess;
         response.data        = chip::MakeOptional(CharSpan::fromCharString("data response"));
         mCurrentChannel      = matchedChannels[0];
         mCurrentChannelIndex = index;

--- a/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
+++ b/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
@@ -40,7 +40,7 @@ void ContentLauncherManager::HandleLaunchContent(CommandResponseHelper<LaunchRes
     LaunchResponseType response;
     // TODO: Insert code here
     response.data   = chip::MakeOptional(CharSpan::fromCharString("exampleData"));
-    response.status = ContentLauncher::StatusEnum::kSuccess;
+    response.status = ContentLauncher::ContentLaunchStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -55,7 +55,7 @@ void ContentLauncherManager::HandleLaunchUrl(CommandResponseHelper<LaunchRespons
     // TODO: Insert code here
     LaunchResponseType response;
     response.data   = chip::MakeOptional(CharSpan::fromCharString("exampleData"));
-    response.status = ContentLauncher::StatusEnum::kSuccess;
+    response.status = ContentLauncher::ContentLaunchStatusEnum::kSuccess;
     helper.Success(response);
 }
 

--- a/examples/tv-app/linux/include/keypad-input/KeypadInputManager.cpp
+++ b/examples/tv-app/linux/include/keypad-input/KeypadInputManager.cpp
@@ -29,31 +29,31 @@ void KeypadInputManager::HandleSendKey(CommandResponseHelper<SendKeyResponseType
     switch (keycCode)
     {
     case CecKeyCodeType::kUp:
-        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kDown:
-        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kLeft:
-        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kRight:
-        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kSelect:
-        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kBackward:
-        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kExit:
-        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
         break;
     case CecKeyCodeType::kRootMenu:
-        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kSuccess;
+        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kSuccess;
         break;
     default:
-        response.status = chip::app::Clusters::KeypadInput::StatusEnum::kUnsupportedKey;
+        response.status = chip::app::Clusters::KeypadInput::KeypadInputStatusEnum::kUnsupportedKey;
     }
 
     helper.Success(response);

--- a/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
+++ b/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
@@ -64,7 +64,7 @@ void MediaPlaybackManager::HandlePlay(CommandResponseHelper<Commands::PlaybackRe
     mCurrentState = PlaybackStateEnum::kPlaying;
     Commands::PlaybackResponse::Type response;
     response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
-    response.status = StatusEnum::kSuccess;
+    response.status = MediaPlaybackStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -74,7 +74,7 @@ void MediaPlaybackManager::HandlePause(CommandResponseHelper<Commands::PlaybackR
     mCurrentState = PlaybackStateEnum::kPaused;
     Commands::PlaybackResponse::Type response;
     response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
-    response.status = StatusEnum::kSuccess;
+    response.status = MediaPlaybackStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -84,7 +84,7 @@ void MediaPlaybackManager::HandleStop(CommandResponseHelper<Commands::PlaybackRe
     mCurrentState = PlaybackStateEnum::kNotPlaying;
     Commands::PlaybackResponse::Type response;
     response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
-    response.status = StatusEnum::kSuccess;
+    response.status = MediaPlaybackStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -93,7 +93,7 @@ void MediaPlaybackManager::HandleFastForward(CommandResponseHelper<Commands::Pla
     // TODO: Insert code here
     Commands::PlaybackResponse::Type response;
     response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
-    response.status = StatusEnum::kSuccess;
+    response.status = MediaPlaybackStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -103,7 +103,7 @@ void MediaPlaybackManager::HandlePrevious(CommandResponseHelper<Commands::Playba
     mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(0) };
     Commands::PlaybackResponse::Type response;
     response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
-    response.status = StatusEnum::kSuccess;
+    response.status = MediaPlaybackStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -113,7 +113,7 @@ void MediaPlaybackManager::HandleRewind(CommandResponseHelper<Commands::Playback
     mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(0) };
     Commands::PlaybackResponse::Type response;
     response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
-    response.status = StatusEnum::kSuccess;
+    response.status = MediaPlaybackStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -126,7 +126,7 @@ void MediaPlaybackManager::HandleSkipBackward(CommandResponseHelper<Commands::Pl
 
     Commands::PlaybackResponse::Type response;
     response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
-    response.status = StatusEnum::kSuccess;
+    response.status = MediaPlaybackStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -140,7 +140,7 @@ void MediaPlaybackManager::HandleSkipForward(CommandResponseHelper<Commands::Pla
 
     Commands::PlaybackResponse::Type response;
     response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
-    response.status = StatusEnum::kSuccess;
+    response.status = MediaPlaybackStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -152,7 +152,7 @@ void MediaPlaybackManager::HandleSeek(CommandResponseHelper<Commands::PlaybackRe
     {
         Commands::PlaybackResponse::Type response;
         response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
-        response.status = StatusEnum::kSeekOutOfRange;
+        response.status = MediaPlaybackStatusEnum::kSeekOutOfRange;
         helper.Success(response);
     }
     else
@@ -161,7 +161,7 @@ void MediaPlaybackManager::HandleSeek(CommandResponseHelper<Commands::PlaybackRe
 
         Commands::PlaybackResponse::Type response;
         response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
-        response.status = StatusEnum::kSuccess;
+        response.status = MediaPlaybackStatusEnum::kSuccess;
         helper.Success(response);
     }
 }
@@ -171,7 +171,7 @@ void MediaPlaybackManager::HandleNext(CommandResponseHelper<Commands::PlaybackRe
     // TODO: Insert code here
     Commands::PlaybackResponse::Type response;
     response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
-    response.status = StatusEnum::kSuccess;
+    response.status = MediaPlaybackStatusEnum::kSuccess;
     helper.Success(response);
 }
 
@@ -181,6 +181,6 @@ void MediaPlaybackManager::HandleStartOver(CommandResponseHelper<Commands::Playb
     mPlaybackPosition = { 0, chip::app::DataModel::Nullable<uint64_t>(0) };
     Commands::PlaybackResponse::Type response;
     response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
-    response.status = StatusEnum::kSuccess;
+    response.status = MediaPlaybackStatusEnum::kSuccess;
     helper.Success(response);
 }

--- a/examples/tv-app/linux/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/linux/include/target-navigator/TargetNavigatorManager.cpp
@@ -56,13 +56,13 @@ void TargetNavigatorManager::HandleNavigateTarget(CommandResponseHelper<Navigate
     if (target == kNoCurrentTarget || target > mTargets.size())
     {
         response.data   = chip::MakeOptional(CharSpan::fromCharString("error"));
-        response.status = StatusEnum::kTargetNotFound;
+        response.status = TargetNavigatorStatusEnum::kTargetNotFound;
         helper.Success(response);
         return;
     }
     mCurrentTarget = static_cast<uint8_t>(target);
 
     response.data   = chip::MakeOptional(CharSpan::fromCharString("data response"));
-    response.status = StatusEnum::kSuccess;
+    response.status = TargetNavigatorStatusEnum::kSuccess;
     helper.Success(response);
 }

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -152,7 +152,7 @@ server cluster ApplicationBasic = 1293 {
 }
 
 server cluster ApplicationLauncher = 1292 {
-  enum StatusEnum : ENUM8 {
+  enum ApplicationLauncherStatusEnum : ENUM8 {
     kSuccess = 0;
     kAppNotAvailable = 1;
     kSystemBusy = 2;
@@ -191,7 +191,7 @@ server cluster ApplicationLauncher = 1292 {
   }
 
   response struct LauncherResponse = 3 {
-    StatusEnum status = 0;
+    ApplicationLauncherStatusEnum status = 0;
     OCTET_STRING data = 1;
   }
 
@@ -308,14 +308,14 @@ server cluster Binding = 30 {
 }
 
 server cluster Channel = 1284 {
-  enum LineupInfoTypeEnum : ENUM8 {
-    kMso = 0;
-  }
-
-  enum StatusEnum : ENUM8 {
+  enum ChannelStatusEnum : ENUM8 {
     kSuccess = 0;
     kMultipleMatches = 1;
     kNoMatches = 2;
+  }
+
+  enum LineupInfoTypeEnum : ENUM8 {
+    kMso = 0;
   }
 
   bitmap ChannelFeature : BITMAP32 {
@@ -358,7 +358,7 @@ server cluster Channel = 1284 {
   }
 
   response struct ChangeChannelResponse = 1 {
-    StatusEnum status = 0;
+    ChannelStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 
@@ -368,6 +368,12 @@ server cluster Channel = 1284 {
 }
 
 server cluster ContentLauncher = 1290 {
+  enum ContentLauncherStatusEnum : ENUM8 {
+    kSuccess = 0;
+    kUrlNotAvailable = 1;
+    kAuthFailed = 2;
+  }
+
   enum MetricTypeEnum : ENUM8 {
     kPixels = 0;
     kPercentage = 1;
@@ -387,12 +393,6 @@ server cluster ContentLauncher = 1290 {
     kSport = 10;
     kSportsTeam = 11;
     kType = 12;
-  }
-
-  enum StatusEnum : ENUM8 {
-    kSuccess = 0;
-    kUrlNotAvailable = 1;
-    kAuthFailed = 2;
   }
 
   bitmap ContentLauncherFeature : BITMAP32 {
@@ -459,7 +459,7 @@ server cluster ContentLauncher = 1290 {
   }
 
   response struct LaunchResponse = 2 {
-    StatusEnum status = 0;
+    ContentLauncherStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 
@@ -863,7 +863,7 @@ server cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum StatusEnum : ENUM8 {
+  enum KeypadInputStatusEnum : ENUM8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;
@@ -1032,20 +1032,20 @@ server cluster MediaInput = 1287 {
 }
 
 server cluster MediaPlayback = 1286 {
-  enum PlaybackStateEnum : ENUM8 {
-    kPlaying = 0;
-    kPaused = 1;
-    kNotPlaying = 2;
-    kBuffering = 3;
-  }
-
-  enum StatusEnum : ENUM8 {
+  enum MediaPlaybackStatusEnum : ENUM8 {
     kSuccess = 0;
     kInvalidStateForCommand = 1;
     kNotAllowed = 2;
     kNotActive = 3;
     kSpeedOutOfRange = 4;
     kSeekOutOfRange = 5;
+  }
+
+  enum PlaybackStateEnum : ENUM8 {
+    kPlaying = 0;
+    kPaused = 1;
+    kNotPlaying = 2;
+    kBuffering = 3;
   }
 
   struct PlaybackPosition {
@@ -1075,7 +1075,7 @@ server cluster MediaPlayback = 1286 {
   }
 
   response struct PlaybackResponse = 10 {
-    StatusEnum status = 0;
+    MediaPlaybackStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 
@@ -1699,7 +1699,7 @@ server cluster SoftwareDiagnostics = 52 {
 }
 
 server cluster TargetNavigator = 1285 {
-  enum StatusEnum : ENUM8 {
+  enum TargetNavigatorStatusEnum : ENUM8 {
     kSuccess = 0;
     kTargetNotFound = 1;
     kNotAllowed = 2;
@@ -1721,7 +1721,7 @@ server cluster TargetNavigator = 1285 {
   }
 
   response struct NavigateTargetResponse = 1 {
-    StatusEnum status = 0;
+    TargetNavigatorStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -368,7 +368,7 @@ server cluster Channel = 1284 {
 }
 
 server cluster ContentLauncher = 1290 {
-  enum ContentLauncherStatusEnum : ENUM8 {
+  enum ContentLaunchStatusEnum : ENUM8 {
     kSuccess = 0;
     kUrlNotAvailable = 1;
     kAuthFailed = 2;
@@ -459,7 +459,7 @@ server cluster ContentLauncher = 1290 {
   }
 
   response struct LaunchResponse = 2 {
-    ContentLauncherStatusEnum status = 0;
+    ContentLaunchStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -346,7 +346,7 @@ client cluster Channel = 1284 {
 }
 
 client cluster ContentLauncher = 1290 {
-  enum ContentLauncherStatusEnum : ENUM8 {
+  enum ContentLaunchStatusEnum : ENUM8 {
     kSuccess = 0;
     kUrlNotAvailable = 1;
     kAuthFailed = 2;

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -141,7 +141,7 @@ client cluster ApplicationBasic = 1293 {
 }
 
 client cluster ApplicationLauncher = 1292 {
-  enum StatusEnum : ENUM8 {
+  enum ApplicationLauncherStatusEnum : ENUM8 {
     kSuccess = 0;
     kAppNotAvailable = 1;
     kSystemBusy = 2;
@@ -292,14 +292,14 @@ server cluster Binding = 30 {
 }
 
 client cluster Channel = 1284 {
-  enum LineupInfoTypeEnum : ENUM8 {
-    kMso = 0;
-  }
-
-  enum StatusEnum : ENUM8 {
+  enum ChannelStatusEnum : ENUM8 {
     kSuccess = 0;
     kMultipleMatches = 1;
     kNoMatches = 2;
+  }
+
+  enum LineupInfoTypeEnum : ENUM8 {
+    kMso = 0;
   }
 
   bitmap ChannelFeature : BITMAP32 {
@@ -346,6 +346,12 @@ client cluster Channel = 1284 {
 }
 
 client cluster ContentLauncher = 1290 {
+  enum ContentLauncherStatusEnum : ENUM8 {
+    kSuccess = 0;
+    kUrlNotAvailable = 1;
+    kAuthFailed = 2;
+  }
+
   enum MetricTypeEnum : ENUM8 {
     kPixels = 0;
     kPercentage = 1;
@@ -365,12 +371,6 @@ client cluster ContentLauncher = 1290 {
     kSport = 10;
     kSportsTeam = 11;
     kType = 12;
-  }
-
-  enum StatusEnum : ENUM8 {
-    kSuccess = 0;
-    kUrlNotAvailable = 1;
-    kAuthFailed = 2;
   }
 
   bitmap ContentLauncherFeature : BITMAP32 {
@@ -950,7 +950,7 @@ client cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum StatusEnum : ENUM8 {
+  enum KeypadInputStatusEnum : ENUM8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;
@@ -1195,20 +1195,20 @@ client cluster MediaInput = 1287 {
 }
 
 client cluster MediaPlayback = 1286 {
-  enum PlaybackStateEnum : ENUM8 {
-    kPlaying = 0;
-    kPaused = 1;
-    kNotPlaying = 2;
-    kBuffering = 3;
-  }
-
-  enum StatusEnum : ENUM8 {
+  enum MediaPlaybackStatusEnum : ENUM8 {
     kSuccess = 0;
     kInvalidStateForCommand = 1;
     kNotAllowed = 2;
     kNotActive = 3;
     kSpeedOutOfRange = 4;
     kSeekOutOfRange = 5;
+  }
+
+  enum PlaybackStateEnum : ENUM8 {
+    kPlaying = 0;
+    kPaused = 1;
+    kNotPlaying = 2;
+    kBuffering = 3;
   }
 
   readonly attribute int16u clusterRevision = 65533;
@@ -1794,7 +1794,7 @@ server cluster Switch = 59 {
 }
 
 client cluster TargetNavigator = 1285 {
-  enum StatusEnum : ENUM8 {
+  enum TargetNavigatorStatusEnum : ENUM8 {
     kSuccess = 0;
     kTargetNotFound = 1;
     kNotAllowed = 2;

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -232,7 +232,7 @@ bool emberAfApplicationLauncherClusterLaunchAppCallback(app::CommandHandler * co
                 LauncherResponseType response;
                 const char * buf = "data";
                 response.data    = ByteSpan(from_const_char(buf), strlen(buf));
-                response.status  = StatusEnum::kAppNotAvailable;
+                response.status  = ApplicationLauncherStatusEnum::kAppNotAvailable;
                 responder.Success(response);
                 return true;
             }
@@ -313,7 +313,7 @@ bool emberAfApplicationLauncherClusterStopAppCallback(app::CommandHandler * comm
                 LauncherResponseType response;
                 const char * buf = "data";
                 response.data    = ByteSpan(from_const_char(buf), strlen(buf));
-                response.status  = StatusEnum::kAppNotAvailable;
+                response.status  = ApplicationLauncherStatusEnum::kAppNotAvailable;
                 responder.Success(response);
                 return true;
             }
@@ -396,7 +396,7 @@ bool emberAfApplicationLauncherClusterHideAppCallback(app::CommandHandler * comm
                 LauncherResponseType response;
                 const char * buf = "data";
                 response.data    = ByteSpan(from_const_char(buf), strlen(buf));
-                response.status  = StatusEnum::kAppNotAvailable;
+                response.status  = ApplicationLauncherStatusEnum::kAppNotAvailable;
                 responder.Success(response);
                 return true;
             }

--- a/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
@@ -46,7 +46,7 @@ limitations under the License.
 
     <command source="server" code="0x03" name="LauncherResponse" optional="false">
       <description>This command SHALL be generated in response to LaunchApp commands.</description>
-      <arg name="status" type="StatusEnum"/>
+      <arg name="status" type="ApplicationLauncherStatusEnum"/>
       <arg name="data"  type="OCTET_STRING"/>
     </command>
 
@@ -64,7 +64,7 @@ limitations under the License.
     <item name="applicationId" type="CHAR_STRING"/>
   </struct>
 
-  <enum name="StatusEnum" type="ENUM8">
+  <enum name="ApplicationLauncherStatusEnum" type="ENUM8">
     <cluster code="0x050c"/>
     <item name="Success" value="0x00"/>
     <item name="AppNotAvailable" value="0x01"/>

--- a/src/app/zap-templates/zcl/data-model/chip/channel-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/channel-cluster.xml
@@ -46,7 +46,7 @@ limitations under the License.
 
     <command source="server" code="0x01" name="ChangeChannelResponse" optional="false">
       <description>Upon receipt, this SHALL display the active status of the input list on screen.</description>
-      <arg name="status" type="StatusEnum"/>
+      <arg name="status" type="ChannelStatusEnum"/>
       <arg name="data"   type="CHAR_STRING" optional="true"/>
     </command>
 
@@ -74,7 +74,7 @@ limitations under the License.
     <item name="Mso" value="0x00"/>
   </enum>
 
-  <enum name="StatusEnum" type="ENUM8">
+  <enum name="ChannelStatusEnum" type="ENUM8">
     <cluster code="0x0504"/>
     <item name="Success" value="0x00"/>
     <item name="MultipleMatches" value="0x01"/>

--- a/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
@@ -44,7 +44,7 @@ limitations under the License.
 
     <command source="server" code="0x02" name="LaunchResponse" optional="false" disableDefaultResponse="true">
       <description>This command SHALL be generated in response to LaunchContent command.</description>
-      <arg name="status" type="ContentLauncherStatusEnum"/>
+      <arg name="status" type="ContentLaunchStatusEnum"/>
       <arg name="data" type="CHAR_STRING" optional="true"/>
     </command>
 
@@ -109,7 +109,7 @@ limitations under the License.
     <item name="type" value="0x0C"/>
   </enum>
 
-  <enum name="ContentLauncherStatusEnum" type="ENUM8">
+  <enum name="ContentLaunchStatusEnum" type="ENUM8">
     <cluster code="0x050a"/>
     <item name="success" value="0x00"/>
     <item name="urlNotAvailable" value="0x01"/>

--- a/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
@@ -44,7 +44,7 @@ limitations under the License.
 
     <command source="server" code="0x02" name="LaunchResponse" optional="false" disableDefaultResponse="true">
       <description>This command SHALL be generated in response to LaunchContent command.</description>
-      <arg name="status" type="StatusEnum"/>
+      <arg name="status" type="ContentLauncherStatusEnum"/>
       <arg name="data" type="CHAR_STRING" optional="true"/>
     </command>
 
@@ -109,7 +109,7 @@ limitations under the License.
     <item name="type" value="0x0C"/>
   </enum>
 
-  <enum name="StatusEnum" type="ENUM8">
+  <enum name="ContentLauncherStatusEnum" type="ENUM8">
     <cluster code="0x050a"/>
     <item name="success" value="0x00"/>
     <item name="urlNotAvailable" value="0x01"/>

--- a/src/app/zap-templates/zcl/data-model/chip/keypad-input-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/keypad-input-cluster.xml
@@ -32,12 +32,12 @@ limitations under the License.
 
     <command source="server" code="0x01" name="SendKeyResponse" optional="false">
       <description>This command SHALL be generated in response to a SendKey Request command.</description>
-      <arg name="status" type="StatusEnum"/>
+      <arg name="status" type="KeypadInputStatusEnum"/>
     </command>
 
   </cluster>
 
-  <enum name="StatusEnum" type="ENUM8">
+  <enum name="KeypadInputStatusEnum" type="ENUM8">
     <cluster code="0x0509"/>
     <item name="Success" value="0x00"/>
     <item name="UnsupportedKey" value="0x01"/>

--- a/src/app/zap-templates/zcl/data-model/chip/media-playback-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-playback-cluster.xml
@@ -83,7 +83,7 @@ limitations under the License.
 
     <command source="server" code="0x0A" name="PlaybackResponse" optional="false">
       <description>This command SHALL be generated in response to various Playback Request commands.</description>
-      <arg name="status" type="StatusEnum"/>
+      <arg name="status" type="MediaPlaybackStatusEnum"/>
       <arg name="data"   type="CHAR_STRING" optional="true"/>
     </command>
 
@@ -103,7 +103,7 @@ limitations under the License.
     <item name="Buffering"  value="0x03"/>
   </enum>
 
-  <enum name="StatusEnum" type="ENUM8">
+  <enum name="MediaPlaybackStatusEnum" type="ENUM8">
     <cluster code="0x0506"/>
     <item name="Success"                value="0x00"/>
     <item name="InvalidStateForCommand" value="0x01"/>

--- a/src/app/zap-templates/zcl/data-model/chip/target-navigator-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/target-navigator-cluster.xml
@@ -35,12 +35,12 @@ limitations under the License.
 
     <command source="server" code="0x01" name="NavigateTargetResponse" optional="false">
       <description>This command SHALL be generated in response to NavigateTarget commands.</description>
-      <arg name="status" type="StatusEnum"/>
+      <arg name="status" type="TargetNavigatorStatusEnum"/>
       <arg name="data"   type="CHAR_STRING" optional="true"/>
     </command>
   </cluster>
 
-  <enum name="StatusEnum" type="ENUM8">
+  <enum name="TargetNavigatorStatusEnum" type="ENUM8">
     <cluster code="0x0505"/>
     <item name="Success"        value="0x00"/>
     <item name="TargetNotFound" value="0x01"/>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -910,7 +910,7 @@ client cluster ColorControl = 768 {
 }
 
 client cluster ContentLauncher = 1290 {
-  enum ContentLauncherStatusEnum : ENUM8 {
+  enum ContentLaunchStatusEnum : ENUM8 {
     kSuccess = 0;
     kUrlNotAvailable = 1;
     kAuthFailed = 2;
@@ -1003,7 +1003,7 @@ client cluster ContentLauncher = 1290 {
   }
 
   response struct LaunchResponse = 2 {
-    ContentLauncherStatusEnum status = 0;
+    ContentLaunchStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -163,7 +163,7 @@ client cluster ApplicationBasic = 1293 {
 }
 
 client cluster ApplicationLauncher = 1292 {
-  enum StatusEnum : ENUM8 {
+  enum ApplicationLauncherStatusEnum : ENUM8 {
     kSuccess = 0;
     kAppNotAvailable = 1;
     kSystemBusy = 2;
@@ -204,7 +204,7 @@ client cluster ApplicationLauncher = 1292 {
   }
 
   response struct LauncherResponse = 3 {
-    StatusEnum status = 0;
+    ApplicationLauncherStatusEnum status = 0;
     OCTET_STRING data = 1;
   }
 
@@ -552,14 +552,14 @@ client cluster BridgedDeviceBasic = 57 {
 }
 
 client cluster Channel = 1284 {
-  enum LineupInfoTypeEnum : ENUM8 {
-    kMso = 0;
-  }
-
-  enum StatusEnum : ENUM8 {
+  enum ChannelStatusEnum : ENUM8 {
     kSuccess = 0;
     kMultipleMatches = 1;
     kNoMatches = 2;
+  }
+
+  enum LineupInfoTypeEnum : ENUM8 {
+    kMso = 0;
   }
 
   bitmap ChannelFeature : BITMAP32 {
@@ -604,7 +604,7 @@ client cluster Channel = 1284 {
   }
 
   response struct ChangeChannelResponse = 1 {
-    StatusEnum status = 0;
+    ChannelStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 
@@ -910,6 +910,12 @@ client cluster ColorControl = 768 {
 }
 
 client cluster ContentLauncher = 1290 {
+  enum ContentLauncherStatusEnum : ENUM8 {
+    kSuccess = 0;
+    kUrlNotAvailable = 1;
+    kAuthFailed = 2;
+  }
+
   enum MetricTypeEnum : ENUM8 {
     kPixels = 0;
     kPercentage = 1;
@@ -929,12 +935,6 @@ client cluster ContentLauncher = 1290 {
     kSport = 10;
     kSportsTeam = 11;
     kType = 12;
-  }
-
-  enum StatusEnum : ENUM8 {
-    kSuccess = 0;
-    kUrlNotAvailable = 1;
-    kAuthFailed = 2;
   }
 
   bitmap ContentLauncherFeature : BITMAP32 {
@@ -1003,7 +1003,7 @@ client cluster ContentLauncher = 1290 {
   }
 
   response struct LaunchResponse = 2 {
-    StatusEnum status = 0;
+    ContentLauncherStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 
@@ -2218,7 +2218,7 @@ client cluster KeypadInput = 1289 {
     kData = 118;
   }
 
-  enum StatusEnum : ENUM8 {
+  enum KeypadInputStatusEnum : ENUM8 {
     kSuccess = 0;
     kUnsupportedKey = 1;
     kInvalidKeyInCurrentState = 2;
@@ -2240,7 +2240,7 @@ client cluster KeypadInput = 1289 {
   }
 
   response struct SendKeyResponse = 1 {
-    StatusEnum status = 0;
+    KeypadInputStatusEnum status = 0;
   }
 
   command SendKey(SendKeyRequest): SendKeyResponse = 0;
@@ -2403,20 +2403,20 @@ client cluster MediaInput = 1287 {
 }
 
 client cluster MediaPlayback = 1286 {
-  enum PlaybackStateEnum : ENUM8 {
-    kPlaying = 0;
-    kPaused = 1;
-    kNotPlaying = 2;
-    kBuffering = 3;
-  }
-
-  enum StatusEnum : ENUM8 {
+  enum MediaPlaybackStatusEnum : ENUM8 {
     kSuccess = 0;
     kInvalidStateForCommand = 1;
     kNotAllowed = 2;
     kNotActive = 3;
     kSpeedOutOfRange = 4;
     kSeekOutOfRange = 5;
+  }
+
+  enum PlaybackStateEnum : ENUM8 {
+    kPlaying = 0;
+    kPaused = 1;
+    kNotPlaying = 2;
+    kBuffering = 3;
   }
 
   struct PlaybackPosition {
@@ -2449,7 +2449,7 @@ client cluster MediaPlayback = 1286 {
   }
 
   response struct PlaybackResponse = 10 {
-    StatusEnum status = 0;
+    MediaPlaybackStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 
@@ -3358,7 +3358,7 @@ client cluster Switch = 59 {
 }
 
 client cluster TargetNavigator = 1285 {
-  enum StatusEnum : ENUM8 {
+  enum TargetNavigatorStatusEnum : ENUM8 {
     kSuccess = 0;
     kTargetNotFound = 1;
     kNotAllowed = 2;
@@ -3382,7 +3382,7 @@ client cluster TargetNavigator = 1285 {
   }
 
   response struct NavigateTargetResponse = 1 {
-    StatusEnum status = 0;
+    TargetNavigatorStatusEnum status = 0;
     optional CHAR_STRING data = 1;
   }
 

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -31692,13 +31692,13 @@ class Channel(Cluster):
     clusterRevision: 'uint' = None
 
     class Enums:
-        class LineupInfoTypeEnum(IntEnum):
-            kMso = 0x00
-
-        class StatusEnum(IntEnum):
+        class ChannelStatusEnum(IntEnum):
             kSuccess = 0x00
             kMultipleMatches = 0x01
             kNoMatches = 0x02
+
+        class LineupInfoTypeEnum(IntEnum):
+            kMso = 0x00
 
 
     class Structs:
@@ -31766,11 +31766,11 @@ class Channel(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=Channel.Enums.StatusEnum),
+                            ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=Channel.Enums.ChannelStatusEnum),
                             ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=typing.Optional[str]),
                     ])
 
-            status: 'Channel.Enums.StatusEnum' = 0
+            status: 'Channel.Enums.ChannelStatusEnum' = 0
             data: 'typing.Optional[str]' = None
 
         @dataclass
@@ -31963,7 +31963,7 @@ class TargetNavigator(Cluster):
     clusterRevision: 'uint' = None
 
     class Enums:
-        class StatusEnum(IntEnum):
+        class TargetNavigatorStatusEnum(IntEnum):
             kSuccess = 0x00
             kTargetNotFound = 0x01
             kNotAllowed = 0x02
@@ -32013,11 +32013,11 @@ class TargetNavigator(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=TargetNavigator.Enums.StatusEnum),
+                            ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=TargetNavigator.Enums.TargetNavigatorStatusEnum),
                             ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=typing.Optional[str]),
                     ])
 
-            status: 'TargetNavigator.Enums.StatusEnum' = 0
+            status: 'TargetNavigator.Enums.TargetNavigatorStatusEnum' = 0
             data: 'typing.Optional[str]' = None
 
 
@@ -32172,19 +32172,19 @@ class MediaPlayback(Cluster):
     clusterRevision: 'uint' = None
 
     class Enums:
-        class PlaybackStateEnum(IntEnum):
-            kPlaying = 0x00
-            kPaused = 0x01
-            kNotPlaying = 0x02
-            kBuffering = 0x03
-
-        class StatusEnum(IntEnum):
+        class MediaPlaybackStatusEnum(IntEnum):
             kSuccess = 0x00
             kInvalidStateForCommand = 0x01
             kNotAllowed = 0x02
             kNotActive = 0x03
             kSpeedOutOfRange = 0x04
             kSeekOutOfRange = 0x05
+
+        class PlaybackStateEnum(IntEnum):
+            kPlaying = 0x00
+            kPaused = 0x01
+            kNotPlaying = 0x02
+            kBuffering = 0x03
 
 
     class Structs:
@@ -32348,11 +32348,11 @@ class MediaPlayback(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=MediaPlayback.Enums.StatusEnum),
+                            ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatusEnum),
                             ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=typing.Optional[str]),
                     ])
 
-            status: 'MediaPlayback.Enums.StatusEnum' = 0
+            status: 'MediaPlayback.Enums.MediaPlaybackStatusEnum' = 0
             data: 'typing.Optional[str]' = None
 
         @dataclass
@@ -33033,7 +33033,7 @@ class KeypadInput(Cluster):
             kF5 = 0x75
             kData = 0x76
 
-        class StatusEnum(IntEnum):
+        class KeypadInputStatusEnum(IntEnum):
             kSuccess = 0x00
             kUnsupportedKey = 0x01
             kInvalidKeyInCurrentState = 0x02
@@ -33066,10 +33066,10 @@ class KeypadInput(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=KeypadInput.Enums.StatusEnum),
+                            ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=KeypadInput.Enums.KeypadInputStatusEnum),
                     ])
 
-            status: 'KeypadInput.Enums.StatusEnum' = 0
+            status: 'KeypadInput.Enums.KeypadInputStatusEnum' = 0
 
 
     class Attributes:
@@ -33181,6 +33181,11 @@ class ContentLauncher(Cluster):
     clusterRevision: 'uint' = None
 
     class Enums:
+        class ContentLauncherStatusEnum(IntEnum):
+            kSuccess = 0x00
+            kUrlNotAvailable = 0x01
+            kAuthFailed = 0x02
+
         class MetricTypeEnum(IntEnum):
             kPixels = 0x00
             kPercentage = 0x01
@@ -33199,11 +33204,6 @@ class ContentLauncher(Cluster):
             kSport = 0x0A
             kSportsTeam = 0x0B
             kType = 0x0C
-
-        class StatusEnum(IntEnum):
-            kSuccess = 0x00
-            kUrlNotAvailable = 0x01
-            kAuthFailed = 0x02
 
 
     class Structs:
@@ -33348,11 +33348,11 @@ class ContentLauncher(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=ContentLauncher.Enums.StatusEnum),
+                            ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=ContentLauncher.Enums.ContentLauncherStatusEnum),
                             ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=typing.Optional[str]),
                     ])
 
-            status: 'ContentLauncher.Enums.StatusEnum' = 0
+            status: 'ContentLauncher.Enums.ContentLauncherStatusEnum' = 0
             data: 'typing.Optional[str]' = None
 
 
@@ -33699,7 +33699,7 @@ class ApplicationLauncher(Cluster):
     clusterRevision: 'uint' = None
 
     class Enums:
-        class StatusEnum(IntEnum):
+        class ApplicationLauncherStatusEnum(IntEnum):
             kSuccess = 0x00
             kAppNotAvailable = 0x01
             kSystemBusy = 0x02
@@ -33792,11 +33792,11 @@ class ApplicationLauncher(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=ApplicationLauncher.Enums.StatusEnum),
+                            ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=ApplicationLauncher.Enums.ApplicationLauncherStatusEnum),
                             ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=bytes),
                     ])
 
-            status: 'ApplicationLauncher.Enums.StatusEnum' = 0
+            status: 'ApplicationLauncher.Enums.ApplicationLauncherStatusEnum' = 0
             data: 'bytes' = b""
 
 

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -33181,7 +33181,7 @@ class ContentLauncher(Cluster):
     clusterRevision: 'uint' = None
 
     class Enums:
-        class ContentLauncherStatusEnum(IntEnum):
+        class ContentLaunchStatusEnum(IntEnum):
             kSuccess = 0x00
             kUrlNotAvailable = 0x01
             kAuthFailed = 0x02
@@ -33348,11 +33348,11 @@ class ContentLauncher(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=ContentLauncher.Enums.ContentLauncherStatusEnum),
+                            ClusterObjectFieldDescriptor(Label="status", Tag=0, Type=ContentLauncher.Enums.ContentLaunchStatusEnum),
                             ClusterObjectFieldDescriptor(Label="data", Tag=1, Type=typing.Optional[str]),
                     ])
 
-            status: 'ContentLauncher.Enums.ContentLauncherStatusEnum' = 0
+            status: 'ContentLauncher.Enums.ContentLaunchStatusEnum' = 0
             data: 'typing.Optional[str]' = None
 
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -17921,18 +17921,17 @@ void CHIPNullableKeypadInputClusterKeypadInputStatusEnumAttributeCallbackSubscri
     }
 }
 
-void CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge::OnSuccessFn(
-    void * context, chip::app::Clusters::ContentLauncher::ContentLauncherStatusEnum value)
+void CHIPContentLauncherClusterContentLaunchStatusEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, chip::app::Clusters::ContentLauncher::ContentLaunchStatusEnum value)
 {
     NSNumber * _Nonnull objCValue;
     objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value)];
     DispatchSuccess(context, objCValue);
 };
 
-void CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
-    void * context)
+void CHIPContentLauncherClusterContentLaunchStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
 {
-    auto * self = static_cast<CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<CHIPContentLauncherClusterContentLaunchStatusEnumAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -17946,8 +17945,8 @@ void CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscri
     }
 }
 
-void CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge::OnSuccessFn(
-    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::ContentLauncher::ContentLauncherStatusEnum> & value)
+void CHIPNullableContentLauncherClusterContentLaunchStatusEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::ContentLauncher::ContentLaunchStatusEnum> & value)
 {
     NSNumber * _Nullable objCValue;
     if (value.IsNull()) {
@@ -17958,11 +17957,11 @@ void CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbac
     DispatchSuccess(context, objCValue);
 };
 
-void CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+void CHIPNullableContentLauncherClusterContentLaunchStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
     void * context)
 {
     auto * self
-        = static_cast<CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscriptionBridge *>(context);
+        = static_cast<CHIPNullableContentLauncherClusterContentLaunchStatusEnumAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -17499,6 +17499,58 @@ void CHIPNullableIasAceClusterIasZoneTypeAttributeCallbackSubscriptionBridge::On
     }
 }
 
+void CHIPChannelClusterChannelStatusEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, chip::app::Clusters::Channel::ChannelStatusEnum value)
+{
+    NSNumber * _Nonnull objCValue;
+    objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value)];
+    DispatchSuccess(context, objCValue);
+};
+
+void CHIPChannelClusterChannelStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+{
+    auto * self = static_cast<CHIPChannelClusterChannelStatusEnumAttributeCallbackSubscriptionBridge *>(context);
+    if (!self->mQueue) {
+        return;
+    }
+
+    if (self->mEstablishedHandler != nil) {
+        dispatch_async(self->mQueue, self->mEstablishedHandler);
+        // On failure, mEstablishedHandler will be cleaned up by our destructor,
+        // but we can clean it up earlier on successful subscription
+        // establishment.
+        self->mEstablishedHandler = nil;
+    }
+}
+
+void CHIPNullableChannelClusterChannelStatusEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::ChannelStatusEnum> & value)
+{
+    NSNumber * _Nullable objCValue;
+    if (value.IsNull()) {
+        objCValue = nil;
+    } else {
+        objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value.Value())];
+    }
+    DispatchSuccess(context, objCValue);
+};
+
+void CHIPNullableChannelClusterChannelStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+{
+    auto * self = static_cast<CHIPNullableChannelClusterChannelStatusEnumAttributeCallbackSubscriptionBridge *>(context);
+    if (!self->mQueue) {
+        return;
+    }
+
+    if (self->mEstablishedHandler != nil) {
+        dispatch_async(self->mQueue, self->mEstablishedHandler);
+        // On failure, mEstablishedHandler will be cleaned up by our destructor,
+        // but we can clean it up earlier on successful subscription
+        // establishment.
+        self->mEstablishedHandler = nil;
+    }
+}
+
 void CHIPChannelClusterLineupInfoTypeEnumAttributeCallbackBridge::OnSuccessFn(
     void * context, chip::app::Clusters::Channel::LineupInfoTypeEnum value)
 {
@@ -17551,17 +17603,18 @@ void CHIPNullableChannelClusterLineupInfoTypeEnumAttributeCallbackSubscriptionBr
     }
 }
 
-void CHIPChannelClusterStatusEnumAttributeCallbackBridge::OnSuccessFn(
-    void * context, chip::app::Clusters::Channel::StatusEnum value)
+void CHIPTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, chip::app::Clusters::TargetNavigator::TargetNavigatorStatusEnum value)
 {
     NSNumber * _Nonnull objCValue;
     objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value)];
     DispatchSuccess(context, objCValue);
 };
 
-void CHIPChannelClusterStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void CHIPTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+    void * context)
 {
-    auto * self = static_cast<CHIPChannelClusterStatusEnumAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<CHIPTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -17575,8 +17628,8 @@ void CHIPChannelClusterStatusEnumAttributeCallbackSubscriptionBridge::OnSubscrip
     }
 }
 
-void CHIPNullableChannelClusterStatusEnumAttributeCallbackBridge::OnSuccessFn(
-    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::StatusEnum> & value)
+void CHIPNullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::TargetNavigator::TargetNavigatorStatusEnum> & value)
 {
     NSNumber * _Nullable objCValue;
     if (value.IsNull()) {
@@ -17587,9 +17640,11 @@ void CHIPNullableChannelClusterStatusEnumAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void CHIPNullableChannelClusterStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void CHIPNullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+    void * context)
 {
-    auto * self = static_cast<CHIPNullableChannelClusterStatusEnumAttributeCallbackSubscriptionBridge *>(context);
+    auto * self
+        = static_cast<CHIPNullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -17603,17 +17658,17 @@ void CHIPNullableChannelClusterStatusEnumAttributeCallbackSubscriptionBridge::On
     }
 }
 
-void CHIPTargetNavigatorClusterStatusEnumAttributeCallbackBridge::OnSuccessFn(
-    void * context, chip::app::Clusters::TargetNavigator::StatusEnum value)
+void CHIPMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, chip::app::Clusters::MediaPlayback::MediaPlaybackStatusEnum value)
 {
     NSNumber * _Nonnull objCValue;
     objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value)];
     DispatchSuccess(context, objCValue);
 };
 
-void CHIPTargetNavigatorClusterStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void CHIPMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
 {
-    auto * self = static_cast<CHIPTargetNavigatorClusterStatusEnumAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<CHIPMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -17627,8 +17682,8 @@ void CHIPTargetNavigatorClusterStatusEnumAttributeCallbackSubscriptionBridge::On
     }
 }
 
-void CHIPNullableTargetNavigatorClusterStatusEnumAttributeCallbackBridge::OnSuccessFn(
-    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::TargetNavigator::StatusEnum> & value)
+void CHIPNullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::MediaPlayback::MediaPlaybackStatusEnum> & value)
 {
     NSNumber * _Nullable objCValue;
     if (value.IsNull()) {
@@ -17639,9 +17694,11 @@ void CHIPNullableTargetNavigatorClusterStatusEnumAttributeCallbackBridge::OnSucc
     DispatchSuccess(context, objCValue);
 };
 
-void CHIPNullableTargetNavigatorClusterStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void CHIPNullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+    void * context)
 {
-    auto * self = static_cast<CHIPNullableTargetNavigatorClusterStatusEnumAttributeCallbackSubscriptionBridge *>(context);
+    auto * self
+        = static_cast<CHIPNullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -17694,58 +17751,6 @@ void CHIPNullableMediaPlaybackClusterPlaybackStateEnumAttributeCallbackBridge::O
 void CHIPNullableMediaPlaybackClusterPlaybackStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
 {
     auto * self = static_cast<CHIPNullableMediaPlaybackClusterPlaybackStateEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
-        return;
-    }
-
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
-        // On failure, mEstablishedHandler will be cleaned up by our destructor,
-        // but we can clean it up earlier on successful subscription
-        // establishment.
-        self->mEstablishedHandler = nil;
-    }
-}
-
-void CHIPMediaPlaybackClusterStatusEnumAttributeCallbackBridge::OnSuccessFn(
-    void * context, chip::app::Clusters::MediaPlayback::StatusEnum value)
-{
-    NSNumber * _Nonnull objCValue;
-    objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value)];
-    DispatchSuccess(context, objCValue);
-};
-
-void CHIPMediaPlaybackClusterStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
-{
-    auto * self = static_cast<CHIPMediaPlaybackClusterStatusEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
-        return;
-    }
-
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
-        // On failure, mEstablishedHandler will be cleaned up by our destructor,
-        // but we can clean it up earlier on successful subscription
-        // establishment.
-        self->mEstablishedHandler = nil;
-    }
-}
-
-void CHIPNullableMediaPlaybackClusterStatusEnumAttributeCallbackBridge::OnSuccessFn(
-    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::MediaPlayback::StatusEnum> & value)
-{
-    NSNumber * _Nullable objCValue;
-    if (value.IsNull()) {
-        objCValue = nil;
-    } else {
-        objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value.Value())];
-    }
-    DispatchSuccess(context, objCValue);
-};
-
-void CHIPNullableMediaPlaybackClusterStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
-{
-    auto * self = static_cast<CHIPNullableMediaPlaybackClusterStatusEnumAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -17863,17 +17868,17 @@ void CHIPNullableKeypadInputClusterCecKeyCodeAttributeCallbackSubscriptionBridge
     }
 }
 
-void CHIPKeypadInputClusterStatusEnumAttributeCallbackBridge::OnSuccessFn(
-    void * context, chip::app::Clusters::KeypadInput::StatusEnum value)
+void CHIPKeypadInputClusterKeypadInputStatusEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, chip::app::Clusters::KeypadInput::KeypadInputStatusEnum value)
 {
     NSNumber * _Nonnull objCValue;
     objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value)];
     DispatchSuccess(context, objCValue);
 };
 
-void CHIPKeypadInputClusterStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void CHIPKeypadInputClusterKeypadInputStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
 {
-    auto * self = static_cast<CHIPKeypadInputClusterStatusEnumAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<CHIPKeypadInputClusterKeypadInputStatusEnumAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -17887,8 +17892,8 @@ void CHIPKeypadInputClusterStatusEnumAttributeCallbackSubscriptionBridge::OnSubs
     }
 }
 
-void CHIPNullableKeypadInputClusterStatusEnumAttributeCallbackBridge::OnSuccessFn(
-    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::KeypadInput::StatusEnum> & value)
+void CHIPNullableKeypadInputClusterKeypadInputStatusEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::KeypadInput::KeypadInputStatusEnum> & value)
 {
     NSNumber * _Nullable objCValue;
     if (value.IsNull()) {
@@ -17899,9 +17904,65 @@ void CHIPNullableKeypadInputClusterStatusEnumAttributeCallbackBridge::OnSuccessF
     DispatchSuccess(context, objCValue);
 };
 
-void CHIPNullableKeypadInputClusterStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void CHIPNullableKeypadInputClusterKeypadInputStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+    void * context)
 {
-    auto * self = static_cast<CHIPNullableKeypadInputClusterStatusEnumAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<CHIPNullableKeypadInputClusterKeypadInputStatusEnumAttributeCallbackSubscriptionBridge *>(context);
+    if (!self->mQueue) {
+        return;
+    }
+
+    if (self->mEstablishedHandler != nil) {
+        dispatch_async(self->mQueue, self->mEstablishedHandler);
+        // On failure, mEstablishedHandler will be cleaned up by our destructor,
+        // but we can clean it up earlier on successful subscription
+        // establishment.
+        self->mEstablishedHandler = nil;
+    }
+}
+
+void CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, chip::app::Clusters::ContentLauncher::ContentLauncherStatusEnum value)
+{
+    NSNumber * _Nonnull objCValue;
+    objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value)];
+    DispatchSuccess(context, objCValue);
+};
+
+void CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+    void * context)
+{
+    auto * self = static_cast<CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscriptionBridge *>(context);
+    if (!self->mQueue) {
+        return;
+    }
+
+    if (self->mEstablishedHandler != nil) {
+        dispatch_async(self->mQueue, self->mEstablishedHandler);
+        // On failure, mEstablishedHandler will be cleaned up by our destructor,
+        // but we can clean it up earlier on successful subscription
+        // establishment.
+        self->mEstablishedHandler = nil;
+    }
+}
+
+void CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::ContentLauncher::ContentLauncherStatusEnum> & value)
+{
+    NSNumber * _Nullable objCValue;
+    if (value.IsNull()) {
+        objCValue = nil;
+    } else {
+        objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value.Value())];
+    }
+    DispatchSuccess(context, objCValue);
+};
+
+void CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+    void * context)
+{
+    auto * self
+        = static_cast<CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -18019,58 +18080,6 @@ void CHIPNullableContentLauncherClusterParameterEnumAttributeCallbackSubscriptio
     }
 }
 
-void CHIPContentLauncherClusterStatusEnumAttributeCallbackBridge::OnSuccessFn(
-    void * context, chip::app::Clusters::ContentLauncher::StatusEnum value)
-{
-    NSNumber * _Nonnull objCValue;
-    objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value)];
-    DispatchSuccess(context, objCValue);
-};
-
-void CHIPContentLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
-{
-    auto * self = static_cast<CHIPContentLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
-        return;
-    }
-
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
-        // On failure, mEstablishedHandler will be cleaned up by our destructor,
-        // but we can clean it up earlier on successful subscription
-        // establishment.
-        self->mEstablishedHandler = nil;
-    }
-}
-
-void CHIPNullableContentLauncherClusterStatusEnumAttributeCallbackBridge::OnSuccessFn(
-    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::ContentLauncher::StatusEnum> & value)
-{
-    NSNumber * _Nullable objCValue;
-    if (value.IsNull()) {
-        objCValue = nil;
-    } else {
-        objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value.Value())];
-    }
-    DispatchSuccess(context, objCValue);
-};
-
-void CHIPNullableContentLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
-{
-    auto * self = static_cast<CHIPNullableContentLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge *>(context);
-    if (!self->mQueue) {
-        return;
-    }
-
-    if (self->mEstablishedHandler != nil) {
-        dispatch_async(self->mQueue, self->mEstablishedHandler);
-        // On failure, mEstablishedHandler will be cleaned up by our destructor,
-        // but we can clean it up earlier on successful subscription
-        // establishment.
-        self->mEstablishedHandler = nil;
-    }
-}
-
 void CHIPAudioOutputClusterOutputTypeEnumAttributeCallbackBridge::OnSuccessFn(
     void * context, chip::app::Clusters::AudioOutput::OutputTypeEnum value)
 {
@@ -18123,17 +18132,19 @@ void CHIPNullableAudioOutputClusterOutputTypeEnumAttributeCallbackSubscriptionBr
     }
 }
 
-void CHIPApplicationLauncherClusterStatusEnumAttributeCallbackBridge::OnSuccessFn(
-    void * context, chip::app::Clusters::ApplicationLauncher::StatusEnum value)
+void CHIPApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackBridge::OnSuccessFn(
+    void * context, chip::app::Clusters::ApplicationLauncher::ApplicationLauncherStatusEnum value)
 {
     NSNumber * _Nonnull objCValue;
     objCValue = [NSNumber numberWithUnsignedChar:chip::to_underlying(value)];
     DispatchSuccess(context, objCValue);
 };
 
-void CHIPApplicationLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void CHIPApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+    void * context)
 {
-    auto * self = static_cast<CHIPApplicationLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge *>(context);
+    auto * self
+        = static_cast<CHIPApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -18147,8 +18158,8 @@ void CHIPApplicationLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge
     }
 }
 
-void CHIPNullableApplicationLauncherClusterStatusEnumAttributeCallbackBridge::OnSuccessFn(
-    void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::StatusEnum> & value)
+void CHIPNullableApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackBridge::OnSuccessFn(void * context,
+    const chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::ApplicationLauncherStatusEnum> & value)
 {
     NSNumber * _Nullable objCValue;
     if (value.IsNull()) {
@@ -18159,9 +18170,12 @@ void CHIPNullableApplicationLauncherClusterStatusEnumAttributeCallbackBridge::On
     DispatchSuccess(context, objCValue);
 };
 
-void CHIPNullableApplicationLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void CHIPNullableApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackSubscriptionBridge::
+    OnSubscriptionEstablished(void * context)
 {
-    auto * self = static_cast<CHIPNullableApplicationLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge *>(context);
+    auto * self
+        = static_cast<CHIPNullableApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackSubscriptionBridge *>(
+            context);
     if (!self->mQueue) {
         return;
     }

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
@@ -501,46 +501,51 @@ typedef void (*NullableIasAceClusterIasAcePanelStatusAttributeCallback)(
 typedef void (*IasAceClusterIasZoneTypeAttributeCallback)(void *, chip::app::Clusters::IasAce::IasZoneType);
 typedef void (*NullableIasAceClusterIasZoneTypeAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::IasAce::IasZoneType> &);
+typedef void (*ChannelClusterChannelStatusEnumAttributeCallback)(void *, chip::app::Clusters::Channel::ChannelStatusEnum);
+typedef void (*NullableChannelClusterChannelStatusEnumAttributeCallback)(
+    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::ChannelStatusEnum> &);
 typedef void (*ChannelClusterLineupInfoTypeEnumAttributeCallback)(void *, chip::app::Clusters::Channel::LineupInfoTypeEnum);
 typedef void (*NullableChannelClusterLineupInfoTypeEnumAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::LineupInfoTypeEnum> &);
-typedef void (*ChannelClusterStatusEnumAttributeCallback)(void *, chip::app::Clusters::Channel::StatusEnum);
-typedef void (*NullableChannelClusterStatusEnumAttributeCallback)(
-    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::StatusEnum> &);
-typedef void (*TargetNavigatorClusterStatusEnumAttributeCallback)(void *, chip::app::Clusters::TargetNavigator::StatusEnum);
-typedef void (*NullableTargetNavigatorClusterStatusEnumAttributeCallback)(
-    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::TargetNavigator::StatusEnum> &);
+typedef void (*TargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallback)(
+    void *, chip::app::Clusters::TargetNavigator::TargetNavigatorStatusEnum);
+typedef void (*NullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallback)(
+    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::TargetNavigator::TargetNavigatorStatusEnum> &);
+typedef void (*MediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallback)(
+    void *, chip::app::Clusters::MediaPlayback::MediaPlaybackStatusEnum);
+typedef void (*NullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallback)(
+    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::MediaPlayback::MediaPlaybackStatusEnum> &);
 typedef void (*MediaPlaybackClusterPlaybackStateEnumAttributeCallback)(void *,
                                                                        chip::app::Clusters::MediaPlayback::PlaybackStateEnum);
 typedef void (*NullableMediaPlaybackClusterPlaybackStateEnumAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::MediaPlayback::PlaybackStateEnum> &);
-typedef void (*MediaPlaybackClusterStatusEnumAttributeCallback)(void *, chip::app::Clusters::MediaPlayback::StatusEnum);
-typedef void (*NullableMediaPlaybackClusterStatusEnumAttributeCallback)(
-    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::MediaPlayback::StatusEnum> &);
 typedef void (*MediaInputClusterInputTypeEnumAttributeCallback)(void *, chip::app::Clusters::MediaInput::InputTypeEnum);
 typedef void (*NullableMediaInputClusterInputTypeEnumAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::MediaInput::InputTypeEnum> &);
 typedef void (*KeypadInputClusterCecKeyCodeAttributeCallback)(void *, chip::app::Clusters::KeypadInput::CecKeyCode);
 typedef void (*NullableKeypadInputClusterCecKeyCodeAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::KeypadInput::CecKeyCode> &);
-typedef void (*KeypadInputClusterStatusEnumAttributeCallback)(void *, chip::app::Clusters::KeypadInput::StatusEnum);
-typedef void (*NullableKeypadInputClusterStatusEnumAttributeCallback)(
-    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::KeypadInput::StatusEnum> &);
+typedef void (*KeypadInputClusterKeypadInputStatusEnumAttributeCallback)(void *,
+                                                                         chip::app::Clusters::KeypadInput::KeypadInputStatusEnum);
+typedef void (*NullableKeypadInputClusterKeypadInputStatusEnumAttributeCallback)(
+    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::KeypadInput::KeypadInputStatusEnum> &);
+typedef void (*ContentLauncherClusterContentLauncherStatusEnumAttributeCallback)(
+    void *, chip::app::Clusters::ContentLauncher::ContentLauncherStatusEnum);
+typedef void (*NullableContentLauncherClusterContentLauncherStatusEnumAttributeCallback)(
+    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::ContentLauncher::ContentLauncherStatusEnum> &);
 typedef void (*ContentLauncherClusterMetricTypeEnumAttributeCallback)(void *, chip::app::Clusters::ContentLauncher::MetricTypeEnum);
 typedef void (*NullableContentLauncherClusterMetricTypeEnumAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::ContentLauncher::MetricTypeEnum> &);
 typedef void (*ContentLauncherClusterParameterEnumAttributeCallback)(void *, chip::app::Clusters::ContentLauncher::ParameterEnum);
 typedef void (*NullableContentLauncherClusterParameterEnumAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::ContentLauncher::ParameterEnum> &);
-typedef void (*ContentLauncherClusterStatusEnumAttributeCallback)(void *, chip::app::Clusters::ContentLauncher::StatusEnum);
-typedef void (*NullableContentLauncherClusterStatusEnumAttributeCallback)(
-    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::ContentLauncher::StatusEnum> &);
 typedef void (*AudioOutputClusterOutputTypeEnumAttributeCallback)(void *, chip::app::Clusters::AudioOutput::OutputTypeEnum);
 typedef void (*NullableAudioOutputClusterOutputTypeEnumAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::AudioOutput::OutputTypeEnum> &);
-typedef void (*ApplicationLauncherClusterStatusEnumAttributeCallback)(void *, chip::app::Clusters::ApplicationLauncher::StatusEnum);
-typedef void (*NullableApplicationLauncherClusterStatusEnumAttributeCallback)(
-    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::StatusEnum> &);
+typedef void (*ApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallback)(
+    void *, chip::app::Clusters::ApplicationLauncher::ApplicationLauncherStatusEnum);
+typedef void (*NullableApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallback)(
+    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::ApplicationLauncherStatusEnum> &);
 typedef void (*ApplicationBasicClusterApplicationStatusEnumAttributeCallback)(
     void *, chip::app::Clusters::ApplicationBasic::ApplicationStatusEnum);
 typedef void (*NullableApplicationBasicClusterApplicationStatusEnumAttributeCallback)(
@@ -15221,6 +15226,64 @@ private:
     SubscriptionEstablishedHandler mEstablishedHandler;
 };
 
+class CHIPChannelClusterChannelStatusEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<ChannelClusterChannelStatusEnumAttributeCallback>
+{
+public:
+    CHIPChannelClusterChannelStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                               CHIPActionBlock action, bool keepAlive = false) :
+        CHIPCallbackBridge<ChannelClusterChannelStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+
+    static void OnSuccessFn(void * context, chip::app::Clusters::Channel::ChannelStatusEnum value);
+};
+
+class CHIPChannelClusterChannelStatusEnumAttributeCallbackSubscriptionBridge
+    : public CHIPChannelClusterChannelStatusEnumAttributeCallbackBridge
+{
+public:
+    CHIPChannelClusterChannelStatusEnumAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                           CHIPActionBlock action,
+                                                                           SubscriptionEstablishedHandler establishedHandler) :
+        CHIPChannelClusterChannelStatusEnumAttributeCallbackBridge(queue, handler, action, true),
+        mEstablishedHandler(establishedHandler)
+    {}
+
+    static void OnSubscriptionEstablished(void * context);
+
+private:
+    SubscriptionEstablishedHandler mEstablishedHandler;
+};
+
+class CHIPNullableChannelClusterChannelStatusEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<NullableChannelClusterChannelStatusEnumAttributeCallback>
+{
+public:
+    CHIPNullableChannelClusterChannelStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                       CHIPActionBlock action, bool keepAlive = false) :
+        CHIPCallbackBridge<NullableChannelClusterChannelStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn,
+                                                                                     keepAlive){};
+
+    static void OnSuccessFn(void * context,
+                            const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::ChannelStatusEnum> & value);
+};
+
+class CHIPNullableChannelClusterChannelStatusEnumAttributeCallbackSubscriptionBridge
+    : public CHIPNullableChannelClusterChannelStatusEnumAttributeCallbackBridge
+{
+public:
+    CHIPNullableChannelClusterChannelStatusEnumAttributeCallbackSubscriptionBridge(
+        dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
+        SubscriptionEstablishedHandler establishedHandler) :
+        CHIPNullableChannelClusterChannelStatusEnumAttributeCallbackBridge(queue, handler, action, true),
+        mEstablishedHandler(establishedHandler)
+    {}
+
+    static void OnSubscriptionEstablished(void * context);
+
+private:
+    SubscriptionEstablishedHandler mEstablishedHandler;
+};
+
 class CHIPChannelClusterLineupInfoTypeEnumAttributeCallbackBridge
     : public CHIPCallbackBridge<ChannelClusterLineupInfoTypeEnumAttributeCallback>
 {
@@ -15279,109 +15342,119 @@ private:
     SubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class CHIPChannelClusterStatusEnumAttributeCallbackBridge : public CHIPCallbackBridge<ChannelClusterStatusEnumAttributeCallback>
+class CHIPTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<TargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallback>
 {
 public:
-    CHIPChannelClusterStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
-                                                        bool keepAlive = false) :
-        CHIPCallbackBridge<ChannelClusterStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+    CHIPTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                               CHIPActionBlock action, bool keepAlive = false) :
+        CHIPCallbackBridge<TargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn,
+                                                                                             keepAlive){};
 
-    static void OnSuccessFn(void * context, chip::app::Clusters::Channel::StatusEnum value);
+    static void OnSuccessFn(void * context, chip::app::Clusters::TargetNavigator::TargetNavigatorStatusEnum value);
 };
 
-class CHIPChannelClusterStatusEnumAttributeCallbackSubscriptionBridge : public CHIPChannelClusterStatusEnumAttributeCallbackBridge
+class CHIPTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackSubscriptionBridge
+    : public CHIPTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackBridge
 {
 public:
-    CHIPChannelClusterStatusEnumAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                    CHIPActionBlock action,
-                                                                    SubscriptionEstablishedHandler establishedHandler) :
-        CHIPChannelClusterStatusEnumAttributeCallbackBridge(queue, handler, action, true),
-        mEstablishedHandler(establishedHandler)
-    {}
-
-    static void OnSubscriptionEstablished(void * context);
-
-private:
-    SubscriptionEstablishedHandler mEstablishedHandler;
-};
-
-class CHIPNullableChannelClusterStatusEnumAttributeCallbackBridge
-    : public CHIPCallbackBridge<NullableChannelClusterStatusEnumAttributeCallback>
-{
-public:
-    CHIPNullableChannelClusterStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<NullableChannelClusterStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
-
-    static void OnSuccessFn(void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::Channel::StatusEnum> & value);
-};
-
-class CHIPNullableChannelClusterStatusEnumAttributeCallbackSubscriptionBridge
-    : public CHIPNullableChannelClusterStatusEnumAttributeCallbackBridge
-{
-public:
-    CHIPNullableChannelClusterStatusEnumAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                            CHIPActionBlock action,
-                                                                            SubscriptionEstablishedHandler establishedHandler) :
-        CHIPNullableChannelClusterStatusEnumAttributeCallbackBridge(queue, handler, action, true),
-        mEstablishedHandler(establishedHandler)
-    {}
-
-    static void OnSubscriptionEstablished(void * context);
-
-private:
-    SubscriptionEstablishedHandler mEstablishedHandler;
-};
-
-class CHIPTargetNavigatorClusterStatusEnumAttributeCallbackBridge
-    : public CHIPCallbackBridge<TargetNavigatorClusterStatusEnumAttributeCallback>
-{
-public:
-    CHIPTargetNavigatorClusterStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<TargetNavigatorClusterStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
-
-    static void OnSuccessFn(void * context, chip::app::Clusters::TargetNavigator::StatusEnum value);
-};
-
-class CHIPTargetNavigatorClusterStatusEnumAttributeCallbackSubscriptionBridge
-    : public CHIPTargetNavigatorClusterStatusEnumAttributeCallbackBridge
-{
-public:
-    CHIPTargetNavigatorClusterStatusEnumAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                            CHIPActionBlock action,
-                                                                            SubscriptionEstablishedHandler establishedHandler) :
-        CHIPTargetNavigatorClusterStatusEnumAttributeCallbackBridge(queue, handler, action, true),
-        mEstablishedHandler(establishedHandler)
-    {}
-
-    static void OnSubscriptionEstablished(void * context);
-
-private:
-    SubscriptionEstablishedHandler mEstablishedHandler;
-};
-
-class CHIPNullableTargetNavigatorClusterStatusEnumAttributeCallbackBridge
-    : public CHIPCallbackBridge<NullableTargetNavigatorClusterStatusEnumAttributeCallback>
-{
-public:
-    CHIPNullableTargetNavigatorClusterStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                        CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<NullableTargetNavigatorClusterStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn,
-                                                                                      keepAlive){};
-
-    static void OnSuccessFn(void * context,
-                            const chip::app::DataModel::Nullable<chip::app::Clusters::TargetNavigator::StatusEnum> & value);
-};
-
-class CHIPNullableTargetNavigatorClusterStatusEnumAttributeCallbackSubscriptionBridge
-    : public CHIPNullableTargetNavigatorClusterStatusEnumAttributeCallbackBridge
-{
-public:
-    CHIPNullableTargetNavigatorClusterStatusEnumAttributeCallbackSubscriptionBridge(
+    CHIPTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
         SubscriptionEstablishedHandler establishedHandler) :
-        CHIPNullableTargetNavigatorClusterStatusEnumAttributeCallbackBridge(queue, handler, action, true),
+        CHIPTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackBridge(queue, handler, action, true),
+        mEstablishedHandler(establishedHandler)
+    {}
+
+    static void OnSubscriptionEstablished(void * context);
+
+private:
+    SubscriptionEstablishedHandler mEstablishedHandler;
+};
+
+class CHIPNullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<NullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallback>
+{
+public:
+    CHIPNullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackBridge(dispatch_queue_t queue,
+                                                                                       ResponseHandler handler,
+                                                                                       CHIPActionBlock action,
+                                                                                       bool keepAlive = false) :
+        CHIPCallbackBridge<NullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallback>(queue, handler, action,
+                                                                                                     OnSuccessFn, keepAlive){};
+
+    static void
+    OnSuccessFn(void * context,
+                const chip::app::DataModel::Nullable<chip::app::Clusters::TargetNavigator::TargetNavigatorStatusEnum> & value);
+};
+
+class CHIPNullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackSubscriptionBridge
+    : public CHIPNullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackBridge
+{
+public:
+    CHIPNullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackSubscriptionBridge(
+        dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
+        SubscriptionEstablishedHandler establishedHandler) :
+        CHIPNullableTargetNavigatorClusterTargetNavigatorStatusEnumAttributeCallbackBridge(queue, handler, action, true),
+        mEstablishedHandler(establishedHandler)
+    {}
+
+    static void OnSubscriptionEstablished(void * context);
+
+private:
+    SubscriptionEstablishedHandler mEstablishedHandler;
+};
+
+class CHIPMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<MediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallback>
+{
+public:
+    CHIPMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                           CHIPActionBlock action, bool keepAlive = false) :
+        CHIPCallbackBridge<MediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn,
+                                                                                         keepAlive){};
+
+    static void OnSuccessFn(void * context, chip::app::Clusters::MediaPlayback::MediaPlaybackStatusEnum value);
+};
+
+class CHIPMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackSubscriptionBridge
+    : public CHIPMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackBridge
+{
+public:
+    CHIPMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackSubscriptionBridge(
+        dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
+        SubscriptionEstablishedHandler establishedHandler) :
+        CHIPMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackBridge(queue, handler, action, true),
+        mEstablishedHandler(establishedHandler)
+    {}
+
+    static void OnSubscriptionEstablished(void * context);
+
+private:
+    SubscriptionEstablishedHandler mEstablishedHandler;
+};
+
+class CHIPNullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<NullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallback>
+{
+public:
+    CHIPNullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                                   CHIPActionBlock action, bool keepAlive = false) :
+        CHIPCallbackBridge<NullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallback>(queue, handler, action,
+                                                                                                 OnSuccessFn, keepAlive){};
+
+    static void
+    OnSuccessFn(void * context,
+                const chip::app::DataModel::Nullable<chip::app::Clusters::MediaPlayback::MediaPlaybackStatusEnum> & value);
+};
+
+class CHIPNullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackSubscriptionBridge
+    : public CHIPNullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackBridge
+{
+public:
+    CHIPNullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackSubscriptionBridge(
+        dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
+        SubscriptionEstablishedHandler establishedHandler) :
+        CHIPNullableMediaPlaybackClusterMediaPlaybackStatusEnumAttributeCallbackBridge(queue, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -15441,64 +15514,6 @@ public:
         dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
         SubscriptionEstablishedHandler establishedHandler) :
         CHIPNullableMediaPlaybackClusterPlaybackStateEnumAttributeCallbackBridge(queue, handler, action, true),
-        mEstablishedHandler(establishedHandler)
-    {}
-
-    static void OnSubscriptionEstablished(void * context);
-
-private:
-    SubscriptionEstablishedHandler mEstablishedHandler;
-};
-
-class CHIPMediaPlaybackClusterStatusEnumAttributeCallbackBridge
-    : public CHIPCallbackBridge<MediaPlaybackClusterStatusEnumAttributeCallback>
-{
-public:
-    CHIPMediaPlaybackClusterStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                              CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<MediaPlaybackClusterStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
-
-    static void OnSuccessFn(void * context, chip::app::Clusters::MediaPlayback::StatusEnum value);
-};
-
-class CHIPMediaPlaybackClusterStatusEnumAttributeCallbackSubscriptionBridge
-    : public CHIPMediaPlaybackClusterStatusEnumAttributeCallbackBridge
-{
-public:
-    CHIPMediaPlaybackClusterStatusEnumAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                          CHIPActionBlock action,
-                                                                          SubscriptionEstablishedHandler establishedHandler) :
-        CHIPMediaPlaybackClusterStatusEnumAttributeCallbackBridge(queue, handler, action, true),
-        mEstablishedHandler(establishedHandler)
-    {}
-
-    static void OnSubscriptionEstablished(void * context);
-
-private:
-    SubscriptionEstablishedHandler mEstablishedHandler;
-};
-
-class CHIPNullableMediaPlaybackClusterStatusEnumAttributeCallbackBridge
-    : public CHIPCallbackBridge<NullableMediaPlaybackClusterStatusEnumAttributeCallback>
-{
-public:
-    CHIPNullableMediaPlaybackClusterStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                      CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<NullableMediaPlaybackClusterStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn,
-                                                                                    keepAlive){};
-
-    static void OnSuccessFn(void * context,
-                            const chip::app::DataModel::Nullable<chip::app::Clusters::MediaPlayback::StatusEnum> & value);
-};
-
-class CHIPNullableMediaPlaybackClusterStatusEnumAttributeCallbackSubscriptionBridge
-    : public CHIPNullableMediaPlaybackClusterStatusEnumAttributeCallbackBridge
-{
-public:
-    CHIPNullableMediaPlaybackClusterStatusEnumAttributeCallbackSubscriptionBridge(
-        dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
-        SubscriptionEstablishedHandler establishedHandler) :
-        CHIPNullableMediaPlaybackClusterStatusEnumAttributeCallbackBridge(queue, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -15623,25 +15638,26 @@ private:
     SubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class CHIPKeypadInputClusterStatusEnumAttributeCallbackBridge
-    : public CHIPCallbackBridge<KeypadInputClusterStatusEnumAttributeCallback>
+class CHIPKeypadInputClusterKeypadInputStatusEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<KeypadInputClusterKeypadInputStatusEnumAttributeCallback>
 {
 public:
-    CHIPKeypadInputClusterStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
-                                                            bool keepAlive = false) :
-        CHIPCallbackBridge<KeypadInputClusterStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+    CHIPKeypadInputClusterKeypadInputStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                       CHIPActionBlock action, bool keepAlive = false) :
+        CHIPCallbackBridge<KeypadInputClusterKeypadInputStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn,
+                                                                                     keepAlive){};
 
-    static void OnSuccessFn(void * context, chip::app::Clusters::KeypadInput::StatusEnum value);
+    static void OnSuccessFn(void * context, chip::app::Clusters::KeypadInput::KeypadInputStatusEnum value);
 };
 
-class CHIPKeypadInputClusterStatusEnumAttributeCallbackSubscriptionBridge
-    : public CHIPKeypadInputClusterStatusEnumAttributeCallbackBridge
+class CHIPKeypadInputClusterKeypadInputStatusEnumAttributeCallbackSubscriptionBridge
+    : public CHIPKeypadInputClusterKeypadInputStatusEnumAttributeCallbackBridge
 {
 public:
-    CHIPKeypadInputClusterStatusEnumAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                        CHIPActionBlock action,
-                                                                        SubscriptionEstablishedHandler establishedHandler) :
-        CHIPKeypadInputClusterStatusEnumAttributeCallbackBridge(queue, handler, action, true),
+    CHIPKeypadInputClusterKeypadInputStatusEnumAttributeCallbackSubscriptionBridge(
+        dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
+        SubscriptionEstablishedHandler establishedHandler) :
+        CHIPKeypadInputClusterKeypadInputStatusEnumAttributeCallbackBridge(queue, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -15651,26 +15667,89 @@ private:
     SubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class CHIPNullableKeypadInputClusterStatusEnumAttributeCallbackBridge
-    : public CHIPCallbackBridge<NullableKeypadInputClusterStatusEnumAttributeCallback>
+class CHIPNullableKeypadInputClusterKeypadInputStatusEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<NullableKeypadInputClusterKeypadInputStatusEnumAttributeCallback>
 {
 public:
-    CHIPNullableKeypadInputClusterStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                    CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<NullableKeypadInputClusterStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+    CHIPNullableKeypadInputClusterKeypadInputStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                               CHIPActionBlock action, bool keepAlive = false) :
+        CHIPCallbackBridge<NullableKeypadInputClusterKeypadInputStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn,
+                                                                                             keepAlive){};
 
     static void OnSuccessFn(void * context,
-                            const chip::app::DataModel::Nullable<chip::app::Clusters::KeypadInput::StatusEnum> & value);
+                            const chip::app::DataModel::Nullable<chip::app::Clusters::KeypadInput::KeypadInputStatusEnum> & value);
 };
 
-class CHIPNullableKeypadInputClusterStatusEnumAttributeCallbackSubscriptionBridge
-    : public CHIPNullableKeypadInputClusterStatusEnumAttributeCallbackBridge
+class CHIPNullableKeypadInputClusterKeypadInputStatusEnumAttributeCallbackSubscriptionBridge
+    : public CHIPNullableKeypadInputClusterKeypadInputStatusEnumAttributeCallbackBridge
 {
 public:
-    CHIPNullableKeypadInputClusterStatusEnumAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                                CHIPActionBlock action,
-                                                                                SubscriptionEstablishedHandler establishedHandler) :
-        CHIPNullableKeypadInputClusterStatusEnumAttributeCallbackBridge(queue, handler, action, true),
+    CHIPNullableKeypadInputClusterKeypadInputStatusEnumAttributeCallbackSubscriptionBridge(
+        dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
+        SubscriptionEstablishedHandler establishedHandler) :
+        CHIPNullableKeypadInputClusterKeypadInputStatusEnumAttributeCallbackBridge(queue, handler, action, true),
+        mEstablishedHandler(establishedHandler)
+    {}
+
+    static void OnSubscriptionEstablished(void * context);
+
+private:
+    SubscriptionEstablishedHandler mEstablishedHandler;
+};
+
+class CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<ContentLauncherClusterContentLauncherStatusEnumAttributeCallback>
+{
+public:
+    CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                               CHIPActionBlock action, bool keepAlive = false) :
+        CHIPCallbackBridge<ContentLauncherClusterContentLauncherStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn,
+                                                                                             keepAlive){};
+
+    static void OnSuccessFn(void * context, chip::app::Clusters::ContentLauncher::ContentLauncherStatusEnum value);
+};
+
+class CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscriptionBridge
+    : public CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge
+{
+public:
+    CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscriptionBridge(
+        dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
+        SubscriptionEstablishedHandler establishedHandler) :
+        CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge(queue, handler, action, true),
+        mEstablishedHandler(establishedHandler)
+    {}
+
+    static void OnSubscriptionEstablished(void * context);
+
+private:
+    SubscriptionEstablishedHandler mEstablishedHandler;
+};
+
+class CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<NullableContentLauncherClusterContentLauncherStatusEnumAttributeCallback>
+{
+public:
+    CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge(dispatch_queue_t queue,
+                                                                                       ResponseHandler handler,
+                                                                                       CHIPActionBlock action,
+                                                                                       bool keepAlive = false) :
+        CHIPCallbackBridge<NullableContentLauncherClusterContentLauncherStatusEnumAttributeCallback>(queue, handler, action,
+                                                                                                     OnSuccessFn, keepAlive){};
+
+    static void
+    OnSuccessFn(void * context,
+                const chip::app::DataModel::Nullable<chip::app::Clusters::ContentLauncher::ContentLauncherStatusEnum> & value);
+};
+
+class CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscriptionBridge
+    : public CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge
+{
+public:
+    CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscriptionBridge(
+        dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
+        SubscriptionEstablishedHandler establishedHandler) :
+        CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge(queue, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -15796,64 +15875,6 @@ private:
     SubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class CHIPContentLauncherClusterStatusEnumAttributeCallbackBridge
-    : public CHIPCallbackBridge<ContentLauncherClusterStatusEnumAttributeCallback>
-{
-public:
-    CHIPContentLauncherClusterStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<ContentLauncherClusterStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
-
-    static void OnSuccessFn(void * context, chip::app::Clusters::ContentLauncher::StatusEnum value);
-};
-
-class CHIPContentLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge
-    : public CHIPContentLauncherClusterStatusEnumAttributeCallbackBridge
-{
-public:
-    CHIPContentLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                            CHIPActionBlock action,
-                                                                            SubscriptionEstablishedHandler establishedHandler) :
-        CHIPContentLauncherClusterStatusEnumAttributeCallbackBridge(queue, handler, action, true),
-        mEstablishedHandler(establishedHandler)
-    {}
-
-    static void OnSubscriptionEstablished(void * context);
-
-private:
-    SubscriptionEstablishedHandler mEstablishedHandler;
-};
-
-class CHIPNullableContentLauncherClusterStatusEnumAttributeCallbackBridge
-    : public CHIPCallbackBridge<NullableContentLauncherClusterStatusEnumAttributeCallback>
-{
-public:
-    CHIPNullableContentLauncherClusterStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                        CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<NullableContentLauncherClusterStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn,
-                                                                                      keepAlive){};
-
-    static void OnSuccessFn(void * context,
-                            const chip::app::DataModel::Nullable<chip::app::Clusters::ContentLauncher::StatusEnum> & value);
-};
-
-class CHIPNullableContentLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge
-    : public CHIPNullableContentLauncherClusterStatusEnumAttributeCallbackBridge
-{
-public:
-    CHIPNullableContentLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge(
-        dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
-        SubscriptionEstablishedHandler establishedHandler) :
-        CHIPNullableContentLauncherClusterStatusEnumAttributeCallbackBridge(queue, handler, action, true),
-        mEstablishedHandler(establishedHandler)
-    {}
-
-    static void OnSubscriptionEstablished(void * context);
-
-private:
-    SubscriptionEstablishedHandler mEstablishedHandler;
-};
-
 class CHIPAudioOutputClusterOutputTypeEnumAttributeCallbackBridge
     : public CHIPCallbackBridge<AudioOutputClusterOutputTypeEnumAttributeCallback>
 {
@@ -15912,25 +15933,28 @@ private:
     SubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class CHIPApplicationLauncherClusterStatusEnumAttributeCallbackBridge
-    : public CHIPCallbackBridge<ApplicationLauncherClusterStatusEnumAttributeCallback>
+class CHIPApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<ApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallback>
 {
 public:
-    CHIPApplicationLauncherClusterStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                    CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<ApplicationLauncherClusterStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+    CHIPApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackBridge(dispatch_queue_t queue,
+                                                                                       ResponseHandler handler,
+                                                                                       CHIPActionBlock action,
+                                                                                       bool keepAlive = false) :
+        CHIPCallbackBridge<ApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallback>(queue, handler, action,
+                                                                                                     OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, chip::app::Clusters::ApplicationLauncher::StatusEnum value);
+    static void OnSuccessFn(void * context, chip::app::Clusters::ApplicationLauncher::ApplicationLauncherStatusEnum value);
 };
 
-class CHIPApplicationLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge
-    : public CHIPApplicationLauncherClusterStatusEnumAttributeCallbackBridge
+class CHIPApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackSubscriptionBridge
+    : public CHIPApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackBridge
 {
 public:
-    CHIPApplicationLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                                CHIPActionBlock action,
-                                                                                SubscriptionEstablishedHandler establishedHandler) :
-        CHIPApplicationLauncherClusterStatusEnumAttributeCallbackBridge(queue, handler, action, true),
+    CHIPApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackSubscriptionBridge(
+        dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
+        SubscriptionEstablishedHandler establishedHandler) :
+        CHIPApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackBridge(queue, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -15940,27 +15964,30 @@ private:
     SubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class CHIPNullableApplicationLauncherClusterStatusEnumAttributeCallbackBridge
-    : public CHIPCallbackBridge<NullableApplicationLauncherClusterStatusEnumAttributeCallback>
+class CHIPNullableApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<NullableApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallback>
 {
 public:
-    CHIPNullableApplicationLauncherClusterStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                            CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<NullableApplicationLauncherClusterStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn,
-                                                                                          keepAlive){};
+    CHIPNullableApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackBridge(dispatch_queue_t queue,
+                                                                                               ResponseHandler handler,
+                                                                                               CHIPActionBlock action,
+                                                                                               bool keepAlive = false) :
+        CHIPCallbackBridge<NullableApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallback>(
+            queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context,
-                            const chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::StatusEnum> & value);
+    static void OnSuccessFn(
+        void * context,
+        const chip::app::DataModel::Nullable<chip::app::Clusters::ApplicationLauncher::ApplicationLauncherStatusEnum> & value);
 };
 
-class CHIPNullableApplicationLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge
-    : public CHIPNullableApplicationLauncherClusterStatusEnumAttributeCallbackBridge
+class CHIPNullableApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackSubscriptionBridge
+    : public CHIPNullableApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackBridge
 {
 public:
-    CHIPNullableApplicationLauncherClusterStatusEnumAttributeCallbackSubscriptionBridge(
+    CHIPNullableApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
         SubscriptionEstablishedHandler establishedHandler) :
-        CHIPNullableApplicationLauncherClusterStatusEnumAttributeCallbackBridge(queue, handler, action, true),
+        CHIPNullableApplicationLauncherClusterApplicationLauncherStatusEnumAttributeCallbackBridge(queue, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
@@ -529,10 +529,10 @@ typedef void (*KeypadInputClusterKeypadInputStatusEnumAttributeCallback)(void *,
                                                                          chip::app::Clusters::KeypadInput::KeypadInputStatusEnum);
 typedef void (*NullableKeypadInputClusterKeypadInputStatusEnumAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::KeypadInput::KeypadInputStatusEnum> &);
-typedef void (*ContentLauncherClusterContentLauncherStatusEnumAttributeCallback)(
-    void *, chip::app::Clusters::ContentLauncher::ContentLauncherStatusEnum);
-typedef void (*NullableContentLauncherClusterContentLauncherStatusEnumAttributeCallback)(
-    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::ContentLauncher::ContentLauncherStatusEnum> &);
+typedef void (*ContentLauncherClusterContentLaunchStatusEnumAttributeCallback)(
+    void *, chip::app::Clusters::ContentLauncher::ContentLaunchStatusEnum);
+typedef void (*NullableContentLauncherClusterContentLaunchStatusEnumAttributeCallback)(
+    void *, const chip::app::DataModel::Nullable<chip::app::Clusters::ContentLauncher::ContentLaunchStatusEnum> &);
 typedef void (*ContentLauncherClusterMetricTypeEnumAttributeCallback)(void *, chip::app::Clusters::ContentLauncher::MetricTypeEnum);
 typedef void (*NullableContentLauncherClusterMetricTypeEnumAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::ContentLauncher::MetricTypeEnum> &);
@@ -15697,26 +15697,26 @@ private:
     SubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge
-    : public CHIPCallbackBridge<ContentLauncherClusterContentLauncherStatusEnumAttributeCallback>
+class CHIPContentLauncherClusterContentLaunchStatusEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<ContentLauncherClusterContentLaunchStatusEnumAttributeCallback>
 {
 public:
-    CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
-                                                                               CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<ContentLauncherClusterContentLauncherStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn,
-                                                                                             keepAlive){};
+    CHIPContentLauncherClusterContentLaunchStatusEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                             CHIPActionBlock action, bool keepAlive = false) :
+        CHIPCallbackBridge<ContentLauncherClusterContentLaunchStatusEnumAttributeCallback>(queue, handler, action, OnSuccessFn,
+                                                                                           keepAlive){};
 
-    static void OnSuccessFn(void * context, chip::app::Clusters::ContentLauncher::ContentLauncherStatusEnum value);
+    static void OnSuccessFn(void * context, chip::app::Clusters::ContentLauncher::ContentLaunchStatusEnum value);
 };
 
-class CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscriptionBridge
-    : public CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge
+class CHIPContentLauncherClusterContentLaunchStatusEnumAttributeCallbackSubscriptionBridge
+    : public CHIPContentLauncherClusterContentLaunchStatusEnumAttributeCallbackBridge
 {
 public:
-    CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscriptionBridge(
+    CHIPContentLauncherClusterContentLaunchStatusEnumAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
         SubscriptionEstablishedHandler establishedHandler) :
-        CHIPContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge(queue, handler, action, true),
+        CHIPContentLauncherClusterContentLaunchStatusEnumAttributeCallbackBridge(queue, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -15726,30 +15726,30 @@ private:
     SubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge
-    : public CHIPCallbackBridge<NullableContentLauncherClusterContentLauncherStatusEnumAttributeCallback>
+class CHIPNullableContentLauncherClusterContentLaunchStatusEnumAttributeCallbackBridge
+    : public CHIPCallbackBridge<NullableContentLauncherClusterContentLaunchStatusEnumAttributeCallback>
 {
 public:
-    CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge(dispatch_queue_t queue,
-                                                                                       ResponseHandler handler,
-                                                                                       CHIPActionBlock action,
-                                                                                       bool keepAlive = false) :
-        CHIPCallbackBridge<NullableContentLauncherClusterContentLauncherStatusEnumAttributeCallback>(queue, handler, action,
-                                                                                                     OnSuccessFn, keepAlive){};
+    CHIPNullableContentLauncherClusterContentLaunchStatusEnumAttributeCallbackBridge(dispatch_queue_t queue,
+                                                                                     ResponseHandler handler,
+                                                                                     CHIPActionBlock action,
+                                                                                     bool keepAlive = false) :
+        CHIPCallbackBridge<NullableContentLauncherClusterContentLaunchStatusEnumAttributeCallback>(queue, handler, action,
+                                                                                                   OnSuccessFn, keepAlive){};
 
     static void
     OnSuccessFn(void * context,
-                const chip::app::DataModel::Nullable<chip::app::Clusters::ContentLauncher::ContentLauncherStatusEnum> & value);
+                const chip::app::DataModel::Nullable<chip::app::Clusters::ContentLauncher::ContentLaunchStatusEnum> & value);
 };
 
-class CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscriptionBridge
-    : public CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge
+class CHIPNullableContentLauncherClusterContentLaunchStatusEnumAttributeCallbackSubscriptionBridge
+    : public CHIPNullableContentLauncherClusterContentLaunchStatusEnumAttributeCallbackBridge
 {
 public:
-    CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackSubscriptionBridge(
+    CHIPNullableContentLauncherClusterContentLaunchStatusEnumAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
         SubscriptionEstablishedHandler establishedHandler) :
-        CHIPNullableContentLauncherClusterContentLauncherStatusEnumAttributeCallbackBridge(queue, handler, action, true),
+        CHIPNullableContentLauncherClusterContentLaunchStatusEnumAttributeCallbackBridge(queue, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
@@ -16503,14 +16503,14 @@ typedef NS_OPTIONS(uint8_t, CHIPIasWdWarningInfo) {
     CHIPIasWdWarningInfoSirenLevel = 0x3,
 };
 
-typedef NS_ENUM(uint8_t, CHIPChannelLineupInfoType) {
-    CHIPChannelLineupInfoTypeMso = 0x00,
-};
-
 typedef NS_ENUM(uint8_t, CHIPChannelStatus) {
     CHIPChannelStatusSuccess = 0x00,
     CHIPChannelStatusMultipleMatches = 0x01,
     CHIPChannelStatusNoMatches = 0x02,
+};
+
+typedef NS_ENUM(uint8_t, CHIPChannelLineupInfoType) {
+    CHIPChannelLineupInfoTypeMso = 0x00,
 };
 
 typedef NS_OPTIONS(uint32_t, CHIPChannelFeature) {
@@ -16524,13 +16524,6 @@ typedef NS_ENUM(uint8_t, CHIPTargetNavigatorStatus) {
     CHIPTargetNavigatorStatusNotAllowed = 0x02,
 };
 
-typedef NS_ENUM(uint8_t, CHIPMediaPlaybackPlaybackState) {
-    CHIPMediaPlaybackPlaybackStatePlaying = 0x00,
-    CHIPMediaPlaybackPlaybackStatePaused = 0x01,
-    CHIPMediaPlaybackPlaybackStateNotPlaying = 0x02,
-    CHIPMediaPlaybackPlaybackStateBuffering = 0x03,
-};
-
 typedef NS_ENUM(uint8_t, CHIPMediaPlaybackStatus) {
     CHIPMediaPlaybackStatusSuccess = 0x00,
     CHIPMediaPlaybackStatusInvalidStateForCommand = 0x01,
@@ -16538,6 +16531,13 @@ typedef NS_ENUM(uint8_t, CHIPMediaPlaybackStatus) {
     CHIPMediaPlaybackStatusNotActive = 0x03,
     CHIPMediaPlaybackStatusSpeedOutOfRange = 0x04,
     CHIPMediaPlaybackStatusSeekOutOfRange = 0x05,
+};
+
+typedef NS_ENUM(uint8_t, CHIPMediaPlaybackPlaybackState) {
+    CHIPMediaPlaybackPlaybackStatePlaying = 0x00,
+    CHIPMediaPlaybackPlaybackStatePaused = 0x01,
+    CHIPMediaPlaybackPlaybackStateNotPlaying = 0x02,
+    CHIPMediaPlaybackPlaybackStateBuffering = 0x03,
 };
 
 typedef NS_ENUM(uint8_t, CHIPMediaInputInputType) {
@@ -16660,6 +16660,12 @@ typedef NS_OPTIONS(uint32_t, CHIPKeypadInputFeature) {
     CHIPKeypadInputFeatureNumberKeys = 0x4,
 };
 
+typedef NS_ENUM(uint8_t, CHIPContentLauncherStatus) {
+    CHIPContentLauncherStatusSuccess = 0x00,
+    CHIPContentLauncherStatusUrlNotAvailable = 0x01,
+    CHIPContentLauncherStatusAuthFailed = 0x02,
+};
+
 typedef NS_ENUM(uint8_t, CHIPContentLauncherMetricType) {
     CHIPContentLauncherMetricTypePIXELS = 0x00,
     CHIPContentLauncherMetricTypePERCENTAGE = 0x01,
@@ -16679,12 +16685,6 @@ typedef NS_ENUM(uint8_t, CHIPContentLauncherParameter) {
     CHIPContentLauncherParameterSport = 0x0A,
     CHIPContentLauncherParameterSportsTeam = 0x0B,
     CHIPContentLauncherParameterType = 0x0C,
-};
-
-typedef NS_ENUM(uint8_t, CHIPContentLauncherStatus) {
-    CHIPContentLauncherStatusSuccess = 0x00,
-    CHIPContentLauncherStatusUrlNotAvailable = 0x01,
-    CHIPContentLauncherStatusAuthFailed = 0x02,
 };
 
 typedef NS_OPTIONS(uint32_t, CHIPContentLauncherFeature) {

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
@@ -16660,10 +16660,10 @@ typedef NS_OPTIONS(uint32_t, CHIPKeypadInputFeature) {
     CHIPKeypadInputFeatureNumberKeys = 0x4,
 };
 
-typedef NS_ENUM(uint8_t, CHIPContentLauncherStatus) {
-    CHIPContentLauncherStatusSuccess = 0x00,
-    CHIPContentLauncherStatusUrlNotAvailable = 0x01,
-    CHIPContentLauncherStatusAuthFailed = 0x02,
+typedef NS_ENUM(uint8_t, CHIPContentLauncherContentLaunchStatus) {
+    CHIPContentLauncherContentLaunchStatusSuccess = 0x00,
+    CHIPContentLauncherContentLaunchStatusUrlNotAvailable = 0x01,
+    CHIPContentLauncherContentLaunchStatusAuthFailed = 0x02,
 };
 
 typedef NS_ENUM(uint8_t, CHIPContentLauncherMetricType) {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -2126,18 +2126,18 @@ namespace WakeOnLan {
 
 namespace Channel {
 
-// Enum for LineupInfoTypeEnum
-enum class LineupInfoTypeEnum : uint8_t
-{
-    kMso = 0x00,
-};
-
-// Enum for StatusEnum
-enum class StatusEnum : uint8_t
+// Enum for ChannelStatusEnum
+enum class ChannelStatusEnum : uint8_t
 {
     kSuccess         = 0x00,
     kMultipleMatches = 0x01,
     kNoMatches       = 0x02,
+};
+
+// Enum for LineupInfoTypeEnum
+enum class LineupInfoTypeEnum : uint8_t
+{
+    kMso = 0x00,
 };
 
 // Bitmap for ChannelFeature
@@ -2150,8 +2150,8 @@ enum class ChannelFeature : uint32_t
 
 namespace TargetNavigator {
 
-// Enum for StatusEnum
-enum class StatusEnum : uint8_t
+// Enum for TargetNavigatorStatusEnum
+enum class TargetNavigatorStatusEnum : uint8_t
 {
     kSuccess        = 0x00,
     kTargetNotFound = 0x01,
@@ -2161,17 +2161,8 @@ enum class StatusEnum : uint8_t
 
 namespace MediaPlayback {
 
-// Enum for PlaybackStateEnum
-enum class PlaybackStateEnum : uint8_t
-{
-    kPlaying    = 0x00,
-    kPaused     = 0x01,
-    kNotPlaying = 0x02,
-    kBuffering  = 0x03,
-};
-
-// Enum for StatusEnum
-enum class StatusEnum : uint8_t
+// Enum for MediaPlaybackStatusEnum
+enum class MediaPlaybackStatusEnum : uint8_t
 {
     kSuccess                = 0x00,
     kInvalidStateForCommand = 0x01,
@@ -2179,6 +2170,15 @@ enum class StatusEnum : uint8_t
     kNotActive              = 0x03,
     kSpeedOutOfRange        = 0x04,
     kSeekOutOfRange         = 0x05,
+};
+
+// Enum for PlaybackStateEnum
+enum class PlaybackStateEnum : uint8_t
+{
+    kPlaying    = 0x00,
+    kPaused     = 0x01,
+    kNotPlaying = 0x02,
+    kBuffering  = 0x03,
 };
 } // namespace MediaPlayback
 
@@ -2304,8 +2304,8 @@ enum class CecKeyCode : uint8_t
     kData                      = 0x76,
 };
 
-// Enum for StatusEnum
-enum class StatusEnum : uint8_t
+// Enum for KeypadInputStatusEnum
+enum class KeypadInputStatusEnum : uint8_t
 {
     kSuccess                  = 0x00,
     kUnsupportedKey           = 0x01,
@@ -2322,6 +2322,14 @@ enum class KeypadInputFeature : uint32_t
 } // namespace KeypadInput
 
 namespace ContentLauncher {
+
+// Enum for ContentLauncherStatusEnum
+enum class ContentLauncherStatusEnum : uint8_t
+{
+    kSuccess         = 0x00,
+    kUrlNotAvailable = 0x01,
+    kAuthFailed      = 0x02,
+};
 
 // Enum for MetricTypeEnum
 enum class MetricTypeEnum : uint8_t
@@ -2346,14 +2354,6 @@ enum class ParameterEnum : uint8_t
     kSport      = 0x0A,
     kSportsTeam = 0x0B,
     kType       = 0x0C,
-};
-
-// Enum for StatusEnum
-enum class StatusEnum : uint8_t
-{
-    kSuccess         = 0x00,
-    kUrlNotAvailable = 0x01,
-    kAuthFailed      = 0x02,
 };
 
 // Bitmap for ContentLauncherFeature
@@ -2393,8 +2393,8 @@ enum class AudioOutputFeature : uint32_t
 
 namespace ApplicationLauncher {
 
-// Enum for StatusEnum
-enum class StatusEnum : uint8_t
+// Enum for ApplicationLauncherStatusEnum
+enum class ApplicationLauncherStatusEnum : uint8_t
 {
     kSuccess         = 0x00,
     kAppNotAvailable = 0x01,

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -2323,8 +2323,8 @@ enum class KeypadInputFeature : uint32_t
 
 namespace ContentLauncher {
 
-// Enum for ContentLauncherStatusEnum
-enum class ContentLauncherStatusEnum : uint8_t
+// Enum for ContentLaunchStatusEnum
+enum class ContentLaunchStatusEnum : uint8_t
 {
     kSuccess         = 0x00,
     kUrlNotAvailable = 0x01,

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -34123,7 +34123,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LaunchResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
-    ContentLauncherStatusEnum status = static_cast<ContentLauncherStatusEnum>(0);
+    ContentLaunchStatusEnum status = static_cast<ContentLaunchStatusEnum>(0);
     Optional<chip::CharSpan> data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -34139,7 +34139,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LaunchResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
-    ContentLauncherStatusEnum status = static_cast<ContentLauncherStatusEnum>(0);
+    ContentLaunchStatusEnum status = static_cast<ContentLaunchStatusEnum>(0);
     Optional<chip::CharSpan> data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -32209,7 +32209,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ChangeChannelResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Channel::Id; }
 
-    StatusEnum status = static_cast<StatusEnum>(0);
+    ChannelStatusEnum status = static_cast<ChannelStatusEnum>(0);
     Optional<chip::CharSpan> data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -32225,7 +32225,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ChangeChannelResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::Channel::Id; }
 
-    StatusEnum status = static_cast<StatusEnum>(0);
+    ChannelStatusEnum status = static_cast<ChannelStatusEnum>(0);
     Optional<chip::CharSpan> data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -32513,7 +32513,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::NavigateTargetResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
 
-    StatusEnum status = static_cast<StatusEnum>(0);
+    TargetNavigatorStatusEnum status = static_cast<TargetNavigatorStatusEnum>(0);
     Optional<chip::CharSpan> data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -32529,7 +32529,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::NavigateTargetResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
 
-    StatusEnum status = static_cast<StatusEnum>(0);
+    TargetNavigatorStatusEnum status = static_cast<TargetNavigatorStatusEnum>(0);
     Optional<chip::CharSpan> data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -33039,7 +33039,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PlaybackResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
-    StatusEnum status = static_cast<StatusEnum>(0);
+    MediaPlaybackStatusEnum status = static_cast<MediaPlaybackStatusEnum>(0);
     Optional<chip::CharSpan> data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -33055,7 +33055,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::PlaybackResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
-    StatusEnum status = static_cast<StatusEnum>(0);
+    MediaPlaybackStatusEnum status = static_cast<MediaPlaybackStatusEnum>(0);
     Optional<chip::CharSpan> data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -33743,7 +33743,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SendKeyResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::KeypadInput::Id; }
 
-    StatusEnum status = static_cast<StatusEnum>(0);
+    KeypadInputStatusEnum status = static_cast<KeypadInputStatusEnum>(0);
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
@@ -33758,7 +33758,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::SendKeyResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::KeypadInput::Id; }
 
-    StatusEnum status = static_cast<StatusEnum>(0);
+    KeypadInputStatusEnum status = static_cast<KeypadInputStatusEnum>(0);
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SendKeyResponse
@@ -34123,7 +34123,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LaunchResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
-    StatusEnum status = static_cast<StatusEnum>(0);
+    ContentLauncherStatusEnum status = static_cast<ContentLauncherStatusEnum>(0);
     Optional<chip::CharSpan> data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -34139,7 +34139,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LaunchResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
-    StatusEnum status = static_cast<StatusEnum>(0);
+    ContentLauncherStatusEnum status = static_cast<ContentLauncherStatusEnum>(0);
     Optional<chip::CharSpan> data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -34662,7 +34662,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LauncherResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
 
-    StatusEnum status = static_cast<StatusEnum>(0);
+    ApplicationLauncherStatusEnum status = static_cast<ApplicationLauncherStatusEnum>(0);
     chip::ByteSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -34678,7 +34678,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::LauncherResponse::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
 
-    StatusEnum status = static_cast<StatusEnum>(0);
+    ApplicationLauncherStatusEnum status = static_cast<ApplicationLauncherStatusEnum>(0);
     chip::ByteSpan data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };


### PR DESCRIPTION
#### Problem
Renaming Types which have different definitions for the same type and name.

#### Change overview
- Renaming the Status enum with the cluster name prefix because we have multiple definitions of Status Enum with the same name and type
- Regerating all the apps after the change

#### Testing
Just making sure existing tests pass. No new tests added for this.
