### PR TITLE
Fix clang warnings -Wformat-nonliteral

### DIFF
--- a/src/lib/support/EnforceFormat.h
+++ b/src/lib/support/EnforceFormat.h
@@ -27,7 +27,7 @@
  * varargs.
  */
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #define ENFORCE_FORMAT(n, m) __attribute__((format(printf, n, m)))
 #else                        // __GNUC__
 #define ENFORCE_FORMAT(n, m) /* How to do with MSVC? */

--- a/src/platform/nxp/k32w/k32w0/Logging.cpp
+++ b/src/platform/nxp/k32w/k32w0/Logging.cpp
@@ -159,7 +159,7 @@ void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char
 /**
  * LwIP log output function.
  */
-extern "C" void LwIPLog(const char * msg, ...)
+extern "C" void ENFORCE_FORMAT(1, 2) LwIPLog(const char * msg, ...)
 {
     va_list v;
     const char * module = "LWIP";
@@ -174,7 +174,7 @@ extern "C" void LwIPLog(const char * msg, ...)
 #undef K32W_LOG_MODULE_NAME
 #define K32W_LOG_MODULE_NAME thread
 
-extern "C" void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char * aFormat, ...)
+extern "C" void ENFORCE_FORMAT(3, 4) otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char * aFormat, ...)
 {
     va_list v;
     const char * module = "OT";

--- a/third_party/openthread/platforms/nxp/k32w/k32w0/BUILD.gn
+++ b/third_party/openthread/platforms/nxp/k32w/k32w0/BUILD.gn
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 import("//build_overrides/k32w0_sdk.gni")
 import("//build_overrides/openthread.gni")
+
+import("${build_root}/config/compiler/compiler.gni")
 import("${chip_root}/third_party/nxp/k32w0_sdk/k32w0_sdk.gni")
 
 openthread_nxp_root = "${chip_root}/third_party/openthread/ot-nxp"
@@ -22,6 +25,10 @@ openthread_nxp_root = "${chip_root}/third_party/openthread/ot-nxp"
 config("openthread_k32w0_config") {
   include_dirs = [ "${openthread_nxp_root}/src/k32w0/k32w061" ]
   include_dirs += [ "${chip_root}/examples/platform/nxp/k32w/k32w0" ]
+
+  if (is_clang) {
+    cflags = [ "-Wno-format-nonliteral" ]
+  }
 
   defines = [
     "OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE=1",


### PR DESCRIPTION
#### Problem

```
../../third_party/connectedhomeip/src/platform/nxp/k32w/k32w0/Logging.cpp:169:16: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
    GenericLog(msg, v, module, chip::Logging::kLogCategory_None);
               ^~~
../../third_party/connectedhomeip/src/platform/nxp/k32w/k32w0/Logging.cpp:187:16: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
    GenericLog(aFormat, v, module, chip::Logging::kLogCategory_None);
               ^~~~~~~
2 errors generated.
```

#### Change overview

Enable format attributes with clang.

#### Testing

Compile examples/lighting-app/nxp/k32w/k32w0 with clang
