### PR TITLE
[chip-tool] Add Nullable supports in test value expressions

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_WNCV_4_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_4_3.yaml
@@ -47,19 +47,18 @@ tests:
               maxValue: 10000
 
     - label:
-          "1b: If (PA_LF & LF) TH reads CurrentPositionLiftPercentage from DUT"
+          "1b 1c: If (PA_LF & LF) TH reads CurrentPositionLiftPercentage from
+          DUT + assert CurrentPositionLiftPercent100ths/100 equals
+          CurrentPositionLiftPercentage"
+      disabled: true
       command: "readAttribute"
       attribute: "CurrentPositionLiftPercentage"
       PICS: WNCV_LF && WNCV_PA_LF && A_CURRENTPOSITIONLIFTPERCENTAGE
       response:
-          saveAs: attrCurrentPositionLiftPercentage
+          value: attrCurrentPositionLiftPercent100ths / 100
           constraints:
               minValue: 0
               maxValue: 100
-
-    ##- label: "1c: If (PA_LF & LF) TH assert CurrentPositionLiftPercent100ths/100 equals CurrentPositionLiftPercentage"
-    ##  PICS: WNCV_LF && WNCV_PA_LF && A_CURRENTPOSITIONLIFTPERCENTAGE
-    # TODO [TC_WNCV_4_3] WindowCovering Fix this arithmetic operation issue #15190
 
     ######## Command BadParams 1 #######
     ### Step 2x -> Verify the GoToLiftPercentage with a BadParam

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -639,6 +639,12 @@ function chip_tests_variables_get_type(name, options)
   return variable.type;
 }
 
+function chip_tests_variables_is_nullable(name, options)
+{
+  const variable = getVariableOrThrow(this, 'tests', name);
+  return variable.isNullable;
+}
+
 function chip_tests_config(options)
 {
   return templateUtil.collectBlocks(this.variables.config, options, this);
@@ -898,6 +904,7 @@ exports.chip_tests_config_get_type          = chip_tests_config_get_type;
 exports.chip_tests_variables                = chip_tests_variables;
 exports.chip_tests_variables_has            = chip_tests_variables_has;
 exports.chip_tests_variables_get_type       = chip_tests_variables_get_type;
+exports.chip_tests_variables_is_nullable    = chip_tests_variables_is_nullable;
 exports.isTestOnlyCluster                   = isTestOnlyCluster;
 exports.isLiteralNull                       = isLiteralNull;
 exports.octetStringEscapedForCLiteral       = octetStringEscapedForCLiteral;

--- a/src/app/zap-templates/common/variables/Variables.js
+++ b/src/app/zap-templates/common/variables/Variables.js
@@ -27,10 +27,10 @@ const templateUtil = require(zapPath + 'generator/template-util.js')
 const { getCommands, getAttributes } = require('../simulated-clusters/SimulatedClusters.js');
 
 const knownVariables = {
-  'nodeId' : { type : 'NODE_ID', defaultValue : 0x12345 },
-  'endpoint' : { type : 'ENDPOINT_NO', defaultValue : '' },
-  'cluster' : { type : 'CHAR_STRING', defaultValue : '' },
-  'timeout' : { type : 'INT16U', defaultValue : "kTimeoutInSeconds" },
+  'nodeId' : { type : 'NODE_ID', defaultValue : 0x12345, isNullable : false },
+  'endpoint' : { type : 'ENDPOINT_NO', defaultValue : '', isNullable : false },
+  'cluster' : { type : 'CHAR_STRING', defaultValue : '', isNullable : false },
+  'timeout' : { type : 'INT16U', defaultValue : "kTimeoutInSeconds", isNullable : false },
 };
 
 function throwError(test, errorStr)
@@ -57,13 +57,13 @@ async function getCommandInformationsFor(context, test, argumentName)
 {
   const command  = await getItems(test, getCommands(context, test.cluster), test.command);
   const argument = command.response.arguments.find(item => item.name.toLowerCase() == argumentName.toLowerCase());
-  return { type : argument.type, chipType : argument.chipType };
+  return { type : argument.type, chipType : argument.chipType, isNullable : argument.isNullable };
 }
 
 async function getAttributeInformationsFor(context, test, attributeName)
 {
   const attribute = await getItems(test, getAttributes(context, test.cluster), attributeName);
-  return { type : attribute.type, chipType : attribute.chipType };
+  return { type : attribute.type, chipType : attribute.chipType, isNullable : attribute.isNullable };
 }
 
 async function extractVariablesFromConfig(context, suite)

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -28,6 +28,7 @@ const dbEnum       = require(zapPath + '../src-shared/db-enum.js')
 
 const StringHelper    = require('../../common/StringHelper.js');
 const ChipTypesHelper = require('../../common/ChipTypesHelper.js');
+const TestHelper      = require('../../common/ClusterTestGeneration.js');
 
 zclHelper['isEvent'] = function(db, event_name, packageId) {
     return queryEvents
@@ -399,6 +400,20 @@ async function asTypedExpression(value, type)
   if (tokens.length < 2) {
     return asTypedLiteral.call(this, value, type);
   }
+
+  value = tokens
+              .map(token => {
+                if (!TestHelper.chip_tests_variables_has.call(this, token)) {
+                  return token;
+                }
+
+                if (!TestHelper.chip_tests_variables_is_nullable.call(this, token)) {
+                  return token;
+                }
+
+                return `${token}.Value()`;
+              })
+              .join(' ');
 
   const resultType = await asNativeType.call(this, type);
   return `static_cast<${resultType}>(${value})`;

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -31528,7 +31528,7 @@ private:
 class Test_TC_WNCV_4_3Suite : public TestCommand
 {
 public:
-    Test_TC_WNCV_4_3Suite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_WNCV_4_3", 6, credsIssuerConfig)
+    Test_TC_WNCV_4_3Suite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_WNCV_4_3", 5, credsIssuerConfig)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
@@ -31550,7 +31550,6 @@ private:
     chip::Optional<uint16_t> mTimeout;
 
     chip::app::DataModel::Nullable<chip::Percent100ths> attrCurrentPositionLiftPercent100ths;
-    chip::app::DataModel::Nullable<chip::Percent> attrCurrentPositionLiftPercentage;
 
     chip::EndpointId GetEndpoint(chip::EndpointId endpoint) { return mEndpoint.HasValue() ? mEndpoint.Value() : endpoint; }
 
@@ -31579,22 +31578,12 @@ private:
             }
             break;
         case 2:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::DataModel::Nullable<chip::Percent> value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckConstraintMinValue("value", value, 0));
-                VerifyOrReturn(CheckConstraintMaxValue("value", value, 100));
-                attrCurrentPositionLiftPercentage = value;
-            }
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 3:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 4:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
-            break;
-        case 5:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         default:
@@ -31624,14 +31613,7 @@ private:
                                  WindowCovering::Attributes::CurrentPositionLiftPercent100ths::Id);
         }
         case 2: {
-            LogStep(2, "1b: If (PA_LF & LF) TH reads CurrentPositionLiftPercentage from DUT");
-            VerifyOrdo(!ShouldSkip("WNCV_LF && WNCV_PA_LF && A_CURRENTPOSITIONLIFTPERCENTAGE"),
-                       return ContinueOnChipMainThread(CHIP_NO_ERROR));
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), WindowCovering::Id,
-                                 WindowCovering::Attributes::CurrentPositionLiftPercentage::Id);
-        }
-        case 3: {
-            LogStep(3, "2b: TH sends GoToLiftPercentage command with BadParam to DUT");
+            LogStep(2, "2b: TH sends GoToLiftPercentage command with BadParam to DUT");
             VerifyOrdo(!ShouldSkip("WNCV_LF && WNCV_PA_LF || WNCV_LF && CR_GOTOLIFTPERCENTAGE"),
                        return ContinueOnChipMainThread(CHIP_NO_ERROR));
             chip::app::Clusters::WindowCovering::Commands::GoToLiftPercentage::Type value;
@@ -31641,8 +31623,8 @@ private:
             return SendCommand(kIdentityAlpha, GetEndpoint(1), WindowCovering::Id, WindowCovering::Commands::GoToLiftPercentage::Id,
                                value);
         }
