### PR TITLE
Suppress clang warnings -Wparentheses-equality, -Wself-assign, unknown argument

### DIFF
--- a/third_party/nxp/k32w0_sdk/k32w0_sdk.gni
+++ b/third_party/nxp/k32w0_sdk/k32w0_sdk.gni
@@ -11,10 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 import("//build_overrides/k32w0_sdk.gni")
 import("//build_overrides/mbedtls.gni")
 import("//build_overrides/openthread.gni")
+
+import("${build_root}/config/compiler/compiler.gni")
 import("${chip_root}/src/crypto/crypto.gni")
 import("${chip_root}/src/platform/nxp/k32w/k32w0/args.gni")
 
@@ -268,11 +272,19 @@ template("k32w0_sdk") {
       "-Wno-sign-compare",
       "-Wno-clobbered",
       "-Wno-implicit-fallthrough",
-      "-fno-optimize-strlen",
       "-mthumb",
       "-MMD",
       "-MP",
     ]
+
+    if (is_clang) {
+      cflags += [
+        "-Wno-self-assign",
+        "-Wno-parentheses-equality",
+      ]
+    } else {
+      cflags += [ "-fno-optimize-strlen" ]
+    }
 
     # Now add our "system-header" include dirs
     foreach(include_dir, _sdk_include_dirs) {


### PR DESCRIPTION
#### Problem

```
clang-14: error: unknown argument: '-fno-optimize-strlen'
```
```
/home/spang/sdk/k32w_sdk/boards/k32w061dk6/wireless_examples/openthread/reed/bm/board.c:1581:23: error: equality comparison with extraneous parentheses [-Werror,-Wparentheses-equality]
    if ( (reset_cause == RESET_WAKE_PD) )
          ~~~~~~~~~~~~^~~~~~~~~~~~~~~~
/home/spang/sdk/k32w_sdk/boards/k32w061dk6/wireless_examples/openthread/reed/bm/board.c:1581:23: note: remove extraneous parentheses around the comparison to silence this warning
    if ( (reset_cause == RESET_WAKE_PD) )
         ~            ^               ~
/home/spang/sdk/k32w_sdk/boards/k32w061dk6/wireless_examples/openthread/reed/bm/board.c:1581:23: note: use '=' to turn this equality comparison into an assignment
    if ( (reset_cause == RESET_WAKE_PD) )
                      ^~
                      =
1 error generated.
```
```
/home/spang/sdk/k32w_sdk/middleware/wireless/framework/Keyboard/Source/Keyboard.c:590:20: error: explicitly assigning value of variable of type 'switchScan_t' (aka 'unsigned int') to itself [-Werror,-Wself-assign]
    previousPressed=previousPressed; /* avoid compiler warnings */
    ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
1 error generated.
```


#### Change overview

Suppress these warnings

#### Testing

Compile examples/lighting-app/nxp/k32w/k32w0 with clang
