### PR TITLE
Update zap and image version blocking pull/17848

### DIFF
--- a/integrations/docker/images/chip-build-zap/Dockerfile
+++ b/integrations/docker/images/chip-build-zap/Dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION=latest
 FROM connectedhomeip/chip-build:${VERSION}
 
-ENV ZAP_COMMIT=7ab717d08dfe9b0ba9de907fc7c6eb6549c86bf7
+ENV ZAP_COMMIT=1136effb0e0ee8cd1f6bfc730492db799f878cba
 
 ENV ZAP_ORIGIN=https://github.com/project-chip/zap.git
 

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.68 Version bump reason: [Tizen] Add Tizen Studio CLI to Tizen docker image
+0.5.69 Version bump reason: [Zap] Stay in sync with submod & CI in pull/17848


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* New zap CI is [failing](https://github.com/project-chip/connectedhomeip/runs/6217157182?check_suite_focus=true) because image is out of sync with the submodule. 
  *  This will be our signal to update the images moving forward

#### Change overview
* Update zap docker commit and update images version
* Once the new image is out I will update pull/17848 to use it; may create a helper script to increase version in build files if there isn't one already.  