### PR TITLE
Fix crash on removal of accessing fabric

### DIFF
--- a/examples/chip-tool-darwin/templates/tests/tests.js
+++ b/examples/chip-tool-darwin/templates/tests/tests.js
@@ -15,15 +15,13 @@
  *    limitations under the License.
  */
 
-function getManualTests()
-{
+function getManualTests() {
   return [];
 }
 
 // clang-format off
 
-function getTests()
-{
+function getTests() {
   const AccessControl = [
     'TestAccessControlCluster',
   ];
@@ -282,6 +280,7 @@ function getTests()
     'TestIdentifyCluster',
     'TestLogCommands',
     'TestOperationalCredentialsCluster',
+    'TestSelfFabricRemoval',
     'TestBinding',
   ];
 
@@ -340,5 +339,5 @@ function getTests()
 //
 // Module exports
 //
-exports.getTests       = getTests;
+exports.getTests = getTests;
 exports.getManualTests = getManualTests;

--- a/examples/chip-tool-darwin/templates/tests/tests.js
+++ b/examples/chip-tool-darwin/templates/tests/tests.js
@@ -15,7 +15,8 @@
  *    limitations under the License.
  */
 
-function getManualTests() {
+function getManualTests()
+{
   return [];
 }
 
@@ -339,5 +340,5 @@ function getTests() {
 //
 // Module exports
 //
-exports.getTests = getTests;
+exports.getTests       = getTests;
 exports.getManualTests = getManualTests;

--- a/examples/chip-tool/templates/tests/tests.js
+++ b/examples/chip-tool/templates/tests/tests.js
@@ -15,7 +15,8 @@
  *    limitations under the License.
  */
 
-function getManualTests() {
+function getManualTests()
+{
   const DeviceDiscovery = [
     'Test_TC_DD_1_5',
     'Test_TC_DD_1_6',
@@ -272,7 +273,8 @@ function getManualTests() {
   return tests.flat(1);
 }
 
-function getTests() {
+function getTests()
+{
   const AccessControl = [
     'TestAccessControlCluster',
   ];
@@ -625,5 +627,5 @@ function getTests() {
 //
 // Module exports
 //
-exports.getTests = getTests;
+exports.getTests       = getTests;
 exports.getManualTests = getManualTests;

--- a/examples/chip-tool/templates/tests/tests.js
+++ b/examples/chip-tool/templates/tests/tests.js
@@ -15,8 +15,7 @@
  *    limitations under the License.
  */
 
-function getManualTests()
-{
+function getManualTests() {
   const DeviceDiscovery = [
     'Test_TC_DD_1_5',
     'Test_TC_DD_1_6',
@@ -273,8 +272,7 @@ function getManualTests()
   return tests.flat(1);
 }
 
-function getTests()
-{
+function getTests() {
   const AccessControl = [
     'TestAccessControlCluster',
   ];
@@ -546,6 +544,7 @@ function getTests()
     'TestIdentifyCluster',
     'TestOperationalCredentialsCluster',
     'TestModeSelectCluster',
+    'TestSelfFabricRemoval',
     'TestSystemCommands',
     'TestBinding',
     'TestUserLabelCluster',
@@ -626,5 +625,5 @@ function getTests()
 //
 // Module exports
 //
-exports.getTests       = getTests;
+exports.getTests = getTests;
 exports.getManualTests = getManualTests;

--- a/scripts/tools/zap_regen_yaml_tests.sh
+++ b/scripts/tools/zap_regen_yaml_tests.sh
@@ -23,4 +23,3 @@
 #
 
 ./scripts/tools/zap_regen_all.py --type tests
-

--- a/scripts/tools/zap_regen_yaml_tests.sh
+++ b/scripts/tools/zap_regen_yaml_tests.sh
@@ -22,5 +22,5 @@
 #      rather than all of zap like `./scripts/tools/zap_regen_all.py
 #
 
-./scripts/tools/zap/generate.py src/controller/data_model/controller-clusters.zap \
-    -o zzz_generated/chip-tool/zap-generated -t examples/chip-tool/templates/templates.json
+./scripts/tools/zap_regen_all.py --type tests
+

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -468,7 +468,6 @@ exit:
     {
         SendNOCResponse(commandObj, commandPath, OperationalCertStatus::kSuccess, fabricBeingRemoved, CharSpan());
 
-        // Use a more direct getter for FabricIndex from commandObj
         chip::Messaging::ExchangeContext * ec = commandObj->GetExchangeContext();
         FabricIndex currentFabricIndex        = commandObj->GetAccessingFabricIndex();
         if (currentFabricIndex == fabricBeingRemoved)

--- a/src/app/tests/suites/TestSelfFabricRemoval.yaml
+++ b/src/app/tests/suites/TestSelfFabricRemoval.yaml
@@ -32,9 +32,9 @@ tests:
       command: "readAttribute"
       attribute: "CommissionedFabrics"
       response:
+          value: 1
           constraints:
               type: uint8
-              value: 1
 
     - label: "Read current fabric index"
       command: "readAttribute"

--- a/src/app/tests/suites/TestSelfFabricRemoval.yaml
+++ b/src/app/tests/suites/TestSelfFabricRemoval.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Validate removal of the only fabric left does not crash
+
+config:
+    nodeId: 0x12344321
+    cluster: "Operational Credentials"
+    endpoint: 0
+
+tests:
+    - label: "Wait for the commissioned device to be retrieved"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
+
+    - label: "Read number of commissioned fabrics"
+      command: "readAttribute"
+      attribute: "CommissionedFabrics"
+      response:
+          constraints:
+              type: uint8
+              value: 1
+
+    - label: "Read current fabric index"
+      command: "readAttribute"
+      attribute: "CurrentFabricIndex"
+      response:
+          saveAs: ourFabricIndex
+          constraints:
+              type: uint8
+              # 0 is not a valid value, but past that we have no idea what the
+              # other side will claim here.
+              minValue: 1
+
+    - label: "Remove single own fabric"
+      command: "RemoveFabric"
+      arguments:
+          values:
+              - name: "FabricIndex"
+                value: ourFabricIndex

--- a/src/darwin/Framework/CHIP/templates/tests/tests.js
+++ b/src/darwin/Framework/CHIP/templates/tests/tests.js
@@ -15,11 +15,13 @@
  *    limitations under the License.
  */
 
-function getManualTests() {
+function getManualTests()
+{
   return [];
 }
 
-function getTests() {
+function getTests()
+{
   const AccessControl = [
     'TestAccessControlCluster',
   ];
@@ -334,5 +336,5 @@ function getTests() {
 //
 // Module exports
 //
-exports.getTests = getTests;
+exports.getTests       = getTests;
 exports.getManualTests = getManualTests;

--- a/src/darwin/Framework/CHIP/templates/tests/tests.js
+++ b/src/darwin/Framework/CHIP/templates/tests/tests.js
@@ -15,13 +15,11 @@
  *    limitations under the License.
  */
 
-function getManualTests()
-{
+function getManualTests() {
   return [];
 }
 
-function getTests()
-{
+function getTests() {
   const AccessControl = [
     'TestAccessControlCluster',
   ];
@@ -278,6 +276,7 @@ function getTests()
     'TestIdentifyCluster',
     'TestLogCommands',
     'TestOperationalCredentialsCluster',
+    // 'TestSelfFabricRemoval',  --> TODO: Integrate here when Darwin can live with current fabric going away
     'TestBinding',
     'TestUserLabelCluster',
   ];
@@ -335,5 +334,5 @@ function getTests()
 //
 // Module exports
 //
-exports.getTests       = getTests;
+exports.getTests = getTests;
 exports.getManualTests = getManualTests;

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -161,6 +161,10 @@ void CASESession::Clear()
     Crypto::ClearSecretData(mIPK);
 
     AbortExchange();
+
+    mLocalNodeId = kUndefinedNodeId;
+    mPeerNodeId = kUndefinedNodeId;
+    mFabricInfo = nullptr;
 }
 
 void CASESession::AbortExchange()
@@ -257,6 +261,10 @@ CHIP_ERROR CASESession::EstablishSession(SessionManager & sessionManager, Fabric
 
     mExchangeCtxt->SetResponseTimeout(kSigma_Response_Timeout + mExchangeCtxt->GetSessionHandle()->GetAckTimeout());
     mPeerNodeId = peerNodeId;
+    mLocalNodeId = fabric->GetNodeId();
+
+    ChipLogProgress(SecureChannel, "Initiating session on local FabricIndex %u from 0x" ChipLogFormatX64 " -> 0x" ChipLogFormatX64,
+        static_cast<unsigned>(fabric->GetFabricIndex()), ChipLogValueX64(mLocalNodeId), ChipLogValueX64(mPeerNodeId));
 
     err = SendSigma1();
     SuccessOrExit(err);
@@ -336,9 +344,13 @@ CHIP_ERROR CASESession::RecoverInitiatorIpk()
     size_t ipkIndex = (ipkKeySet.num_keys_used > 1) ? ((ipkKeySet.num_keys_used - 1) - 1) : 0;
     memcpy(&mIPK[0], ipkKeySet.epoch_keys[ipkIndex].key, sizeof(mIPK));
 
+    // Leaving this logging code for debug, but this cannot be enabled at runtime
+    // since it leaks private security material.
+#if 0
     ChipLogProgress(SecureChannel, "RecoverInitiatorIpk: GroupDataProvider %p, Got IPK for FabricIndex %u", mGroupDataProvider,
                     static_cast<unsigned>(mFabricInfo->GetFabricIndex()));
     ChipLogByteSpan(SecureChannel, ByteSpan(mIPK));
+#endif
 
     return CHIP_NO_ERROR;
 }
@@ -492,6 +504,7 @@ CHIP_ERROR CASESession::FindLocalNodeFromDestionationId(const ByteSpan & destina
                 MutableByteSpan ipkSpan(mIPK);
                 CopySpanToMutableSpan(candidateIpkSpan, ipkSpan);
                 mFabricInfo = &fabricInfo;
+                mLocalNodeId = nodeId;
                 break;
             }
         }
@@ -524,6 +537,7 @@ CHIP_ERROR CASESession::TryResumeSession(SessionResumptionStorage::ConstResumpti
         return CHIP_ERROR_INTERNAL;
 
     mPeerNodeId = node.GetNodeId();
+    mLocalNodeId = mFabricInfo->GetNodeId();
 
     return CHIP_NO_ERROR;
 }
@@ -569,11 +583,15 @@ CHIP_ERROR CASESession::HandleSigma1(System::PacketBufferHandle && msg)
         return CHIP_NO_ERROR;
     }
 
+    // Attempt to match the initiator's desired destination based on local fabric table.
     err = FindLocalNodeFromDestionationId(destinationIdentifier, initiatorRandom);
     if (err == CHIP_NO_ERROR)
     {
         ChipLogProgress(SecureChannel, "CASE matched destination ID: fabricIndex %u, NodeID 0x" ChipLogFormatX64,
-                        static_cast<unsigned>(mFabricInfo->GetFabricIndex()), ChipLogValueX64(mFabricInfo->GetNodeId()));
+                        static_cast<unsigned>(mFabricInfo->GetFabricIndex()), ChipLogValueX64(mLocalNodeId));
+
+        // Side-effect of FindLocalNodeFromDestionationId success was that mFabricInfo/mLocalNodeId are now
+        // set to the local fabric and associated NodeId that was targeted by the initiator.
     }
     else
     {

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -163,8 +163,8 @@ void CASESession::Clear()
     AbortExchange();
 
     mLocalNodeId = kUndefinedNodeId;
-    mPeerNodeId = kUndefinedNodeId;
-    mFabricInfo = nullptr;
+    mPeerNodeId  = kUndefinedNodeId;
+    mFabricInfo  = nullptr;
 }
 
 void CASESession::AbortExchange()
@@ -260,11 +260,11 @@ CHIP_ERROR CASESession::EstablishSession(SessionManager & sessionManager, Fabric
     mLocalMRPConfig = mrpConfig;
 
     mExchangeCtxt->SetResponseTimeout(kSigma_Response_Timeout + mExchangeCtxt->GetSessionHandle()->GetAckTimeout());
-    mPeerNodeId = peerNodeId;
+    mPeerNodeId  = peerNodeId;
     mLocalNodeId = fabric->GetNodeId();
 
     ChipLogProgress(SecureChannel, "Initiating session on local FabricIndex %u from 0x" ChipLogFormatX64 " -> 0x" ChipLogFormatX64,
-        static_cast<unsigned>(fabric->GetFabricIndex()), ChipLogValueX64(mLocalNodeId), ChipLogValueX64(mPeerNodeId));
+                    static_cast<unsigned>(fabric->GetFabricIndex()), ChipLogValueX64(mLocalNodeId), ChipLogValueX64(mPeerNodeId));
 
     err = SendSigma1();
     SuccessOrExit(err);
@@ -503,7 +503,7 @@ CHIP_ERROR CASESession::FindLocalNodeFromDestionationId(const ByteSpan & destina
                 found = true;
                 MutableByteSpan ipkSpan(mIPK);
                 CopySpanToMutableSpan(candidateIpkSpan, ipkSpan);
-                mFabricInfo = &fabricInfo;
+                mFabricInfo  = &fabricInfo;
                 mLocalNodeId = nodeId;
                 break;
             }
@@ -536,7 +536,7 @@ CHIP_ERROR CASESession::TryResumeSession(SessionResumptionStorage::ConstResumpti
     if (mFabricInfo == nullptr)
         return CHIP_ERROR_INTERNAL;
 
-    mPeerNodeId = node.GetNodeId();
+    mPeerNodeId  = node.GetNodeId();
     mLocalNodeId = mFabricInfo->GetNodeId();
 
     return CHIP_NO_ERROR;

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -64,6 +64,7 @@ public:
 
     Transport::SecureSession::Type GetSecureSessionType() const override { return Transport::SecureSession::Type::kCASE; }
     ScopedNodeId GetPeer() const override { return ScopedNodeId(mPeerNodeId, GetFabricIndex()); }
+    ScopedNodeId GetLocalScopedNodeId() const override { return ScopedNodeId(mLocalNodeId, GetFabricIndex()); }
     CATValues GetPeerCATs() const override { return mPeerCATs; };
 
     /**
@@ -253,6 +254,7 @@ private:
     FabricTable * mFabricsTable    = nullptr;
     const FabricInfo * mFabricInfo = nullptr;
     NodeId mPeerNodeId             = kUndefinedNodeId;
+    NodeId mLocalNodeId            = kUndefinedNodeId;
     CATValues mPeerCATs;
 
     // This field is only used for CASE responder, when during sending sigma2 and waiting for sigma3

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -78,6 +78,13 @@ public:
     {
         return ScopedNodeId(NodeIdFromPAKEKeyId(kDefaultCommissioningPasscodeId), kUndefinedFabricIndex);
     }
+
+    ScopedNodeId GetLocalScopedNodeId() const override
+    {
+        // For PASE, source is always the undefined node ID
+        return ScopedNodeId();
+    }
+
     CATValues GetPeerCATs() const override { return CATValues(); };
 
     CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override;

--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -27,7 +27,7 @@ namespace Transport {
 class IncomingGroupSession : public Session
 {
 public:
-    IncomingGroupSession(GroupId group, FabricIndex fabricIndex, NodeId sourceNodeId) : mGroupId(group), mSourceNodeId(sourceNodeId)
+    IncomingGroupSession(GroupId group, FabricIndex fabricIndex, NodeId peerNodeId) : mGroupId(group), mPeerNodeId(peerNodeId)
     {
         SetFabricIndex(fabricIndex);
     }
@@ -38,7 +38,8 @@ public:
     const char * GetSessionTypeString() const override { return "incoming group"; };
 #endif
 
-    ScopedNodeId GetPeer() const override { return ScopedNodeId(mSourceNodeId, GetFabricIndex()); }
+    ScopedNodeId GetPeer() const override { return ScopedNodeId(mPeerNodeId, GetFabricIndex()); }
+    ScopedNodeId GetLocalScopedNodeId() const override { return ScopedNodeId(kUndefinedNodeId, GetFabricIndex()); }
 
     Access::SubjectDescriptor GetSubjectDescriptor() const override
     {
@@ -68,11 +69,9 @@ public:
 
     GroupId GetGroupId() const { return mGroupId; }
 
-    NodeId GetSourceNodeId() const { return mSourceNodeId; }
-
 private:
     const GroupId mGroupId;
-    const NodeId mSourceNodeId;
+    const NodeId mPeerNodeId;
 };
 
 class OutgoingGroupSession : public Session
@@ -86,7 +85,10 @@ public:
     const char * GetSessionTypeString() const override { return "outgoing group"; };
 #endif
 
+    // Peer node ID is unused: users care about the group, not the node
     ScopedNodeId GetPeer() const override { return ScopedNodeId(); }
+    // Local node ID is unused: users care about the group, not the node
+    ScopedNodeId GetLocalScopedNodeId() const override { return ScopedNodeId(); }
 
     Access::SubjectDescriptor GetSubjectDescriptor() const override
     {

--- a/src/transport/PairingSession.cpp
+++ b/src/transport/PairingSession.cpp
@@ -48,7 +48,8 @@ CHIP_ERROR PairingSession::ActivateSecureSession(const Transport::PeerAddress & 
 
     // Call Activate last, otherwise errors on anything after would lead to
     // a partially valid session.
-    secureSession->Activate(GetSecureSessionType(), GetPeer(), GetLocalScopedNodeId(), GetPeerCATs(), peerSessionId, mRemoteMRPConfig);
+    secureSession->Activate(GetSecureSessionType(), GetPeer(), GetLocalScopedNodeId(), GetPeerCATs(), peerSessionId,
+                            mRemoteMRPConfig);
 
     ChipLogDetail(Inet, "New secure session created for device " ChipLogFormatScopedNodeId ", LSID:%d PSID:%d!",
                   ChipLogValueScopedNodeId(GetPeer()), secureSession->GetLocalSessionId(), peerSessionId);

--- a/src/transport/PairingSession.cpp
+++ b/src/transport/PairingSession.cpp
@@ -48,7 +48,7 @@ CHIP_ERROR PairingSession::ActivateSecureSession(const Transport::PeerAddress & 
 
     // Call Activate last, otherwise errors on anything after would lead to
     // a partially valid session.
-    secureSession->Activate(GetSecureSessionType(), GetPeer(), GetPeerCATs(), peerSessionId, mRemoteMRPConfig);
+    secureSession->Activate(GetSecureSessionType(), GetPeer(), GetLocalScopedNodeId(), GetPeerCATs(), peerSessionId, mRemoteMRPConfig);
 
     ChipLogDetail(Inet, "New secure session created for device " ChipLogFormatScopedNodeId ", LSID:%d PSID:%d!",
                   ChipLogValueScopedNodeId(GetPeer()), secureSession->GetLocalSessionId(), peerSessionId);

--- a/src/transport/PairingSession.cpp
+++ b/src/transport/PairingSession.cpp
@@ -48,7 +48,7 @@ CHIP_ERROR PairingSession::ActivateSecureSession(const Transport::PeerAddress & 
 
     // Call Activate last, otherwise errors on anything after would lead to
     // a partially valid session.
-    secureSession->Activate(GetSecureSessionType(), GetPeer(), GetLocalScopedNodeId(), GetPeerCATs(), peerSessionId,
+    secureSession->Activate(GetSecureSessionType(), GetLocalScopedNodeId(), GetPeer(), GetPeerCATs(), peerSessionId,
                             mRemoteMRPConfig);
 
     ChipLogDetail(Inet, "New secure session created for device " ChipLogFormatScopedNodeId ", LSID:%d PSID:%d!",

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -44,6 +44,7 @@ public:
 
     virtual Transport::SecureSession::Type GetSecureSessionType() const = 0;
     virtual ScopedNodeId GetPeer() const                                = 0;
+    virtual ScopedNodeId GetLocalScopedNodeId() const                   = 0;
     virtual CATValues GetPeerCATs() const                               = 0;
 
     Optional<uint16_t> GetLocalSessionId() const

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -20,11 +20,6 @@
 namespace chip {
 namespace Transport {
 
-ScopedNodeId SecureSession::GetPeer() const
-{
-    return ScopedNodeId(mPeerNodeId, GetFabricIndex());
-}
-
 Access::SubjectDescriptor SecureSession::GetSubjectDescriptor() const
 {
     Access::SubjectDescriptor subjectDescriptor;

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -72,11 +72,11 @@ public:
 
     // TODO: This constructor should be private.  Tests should allocate a
     // kPending session and then call Activate(), just like non-test code does.
-    SecureSession(Type secureSessionType, uint16_t localSessionId, NodeId peerNodeId, NodeId localNodeId, CATValues peerCATs, uint16_t peerSessionId,
-                  FabricIndex fabric, const ReliableMessageProtocolConfig & config) :
+    SecureSession(Type secureSessionType, uint16_t localSessionId, NodeId peerNodeId, NodeId localNodeId, CATValues peerCATs,
+                  uint16_t peerSessionId, FabricIndex fabric, const ReliableMessageProtocolConfig & config) :
         mSecureSessionType(secureSessionType),
-        mPeerNodeId(peerNodeId), mLocalNodeId(localNodeId), mPeerCATs(peerCATs), mLocalSessionId(localSessionId), mPeerSessionId(peerSessionId),
-        mLastActivityTime(System::SystemClock().GetMonotonicTimestamp()),
+        mPeerNodeId(peerNodeId), mLocalNodeId(localNodeId), mPeerCATs(peerCATs), mLocalSessionId(localSessionId),
+        mPeerSessionId(peerSessionId), mLastActivityTime(System::SystemClock().GetMonotonicTimestamp()),
         mLastPeerActivityTime(System::SystemClock().GetMonotonicTimestamp()), mMRPConfig(config)
     {
         SetFabricIndex(fabric);
@@ -89,7 +89,8 @@ public:
      *   receives a local session ID, but no other state.
      */
     SecureSession(uint16_t localSessionId) :
-        SecureSession(Type::kPending, localSessionId, kUndefinedNodeId, kUndefinedNodeId, CATValues{}, 0, kUndefinedFabricIndex, GetLocalMRPConfig())
+        SecureSession(Type::kPending, localSessionId, kUndefinedNodeId, kUndefinedNodeId, CATValues{}, 0, kUndefinedFabricIndex,
+                      GetLocalMRPConfig())
     {}
 
     /**
@@ -108,7 +109,8 @@ public:
         // CASE sessions must always start "associated" a given Fabric!
         VerifyOrDie(!((secureSessionType == Type::kCASE) && (peerNode.GetFabricIndex() == kUndefinedFabricIndex)));
         // CASE sessions can only be activated against operational node IDs!
-        VerifyOrDie(!((secureSessionType == Type::kCASE) && (!IsOperationalNodeId(peerNode.GetNodeId()) || !IsOperationalNodeId(localNode.GetNodeId()))));
+        VerifyOrDie(!((secureSessionType == Type::kCASE) &&
+                      (!IsOperationalNodeId(peerNode.GetNodeId()) || !IsOperationalNodeId(localNode.GetNodeId()))));
 
         mSecureSessionType = secureSessionType;
         mPeerNodeId        = peerNode.GetNodeId();
@@ -130,15 +132,9 @@ public:
     const char * GetSessionTypeString() const override { return "secure"; };
 #endif
 
-    ScopedNodeId GetPeer() const override
-    {
-        return ScopedNodeId(mPeerNodeId, GetFabricIndex());
-    }
+    ScopedNodeId GetPeer() const override { return ScopedNodeId(mPeerNodeId, GetFabricIndex()); }
 
-    ScopedNodeId GetLocalScopedNodeId() const override
-    {
-        return ScopedNodeId(mLocalNodeId, GetFabricIndex());
-    }
+    ScopedNodeId GetLocalScopedNodeId() const override { return ScopedNodeId(mLocalNodeId, GetFabricIndex()); }
 
     Access::SubjectDescriptor GetSubjectDescriptor() const override;
 

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -72,10 +72,10 @@ public:
 
     // TODO: This constructor should be private.  Tests should allocate a
     // kPending session and then call Activate(), just like non-test code does.
-    SecureSession(Type secureSessionType, uint16_t localSessionId, NodeId peerNodeId, NodeId localNodeId, CATValues peerCATs,
+    SecureSession(Type secureSessionType, uint16_t localSessionId, NodeId localNodeId, NodeId peerNodeId, CATValues peerCATs,
                   uint16_t peerSessionId, FabricIndex fabric, const ReliableMessageProtocolConfig & config) :
         mSecureSessionType(secureSessionType),
-        mPeerNodeId(peerNodeId), mLocalNodeId(localNodeId), mPeerCATs(peerCATs), mLocalSessionId(localSessionId),
+        mLocalSessionId(localSessionId), mLocalNodeId(localNodeId), mPeerNodeId(peerNodeId), mPeerCATs(peerCATs),
         mPeerSessionId(peerSessionId), mLastActivityTime(System::SystemClock().GetMonotonicTimestamp()),
         mLastPeerActivityTime(System::SystemClock().GetMonotonicTimestamp()), mMRPConfig(config)
     {
@@ -208,10 +208,10 @@ public:
 
 private:
     Type mSecureSessionType;
-    NodeId mPeerNodeId;
-    NodeId mLocalNodeId;
-    CATValues mPeerCATs;
     const uint16_t mLocalSessionId;
+    NodeId mLocalNodeId;
+    NodeId mPeerNodeId;
+    CATValues mPeerCATs;
     uint16_t mPeerSessionId;
 
     PeerAddress mPeerAddress;

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -99,7 +99,7 @@ public:
      *   PASE, setting internal state according to the parameters used and
      *   discovered during session establishment.
      */
-    void Activate(Type secureSessionType, const ScopedNodeId & peerNode, const ScopedNodeId & localNode, CATValues peerCATs,
+    void Activate(Type secureSessionType, const ScopedNodeId & localNode, const ScopedNodeId & peerNode, CATValues peerCATs,
                   uint16_t peerSessionId, const ReliableMessageProtocolConfig & config)
     {
         VerifyOrDie(peerNode.GetFabricIndex() == localNode.GetFabricIndex());

--- a/src/transport/SecureSessionTable.h
+++ b/src/transport/SecureSessionTable.h
@@ -62,8 +62,9 @@ public:
      */
     CHECK_RETURN_VALUE
     Optional<SessionHandle> CreateNewSecureSessionForTest(SecureSession::Type secureSessionType, uint16_t localSessionId,
-                                                          NodeId peerNodeId, NodeId localNodeId, CATValues peerCATs, uint16_t peerSessionId,
-                                                          FabricIndex fabricIndex, const ReliableMessageProtocolConfig & config)
+                                                          NodeId peerNodeId, NodeId localNodeId, CATValues peerCATs,
+                                                          uint16_t peerSessionId, FabricIndex fabricIndex,
+                                                          const ReliableMessageProtocolConfig & config)
     {
         if (secureSessionType == SecureSession::Type::kCASE)
         {
@@ -83,13 +84,13 @@ public:
                 }
                 else
                 {
-                    (void)fabricIndex;
+                    (void) fabricIndex;
                 }
             }
         }
 
-        SecureSession * result =
-            mEntries.CreateObject(secureSessionType, localSessionId, peerNodeId, localNodeId, peerCATs, peerSessionId, fabricIndex, config);
+        SecureSession * result = mEntries.CreateObject(secureSessionType, localSessionId, peerNodeId, localNodeId, peerCATs,
+                                                       peerSessionId, fabricIndex, config);
         return result != nullptr ? MakeOptional<SessionHandle>(*result) : Optional<SessionHandle>::Missing();
     }
 

--- a/src/transport/SecureSessionTable.h
+++ b/src/transport/SecureSessionTable.h
@@ -49,6 +49,7 @@ public:
      * @param secureSessionType secure session type
      * @param localSessionId unique identifier for the local node's secure unicast session context
      * @param peerNodeId represents peer Node's ID
+     * @param localNodeId represents local Node's ID
      * @param peerCATs represents peer CASE Authenticated Tags
      * @param peerSessionId represents the encryption key ID assigned by peer node
      * @param fabric represents fabric ID for the session
@@ -61,11 +62,34 @@ public:
      */
     CHECK_RETURN_VALUE
     Optional<SessionHandle> CreateNewSecureSessionForTest(SecureSession::Type secureSessionType, uint16_t localSessionId,
-                                                          NodeId peerNodeId, CATValues peerCATs, uint16_t peerSessionId,
-                                                          FabricIndex fabric, const ReliableMessageProtocolConfig & config)
+                                                          NodeId peerNodeId, NodeId localNodeId, CATValues peerCATs, uint16_t peerSessionId,
+                                                          FabricIndex fabricIndex, const ReliableMessageProtocolConfig & config)
     {
+        if (secureSessionType == SecureSession::Type::kCASE)
+        {
+            if ((fabricIndex == kUndefinedFabricIndex) || (localNodeId == kUndefinedNodeId) || (peerNodeId == kUndefinedNodeId))
+            {
+                return Optional<SessionHandle>::Missing();
+            }
+        }
+        else if (secureSessionType == SecureSession::Type::kPASE)
+        {
+            if ((fabricIndex != kUndefinedFabricIndex) || (localNodeId != kUndefinedNodeId) || (peerNodeId != kUndefinedNodeId))
+            {
+                // TODO: This secure session type is infeasible! We must fix the tests
+                if (false)
+                {
+                    return Optional<SessionHandle>::Missing();
+                }
+                else
+                {
+                    (void)fabricIndex;
+                }
+            }
+        }
+
         SecureSession * result =
-            mEntries.CreateObject(secureSessionType, localSessionId, peerNodeId, peerCATs, peerSessionId, fabric, config);
+            mEntries.CreateObject(secureSessionType, localSessionId, peerNodeId, localNodeId, peerCATs, peerSessionId, fabricIndex, config);
         return result != nullptr ? MakeOptional<SessionHandle>(*result) : Optional<SessionHandle>::Missing();
     }
 

--- a/src/transport/SecureSessionTable.h
+++ b/src/transport/SecureSessionTable.h
@@ -48,11 +48,11 @@ public:
      *
      * @param secureSessionType secure session type
      * @param localSessionId unique identifier for the local node's secure unicast session context
+     * @param localNodeId represents the local Node ID for this node
      * @param peerNodeId represents peer Node's ID
-     * @param localNodeId represents local Node's ID
      * @param peerCATs represents peer CASE Authenticated Tags
      * @param peerSessionId represents the encryption key ID assigned by peer node
-     * @param fabric represents fabric ID for the session
+     * @param fabricIndex represents fabric index for the session
      * @param config represents the reliable message protocol configuration
      *
      * @note the newly created state will have an 'active' time set based on the current time source.
@@ -62,7 +62,7 @@ public:
      */
     CHECK_RETURN_VALUE
     Optional<SessionHandle> CreateNewSecureSessionForTest(SecureSession::Type secureSessionType, uint16_t localSessionId,
-                                                          NodeId peerNodeId, NodeId localNodeId, CATValues peerCATs,
+                                                          NodeId localNodeId, NodeId peerNodeId, CATValues peerCATs,
                                                           uint16_t peerSessionId, FabricIndex fabricIndex,
                                                           const ReliableMessageProtocolConfig & config)
     {
@@ -89,7 +89,7 @@ public:
             }
         }
 
-        SecureSession * result = mEntries.CreateObject(secureSessionType, localSessionId, peerNodeId, localNodeId, peerCATs,
+        SecureSession * result = mEntries.CreateObject(secureSessionType, localSessionId, localNodeId, peerNodeId, peerCATs,
                                                        peerSessionId, fabricIndex, config);
         return result != nullptr ? MakeOptional<SessionHandle>(*result) : Optional<SessionHandle>::Missing();
     }

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -70,6 +70,7 @@ public:
     virtual void Release() {}
 
     virtual ScopedNodeId GetPeer() const                               = 0;
+    virtual ScopedNodeId GetLocalScopedNodeId() const                  = 0;
     virtual Access::SubjectDescriptor GetSubjectDescriptor() const     = 0;
     virtual bool RequireMRP() const                                    = 0;
     virtual const ReliableMessageProtocolConfig & GetMRPConfig() const = 0;

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -400,8 +400,8 @@ CHIP_ERROR SessionManager::InjectPaseSessionWithTestKey(SessionHolder & sessionH
 {
     NodeId localNodeId = kUndefinedNodeId;
     Optional<SessionHandle> session =
-        mSecureSessions.CreateNewSecureSessionForTest(chip::Transport::SecureSession::Type::kPASE, localSessionId, localNodeId, peerNodeId,
-                                                      CATValues{}, peerSessionId, fabric, GetLocalMRPConfig());
+        mSecureSessions.CreateNewSecureSessionForTest(chip::Transport::SecureSession::Type::kPASE, localSessionId, localNodeId,
+                                                      peerNodeId, CATValues{}, peerSessionId, fabric, GetLocalMRPConfig());
     VerifyOrReturnError(session.HasValue(), CHIP_ERROR_NO_MEMORY);
     SecureSession * secureSession = session.Value()->AsSecureSession();
     secureSession->SetPeerAddress(peerAddress);

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -158,7 +158,8 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         mGroupClientCounter.IncrementCounter(isControlMsg);
         packetHeader.SetFlags(Header::SecFlagValues::kPrivacyFlag);
         packetHeader.SetSessionType(Header::SessionType::kGroupSession);
-        packetHeader.SetSourceNodeId(fabric->GetNodeId());
+        NodeId sourceNodeId = fabric->GetNodeId();
+        packetHeader.SetSourceNodeId(sourceNodeId);
 
         if (!packetHeader.IsValidGroupMsg())
         {
@@ -174,7 +175,7 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
 
         packetHeader.SetSessionId(keyContext->GetKeyHash());
         CryptoContext::NonceStorage nonce;
-        CryptoContext::BuildNonce(nonce, packetHeader.GetSecurityFlags(), packetHeader.GetMessageCounter(), fabric->GetNodeId());
+        CryptoContext::BuildNonce(nonce, packetHeader.GetSecurityFlags(), packetHeader.GetMessageCounter(), sourceNodeId);
         CHIP_ERROR err = SecureMessageCodec::Encrypt(CryptoContext(keyContext), nonce, payloadHeader, packetHeader, message);
         keyContext->Release();
         ReturnErrorOnFailure(err);
@@ -203,18 +204,9 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         CHIP_TRACE_MESSAGE_SENT(payloadHeader, packetHeader, message->Start(), message->TotalLength());
 
         CryptoContext::NonceStorage nonce;
-        if (session->GetSecureSessionType() == SecureSession::Type::kCASE)
-        {
-            FabricInfo * fabric = mFabricTable->FindFabricWithIndex(session->GetFabricIndex());
-            VerifyOrDie(fabric != nullptr);
-            CryptoContext::BuildNonce(nonce, packetHeader.GetSecurityFlags(), messageCounter, fabric->GetNodeId());
-        }
-        else
-        {
-            // PASE Sessions use the undefined node ID of all zeroes, since there is no node ID to use
-            // and the key is short-lived and always different for each PASE session.
-            CryptoContext::BuildNonce(nonce, packetHeader.GetSecurityFlags(), messageCounter, kUndefinedNodeId);
-        }
+        NodeId sourceNodeId = session->GetLocalScopedNodeId().GetNodeId();
+        CryptoContext::BuildNonce(nonce, packetHeader.GetSecurityFlags(), messageCounter, sourceNodeId);
+
         ReturnErrorOnFailure(SecureMessageCodec::Encrypt(session->GetCryptoContext(), nonce, payloadHeader, packetHeader, message));
         ReturnErrorOnFailure(counter.Advance());
 
@@ -406,9 +398,10 @@ CHIP_ERROR SessionManager::InjectPaseSessionWithTestKey(SessionHolder & sessionH
                                                         uint16_t peerSessionId, FabricIndex fabric,
                                                         const Transport::PeerAddress & peerAddress, CryptoContext::SessionRole role)
 {
+    NodeId localNodeId = kUndefinedNodeId;
     Optional<SessionHandle> session =
         mSecureSessions.CreateNewSecureSessionForTest(chip::Transport::SecureSession::Type::kPASE, localSessionId, peerNodeId,
-                                                      CATValues{}, peerSessionId, fabric, GetLocalMRPConfig());
+                                                      localNodeId, CATValues{}, peerSessionId, fabric, GetLocalMRPConfig());
     VerifyOrReturnError(session.HasValue(), CHIP_ERROR_NO_MEMORY);
     SecureSession * secureSession = session.Value()->AsSecureSession();
     secureSession->SetPeerAddress(peerAddress);

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -400,8 +400,8 @@ CHIP_ERROR SessionManager::InjectPaseSessionWithTestKey(SessionHolder & sessionH
 {
     NodeId localNodeId = kUndefinedNodeId;
     Optional<SessionHandle> session =
-        mSecureSessions.CreateNewSecureSessionForTest(chip::Transport::SecureSession::Type::kPASE, localSessionId, peerNodeId,
-                                                      localNodeId, CATValues{}, peerSessionId, fabric, GetLocalMRPConfig());
+        mSecureSessions.CreateNewSecureSessionForTest(chip::Transport::SecureSession::Type::kPASE, localSessionId, localNodeId, peerNodeId,
+                                                      CATValues{}, peerSessionId, fabric, GetLocalMRPConfig());
     VerifyOrReturnError(session.HasValue(), CHIP_ERROR_NO_MEMORY);
     SecureSession * secureSession = session.Value()->AsSecureSession();
     secureSession->SetPeerAddress(peerAddress);

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -158,8 +158,8 @@ public:
 
     // Test-only: create a session on the fly.
     CHIP_ERROR InjectPaseSessionWithTestKey(SessionHolder & sessionHolder, uint16_t localSessionId, NodeId peerNodeId,
-                                            uint16_t peerSessionId, FabricIndex fabric, const Transport::PeerAddress & peerAddress,
-                                            CryptoContext::SessionRole role);
+                                            uint16_t peerSessionId, FabricIndex fabricIndex,
+                                            const Transport::PeerAddress & peerAddress, CryptoContext::SessionRole role);
 
     /**
      * @brief

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -83,7 +83,7 @@ public:
     void Release() override { ReferenceCounted<UnauthenticatedSession, UnauthenticatedSessionDeleter, 0>::Release(); }
 
     ScopedNodeId GetPeer() const override { return ScopedNodeId(GetPeerNodeId(), kUndefinedFabricIndex); }
-    ScopedNodeId GetLocalScopedNodeId() const override { return ScopedNodeId(kUndefinedFabricIndex, kUndefinedFabricIndex); }
+    ScopedNodeId GetLocalScopedNodeId() const override { return ScopedNodeId(kUndefinedNodeId, kUndefinedFabricIndex); }
 
     Access::SubjectDescriptor GetSubjectDescriptor() const override
     {

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -82,7 +82,8 @@ public:
     void Retain() override { ReferenceCounted<UnauthenticatedSession, UnauthenticatedSessionDeleter, 0>::Retain(); }
     void Release() override { ReferenceCounted<UnauthenticatedSession, UnauthenticatedSessionDeleter, 0>::Release(); }
 
-    ScopedNodeId GetPeer() const override { return ScopedNodeId(kUndefinedNodeId, GetFabricIndex()); }
+    ScopedNodeId GetPeer() const override { return ScopedNodeId(GetPeerNodeId(), kUndefinedFabricIndex); }
+    ScopedNodeId GetLocalScopedNodeId() const override { return ScopedNodeId(kUndefinedFabricIndex, kUndefinedFabricIndex); }
 
     Access::SubjectDescriptor GetSubjectDescriptor() const override
     {

--- a/src/transport/tests/TestPairingSession.cpp
+++ b/src/transport/tests/TestPairingSession.cpp
@@ -43,6 +43,7 @@ class TestPairingSession : public PairingSession
 public:
     Transport::SecureSession::Type GetSecureSessionType() const override { return Transport::SecureSession::Type::kPASE; }
     ScopedNodeId GetPeer() const override { return ScopedNodeId(); }
+    ScopedNodeId GetLocalScopedNodeId() const override { return ScopedNodeId(); }
     CATValues GetPeerCATs() const override { return CATValues(); };
 
     const ReliableMessageProtocolConfig & GetRemoteMRPConfig() const { return mRemoteMRPConfig; }

--- a/src/transport/tests/TestPeerConnections.cpp
+++ b/src/transport/tests/TestPeerConnections.cpp
@@ -44,13 +44,13 @@ PeerAddress AddressFromString(const char * str)
     return PeerAddress::UDP(addr);
 }
 
-const PeerAddress kPeer1Addr = AddressFromString("fe80::1");
-const PeerAddress kPeer2Addr = AddressFromString("fe80::2");
+const PeerAddress kPeer1Addr    = AddressFromString("fe80::1");
+const PeerAddress kPeer2Addr    = AddressFromString("fe80::2");
 const PeerAddress kPasePeerAddr = AddressFromString("fe80::3");
 
-const NodeId kLocalNodeId = 0xC439A991071292DB;
-const NodeId kCasePeer1NodeId = 123;
-const NodeId kCasePeer2NodeId = 6;
+const NodeId kLocalNodeId      = 0xC439A991071292DB;
+const NodeId kCasePeer1NodeId  = 123;
+const NodeId kCasePeer2NodeId  = 6;
 const FabricIndex kFabricIndex = 8;
 
 const NodeId kPasePeerNodeId = kUndefinedNodeId; // PASE is always undefined
@@ -69,8 +69,8 @@ void TestBasicFunctionality(nlTestSuite * inSuite, void * inContext)
     CATValues peerCATs;
 
     // First node, peer session id 1, local session id 2
-    auto optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kCasePeer1NodeId, kLocalNodeId, kPeer1CATs, 1,
-                                                                     kFabricIndex, GetLocalMRPConfig());
+    auto optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kCasePeer1NodeId, kLocalNodeId,
+                                                                     kPeer1CATs, 1, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetSecureSessionType() == SecureSession::Type::kCASE);
     NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetPeerNodeId() == kCasePeer1NodeId);
@@ -81,8 +81,8 @@ void TestBasicFunctionality(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, memcmp(&peerCATs, &kPeer1CATs, sizeof(CATValues)) == 0);
 
     // Second node, peer session id 3, local session id 4
-    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 4, kCasePeer2NodeId, kLocalNodeId, kPeer2CATs, 3,
-                                                                kFabricIndex, GetLocalMRPConfig());
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 4, kCasePeer2NodeId, kLocalNodeId,
+                                                                kPeer2CATs, 3, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetSecureSessionType() == SecureSession::Type::kCASE);
     NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetPeerNodeId() == kCasePeer2NodeId);
@@ -94,8 +94,8 @@ void TestBasicFunctionality(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, memcmp(&peerCATs, &kPeer2CATs, sizeof(CATValues)) == 0);
 
     // Insufficient space for new connections. Object is max size 2
-    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kPASE, 6, kPasePeerNodeId, kLocalNodeId, kPeer3CATs, 5,
-                                                                kUndefinedFabricIndex, GetLocalMRPConfig());
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kPASE, 6, kPasePeerNodeId, kLocalNodeId,
+                                                                kPeer3CATs, 5, kUndefinedFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, !optionalSession.HasValue());
     System::Clock::Internal::SetSystemClockForTesting(realClock);
 }
@@ -108,16 +108,16 @@ void TestFindByKeyId(nlTestSuite * inSuite, void * inContext)
     System::Clock::Internal::SetSystemClockForTesting(&clock);
 
     // First node, peer session id 1, local session id 2
-    auto optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kCasePeer1NodeId, kLocalNodeId, kPeer1CATs, 1,
-                                                                     kFabricIndex, GetLocalMRPConfig());
+    auto optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kCasePeer1NodeId, kLocalNodeId,
+                                                                     kPeer1CATs, 1, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
 
     NL_TEST_ASSERT(inSuite, !connections.FindSecureSessionByLocalKey(1).HasValue());
     NL_TEST_ASSERT(inSuite, connections.FindSecureSessionByLocalKey(2).HasValue());
 
     // Second node, peer session id 3, local session id 4
-    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 4, kCasePeer2NodeId, kLocalNodeId, kPeer2CATs, 3,
-                                                                kFabricIndex, GetLocalMRPConfig());
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 4, kCasePeer2NodeId, kLocalNodeId,
+                                                                kPeer2CATs, 3, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
 
     NL_TEST_ASSERT(inSuite, !connections.FindSecureSessionByLocalKey(3).HasValue());
@@ -145,22 +145,22 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
     clock.SetMonotonic(100_ms64);
 
     // First node, peer session id 1, local session id 2
-    auto optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kCasePeer1NodeId, kLocalNodeId, kPeer1CATs, 1,
-                                                                     kFabricIndex, GetLocalMRPConfig());
+    auto optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kCasePeer1NodeId, kLocalNodeId,
+                                                                     kPeer1CATs, 1, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     optionalSession.Value()->AsSecureSession()->SetPeerAddress(kPeer1Addr);
 
     clock.SetMonotonic(200_ms64);
     // Second node, peer session id 3, local session id 4
-    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 4, kCasePeer2NodeId, kLocalNodeId, kPeer2CATs, 3,
-                                                                kFabricIndex, GetLocalMRPConfig());
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 4, kCasePeer2NodeId, kLocalNodeId,
+                                                                kPeer2CATs, 3, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     optionalSession.Value()->AsSecureSession()->SetPeerAddress(kPeer2Addr);
 
     // cannot add before expiry
     clock.SetMonotonic(300_ms64);
-    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kPASE, 6, kPasePeerNodeId, kLocalNodeId, kPeer3CATs, 5,
-                                                                kFabricIndex, GetLocalMRPConfig());
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kPASE, 6, kPasePeerNodeId, kLocalNodeId,
+                                                                kPeer3CATs, 5, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, !optionalSession.HasValue());
 
     // at time 300, this expires ip addr 1
@@ -177,8 +177,8 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
     // now that the connections were expired, we can add peer3
     clock.SetMonotonic(300_ms64);
     // Third node (PASE session), peer session id 5, local session id 6
-    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kPASE, 6, kPasePeerNodeId, kLocalNodeId, kPeer3CATs, 5,
-                                                                kFabricIndex, GetLocalMRPConfig());
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kPASE, 6, kPasePeerNodeId, kLocalNodeId,
+                                                                kPeer3CATs, 5, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     optionalSession.Value()->AsSecureSession()->SetPeerAddress(kPasePeerAddr);
 
@@ -210,8 +210,8 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !connections.FindSecureSessionByLocalKey(6).HasValue());
 
     // First node, peer session id 1, local session id 2
-    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kCasePeer1NodeId, kLocalNodeId, kPeer1CATs, 1,
-                                                                kFabricIndex, GetLocalMRPConfig());
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kCasePeer1NodeId, kLocalNodeId,
+                                                                kPeer1CATs, 1, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     NL_TEST_ASSERT(inSuite, connections.FindSecureSessionByLocalKey(2).HasValue());
     NL_TEST_ASSERT(inSuite, connections.FindSecureSessionByLocalKey(4).HasValue());

--- a/src/transport/tests/TestPeerConnections.cpp
+++ b/src/transport/tests/TestPeerConnections.cpp
@@ -69,7 +69,7 @@ void TestBasicFunctionality(nlTestSuite * inSuite, void * inContext)
     CATValues peerCATs;
 
     // First node, peer session id 1, local session id 2
-    auto optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kCasePeer1NodeId, kLocalNodeId,
+    auto optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kLocalNodeId, kCasePeer1NodeId,
                                                                      kPeer1CATs, 1, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetSecureSessionType() == SecureSession::Type::kCASE);
@@ -81,7 +81,7 @@ void TestBasicFunctionality(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, memcmp(&peerCATs, &kPeer1CATs, sizeof(CATValues)) == 0);
 
     // Second node, peer session id 3, local session id 4
-    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 4, kCasePeer2NodeId, kLocalNodeId,
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 4, kLocalNodeId, kCasePeer2NodeId,
                                                                 kPeer2CATs, 3, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetSecureSessionType() == SecureSession::Type::kCASE);
@@ -94,7 +94,7 @@ void TestBasicFunctionality(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, memcmp(&peerCATs, &kPeer2CATs, sizeof(CATValues)) == 0);
 
     // Insufficient space for new connections. Object is max size 2
-    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kPASE, 6, kPasePeerNodeId, kLocalNodeId,
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kPASE, 6, kLocalNodeId, kPasePeerNodeId,
                                                                 kPeer3CATs, 5, kUndefinedFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, !optionalSession.HasValue());
     System::Clock::Internal::SetSystemClockForTesting(realClock);
@@ -108,7 +108,7 @@ void TestFindByKeyId(nlTestSuite * inSuite, void * inContext)
     System::Clock::Internal::SetSystemClockForTesting(&clock);
 
     // First node, peer session id 1, local session id 2
-    auto optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kCasePeer1NodeId, kLocalNodeId,
+    auto optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kLocalNodeId, kCasePeer1NodeId,
                                                                      kPeer1CATs, 1, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
 
@@ -116,7 +116,7 @@ void TestFindByKeyId(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, connections.FindSecureSessionByLocalKey(2).HasValue());
 
     // Second node, peer session id 3, local session id 4
-    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 4, kCasePeer2NodeId, kLocalNodeId,
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 4, kLocalNodeId, kCasePeer2NodeId,
                                                                 kPeer2CATs, 3, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
 
@@ -145,21 +145,21 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
     clock.SetMonotonic(100_ms64);
 
     // First node, peer session id 1, local session id 2
-    auto optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kCasePeer1NodeId, kLocalNodeId,
+    auto optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kLocalNodeId, kCasePeer1NodeId,
                                                                      kPeer1CATs, 1, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     optionalSession.Value()->AsSecureSession()->SetPeerAddress(kPeer1Addr);
 
     clock.SetMonotonic(200_ms64);
     // Second node, peer session id 3, local session id 4
-    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 4, kCasePeer2NodeId, kLocalNodeId,
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 4, kLocalNodeId, kCasePeer2NodeId,
                                                                 kPeer2CATs, 3, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     optionalSession.Value()->AsSecureSession()->SetPeerAddress(kPeer2Addr);
 
     // cannot add before expiry
     clock.SetMonotonic(300_ms64);
-    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kPASE, 6, kPasePeerNodeId, kLocalNodeId,
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kPASE, 6, kLocalNodeId, kPasePeerNodeId,
                                                                 kPeer3CATs, 5, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, !optionalSession.HasValue());
 
@@ -177,7 +177,7 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
     // now that the connections were expired, we can add peer3
     clock.SetMonotonic(300_ms64);
     // Third node (PASE session), peer session id 5, local session id 6
-    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kPASE, 6, kPasePeerNodeId, kLocalNodeId,
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kPASE, 6, kLocalNodeId, kPasePeerNodeId,
                                                                 kPeer3CATs, 5, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     optionalSession.Value()->AsSecureSession()->SetPeerAddress(kPasePeerAddr);
@@ -210,7 +210,7 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !connections.FindSecureSessionByLocalKey(6).HasValue());
 
     // First node, peer session id 1, local session id 2
-    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kCasePeer1NodeId, kLocalNodeId,
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kLocalNodeId, kCasePeer1NodeId,
                                                                 kPeer1CATs, 1, kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     NL_TEST_ASSERT(inSuite, connections.FindSecureSessionByLocalKey(2).HasValue());

--- a/src/transport/tests/TestPeerConnections.cpp
+++ b/src/transport/tests/TestPeerConnections.cpp
@@ -46,15 +46,14 @@ PeerAddress AddressFromString(const char * str)
 
 const PeerAddress kPeer1Addr = AddressFromString("fe80::1");
 const PeerAddress kPeer2Addr = AddressFromString("fe80::2");
-const PeerAddress kPeer3Addr = AddressFromString("fe80::3");
+const PeerAddress kPasePeerAddr = AddressFromString("fe80::3");
 
-const NodeId kPeer1NodeId = 123;
-const NodeId kPeer2NodeId = 6;
-const NodeId kPeer3NodeId = 81;
+const NodeId kLocalNodeId = 0xC439A991071292DB;
+const NodeId kCasePeer1NodeId = 123;
+const NodeId kCasePeer2NodeId = 6;
+const FabricIndex kFabricIndex = 8;
 
-const SecureSession::Type kPeer1SessionType = SecureSession::Type::kCASE;
-const SecureSession::Type kPeer2SessionType = SecureSession::Type::kCASE;
-const SecureSession::Type kPeer3SessionType = SecureSession::Type::kPASE;
+const NodeId kPasePeerNodeId = kUndefinedNodeId; // PASE is always undefined
 
 const CATValues kPeer1CATs = { { 0xABCD0001, 0xABCE0100, 0xABCD0020 } };
 const CATValues kPeer2CATs = { { 0xABCD0012, kUndefinedCAT, kUndefinedCAT } };
@@ -69,28 +68,34 @@ void TestBasicFunctionality(nlTestSuite * inSuite, void * inContext)
     clock.SetMonotonic(100_ms64);
     CATValues peerCATs;
 
-    // Node ID 1, peer key 1, local key 2
-    auto optionalSession = connections.CreateNewSecureSessionForTest(kPeer1SessionType, 2, kPeer1NodeId, kPeer1CATs, 1,
-                                                                     0 /* fabricIndex */, GetLocalMRPConfig());
+    // First node, peer session id 1, local session id 2
+    auto optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kCasePeer1NodeId, kLocalNodeId, kPeer1CATs, 1,
+                                                                     kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
-    NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetSecureSessionType() == kPeer1SessionType);
-    NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetPeerNodeId() == kPeer1NodeId);
+    NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetSecureSessionType() == SecureSession::Type::kCASE);
+    NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetPeerNodeId() == kCasePeer1NodeId);
+    NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetLocalNodeId() == kLocalNodeId);
+    NL_TEST_ASSERT(inSuite, optionalSession.Value()->GetPeer() == ScopedNodeId(kCasePeer1NodeId, kFabricIndex));
+    NL_TEST_ASSERT(inSuite, optionalSession.Value()->GetLocalScopedNodeId() == ScopedNodeId(kLocalNodeId, kFabricIndex));
     peerCATs = optionalSession.Value()->AsSecureSession()->GetPeerCATs();
     NL_TEST_ASSERT(inSuite, memcmp(&peerCATs, &kPeer1CATs, sizeof(CATValues)) == 0);
 
-    // Node ID 2, peer key 3, local key 4
-    optionalSession = connections.CreateNewSecureSessionForTest(kPeer2SessionType, 4, kPeer2NodeId, kPeer2CATs, 3,
-                                                                0 /* fabricIndex */, GetLocalMRPConfig());
+    // Second node, peer session id 3, local session id 4
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 4, kCasePeer2NodeId, kLocalNodeId, kPeer2CATs, 3,
+                                                                kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
-    NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetSecureSessionType() == kPeer2SessionType);
-    NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetPeerNodeId() == kPeer2NodeId);
+    NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetSecureSessionType() == SecureSession::Type::kCASE);
+    NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetPeerNodeId() == kCasePeer2NodeId);
+    NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetLocalNodeId() == kLocalNodeId);
+    NL_TEST_ASSERT(inSuite, optionalSession.Value()->GetPeer() == ScopedNodeId(kCasePeer2NodeId, kFabricIndex));
+    NL_TEST_ASSERT(inSuite, optionalSession.Value()->GetLocalScopedNodeId() == ScopedNodeId(kLocalNodeId, kFabricIndex));
     NL_TEST_ASSERT(inSuite, optionalSession.Value()->AsSecureSession()->GetLastActivityTime() == 100_ms64);
     peerCATs = optionalSession.Value()->AsSecureSession()->GetPeerCATs();
     NL_TEST_ASSERT(inSuite, memcmp(&peerCATs, &kPeer2CATs, sizeof(CATValues)) == 0);
 
     // Insufficient space for new connections. Object is max size 2
-    optionalSession = connections.CreateNewSecureSessionForTest(kPeer3SessionType, 6, kPeer3NodeId, kPeer3CATs, 5,
-                                                                0 /* fabricIndex */, GetLocalMRPConfig());
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kPASE, 6, kPasePeerNodeId, kLocalNodeId, kPeer3CATs, 5,
+                                                                kUndefinedFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, !optionalSession.HasValue());
     System::Clock::Internal::SetSystemClockForTesting(realClock);
 }
@@ -102,17 +107,17 @@ void TestFindByKeyId(nlTestSuite * inSuite, void * inContext)
     System::Clock::ClockBase * realClock = &System::SystemClock();
     System::Clock::Internal::SetSystemClockForTesting(&clock);
 
-    // Node ID 1, peer key 1, local key 2
-    auto optionalSession = connections.CreateNewSecureSessionForTest(kPeer1SessionType, 2, kPeer1NodeId, kPeer1CATs, 1,
-                                                                     0 /* fabricIndex */, GetLocalMRPConfig());
+    // First node, peer session id 1, local session id 2
+    auto optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kCasePeer1NodeId, kLocalNodeId, kPeer1CATs, 1,
+                                                                     kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
 
     NL_TEST_ASSERT(inSuite, !connections.FindSecureSessionByLocalKey(1).HasValue());
     NL_TEST_ASSERT(inSuite, connections.FindSecureSessionByLocalKey(2).HasValue());
 
-    // Node ID 2, peer key 3, local key 4
-    optionalSession = connections.CreateNewSecureSessionForTest(kPeer2SessionType, 4, kPeer2NodeId, kPeer2CATs, 3,
-                                                                0 /* fabricIndex */, GetLocalMRPConfig());
+    // Second node, peer session id 3, local session id 4
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 4, kCasePeer2NodeId, kLocalNodeId, kPeer2CATs, 3,
+                                                                kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
 
     NL_TEST_ASSERT(inSuite, !connections.FindSecureSessionByLocalKey(3).HasValue());
@@ -139,23 +144,23 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
 
     clock.SetMonotonic(100_ms64);
 
-    // Node ID 1, peer key 1, local key 2
-    auto optionalSession = connections.CreateNewSecureSessionForTest(kPeer1SessionType, 2, kPeer1NodeId, kPeer1CATs, 1,
-                                                                     0 /* fabricIndex */, GetLocalMRPConfig());
+    // First node, peer session id 1, local session id 2
+    auto optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kCasePeer1NodeId, kLocalNodeId, kPeer1CATs, 1,
+                                                                     kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     optionalSession.Value()->AsSecureSession()->SetPeerAddress(kPeer1Addr);
 
     clock.SetMonotonic(200_ms64);
-    // Node ID 2, peer key 3, local key 4
-    optionalSession = connections.CreateNewSecureSessionForTest(kPeer2SessionType, 4, kPeer2NodeId, kPeer2CATs, 3,
-                                                                0 /* fabricIndex */, GetLocalMRPConfig());
+    // Second node, peer session id 3, local session id 4
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 4, kCasePeer2NodeId, kLocalNodeId, kPeer2CATs, 3,
+                                                                kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     optionalSession.Value()->AsSecureSession()->SetPeerAddress(kPeer2Addr);
 
     // cannot add before expiry
     clock.SetMonotonic(300_ms64);
-    optionalSession = connections.CreateNewSecureSessionForTest(kPeer3SessionType, 6, kPeer3NodeId, kPeer3CATs, 5,
-                                                                0 /* fabricIndex */, GetLocalMRPConfig());
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kPASE, 6, kPasePeerNodeId, kLocalNodeId, kPeer3CATs, 5,
+                                                                kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, !optionalSession.HasValue());
 
     // at time 300, this expires ip addr 1
@@ -165,17 +170,17 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
         callInfo.lastCallPeerAddress = state.GetPeerAddress();
     });
     NL_TEST_ASSERT(inSuite, callInfo.callCount == 1);
-    NL_TEST_ASSERT(inSuite, callInfo.lastCallNodeId == kPeer1NodeId);
+    NL_TEST_ASSERT(inSuite, callInfo.lastCallNodeId == kCasePeer1NodeId);
     NL_TEST_ASSERT(inSuite, callInfo.lastCallPeerAddress == kPeer1Addr);
     NL_TEST_ASSERT(inSuite, !connections.FindSecureSessionByLocalKey(2).HasValue());
 
     // now that the connections were expired, we can add peer3
     clock.SetMonotonic(300_ms64);
-    // Node ID 3, peer key 5, local key 6
-    optionalSession = connections.CreateNewSecureSessionForTest(kPeer3SessionType, 6, kPeer3NodeId, kPeer3CATs, 5,
-                                                                0 /* fabricIndex */, GetLocalMRPConfig());
+    // Third node (PASE session), peer session id 5, local session id 6
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kPASE, 6, kPasePeerNodeId, kLocalNodeId, kPeer3CATs, 5,
+                                                                kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
-    optionalSession.Value()->AsSecureSession()->SetPeerAddress(kPeer3Addr);
+    optionalSession.Value()->AsSecureSession()->SetPeerAddress(kPasePeerAddr);
 
     clock.SetMonotonic(400_ms64);
     optionalSession = connections.FindSecureSessionByLocalKey(4);
@@ -198,15 +203,15 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
 
     // peer 2 stays active
     NL_TEST_ASSERT(inSuite, callInfo.callCount == 1);
-    NL_TEST_ASSERT(inSuite, callInfo.lastCallNodeId == kPeer3NodeId);
-    NL_TEST_ASSERT(inSuite, callInfo.lastCallPeerAddress == kPeer3Addr);
+    NL_TEST_ASSERT(inSuite, callInfo.lastCallNodeId == kPasePeerNodeId);
+    NL_TEST_ASSERT(inSuite, callInfo.lastCallPeerAddress == kPasePeerAddr);
     NL_TEST_ASSERT(inSuite, !connections.FindSecureSessionByLocalKey(2).HasValue());
     NL_TEST_ASSERT(inSuite, connections.FindSecureSessionByLocalKey(4).HasValue());
     NL_TEST_ASSERT(inSuite, !connections.FindSecureSessionByLocalKey(6).HasValue());
 
-    // Node ID 1, peer key 1, local key 2
-    optionalSession = connections.CreateNewSecureSessionForTest(kPeer1SessionType, 2, kPeer1NodeId, kPeer1CATs, 1,
-                                                                0 /* fabricIndex */, GetLocalMRPConfig());
+    // First node, peer session id 1, local session id 2
+    optionalSession = connections.CreateNewSecureSessionForTest(SecureSession::Type::kCASE, 2, kCasePeer1NodeId, kLocalNodeId, kPeer1CATs, 1,
+                                                                kFabricIndex, GetLocalMRPConfig());
     NL_TEST_ASSERT(inSuite, optionalSession.HasValue());
     NL_TEST_ASSERT(inSuite, connections.FindSecureSessionByLocalKey(2).HasValue());
     NL_TEST_ASSERT(inSuite, connections.FindSecureSessionByLocalKey(4).HasValue());

--- a/zzz_generated/chip-tool-darwin/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool-darwin/zap-generated/test/Commands.h
@@ -63850,6 +63850,11 @@ private:
 
             VerifyOrReturn(CheckValue("status", err, 0));
 
+            {
+                id actualValue = value;
+                VerifyOrReturn(CheckValue("CommissionedFabrics", actualValue, 1));
+            }
+
             VerifyOrReturn(CheckConstraintType("commissionedFabrics", "", "uint8"));
             NextTest();
         }];

--- a/zzz_generated/chip-tool-darwin/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool-darwin/zap-generated/test/Commands.h
@@ -186,6 +186,7 @@ public:
         printf("TestIdentifyCluster\n");
         printf("TestLogCommands\n");
         printf("TestOperationalCredentialsCluster\n");
+        printf("TestSelfFabricRemoval\n");
         printf("TestBinding\n");
         printf("Test_TC_SWDIAG_1_1\n");
         printf("Test_TC_SWDIAG_2_1\n");
@@ -63754,6 +63755,160 @@ private:
     }
 };
 
