### PR TITLE
[Inet] Add locking mechanism in UDPEndpointImplOpenThread

### DIFF
--- a/examples/light-switch-app/efr32/src/main.cpp
+++ b/examples/light-switch-app/efr32/src/main.cpp
@@ -50,7 +50,7 @@
 
 #include <mbedtls/platform.h>
 #if CHIP_ENABLE_OPENTHREAD
-#include <inet/EndpointStateOpenThread.h>
+#include <inet/EndPointStateOpenThread.h>
 #include <openthread/cli.h>
 #include <openthread/dataset.h>
 #include <openthread/error.h>
@@ -188,7 +188,7 @@ int main(void)
     nativeParams.lockCb                = LockOpenThreadTask;
     nativeParams.unlockCb              = UnlockOpenThreadTask;
     nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
-    initParams.networkNativeParams     = static_cast<void *>(&nativeParams);
+    initParams.endpointNativeParams    = static_cast<void *>(&nativeParams);
 #endif
     chip::Server::GetInstance().Init(initParams);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();

--- a/examples/light-switch-app/efr32/src/main.cpp
+++ b/examples/light-switch-app/efr32/src/main.cpp
@@ -50,6 +50,7 @@
 
 #include <mbedtls/platform.h>
 #if CHIP_ENABLE_OPENTHREAD
+#include <inet/EndpointStateOpenThread.h>
 #include <openthread/cli.h>
 #include <openthread/dataset.h>
 #include <openthread/error.h>
@@ -108,7 +109,20 @@ extern "C" void vApplicationIdleHook(void)
     // Check CHIP Config nvm3 and repack flash if necessary.
     Internal::EFR32Config::RepackNvm3Flash();
 }
+#if CHIP_ENABLE_OPENTHREAD
+// ================================================================================
+// Matter Networking Callbacks
+// ================================================================================
+void LockOpenThreadTask(void)
+{
+    chip::DeviceLayer::ThreadStackMgr().LockThreadStack();
+}
 
+void UnlockOpenThreadTask(void)
+{
+    chip::DeviceLayer::ThreadStackMgr().UnlockThreadStack();
+}
+#endif
 // ================================================================================
 // Main Code
 // ================================================================================
@@ -169,6 +183,13 @@ int main(void)
     // Init ZCL Data Model
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+#if CHIP_ENABLE_OPENTHREAD
+    chip::Inet::EndPointStateOpenThread::OpenThreadEndpointInitParam nativeParams;
+    nativeParams.lockCb                = LockOpenThreadTask;
+    nativeParams.unlockCb              = UnlockOpenThreadTask;
+    nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
+    initParams.networkNativeParams     = static_cast<void *>(&nativeParams);
+#endif
     chip::Server::GetInstance().Init(initParams);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 

--- a/examples/lighting-app/efr32/src/main.cpp
+++ b/examples/lighting-app/efr32/src/main.cpp
@@ -54,6 +54,7 @@
 
 #include <mbedtls/platform.h>
 #if CHIP_ENABLE_OPENTHREAD
+#include <inet/EndpointStateOpenThread.h>
 #include <openthread/cli.h>
 #include <openthread/dataset.h>
 #include <openthread/error.h>
@@ -113,6 +114,20 @@ extern "C" void vApplicationIdleHook(void)
     Internal::EFR32Config::RepackNvm3Flash();
 }
 
+#if CHIP_ENABLE_OPENTHREAD
+// ================================================================================
+// Matter Networking Callbacks
+// ================================================================================
+void LockOpenThreadTask(void)
+{
+    chip::DeviceLayer::ThreadStackMgr().LockThreadStack();
+}
+
+void UnlockOpenThreadTask(void)
+{
+    chip::DeviceLayer::ThreadStackMgr().UnlockThreadStack();
+}
+#endif
 // ================================================================================
 // Main Code
 // ================================================================================
@@ -173,6 +188,13 @@ int main(void)
     // Init ZCL Data Model
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+#if CHIP_ENABLE_OPENTHREAD
+    chip::Inet::EndPointStateOpenThread::OpenThreadEndpointInitParam nativeParams;
+    nativeParams.lockCb                = LockOpenThreadTask;
+    nativeParams.unlockCb              = UnlockOpenThreadTask;
+    nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
+    initParams.networkNativeParams     = static_cast<void *>(&nativeParams);
+#endif
     chip::Server::GetInstance().Init(initParams);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 

--- a/examples/lighting-app/efr32/src/main.cpp
+++ b/examples/lighting-app/efr32/src/main.cpp
@@ -54,7 +54,7 @@
 
 #include <mbedtls/platform.h>
 #if CHIP_ENABLE_OPENTHREAD
