### PR TITLE
[Tests] Increase the tests timeout for darwin tests from 45 minutes t…

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -184,7 +184,7 @@ jobs:
                         --copy-artifacts-to objdir-clone \
                      "
             - name: Run Tests
-              timeout-minutes: 45
+              timeout-minutes: 50
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \


### PR DESCRIPTION
…o 50 minutes

#### Problem

Similarly to https://github.com/project-chip/connectedhomeip/pull/17838 which was happening on Linux I'm seeing those timeout on darwin...
https://github.com/project-chip/connectedhomeip/runs/6230354556?check_suite_focus=true
https://github.com/project-chip/connectedhomeip/runs/6228073597?check_suite_focus=true
https://github.com/project-chip/connectedhomeip/runs/6223631719?check_suite_focus=true

#### Change overview
 * Up the timeout from 45 to 50 minutes..
