### PR TITLE
[Testing] Add a command line argument to the all-clusters-app to Configure the minimal commissioning timeout

### DIFF
--- a/examples/all-clusters-app/esp32/main/DeviceWithDisplay.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceWithDisplay.cpp
@@ -444,8 +444,9 @@ public:
         else if (i == 2)
         {
             chip::Server::GetInstance().GetFabricTable().DeleteAllFabrics();
-            chip::Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow(
-                CommissioningWindowManager::MaxCommissioningTimeout(), CommissioningWindowAdvertisement::kDnssdOnly);
+            auto & commissionMgr = chip::Server::GetInstance().GetCommissioningWindowManager();
+            commissionMgr.OpenBasicCommissioningWindow(commissionMgr.MaxCommissioningTimeout(),
+                                                       CommissioningWindowAdvertisement::kDnssdOnly);
         }
     }
 

--- a/examples/all-clusters-app/linux/main.cpp
+++ b/examples/all-clusters-app/linux/main.cpp
@@ -26,6 +26,7 @@ int main(int argc, char * argv[])
     VerifyOrDie(InitBindingHandlers() == CHIP_NO_ERROR);
 
     LinuxDeviceOptions::GetInstance().dacProvider = AppOptions::GetDACProvider();
+
     ChipLinuxAppMainLoop();
     return 0;
 }

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -182,8 +182,7 @@ void CommissioningWindowManager::OnSessionEstablished(const SessionHandle & sess
 
 CHIP_ERROR CommissioningWindowManager::OpenCommissioningWindow(Seconds16 commissioningTimeout)
 {
-    VerifyOrReturnError(commissioningTimeout <= MaxCommissioningTimeout() &&
-                            commissioningTimeout >= mMinCommissioningTimeoutOverride.ValueOr(MinCommissioningTimeout()),
+    VerifyOrReturnError(commissioningTimeout <= MaxCommissioningTimeout() && commissioningTimeout >= MinCommissioningTimeout(),
                         CHIP_ERROR_INVALID_ARGUMENT);
     DeviceLayer::FailSafeContext & failSafeContext = DeviceLayer::DeviceControlServer::DeviceControlSvr().GetFailSafeContext();
     VerifyOrReturnError(!failSafeContext.IsFailSafeArmed(), CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -56,10 +56,10 @@ public:
         return System::Clock::Seconds16(15 * 60);
     }
 
-    static constexpr System::Clock::Seconds16 MinCommissioningTimeout()
+    System::Clock::Seconds16 MinCommissioningTimeout() const
     {
         // Specification section 5.4.2.3. Announcement Duration says 3 minutes.
-        return System::Clock::Seconds16(3 * 60);
+        return mMinCommissioningTimeoutOverride.ValueOr(System::Clock::Seconds16(3 * 60));
     }
 
     void SetAppDelegate(AppDelegate * delegate) { mAppDelegate = delegate; }

--- a/src/app/tests/TestCommissionManager.cpp
+++ b/src/app/tests/TestCommissionManager.cpp
@@ -87,7 +87,7 @@ void CheckCommissioningWindowManagerBasicWindowOpenCloseTask(intptr_t context)
 {
     nlTestSuite * suite                        = reinterpret_cast<nlTestSuite *>(context);
     CommissioningWindowManager & commissionMgr = Server::GetInstance().GetCommissioningWindowManager();
-    CHIP_ERROR err = commissionMgr.OpenBasicCommissioningWindow(CommissioningWindowManager::MaxCommissioningTimeout(),
+    CHIP_ERROR err                             = commissionMgr.OpenBasicCommissioningWindow(commissionMgr.MaxCommissioningTimeout(),
                                                                 CommissioningWindowAdvertisement::kDnssdOnly);
     NL_TEST_ASSERT(suite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(suite,
@@ -196,8 +196,8 @@ void CheckCommissioningWindowManagerEnhancedWindowTask(intptr_t context)
     uint8_t salt[chip::kSpake2p_Min_PBKDF_Salt_Length];
     chip::ByteSpan saltData(salt);
 
-    err = commissionMgr.OpenEnhancedCommissioningWindow(CommissioningWindowManager::MaxCommissioningTimeout(), newDiscriminator,
-                                                        verifier, kIterations, saltData);
+    err = commissionMgr.OpenEnhancedCommissioningWindow(commissionMgr.MaxCommissioningTimeout(), newDiscriminator, verifier,
+                                                        kIterations, saltData);
     NL_TEST_ASSERT(suite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(suite,
                    commissionMgr.CommissioningWindowStatus() ==


### PR DESCRIPTION
#### Problem

The tests from #17837 are trying to use a delay for the minimum timeout of the commissioning window, which is currently 3 minutes per spec (and worse the test plan states 5 minutes). That is just lost time when it comes to our CI.

#### Change overview
 * Allow the minimum commissioning timeout of the `all-clusters-app` to be 1 second.

#### Testing
The command `./out/debug/standalone/chip-tool administratorcommissioning open-basic-commissioning-window 10 0x12344321 0 --timedInteractionTimeoutMs 1000` fails with an `INVALID_COMMAND` without this patch.