### PR TITLE
Telink android app

### DIFF
--- a/src/platform/telink/BLEManagerImpl.cpp
+++ b/src/platform/telink/BLEManagerImpl.cpp
@@ -791,7 +791,14 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
 {
     ble_sts_t status = BLE_SUCCESS;
 
-    status = blc_gatt_pushHandleValueIndicate(conId, Matter_TX_DP_H, pBuf->Start(), pBuf->DataLength());
+    do
+    {
+        if (status != BLE_SUCCESS)
+        {
+            k_msleep(1);
+        }
+        status = blc_gatt_pushHandleValueIndicate(conId, Matter_TX_DP_H, pBuf->Start(), pBuf->DataLength());
+    } while (status == GATT_ERR_DATA_PENDING_DUE_TO_SERVICE_DISCOVERY_BUSY);
     if (status != BLE_SUCCESS)
     {
         ChipLogError(DeviceLayer, "Fail to send indication. Error %d", status);

--- a/src/platform/telink/BLEManagerImpl.cpp
+++ b/src/platform/telink/BLEManagerImpl.cpp
@@ -220,28 +220,22 @@ void BLEManagerImpl::ConnectCallback(uint8_t bleEvent, uint8_t * data, int len)
     ChipDeviceEvent event;
     ble_sts_t status = BLE_SUCCESS;
 
-    PlatformMgr().LockChipStack();
-
     event.Type                             = DeviceEventType::kPlatformTelinkBleConnected;
     event.Platform.BleConnEvent.connHandle = BLS_CONN_HANDLE;
     event.Platform.BleConnEvent.HciResult  = BLE_SUCCESS;
 
     PlatformMgr().PostEventOrDie(&event);
-    PlatformMgr().UnlockChipStack();
 }
 
 void BLEManagerImpl::DisconnectCallback(uint8_t bleEvent, uint8_t * data, int len)
 {
     ChipDeviceEvent event;
 
-    PlatformMgr().LockChipStack();
-
     event.Type                             = DeviceEventType::kPlatformTelinkBleDisconnected;
     event.Platform.BleConnEvent.connHandle = BLS_CONN_HANDLE;
     event.Platform.BleConnEvent.HciResult  = *data; // Reason of disconnection stored in first data byte
 
     PlatformMgr().PostEventOrDie(&event);
-    PlatformMgr().UnlockChipStack();
 }
 
 int BLEManagerImpl::TxCccWriteCallback(uint16_t connHandle, void * p)

--- a/src/platform/telink/BLEManagerImpl.cpp
+++ b/src/platform/telink/BLEManagerImpl.cpp
@@ -169,6 +169,8 @@ CHIP_ERROR BLEManagerImpl::_Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+    ThreadConnectivityReady = false;
+
     /* Initialize the CHIP BleLayer. */
     err = BleLayer::Init(this, this, &DeviceLayer::SystemLayer());
     SuccessOrExit(err);
@@ -968,6 +970,9 @@ CHIP_ERROR BLEManagerImpl::HandleThreadStateChange(const ChipDeviceEvent * event
         error = PlatformMgr().PostEvent(&attachEvent);
         VerifyOrExit(error == CHIP_NO_ERROR,
                      ChipLogError(DeviceLayer, "Failed to post Thread connectivity change: %" CHIP_ERROR_FORMAT, error.Format()));
+
+        ChipLogDetail(DeviceLayer, "Thread Connectivity Ready");
+        ThreadConnectivityReady = true;
     }
 
 exit:
@@ -977,7 +982,7 @@ exit:
 CHIP_ERROR BLEManagerImpl::HandleBleConnectionClosed(const ChipDeviceEvent * event)
 {
     /* It is time to swich to IEEE802154 radio if it is provisioned */
-    if (ConnectivityMgr().IsThreadProvisioned())
+    if (ThreadConnectivityReady)
     {
         SwitchToIeee802154();
     }

--- a/src/platform/telink/BLEManagerImpl.h
+++ b/src/platform/telink/BLEManagerImpl.h
@@ -115,6 +115,7 @@ private:
     uint8_t mScanRespDataBuf[kMaxAdvertisementDataSetSize];
     uint8_t mRxDataBuff[kMaxRxDataBuffSize];
     uint8_t mTxDataBuff[kMaxRxDataBuffSize];
+    bool ThreadConnectivityReady;
 
     void DriveBLEState(void);
     CHIP_ERROR ConfigureAdvertisingData(void);

--- a/src/platform/telink/crypto/internal/multithread.c
+++ b/src/platform/telink/crypto/internal/multithread.c
@@ -27,14 +27,62 @@
  * See documentation for your RTOS.
  ****************************************************************/
 
-void mbedtls_entropy_lock(void) {}
+#include <kernel.h>
 
-void mbedtls_entropy_unlock(void) {}
+K_MUTEX_DEFINE(mbedtls_entropy_mutex);
+K_MUTEX_DEFINE(mbedtls_ecp_mutex);
+K_MUTEX_DEFINE(mbedtls_aes_mutex);
 
-void mbedtls_ecp_lock(void) {}
+void mbedtls_entropy_lock(void)
+{
 
-void mbedtls_ecp_unlock(void) {}
+    if (k_mutex_lock(&mbedtls_entropy_mutex, K_FOREVER) != 0)
+    {
+        printk("mbedtls_entropy_lock fail\n");
+    }
+}
 
-void mbedtls_aes_lock(void) {}
+void mbedtls_entropy_unlock(void)
+{
 
-void mbedtls_aes_unlock(void) {}
+    if (k_mutex_unlock(&mbedtls_entropy_mutex) != 0)
+    {
+        printk("mbedtls_entropy_unlock fail\n");
+    }
+}
+
+void mbedtls_ecp_lock(void)
+{
+
+    if (k_mutex_lock(&mbedtls_ecp_mutex, K_FOREVER) != 0)
+    {
+        printk("mbedtls_ecp_lock fail\n");
+    }
+}
+
+void mbedtls_ecp_unlock(void)
+{
+
+    if (k_mutex_unlock(&mbedtls_ecp_mutex) != 0)
+    {
+        printk("mbedtls_ecp_unlock fail\n");
+    }
+}
+
+void mbedtls_aes_lock(void)
+{
+
+    if (k_mutex_lock(&mbedtls_aes_mutex, K_FOREVER) != 0)
+    {
+        printk("mbedtls_aes_lock fail\n");
+    }
+}
+
+void mbedtls_aes_unlock(void)
+{
+
+    if (k_mutex_unlock(&mbedtls_aes_mutex) != 0)
+    {
+        printk("mbedtls_aes_unlock fail\n");
+    }
+}


### PR DESCRIPTION
#### Problem
These changes fix commissioning procedure with Telink B91 target using Android CHIPTool application

#### Change overview
 * Fixed commissioning using Android CHIPTool apllication
 * Fixed failed BLE indication sending when BLE stack is busy
 * Added multithread support for HW crypto-unit

#### Testing
Tested manually using Android CHIPTool application.
Steps:
 * Start Android CHIPTool application
 * Push application button "PROVISION CHIP DEVICE WITH THREAD"
 * Open in browser link provided in serial traces from target
 * Scan barcode from browser
 * Press start BLE advertisement button on the B91 target (SW4)
 * Push application button "SAVE NETWORK"
 * Wait till the end of commissioning procedure. Success result should be shown in application and serial traces from target.
