### PR TITLE
Update git in dockerfile to 2.25.1-1ubuntu3.4 (from 3.3 which does no…

### DIFF
--- a/integrations/docker/images/chip-build-crosscompile/Dockerfile
+++ b/integrations/docker/images/chip-build-crosscompile/Dockerfile
@@ -4,7 +4,7 @@ FROM connectedhomeip/chip-build:${VERSION} as build
 RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
-    git=1:2.25.1-1ubuntu3.3 \
+    git=1:2.25.1-1ubuntu3.4 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line

--- a/integrations/docker/images/chip-build-esp32-qemu/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32-qemu/Dockerfile
@@ -5,7 +5,7 @@ RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
     ninja-build=1.10.0-1build1 \
-    git=1:2.25.1-1ubuntu3.3 \
+    git=1:2.25.1-1ubuntu3.4 \
     libgcrypt20-dev=1.8.5-5ubuntu1.1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \

--- a/integrations/docker/images/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32/Dockerfile
@@ -4,7 +4,7 @@ FROM connectedhomeip/chip-build:${VERSION} as build
 RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
-    git=1:2.25.1-1ubuntu3.3 \
+    git=1:2.25.1-1ubuntu3.4 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.69 Version bump reason: [Tizen] Install AUL development files
+0.5.70 Version bump reason: push git to 2.25.1-1ubuntu3.4 (from 3.3)


### PR DESCRIPTION
…t exist anymore)

#### Problem
Docker builds fail:

```
E: Version '1:2.25.1-1ubuntu3.3' for 'git' was not found
```

#### Change overview
Update git version.

#### Testing
Will validate when building images. This change is similar to #17611 which fixed the doxygen image.