### PR TITLE
Add clang support for arm-none-eabi

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -72,8 +72,15 @@ if (_chip_defaults.custom_toolchain != "") {
 } else if (target_os == host_os && target_cpu == host_cpu) {
   _default_toolchain = host_toolchain
 } else if (target_os == "freertos") {
+  if (_chip_defaults.is_clang) {
+    _target_compiler = "clang"
+  } else {
+    _target_compiler = "gcc"
+  }
+
   if (target_cpu == "arm") {
-    _default_toolchain = "${_build_overrides.build_root}/toolchain/arm_gcc"
+    _default_toolchain =
+        "${_build_overrides.build_root}/toolchain/arm_${_target_compiler}"
   } else if (target_cpu == "riscv") {
     _default_toolchain = "${_build_overrides.build_root}/toolchain/riscv_gcc"
   } else {

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -23,15 +23,6 @@ if (current_os == "mac") {
   import("${build_root}/config/mac/mac_sdk.gni")
 }
 
-if (current_os == "webos") {
-  import("${build_root}/config/webos/webos_sdk.gni")
-  target_defines += []
-  target_cflags += [ "--sysroot=" + sysroot_webos ]
-  target_cflags_cc += []
-  target_cflags_c += []
-  target_ldflags += [ "--sysroot=" + sysroot_webos ]
-}
-
 declare_args() {
   # Enable -Werror. This can be disabled if using a different compiler
   # with unfixed or unsupported wanings.
@@ -330,10 +321,17 @@ config("runtime_default") {
       "rt",
     ]
   }
+
+  cflags = []
+  ldflags = []
+
   if (sysroot != "") {
-    cflags = [ "--sysroot=${sysroot}" ]
-    ldflags = [ "--sysroot=${sysroot}" ]
+    cflags += [ "--sysroot=${sysroot}" ]
+    ldflags += [ "--sysroot=${sysroot}" ]
   }
+
+  cflags += runtime_library_cflags
+  ldflags += runtime_library_ldflags
 }
 
 # To use different sanitizer options, use `gn args .` in the out folder and
@@ -528,7 +526,7 @@ config("aliasing_default") {
 }
 
 config("specs_default") {
-  if (current_cpu == "arm" && current_os == "freertos") {
+  if (current_cpu == "arm" && current_os == "freertos" && !is_clang) {
     cflags = [
       "--specs=nosys.specs",
       "--specs=nano.specs",

--- a/build/config/sysroot.gni
+++ b/build/config/sysroot.gni
@@ -12,6 +12,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/build.gni")
+
+import("${build_root}/config/compiler/compiler.gni")
+
 declare_args() {
+  # Build file to import for sysroot defaults.
+  sysroot_platform_config = ""
+}
+
+if (sysroot_platform_config == "") {
+  if (current_os == "webos") {
+    sysroot_platform_config = "${build_root}/config/webos/webos_sysroot.gni"
+  } else if (is_clang && current_cpu == "arm" && current_os == "freertos") {
+    sysroot_platform_config = "${build_root}/toolchain/arm/arm_sysroot.gni"
+  }
+}
+
+# Allow platforms to override how sysroot flags are chosen by
+# providing a file to import.
+if (sysroot_platform_config != "") {
+  _platform_defaults = {
+    import(sysroot_platform_config)
+  }
+}
+
+_defaults = {
   sysroot = ""
+  runtime_library_cflags = []
+  runtime_library_ldflags = []
+
+  # Update defaults with platform values, if any.
+  if (sysroot_platform_config != "") {
+    forward_variables_from(_platform_defaults, "*")
+  }
+}
+
+declare_args() {
+  # Logical root directory for system headers and libraries.
+  sysroot = _defaults.sysroot
+
+  # Extra cflags for runtime library.
+  runtime_library_cflags = _defaults.runtime_library_cflags
+
+  # Extra ldflags for runtime library.
+  runtime_library_ldflags = _defaults.runtime_library_ldflags
 }

--- a/build/config/webos/webos_sysroot.gni
+++ b/build/config/webos/webos_sysroot.gni
@@ -1,0 +1,17 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("${build_root}/config/webos/webos_sdk.gni")
+
+sysroot = webos_sysroot

--- a/build/toolchain/arm/arm_sysroot.gni
+++ b/build/toolchain/arm/arm_sysroot.gni
@@ -1,0 +1,57 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/pigweed.gni")
+
+import("${build_root}/config/arm.gni")
+
+assert(arm_arch != "", "Must specify arm_arch to configure clang for ARM")
+
+_script_flags = [
+  "--gn-scope",
+  "--cflags",
+  "--ldflags",
+  "--",
+]
+
+if (arm_arch != "") {
+  _script_flags += [ "-march=${arm_arch}" ]
+}
+if (arm_cpu != "") {
+  _script_flags += [ "-mcpu=${arm_cpu}" ]
+}
+if (arm_tune != "") {
+  _script_flags += [ "-mtune=${arm_tune}" ]
+}
+if (arm_abi != "") {
+  _script_flags += [ "-mabi=${arm_abi}" ]
+}
+if (arm_fpu != "") {
+  _script_flags += [ "-mfpu=${arm_fpu}" ]
+}
+if (arm_float_abi != "") {
+  _script_flags += [ "-mfloat-abi=${arm_float_abi}" ]
+}
+if (arm_use_thumb) {
+  _script_flags += [ "-mthumb" ]
+}
+
+_arm_flags =
+    exec_script("$dir_pw_toolchain/py/pw_toolchain/clang_arm_toolchain.py",
+                _script_flags,
+                "scope")
+
+runtime_library_cflags = _arm_flags.cflags
+runtime_library_ldflags = _arm_flags.cflags + _arm_flags.ldflags

--- a/build/toolchain/arm_clang/BUILD.gn
+++ b/build/toolchain/arm_clang/BUILD.gn
@@ -1,0 +1,20 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("arm_clang_toolchain.gni")
+
+arm_clang_toolchain("arm_clang") {
+  toolchain_args = {
+  }
+}

--- a/build/toolchain/arm_clang/arm_clang_toolchain.gni
+++ b/build/toolchain/arm_clang/arm_clang_toolchain.gni
@@ -1,0 +1,31 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+
+import("${build_root}/toolchain/gcc_toolchain.gni")
+
+template("arm_clang_toolchain") {
+  gcc_toolchain(target_name) {
+    ar = "llvm-ar"
+
+    toolchain_args = {
+      current_cpu = "arm"
+      current_os = invoker.current_os
+      is_clang = true
+
+      forward_variables_from(invoker.toolchain_args, "*")
+    }
+  }
+}


### PR DESCRIPTION
#### Problem

Embedded ARM builds should support building with clang as well as gcc.

#### Change overview

This requires a number of extra arguments to compile and link against a
suitable runtime library. Some additional mechanisms were added to
configure this, and the newlib and libc++ based runtime library
distributed by pigweed is selected by default for the freertos platform.

#### Testing

Include is_clang=true in the arguments to GN to enable this, e.g.

```
(cd examples/lighting-app/nxp/k32w/k32w0 && gn gen out/clang_release --args="k32w0_sdk_root=\"${NXP_K32W061_SDK_ROOT}\" is_clang=true is_debug=false" && ninja -C out/clang_release)
```

[Regrettably this build does not currently fit in flash.]