### PR TITLE
Resolve SDK integration issues for JsonTLV library

### DIFF
--- a/build_overrides/jsoncpp.gni
+++ b/build_overrides/jsoncpp.gni
@@ -12,20 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("//build_overrides/chip.gni")
-import("//build_overrides/jsoncpp.gni")
-
-config("jsontlv_config") {
-  cflags = [ "-Wno-implicit-fallthrough" ]
-}
-
-static_library("jsontlv") {
-  sources = [ "TlvJson.cpp" ]
-
-  public_configs = [ ":jsontlv_config" ]
-
-  public_deps = [
-    "${chip_root}/src/lib/core",
-    jsoncpp_root,
-  ]
+declare_args() {
+  jsoncpp_root = "//third_party/jsoncpp"
 }

--- a/examples/build_overrides/jsoncpp.gni
+++ b/examples/build_overrides/jsoncpp.gni
@@ -12,20 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("//build_overrides/chip.gni")
-import("//build_overrides/jsoncpp.gni")
-
-config("jsontlv_config") {
-  cflags = [ "-Wno-implicit-fallthrough" ]
-}
-
-static_library("jsontlv") {
-  sources = [ "TlvJson.cpp" ]
-
-  public_configs = [ ":jsontlv_config" ]
-
-  public_deps = [
-    "${chip_root}/src/lib/core",
-    jsoncpp_root,
-  ]
+declare_args() {
+  jsoncpp_root = "//third_party/connectedhomeip/third_party/jsoncpp"
 }

--- a/src/lib/support/jsontlv/BUILD.gn
+++ b/src/lib/support/jsontlv/BUILD.gn
@@ -14,11 +14,17 @@
 
 import("//build_overrides/chip.gni")
 
+config("jsontlv_config") {
+  cflags = [ "-Wno-implicit-fallthrough" ]
+}
+
 static_library("jsontlv") {
+  sources = [ "TlvJson.cpp" ]
+
+  public_configs = [ ":jsontlv_config" ]
+
   public_deps = [
     "${chip_root}/src/lib/core",
     "${chip_root}/third_party/jsoncpp",
   ]
-
-  sources = [ "TlvJson.cpp" ]
 }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Build errors occurred due to a fall-through switch case, when treating -Wimplicit-fallthrough as errors.
* JsonTlv required using the jsoncpp from this repository, causing duplicate symbol errors if it was already included in the build.

#### Change overview
* Build JsonTlv without -Wimplicit-fallthrough, following other code with fall-through cases.
* Add a build override for jsoncpp.

#### Testing
* Verified TestTlvToJson still builds and passes on x86-64.
