### PR TITLE
[chip-tool] Update chip-tool documentation to add info on interactive mode and timeout

### DIFF
--- a/docs/guides/chip_tool_guide.md
+++ b/docs/guides/chip_tool_guide.md
@@ -403,7 +403,7 @@ Example of error:
 [1650992689511] [32397:1415601] CHIP: [TOO] Run command failure: ../../../examples/chip-tool/commands/common/CHIPCommand.cpp:392: CHIP Error 0x00000032: Timeout
 ```
 
-This timeout can be modified for any command execution bu supplying the optional
+This timeout can be modified for any command execution by supplying the optional
 `--timeout` parameter, which takes a value in seconds, with the maximum being
 65535 seconds.
 

--- a/docs/guides/chip_tool_guide.md
+++ b/docs/guides/chip_tool_guide.md
@@ -403,8 +403,18 @@ Example of error:
 [1650992689511] [32397:1415601] CHIP: [TOO] Run command failure: ../../../examples/chip-tool/commands/common/CHIPCommand.cpp:392: CHIP Error 0x00000032: Timeout
 ```
 
-For commands such as event subscriptions that need to run for longer periods of
-time, chip-tool can be started in interactive mode first before running the
+This timeout can be modified for any command execution bu supplying the optional
+`--timeout` parameter, which takes a value in seconds, with the maximum being
+65535 seconds.
+
+Example of command:
+
+```
+$ ./chip-tool otasoftwareupdaterequestor subscribe-event state-transition 5 10 0x1234567890 0 --timeout 65535
+```
+
+For commands such as event subscriptions that need to run for an extended period
+of time, chip-tool can be started in interactive mode first before running the
 command. In interactive mode, there will be no timeout and multiple commands can
 be issued.
 

--- a/docs/guides/chip_tool_guide.md
+++ b/docs/guides/chip_tool_guide.md
@@ -412,7 +412,7 @@ Example of command:
 
 ```
 $ ./chip-tool interactive start
-otasoftwareupdaterequestor subscribe-event state-transition 5 10 0x1234567890 0
+otasoftwareupdaterequestor subscribe-event state-transition 5 10 ${NODE_ID} 0
 ```
 
 ### Printing all supported clusters

--- a/docs/guides/chip_tool_guide.md
+++ b/docs/guides/chip_tool_guide.md
@@ -391,6 +391,30 @@ $ ./chip-tool basic
 This section contains a general list of various CHIP Tool commands and options,
 not limited to commissioning procedure and cluster interaction.
 
+### Interactive mode versus single command mode
+
+By default, chip-tool runs in single command mode where if any single command
+does not complete within a certain timeout period, chip-tool will exit with a
+timeout error.
+
+Example of error:
+
+```
+[1650992689511] [32397:1415601] CHIP: [TOO] Run command failure: ../../../examples/chip-tool/commands/common/CHIPCommand.cpp:392: CHIP Error 0x00000032: Timeout
+```
+
+For commands such as event subscriptions that need to run for longer periods of
+time, chip-tool can be started in interactive mode first before running the
+command. In interactive mode, there will be no timeout and multiple commands can
+be issued.
+
+Example of command:
+
+```
+$ ./chip-tool interactive start
+otasoftwareupdaterequestor subscribe-event state-transition 5 10 0x1234567890 0
+```
+
 ### Printing all supported clusters
 
 To print all clusters supported by the CHIP Tool, run the following command:


### PR DESCRIPTION
#### Problem

Chiptool has a default timeout which causes a timeout crash if the chiptool command run is not completed within the timeframe set by this default timeout. This behavior is currently not documented.

Fixes: https://github.com/project-chip/connectedhomeip/issues/17847

#### Change overview

Update chip-tool documentation to describe interactive mode and timeout.

#### Testing

Documentation update so no testing neccessary.
