### PR TITLE
Fix BLE device name for qpg and EFR32 to match the other platforms.

### DIFF
--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -500,7 +500,7 @@
  * CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX
  *
  * A prefix string used in forming the BLE device name.  The remainder of the name
- * consists of the final two bytes of the device's chip node id in hex.
+ * typically contains the setup discriminator as a 4-digit decimal number.
  *
  * NOTE: The device layer limits the total length of a device name to 16 characters.
  * However, due to other data sent in CHIPoBLE advertise packets, the device name

--- a/src/platform/EFR32/BLEManagerImpl.cpp
+++ b/src/platform/EFR32/BLEManagerImpl.cpp
@@ -37,7 +37,9 @@
 #include <ble/CHIPBleServiceData.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/CommissionableDataProvider.h>
 #include <platform/EFR32/freertos_bluetooth.h>
+
 using namespace ::chip;
 using namespace ::chip::Ble;
 
@@ -650,7 +652,10 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
 
     if (!mFlags.Has(Flags::kDeviceNameSet))
     {
-        snprintf(mDeviceName, sizeof(mDeviceName), "%s%04" PRIX32, CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, (uint32_t) 0);
+        uint16_t discriminator;
+        SuccessOrExit(err = GetCommissionableDataProvider()->GetSetupDiscriminator(discriminator));
+
+        snprintf(mDeviceName, sizeof(mDeviceName), "%s%04u", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);
 
         mDeviceName[kMaxDeviceNameLength] = 0;
         mDeviceNameLength                 = strlen(mDeviceName);

--- a/src/platform/qpg/BLEManagerImpl.cpp
+++ b/src/platform/qpg/BLEManagerImpl.cpp
@@ -27,6 +27,7 @@
 
 #include <ble/BleUUID.h>
 #include <ble/CHIPBleServiceData.h>
+#include <platform/CommissionableDataProvider.h>
 #include <platform/internal/BLEManager.h>
 
 #include <lib/support/CodeUtils.h>
@@ -459,7 +460,10 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
 
     if (!mFlags.Has(Flags::kDeviceNameSet))
     {
-        snprintf(deviceName, sizeof(deviceName), "%s%04" PRIX32, CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, (uint32_t) 0);
+        uint16_t discriminator;
+        SuccessOrExit(err = GetCommissionableDataProvider()->GetSetupDiscriminator(discriminator));
+
+        snprintf(deviceName, sizeof(deviceName), "%s%04u", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);
 
         deviceName[kMaxDeviceNameLength] = 0;
         err                              = MapBLEError(qvCHIP_BleSetDeviceName(deviceName));


### PR DESCRIPTION
These had hardcoded 0, while other platforms use the discriminator.

Fixes https://github.com/project-chip/connectedhomeip/issues/112

#### Problem
See above.

#### Change overview
See above.

#### Testing
Not clear how to test this, apart from CI compilation testing.