### PR TITLE
Fix off-by-one error in FindLocalNodeFromDestionationId

### DIFF
--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -460,7 +460,7 @@ CHIP_ERROR CASESession::FindLocalNodeFromDestionationId(const ByteSpan & destina
         }
 
         // Try every IPK candidate we have for a match
-        for (size_t keyIdx = 0; keyIdx <= ipkKeySet.num_keys_used; ++keyIdx)
+        for (size_t keyIdx = 0; keyIdx < ipkKeySet.num_keys_used; ++keyIdx)
         {
             uint8_t candidateDestinationId[kSHA256_Hash_Length];
             MutableByteSpan candidateDestinationIdSpan(candidateDestinationId);


### PR DESCRIPTION
#### Problem

FindLocalNodeFromDestionationId is indexing 1 entry past the initialized IPK epoch keys, with the result that an all-zero key is accepted when one or two epoch-keys are installed.  If three epoch keys are installed, this will reference out of bounds.

#### Change overview

This commit corrects the loop bound in this method to fix the problem.

Fixes #17940

#### Testing

Manually tested with an initiator using an incorrect, all-zero key.  Without the fix, CASE establishment succeeds.  With the fix, the responder now correctly rejects the incoming establishment request.
