### PR TITLE
Build chef

### DIFF
--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -43,8 +43,6 @@ jobs:
                       token: ${{ github.token }}
             - name: Setup ZAP
               run: |
-                  # mkdir ./third_party/zap
-                  # mkdir ./third_party/zap/repo
                   rm -R ./third_party/zap/repo/
                   mv /opt/zap ./third_party/zap/repo/
             - name: Generate all

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -36,15 +36,28 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         steps:
-            - uses: actions/checkout@v3 #Wandalen/wretry.action@v1.0.11
+            - uses: Wandalen/wretry.action@v1.0.11
               name: Checkout
               with:
+                  action: actions/checkout@v3
                   with: |
                       token: ${{ github.token }}
+                  attempt_limit: 3
+                  attempt_delay: 2000
             - name: Setup ZAP
+              timeout-minutes: 10
               run: |
                   rm -R ./third_party/zap/repo/
                   mv /opt/zap ./third_party/zap/repo/
             - name: Generate all
+              timeout-minutes: 30
               run: scripts/tools/zap_regen_all.py
-
+            - name: Check for uncommited changes
+              run: |
+                  git add .
+                  # Show the full diff
+                  git diff-index -p HEAD --
+                  # Also show just the files that are different, to make it easy
+                  # to tell at a glance what might be going on.  And throw in
+                  # --exit-code to make this job fail if there is a difference.
+                  git diff-index --exit-code HEAD --

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -29,40 +29,24 @@ jobs:
 
         runs-on: ubuntu-20.04
         container:
-            image: connectedhomeip/chip-build-zap:0.5.64
+            image: connectedhomeip/chip-build-zap:0.5.65
         defaults:
             run:
                 shell: sh
         if: github.actor != 'restyled-io[bot]'
 
         steps:
-            - uses: Wandalen/wretry.action@v1.0.11
+            - uses: actions/checkout@v3 #Wandalen/wretry.action@v1.0.11
               name: Checkout
               with:
-                  action: actions/checkout@v3
                   with: |
                       token: ${{ github.token }}
-                  attempt_limit: 3
-                  attempt_delay: 2000
-            - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform linux
             - name: Setup ZAP
-              timeout-minutes: 10
               run: |
-                  cd third_party/zap/repo/
-                  npm ci
-                  npm run version-stamp
-                  npm rebuild canvas --update-binary
-                  npm run build-spa
+                  # mkdir ./third_party/zap
+                  # mkdir ./third_party/zap/repo
+                  rm -R ./third_party/zap/repo/
+                  mv /opt/zap ./third_party/zap/repo/
             - name: Generate all
-              timeout-minutes: 30
               run: scripts/tools/zap_regen_all.py
-            - name: Check for uncommited changes
-              run: |
-                  git add .
-                  # Show the full diff
-                  git diff-index -p HEAD --
-                  # Also show just the files that are different, to make it easy
-                  # to tell at a glance what might be going on.  And throw in
-                  # --exit-code to make this job fail if there is a difference.
-                  git diff-index --exit-code HEAD --
+

--- a/examples/chef/platforms.json
+++ b/examples/chef/platforms.json
@@ -1,0 +1,7 @@
+{
+   "platforms":[
+      "linux",
+      "esp32",
+      "nrfconnect"
+   ]
+}

--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.5.64"
+    - name: "connectedhomeip/chip-build-vscode:0.5.65"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -12,14 +12,16 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.64"
+    - name: "connectedhomeip/chip-build-vscode:0.5.65"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - >-
+              rm -R /workspace/third_party/zap/repo;
+              cp -r /opt/zap /workspace/third_party/zap/repo;
               ./scripts/build/build_examples.py --enable-flashbundle
               --target-glob '*' --skip-target-glob '*-tests' build