+class TestSelfFabricRemoval : public TestCommandBridge {
+public:
+    // NOLINTBEGIN(clang-analyzer-nullability.NullPassedToNonnull): Test constructor nullability not enforced
+    TestSelfFabricRemoval()
+        : TestCommandBridge("TestSelfFabricRemoval")
+        , mTestIndex(0)
+    {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
+        AddArgument("cluster", &mCluster);
+        AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
+        AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
+    }
+    // NOLINTEND(clang-analyzer-nullability.NullPassedToNonnull)
+
+    ~TestSelfFabricRemoval() {}
+
+    /////////// TestCommand Interface /////////
+    void NextTest() override
+    {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        if (0 == mTestIndex) {
+            ChipLogProgress(chipTool, " **** Test Start: TestSelfFabricRemoval\n");
+        }
+
+        if (mTestCount == mTestIndex) {
+            ChipLogProgress(chipTool, " **** Test Complete: TestSelfFabricRemoval\n");
+            SetCommandExitStatus(CHIP_NO_ERROR);
+            return;
+        }
+
+        Wait();
+
+        // Ensure we increment mTestIndex before we start running the relevant
+        // command.  That way if we lose the timeslice after we send the message
+        // but before our function call returns, we won't end up with an
+        // incorrect mTestIndex value observed when we get the response.
+        switch (mTestIndex++) {
+        case 0:
+            ChipLogProgress(chipTool, " ***** Test Step 0 : Wait for the commissioned device to be retrieved\n");
+            err = TestWaitForTheCommissionedDeviceToBeRetrieved_0();
+            break;
+        case 1:
+            ChipLogProgress(chipTool, " ***** Test Step 1 : Read number of commissioned fabrics\n");
+            err = TestReadNumberOfCommissionedFabrics_1();
+            break;
+        case 2:
+            ChipLogProgress(chipTool, " ***** Test Step 2 : Read current fabric index\n");
+            err = TestReadCurrentFabricIndex_2();
+            break;
+        case 3:
+            ChipLogProgress(chipTool, " ***** Test Step 3 : Remove single own fabric\n");
+            err = TestRemoveSingleOwnFabric_3();
+            break;
+        }
+
+        if (CHIP_NO_ERROR != err) {
+            ChipLogError(chipTool, " ***** Test Failure: %s\n", chip::ErrorStr(err));
+            SetCommandExitStatus(err);
+        }
+    }
+
+    chip::System::Clock::Timeout GetWaitDuration() const override
+    {
+        return chip::System::Clock::Seconds16(mTimeout.ValueOr(kTimeoutInSeconds));
+    }
+
+private:
+    std::atomic_uint16_t mTestIndex;
+    const uint16_t mTestCount = 4;
+
+    chip::Optional<chip::NodeId> mNodeId;
+    chip::Optional<chip::CharSpan> mCluster;
+    chip::Optional<chip::EndpointId> mEndpoint;
+    chip::Optional<uint16_t> mTimeout;
+
+    CHIP_ERROR TestWaitForTheCommissionedDeviceToBeRetrieved_0()
+    {
+        WaitForCommissionee(mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL);
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR TestReadNumberOfCommissionedFabrics_1()
+    {
+        CHIPDevice * device = GetConnectedDevice();
+        CHIPTestOperationalCredentials * cluster = [[CHIPTestOperationalCredentials alloc] initWithDevice:device
+                                                                                                 endpoint:0
+                                                                                                    queue:mCallbackQueue];
+        VerifyOrReturnError(cluster != nil, CHIP_ERROR_INCORRECT_STATE);
+
+        [cluster readAttributeCommissionedFabricsWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+            NSLog(@"Read number of commissioned fabrics Error: %@", err);
+
+            VerifyOrReturn(CheckValue("status", err, 0));
+
+            VerifyOrReturn(CheckConstraintType("commissionedFabrics", "", "uint8"));
+            NextTest();
+        }];
+
+        return CHIP_NO_ERROR;
+    }
+    NSNumber * _Nonnull ourFabricIndex;
+
+    CHIP_ERROR TestReadCurrentFabricIndex_2()
+    {
+        CHIPDevice * device = GetConnectedDevice();
+        CHIPTestOperationalCredentials * cluster = [[CHIPTestOperationalCredentials alloc] initWithDevice:device
+                                                                                                 endpoint:0
+                                                                                                    queue:mCallbackQueue];
+        VerifyOrReturnError(cluster != nil, CHIP_ERROR_INCORRECT_STATE);
+
+        [cluster readAttributeCurrentFabricIndexWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+            NSLog(@"Read current fabric index Error: %@", err);
+
+            VerifyOrReturn(CheckValue("status", err, 0));
+
+            VerifyOrReturn(CheckConstraintType("currentFabricIndex", "", "uint8"));
+            if (value != nil) {
+                VerifyOrReturn(CheckConstraintMinValue<chip::FabricIndex>("currentFabricIndex", [value unsignedCharValue], 1));
+            }
+            {
+                ourFabricIndex = value;
+            }
+
+            NextTest();
+        }];
+
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR TestRemoveSingleOwnFabric_3()
+    {
+        CHIPDevice * device = GetConnectedDevice();
+        CHIPTestOperationalCredentials * cluster = [[CHIPTestOperationalCredentials alloc] initWithDevice:device
+                                                                                                 endpoint:0
+                                                                                                    queue:mCallbackQueue];
+        VerifyOrReturnError(cluster != nil, CHIP_ERROR_INCORRECT_STATE);
+
+        __auto_type * params = [[CHIPOperationalCredentialsClusterRemoveFabricParams alloc] init];
+        params.fabricIndex = [ourFabricIndex copy];
+        [cluster removeFabricWithParams:params
+                      completionHandler:^(
+                          CHIPOperationalCredentialsClusterNOCResponseParams * _Nullable values, NSError * _Nullable err) {
+                          NSLog(@"Remove single own fabric Error: %@", err);
+
+                          VerifyOrReturn(CheckValue("status", err, 0));
+
+                          NextTest();
+                      }];
+
+        return CHIP_NO_ERROR;
+    }
+};
+
 class TestBinding : public TestCommandBridge {
 public:
     // NOLINTBEGIN(clang-analyzer-nullability.NullPassedToNonnull): Test constructor nullability not enforced
@@ -64947,6 +65102,7 @@ void registerCommandsTests(Commands & commands)
         make_unique<TestIdentifyCluster>(),
         make_unique<TestLogCommands>(),
         make_unique<TestOperationalCredentialsCluster>(),
+        make_unique<TestSelfFabricRemoval>(),
         make_unique<TestBinding>(),
         make_unique<Test_TC_SWDIAG_1_1>(),
         make_unique<Test_TC_SWDIAG_2_1>(),

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -53343,11 +53343,11 @@ private:
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Type value;
             value.commissioningTimeout = 120U;
             value.PAKEVerifier         = chip::ByteSpan(
-                        chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
-                                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
-                                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
-                                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
-                        97);
+                chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
+                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
+                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
+                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
+                97);
             value.discriminator = 3840U;
             value.iterations    = 1000UL;
             value.salt = chip::ByteSpan(chip::Uint8::from_const_char("SPAKE2P Key Saltgarbage: not in length on purpose"), 16);
