### PR TITLE
Fix clang warnings -Wmissing-declarations

### DIFF
--- a/src/platform/nxp/k32w/k32w0/CHIPDevicePlatformEvent.h
+++ b/src/platform/nxp/k32w/k32w0/CHIPDevicePlatformEvent.h
@@ -56,10 +56,6 @@ enum InternalPlatformSpecificEventTypes
 
 struct ChipDevicePlatformEvent final
 {
-    union
-    {
-        /* None currently defined */
-    };
 };
 
 } // namespace DeviceLayer


### PR DESCRIPTION
#### Problem

```
../../third_party/connectedhomeip/src/platform/nxp/k32w/k32w0/CHIPDevicePlatformEvent.h:59:5: error: declaration does not declare anything [-Werror,-Wmissing-declarations]
    union
    ^
1 error generated.
```

#### Change overview

Remove the empty union

#### Testing

Compile examples/lighting-app/nxp/k32w/k32w0 with clang