-        case 4: {
-            LogStep(4, "3a: TH sends GoToLiftPercentage command with 10001 to DUT");
+        case 3: {
+            LogStep(3, "3a: TH sends GoToLiftPercentage command with 10001 to DUT");
             VerifyOrdo(!ShouldSkip("WNCV_LF && WNCV_PA_LF || WNCV_LF && CR_GOTOLIFTPERCENTAGE"),
                        return ContinueOnChipMainThread(CHIP_NO_ERROR));
             chip::app::Clusters::WindowCovering::Commands::GoToLiftPercentage::Type value;
@@ -31652,8 +31634,8 @@ private:
             return SendCommand(kIdentityAlpha, GetEndpoint(1), WindowCovering::Id, WindowCovering::Commands::GoToLiftPercentage::Id,
                                value);
         }
-        case 5: {
-            LogStep(5, "4a: TH sends GoToLiftPercentage command with 0xFFFF to DUT");
+        case 4: {
+            LogStep(4, "4a: TH sends GoToLiftPercentage command with 0xFFFF to DUT");
             VerifyOrdo(!ShouldSkip("WNCV_LF && WNCV_PA_LF || WNCV_LF && CR_GOTOLIFTPERCENTAGE"),
                        return ContinueOnChipMainThread(CHIP_NO_ERROR));
             chip::app::Clusters::WindowCovering::Commands::GoToLiftPercentage::Type value;


### PR DESCRIPTION
#### Problem

The window covering test suite uses a Nullable value into an expression that validates some test results.

#### Change overview
 * Add supports for `chip::Nullable` into expressions

#### Testing
The test runs but it is failing for now as there is a bug in the window covering cluster. This is why it is disabled. @jmeg-sfy will turn it on soon.