### PR TITLE
[binding] fix wrong cluster ID type when loading from storage

### DIFF
--- a/src/app/tests/TestBindingTable.cpp
+++ b/src/app/tests/TestBindingTable.cpp
@@ -135,7 +135,7 @@ void TestPersistentStorage(nlTestSuite * aSuite, void * aContext)
     chip::TestPersistentStorageDelegate testStorage;
     BindingTable table;
     chip::DefaultStorageKeyAllocator key;
-    chip::Optional<chip::ClusterId> cluster      = chip::MakeOptional<chip::ClusterId>(static_cast<chip::ClusterId>(6));
+    chip::Optional<chip::ClusterId> cluster = chip::MakeOptional<chip::ClusterId>(static_cast<chip::ClusterId>(UINT16_MAX + 6));
     std::vector<EmberBindingTableEntry> expected = {
         EmberBindingTableEntry::ForNode(0, 0, 0, 0, NullOptional),
         EmberBindingTableEntry::ForNode(1, 1, 0, 0, cluster),

--- a/src/app/util/binding-table.cpp
+++ b/src/app/util/binding-table.cpp
@@ -198,7 +198,7 @@ CHIP_ERROR BindingTable::LoadEntryFromStorage(uint8_t index, uint8_t & nextIndex
     ReturnErrorOnFailure(reader.Next());
     if (reader.GetTag() == TLV::ContextTag(kTagCluster))
     {
-        uint16_t clusterId;
+        ClusterId clusterId;
         ReturnErrorOnFailure(reader.Get(clusterId));
         entry.clusterId.SetValue(clusterId);
         ReturnErrorOnFailure(reader.Next());


### PR DESCRIPTION
#### Problem

The cluster ID is of wrong type when loading from storage.

#### Change overview

User correct `ClusterID` type.

#### Testing

* Unit test modified to verify the change.
