### PR TITLE
[Tests] Increase the tests timeout from 30 minutes to 40 minutes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -88,7 +88,7 @@ jobs:
                         --copy-artifacts-to objdir-clone \
                      "
             - name: Run Tests
-              timeout-minutes: 30
+              timeout-minutes: 40
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \


### PR DESCRIPTION
#### Problem

The last 2 commits on ToT seems to be red because the tests suites on Linux takes more than 30 minutes to run.

See https://github.com/project-chip/connectedhomeip/runs/6205632890?check_suite_focus=true and https://github.com/project-chip/connectedhomeip/runs/6205026317?check_suite_focus=true

#### Change overview
 * Increase the test timeout from 30 to 40 minutes.
