### PR TITLE
Fix 0-length string parsing in `TLVReader`

### DIFF
--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -629,10 +629,12 @@ public:
     /**
      * Get a pointer to the initial encoded byte of a TLV byte or UTF8 string element.
      *
-     * This method returns a direct pointer the encoded string value within the underlying input buffer.
-     * To succeed, the method requires that the entirety of the string value be present in a single buffer.
-     * Otherwise the method returns #CHIP_ERROR_TLV_UNDERRUN.  This makes the method of limited use when
-     * reading data from multiple discontiguous buffers.
+     * This method returns a direct pointer to the encoded string value within the underlying input buffer
+     * if a non-zero length string payload is present. To succeed, the method requires that the entirety of the
+     * string value be present in a single buffer. Otherwise the method returns #CHIP_ERROR_TLV_UNDERRUN.
+     * This makes the method of limited use when reading data from multiple discontiguous buffers.
+     *
+     * If no string data is present (i.e the length is zero), data shall be updated to point to null.
      *
      * @param[out] data                     A reference to a const pointer that will receive a pointer to
      *                                      the underlying string data.

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -397,6 +397,12 @@ CHIP_ERROR TLVReader::GetDataPtr(const uint8_t *& data)
     if (!TLVTypeIsString(ElementType()))
         return CHIP_ERROR_WRONG_TLV_TYPE;
 
+    if (GetLength() == 0)
+    {
+        data = nullptr;
+        return CHIP_NO_ERROR;
+    }
+
     err = EnsureData(CHIP_ERROR_TLV_UNDERRUN);
     if (err != CHIP_NO_ERROR)
         return err;

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -3101,6 +3101,35 @@ void TestCHIPTLVWriterErrorHandling(nlTestSuite * inSuite)
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
 }
 
+void TestCHIPTLVEmptyString(nlTestSuite * inSuite)
+{
+    uint8_t buf[2];
+    TLVWriter writer;
+    CHIP_ERROR err;
+    ByteSpan s;
+
+    writer.Init(buf);
+
+    err = writer.PutString(AnonymousTag(), nullptr, 0);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Finalize();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    TLVReader reader;
+
+    reader.Init(buf);
+
+    err = reader.Next();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = reader.Get(s);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, s.data() == nullptr);
+    NL_TEST_ASSERT(inSuite, s.size() == 0);
+}
+
 /**
  *  Test CHIP TLV Writer
  */
@@ -3113,6 +3142,8 @@ void CheckCHIPTLVWriter(nlTestSuite * inSuite, void * inContext)
     TestCHIPTLVWriterPreserveSize(inSuite);
 
     TestCHIPTLVWriterErrorHandling(inSuite);
+
+    TestCHIPTLVEmptyString(inSuite);
 }
 
 void SkipNonContainer(nlTestSuite * inSuite)


### PR DESCRIPTION
#### Problem

Calling `ClusterStateCache::Get` on an octstr attribute that had a length of zero was failing with a `CHIP_ERROR_TLV_UNDERRUN`. The underlying call to `TLVReader::Get` was returning that error, which it shouldn't be. Instead, the returned span should point to null, with a length of zero.

This was because that method calls `GetDataPtr`, which checks to see if there is sufficient data remaining in the buffer to return back a pointer to. This fails in the case of a zero-length string AND there is no more data remaining in the buffer.

This latter case doesn't actually happen all that often when parsing TLV payloads, most usually in the IM/DM. In most of those cases, the octet string is usually a field within a larger payload (like a struct, or within a command) and there are remaining bytes in the underlying buffer, falsely returning back a pointer to a location in the buffer that doesn't actually contain valid data for that field.

#### Fix

Call `GetLength` within `GetDataPtr` and if that length is zero, return back a null pointer instead with success instead of an error.


#### Testing

Added a new TLV unit test that reproduced the original issue and validated the fix with that test.