### PR TITLE
Only Cache requested path with wildcard attributeId

### DIFF
--- a/src/app/AttributePathExpandIterator.cpp
+++ b/src/app/AttributePathExpandIterator.cpp
@@ -169,12 +169,12 @@ bool AttributePathExpandIterator::Next()
 {
     for (; mpAttributePath != nullptr; (mpAttributePath = mpAttributePath->mpNext, mEndpointIndex = UINT16_MAX))
     {
-        mOutputPath.mExpanded = mpAttributePath->mValue.HasAttributeWildcard();
+        mOutputPath.mExpanded = mpAttributePath->mValue.IsWildcardPath();
 
         if (mEndpointIndex == UINT16_MAX)
         {
             // Special case: If this is a concrete path, we just return its value as-is.
-            if (!mpAttributePath->mValue.HasAttributeWildcard())
+            if (!mpAttributePath->mValue.IsWildcardPath())
             {
                 mOutputPath.mEndpointId  = mpAttributePath->mValue.mEndpointId;
                 mOutputPath.mClusterId   = mpAttributePath->mValue.mClusterId;

--- a/src/app/AttributePathParams.h
+++ b/src/app/AttributePathParams.h
@@ -49,7 +49,7 @@ struct AttributePathParams
 
     AttributePathParams() {}
 
-    bool HasAttributeWildcard() const { return HasWildcardEndpointId() || HasWildcardClusterId() || HasWildcardAttributeId(); }
+    bool IsWildcardPath() const { return HasWildcardEndpointId() || HasWildcardClusterId() || HasWildcardAttributeId(); }
 
     /**
      * SPEC 8.9.2.2

--- a/src/app/ClusterStateCache.cpp
+++ b/src/app/ClusterStateCache.cpp
@@ -452,7 +452,7 @@ CHIP_ERROR ClusterStateCache::OnUpdateDataVersionFilterList(DataVersionFilterIBs
 
     for (auto & attribute : aAttributePaths)
     {
-        if (attribute.HasAttributeWildcard())
+        if (attribute.HasWildcardAttributeId())
         {
             mRequestPathSet.insert(attribute);
         }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -865,7 +865,7 @@ void InteractionModelEngine::RemoveDuplicateConcreteAttributePath(ObjectList<Att
     {
         bool duplicate = false;
         // skip all wildcard paths and invalid concrete attribute
-        if (path1->mValue.HasAttributeWildcard() ||
+        if (path1->mValue.IsWildcardPath() ||
             !emberAfContainsAttribute(path1->mValue.mEndpointId, path1->mValue.mClusterId, path1->mValue.mAttributeId, true))
         {
             prev  = path1;
@@ -881,7 +881,7 @@ void InteractionModelEngine::RemoveDuplicateConcreteAttributePath(ObjectList<Att
                 continue;
             }
 
-            if (path2->mValue.HasAttributeWildcard() && path2->mValue.IsAttributePathSupersetOf(path1->mValue))
+            if (path2->mValue.IsWildcardPath() && path2->mValue.IsAttributePathSupersetOf(path1->mValue))
             {
                 duplicate = true;
                 break;


### PR DESCRIPTION
#### Problem
We only need to cache requested path with wildcard attributeId in ClusterStateCache
HasAttributeWildcard in ClusterStateCache::OnUpdateDataVersionFilterList is wrong: that callsite wants paths with a wildcard attribute, not with any wildcard. 

#### Change overview
HasAttributeWildcard() should be named IsWildcardPath()
Update HasAttributeWildcardId inside OnUpdateDataVersionFilterList

#### Testing
Add wildcard path without wildcard attribute, the version would be not cached