### PR TITLE
Handle error cases in Android OnAttributeData

### DIFF
--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -244,11 +244,14 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
     // Convert TLV to JSON
     Json::Value json;
     err = TlvToJson(readerForJson, json);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ReportError(attributePathObj, err));
+
     UtfString jsonString(env, JsonToString(json).c_str());
 
     // Create AttributeState object
     jclass attributeStateCls;
     err = JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/model/AttributeState", attributeStateCls);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Could not find AttributeState class"));
     VerifyOrReturn(attributeStateCls != nullptr, ChipLogError(Controller, "Could not find AttributeState class"));
     chip::JniClass attributeStateJniCls(attributeStateCls);
     jmethodID attributeStateCtor = env->GetMethodID(attributeStateCls, "<init>", "(Ljava/lang/Object;[BLjava/lang/String;)V");
@@ -261,7 +264,7 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
     jmethodID addAttributeMethod;
     err = JniReferences::GetInstance().FindMethod(env, mNodeStateObj, "addAttribute",
                                                   "(IJJLchip/devicecontroller/model/AttributeState;)V", &addAttributeMethod);
-    VerifyOrReturnError(err == CHIP_NO_ERROR, ChipLogError(Controller, "Could not find addAttribute method"));
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Could not find addAttribute method"));
     env->CallVoidMethod(mNodeStateObj, addAttributeMethod, static_cast<jint>(aPath.mEndpointId),
                         static_cast<jlong>(aPath.mClusterId), static_cast<jlong>(aPath.mAttributeId), attributeStateObj);
     VerifyOrReturnError(!env->ExceptionCheck(), env->ExceptionDescribe());


### PR DESCRIPTION
#### Problem
* Certain error paths in `AndroidCallbacks.cpp` (`ReportCallback::OnAttributeData`) were being ignored.

#### Change overview
Add `VerifyOrReturn` statements to handle these error cases.

#### Testing
Manually did a wildcard read of paths from all-clusters-app before and after. No new issues seen. The actual failure case (invalid TLV, missing class) were not reproduced.