### PR TITLE
[System] Add locking mechanism UDPEndpointOpenThread

### DIFF
--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -283,7 +283,7 @@ otIp6Address IPAddress::ToIPv6() const
     return otAddr;
 }
 
-IPAddress IPAddress::FromOtAddr(otIp6Address & address)
+IPAddress IPAddress::FromOtAddr(const otIp6Address & address)
 {
     IPAddress addr;
     static_assert(sizeof(address.mFields.m32) == sizeof(addr), "otIp6Address size mismatch");

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -556,7 +556,7 @@ public:
 
 #if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
     otIp6Address ToIPv6() const;
-    static IPAddress FromOtAddr(otIp6Address & address);
+    static IPAddress FromOtAddr(const otIp6Address & address);
 #endif // CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 
     /**

--- a/src/platform/FreeRTOS/GenericThreadStackManagerImpl_FreeRTOS.cpp
+++ b/src/platform/FreeRTOS/GenericThreadStackManagerImpl_FreeRTOS.cpp
@@ -44,6 +44,9 @@ template <class ImplClass>
 CHIP_ERROR GenericThreadStackManagerImpl_FreeRTOS<ImplClass>::DoInit(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
+    System::LayerFreeRTOS & lSystemLayer = static_cast<System::LayerFreeRTOS &>(chip::DeviceLayer::SystemLayer());
+#endif
 #if defined(CHIP_CONFIG_FREERTOS_USE_STATIC_SEMAPHORE) && CHIP_CONFIG_FREERTOS_USE_STATIC_SEMAPHORE
     mThreadStackLock = xSemaphoreCreateMutexStatic(&mThreadStackLockMutex);
 #else
@@ -55,7 +58,9 @@ CHIP_ERROR GenericThreadStackManagerImpl_FreeRTOS<ImplClass>::DoInit(void)
         ChipLogError(DeviceLayer, "Failed to create Thread stack lock");
         ExitNow(err = CHIP_ERROR_NO_MEMORY);
     }
-
+#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
+    lSystemLayer.RegisterLock(chip::System::Layer::TaskLocks_e::THREAD_TASK, &mThreadStackLock);
+#endif
     mThreadTask = NULL;
 
 exit:


### PR DESCRIPTION
#### Problem
Locking is needed to prevent segmentation fault should the UDPEndpoint be deleted while the OpenThread stack is still processing an incoming message.

Since there is not Global locking API within the OpenThread stack, a custom API needs to be implemented for the Matter use case

#### Change overview
Implement a locking mechanism to prevent the use of a deleted Endpoint in the reception callback.

#### Testing
Tested on EFR32 platform
