### PR TITLE
[OTA] Use-after-free in OTAProviderExample::HandleQueryImage

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
@@ -94,7 +94,7 @@ private:
                           const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::DecodableType & commandData,
                           uint32_t targetVersion);
 
-    bool ParseOTAHeader(const char * otaFilePath, chip::OTAImageHeader & header);
+    bool ParseOTAHeader(chip::OTAImageHeaderParser & parser, const char * otaFilePath, chip::OTAImageHeader & header);
 
     /**
      * Called to send the response for a QueryImage command. If an error is encountered, an error status will be sent.


### PR DESCRIPTION
#### Problem

When running the steps to test the OTA feature, it crashes because of a `use-after-free`

```
==23972==ERROR: AddressSanitizer: heap-use-after-free on address 0x60700006c35f at pc 0x0001104ef590 bp 0x700001164eb0 sp 0x700001164678
READ of size 9 at 0x60700006c35f thread T19
    #0 0x1104ef58f in __asan_memcpy+0x1af (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x4658f)
    #1 0x10f856af6 in OTAProviderExample::HandleQueryImage(chip::app::CommandHandler*, chip::app::ConcreteCommandPath const&, chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::DecodableType const&) OTAProviderExample.cpp:355
    #2 0x10f8e01eb in emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(chip::app::CommandHandler*, chip::app::ConcreteCommandPath const&, chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::DecodableType const&) ota-provider.cpp:216
    #3 0x10f8e9a51 in chip::app::Clusters::OtaSoftwareUpdateProvider::DispatchServerCommand(chip::app::CommandHandler*, chip::app::ConcreteCommandPath const&, chip::TLV::TLVReader&) IMClusterCommandHandler.cpp:198
    #4 0x10f8eb5d3 in chip::app::DispatchSingleClusterCommand(chip::app::ConcreteCommandPath const&, chip::TLV::TLVReader&, chip::app::CommandHandler*) IMClusterCommandHandler.cpp:350


freed by thread T19 here:
    #0 0x1104f1609 in wrap_free+0xa9 (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x48609)
    #1 0x10faeafd6 in chip::Platform::MemoryFree(void*)+0x86 (chip-ota-provider-app:x86_64+0x1002b5fd6)
    #2 0x10f858de4 in chip::Platform::Impl::PlatformMemoryManagement::MemoryFree(void*) ScopedBuffer.h:119
    #3 0x10f858d93 in chip::Platform::Impl::ScopedMemoryBufferBase<chip::Platform::Impl::PlatformMemoryManagement>::Free() ScopedBuffer.h:78
    #4 0x10fabf37e in chip::OTAImageHeaderParser::Clear()+0x13e (chip-ota-provider-app:x86_64+0x10028a37e)
    #5 0x10f851e8a in OTAProviderExample::ParseOTAHeader(char const*, chip::OTAImageHeader&) OTAProviderExample.cpp:226
    #6 0x10f8568ca in OTAProviderExample::HandleQueryImage(chip::app::CommandHandler*, chip::app::ConcreteCommandPath const&, chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::DecodableType const&) OTAProviderExample.cpp:352
    #7 0x10f8e01eb in emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(chip::app::CommandHandler*, chip::app::ConcreteCommandPath const&, chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::DecodableType const&) ota-provider.cpp:216
    #8 0x10f8e9a51 in chip::app::Clusters::OtaSoftwareUpdateProvider::DispatchServerCommand(chip::app::CommandHandler*, chip::app::ConcreteCommandPath const&, chip::TLV::TLVReader&) IMClusterCommandHandler.cpp:198
    #9 0x10f8eb5d3 in chip::app::DispatchSingleClusterCommand(chip::app::ConcreteCommandPath const&, chip::TLV::TLVReader&, chip::app::CommandHandler*) IMClusterCommandHandler.cpp:350
```

The use-after-free issue is likely because of https://github.com/project-chip/connectedhomeip/blob/8ce90acbc95398e576b045addaeef1a385667967/src/lib/core/OTAImageHeader.h#L52
The OTAImageHeader does not hold the buffer data. So when [https://github.com/project-chip/connectedhomeip/blob/b63d8971c6a133a663880fc59707c[…]les/ota-provider-app/ota-provider-common/OTAProviderExample.cpp](https://github.com/project-chip/connectedhomeip/blob/b63d8971c6a133a663880fc59707c200d5ef0585/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp#L226) is called, it is relying the mBuffer member of the parser.
And so trying to read the content at [https://github.com/project-chip/connectedhomeip/blob/b63d8971c6a133a663880fc59707c[…]les/ota-provider-app/ota-provider-common/OTAProviderExample.cpp](https://github.com/project-chip/connectedhomeip/blob/b63d8971c6a133a663880fc59707c200d5ef0585/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp#L355) is undefined behavior.


#### Change overview
 * Creates the parse out of the `ParseOTAHeader` method to manage its lifetime.
 
#### Testing
The steps are not crashing afterwards.