### PR TITLE
[IM] Subscribing to an event crashes

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -312,8 +312,8 @@ CHIP_ERROR InteractionModelEngine::OnReadInitialRequest(Messaging::ExchangeConte
             if (err == CHIP_NO_ERROR)
             {
                 TLV::TLVReader pathReader;
-                attributePathListParser.GetReader(&pathReader);
-                TLV::Utilities::Count(pathReader, requestedAttributePathCount, false);
+                eventpathListParser.GetReader(&pathReader);
+                TLV::Utilities::Count(pathReader, requestedEventPathCount, false);
             }
             else if (err != CHIP_ERROR_END_OF_TLV)
             {

--- a/src/app/tests/suites/TestEvents.yaml
+++ b/src/app/tests/suites/TestEvents.yaml
@@ -85,3 +85,37 @@ tests:
                 - value: { arg1: 1, arg2: 2, arg3: true }
           - values:
                 - value: { arg1: 3, arg2: 4, arg3: false }
+
+    - label: "Subscribe to the event"
+      command: "subscribeEvent"
+      event: "TestEvent"
+      minInterval: 3
+      maxInterval: 5
+      response:
+          - values:
+                - value: { arg1: 1, arg2: 2, arg3: true }
+          - values:
+                - value: { arg1: 3, arg2: 4, arg3: false }
+
+    - label: "Generate a third event on the accessory"
+      command: "TestEmitTestEventRequest"
+      arguments:
+          values:
+              - name: "arg1"
+                value: 4
+              - name: "arg2"
+                value: 5
+              - name: "arg3"
+                value: true
+      response:
+          values:
+              - name: "value"
+                value: eventNumber + 2
+
+    - label: "Check for event report"
+      command: "waitForReport"
+      event: "TestEvent"
+      response:
+          values:
+              - name: "TestEvent"
+                value: { arg1: 4, arg2: 5, arg3: true }

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -173,8 +173,12 @@ function setDefaultTypeForCommand(test)
     break;
 
   case 'waitForReport':
-    test.commandName     = 'WaitForReport';
-    test.isAttribute     = true;
+    test.commandName = 'WaitForReport';
+    if ('attribute' in test) {
+      test.isAttribute = true;
+    } else if ('event' in test) {
+      test.isEvent = true;
+    }
     test.isWaitForReport = true;
     break;
 


### PR DESCRIPTION
#### Problem

After https://github.com/project-chip/connectedhomeip/pull/16811, running `./out/debug/standalone/chip-tool otasoftwareupdaterequestor subscribe-event state-transition 5 10 0x12344321 0` ends up crashing the server.

I found it while trying to look at https://github.com/project-chip/connectedhomeip/issues/17764

#### Change overview
 * Use the right `TLVReader`
 * Add a yaml test to subscribe to an event
 * Update the YAML backend to make it possible to wait for an event report

#### Testing
Without the changes in `InteractionModelEngine.cpp` the test crashes, with the changes it does not.
