### PR TITLE
Handle OnSessionReleased in PairingSessions

### DIFF
--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -127,6 +127,13 @@ CASESession::~CASESession()
     Clear();
 }
 
+void CASESession::OnSessionReleased()
+{
+    Clear();
+    // Do this last in case the delegate frees us.
+    mDelegate->OnSessionEstablishmentError(CHIP_ERROR_CONNECTION_ABORTED);
+}
+
 void CASESession::Clear()
 {
     // This function zeroes out and resets the memory used by the object.

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -154,6 +154,9 @@ public:
     void OnResponseTimeout(Messaging::ExchangeContext * ec) override;
     Messaging::ExchangeMessageDispatch & GetMessageDispatch() override { return SessionEstablishmentExchangeDispatch::Instance(); }
 
+    //// SessionReleaseDelegate ////
+    void OnSessionReleased() override;
+
     FabricIndex GetFabricIndex() const { return mFabricInfo != nullptr ? mFabricInfo->GetFabricIndex() : kUndefinedFabricIndex; }
 
     // TODO: remove Clear, we should create a new instance instead reset the old instance.

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -69,6 +69,13 @@ PASESession::~PASESession()
     Clear();
 }
 
+void PASESession::OnSessionReleased()
+{
+    Clear();
+    // Do this last in case the delegate frees us.
+    mDelegate->OnSessionEstablishmentError(CHIP_ERROR_CONNECTION_ABORTED);
+}
+
 void PASESession::Finish()
 {
     mPairingComplete = true;

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -178,6 +178,9 @@ public:
 
     Messaging::ExchangeMessageDispatch & GetMessageDispatch() override { return SessionEstablishmentExchangeDispatch::Instance(); }
 
+    //// SessionReleaseDelegate ////
+    void OnSessionReleased() override;
+
 private:
     enum Spake2pErrorType : uint8_t
     {

--- a/src/protocols/secure_channel/PairingSession.cpp
+++ b/src/protocols/secure_channel/PairingSession.cpp
@@ -153,21 +153,20 @@ void PairingSession::Clear()
         mExchangeCtxt = nullptr;
     }
 
-    if (mSessionManager != nullptr)
+    if (mSecureSessionHolder)
     {
-        if (mSecureSessionHolder && !mSecureSessionHolder->AsSecureSession()->IsActiveSession())
+        SessionHandle session = mSecureSessionHolder.Get();
+        // Call Release before ExpirePairing because we don't want to receive OnSessionReleased() event here
+        mSecureSessionHolder.Release();
+        if (!session->AsSecureSession()->IsActiveSession() && mSessionManager != nullptr)
         {
             // Make sure to clean up our pending session, since we're the only
             // ones who have access to it do do so.
-            mSessionManager->ExpirePairing(mSecureSessionHolder.Get());
+            mSessionManager->ExpirePairing(session);
         }
     }
 
     mPeerSessionId.ClearValue();
-    // If we called ExpirePairing above, the holder has already released the
-    // session (due to it being destroyed).  If not, we need to release it.
-    // Release is idempotent, so it's OK to just call it here.
-    mSecureSessionHolder.Release();
     mSessionManager = nullptr;
 }
 

--- a/src/protocols/secure_channel/PairingSession.h
+++ b/src/protocols/secure_channel/PairingSession.h
@@ -38,9 +38,10 @@ namespace chip {
 
 class SessionManager;
 
-class DLL_EXPORT PairingSession
+class DLL_EXPORT PairingSession : public SessionReleaseDelegate
 {
 public:
+    PairingSession() : mSecureSessionHolder(*this) {}
     virtual ~PairingSession() { Clear(); }
 
     virtual Transport::SecureSession::Type GetSecureSessionType() const = 0;
@@ -170,7 +171,7 @@ protected:
 
 protected:
     CryptoContext::SessionRole mRole;
-    SessionHolder mSecureSessionHolder;
+    SessionHolderWithDelegate mSecureSessionHolder;
     // mSessionManager is set if we actually allocate a secure session, so we
     // can clean it up later as needed.
     SessionManager * mSessionManager           = nullptr;

--- a/src/protocols/secure_channel/tests/TestPairingSession.cpp
+++ b/src/protocols/secure_channel/tests/TestPairingSession.cpp
@@ -44,6 +44,8 @@ public:
     ScopedNodeId GetLocalScopedNodeId() const override { return ScopedNodeId(); }
     CATValues GetPeerCATs() const override { return CATValues(); };
 
+    void OnSessionReleased() override {}
+
     const ReliableMessageProtocolConfig & GetRemoteMRPConfig() const { return mRemoteMRPConfig; }
 
     CHIP_ERROR DeriveSecureSession(CryptoContext & session) const override { return CHIP_NO_ERROR; }


### PR DESCRIPTION
#### Problem
PairingSessions creates a session at beginning of the pairing, the session can be release during pairing. Handle session released event in this period.

#### Change overview
Implement `OnSessionReleased` for CASE/PASE session

#### Testing
Passed unit-tests