-#include <inet/EndpointStateOpenThread.h>
+#include <inet/EndPointStateOpenThread.h>
 #include <openthread/cli.h>
 #include <openthread/dataset.h>
 #include <openthread/error.h>
@@ -193,7 +193,7 @@ int main(void)
     nativeParams.lockCb                = LockOpenThreadTask;
     nativeParams.unlockCb              = UnlockOpenThreadTask;
     nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
-    initParams.networkNativeParams     = static_cast<void *>(&nativeParams);
+    initParams.endpointNativeParams    = static_cast<void *>(&nativeParams);
 #endif
     chip::Server::GetInstance().Init(initParams);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();

--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -35,6 +35,8 @@
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 
+#include <inet/EndpointStateOpenThread.h>
+
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
 
@@ -70,6 +72,16 @@ AppTask AppTask::sAppTask;
 
 namespace {
 constexpr int extDiscTimeoutSecs = 20;
+}
+
+void LockOpenThreadTask(void)
+{
+    chip::DeviceLayer::ThreadStackMgr().LockThreadStack();
+}
+
+void UnlockOpenThreadTask(void)
+{
+    chip::DeviceLayer::ThreadStackMgr().UnlockThreadStack();
 }
 
 CHIP_ERROR AppTask::StartAppTask()
@@ -115,6 +127,11 @@ CHIP_ERROR AppTask::Init()
     // Init ZCL Data Model
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    chip::Inet::EndPointStateOpenThread::OpenThreadEndpointInitParam nativeParams;
+    nativeParams.lockCb                = LockOpenThreadTask;
+    nativeParams.unlockCb              = UnlockOpenThreadTask;
+    nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
+    initParams.networkNativeParams     = static_cast<void *>(&nativeParams);
     chip::Server::GetInstance().Init(initParams);
 
     // Init OTA engine

--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -35,7 +35,7 @@
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 
-#include <inet/EndpointStateOpenThread.h>
+#include <inet/EndPointStateOpenThread.h>
 
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
@@ -131,7 +131,7 @@ CHIP_ERROR AppTask::Init()
     nativeParams.lockCb                = LockOpenThreadTask;
     nativeParams.unlockCb              = UnlockOpenThreadTask;
     nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
-    initParams.networkNativeParams     = static_cast<void *>(&nativeParams);
+    initParams.endpointNativeParams    = static_cast<void *>(&nativeParams);
     chip::Server::GetInstance().Init(initParams);
 
     // Init OTA engine

--- a/examples/lock-app/efr32/src/main.cpp
+++ b/examples/lock-app/efr32/src/main.cpp
@@ -54,7 +54,7 @@
 
 #include <mbedtls/platform.h>
 #if CHIP_ENABLE_OPENTHREAD
-#include <inet/EndpointStateOpenThread.h>
+#include <inet/EndPointStateOpenThread.h>
 #include <openthread/cli.h>
 #include <openthread/dataset.h>
 #include <openthread/error.h>
@@ -192,7 +192,7 @@ int main(void)
     nativeParams.lockCb                = LockOpenThreadTask;
     nativeParams.unlockCb              = UnlockOpenThreadTask;
     nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
-    initParams.networkNativeParams     = static_cast<void *>(&nativeParams);
+    initParams.endpointNativeParams    = static_cast<void *>(&nativeParams);
 #endif
     chip::Server::GetInstance().Init(initParams);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -35,7 +35,7 @@
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 
-#include <inet/EndpointStateOpenThread.h>
+#include <inet/EndPointStateOpenThread.h>
 
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
@@ -135,7 +135,7 @@ CHIP_ERROR AppTask::Init()
     nativeParams.lockCb                = LockOpenThreadTask;
     nativeParams.unlockCb              = UnlockOpenThreadTask;
     nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
-    initParams.networkNativeParams     = static_cast<void *>(&nativeParams);
+    initParams.endpointNativeParams    = static_cast<void *>(&nativeParams);
     chip::Server::GetInstance().Init(initParams);
 
     // Init OTA engine

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -35,6 +35,8 @@
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 
+#include <inet/EndpointStateOpenThread.h>
+
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
 
@@ -72,6 +74,16 @@ AppTask AppTask::sAppTask;
 
 namespace {
 constexpr int extDiscTimeoutSecs = 20;
+}
+
+void LockOpenThreadTask(void)
+{
+    chip::DeviceLayer::ThreadStackMgr().LockThreadStack();
+}
+
+void UnlockOpenThreadTask(void)
+{
+    chip::DeviceLayer::ThreadStackMgr().UnlockThreadStack();
 }
 
 CHIP_ERROR AppTask::StartAppTask()
