### PR TITLE
[coverage] Add use_coverage flag to add --coverage to clang builds.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -439,6 +439,18 @@ config("fuzzing_default") {
   }
 }
 
+config("coverage") {
+  cflags = [ "--coverage" ]
+  ldflags = cflags
+}
+
+config("coverage_default") {
+  configs = []
+  if (use_coverage) {
+    configs += [ ":coverage" ]
+  }
+}
+
 declare_args() {
   # Enable Runtime Type Information (RTTI)
   enable_rtti = false

--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -47,4 +47,7 @@ declare_args() {
 
   # enable libfuzzer
   is_libfuzzer = false
+
+  # initialize gn argument: use_coverage
+  use_coverage = false
 }

--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -48,6 +48,6 @@ declare_args() {
   # enable libfuzzer
   is_libfuzzer = false
 
-  # initialize gn argument: use_coverage
+  # Passes `--coverage` flag to clang when enabled.
   use_coverage = false
 }

--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -48,6 +48,6 @@ declare_args() {
   # enable libfuzzer
   is_libfuzzer = false
 
-  # Passes `--coverage` flag to clang when enabled.
+  # Generate code coverage analysis artifacts when enabled.
   use_coverage = false
 }

--- a/build/config/defaults.gni
+++ b/build/config/defaults.gni
@@ -80,7 +80,8 @@ declare_args() {
   default_configs_fuzzing = [ "${build_root}/config/compiler:fuzzing_default" ]
 
   # Defaults coverage configs.
-  default_configs_coverage = [ "${build_root}/config/compiler:coverage_default" ]
+  default_configs_coverage =
+      [ "${build_root}/config/compiler:coverage_default" ]
 
   # Defaults target-specific configs.
   default_configs_target = [ "${build_root}/config/compiler:target_default" ]

--- a/build/config/defaults.gni
+++ b/build/config/defaults.gni
@@ -79,6 +79,9 @@ declare_args() {
   # Defaults fuzzing configs.
   default_configs_fuzzing = [ "${build_root}/config/compiler:fuzzing_default" ]
 
+  # Defaults coverage configs.
+  default_configs_coverage = [ "${build_root}/config/compiler:coverage_default" ]
+
   # Defaults target-specific configs.
   default_configs_target = [ "${build_root}/config/compiler:target_default" ]
 
@@ -108,6 +111,7 @@ default_configs += default_configs_runtime
 default_configs += default_configs_aliasing
 default_configs += default_configs_sanitize
 default_configs += default_configs_fuzzing
+default_configs += default_configs_coverage
 default_configs += default_configs_target
 default_configs += default_configs_dead_code
 default_configs += default_configs_extra

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -271,8 +271,6 @@ def HostTargets():
     builder.AppendVariant(name="asan", conflicts=['tsan'], use_asan=True),
     builder.AppendVariant(name="libfuzzer", requires=[
                           "clang"], use_libfuzzer=True),
-    builder.AppendVariant(name="coverage", requires=[
-                          "clang"], use_coverage=True),
     builder.AppendVariant(name="clang", use_clang=True),
     builder.AppendVariant(name="test", extra_tests=True),
 

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -271,6 +271,8 @@ def HostTargets():
     builder.AppendVariant(name="asan", conflicts=['tsan'], use_asan=True),
     builder.AppendVariant(name="libfuzzer", requires=[
                           "clang"], use_libfuzzer=True),
+    builder.AppendVariant(name="coverage", requires=[
+                          "clang"], use_coverage=True),
     builder.AppendVariant(name="clang", use_clang=True),
     builder.AppendVariant(name="test", extra_tests=True),
 

--- a/scripts/build_coverage.sh
+++ b/scripts/build_coverage.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+_normpath() {
+    python -c "import os.path; print(os.path.normpath('$@'))"
+}
+
+CHIP_ROOT=$(_normpath "$(dirname "$0")/..")
+OUTPUT_ROOT="$CHIP_ROOT/out/coverage"
+COVERAGE_ROOT="$OUTPUT_ROOT/coverage"
+
+help() {
+
+    echo "Usage: $file_name [ options ... ]"
+
+    echo "General Options:
+  -h, --help                Display this information.
+Input Options:
+  -o, --output_root         Set the build output directory"
+}
+
+file_name=${0##*/}
+
+while (($#)); do
+    case $1 in
+        --help | -h)
+            help
+            exit 1
+            ;;
+        --output_root | -o)
+            OUTPUT_ROOT=$2
+            shift
+            ;;
+        -*)
+            help
+            echo "Unknown Option \"$1\""
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Print input values
+echo "Input values: chip_detail_logging = $chip_detail_logging , chip_mdns = \"$chip_mdns\", enable_pybindings = $enable_pybindings, chip_case_retry_delta=\"$chip_case_retry_delta\""
+
+# Ensure we have a compilation environment
+source "$CHIP_ROOT/scripts/activate.sh"
+
+# Generates ninja files
+gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args='use_coverage=true'
+ninja -C "$OUTPUT_ROOT" check
+
+mkdir -p "$COVERAGE_ROOT"
+lcov --initial --capture --directory "$OUTPUT_ROOT/obj" --output-file "$COVERAGE_ROOT/lcov_base.info"
+lcov --capture --directory "$OUTPUT_ROOT"/obj --output-file "$COVERAGE_ROOT/lcov_test.info"
+lcov --add-tracefile "$COVERAGE_ROOT/lcov_base.info" --add-tracefile "$COVERAGE_ROOT/lcov_test.info" --output-file "$COVERAGE_ROOT/lcov_final.info"
+genhtml "$COVERAGE_ROOT/lcov_final.info" --output-directory "$COVERAGE_ROOT/html"

--- a/scripts/build_coverage.sh
+++ b/scripts/build_coverage.sh
@@ -25,6 +25,7 @@ _normpath() {
 CHIP_ROOT=$(_normpath "$(dirname "$0")/..")
 OUTPUT_ROOT="$CHIP_ROOT/out/coverage"
 COVERAGE_ROOT="$OUTPUT_ROOT/coverage"
+skip_gn=false
 
 help() {
 
@@ -33,7 +34,10 @@ help() {
     echo "General Options:
   -h, --help                Display this information.
 Input Options:
-  -o, --output_root         Set the build output directory"
+  -o, --output_root         Set the build output directory.  When set manually, performs only lcov stage
+                            on provided build output.  Assumes output_root has been built with 'use_coverage=true'
+                            and that 'ninja check' was run.
+  "
 }
 
 file_name=${0##*/}
@@ -46,6 +50,8 @@ while (($#)); do
             ;;
         --output_root | -o)
             OUTPUT_ROOT=$2
+            COVERAGE_ROOT="$OUTPUT_ROOT/coverage"
+            skip_gn=true
             shift
             ;;
         -*)
@@ -64,8 +70,10 @@ echo "Input values: chip_detail_logging = $chip_detail_logging , chip_mdns = \"$
 source "$CHIP_ROOT/scripts/activate.sh"
 
 # Generates ninja files
-gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args='use_coverage=true'
-ninja -C "$OUTPUT_ROOT" check
+if [ "$skip_gn" == false ]; then
+    gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args='use_coverage=true'
+    ninja -C "$OUTPUT_ROOT" check
+fi
 
 mkdir -p "$COVERAGE_ROOT"
 lcov --initial --capture --directory "$OUTPUT_ROOT/obj" --output-file "$COVERAGE_ROOT/lcov_base.info"

--- a/scripts/build_coverage.sh
+++ b/scripts/build_coverage.sh
@@ -63,9 +63,6 @@ while (($#)); do
     shift
 done
 
-# Print input values
-echo "Input values: chip_detail_logging = $chip_detail_logging , chip_mdns = \"$chip_mdns\", enable_pybindings = $enable_pybindings, chip_case_retry_delta=\"$chip_case_retry_delta\""
-
 # Ensure we have a compilation environment
 source "$CHIP_ROOT/scripts/activate.sh"
 


### PR DESCRIPTION
#### Problem
The build system does not have hooks to build test coverage reports.

#### Change overview
Add `use_coverage=true` support.  Add `script/build_coverage.sh` to generate html code coverage reports.

Example:

```
./gn_build.sh use_coverage=true
./script/build_coverage.sh out/debug/fake_x86_clang
# Browse output at out/debug/fake_x86_clang/coverage/html/index.html
```

#### Testing
CI and manually on desktop.