### PR TITLE
Fix RAM0 overflow

### DIFF
--- a/examples/platform/nxp/k32w/k32w0/app/ldscripts/chip-k32w061-linker.ld
+++ b/examples/platform/nxp/k32w/k32w0/app/ldscripts/chip-k32w061-linker.ld
@@ -211,8 +211,9 @@ SECTIONS
 
     _etext = .;
 
-    .heap (COPY):
+    .heap_controller (COPY):
     {
+        *(.ll_exchange_mem)
         __HeapBase = .;
          _heap = .;
         KEEP(*(.heap*))

--- a/third_party/nxp/k32w0_sdk/k32w0_sdk.gni
+++ b/third_party/nxp/k32w0_sdk/k32w0_sdk.gni
@@ -158,7 +158,7 @@ template("k32w0_sdk") {
       "USE_SDK_OSA=0",
       "gSerialManagerMaxInterfaces_c=2",
       "FSL_RTOS_FREE_RTOS=1",
-      "gTotalHeapSize_c=0xF000",
+      "gTotalHeapSize_c=0xDC00",
       "gUartDebugConsole_d=1",
       "DEBUG_SERIAL_INTERFACE_INSTANCE=0",
       "APP_SERIAL_INTERFACE_INSTANCE=1",
@@ -189,7 +189,7 @@ template("k32w0_sdk") {
       "gEnableBleInactivityTimeNotify=1",
       "DUAL_MODE_APP=1",
       "gMainThreadStackSize_c=5096",
-      "HEAP_SIZE=0xF000",
+      "HEAP_SIZE=gTotalHeapSize_c",
       "gLoggingActive_d=0",
       "gLogRingPlacementOffset_c=0xF000",
     ]


### PR DESCRIPTION
#### Problem
* ram0 usage is at the limit.

#### Change overview
Place BLE controller exchange buffer in RAM1.

#### Testing
End-to-end flow commissioning testing using chip-tool.