@@ -119,6 +131,11 @@ CHIP_ERROR AppTask::Init()
     // Init ZCL Data Model
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    chip::Inet::EndPointStateOpenThread::OpenThreadEndpointInitParam nativeParams;
+    nativeParams.lockCb                = LockOpenThreadTask;
+    nativeParams.unlockCb              = UnlockOpenThreadTask;
+    nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
+    initParams.networkNativeParams     = static_cast<void *>(&nativeParams);
     chip::Server::GetInstance().Init(initParams);
 
     // Init OTA engine

--- a/examples/window-app/efr32/src/main.cpp
+++ b/examples/window-app/efr32/src/main.cpp
@@ -30,7 +30,7 @@
 
 #include <mbedtls/platform.h>
 #if CHIP_ENABLE_OPENTHREAD
-#include <inet/EndpointStateOpenThread.h>
+#include <inet/EndPointStateOpenThread.h>
 #include <openthread/cli.h>
 #include <openthread/dataset.h>
 #include <openthread/error.h>
@@ -164,7 +164,7 @@ int main(void)
     nativeParams.lockCb                = LockOpenThreadTask;
     nativeParams.unlockCb              = UnlockOpenThreadTask;
     nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
-    initParams.networkNativeParams     = static_cast<void *>(&nativeParams);
+    initParams.endpointNativeParams    = static_cast<void *>(&nativeParams);
 #endif
     chip::Server::GetInstance().Init(initParams);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();

--- a/examples/window-app/efr32/src/main.cpp
+++ b/examples/window-app/efr32/src/main.cpp
@@ -30,6 +30,7 @@
 
 #include <mbedtls/platform.h>
 #if CHIP_ENABLE_OPENTHREAD
+#include <inet/EndpointStateOpenThread.h>
 #include <openthread/cli.h>
 #include <openthread/dataset.h>
 #include <openthread/error.h>
@@ -84,7 +85,20 @@ void appError(CHIP_ERROR err)
     while (1)
         ;
 }
+#if CHIP_ENABLE_OPENTHREAD
+// ================================================================================
+// Matter Networking Callbacks
+// ================================================================================
+void LockOpenThreadTask(void)
+{
+    chip::DeviceLayer::ThreadStackMgr().LockThreadStack();
+}
 
+void UnlockOpenThreadTask(void)
+{
+    chip::DeviceLayer::ThreadStackMgr().UnlockThreadStack();
+}
+#endif
 // ================================================================================
 // Main Code
 // ================================================================================
@@ -145,6 +159,13 @@ int main(void)
     // Init ZCL Data Model
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+#if CHIP_ENABLE_OPENTHREAD
+    chip::Inet::EndPointStateOpenThread::OpenThreadEndpointInitParam nativeParams;
+    nativeParams.lockCb                = LockOpenThreadTask;
+    nativeParams.unlockCb              = UnlockOpenThreadTask;
+    nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
+    initParams.networkNativeParams     = static_cast<void *>(&nativeParams);
+#endif
     chip::Server::GetInstance().Init(initParams);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -155,7 +155,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     err = mTransports.Init(UdpListenParameters(DeviceLayer::UDPEndPointManager())
                                .SetAddressType(IPAddressType::kIPv6)
                                .SetListenPort(mOperationalServicePort)
-                               .SetNativeParams(initParams.networkNativeParams)
+                               .SetNativeParams(initParams.endpointNativeParams)
 
 #if INET_CONFIG_ENABLE_IPV4
                                ,

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -155,9 +155,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     err = mTransports.Init(UdpListenParameters(DeviceLayer::UDPEndPointManager())
                                .SetAddressType(IPAddressType::kIPv6)
                                .SetListenPort(mOperationalServicePort)
-#if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
-                               .SetNativeParams(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance())
-#endif // CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
+                               .SetNativeParams(initParams.networkNativeParams)
 
 #if INET_CONFIG_ENABLE_IPV4
                                ,

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -98,6 +98,9 @@ struct ServerInitParams
     // Access control delegate: MUST be injected. Used to look up access control rules. Must be
     // initialized before being provided
     Access::AccessControl::Delegate * accessDelegate = nullptr;
+    // Network native params can be injected depending on the
+    // selected Endpoint implementation
+    void * networkNativeParams = nullptr;
 };
 
 /**

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -100,7 +100,7 @@ struct ServerInitParams
     Access::AccessControl::Delegate * accessDelegate = nullptr;
     // Network native params can be injected depending on the
     // selected Endpoint implementation
-    void * networkNativeParams = nullptr;
+    void * endpointNativeParams = nullptr;
 };
 
 /**

--- a/src/inet/EndPointStateOpenThread.h
+++ b/src/inet/EndPointStateOpenThread.h
@@ -34,6 +34,15 @@ namespace Inet {
  */
 class DLL_EXPORT EndPointStateOpenThread
 {
+public:
+    typedef void (*openThreadTaskSyncCb)(void);
+    struct OpenThreadEndpointInitParam
+    {
+        openThreadTaskSyncCb lockCb        = nullptr;
+        openThreadTaskSyncCb unlockCb      = nullptr;
+        otInstance * openThreadInstancePtr = nullptr;
+    };
+
 protected:
     EndPointStateOpenThread() : mOpenThreadEndPointType(OpenThreadEndPointType::Unknown) {}
 
@@ -43,6 +52,21 @@ protected:
         UDP     = 1,
         TCP     = 2
     } mOpenThreadEndPointType;
+
+    void LockOpenThread(void)
+    {
+        if (lockOpenThread != nullptr)
+            lockOpenThread();
+    }
+    void UnlockOpenThread(void)
+    {
+        if (unlockOpenThread != nullptr)
+            unlockOpenThread();
+    }
+
+    otInstance * mOTInstance              = nullptr;
+    openThreadTaskSyncCb lockOpenThread   = nullptr;
+    openThreadTaskSyncCb unlockOpenThread = nullptr;
 };
 
 } // namespace Inet

