### PR TITLE
Remove the concept of client attributes from EmberAfAttributeSearchRecord.

### DIFF
--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -159,13 +159,6 @@ typedef struct
     chip::ClusterId clusterId;
 
     /**
-     * Cluster mask for the cluster, used to determine if it is
-     * the server or client version of the cluster. See CLUSTER_MASK_
-     * macros defined in att-storage.h
-     */
-    EmberAfClusterMask clusterMask;
-
-    /**
      * The identifier for the attribute.
      */
     chip::AttributeId attributeId;

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -90,12 +90,11 @@ static constexpr uint16_t kEmberInvalidEndpointIndex = 0xFFFF;
  * @param endpoint Zigbee endpoint number.
  * @param clusterId Cluster ID of the sought cluster.
  * @param attributeId Attribute ID of the sought attribute.
- * @param mask CLUSTER_MASK_SERVER or CLUSTER_MASK_CLIENT
  *
  * @return Returns pointer to the attribute metadata location.
  */
 const EmberAfAttributeMetadata * emberAfLocateAttributeMetadata(chip::EndpointId endpoint, chip::ClusterId clusterId,
-                                                                chip::AttributeId attributeId, uint8_t mask);
+                                                                chip::AttributeId attributeId);
 
 /**
  * @brief Returns true if endpoint contains the ZCL cluster with specified id.
@@ -248,13 +247,6 @@ uint8_t emberAfGetDataSize(uint8_t dataType);
  * @param cluster EmberAfCluster* to consider
  */
 #define emberAfClusterIsManufacturerSpecific(cluster) ((cluster)->clusterId >= 0xFC00)
-
-/**
- * @brief macro that returns true if client attribute, and false if server.
- *
- * @param metadata EmberAfAttributeMetadata* to consider.
- */
-#define emberAfAttributeIsClient(metadata) (((metadata)->mask & ATTRIBUTE_MASK_CLIENT) != 0)
 
 /**
  * @brief macro that returns true if attribute is saved in external storage.

--- a/src/app/util/attribute-metadata.h
+++ b/src/app/util/attribute-metadata.h
@@ -136,10 +136,8 @@ union EmberAfDefaultOrMinMaxAttributeValue
 #define ATTRIBUTE_MASK_EXTERNAL_STORAGE (0x10)
 // Attribute is singleton
 #define ATTRIBUTE_MASK_SINGLETON (0x20)
-// Attribute is a client attribute
-#define ATTRIBUTE_MASK_CLIENT (0x40)
 // Attribute is nullable
-#define ATTRIBUTE_MASK_NULLABLE (0x80)
+#define ATTRIBUTE_MASK_NULLABLE (0x40)
 
 /**
  * @brief Each attribute has it's metadata stored in such struct.

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -415,14 +415,12 @@ void emAfCallInits(void)
 }
 
 // Returns the pointer to metadata, or null if it is not found
-const EmberAfAttributeMetadata * emberAfLocateAttributeMetadata(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId,
-                                                                uint8_t mask)
+const EmberAfAttributeMetadata * emberAfLocateAttributeMetadata(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId)
 {
     const EmberAfAttributeMetadata * metadata = nullptr;
     EmberAfAttributeSearchRecord record;
     record.endpoint    = endpoint;
     record.clusterId   = clusterId;
-    record.clusterMask = mask;
     record.attributeId = attributeId;
     emAfReadOrWriteAttribute(&record, &metadata,
                              nullptr, // buffer
@@ -512,12 +510,11 @@ static EmberAfStatus typeSensitiveMemCopy(ClusterId clusterId, uint8_t * dest, u
  *
  * Clusters match if:
  *   1. Cluster ids match AND
- *   2. Cluster directions match as defined by cluster->mask
- *        and attRecord->clusterMask
+ *   2. Cluster is a server cluster (because there are no client attributes).
  */
 bool emAfMatchCluster(const EmberAfCluster * cluster, EmberAfAttributeSearchRecord * attRecord)
 {
-    return (cluster->clusterId == attRecord->clusterId && cluster->mask & attRecord->clusterMask);
+    return (cluster->clusterId == attRecord->clusterId && (cluster->mask & CLUSTER_MASK_SERVER));
 }
 
 /**
@@ -1244,7 +1241,6 @@ void emAfLoadAttributeDefaults(EndpointId endpoint, bool ignoreStorage, Optional
                     EmberAfAttributeSearchRecord record;
                     record.endpoint    = de->endpoint;
                     record.clusterId   = cluster->clusterId;
-                    record.clusterMask = (emberAfAttributeIsClient(am) ? CLUSTER_MASK_CLIENT : CLUSTER_MASK_SERVER);
                     record.attributeId = am->attributeId;
 
                     if (ptr == nullptr)

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -540,8 +540,7 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, b
         attributeCluster = emberAfFindCluster(aPath.mEndpointId, aPath.mClusterId, CLUSTER_MASK_SERVER);
         break;
     default:
-        attributeMetadata =
-            emberAfLocateAttributeMetadata(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId, CLUSTER_MASK_SERVER);
+        attributeMetadata = emberAfLocateAttributeMetadata(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId);
     }
 
     if (attributeCluster == nullptr && attributeMetadata == nullptr)
@@ -611,7 +610,6 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, b
     EmberAfAttributeSearchRecord record;
     record.endpoint           = aPath.mEndpointId;
     record.clusterId          = aPath.mClusterId;
-    record.clusterMask        = CLUSTER_MASK_SERVER;
     record.attributeId        = aPath.mAttributeId;
     EmberAfStatus emberStatus = emAfReadOrWriteAttribute(&record, &attributeMetadata, attributeData, sizeof(attributeData),
                                                          /* write = */ false);
@@ -965,7 +963,7 @@ CHIP_ERROR prepareWriteData(const EmberAfAttributeMetadata * attributeMetadata, 
 const EmberAfAttributeMetadata * GetAttributeMetadata(const ConcreteAttributePath & aConcreteClusterPath)
 {
     return emberAfLocateAttributeMetadata(aConcreteClusterPath.mEndpointId, aConcreteClusterPath.mClusterId,
-                                          aConcreteClusterPath.mAttributeId, CLUSTER_MASK_SERVER);
+                                          aConcreteClusterPath.mAttributeId);
 }
 
 CHIP_ERROR WriteSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, const ConcreteDataAttributePath & aPath,

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -771,15 +771,21 @@ uint8_t emberAfMake8bitEncodedChanPg(uint8_t page, uint8_t channel)
 
 bool emberAfContainsAttribute(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId, bool asServer)
 {
-    uint8_t mask = asServer ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT;
-    return (emberAfLocateAttributeMetadata(endpoint, clusterId, attributeId, mask) != nullptr);
+    if (!asServer)
+    {
+        return false;
+    }
+    return (emberAfLocateAttributeMetadata(endpoint, clusterId, attributeId) != nullptr);
 }
 
 bool emberAfIsNonVolatileAttribute(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
                                    bool asServer)
 {
-    uint8_t mask                              = asServer ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT;
-    const EmberAfAttributeMetadata * metadata = emberAfLocateAttributeMetadata(endpoint, clusterId, attributeId, mask);
+    if (!asServer)
+    {
+        return false;
+    }
+    const EmberAfAttributeMetadata * metadata = emberAfLocateAttributeMetadata(endpoint, clusterId, attributeId);
 
     if (metadata == nullptr)
     {


### PR DESCRIPTION
All attributes in Matter are server attributes.

#### Problem
Unnecessary sides for attributes being passed around.

#### Change overview
Remove some of them.  There are more to remove, but those will be separate PRs.

#### Testing
No behavior changes, just code removal.