### PR TITLE
Move toward enforcing use of DefaultStorageKeyAllocator with PersistentStorageDelegate.

### DIFF
--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -509,7 +509,7 @@ public:
     static constexpr uint8_t kTagSubjects    = 5;
     static constexpr uint8_t kTagTargets     = 6;
 
-    CHIP_ERROR Serialize(chip::PersistentStorageDelegate * storage, const char * key)
+    CHIP_ERROR Serialize(chip::PersistentStorageDelegate * storage, const chip::DefaultStorageKeyAllocator & key)
     {
         uint8_t buffer[kStorageBufferSize] = { 0 };
         chip::TLV::TLVWriter writer;
@@ -545,7 +545,7 @@ public:
         return storage->SyncSetKeyValue(key, buffer, static_cast<uint16_t>(writer.GetLengthWritten()));
     }
 
-    CHIP_ERROR Deserialize(chip::PersistentStorageDelegate * storage, const char * key)
+    CHIP_ERROR Deserialize(chip::PersistentStorageDelegate * storage, const chip::DefaultStorageKeyAllocator & key)
     {
         uint8_t buffer[kStorageBufferSize] = { 0 };
         uint16_t bufferSize                = static_cast<uint16_t>(sizeof(buffer));

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
@@ -55,7 +55,7 @@ CHIP_ERROR DefaultOTARequestorStorage::StoreDefaultProviders(const ProviderLocat
 
     ReturnErrorOnFailure(writer.EndContainer(outerType));
 
-    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTADefaultProviders(), buffer,
+    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator().OTADefaultProviders(), buffer,
                                                static_cast<uint16_t>(writer.GetLengthWritten()));
 }
 
@@ -64,7 +64,7 @@ CHIP_ERROR DefaultOTARequestorStorage::LoadDefaultProviders(ProviderLocationList
     uint8_t buffer[kProviderListMaxSerializedSize];
     MutableByteSpan bufferSpan(buffer);
 
-    ReturnErrorOnFailure(Load(DefaultStorageKeyAllocator::OTADefaultProviders(), bufferSpan));
+    ReturnErrorOnFailure(Load(DefaultStorageKeyAllocator().OTADefaultProviders(), bufferSpan));
 
     TLV::TLVReader reader;
     TLV::TLVType outerType;
@@ -93,13 +93,13 @@ CHIP_ERROR DefaultOTARequestorStorage::StoreCurrentProviderLocation(const Provid
     writer.Init(buffer);
     ReturnErrorOnFailure(provider.EncodeForRead(writer, TLV::AnonymousTag(), provider.fabricIndex));
 
-    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTACurrentProvider(), buffer,
+    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator().OTACurrentProvider(), buffer,
                                                static_cast<uint16_t>(writer.GetLengthWritten()));
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::ClearCurrentProviderLocation()
 {
-    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::OTACurrentProvider());
+    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator().OTACurrentProvider());
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::LoadCurrentProviderLocation(ProviderLocationType & provider)
@@ -107,7 +107,7 @@ CHIP_ERROR DefaultOTARequestorStorage::LoadCurrentProviderLocation(ProviderLocat
     uint8_t buffer[kProviderMaxSerializedSize];
     MutableByteSpan bufferSpan(buffer);
 
-    ReturnErrorOnFailure(Load(DefaultStorageKeyAllocator::OTACurrentProvider(), bufferSpan));
+    ReturnErrorOnFailure(Load(DefaultStorageKeyAllocator().OTACurrentProvider(), bufferSpan));
 
     TLV::TLVReader reader;
 
@@ -120,55 +120,55 @@ CHIP_ERROR DefaultOTARequestorStorage::LoadCurrentProviderLocation(ProviderLocat
 
 CHIP_ERROR DefaultOTARequestorStorage::StoreUpdateToken(ByteSpan updateToken)
 {
-    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTAUpdateToken(), updateToken.data(),
+    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator().OTAUpdateToken(), updateToken.data(),
                                                static_cast<uint16_t>(updateToken.size()));
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::ClearUpdateToken()
 {
-    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::OTAUpdateToken());
+    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator().OTAUpdateToken());
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::LoadUpdateToken(MutableByteSpan & updateToken)
 {
-    return Load(DefaultStorageKeyAllocator::OTAUpdateToken(), updateToken);
+    return Load(DefaultStorageKeyAllocator().OTAUpdateToken(), updateToken);
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::StoreCurrentUpdateState(OTAUpdateStateEnum currentUpdateState)
 {
-    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTACurrentUpdateState(), &currentUpdateState,
+    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator().OTACurrentUpdateState(), &currentUpdateState,
                                                sizeof(currentUpdateState));
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::LoadCurrentUpdateState(OTAUpdateStateEnum & currentUpdateState)
 {
     uint16_t size = static_cast<uint16_t>(sizeof(currentUpdateState));
-    return mPersistentStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::OTACurrentUpdateState(), &currentUpdateState, size);
+    return mPersistentStorage->SyncGetKeyValue(DefaultStorageKeyAllocator().OTACurrentUpdateState(), &currentUpdateState, size);
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::ClearCurrentUpdateState()
 {
-    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::OTACurrentUpdateState());
+    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator().OTACurrentUpdateState());
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::StoreTargetVersion(uint32_t targetVersion)
 {
-    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTATargetVersion(), &targetVersion,
+    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator().OTATargetVersion(), &targetVersion,
                                                sizeof(targetVersion));
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::LoadTargetVersion(uint32_t & targetVersion)
 {
     uint16_t size = static_cast<uint16_t>(sizeof(targetVersion));
-    return mPersistentStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::OTATargetVersion(), &targetVersion, size);
+    return mPersistentStorage->SyncGetKeyValue(DefaultStorageKeyAllocator().OTATargetVersion(), &targetVersion, size);
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::ClearTargetVersion()
 {
-    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::OTATargetVersion());
+    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator().OTATargetVersion());
 }
 
