### PR TITLE
[YAML] Update WaitForMs signature to use a uint32_t

### DIFF
--- a/src/app/tests/suites/commands/delay/DelayCommands.cpp
+++ b/src/app/tests/suites/commands/delay/DelayCommands.cpp
@@ -26,7 +26,7 @@ const char * getScriptsFolder()
 }
 } // namespace
 
-CHIP_ERROR DelayCommands::WaitForMs(uint16_t ms)
+CHIP_ERROR DelayCommands::WaitForMs(uint32_t ms)
 {
     const auto duration = chip::System::Clock::Milliseconds32(ms);
     return chip::DeviceLayer::SystemLayer().StartTimer(duration, OnWaitForMsFn, this);

--- a/src/app/tests/suites/commands/delay/DelayCommands.h
+++ b/src/app/tests/suites/commands/delay/DelayCommands.h
@@ -33,7 +33,7 @@ public:
 
     virtual CHIP_ERROR WaitForCommissionee(chip::NodeId nodeId) { return CHIP_ERROR_NOT_IMPLEMENTED; };
     virtual CHIP_ERROR WaitForCommissioning() { return CHIP_ERROR_NOT_IMPLEMENTED; };
-    CHIP_ERROR WaitForMs(uint16_t ms);
+    CHIP_ERROR WaitForMs(uint32_t ms);
     CHIP_ERROR WaitForCommissionableAdvertisement();
     CHIP_ERROR WaitForOperationalAdvertisement();
 


### PR DESCRIPTION
#### Problem

YAML support for "WaitForMs" command is not supporting 5(300 sec) minutes time delay,need yaml support for handling 5 minutes time delay

fix #17891

#### Change overview
* Update the `WaitForMs` method signature to allow for a `uint32_t`
