### PR TITLE
Remove unused code FindCommissioneeDevice(session)

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -83,11 +83,6 @@ CHIP_ERROR CASESessionManager::GetPeerAddress(PeerId peerId, Transport::PeerAddr
     return CHIP_NO_ERROR;
 }
 
-OperationalDeviceProxy * CASESessionManager::FindSession(const SessionHandle & session) const
-{
-    return mConfig.devicePool->FindDevice(session);
-}
-
 OperationalDeviceProxy * CASESessionManager::FindExistingSession(PeerId peerId) const
 {
     return mConfig.devicePool->FindDevice(peerId);

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -82,7 +82,6 @@ public:
     CHIP_ERROR GetPeerAddress(PeerId peerId, Transport::PeerAddress & addr);
 
 private:
-    OperationalDeviceProxy * FindSession(const SessionHandle & session) const;
     void ReleaseSession(OperationalDeviceProxy * device) const;
 
     CASESessionManagerConfig mConfig;

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -179,8 +179,6 @@ public:
 
     PeerId GetPeerId() const { return mPeerId; }
 
-    bool MatchesSession(const SessionHandle & session) const { return mSecureSession.Contains(session); }
-
     CHIP_ERROR ShutdownSubscriptions() override;
 
     Messaging::ExchangeManager * GetExchangeManager() const override { return mInitParams.exchangeMgr; }

--- a/src/app/OperationalDeviceProxyPool.h
+++ b/src/app/OperationalDeviceProxyPool.h
@@ -33,8 +33,6 @@ public:
 
     virtual void Release(OperationalDeviceProxy * device) = 0;
 
-    virtual OperationalDeviceProxy * FindDevice(const SessionHandle & session) = 0;
-
     virtual OperationalDeviceProxy * FindDevice(PeerId peerId) = 0;
 
     virtual void ReleaseDevicesForFabric(CompressedFabricId compressedFabricId) = 0;
@@ -62,21 +60,6 @@ public:
     }
 
     void Release(OperationalDeviceProxy * device) override { mDevicePool.ReleaseObject(device); }
-
-    OperationalDeviceProxy * FindDevice(const SessionHandle & session) override
-    {
-        OperationalDeviceProxy * foundDevice = nullptr;
-        mDevicePool.ForEachActiveObject([&](auto * activeDevice) {
-            if (activeDevice->MatchesSession(session))
-            {
-                foundDevice = activeDevice;
-                return Loop::Break;
-            }
-            return Loop::Continue;
-        });
-
-        return foundDevice;
-    }
 
     OperationalDeviceProxy * FindDevice(PeerId peerId) override
     {

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -426,22 +426,6 @@ CHIP_ERROR DeviceCommissioner::Shutdown()
     return CHIP_NO_ERROR;
 }
 
-CommissioneeDeviceProxy * DeviceCommissioner::FindCommissioneeDevice(const SessionHandle & session)
-{
-    MATTER_TRACE_EVENT_SCOPE("FindCommissioneeDevice", "DeviceCommissioner");
-    CommissioneeDeviceProxy * foundDevice = nullptr;
-    mCommissioneeDevicePool.ForEachActiveObject([&](auto * deviceProxy) {
-        if (deviceProxy->MatchesSession(session))
-        {
-            foundDevice = deviceProxy;
-            return Loop::Break;
-        }
-        return Loop::Continue;
-    });
-
-    return foundDevice;
-}
-
 CommissioneeDeviceProxy * DeviceCommissioner::FindCommissioneeDevice(NodeId id)
 {
     MATTER_TRACE_EVENT_SCOPE("FindCommissioneeDevice", "DeviceCommissioner");

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -730,7 +730,6 @@ private:
 
     void HandleAttestationResult(CHIP_ERROR err);
 
-    CommissioneeDeviceProxy * FindCommissioneeDevice(const SessionHandle & session);
     CommissioneeDeviceProxy * FindCommissioneeDevice(NodeId id);
     CommissioneeDeviceProxy * FindCommissioneeDevice(const Transport::PeerAddress & peerAddress);
     void ReleaseCommissioneeDevice(CommissioneeDeviceProxy * device);

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -138,7 +138,6 @@ public:
     CHIP_ERROR SetPeerId(ByteSpan rcac, ByteSpan noc) override;
     const Transport::PeerAddress & GetPeerAddress() const { return mDeviceAddress; }
 
-    SessionHolder & GetSecureSessionHolder() { return mSecureSession; }
     chip::Optional<SessionHandle> GetSecureSession() const override { return mSecureSession.ToOptional(); }
 
     Messaging::ExchangeManager * GetExchangeManager() const override { return mExchangeMgr; }

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -138,8 +138,6 @@ public:
     CHIP_ERROR SetPeerId(ByteSpan rcac, ByteSpan noc) override;
     const Transport::PeerAddress & GetPeerAddress() const { return mDeviceAddress; }
 
-    bool MatchesSession(const SessionHandle & session) const { return mSecureSession.Contains(session); }
-
     SessionHolder & GetSecureSessionHolder() { return mSecureSession; }
     chip::Optional<SessionHandle> GetSecureSession() const override { return mSecureSession.ToOptional(); }
 


### PR DESCRIPTION
#### Problem
Some code is not being used, and may be broken after #17569.

Because we are allowing session migrate to a new one, find a device using a session won't be consistent.

Before implementing #17569, I'm auditing all `SessionHolder` uses, figure out whether they support automatically migration or not. These unused API is preventing this `SessionHolder` from benefiting automatically migration, so we should remove them.

#### Change overview
Remove that potential broken and unused API.

#### Testing
Passed unit-tests