-CHIP_ERROR DefaultOTARequestorStorage::Load(const char * key, MutableByteSpan & buffer)
+CHIP_ERROR DefaultOTARequestorStorage::Load(const DefaultStorageKeyAllocator & key, MutableByteSpan & buffer)
 {
     uint16_t size = static_cast<uint16_t>(buffer.size());
     ReturnErrorOnFailure(mPersistentStorage->SyncGetKeyValue(key, buffer.data(), size));

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.h
@@ -20,6 +20,8 @@
 
 #include "OTARequestorStorage.h"
 
+#include <lib/support/DefaultStorageKeyAllocator.h>
+
 namespace chip {
 
 class PersistentStorageDelegate;
@@ -49,7 +51,7 @@ public:
     CHIP_ERROR ClearTargetVersion() override;
 
 private:
-    CHIP_ERROR Load(const char * key, MutableByteSpan & buffer);
+    CHIP_ERROR Load(const DefaultStorageKeyAllocator & key, MutableByteSpan & buffer);
     PersistentStorageDelegate * mPersistentStorage = nullptr;
 };
 

--- a/src/app/tests/TestBindingTable.cpp
+++ b/src/app/tests/TestBindingTable.cpp
@@ -150,13 +150,13 @@ void TestPersistentStorage(nlTestSuite * aSuite, void * aContext)
     VerifyRestored(aSuite, testStorage, expected);
 
     // Verify storage untouched if add fails
-    testStorage.AddPoisonKey(key.BindingTableEntry(4));
+    testStorage.AddPoisonKey(key.BindingTableEntry(4).KeyName());
     NL_TEST_ASSERT(aSuite, table.Add(EmberBindingTableEntry::ForNode(4, 4, 0, 0, NullOptional)) != CHIP_NO_ERROR);
     VerifyRestored(aSuite, testStorage, expected);
     testStorage.ClearPoisonKeys();
 
     // Verify storage untouched if removing head fails
-    testStorage.AddPoisonKey(key.BindingTable());
+    testStorage.AddPoisonKey(key.BindingTable().KeyName());
     auto iter = table.begin();
     NL_TEST_ASSERT(aSuite, table.RemoveAt(iter) != CHIP_NO_ERROR);
     VerifyTableSame(aSuite, table, expected);
@@ -164,7 +164,7 @@ void TestPersistentStorage(nlTestSuite * aSuite, void * aContext)
     VerifyRestored(aSuite, testStorage, expected);
 
     // Verify storage untouched if removing other nodes fails
-    testStorage.AddPoisonKey(key.BindingTableEntry(0));
+    testStorage.AddPoisonKey(key.BindingTableEntry(0).KeyName());
     iter = table.begin();
     ++iter;
     NL_TEST_ASSERT(aSuite, table.RemoveAt(iter) != CHIP_NO_ERROR);

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -58,7 +58,7 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
         uint16_t keySize = static_cast<uint16_t>(serializedKey.Capacity());
 
         PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsIssuerKeypairStorage, key,
-                          err = storage.SyncGetKeyValue(key, serializedKey.Bytes(), keySize));
+                          err = storage.SyncGetKeyValueDeprecated(key, serializedKey.Bytes(), keySize));
         serializedKey.SetLength(keySize);
     }
 
@@ -70,8 +70,8 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
         ReturnErrorOnFailure(mIssuer.Serialize(serializedKey));
 
         PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsIssuerKeypairStorage, key,