@@ -53360,11 +53360,11 @@ private:
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Type value;
             value.commissioningTimeout = 1000U;
             value.PAKEVerifier         = chip::ByteSpan(
-                        chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
-                                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
-                                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
-                                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
-                        97);
+                chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
+                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
+                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
+                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
+                97);
             value.discriminator = 3840U;
             value.iterations    = 1000UL;
             value.salt = chip::ByteSpan(chip::Uint8::from_const_char("SPAKE2P Key Saltgarbage: not in length on purpose"), 16);
@@ -53377,11 +53377,11 @@ private:
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Type value;
             value.commissioningTimeout = 180U;
             value.PAKEVerifier         = chip::ByteSpan(
-                        chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
-                                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
-                                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
-                                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
-                        97);
+                chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
+                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
+                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
+                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
+                97);
             value.discriminator = 3840U;
             value.iterations    = 1000UL;
             value.salt = chip::ByteSpan(chip::Uint8::from_const_char("SPAKE2P Key Saltgarbage: not in length on purpose"), 16);

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -41236,6 +41236,7 @@ private:
             {
                 uint8_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("commissionedFabrics", value, 1));
                 VerifyOrReturn(CheckConstraintType("value", "", "uint8"));
             }
             break;
@@ -53343,11 +53344,11 @@ private:
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Type value;
             value.commissioningTimeout = 120U;
             value.PAKEVerifier         = chip::ByteSpan(
-                chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
-                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
-                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
-                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
-                97);
+                        chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
+                                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
+                                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
+                                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
+                        97);
             value.discriminator = 3840U;
             value.iterations    = 1000UL;
             value.salt = chip::ByteSpan(chip::Uint8::from_const_char("SPAKE2P Key Saltgarbage: not in length on purpose"), 16);
