### PR TITLE
Fix clang warnings -Wshadow

### DIFF
--- a/src/platform/nxp/k32w/k32w0/BLEManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/BLEManagerImpl.cpp
@@ -127,7 +127,7 @@ TimerHandle_t connectionTimeout;
 EventGroupHandle_t bleAppTaskLoopEvent;
 
 /* keep the device ID of the connected peer */
-uint8_t device_id;
+uint8_t g_device_id;
 
 const uint8_t ShortUUID_CHIPoBLEService[]  = { 0xF6, 0xFF };
 const ChipBleUUID ChipUUID_CHIPoBLEChar_RX = { { 0x18, 0xEE, 0x2E, 0xF5, 0x26, 0x3D, 0x45, 0x59, 0x95, 0x9F, 0x4F, 0x9C, 0x42, 0x9F,
@@ -1035,7 +1035,7 @@ void BLEManagerImpl::bleAppTask(void * p_arg)
                 ChipLogProgress(DeviceLayer, "BLE connection timeout: Forcing disconnection.");
 
                 /* Set the advertising parameters */
-                if (Gap_Disconnect(device_id) != gBleSuccess_c)
+                if (Gap_Disconnect(g_device_id) != gBleSuccess_c)
                 {
                     ChipLogProgress(DeviceLayer, "Gap_Disconnect() failed.");
                 }
@@ -1053,7 +1053,7 @@ void BLEManagerImpl::HandleConnectEvent(blekw_msg_t * msg)
     uint8_t device_id_loc = msg->data.u8;
     ChipLogProgress(DeviceLayer, "BLE is connected with device: %d.\n", device_id_loc);
 
-    device_id = device_id_loc;
+    g_device_id = device_id_loc;
     blekw_start_connection_timeout();
     sInstance.AddConnection(device_id_loc);
     mFlags.Set(Flags::kRestartAdvertising);


### PR DESCRIPTION
#### Problem

```
../../third_party/connectedhomeip/src/platform/nxp/k32w/k32w0/BLEManagerImpl.cpp:1400:85: error: declaration shadows a variable in namespace 'chip::DeviceLayer::Internal::(anonymous)' [-Werror,-Wshadow]
CHIP_ERROR BLEManagerImpl::blekw_msg_add_att_written(blekw_msg_type_t type, uint8_t device_id, uint16_t handle, uint8_t * data,
                                                                                    ^
../../third_party/connectedhomeip/src/platform/nxp/k32w/k32w0/BLEManagerImpl.cpp:130:9: note: previous declaration is here
uint8_t device_id;
        ^
../../third_party/connectedhomeip/src/platform/nxp/k32w/k32w0/BLEManagerImpl.cpp:1435:82: error: declaration shadows a variable in namespace 'chip::DeviceLayer::Internal::(anonymous)' [-Werror,-Wshadow]
CHIP_ERROR BLEManagerImpl::blekw_msg_add_att_read(blekw_msg_type_t type, uint8_t device_id, uint16_t handle)
                                                                                 ^
../../third_party/connectedhomeip/src/platform/nxp/k32w/k32w0/BLEManagerImpl.cpp:130:9: note: previous declaration is here
uint8_t device_id;
        ^
4 errors generated.
```

#### Change overview

Add g_ prefix to global variable.

#### Testing

Compile examples/lighting-app/nxp/k32w/k32w0 with clang
