### PR TITLE
Remove perfetto from third_party.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -225,9 +225,6 @@
 	path = third_party/mbed-mcu-boot/repo
 	url = https://github.com/ATmobica/mcuboot.git
 	platforms = mbed
-[submodule "perfetto"]
-	path = third_party/perfetto/repo
-	url = https://github.com/google/perfetto
 [submodule "p6/serial-flash"]
 	path = third_party/p6/p6_sdk/libs/serial-flash
 	url = https://github.com/Infineon/serial-flash


### PR DESCRIPTION
#### Problem
Perfetto repository was added to support traces. Remove this since it is not needed anymore.

#### Change overview
remove perfetto repo from third_party folder.