@@ -53360,11 +53361,11 @@ private:
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Type value;
             value.commissioningTimeout = 1000U;
             value.PAKEVerifier         = chip::ByteSpan(
-                chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
-                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
-                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
-                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
-                97);
+                        chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
+                                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
+                                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
+                                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
+                        97);
             value.discriminator = 3840U;
             value.iterations    = 1000UL;
             value.salt = chip::ByteSpan(chip::Uint8::from_const_char("SPAKE2P Key Saltgarbage: not in length on purpose"), 16);
@@ -53377,11 +53378,11 @@ private:
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Type value;
             value.commissioningTimeout = 180U;
             value.PAKEVerifier         = chip::ByteSpan(
-                chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
-                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
-                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
-                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
-                97);
+                        chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
+                                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
+                                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
+                                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
+                        97);
             value.discriminator = 3840U;
             value.iterations    = 1000UL;
             value.salt = chip::ByteSpan(chip::Uint8::from_const_char("SPAKE2P Key Saltgarbage: not in length on purpose"), 16);

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -53344,11 +53344,11 @@ private:
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Type value;
             value.commissioningTimeout = 120U;
             value.PAKEVerifier         = chip::ByteSpan(
-                        chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
-                                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
-                                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
-                                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
-                        97);
+                chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
+                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
+                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
+                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
+                97);
             value.discriminator = 3840U;
             value.iterations    = 1000UL;
             value.salt = chip::ByteSpan(chip::Uint8::from_const_char("SPAKE2P Key Saltgarbage: not in length on purpose"), 16);