-                          ReturnErrorOnFailure(
-                              storage.SyncSetKeyValue(key, serializedKey.Bytes(), static_cast<uint16_t>(serializedKey.Length()))));
+                          ReturnErrorOnFailure(storage.SyncSetKeyValueDeprecated(key, serializedKey.Bytes(),
+                                                                                 static_cast<uint16_t>(serializedKey.Length()))));
     }
     else
     {
@@ -84,7 +84,7 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
         uint16_t keySize = static_cast<uint16_t>(serializedKey.Capacity());
 
         PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsIntermediateIssuerKeypairStorage, key,
-                          err = storage.SyncGetKeyValue(key, serializedKey.Bytes(), keySize));
+                          err = storage.SyncGetKeyValueDeprecated(key, serializedKey.Bytes(), keySize));
         serializedKey.SetLength(keySize);
     }
 
@@ -97,8 +97,8 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
         ReturnErrorOnFailure(mIntermediateIssuer.Serialize(serializedKey));
 
         PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsIntermediateIssuerKeypairStorage, key,
-                          ReturnErrorOnFailure(
-                              storage.SyncSetKeyValue(key, serializedKey.Bytes(), static_cast<uint16_t>(serializedKey.Length()))));
+                          ReturnErrorOnFailure(storage.SyncSetKeyValueDeprecated(key, serializedKey.Bytes(),
+                                                                                 static_cast<uint16_t>(serializedKey.Length()))));
     }
     else
     {
@@ -121,7 +121,7 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
     CHIP_ERROR err      = CHIP_NO_ERROR;
     uint16_t rcacBufLen = static_cast<uint16_t>(std::min(rcac.size(), static_cast<size_t>(UINT16_MAX)));
     PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsRootCertificateStorage, key,
-                      err = mStorage->SyncGetKeyValue(key, rcac.data(), rcacBufLen));
+                      err = mStorage->SyncGetKeyValueDeprecated(key, rcac.data(), rcacBufLen));
     if (err == CHIP_NO_ERROR)
     {
         uint64_t rcacId;
@@ -141,14 +141,15 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
         ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuer, rcac));
 
         VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);
-        PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsRootCertificateStorage, key,
-                          ReturnErrorOnFailure(mStorage->SyncSetKeyValue(key, rcac.data(), static_cast<uint16_t>(rcac.size()))));
+        PERSISTENT_KEY_OP(
+            mIndex, kOperationalCredentialsRootCertificateStorage, key,
+            ReturnErrorOnFailure(mStorage->SyncSetKeyValueDeprecated(key, rcac.data(), static_cast<uint16_t>(rcac.size()))));
     }
 
     ChipDN icac_dn;
     uint16_t icacBufLen = static_cast<uint16_t>(std::min(icac.size(), static_cast<size_t>(UINT16_MAX)));
     PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsIntermediateCertificateStorage, key,
-                      err = mStorage->SyncGetKeyValue(key, icac.data(), icacBufLen));
+                      err = mStorage->SyncGetKeyValueDeprecated(key, icac.data(), icacBufLen));
     if (err == CHIP_NO_ERROR)
     {
         uint64_t icacId;
@@ -168,8 +169,9 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
         ReturnErrorOnFailure(NewICAX509Cert(icac_request, mIntermediateIssuer.Pubkey(), mIssuer, icac));
 
         VerifyOrReturnError(CanCastTo<uint16_t>(icac.size()), CHIP_ERROR_INTERNAL);
-        PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsIntermediateCertificateStorage, key,
-                          ReturnErrorOnFailure(mStorage->SyncSetKeyValue(key, icac.data(), static_cast<uint16_t>(icac.size()))));
+        PERSISTENT_KEY_OP(
+            mIndex, kOperationalCredentialsIntermediateCertificateStorage, key,
+            ReturnErrorOnFailure(mStorage->SyncSetKeyValueDeprecated(key, icac.data(), static_cast<uint16_t>(icac.size()))));
     }
 
     ChipDN noc_dn;

--- a/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
+++ b/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
@@ -55,14 +55,15 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::Initialize(PersistentStorageDele
     Crypto::P256SerializedKeypair serializedKey;
     uint16_t keySize = static_cast<uint16_t>(sizeof(serializedKey));
 
-    if (storage.SyncGetKeyValue(kOperationalCredentialsIssuerKeypairStorage, &serializedKey, keySize) != CHIP_NO_ERROR)
+    if (storage.SyncGetKeyValueDeprecated(kOperationalCredentialsIssuerKeypairStorage, &serializedKey, keySize) != CHIP_NO_ERROR)
     {
         // Storage doesn't have an existing keypair. Let's create one and add it to the storage.
         ReturnErrorOnFailure(mIssuer.Initialize());
         ReturnErrorOnFailure(mIssuer.Serialize(serializedKey));
 
         keySize = static_cast<uint16_t>(sizeof(serializedKey));
-        ReturnErrorOnFailure(storage.SyncSetKeyValue(kOperationalCredentialsIssuerKeypairStorage, &serializedKey, keySize));
+        ReturnErrorOnFailure(
+            storage.SyncSetKeyValueDeprecated(kOperationalCredentialsIssuerKeypairStorage, &serializedKey, keySize));
     }
     else
     {
@@ -87,7 +88,7 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
     uint16_t rcacBufLen = static_cast<uint16_t>(std::min(rcac.size(), static_cast<size_t>(UINT16_MAX)));
     CHIP_ERROR err      = CHIP_NO_ERROR;
     PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
-                      err = mStorage->SyncGetKeyValue(key, rcac.data(), rcacBufLen));
+                      err = mStorage->SyncGetKeyValueDeprecated(key, rcac.data(), rcacBufLen));
     if (err == CHIP_NO_ERROR)
     {
         uint64_t rcacId;
@@ -107,8 +108,9 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
         ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuer, rcac));
 
         VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);
