### PR TITLE
Simplify implementation of emberAfContainsAttribute.

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -650,10 +650,6 @@ EmberAfStatus emAfReadOrWriteAttribute(EmberAfAttributeSearchRecord * attRecord,
             // Dynamic endpoints are external and don't factor into storage size
             if (!isDynamicEndpoint)
             {
-                if (emAfEndpoints[ep].endpointType == nullptr)
-                {
-                    return EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE;
-                }
                 attributeOffsetIndex = static_cast<uint16_t>(attributeOffsetIndex + emAfEndpoints[ep].endpointType->endpointSize);
             }
         }

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -771,7 +771,7 @@ uint8_t emberAfMake8bitEncodedChanPg(uint8_t page, uint8_t channel)
 
 bool emberAfContainsAttribute(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId)
 {
-    return (emberAfLocateAttributeMetadata(endpoint, clusterId, attributeId) != nullptr);
+    return (emberAfGetServerAttributeIndexByAttributeId(endpoint, clusterId, attributeId) != UINT16_MAX);
 }
 
 bool emberAfIsNonVolatileAttribute(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId)


### PR DESCRIPTION
The current implementation looks up the attribute metadata, which
involves figuring out where in the global attribute storage the
attribute might live, which depends on the state of other endpoints.

Instead, use emberAfGetServerAttributeIndexByAttributeId, which only
depends on the state of the one endpoint in question.

This allows removing a workaround for the "calling these functions
when endpoints are not initialized yet" bits that was added in #17719.

#### Problem
Slightly more complicated and slower code than we could have.

#### Change overview
Slightly simpler code.

#### Testing
No behavior changes.