-              --create-archives /workspace/artifacts/
+              --create-archives /workspace/artifacts/;
       id: CompileAll
       waitFor:
           - Bootstrap

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.5.64"
+    - name: "connectedhomeip/chip-build-vscode:0.5.65"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -12,7 +12,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.64"
+    - name: "connectedhomeip/chip-build-vscode:0.5.65"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -28,7 +28,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.64"
+    - name: "connectedhomeip/chip-build-vscode:0.5.65"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -45,7 +45,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.64"
+    - name: "connectedhomeip/chip-build-vscode:0.5.65"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -62,7 +62,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.64"
+    - name: "connectedhomeip/chip-build-vscode:0.5.65"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -79,7 +79,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.64"
+    - name: "connectedhomeip/chip-build-vscode:0.5.65"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -91,6 +91,23 @@ steps:
       waitFor:
           - Bootstrap
           - Linux
+      entrypoint: ./scripts/run_in_build_env.sh
+      volumes:
+          - name: pwenv
+            path: /pwenv
+
+    - name: "connectedhomeip/chip-build-vscode:0.5.65"
+      id: Chef
+      env:
+          - PW_ENVIRONMENT_ROOT=/pwenv
+      args:
+          - >-
+              rm -R /workspace/third_party/zap/repo;
+              cp -r /opt/zap /workspace/third_party/zap/repo;
+              ./scripts/build/build_examples.py --enable-flashbundle
+              --target-glob 'chef-all' --skip-target-glob '*-tests' build
+              --create-archives /workspace/artifacts/;
+      # waitFor: ALL
       entrypoint: ./scripts/run_in_build_env.sh
       volumes:
           - name: pwenv

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -32,6 +32,7 @@ from builders.telink import TelinkApp, TelinkBoard, TelinkBuilder
 from builders.tizen import TizenApp, TizenBoard, TizenBuilder
 from builders.bl602 import Bl602App, Bl602Board, Bl602Builder
 from builders.imx import IMXApp, IMXBuilder
+from builders.chef import ChefApp, ChefBuilder
 
 
 class Target:
@@ -554,6 +555,10 @@ def IMXTargets():
     yield target.Extend('all-clusters-app-release', app=IMXApp.ALL_CLUSTERS, release=True)
     yield target.Extend('ota-provider-app-release', app=IMXApp.OTA_PROVIDER, release=True)
 
+def ChefTargets():
+    target = Target('chef', ChefBuilder)
+
+    yield target.Extend('all', app=ChefApp.ALL_DEVICES)
 
 ALL = []
 
@@ -573,6 +578,7 @@ target_generators = [
     TizenTargets(),
     Bl602Targets(),
     IMXTargets(),
+    ChefTargets(),
 ]
 
 for generator in target_generators:

--- a/scripts/build/builders/chef.py
+++ b/scripts/build/builders/chef.py
@@ -43,13 +43,13 @@ class ChefBuilderUtil():
 
     def build(self):
         for device in self.load_devices():
-            for platform in filter(lambda x: x == 'linux', self.load_platforms()): # TODO: support all plats
+            for platform in [p for p in self.load_platforms() if p == "linux"]:
                 command = self.create_build_command(device, platform)
                 subprocess.check_call(command, cwd=self.chef_builder.root, shell=True)
 
     def create_manifest(self):
         manifest = {}
-        for platform in filter(lambda x: x == 'linux', self.load_platforms()): # TODO: support all plats
+        for platform in [p for p in self.load_platforms() if p == "linux"]:
             manifest[platform] = '{}/{}/out/'.format(self.chef_builder.root, platform)
         return manifest
 

