### PR TITLE
Revert "[linux] Use BLE notification instead of indication (#17692)"

### DIFF
--- a/src/platform/Linux/bluez/Helper.cpp
+++ b/src/platform/Linux/bluez/Helper.cpp
@@ -627,6 +627,18 @@ exit:
     return isSuccess ? TRUE : FALSE;
 }
 
+static gboolean BluezCharacteristicConfirm(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
+                                           gpointer apClosure)
+{
+    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
+    BluezConnection * conn   = GetBluezConnectionViaDevice(endpoint);
+
+    ChipLogDetail(Ble, "Indication confirmation, %p", conn);
+    BLEManagerImpl::HandleTXComplete(conn);
+
+    return TRUE;
+}
+
 static gboolean BluezCharacteristicStopNotifyError(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation)
 {
     g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed",
@@ -1223,7 +1235,7 @@ static void BluezPeripheralObjectsSetup(gpointer apClosure)
 {
 
     static const char * const c1_flags[] = { "write", nullptr };
-    static const char * const c2_flags[] = { "read", "notify", nullptr };
+    static const char * const c2_flags[] = { "read", "indicate", nullptr };
     static const char * const c3_flags[] = { "read", nullptr };
 
     BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
@@ -1252,7 +1264,7 @@ static void BluezPeripheralObjectsSetup(gpointer apClosure)
     g_signal_connect(endpoint->mpC2, "handle-acquire-notify", G_CALLBACK(BluezCharacteristicAcquireNotify), apClosure);
     g_signal_connect(endpoint->mpC2, "handle-start-notify", G_CALLBACK(BluezCharacteristicStartNotify), apClosure);
     g_signal_connect(endpoint->mpC2, "handle-stop-notify", G_CALLBACK(BluezCharacteristicStopNotify), apClosure);
-    g_signal_connect(endpoint->mpC2, "handle-confirm", G_CALLBACK(BluezCharacteristicConfirmError), apClosure);
+    g_signal_connect(endpoint->mpC2, "handle-confirm", G_CALLBACK(BluezCharacteristicConfirm), apClosure);
 
     ChipLogDetail(DeviceLayer, "CHIP BTP C1 %s", bluez_gatt_characteristic1_get_service(endpoint->mpC1));
     ChipLogDetail(DeviceLayer, "CHIP BTP C2 %s", bluez_gatt_characteristic1_get_service(endpoint->mpC2));
@@ -1269,7 +1281,7 @@ static void BluezPeripheralObjectsSetup(gpointer apClosure)
     g_signal_connect(endpoint->mpC3, "handle-acquire-notify", G_CALLBACK(BluezCharacteristicAcquireNotify), apClosure);
     g_signal_connect(endpoint->mpC3, "handle-start-notify", G_CALLBACK(BluezCharacteristicStartNotify), apClosure);
     g_signal_connect(endpoint->mpC3, "handle-stop-notify", G_CALLBACK(BluezCharacteristicStopNotify), apClosure);
-    g_signal_connect(endpoint->mpC3, "handle-confirm", G_CALLBACK(BluezCharacteristicConfirmError), apClosure);
+    g_signal_connect(endpoint->mpC3, "handle-confirm", G_CALLBACK(BluezCharacteristicConfirm), apClosure);
     // update the characteristic value
     UpdateAdditionalDataCharacteristic(endpoint->mpC3);
     ChipLogDetail(DeviceLayer, "CHIP BTP C3 %s", bluez_gatt_characteristic1_get_service(endpoint->mpC3));
@@ -1357,7 +1369,7 @@ exit:
     return 0;
 }
 
-static gboolean BluezC2Notify(ConnectionDataBundle * closure)
+static gboolean BluezC2Indicate(ConnectionDataBundle * closure)
 {
     BluezConnection * conn = nullptr;
     GError * error         = nullptr;
@@ -1369,7 +1381,7 @@ static gboolean BluezC2Notify(ConnectionDataBundle * closure)
 
     conn = closure->mpConn;
     VerifyOrExit(conn != nullptr, ChipLogError(DeviceLayer, "BluezConnection is NULL in %s", __func__));
-    VerifyOrExit(conn->mpC2 != nullptr, ChipLogError(DeviceLayer, "FAIL: C2 Notify: %s", "NULL C2"));
+    VerifyOrExit(conn->mpC2 != nullptr, ChipLogError(DeviceLayer, "FAIL: C2 Indicate: %s", "NULL C2"));
 
     if (bluez_gatt_characteristic1_get_notify_acquired(conn->mpC2) == TRUE)
     {
@@ -1380,15 +1392,13 @@ static gboolean BluezC2Notify(ConnectionDataBundle * closure)
         g_variant_unref(closure->mpVal);
         closure->mpVal = nullptr;
 
-        VerifyOrExit(status == G_IO_STATUS_NORMAL, ChipLogError(DeviceLayer, "FAIL: C2 Notify: %s", error->message));
+        VerifyOrExit(status == G_IO_STATUS_NORMAL, ChipLogError(DeviceLayer, "FAIL: C2 Indicate: %s", error->message));
     }
     else
     {
         bluez_gatt_characteristic1_set_value(conn->mpC2, closure->mpVal);
         closure->mpVal = nullptr;
     }
-
-    BLEManagerImpl::HandleTXComplete(conn);
 
 exit:
     if (closure != nullptr)
@@ -1420,7 +1430,7 @@ bool SendBluezIndication(BLE_CONNECTION_OBJECT apConn, chip::System::PacketBuffe
 
     VerifyOrExit(!apBuf.IsNull(), ChipLogError(DeviceLayer, "apBuf is NULL in %s", __func__));
 
-    success = MainLoop::Instance().Schedule(BluezC2Notify, MakeConnectionDataBundle(apConn, apBuf));
+    success = MainLoop::Instance().Schedule(BluezC2Indicate, MakeConnectionDataBundle(apConn, apBuf));
 
 exit:
     return success;
@@ -1673,7 +1683,7 @@ static gboolean SubscribeCharacteristicImpl(BluezConnection * connection)
     VerifyOrExit(connection->mpC2 != nullptr, ChipLogError(DeviceLayer, "C2 is NULL in %s", __func__));
     c2 = BLUEZ_GATT_CHARACTERISTIC1(connection->mpC2);
 
-    // Get notifications on the TX characteristic change (e.g. notification is received)
+    // Get notifications on the TX characteristic change (e.g. indication is received)
     g_signal_connect(c2, "g-properties-changed", G_CALLBACK(OnCharacteristicChanged), connection);
     bluez_gatt_characteristic1_call_start_notify(connection->mpC2, nullptr, SubscribeCharacteristicDone, connection);
 


### PR DESCRIPTION
#### Problem
6160935fa23987c90f2f6e3ac24ce70de82d37df although fills the spec compliance gap, apparently causes some communication issues on a Raspberry Pi - looks like sometimes notification packets are not sent/received.

#### Change overview
Revert the change.
Fixes #17806

#### Testing
Don't have access to a RPi at the moment, but it's just a revert, so should work as before.
