### PR TITLE
Move PairingSession from transport/ to protocols/secure_channel/

### DIFF
--- a/src/protocols/secure_channel/BUILD.gn
+++ b/src/protocols/secure_channel/BUILD.gn
@@ -14,6 +14,8 @@ static_library("secure_channel") {
     "DefaultSessionResumptionStorage.h",
     "PASESession.cpp",
     "PASESession.h",
+    "PairingSession.cpp",
+    "PairingSession.h",
     "RendezvousParameters.h",
     "SessionEstablishmentDelegate.h",
     "SessionEstablishmentExchangeDispatch.cpp",

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -137,8 +137,6 @@ void CASESession::Clear()
     mState = State::kInitialized;
     Crypto::ClearSecretData(mIPK);
 
-    AbortExchange();
-
     mLocalNodeId = kUndefinedNodeId;
     mPeerNodeId  = kUndefinedNodeId;
     mFabricInfo  = nullptr;

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -37,11 +37,11 @@
 #include <lib/support/TypeTraits.h>
 #include <protocols/Protocols.h>
 #include <protocols/secure_channel/CASEDestinationId.h>
+#include <protocols/secure_channel/PairingSession.h>
 #include <protocols/secure_channel/SessionResumptionStorage.h>
 #include <protocols/secure_channel/StatusReport.h>
 #include <system/TLVPacketBufferBackingStore.h>
 #include <trace/trace.h>
-#include <transport/PairingSession.h>
 #include <transport/SessionManager.h>
 #if CHIP_CRYPTO_HSM
 #include <crypto/hsm/CHIPCryptoPALHsm.h>
@@ -127,24 +127,6 @@ CASESession::~CASESession()
     Clear();
 }
 
-void CASESession::Finish()
-{
-    Transport::PeerAddress address = mExchangeCtxt->GetSessionHandle()->AsUnauthenticatedSession()->GetPeerAddress();
-
-    // Discard the exchange so that Clear() doesn't try closing it. The exchange will handle that.
-    DiscardExchange();
-
-    CHIP_ERROR err = ActivateSecureSession(address);
-    if (err == CHIP_NO_ERROR)
-    {
-        mDelegate->OnSessionEstablished(mSecureSessionHolder.Get());
-    }
-    else
-    {
-        mDelegate->OnSessionEstablishmentError(err);
-    }
-}
-
 void CASESession::Clear()
 {
     // This function zeroes out and resets the memory used by the object.
@@ -160,32 +142,6 @@ void CASESession::Clear()
     mLocalNodeId = kUndefinedNodeId;
     mPeerNodeId  = kUndefinedNodeId;
     mFabricInfo  = nullptr;
-}
-
-void CASESession::AbortExchange()
-{
-    if (mExchangeCtxt != nullptr)
-    {
-        // The only time we reach this is if we are getting destroyed in the
-        // middle of our handshake.  In that case, there is no point trying to
-        // do MRP resends of the last message we sent, so abort the exchange
-        // instead of just closing it.
-        mExchangeCtxt->Abort();
-        mExchangeCtxt = nullptr;
-    }
-}
-
-void CASESession::DiscardExchange()
-{
-    if (mExchangeCtxt != nullptr)
-    {
-        // Make sure the exchange doesn't try to notify us when it closes,
-        // since we might be dead by then.
-        mExchangeCtxt->SetDelegate(nullptr);
-        // Null out mExchangeCtxt so that Clear() doesn't try closing it.  The
-        // exchange will handle that.
-        mExchangeCtxt = nullptr;
-    }
 }
 
 CHIP_ERROR CASESession::Init(SessionManager & sessionManager, SessionEstablishmentDelegate * delegate)

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -38,12 +38,11 @@
 #include <messaging/ExchangeDelegate.h>
 #include <protocols/secure_channel/CASEDestinationId.h>
 #include <protocols/secure_channel/Constants.h>
-#include <protocols/secure_channel/SessionEstablishmentDelegate.h>
+#include <protocols/secure_channel/PairingSession.h>
 #include <protocols/secure_channel/SessionEstablishmentExchangeDispatch.h>
 #include <protocols/secure_channel/SessionResumptionStorage.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/CryptoContext.h>
-#include <transport/PairingSession.h>
 #include <transport/raw/MessageHeader.h>
 #include <transport/raw/PeerAddress.h>
 