--- a/scripts/build/builders/chef.py
+++ b/scripts/build/builders/chef.py
@@ -1,0 +1,76 @@
+import os
+import json
+import subprocess
+from enum import Enum, auto
+
+from .builder import Builder
+
+
+class ChefApp(Enum):
+
+    ALL_DEVICES = auto()
+
+    def AppPath(self):
+        if self == ChefApp.ALL_DEVICES:
+            return 'chef'
+
+    def AppNamePrefix(self):
+        if self == ChefApp.ALL_DEVICES:
+            return 'chip-chef-examples'
+        else:
+            raise Exception('Unknown app type: %r' % self)
+
+
+class ChefBuilderUtil():
+
+    def __init__(self, chef_builder):
+        self.chef_builder = chef_builder
+
+    def load_platforms(self):
+        chef_platforms = os.path.join(self.chef_builder.root, 'platforms.json')
+        with open(chef_platforms) as platforms:
+            for platform in json.load(platforms)['platforms']:
+                yield platform
+
+    def load_devices(self):
+        devices_dir = os.path.join(self.chef_builder.root, 'devices')
+        for device in os.listdir(devices_dir):
+            if device.endswith('.zap'):
+                yield device[:len(device)-len('.zap')]
+
+    def create_build_command(self, zap, target):
+        return './chef.py -zbr -d {} -t {}'.format(zap, target)
+
+    def build(self):
+        for device in self.load_devices():
+            for platform in filter(lambda x: x == 'linux', self.load_platforms()): # TODO: support all plats
+                command = self.create_build_command(device, platform)
+                subprocess.check_call(command, cwd=self.chef_builder.root, shell=True)
+
+    def create_manifest(self):
+        manifest = {}
+        for platform in filter(lambda x: x == 'linux', self.load_platforms()): # TODO: support all plats
+            manifest[platform] = '{}/{}/out/'.format(self.chef_builder.root, platform)
+        return manifest
+
+
+class ChefBuilder(Builder):
+
+    def __init__(self,
+                 root,
+                 runner,
+                 app: ChefApp = ChefApp.ALL_DEVICES,
+                 enable_rpcs: bool = False):
+        super(ChefBuilder, self).__init__(root=os.path.join(root, 'examples', app.AppPath()),runner=runner)
+        self.app = app
+        self.enable_rpcs = enable_rpcs
+        self.build_util = ChefBuilderUtil(self)
+
+    def generate(self):
+        pass
+
+    def _build(self):
+        self.build_util.build()
+
+    def build_outputs(self):
+        return self.build_util.create_manifest()

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -22,6 +22,7 @@ cc13x2x7_26x2x7-lock-ftd
 cc13x2x7_26x2x7-lock-mtd
 cc13x2x7_26x2x7-pump
 cc13x2x7_26x2x7-pump-controller
+chef-all
 cyw30739-cyw930739m2evb_01-light
 cyw30739-cyw930739m2evb_01-lock
 cyw30739-cyw930739m2evb_01-ota-requestor (NOGLOB: Running out of XIP flash space)

--- a/scripts/build/testdata/glob_star_targets_except_host.txt
+++ b/scripts/build/testdata/glob_star_targets_except_host.txt
@@ -22,6 +22,7 @@ cc13x2x7_26x2x7-lock-ftd
 cc13x2x7_26x2x7-lock-mtd
 cc13x2x7_26x2x7-pump
 cc13x2x7_26x2x7-pump-controller
+chef-all
 cyw30739-cyw930739m2evb_01-light
 cyw30739-cyw930739m2evb_01-lock
 cyw30739-cyw930739m2evb_01-ota-requestor-no-progress-logging


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Add chef to CD; update CI
  *  Note that chef is integrated into the existing pipeline only to build all examples. 
    *   To prevent chef maintainers from having to update CD code for new platforms, targeting platform with the existing build pipeline was not implemented; CD platforms for chef may be controlled via the json file in chef example.
      * chef is meant to be a friendly system for end users; I think if users are interacting with chef via CLI, then chef.py should be used directly, not indirectly through the build strategy here. However having the build all command here is convenient for first time setups.
      * the json file may be integrated into chef.py  
  * Only linux is included in this PR with plans to support all platforms in the future. 
* Update ZAP workflow to use new image decreasing workflow execution time

#### Change overview
* Updated ZAP workflow
* Updated both cloud build configs
* New builder for chef all examples

#### Testing
How was this tested? (at least one bullet point required)
* Locally tested builder and inspected output archive; compared with chef build output folder and ran with multiple input devices
* Tested with cloud build local builder
* Ran workflows in another branch before merge both on GitHub and with local test tool