### PR TITLE
Move extern template instantiates to the end of file

### DIFF
--- a/src/include/platform/internal/GenericConnectivityManagerImpl_BLE.ipp
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_BLE.ipp
@@ -31,9 +31,6 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-// Fully instantiate the template class in whatever compilation unit includes this file.
-template class GenericConnectivityManagerImpl_BLE<ConnectivityManagerImpl>;
-
 template <class ImplClass>
 const char * GenericConnectivityManagerImpl_BLE<ImplClass>::_CHIPoBLEServiceModeToStr(ConnectivityManager::CHIPoBLEServiceMode mode)
 {
@@ -49,6 +46,10 @@ const char * GenericConnectivityManagerImpl_BLE<ImplClass>::_CHIPoBLEServiceMode
         return "(unknown)";
     }
 }
+
+// Fully instantiate the template class in whatever compilation unit includes this file.
+// NB: This must come after all templated class members are defined.
+template class GenericConnectivityManagerImpl_BLE<ConnectivityManagerImpl>;
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.ipp
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.ipp
@@ -32,9 +32,6 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
-template class GenericConnectivityManagerImpl_WiFi<ConnectivityManagerImpl>;
-
 template <class ImplClass>
 const char * GenericConnectivityManagerImpl_WiFi<ImplClass>::_WiFiStationModeToStr(ConnectivityManager::WiFiStationMode mode)
 {
@@ -120,6 +117,10 @@ bool GenericConnectivityManagerImpl_WiFi<ImplClass>::_IsWiFiStationEnabled()
 {
     return Impl()->GetWiFiStationMode() == ConnectivityManager::kWiFiStationMode_Enabled;
 }
+
+// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
+// NB: This must come after all templated class members are defined.
+template class GenericConnectivityManagerImpl_WiFi<ConnectivityManagerImpl>;
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/include/platform/internal/GenericPlatformManagerImpl.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.ipp
@@ -321,6 +321,7 @@ void GenericPlatformManagerImpl<ImplClass>::HandleMessageLayerActivityChanged(bo
 }
 
 // Fully instantiate the generic implementation class in whatever compilation unit includes this file.
+// NB: This must come after all templated class members are defined.
 template class GenericPlatformManagerImpl<PlatformManagerImpl>;
 
 } // namespace Internal

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
@@ -39,9 +39,6 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
-template class GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>;
-
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_InitChipStack(void)
 {
@@ -287,6 +284,10 @@ CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_StopEventLoopTask(vo
     mShouldRunEventLoop.store(false);
     return CHIP_NO_ERROR;
 }
+
+// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
+// NB: This must come after all templated class members are defined.
+template class GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>;
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
@@ -311,6 +311,7 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_Shutdown()
 }
 
 // Fully instantiate the generic implementation class in whatever compilation unit includes this file.
+// NB: This must come after all templated class members are defined.
 template class GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>;
 
 } // namespace Internal

--- a/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.ipp
@@ -51,9 +51,6 @@ System::LayerSocketsLoop & SystemLayerSocketsLoop()
 
 } // anonymous namespace
 
-// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
-template class GenericPlatformManagerImpl_Zephyr<PlatformManagerImpl>;
-
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_InitChipStack(void)
 {
@@ -196,6 +193,10 @@ CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_StartEventLoopTask(voi
 
     return CHIP_NO_ERROR;
 }
+
+// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
+// NB: This must come after all templated class members are defined.
+template class GenericPlatformManagerImpl_Zephyr<PlatformManagerImpl>;
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/FreeRTOS/GenericThreadStackManagerImpl_FreeRTOS.cpp
+++ b/src/platform/FreeRTOS/GenericThreadStackManagerImpl_FreeRTOS.cpp
@@ -37,9 +37,6 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
-template class GenericThreadStackManagerImpl_FreeRTOS<ThreadStackManagerImpl>;
-
 template <class ImplClass>
 CHIP_ERROR GenericThreadStackManagerImpl_FreeRTOS<ImplClass>::DoInit(void)
 {
@@ -143,6 +140,10 @@ void GenericThreadStackManagerImpl_FreeRTOS<ImplClass>::ThreadTaskMain(void * ar
         ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
     }
 }
+
+// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
+// NB: This must come after all templated class members are defined.
+template class GenericThreadStackManagerImpl_FreeRTOS<ThreadStackManagerImpl>;
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -102,8 +102,6 @@ void initNetworkCommissioningThreadDriver(void)
 NetworkCommissioning::ThreadScanResponse * sScanResult;
 otScanResponseIterator<NetworkCommissioning::ThreadScanResponse> mScanResponseIter(sScanResult);
 } // namespace
-// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
-template class GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>;
 
 /**
  * Called by OpenThread to alert the ThreadStackManager of a change in the state of the Thread stack.
@@ -2583,6 +2581,10 @@ exit:
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_DNS_CLIENT
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
+// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
+// NB: This must come after all templated class members are defined.
+template class GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>;
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
@@ -48,9 +48,6 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
-template class GenericThreadStackManagerImpl_OpenThread_LwIP<ThreadStackManagerImpl>;
-
 template <class ImplClass>
 void GenericThreadStackManagerImpl_OpenThread_LwIP<ImplClass>::_OnPlatformEvent(const ChipDeviceEvent * event)
 {
@@ -421,6 +418,10 @@ exit:
         // TODO: deliver CHIP platform event signaling loss of inbound packet.
     }
 }
+
+// Fully instantiate the generic implementation class in whatever compilation unit includes this file.
+// NB: This must come after all templated class members are defined.
+template class GenericThreadStackManagerImpl_OpenThread_LwIP<ThreadStackManagerImpl>;
 
 } // namespace Internal
 } // namespace DeviceLayer


### PR DESCRIPTION
#### Problem

There is a difference in behavior between gcc and clang when it comes to
explicit instantiating extern templates. With clang, instantiating
before all templated member definitions are defined will leave those
members uninstantiated in the translation unit, causing undefined symbol
errors.

#### Change overview

Move the instantiation to the end of file so these platforms can build
with clang.

#### Testing

Built NXP lighting-app with clang.