@@ -216,25 +215,12 @@ private:
     void OnSuccessStatusReport() override;
     CHIP_ERROR OnFailureStatusReport(Protocols::SecureChannel::GeneralStatusCode generalCode, uint16_t protocolCode) override;
 
-    // TODO: pull up Finish to PairingSession class
-    void Finish();
-
-    void AbortExchange();
-
-    /**
-     * Clear our reference to our exchange context pointer so that it can close
-     * itself at some later time.
-     */
-    void DiscardExchange();
-
     CHIP_ERROR GetHardcodedTime();
 
     CHIP_ERROR SetEffectiveTime();
 
     CHIP_ERROR ValidateReceivedMessage(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
                                        const System::PacketBufferHandle & msg);
-
-    SessionEstablishmentDelegate * mDelegate = nullptr;
 
     Crypto::Hash_SHA256_stream mCommissioningHash;
     Crypto::P256PublicKey mRemotePubKey;
@@ -250,7 +236,6 @@ private:
     uint8_t mMessageDigest[Crypto::kSHA256_Hash_Length];
     uint8_t mIPK[kIPKSize];
 
-    Messaging::ExchangeContext * mExchangeCtxt           = nullptr;
     SessionResumptionStorage * mSessionResumptionStorage = nullptr;
 
     FabricTable * mFabricsTable    = nullptr;

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -96,7 +96,6 @@ void PASESession::Clear()
     mKeLen           = sizeof(mKe);
     mPairingComplete = false;
     PairingSession::Clear();
-    CloseExchange();
 }
 
 CHIP_ERROR PASESession::Init(SessionManager & sessionManager, uint32_t setupCode, SessionEstablishmentDelegate * delegate)

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -72,21 +72,7 @@ PASESession::~PASESession()
 void PASESession::Finish()
 {
     mPairingComplete = true;
-
-    Transport::PeerAddress address = mExchangeCtxt->GetSessionHandle()->AsUnauthenticatedSession()->GetPeerAddress();
-
-    // Discard the exchange so that Clear() doesn't try closing it. The exchange will handle that.
-    DiscardExchange();
-
-    CHIP_ERROR err = ActivateSecureSession(address);
-    if (err == CHIP_NO_ERROR)
-    {
-        mDelegate->OnSessionEstablished(mSecureSessionHolder.Get());
-    }
-    else
-    {
-        mDelegate->OnSessionEstablishmentError(err);
-    }
+    PairingSession::Finish();
 }
 
 void PASESession::Clear()
@@ -111,28 +97,6 @@ void PASESession::Clear()
     mPairingComplete = false;
     PairingSession::Clear();
     CloseExchange();
-}
-
-void PASESession::CloseExchange()
-{
-    if (mExchangeCtxt != nullptr)
-    {
-        mExchangeCtxt->Close();
-        mExchangeCtxt = nullptr;
-    }
-}
-
-void PASESession::DiscardExchange()
-{
-    if (mExchangeCtxt != nullptr)
-    {
-        // Make sure the exchange doesn't try to notify us when it closes,
-        // since we might be dead by then.
-        mExchangeCtxt->SetDelegate(nullptr);
-        // Null out mExchangeCtxt so that Clear() doesn't try closing it.  The
-        // exchange will handle that.
-        mExchangeCtxt = nullptr;
-    }
 }
 
 CHIP_ERROR PASESession::Init(SessionManager & sessionManager, uint32_t setupCode, SessionEstablishmentDelegate * delegate)

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -35,11 +35,10 @@
 #include <messaging/ExchangeDelegate.h>
 #include <messaging/ExchangeMessageDispatch.h>
 #include <protocols/secure_channel/Constants.h>
-#include <protocols/secure_channel/SessionEstablishmentDelegate.h>
+#include <protocols/secure_channel/PairingSession.h>
 #include <protocols/secure_channel/SessionEstablishmentExchangeDispatch.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/CryptoContext.h>
-#include <transport/PairingSession.h>
 #include <transport/raw/MessageHeader.h>
 #include <transport/raw/PeerAddress.h>
 
@@ -208,18 +207,7 @@ private:
     void OnSuccessStatusReport() override;
     CHIP_ERROR OnFailureStatusReport(Protocols::SecureChannel::GeneralStatusCode generalCode, uint16_t protocolCode) override;
 
-    // TODO: pull up Finish to PairingSession class
     void Finish();
