### PR TITLE
Enable traces to use custom trace system instead of pigweed only

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -769,6 +769,7 @@ ManufacturingDate
 masterkey
 matterBuildSrcDir
 matterc
+MatterCustomTrace
 matterd
 MatterLock
 matterSdkSourceBuild

--- a/src/trace/README.md
+++ b/src/trace/README.md
@@ -4,6 +4,10 @@ Matter tracing provides a tool for applications to trace information about the
 execution of the application. It depends on
 [pw_trace module](https://pigweed.dev/pw_trace/).
 
+Application can override trace events with custom trace system by setting
+MATTER_CUSTOM_TRACE to true and direct trace macros to
+trace/MatterCustomTrace.h.
+
 ## How to add trace events
 
 1. Include "trace/trace.h" in the source file.

--- a/src/trace/trace.h
+++ b/src/trace/trace.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#if MATTER_CUSTOM_TRACE
+#if defined(MATTER_CUSTOM_TRACE) && MATTER_CUSTOM_TRACE
 
 #include "trace/MatterCustomTrace.h"
 
@@ -76,4 +76,4 @@
 
 #endif // defined(PW_TRACE_BACKEND_SET) && PW_TRACE_BACKEND_SET
 
-#endif // MATTER_CUSTOM_TRACE
+#endif // defined(MATTER_CUSTOM_TRACE) && MATTER_CUSTOM_TRACE

--- a/src/trace/trace.h
+++ b/src/trace/trace.h
@@ -21,7 +21,7 @@
 
 #include "trace/MatterCustomTrace.h"
 
-#else  // MATTER_CUSTOM_TRACE
+#else // MATTER_CUSTOM_TRACE
 
 #if defined(PW_TRACE_BACKEND_SET) && PW_TRACE_BACKEND_SET
 

--- a/src/trace/trace.h
+++ b/src/trace/trace.h
@@ -17,6 +17,12 @@
 
 #pragma once
 
+#if MATTER_CUSTOM_TRACE
+
+#include "trace/MatterCustomTrace.h"
+
+#else  // MATTER_CUSTOM_TRACE
+
 #if defined(PW_TRACE_BACKEND_SET) && PW_TRACE_BACKEND_SET
 
 /* ignore GCC Wconversion warnings for pigweed */
@@ -69,3 +75,5 @@
 #define MATTER_TRACE_EVENT_FUNCTION_FLAG(...) _MATTER_TRACE_EVENT_DISABLE(__VA_ARGS__)
 
 #endif // defined(PW_TRACE_BACKEND_SET) && PW_TRACE_BACKEND_SET
+
+#endif // MATTER_CUSTOM_TRACE


### PR DESCRIPTION
#### Change overview
Change trace header to be able to include custom tracing system. Currently only pigweed trace is used.

