### PR TITLE
Bug fix to initialize pid correctly from 2nd shell argument

### DIFF
--- a/examples/tv-app/linux/AppPlatformShellCommands.cpp
+++ b/examples/tv-app/linux/AppPlatformShellCommands.cpp
@@ -139,7 +139,7 @@ static CHIP_ERROR AppPlatformHandler(int argc, char ** argv)
         uint16_t pid = 0;
         if (argc >= 3)
         {
-            pid = (uint16_t) strtol(argv[1], &eptr, 10);
+            pid = (uint16_t) strtol(argv[2], &eptr, 10);
         }
         ContentAppPlatform::GetInstance().LoadContentAppByClient(vid, pid);
 


### PR DESCRIPTION
#### Problem
Fixes wrongly initialized value passed in via a shell command line
#### Change overview
The tv-app sample application shell wrongly initialized the pid (product id) value from the vid (vendor id) sent by the shell command user.

#### Testing
This is a minor change to example application, and does not impact the framework
* Tested using the following shell command
app add 65521 32769

before change would add the app with vid = pid, after the change would add the app to the endpoint properly