-        PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
-                          ReturnErrorOnFailure(mStorage->SyncSetKeyValue(key, rcac.data(), static_cast<uint16_t>(rcac.size()))));
+        PERSISTENT_KEY_OP(
+            fabricId, kOperationalCredentialsRootCertificateStorage, key,
+            ReturnErrorOnFailure(mStorage->SyncSetKeyValueDeprecated(key, rcac.data(), static_cast<uint16_t>(rcac.size()))));
     }
 
     icac.reduce_size(0);

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -295,7 +295,7 @@ CHIP_ERROR FabricInfo::DeleteFromStorage(PersistentStorageDelegate * storage, Fa
     DefaultStorageKeyAllocator keyAlloc;
 
     // Try to delete all the state even if one of the deletes fails.
-    typedef const char * (DefaultStorageKeyAllocator::*KeyGetter)(FabricIndex);
+    typedef const DefaultStorageKeyAllocator & (DefaultStorageKeyAllocator::*KeyGetter)(FabricIndex);
     constexpr KeyGetter keyGetters[] = { &DefaultStorageKeyAllocator::FabricNOC, &DefaultStorageKeyAllocator::FabricICAC,
                                          &DefaultStorageKeyAllocator::FabricRCAC, &DefaultStorageKeyAllocator::FabricMetadata,
                                          &DefaultStorageKeyAllocator::FabricOpKey };

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -60,7 +60,7 @@ struct PersistentData
         ReturnErrorOnFailure(Serialize(writer));
 
         // Save serialized data
-        return storage->SyncSetKeyValue(key.KeyName(), buffer, static_cast<uint16_t>(writer.GetLengthWritten()));
+        return storage->SyncSetKeyValue(key, buffer, static_cast<uint16_t>(writer.GetLengthWritten()));
     }
 
     CHIP_ERROR Load(PersistentStorageDelegate * storage)
@@ -78,7 +78,7 @@ struct PersistentData
 
         // Load the serialized data
         uint16_t size  = static_cast<uint16_t>(sizeof(buffer));
-        CHIP_ERROR err = storage->SyncGetKeyValue(key.KeyName(), buffer, size);
+        CHIP_ERROR err = storage->SyncGetKeyValue(key, buffer, size);
         VerifyOrReturnError(CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND != err, CHIP_ERROR_NOT_FOUND);
         ReturnErrorOnFailure(err);
 
@@ -96,7 +96,7 @@ struct PersistentData
         // Update storage key
         ReturnErrorOnFailure(UpdateKey(key));
         // Delete stored data