@@ -53361,11 +53361,11 @@ private:
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Type value;
             value.commissioningTimeout = 1000U;
             value.PAKEVerifier         = chip::ByteSpan(
-                        chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
-                                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
-                                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
-                                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
-                        97);
+                chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
+                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
+                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
+                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
+                97);
             value.discriminator = 3840U;
             value.iterations    = 1000UL;
             value.salt = chip::ByteSpan(chip::Uint8::from_const_char("SPAKE2P Key Saltgarbage: not in length on purpose"), 16);
@@ -53378,11 +53378,11 @@ private:
             chip::app::Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Type value;
             value.commissioningTimeout = 180U;
             value.PAKEVerifier         = chip::ByteSpan(
-                        chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
-                                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
-                                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
-                                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
-                        97);
+                chip::Uint8::from_const_char("\006\307V\337\374\327\042e4R\241-\315\224]\214T\332+\017<\275\033M\303\361\255\262#"
+                                             "\256\262k\004|\322L\226\206o\227\233\035\203\354P\342\264\2560\315\362\375\263+"
+                                             "\330\242\021\2707\334\224\355\315V\364\321Cw\031\020v\277\305\235\231\267\3350S\357"
+                                             "\326\360,D4\362\275\322z\244\371\316\247\015s\216Lgarbage: not in length on purpose"),
+                97);
             value.discriminator = 3840U;
             value.iterations    = 1000UL;
             value.salt = chip::ByteSpan(chip::Uint8::from_const_char("SPAKE2P Key Saltgarbage: not in length on purpose"), 16);