--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -270,7 +270,7 @@ otIp6Address IPAddress::ToIPv6() const
     return otAddr;
 }
 
-IPAddress IPAddress::FromOtAddr(otIp6Address & address)
+IPAddress IPAddress::FromOtAddr(const otIp6Address & address)
 {
     IPAddress addr;
     static_assert(sizeof(address.mFields.m32) == sizeof(addr), "otIp6Address size mismatch");

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -547,7 +547,7 @@ public:
 
 #if CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
     otIp6Address ToIPv6() const;
-    static IPAddress FromOtAddr(otIp6Address & address);
+    static IPAddress FromOtAddr(const otIp6Address & address);
 #endif // CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 
     /**

--- a/src/inet/UDPEndPointImplOpenThread.cpp
+++ b/src/inet/UDPEndPointImplOpenThread.cpp
@@ -177,7 +177,7 @@ void UDPEndPointImplOT::SetNativeParams(void * params)
 {
     if (params == nullptr)
     {
-        ChipLogError(Inet, "FATAL!! Failed to provide OtInstance!!!!!");
+        ChipLogError(Inet, "FATAL!! No native parameters provided!!!!!");
         VerifyOrDie(false);
     }
 

--- a/src/inet/UDPEndPointImplOpenThread.cpp
+++ b/src/inet/UDPEndPointImplOpenThread.cpp
@@ -50,8 +50,8 @@ void UDPEndPointImplOT::handleUdpReceive(void * aContext, otMessage * aMessage, 
         return;
     }
 
-    pktInfo.SrcAddress  = chip::DeviceLayer::Internal::ToIPAddress(aMessageInfo->mPeerAddr);
-    pktInfo.DestAddress = chip::DeviceLayer::Internal::ToIPAddress(aMessageInfo->mSockAddr);
+    pktInfo.SrcAddress  = IPAddress::FromOtAddr(aMessageInfo->mPeerAddr);
+    pktInfo.DestAddress = IPAddress::FromOtAddr(aMessageInfo->mSockAddr);
     pktInfo.SrcPort     = aMessageInfo->mPeerPort;
     pktInfo.DestPort    = aMessageInfo->mSockPort;
 
@@ -108,10 +108,12 @@ CHIP_ERROR UDPEndPointImplOT::IPv6Bind(otUdpSocket & socket, const IPAddress & a
     memset(&listenSockAddr, 0, sizeof(listenSockAddr));
 
     listenSockAddr.mPort    = port;
-    listenSockAddr.mAddress = chip::DeviceLayer::Internal::ToOpenThreadIP6Address(address);
+    listenSockAddr.mAddress = address.ToIPv6();
 
+    LockOpenThread();
     otUdpOpen(mOTInstance, &socket, handleUdpReceive, this);
     otUdpBind(mOTInstance, &socket, &listenSockAddr, OT_NETIF_THREAD);
+    UnlockOpenThread();
 
     return chip::DeviceLayer::Internal::MapOpenThreadError(err);
 }
@@ -173,8 +175,18 @@ void UDPEndPointImplOT::HandleDataReceived(System::PacketBufferHandle && msg)
 
 void UDPEndPointImplOT::SetNativeParams(void * params)
 {
-    mOTInstance      = static_cast<otInstance *>(params);
-    globalOtInstance = mOTInstance;
+    if (params == nullptr)
+    {
+        ChipLogError(Inet, "FATAL!! Failed to provide OtInstance!!!!!");
+        VerifyOrDie(false);
+    }
+
+    OpenThreadEndpointInitParam * initParams = static_cast<OpenThreadEndpointInitParam *>(params);
+    mOTInstance                              = initParams->openThreadInstancePtr;
+    globalOtInstance                         = mOTInstance;
+
+    lockOpenThread   = initParams->lockCb;
+    unlockOpenThread = initParams->unlockCb;
 }
 
 CHIP_ERROR UDPEndPointImplOT::SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback)
@@ -203,10 +215,11 @@ CHIP_ERROR UDPEndPointImplOT::SendMsgImpl(const IPPacketInfo * aPktInfo, System:
 
     memset(&messageInfo, 0, sizeof(messageInfo));
 
-    messageInfo.mSockAddr = chip::DeviceLayer::Internal::ToOpenThreadIP6Address(aPktInfo->SrcAddress);
-    messageInfo.mPeerAddr = chip::DeviceLayer::Internal::ToOpenThreadIP6Address(aPktInfo->DestAddress);
+    messageInfo.mSockAddr = aPktInfo->SrcAddress.ToIPv6();
+    messageInfo.mPeerAddr = aPktInfo->DestAddress.ToIPv6();
     messageInfo.mPeerPort = aPktInfo->DestPort;
 
+    LockOpenThread();
     message = otUdpNewMessage(mOTInstance, NULL);
     VerifyOrExit(message != NULL, error = OT_ERROR_NO_BUFS);
 
@@ -223,15 +236,19 @@ exit:
         otMessageFree(message);
     }
 
+    UnlockOpenThread();
+
     return chip::DeviceLayer::Internal::MapOpenThreadError(error);
 }
 
 void UDPEndPointImplOT::CloseImpl()
 {
+    LockOpenThread();
     if (otUdpIsOpen(mOTInstance, &mSocket))
     {
         otUdpClose(mOTInstance, &mSocket);
     }
+    UnlockOpenThread();
 }
 
 void UDPEndPointImplOT::Free()
@@ -242,16 +259,22 @@ void UDPEndPointImplOT::Free()
 
 CHIP_ERROR UDPEndPointImplOT::IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join)
 {
-    const otIp6Address otAddress = chip::DeviceLayer::Internal::ToOpenThreadIP6Address(aAddress);
+    const otIp6Address otAddress = aAddress.ToIPv6();
+    otError err;
 
+    LockOpenThread();
     if (join)
     {
-        return chip::DeviceLayer::Internal::MapOpenThreadError(otIp6SubscribeMulticastAddress(mOTInstance, &otAddress));
+        err = otIp6SubscribeMulticastAddress(mOTInstance, &otAddress);
     }
     else
     {
-        return chip::DeviceLayer::Internal::MapOpenThreadError(otIp6UnsubscribeMulticastAddress(mOTInstance, &otAddress));
+        err = otIp6UnsubscribeMulticastAddress(mOTInstance, &otAddress);
     }
+
+    UnlockOpenThread();
+
+    return chip::DeviceLayer::Internal::MapOpenThreadError(err);
 }
 
 IPPacketInfo * UDPEndPointImplOT::GetPacketInfo(const System::PacketBufferHandle & aBuffer)

--- a/src/inet/UDPEndPointImplOpenThread.h
+++ b/src/inet/UDPEndPointImplOpenThread.h
@@ -65,7 +65,6 @@ private:
     InterfaceId mBoundIntfId;
     uint16_t mBoundPort;
     otUdpSocket mSocket;
-    otInstance * mOTInstance = nullptr;
 };
 
 using UDPEndPointImpl = UDPEndPointImplOT;


### PR DESCRIPTION
Problem
Locking is needed to prevent segmentation fault should the UDPEndpoint be deleted while the OpenThread stack is still processing an incoming message.

Since there is not Global locking API within the OpenThread stack, a custom API needs to be implemented for the Matter use case

Change overview
Implement a locking mechanism to prevent the use of a deleted Endpoint in the reception callback.

Testing
Tested on EFR32 platform