### PR TITLE
Remove an extra space in darwin-tests.yaml as it may cause build fail…

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -41,8 +41,16 @@ jobs:
         runs-on: macos-latest
 
         steps:
+            - uses: Wandalen/wretry.action@v1.0.11
+              name: Checkout
+              with:
+                  action: actions/checkout@v3
+                  with: |
+                      token: ${{ github.token }}
+                  attempt_limit: 3
+                  attempt_delay: 2000
             - name: Checkout submodules
-               run: scripts/checkout_submodules.py --shallow --platform darwin
+              run: scripts/checkout_submodules.py --shallow --platform darwin
             - name: Setup Environment
               # coreutils for stdbuf
               run: brew install openssl pkg-config coreutils


### PR DESCRIPTION
…ure (see https://github.com/project-chip/connectedhomeip/actions/runs/2240701948/workflow)

#### Problem

@mlepage-google reports on slack that he is saying sporadic failure on the `.github/workflows/darwin-tests.yaml` file.

It seems that the failure report happens line 45 where there is an extra space - I'm not sure why it does not happens all the time, but it is cheap to just fix it and see it that was the cause of the failure.
```
 Check failure on line 45 in .github/workflows/darwin-tests.yaml

 GitHub Actions
/ .github/workflows/darwin-tests.yaml

Invalid workflow file
You have an error in your yaml syntax on line 45
```

#### Change overview
 * Remove an extra whitespace