-
-    void CloseExchange();
-
-    /**
-     * Clear our reference to our exchange context pointer so that it can close
-     * itself at some later time.
-     */
-    void DiscardExchange();
-
-    SessionEstablishmentDelegate * mDelegate = nullptr;
 
     Protocols::SecureChannel::MsgType mNextExpectedMsg = Protocols::SecureChannel::MsgType::PASE_PakeError;
 
@@ -241,8 +229,6 @@ private:
     uint32_t mIterationCount = 0;
     uint16_t mSaltLength     = 0;
     uint8_t * mSalt          = nullptr;
-
-    Messaging::ExchangeContext * mExchangeCtxt = nullptr;
 
     struct Spake2pErrorMsg
     {

--- a/src/protocols/secure_channel/PairingSession.cpp
+++ b/src/protocols/secure_channel/PairingSession.cpp
@@ -16,7 +16,7 @@
  *    limitations under the License.
  */
 
-#include <transport/PairingSession.h>
+#include <protocols/secure_channel/PairingSession.h>
 
 #include <lib/core/CHIPTLVTypes.h>
 #include <lib/support/SafeInt.h>
@@ -55,6 +55,59 @@ CHIP_ERROR PairingSession::ActivateSecureSession(const Transport::PeerAddress & 
                   ChipLogValueScopedNodeId(GetPeer()), secureSession->GetLocalSessionId(), peerSessionId);
 
     return CHIP_NO_ERROR;
+}
+
+void PairingSession::Finish()
+{
+    Transport::PeerAddress address = mExchangeCtxt->GetSessionHandle()->AsUnauthenticatedSession()->GetPeerAddress();
+
+    // Discard the exchange so that Clear() doesn't try closing it. The exchange will handle that.
+    DiscardExchange();
+
+    CHIP_ERROR err = ActivateSecureSession(address);
+    if (err == CHIP_NO_ERROR)
+    {
+        mDelegate->OnSessionEstablished(mSecureSessionHolder.Get());
+    }
+    else
+    {
+        mDelegate->OnSessionEstablishmentError(err);
+    }
+}
+
+void PairingSession::AbortExchange()
+{
+    if (mExchangeCtxt != nullptr)
+    {
+        // The only time we reach this is if we are getting destroyed in the
+        // middle of our handshake.  In that case, there is no point trying to
+        // do MRP resends of the last message we sent, so abort the exchange
+        // instead of just closing it.
+        mExchangeCtxt->Abort();
+        mExchangeCtxt = nullptr;
+    }
+}
+
+void PairingSession::CloseExchange()
+{
+    if (mExchangeCtxt != nullptr)
+    {
+        mExchangeCtxt->Close();
+        mExchangeCtxt = nullptr;
+    }
+}
+
+void PairingSession::DiscardExchange()
+{
+    if (mExchangeCtxt != nullptr)
+    {
+        // Make sure the exchange doesn't try to notify us when it closes,
+        // since we might be dead by then.
+        mExchangeCtxt->SetDelegate(nullptr);
+        // Null out mExchangeCtxt so that Clear() doesn't try closing it.  The
+        // exchange will handle that.
+        mExchangeCtxt = nullptr;
+    }
 }
 
 CHIP_ERROR PairingSession::EncodeMRPParameters(TLV::Tag tag, const ReliableMessageProtocolConfig & mrpConfig,

--- a/src/protocols/secure_channel/PairingSession.h
+++ b/src/protocols/secure_channel/PairingSession.h
@@ -29,6 +29,7 @@
 #include <lib/core/CHIPTLV.h>
 #include <messaging/ExchangeContext.h>
 #include <protocols/secure_channel/Constants.h>
+#include <protocols/secure_channel/SessionEstablishmentDelegate.h>
 #include <protocols/secure_channel/StatusReport.h>
 #include <transport/CryptoContext.h>
 #include <transport/SecureSession.h>
@@ -94,6 +95,12 @@ protected:
     CHIP_ERROR AllocateSecureSession(SessionManager & sessionManager);
 
     CHIP_ERROR ActivateSecureSession(const Transport::PeerAddress & peerAddress);
+
+    void Finish();
+
+    void AbortExchange();
+    void CloseExchange();
+    void DiscardExchange();
 
     void SetPeerSessionId(uint16_t id) { mPeerSessionId.SetValue(id); }
     virtual void OnSuccessStatusReport() {}
@@ -168,7 +175,9 @@ protected:
     SessionHolder mSecureSessionHolder;
     // mSessionManager is set if we actually allocate a secure session, so we
     // can clean it up later as needed.
-    SessionManager * mSessionManager = nullptr;
+    SessionManager * mSessionManager           = nullptr;
+    Messaging::ExchangeContext * mExchangeCtxt = nullptr;
+    SessionEstablishmentDelegate * mDelegate   = nullptr;
 
     // mLocalMRPConfig is our config which is sent to the other end and used by the peer session.
     // mRemoteMRPConfig is received from other end and set to our session.

--- a/src/protocols/secure_channel/PairingSession.h
+++ b/src/protocols/secure_channel/PairingSession.h
@@ -98,9 +98,7 @@ protected:
 
     void Finish();
 
-    void AbortExchange();
-    void CloseExchange();
-    void DiscardExchange();
+    void DiscardExchange(); // Clear our reference to our exchange context pointer so that it can close itself at some later time.
 
     void SetPeerSessionId(uint16_t id) { mPeerSessionId.SetValue(id); }
     virtual void OnSuccessStatusReport() {}

--- a/src/protocols/secure_channel/tests/BUILD.gn
+++ b/src/protocols/secure_channel/tests/BUILD.gn
@@ -15,6 +15,7 @@ chip_test_suite("tests") {
     #    "TestMessageCounterManager.cpp",
     "TestDefaultSessionResumptionStorage.cpp",
     "TestPASESession.cpp",
+    "TestPairingSession.cpp",
     "TestSimpleSessionResumptionStorage.cpp",
     "TestStatusReport.cpp",
   ]

--- a/src/protocols/secure_channel/tests/TestPairingSession.cpp
+++ b/src/protocols/secure_channel/tests/TestPairingSession.cpp
@@ -26,11 +26,9 @@
 
 #include <lib/core/CHIPCore.h>
 #include <lib/support/CodeUtils.h>
-
-#include <messaging/ReliableMessageProtocolConfig.h>
-#include <transport/PairingSession.h>
-
 #include <lib/support/UnitTestRegistration.h>
+#include <messaging/ReliableMessageProtocolConfig.h>
+#include <protocols/secure_channel/PairingSession.h>
 #include <stdarg.h>
 #include <system/SystemClock.h>
 #include <system/TLVPacketBufferBackingStore.h>

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -30,7 +30,6 @@ static_library("transport") {
     "MessageCounter.cpp",
     "MessageCounter.h",
     "MessageCounterManagerInterface.h",
-    "PairingSession.cpp",
     "PeerMessageCounter.h",
     "SecureMessageCodec.cpp",
     "SecureMessageCodec.h",

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -40,7 +40,6 @@
 #include <protocols/secure_channel/Constants.h>
 #include <transport/GroupPeerMessageCounter.h>
 #include <transport/GroupSession.h>
-#include <transport/PairingSession.h>
 #include <transport/SecureMessageCodec.h>
 #include <transport/TransportMgr.h>
 

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -53,8 +53,6 @@
 
 namespace chip {
 
-class PairingSession;
-
 /**
  * @brief
  *  Tracks ownership of a encrypted packet buffer.

--- a/src/transport/tests/BUILD.gn
+++ b/src/transport/tests/BUILD.gn
@@ -34,7 +34,6 @@ chip_test_suite("tests") {
 
   test_sources = [
     "TestGroupMessageCounter.cpp",
-    "TestPairingSession.cpp",
     "TestPeerConnections.cpp",
     "TestPeerMessageCounter.cpp",
     "TestSecureSession.cpp",


### PR DESCRIPTION
#### Problem
Originally `NewPairing` in `SessionManager` depends on `PairingSession` class, but we have moved it into PASE/CASE session. So there is nothing depends on `PairingSession` in transport layer. We should move it into `protocols`.

By doing this, allowing `PairingSession` depends on messaging layer, such that we can pull up some methods and fields to it, to save code space.

#### Change overview
* Move `PairingSession` from `transport/` to `protocols/secure_channel/`
* Pull up method `Finish`/`AbortExchange`/`CloseExchange`/`DiscardExchange`
* Pull up member `mDelegate`/`mExchangeCtxt`

~~Only refactor, no actual change.~~ Calling `AbortExchange` and `DiscardExchange` for error path is changed according to comment https://github.com/project-chip/connectedhomeip/pull/17889#discussion_r862119821

#### Testing
Passed unit-tests