### PR TITLE
[chip-tool] Do not try to reset an element that does not exists in th…

### DIFF
--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -104,8 +104,11 @@ public:
 
     virtual void OnDone(chip::app::CommandSender * client) override
     {
-        mCommandSender.front().reset();
-        mCommandSender.erase(mCommandSender.begin());
+        if (mCommandSender.size())
+        {
+            mCommandSender.front().reset();
+            mCommandSender.erase(mCommandSender.begin());
+        }
 
         // If the command is repeated N times, wait for all the responses to comes in
         // before exiting.


### PR DESCRIPTION
…e case of a group command

#### Problem

When sending a group command `chip-tool` crashes because there is nothing into the vector but the code tries to reset/erase it.

#### Change overview
 * check the vector size first
 