### PR TITLE
Report trust path at startup

### DIFF
--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -335,9 +335,12 @@ ChipError::StorageType pychip_OpCreds_AllocateController(OpCredsContext * contex
     auto devCtrl = std::make_unique<chip::Controller::DeviceCommissioner>();
     VerifyOrReturnError(devCtrl != nullptr, CHIP_ERROR_NO_MEMORY.AsInteger());
 
+    if (paaTrustStorePath == nullptr)
+        paaTrustStorePath = "./credentials/development/paa-root-certs";
+    ChipLogProgress(Support, "Using trust store path %s.", paaTrustStorePath);
+
     // Initialize device attestation verifier
-    const chip::Credentials::AttestationTrustStore * testingRootStore = GetTestFileAttestationTrustStore(
-        paaTrustStorePath == nullptr ? "./credentials/development/paa-root-certs" : paaTrustStorePath);
+    const chip::Credentials::AttestationTrustStore * testingRootStore = GetTestFileAttestationTrustStore(paaTrustStorePath);
     SetDeviceAttestationVerifier(GetDefaultDACVerifier(testingRootStore));
 
     chip::Crypto::P256Keypair ephemeralKey;

--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -337,7 +337,7 @@ ChipError::StorageType pychip_OpCreds_AllocateController(OpCredsContext * contex
 
     if (paaTrustStorePath == nullptr)
         paaTrustStorePath = "./credentials/development/paa-root-certs";
-    ChipLogProgress(Support, "Using trust store path %s.", paaTrustStorePath);
+    ChipLogProgress(Support, "Using device attestation PAA trust store path %s.", paaTrustStorePath);
 
     // Initialize device attestation verifier
     const chip::Credentials::AttestationTrustStore * testingRootStore = GetTestFileAttestationTrustStore(paaTrustStorePath);

--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -336,7 +336,9 @@ ChipError::StorageType pychip_OpCreds_AllocateController(OpCredsContext * contex
     VerifyOrReturnError(devCtrl != nullptr, CHIP_ERROR_NO_MEMORY.AsInteger());
 
     if (paaTrustStorePath == nullptr)
+    {
         paaTrustStorePath = "./credentials/development/paa-root-certs";
+    }
     ChipLogProgress(Support, "Using device attestation PAA trust store path %s.", paaTrustStorePath);
 
     // Initialize device attestation verifier


### PR DESCRIPTION
#### Problem
Inform the user what trust path is used. This helps the user to understand that the `credentials` directory is essential for operation.

* Relates #17981

#### Change overview
What's in this PR

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
* If unit tests existed, how were they fixed/modified to prevent this in future?
* If new unit tests are not added, why not?
* If integration tests were added, how do they verify this change?
* If new integration tests are not added, why not?
* If manually tested, what platforms controller and device platforms were manually tested, and how? Tested on Linux using `chip-device-ctrl`
* If no testing is required, why not?
