### PR TITLE
Fix NameError when getting the device fails

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -515,7 +515,7 @@ class ChipDeviceController():
                 deviceAvailableCV.wait()
 
         if returnDevice.value is None:
-            raise self._ChipStack.ErrorToException(CHIP_ERROR_INTERNAL)
+            raise RuntimeError("Failed to get connected device!")
         return returnDevice
 
     async def SendCommand(self, nodeid: int, endpoint: int, payload: ClusterObjects.ClusterCommand, responseType=None, timedRequestTimeoutMs: int = None):


### PR DESCRIPTION
CHIP_ERROR_INTERNAL is not defined in this context. Raise
RuntimeException instead.

#### Problem
What is being fixed?  Examples:

```
2022-05-03 08:26:51 1d602ee33d73 chip.DIS[2985] INFO Discovery does not require any more timeouts
  File "/usr/src/connectedhomeip/out/python_env/lib/python3.9/site-packages/chip/ChipDeviceCtrl.py", line 518, in GetConnectedDeviceSync
    raise self._ChipStack.ErrorToException(CHIP_ERROR_INTERNAL)
NameError: name 'CHIP_ERROR_INTERNAL' is not defined
name 'CHIP_ERROR_INTERNAL' is not defined
```


#### Change overview
What's in this PR

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
* If unit tests existed, how were they fixed/modified to prevent this in future?
* If new unit tests are not added, why not?
* If integration tests were added, how do they verify this change?
* If new integration tests are not added, why not?
* If manually tested, what platforms controller and device platforms were manually tested, and how?
* If no testing is required, why not?