### PR DESCRIPTION
#### Problem
Fix crash on removal of accessing fabric
    
Because of an access to prior fabric data that is now deleted,
in `SessionManager::PrepareMessage`, while trying to reply to `RemoveFabric`,
applications crash when `RemoveFabric` is done on the accessing fabric.
  
This crash was awaiting full fix of  #16748 to be fixed, but that
issue is much bigger scope. We can actually fix the crash with a
suggestion made by @turon
(https://github.com/project-chip/connectedhomeip/issues/16748#issuecomment-1082228657)
to keep the *local node ID* in the SecureSession so that
SessionManager does not try to look-back at the FabricTable
whenever preparing a CASE message where the fabric may be gone.
  
This is a root cause fix for that very crash, but does not address
the other aspects of #16748 which relate to completely cleanly
handling fabric removal edge cases.
  
Issue #16748
Fixes #17579
Fixes #17680
Fixes #16729
  
#### Change overview

- Add local node ID to the SecureSession and fix all associated plumbing
- Use the local node ID for nonce generation in PrepareMessage rather
  than looking-up the fabric table (which may no longer hold the
  fabric that has that prior node ID)
- Improve CASE session establishment logging
- Fix the tests needed
- Fix bad comments in TestPairingSession tests
  
#### Testing

- Added a YAML test (TestSelfFabricRemoval.yaml) for this case
  - Validated it failed before code fixes with the previously seen
    crash.
  - Validated that it passes with the new fixes
- Added necessary tests to TestPairingSession for new methods
- Unit tests pass
- Cert tests pass

