### PR TITLE
[Tizen] Install devel files required by appfw

### DIFF
--- a/integrations/docker/images/chip-build-tizen/Dockerfile
+++ b/integrations/docker/images/chip-build-tizen/Dockerfile
@@ -85,27 +85,36 @@ RUN set -x \
     http://download.tizen.org/sdk/tizenstudio/official/binary/mobile-$TIZEN_VERSION-core-add-ons_0.0.262_ubuntu-64.zip \
     http://download.tizen.org/sdk/tizenstudio/official/binary/mobile-$TIZEN_VERSION-rs-device.core_0.0.123_ubuntu-64.zip \
     # Base packages
-    && wget -r -nd --no-parent -q -A 'pcre-devel-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/base/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'libffi-devel-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/base/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'libmount-devel-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/base/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'libblkid-devel-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/base/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'libcap-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/base/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'liblzma-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/base/latest/repos/standard/packages/armv7l/ \
+    && wget --progress=dot:mega -r -nd --no-parent \
+    http://download.tizen.org/releases/milestone/tizen/base/latest/repos/standard/packages/armv7l/ \
+    -A 'libblkid-devel-*.armv7l.rpm' \
+    -A 'libcap-*.armv7l.rpm' \
+    -A 'libffi-devel-*.armv7l.rpm' \
+    -A 'liblzma-*.armv7l.rpm' \
+    -A 'libmount-devel-*.armv7l.rpm' \
+    -A 'pcre-devel-*.armv7l.rpm' \
+    -A 'xdgmime-*.armv7l.rpm' \
     # Unified packages
-    && wget -r -nd --no-parent -q -A 'vconf-compat-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/unified/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'libcynara-commons-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/unified/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'cynara-devel-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/unified/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'libcynara-client-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/unified/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'dbus-1*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/unified/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'dbus-devel-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/unified/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'dbus-libs-1*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/unified/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'glib2-devel-2*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/unified/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'libdns_sd-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/unified/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'buxton2-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/unified/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'libsystemd-*.armv7l.rpm' http://download.tizen.org/releases/milestone/tizen/unified/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'capi-network-nsd-*.armv7l.rpm' http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'libnsd-dns-sd-*.armv7l.rpm' http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/armv7l/ \
-    && wget -r -nd --no-parent -q -A 'capi-network-thread-*.armv7l.rpm' http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/armv7l/ \
+    && wget --progress=dot:mega -r -nd --no-parent \
+    http://download.tizen.org/releases/milestone/tizen/unified/latest/repos/standard/packages/armv7l/ \
+    -A 'aul-0*.armv7l.rpm' \
+    -A 'aul-devel-*.armv7l.rpm' \
+    -A 'buxton2-*.armv7l.rpm' \
+    -A 'capi-network-nsd-*.armv7l.rpm' \
+    -A 'capi-network-thread-*.armv7l.rpm' \
+    -A 'cynara-devel-*.armv7l.rpm' \
+    -A 'dbus-1*.armv7l.rpm' \
+    -A 'dbus-devel-*.armv7l.rpm' \
+    -A 'dbus-libs-1*.armv7l.rpm' \
+    -A 'glib2-devel-2*.armv7l.rpm' \
+    -A 'libtzplatform-config-*.armv7l.rpm' \
+    -A 'libcynara-client-*.armv7l.rpm' \
+    -A 'libcynara-commons-*.armv7l.rpm' \
+    -A 'libdns_sd-*.armv7l.rpm' \
+    -A 'libnsd-dns-sd-*.armv7l.rpm' \
+    -A 'libsystemd-*.armv7l.rpm' \
+    -A 'vconf-compat-*.armv7l.rpm' \
+    -A 'vconf-internal-keys-devel-*.armv7l.rpm' \
     # Install base sysroot
     && unzip -o '*.zip' \
     && cp -rf data/* $TIZEN_SDK_ROOT \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.68 Version bump reason: [Tizen] Add Tizen Studio CLI to Tizen docker image
+0.5.69 Version bump reason: [Tizen] Install AUL development files


### PR DESCRIPTION
#### Problem

It is impossible to create Tizen native application with current tizen-sdk - there are missing libraries.

#### Change overview

- added AUL (application utility library) and libtzplatform are required by capi-appfw-service-application and capi-appfw-application packages.
- simplified downloading RPMs in Dockerfile

#### Testing

Tested locally whether this will work:
```gn
pkg_config("capi-appfw-app") {
  packages = [ "capi-appfw-service-application",  "capi-appfw-application" ]
}
```