### PR TITLE
server: Fix valid log being printed as error log

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -68,7 +68,7 @@ void CommissioningWindowManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEv
     else if (event->Type == DeviceLayer::DeviceEventType::kOperationalNetworkEnabled)
     {
         app::DnssdServer::Instance().AdvertiseOperational();
-        ChipLogError(AppServer, "Operational advertising enabled");
+        ChipLogProgress(AppServer, "Operational advertising enabled");
     }
 }
 


### PR DESCRIPTION
#### Problem
Following log is being printed with level error
```
E (266790) chip[SVR]: Operational advertising enabled
```

#### Change overview
Changed log level from `Error` to `Progress`

#### Testing
```
I (22192) chip[SVR]: Operational advertising enabled
```