-        return storage->SyncDeleteKeyValue(key.KeyName());
+        return storage->SyncDeleteKeyValue(key);
     }
 };
 

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -41,7 +41,6 @@ namespace chip {
 namespace app {
 namespace TestGroups {
 
-static const char * kKey1   = "abc/def";
 static const char * kValue1 = "abc/def";
 static const char * kValue2 = "abc/ghi/xyz";
 static const size_t kSize1  = strlen(kValue1) + 1;
@@ -183,6 +182,9 @@ void TestStorageDelegate(nlTestSuite * apSuite, void * apContext)
     char out[128];
     uint16_t size = static_cast<uint16_t>(sizeof(out));
 
+    DefaultStorageKeyAllocator kKey1;
+    // Just pick a random key to use here.
+    kKey1.GroupFabricList();
     NL_TEST_ASSERT(apSuite, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND == delegate.SyncGetKeyValue(kKey1, out, size));
 
     size = static_cast<uint16_t>(kSize1);

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -18,7 +18,6 @@
 
 #include <app/ConcreteAttributePath.h>
 #include <app/util/basic-types.h>
-#include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/support/EnforceFormat.h>
 #include <lib/support/logging/Constants.h>
 #include <string.h>
@@ -38,63 +37,65 @@ namespace chip {
 class DefaultStorageKeyAllocator
 {
 public:
+    static constexpr size_t kKeyLengthMax = 32;
+
     DefaultStorageKeyAllocator() = default;
-    const char * KeyName() { return mKeyName; }
+    const char * KeyName() const { return mKeyName; }
 
     // Fabric Table
-    const char * FabricIndexInfo() { return Format("g/fidx"); }
-    const char * FabricNOC(FabricIndex fabric) { return Format("f/%x/n", fabric); }
-    const char * FabricICAC(FabricIndex fabric) { return Format("f/%x/i", fabric); }
-    const char * FabricRCAC(FabricIndex fabric) { return Format("f/%x/r", fabric); }
-    const char * FabricMetadata(FabricIndex fabric) { return Format("f/%x/m", fabric); }
-    const char * FabricOpKey(FabricIndex fabric) { return Format("f/%x/o", fabric); }
+    auto & FabricIndexInfo() { return Format("g/fidx"); }
+    auto & FabricNOC(FabricIndex fabric) { return Format("f/%x/n", fabric); }
+    auto & FabricICAC(FabricIndex fabric) { return Format("f/%x/i", fabric); }
+    auto & FabricRCAC(FabricIndex fabric) { return Format("f/%x/r", fabric); }
+    auto & FabricMetadata(FabricIndex fabric) { return Format("f/%x/m", fabric); }
+    auto & FabricOpKey(FabricIndex fabric) { return Format("f/%x/o", fabric); }
 
     // FailSafeContext
-    const char * FailSafeContextKey() { return Format("g/fs/c"); }
-    static const char * FailSafeNetworkConfig() { return "g/fs/n"; }
+    auto & FailSafeContextKey() { return Format("g/fs/c"); }
+    auto & FailSafeNetworkConfig() { return Format("g/fs/n"); }
 
     // Session resumption
-    const char * FabricSession(FabricIndex fabric, NodeId nodeId)
+    auto & FabricSession(FabricIndex fabric, NodeId nodeId)
     {
         return Format("f/%x/s/%08" PRIX32 "%08" PRIX32, fabric, static_cast<uint32_t>(nodeId >> 32), static_cast<uint32_t>(nodeId));
     }
-    const char * SessionResumptionIndex() { return Format("g/sri"); }
-    const char * SessionResumption(const char * resumptionIdBase64) { return Format("g/s/%s", resumptionIdBase64); }
+    auto & SessionResumptionIndex() { return Format("g/sri"); }
+    auto & SessionResumption(const char * resumptionIdBase64) { return Format("g/s/%s", resumptionIdBase64); }
 
     // Access Control
-    const char * AccessControlExtensionEntry(FabricIndex fabric) { return Format("f/%x/ac/1", fabric); }
+    auto & AccessControlExtensionEntry(FabricIndex fabric) { return Format("f/%x/ac/1", fabric); }
 
     // TODO: We should probably store the fabric-specific parts of the ACL list
     // under keys starting with "f/%x/".
-    const char * AccessControlList() { return Format("g/acl"); }
-    const char * AccessControlEntry(size_t index)
+    auto & AccessControlList() { return Format("g/acl"); }
+    auto & AccessControlEntry(size_t index)
     {
         // This cast will never overflow because the number of ACL entries will be low.
         return Format("g/acl/%x", static_cast<unsigned int>(index));
     }
 
     // Group Message Counters
-    const char * GroupDataCounter() { return Format("g/gdc"); }
-    const char * GroupControlCounter() { return Format("g/gcc"); }
+    auto & GroupDataCounter() { return Format("g/gdc"); }
+    auto & GroupControlCounter() { return Format("g/gcc"); }
 
     // Device Information Provider
-    const char * UserLabelLengthKey(EndpointId endpoint) { return Format("g/userlbl/%x", endpoint); }
-    const char * UserLabelIndexKey(EndpointId endpoint, uint32_t index) { return Format("g/userlbl/%x/%" PRIx32, endpoint, index); }
+    auto & UserLabelLengthKey(EndpointId endpoint) { return Format("g/userlbl/%x", endpoint); }
+    auto & UserLabelIndexKey(EndpointId endpoint, uint32_t index) { return Format("g/userlbl/%x/%" PRIx32, endpoint, index); }
 
     // Group Data Provider
 
     // List of fabric indices that have endpoint-to-group associations defined.
-    const char * GroupFabricList() { return Format("g/gfl"); }
-    const char * FabricGroups(chip::FabricIndex fabric) { return Format("f/%x/g", fabric); }
-    const char * FabricGroup(chip::FabricIndex fabric, chip::GroupId group) { return Format("f/%x/g/%x", fabric, group); }
-    const char * FabricGroupKey(chip::FabricIndex fabric, uint16_t index) { return Format("f/%x/gk/%x", fabric, index); }
-    const char * FabricGroupEndpoint(chip::FabricIndex fabric, chip::GroupId group, chip::EndpointId endpoint)
+    auto & GroupFabricList() { return Format("g/gfl"); }
+    auto & FabricGroups(chip::FabricIndex fabric) { return Format("f/%x/g", fabric); }
+    auto & FabricGroup(chip::FabricIndex fabric, chip::GroupId group) { return Format("f/%x/g/%x", fabric, group); }
+    auto & FabricGroupKey(chip::FabricIndex fabric, uint16_t index) { return Format("f/%x/gk/%x", fabric, index); }
+    auto & FabricGroupEndpoint(chip::FabricIndex fabric, chip::GroupId group, chip::EndpointId endpoint)
     {
         return Format("f/%x/g/%x/e/%x", fabric, group, endpoint);
     }
-    const char * FabricKeyset(chip::FabricIndex fabric, uint16_t keyset) { return Format("f/%x/k/%x", fabric, keyset); }
+    auto & FabricKeyset(chip::FabricIndex fabric, uint16_t keyset) { return Format("f/%x/k/%x", fabric, keyset); }
 
-    const char * AttributeValue(const app::ConcreteAttributePath & aPath)
+    auto & AttributeValue(const app::ConcreteAttributePath & aPath)
     {
         // Needs at most 26 chars: 6 for "g/a///", 4 for the endpoint id, 8 each
         // for the cluster and attribute ids.
@@ -103,31 +104,31 @@ public:
 
     // TODO: Should store fabric-specific parts of the binding list under keys
     // starting with "f/%x/".
-    const char * BindingTable() { return Format("g/bt"); }
-    const char * BindingTableEntry(uint8_t index) { return Format("g/bt/%x", index); }
+    auto & BindingTable() { return Format("g/bt"); }
+    auto & BindingTableEntry(uint8_t index) { return Format("g/bt/%x", index); }
 
-    static const char * OTADefaultProviders() { return "g/o/dp"; }
-    static const char * OTACurrentProvider() { return "g/o/cp"; }
-    static const char * OTAUpdateToken() { return "g/o/ut"; }
-    static const char * OTACurrentUpdateState() { return "g/o/us"; }
-    static const char * OTATargetVersion() { return "g/o/tv"; }
+    auto & OTADefaultProviders() { return Format("g/o/dp"); }
+    auto & OTACurrentProvider() { return Format("g/o/cp"); }
+    auto & OTAUpdateToken() { return Format("g/o/ut"); }
+    auto & OTACurrentUpdateState() { return Format("g/o/us"); }
+    auto & OTATargetVersion() { return Format("g/o/tv"); }
 
     // Event number counter.
-    const char * IMEventNumber() { return Format("g/im/e"); }
+    auto & IMEventNumber() { return Format("g/im/e"); }
 
 private:
     // The ENFORCE_FORMAT args are "off by one" because this is a class method,
     // with an implicit "this" as first arg.
-    const char * ENFORCE_FORMAT(2, 3) Format(const char * format, ...)
+    const DefaultStorageKeyAllocator & ENFORCE_FORMAT(2, 3) Format(const char * format, ...)
     {
         va_list args;
         va_start(args, format);
         vsnprintf(mKeyName, sizeof(mKeyName), format, args);
         va_end(args);
-        return mKeyName;
+        return *this;
     }
 
-    char mKeyName[PersistentStorageDelegate::kKeyLengthMax + 1] = { 0 };
+    char mKeyName[kKeyLengthMax + 1] = { 0 };
 };
 
 } // namespace chip

--- a/src/lib/support/PersistedCounter.h
+++ b/src/lib/support/PersistedCounter.h
@@ -60,7 +60,7 @@ public:
     PersistedCounter();
     ~PersistedCounter() override;
 
-    typedef const char * (DefaultStorageKeyAllocator::*KeyType)();
+    typedef const DefaultStorageKeyAllocator & (DefaultStorageKeyAllocator::*KeyType)();
 
     /**
      *  @brief

--- a/src/lib/support/TestPersistentStorageDelegate.h
+++ b/src/lib/support/TestPersistentStorageDelegate.h
@@ -46,6 +46,10 @@ class TestPersistentStorageDelegate : public PersistentStorageDelegate
 public:
     TestPersistentStorageDelegate() {}
 
+    using PersistentStorageDelegate::SyncDeleteKeyValue;
+    using PersistentStorageDelegate::SyncGetKeyValue;
+    using PersistentStorageDelegate::SyncSetKeyValue;
+
     CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
     {
         if ((buffer == nullptr) && (size != 0))

--- a/src/platform/FailSafeContext.cpp
+++ b/src/platform/FailSafeContext.cpp
@@ -147,7 +147,7 @@ CHIP_ERROR FailSafeContext::CommitToStorage()
     const auto failSafeContextTLVLength = writer.GetLengthWritten();
     VerifyOrReturnError(CanCastTo<uint16_t>(failSafeContextTLVLength), CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    return PersistedStorage::KeyValueStoreMgr().Put(keyAlloc.FailSafeContextKey(), buf,
+    return PersistedStorage::KeyValueStoreMgr().Put(keyAlloc.FailSafeContextKey().KeyName(), buf,
                                                     static_cast<uint16_t>(failSafeContextTLVLength));
 }
 
@@ -155,7 +155,7 @@ CHIP_ERROR FailSafeContext::LoadFromStorage(FabricIndex & fabricIndex, bool & ad
 {
     DefaultStorageKeyAllocator keyAlloc;
     uint8_t buf[FailSafeContextTLVMaxSize()];
-    ReturnErrorOnFailure(PersistedStorage::KeyValueStoreMgr().Get(keyAlloc.FailSafeContextKey(), buf, sizeof(buf)));
+    ReturnErrorOnFailure(PersistedStorage::KeyValueStoreMgr().Get(keyAlloc.FailSafeContextKey().KeyName(), buf, sizeof(buf)));
 
     TLV::ContiguousBufferTLVReader reader;
     reader.Init(buf, sizeof(buf));
@@ -183,7 +183,7 @@ CHIP_ERROR FailSafeContext::DeleteFromStorage()
 {
     DefaultStorageKeyAllocator keyAlloc;
 
-    return PersistedStorage::KeyValueStoreMgr().Delete(keyAlloc.FailSafeContextKey());
+    return PersistedStorage::KeyValueStoreMgr().Delete(keyAlloc.FailSafeContextKey().KeyName());
 }
 
 void FailSafeContext::ForceFailSafeTimerExpiry()

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -69,7 +69,7 @@ CHIP_ERROR GenericThreadDriver::CommitConfiguration()
     // the backup, so that it cannot be restored. If no backup could be found, it means that the
     // configuration has not been modified since the fail-safe was armed, so return with no error.
 
-    CHIP_ERROR error = KeyValueStoreMgr().Delete(DefaultStorageKeyAllocator::FailSafeNetworkConfig());
+    CHIP_ERROR error = KeyValueStoreMgr().Delete(DefaultStorageKeyAllocator().FailSafeNetworkConfig().KeyName());
 
     return error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND ? CHIP_NO_ERROR : error;
 }
@@ -79,7 +79,7 @@ CHIP_ERROR GenericThreadDriver::RevertConfiguration()
     uint8_t datasetBytes[Thread::kSizeOperationalDataset];
     size_t datasetLength;
 
-    CHIP_ERROR error = KeyValueStoreMgr().Get(DefaultStorageKeyAllocator::FailSafeNetworkConfig(), datasetBytes,
+    CHIP_ERROR error = KeyValueStoreMgr().Get(DefaultStorageKeyAllocator().FailSafeNetworkConfig().KeyName(), datasetBytes,
                                               sizeof(datasetBytes), &datasetLength);
 
     // If no backup could be found, it means that the network configuration has not been modified
@@ -98,7 +98,7 @@ CHIP_ERROR GenericThreadDriver::RevertConfiguration()
     ReturnErrorOnFailure(mStagingNetwork.Init(dataset));
     ReturnErrorOnFailure(DeviceLayer::ThreadStackMgrImpl().AttachToThreadNetwork(mStagingNetwork, /* callback */ nullptr));
 
-    return KeyValueStoreMgr().Delete(DefaultStorageKeyAllocator::FailSafeNetworkConfig());
+    return KeyValueStoreMgr().Delete(DefaultStorageKeyAllocator().FailSafeNetworkConfig().KeyName());
 }
 
 Status GenericThreadDriver::AddOrUpdateNetwork(ByteSpan operationalDataset, MutableCharSpan & outDebugText,
@@ -208,7 +208,8 @@ CHIP_ERROR GenericThreadDriver::BackupConfiguration()
     uint8_t dummy;
 
     // If configuration is already backed up, return with no error
-    if (KeyValueStoreMgr().Get(DefaultStorageKeyAllocator::FailSafeNetworkConfig(), &dummy, 0) == CHIP_ERROR_BUFFER_TOO_SMALL)
+    if (KeyValueStoreMgr().Get(DefaultStorageKeyAllocator().FailSafeNetworkConfig().KeyName(), &dummy, 0) ==
+        CHIP_ERROR_BUFFER_TOO_SMALL)
     {
         return CHIP_NO_ERROR;
     }
@@ -216,7 +217,7 @@ CHIP_ERROR GenericThreadDriver::BackupConfiguration()
     // Not all KVS implementations support zero-length values, so use a special value in such a case.
     ByteSpan dataset = mStagingNetwork.IsEmpty() ? ByteSpan(kEmptyDataset) : mStagingNetwork.AsByteSpan();
 
-    return KeyValueStoreMgr().Put(DefaultStorageKeyAllocator::FailSafeNetworkConfig(), dataset.data(), dataset.size());
+    return KeyValueStoreMgr().Put(DefaultStorageKeyAllocator().FailSafeNetworkConfig().KeyName(), dataset.data(), dataset.size());
 }
 
 size_t GenericThreadDriver::ThreadNetworkIterator::Count()

--- a/src/protocols/secure_channel/SimpleSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/SimpleSessionResumptionStorage.cpp
@@ -35,12 +35,14 @@ constexpr TLV::Tag SimpleSessionResumptionStorage::kResumptionIdTag;
 constexpr TLV::Tag SimpleSessionResumptionStorage::kSharedSecretTag;
 constexpr TLV::Tag SimpleSessionResumptionStorage::kCATTag;
 
-const char * SimpleSessionResumptionStorage::StorageKey(DefaultStorageKeyAllocator & keyAlloc, const ScopedNodeId & node)
+const DefaultStorageKeyAllocator & SimpleSessionResumptionStorage::StorageKey(DefaultStorageKeyAllocator & keyAlloc,
+                                                                              const ScopedNodeId & node)
 {
     return keyAlloc.FabricSession(node.GetFabricIndex(), node.GetNodeId());
 }
 
-const char * SimpleSessionResumptionStorage::StorageKey(DefaultStorageKeyAllocator & keyAlloc, ConstResumptionIdView resumptionId)
+const DefaultStorageKeyAllocator & SimpleSessionResumptionStorage::StorageKey(DefaultStorageKeyAllocator & keyAlloc,
+                                                                              ConstResumptionIdView resumptionId)
 {
     char resumptionIdBase64[BASE64_ENCODED_LEN(resumptionId.size()) + 1];
     auto len                = Base64Encode(resumptionId.data(), resumptionId.size(), resumptionIdBase64);

--- a/src/protocols/secure_channel/SimpleSessionResumptionStorage.h
+++ b/src/protocols/secure_channel/SimpleSessionResumptionStorage.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/core/CHIPTLV.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <protocols/secure_channel/SessionResumptionStorage.h>
@@ -57,8 +58,8 @@ public:
     CHIP_ERROR DeleteState(const ScopedNodeId & node) override;
 
 private:
-    static const char * StorageKey(DefaultStorageKeyAllocator & keyAlloc, const ScopedNodeId & node);
-    static const char * StorageKey(DefaultStorageKeyAllocator & keyAlloc, ConstResumptionIdView resumptionId);
+    static const DefaultStorageKeyAllocator & StorageKey(DefaultStorageKeyAllocator & keyAlloc, const ScopedNodeId & node);
+    static const DefaultStorageKeyAllocator & StorageKey(DefaultStorageKeyAllocator & keyAlloc, ConstResumptionIdView resumptionId);
 
     static constexpr size_t MaxScopedNodeIdSize() { return TLV::EstimateStructOverhead(sizeof(NodeId), sizeof(FabricIndex)); }
 

--- a/src/transport/GroupPeerMessageCounter.cpp
+++ b/src/transport/GroupPeerMessageCounter.cpp
@@ -346,11 +346,11 @@ CHIP_ERROR GroupOutgoingCounters::IncrementCounter(bool isControl)
         return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     }
 
-    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(key.KeyName(), &temp, size));
+    ReturnErrorOnFailure(mStorage->SyncGetKeyValue(key, &temp, size));
     if (temp == value)
     {
         temp = value + GROUP_MSG_COUNTER_MIN_INCREMENT;
-        return mStorage->SyncSetKeyValue(key.KeyName(), &temp, sizeof(uint32_t));
+        return mStorage->SyncSetKeyValue(key, &temp, sizeof(uint32_t));
     }
     return CHIP_NO_ERROR;
 }

--- a/src/transport/tests/TestGroupMessageCounter.cpp
+++ b/src/transport/tests/TestGroupMessageCounter.cpp
@@ -65,7 +65,7 @@ public:
 
         // Always Update storage for Test purposes
         temp = value + GROUP_MSG_COUNTER_MIN_INCREMENT;
-        mStorage->SyncSetKeyValue(key.KeyName(), &temp, sizeof(uint32_t));
+        mStorage->SyncSetKeyValue(key, &temp, sizeof(uint32_t));
     }
 };
 


### PR DESCRIPTION
For now we still have a few callsites of the *Deprecated methods, but
now it's clear what those are and we can work on removing them.

#### Problem
Possible for consumers to use keys not coming from DefaultStorageKeyAllocator with PersistentStorageDelegate.

#### Change overview
Move toward enforcing that the keys come from the key allocator.

#### Testing
No behavior changes.