### PR TITLE
Remove false TODO in ModeSelectCluster.

### DIFF
--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -106,7 +106,6 @@ bool emberAfModeSelectClusterChangeToModeCallback(CommandHandler * commandHandle
         return false;
     }
     ModeSelect::Attributes::CurrentMode::Set(endpointId, newMode);
-    // TODO: Implement application logic
 
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "ModeSelect: ChangeToMode successful");
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* #14042 

#### Change overview
Remove the bogus TODO comment

#### Testing
How was this tested? (at least one bullet point required)
* If no testing is required, why not?
This is just editorial change. 