### PR TITLE
docs: Recommend Debian 11 & fix Python CHIP Controller how-to

### DIFF
--- a/docs/guides/BUILDING.md
+++ b/docs/guides/BUILDING.md
@@ -7,7 +7,7 @@ that generates inputs to [ninja](https://ninja-build.org/).
 Tested on:
 
 -   macOS 10.15
--   Debian 10
+-   Debian 11
 -   Ubuntu 20.04 LTS
 
 Build system features:

--- a/docs/guides/python_chip_controller_building.md
+++ b/docs/guides/python_chip_controller_building.md
@@ -77,7 +77,7 @@ To build and run the Python CHIP controller:
 5. Build and install the Python CHIP controller:
 
     ```
-    scripts/build_python.sh -m platform
+    scripts/build_python.sh -m platform -i separate
     ```
 
     > Note: To get more details about available build configurations, run the


### PR DESCRIPTION
#### Problem

* Debian 10 fails with

```
  Setting up Python environment.....[|]============================================================
Unexpected Python version: Python 3.7.3
```

* Following `docs/guides/python_chip_controller_building.md` venv `source out/python_env/bin/activate` doesn't exist

#### Change overview
* Recommend Debian 11. Debian 10 brings Python 3.7 which isn't supported anymore.
* Use ` -i separate` to setup venv for Python CHIP Controller

#### Testing
