### PR TITLE
[python] handle storage Sync issues properly

### DIFF
--- a/src/controller/python/chip/storage/__init__.py
+++ b/src/controller/python/chip/storage/__init__.py
@@ -108,7 +108,7 @@ class PersistentStorage:
                 self._file = open(self._path, 'w')
             except Exception as ex:
                 logging.warn(
-                    f"Could not open {self._file} for writing configuration. Error:")
+                    f"Could not open {self._path} for writing configuration. Error:")
                 logging.warn(ex)
                 return
 

--- a/src/controller/python/chip/storage/__init__.py
+++ b/src/controller/python/chip/storage/__init__.py
@@ -108,8 +108,9 @@ class PersistentStorage:
                 self._file = open(self._path, 'w')
             except Exception as ex:
                 logging.warn(
-                    f"Could not open {path} for writing configuration. Error:")
+                    f"Could not open {self._file} for writing configuration. Error:")
                 logging.warn(ex)
+                return
 
         self._file.seek(0)
         json.dump(self.jsonData, self._file, ensure_ascii=True, indent=4)


### PR DESCRIPTION
The variable "path" doesn't exist when handling this exception. Use
self._file and return after reporting the error to avoid further
exceptions.

#### Problem
What is being fixed?  Examples:
* Fix crash on startup
* 
```
2022-04-30 11:00:22 allenwind root[270500] CRITICAL Loading configuration from /tmp/chip-device-ctrl-storage.json...                                                                                                                                                                                                                                                                                                          
2022-04-30 11:00:22 allenwind root[270500] INFO SetSdkKey: g/gcc = b'\xd0\x07\x00\x00'                                                                                                                                                                                                                                                                                                                                        
Exception ignored on calling ctypes callback function: <function _OnSyncSetKeyValueCb at 0x7f6230043af0>                                                                                                                                                                                                                                                                                                                      
Traceback (most recent call last):                                                                                                                                                                                                                                                                                                                                                                                            
  File "/home/sag/projects/project-chip/connectedhomeip/out/python_env/lib/python3.9/site-packages/chip/storage/__init__.py", line 44, in _OnSyncSetKeyValueCb                                                                                                                                                                                                                                                                
    storageObj.SetSdkKey(key.decode("utf-8"), ctypes.string_at(value, size))                                                                                                                                                                                                                                                                                                                                                  
  File "/home/sag/projects/project-chip/connectedhomeip/out/python_env/lib/python3.9/site-packages/chip/storage/__init__.py", line 147, in SetSdkKey                                                                                                                                                                                                                                                                          
    self.Sync()                                                                                                                                                                                                                                                                                                                                                                                                               
  File "/home/sag/projects/project-chip/connectedhomeip/out/python_env/lib/python3.9/site-packages/chip/storage/__init__.py", line 111, in Sync                                                                                                                                                                                                                                                                               
    f"Could not open {path} for writing configuration. Error:")                                                                                                                                                                                                                                                                                                                                                               
NameError: name 'path' is not defined
```

#### Change overview
Improve exception handling.

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
* If unit tests existed, how were they fixed/modified to prevent this in future?
* If new unit tests are not added, why not?
* If integration tests were added, how do they verify this change?
* If new integration tests are not added, why not?
* If manually tested, what platforms controller and device platforms were manually tested, and how?
* If no testing is required, why not?
