### PR TITLE
Chef Refactor

### DIFF
--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -19,6 +19,7 @@ import optparse
 import os
 import sys
 import textwrap
+from typing import Sequence
 import yaml
 
 import constants
@@ -37,7 +38,7 @@ _DEVICE_LIST = [file[:-4] for file in os.listdir(_DEVICE_FOLDER) if file.endswit
 gen_dir = ""  # Filled in after sample app type is read from args.
 
 
-def splash():
+def splash() -> None:
     splashText = textwrap.dedent(
         f"""\
         {TermColors.STRBOLD}{TermColors.STRYELLOW}
@@ -51,7 +52,7 @@ def splash():
     print(splashText)
 
 
-def load_config():
+def load_config() -> None:
     config = dict()
     config["nrfconnect"] = dict()
     config["esp32"] = dict()
@@ -77,14 +78,14 @@ def load_config():
     return config
 
 
-def check_python_version():
+def check_python_version() -> None:
     if sys.version_info[0] < 3:
         print('Must use Python 3. Current version is ' +
               str(sys.version_info[0]))
         exit(1)
 
 
-def main(argv):
+def main(argv: Sequence[str]) -> None:
     check_python_version()
     config = load_config()
 

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -19,6 +19,7 @@ import optparse
 import os
 from pathlib import Path
 import sys
+import textwrap
 import yaml
 
 import constants
@@ -34,15 +35,17 @@ shell = stateful_shell.StatefulShell()
 
 
 def splash():
-    splashText = TermColors.STRBOLD + TermColors.STRYELLOW + '''\
-  ______  __    __   _______  _______
- /      ||  |  |  | |   ____||   ____|
-|  ,----'|  |__|  | |  |__   |  |__
-|  |     |   __   | |   __|  |   __|
-|  `----.|  |  |  | |  |____ |  |
- \\______||__|  |__| |_______||__|\
-''' + TermColors.STRRESET
-    return splash
+    splashText = textwrap.dedent(
+        f"""\
+        {TermColors.STRBOLD}{TermColors.STRYELLOW}
+          ______  __    __   _______  _______
+         /      ||  |  |  | |   ____||   ____|
+        |  ,----'|  |__|  | |  |__   |  |__
+        |  |     |   __   | |   __|  |   __|
+        |  `----.|  |  |  | |  |____ |  |
+         \\______||__|  |__| |_______||__|{TermColors.STRRESET}
+        """)
+    print(splashText)
 
 
 def printc(strInput):

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -51,11 +51,6 @@ def splash():
     print(splashText)
 
 
-def printc(strInput):
-    color = TermColors.STRCYAN
-    print(color + strInput + TermColors.STRRESET)
-
-
 def loadConfig():
     config = dict()
     config["nrfconnect"] = dict()
@@ -92,9 +87,6 @@ def checkPythonVersion():
 def main(argv):
     checkPythonVersion()
     config = loadConfig()
-
-    global myEnv
-    myEnv = os.environ.copy()
 
     #
     # Build environment switches

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -17,20 +17,20 @@
 import sys
 import optparse
 import os
-import subprocess
 from pathlib import Path
-from sys import platform
+import sys
 import yaml
+
+import constants
+import stateful_shell
+
 
 global commandQueue
 commandQueue = ""
 
+TermColors = constants.TermColors
 
-class TermColors:
-    STRBOLD = '\033[1m'
-    STRRESET = '\033[0m'
-    STRCYAN = '\033[1;36m'
-    STRYELLOW = '\033[1;33m'
+shell = stateful_shell.StatefulShell()
 
 
 def splash():
@@ -111,9 +111,8 @@ def queueCommand(command):
 
 
 def execQueue():
-    global commandQueue
-    subprocess.run(commandQueue, shell=True, executable=shellApp)
-    commandQueue = ""
+    for command in commandQueue.split("; "):
+        shell.run_cmd(command)
 
 
 def hexInputToInt(valIn):
@@ -143,12 +142,7 @@ def main(argv):
     # Build environment switches
     #
 
-    global shellApp
-    if platform == "linux" or platform == "linux2":
-        shellApp = '/bin/bash'
-    elif platform == "darwin":
-        shellApp = '/bin/zsh'
-    elif platform == "win32":
+    if sys.platform == "win32":
         print('Windows is currently not supported. Use Linux or MacOS platforms')
         exit(1)
 
@@ -266,12 +260,12 @@ Notes:
     #
 
     if options.doBootstrapZap:
-        if platform == "linux" or platform == "linux2":
+        if sys.platform == "linux" or sys.platform == "linux2":
             queuePrint("Installing ZAP OS package dependencies")
             queueCommand(f"sudo apt-get install sudo apt-get install node node-yargs npm libpixman-1-dev libcairo2-dev libpango1.0-dev node-pre-gyp libjpeg9-dev libgif-dev node-typescript")
-        if platform == "darwin":
+        if sys.platform == "darwin":
             queuePrint("Installation of ZAP OS packages not supported on MacOS")
-        if platform == "win32":
+        if sys.platform == "win32":
             queuePrint(
                 "Installation of ZAP OS packages not supported on Windows")
 

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -155,20 +155,21 @@ def main(argv):
 
     deviceTypes = "\n    ".join(paths["devices"])
 
-    usage = f'''usage: chef.py [options]
+    usage = textwrap.dedent(f"""\
+        usage: chef.py [options]
 
-Platforms:
-    nrfconnect
-    esp32
-    linux
+        Platforms:
+            nrfconnect
+            esp32
+            linux
 
-Device Types:
-    {deviceTypes}
+        Device Types:
+            {deviceTypes}
 
-Notes:
-- Whenever you change a device type, make sure to also use options -zbe
-- Be careful if you have more than one device connected. The script assumes you have only one device connected and might flash the wrong one\
-'''
+        Notes:
+        - Whenever you change a device type, make sure to also use options -zbe
+        - Be careful if you have more than one device connected. The script assumes you have only one device connected and might flash the wrong one\
+        """)
     parser = optparse.OptionParser(usage=usage)
 
     parser.add_option("-u", "--update_toolchain", help="updates toolchain & installs zap",
@@ -330,14 +331,14 @@ Notes:
         queueCommand(f"cd {paths['rootSampleFolder']}")
 
         if (options.buildTarget == "esp32") or (options.buildTarget == "nrfconnect"):
-            queueCommand(f'''
-cat > project_include.cmake <<EOF
-set(CONFIG_DEVICE_VENDOR_ID {options.vid})
-set(CONFIG_DEVICE_PRODUCT_ID {options.pid})
-set(CONFIG_ENABLE_PW_RPC {"1" if options.doRPC else "0"})
-set(SAMPLE_NAME {options.sampleDeviceTypeName})
-EOF
-true''')
+            queueCommand(textwrap.dedent(f"""\
+                    cat > project_include.cmake <<EOF
+                    set(CONFIG_DEVICE_VENDOR_ID {options.vid})
+                    set(CONFIG_DEVICE_PRODUCT_ID {options.pid})
+                    set(CONFIG_ENABLE_PW_RPC {"1" if options.doRPC else "0"})
+                    set(SAMPLE_NAME {options.sampleDeviceTypeName})
+                    EOF
+                    true"""))
 
         if options.buildTarget == "esp32":
             queueCommand(f"cd {paths['rootSampleFolder']}/esp32")
@@ -356,19 +357,19 @@ true''')
                 queueCommand(f"west build -b nrf52840dk_nrf52840")
         elif options.buildTarget == "linux":
             queueCommand(f"cd {paths['rootSampleFolder']}/linux")
-            queueCommand(f'''
-cat > args.gni <<EOF
-import("//build_overrides/chip.gni")
-import("\\${{chip_root}}/config/standalone/args.gni")
-chip_shell_cmd_server = false
-target_defines = ["CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID={options.vid}", "CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID={options.pid}", "CONFIG_ENABLE_PW_RPC={'1' if options.doRPC else '0'}"]
-EOF
+            queueCommand(textwrap.dedent(f"""\
+                    cat > args.gni <<EOF
+                    import("//build_overrides/chip.gni")
+                    import("\\${{chip_root}}/config/standalone/args.gni")
+                    chip_shell_cmd_server = false
+                    target_defines = ["CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID={options.vid}", "CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID={options.pid}", "CONFIG_ENABLE_PW_RPC={'1' if options.doRPC else '0'}"]
+                    EOF
 
-cat > sample.gni <<EOF
-sample_zap_file = "{options.sampleDeviceTypeName}.zap"
-sample_name = "{options.sampleDeviceTypeName}"
-EOF
-true''')
+                    cat > sample.gni <<EOF
+                    sample_zap_file = "{options.sampleDeviceTypeName}.zap"
+                    sample_name = "{options.sampleDeviceTypeName}"
+                    EOF
+                    true"""))
             if options.doClean:
                 queueCommand(f"rm -rf out")
             queueCommand("gn gen out")

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -89,21 +89,6 @@ def checkPythonVersion():
         exit(1)
 
 
-def hexInputToInt(valIn):
-    '''Parses inputs as hexadecimal numbers, takes into account optional 0x
-       prefix
-    '''
-    if (type(valIn) is str):
-        if (valIn[0:2].lower() == "0x"):
-            valOut = valIn[2:]
-        else:
-            valOut = valIn
-        valOut = int(valOut, 16)
-    else:
-        valOut = valIn
-    return valOut
-
-
 def main(argv):
     checkPythonVersion()
     config = loadConfig()
@@ -172,9 +157,9 @@ def main(argv):
                       metavar="TARGET",
                       default="esp32")
     parser.add_option("-r", "--rpc", help="enables Pigweed RPC interface. Enabling RPC disables the shell interface. Your sdkconfig configurations will be reverted to default. Default is PW RPC off. When enabling or disabling this flag, on the first build force a clean build with -c", action="store_true", dest="doRPC")
-    parser.add_option("-v", "--vid", dest="vid",
+    parser.add_option("-v", "--vid", dest="vid", type=int,
                       help="specifies the Vendor ID. Default is 0xFFF1", metavar="VID", default=0xFFF1)
-    parser.add_option("-p", "--pid", dest="pid",
+    parser.add_option("-p", "--pid", dest="pid", type=int,
                       help="specifies the Product ID. Default is 0x8000", metavar="PID", default=0x8000)
     parser.add_option("", "--rpc_console", help="Opens PW RPC Console",
                       action="store_true", dest="doRPC_CONSOLE")
@@ -295,8 +280,6 @@ def main(argv):
             print("RPC PW disabled")
             shell.run_cmd(
                 f"export SDKCONFIG_DEFAULTS={_CHEF_SCRIPT_PATH}/esp32/sdkconfig.defaults")
-        options.vid = hexInputToInt(options.vid)
-        options.pid = hexInputToInt(options.pid)
         print(
             f"Product ID 0x{options.pid:02X} / Vendor ID 0x{options.vid:02X}")
         shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}")

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -310,14 +310,12 @@ def main(argv):
         shell.run_cmd(f"cd {paths['rootSampleFolder']}")
 
         if (options.buildTarget == "esp32") or (options.buildTarget == "nrfconnect"):
-            shell.run_cmd(textwrap.dedent(f"""\
-                    cat > project_include.cmake <<EOF
-                    set(CONFIG_DEVICE_VENDOR_ID {options.vid})
-                    set(CONFIG_DEVICE_PRODUCT_ID {options.pid})
-                    set(CONFIG_ENABLE_PW_RPC {"1" if options.doRPC else "0"})
-                    set(SAMPLE_NAME {options.sampleDeviceTypeName})
-                    EOF
-                    true"""))
+            with open("project_include.cmake", "w") as f:
+                f.write(textwrap.dedent(f"""\
+                        set(CONFIG_DEVICE_VENDOR_ID {options.vid})
+                        set(CONFIG_DEVICE_PRODUCT_ID {options.pid})
+                        set(CONFIG_ENABLE_PW_RPC {"1" if options.doRPC else "0"})
+                        set(SAMPLE_NAME {options.sampleDeviceTypeName})"""))
 
         if options.buildTarget == "esp32":
             shell.run_cmd(f"cd {paths['rootSampleFolder']}/esp32")
@@ -336,19 +334,18 @@ def main(argv):
                 shell.run_cmd("west build -b nrf52840dk_nrf52840")
         elif options.buildTarget == "linux":
             shell.run_cmd(f"cd {paths['rootSampleFolder']}/linux")
-            shell.run_cmd(textwrap.dedent(f"""\
-                    cat > args.gni <<EOF
-                    import("//build_overrides/chip.gni")
-                    import("\\${{chip_root}}/config/standalone/args.gni")
-                    chip_shell_cmd_server = false
-                    target_defines = ["CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID={options.vid}", "CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID={options.pid}", "CONFIG_ENABLE_PW_RPC={'1' if options.doRPC else '0'}"]
-                    EOF
-
-                    cat > sample.gni <<EOF
-                    sample_zap_file = "{options.sampleDeviceTypeName}.zap"
-                    sample_name = "{options.sampleDeviceTypeName}"
-                    EOF
-                    true"""))
+            with open(f"{paths['rootSampleFolder']}/linux/args.gni", "w") as f:
+                f.write(textwrap.dedent(f"""\
+                        import("//build_overrides/chip.gni")
+                        import("\\${{chip_root}}/config/standalone/args.gni")
+                        chip_shell_cmd_server = false
+                        target_defines = ["CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID={options.vid}", "CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID={options.pid}", "CONFIG_ENABLE_PW_RPC={'1' if options.doRPC else '0'}"]
+                        """))
+            with open(f"{paths['rootSampleFolder']}/linux/sample.gni", "w") as f:
+                f.write(textwrap.dedent(f"""\
+                        sample_zap_file = "{options.sampleDeviceTypeName}.zap"
+                        sample_name = "{options.sampleDeviceTypeName}"
+                        """))
             if options.doClean:
                 shell.run_cmd(f"rm -rf out")
             shell.run_cmd("gn gen out")

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -51,7 +51,7 @@ def splash():
     print(splashText)
 
 
-def loadConfig():
+def load_config():
     config = dict()
     config["nrfconnect"] = dict()
     config["esp32"] = dict()
@@ -77,7 +77,7 @@ def loadConfig():
     return config
 
 
-def checkPythonVersion():
+def check_python_version():
     if sys.version_info[0] < 3:
         print('Must use Python 3. Current version is ' +
               str(sys.version_info[0]))
@@ -85,8 +85,8 @@ def checkPythonVersion():
 
 
 def main(argv):
-    checkPythonVersion()
-    config = loadConfig()
+    check_python_version()
+    config = load_config()
 
     #
     # Build environment switches
@@ -120,41 +120,41 @@ def main(argv):
     parser = optparse.OptionParser(usage=usage)
 
     parser.add_option("-u", "--update_toolchain", help="updates toolchain & installs zap",
-                      action="store_true", dest="doUpdateToolchain")
+                      action="store_true", dest="do_update_toolchain")
     parser.add_option("-b", "--build", help="builds",
-                      action="store_true", dest="doBuild")
+                      action="store_true", dest="do_build")
     parser.add_option("-c", "--clean", help="clean build. Only valid if also building",
-                      action="store_true", dest="doClean")
+                      action="store_true", dest="do_clean")
     parser.add_option("-f", "--flash", help="flashes device",
-                      action="store_true", dest="doFlash")
+                      action="store_true", dest="do_flash")
     parser.add_option("-e", "--erase", help="erases flash before flashing. Only valid if also flashing",
-                      action="store_true", dest="doErase")
+                      action="store_true", dest="do_erase")
     parser.add_option("-i", "--terminal", help="opens terminal to interact with with device",
-                      action="store_true", dest="doInteract")
+                      action="store_true", dest="do_interact")
     parser.add_option("-m", "--menuconfig", help="runs menuconfig on platforms that support it",
-                      action="store_true", dest="doMenuconfig")
+                      action="store_true", dest="do_menuconfig")
     parser.add_option("", "--bootstrap_zap", help="installs zap dependencies",
-                      action="store_true", dest="doBootstrapZap")
+                      action="store_true", dest="do_bootstrap_zap")
     parser.add_option("-z", "--zap", help="runs zap to generate data model & interaction model artifacts",
-                      action="store_true", dest="doRunZap")
+                      action="store_true", dest="do_run_zap")
     parser.add_option("-g", "--zapgui", help="runs zap GUI display to allow editing of data model",
-                      action="store_true", dest="doRunGui")
-    parser.add_option("-d", "--device", dest="sampleDeviceTypeName",
+                      action="store_true", dest="do_run_gui")
+    parser.add_option("-d", "--device", dest="sample_device_type_name",
                       help="specifies device type. Default is lighting. See info above for supported device types", metavar="TARGET", default="lighting")
     parser.add_option("-t", "--target", type='choice',
                       action='store',
-                      dest="buildTarget",
+                      dest="build_target",
                       help="specifies target platform. Default is esp32. See info below for currently supported target platforms",
                       choices=['nrfconnect', 'esp32', 'linux', ],
                       metavar="TARGET",
                       default="esp32")
-    parser.add_option("-r", "--rpc", help="enables Pigweed RPC interface. Enabling RPC disables the shell interface. Your sdkconfig configurations will be reverted to default. Default is PW RPC off. When enabling or disabling this flag, on the first build force a clean build with -c", action="store_true", dest="doRPC")
+    parser.add_option("-r", "--rpc", help="enables Pigweed RPC interface. Enabling RPC disables the shell interface. Your sdkconfig configurations will be reverted to default. Default is PW RPC off. When enabling or disabling this flag, on the first build force a clean build with -c", action="store_true", dest="do_rpc")
     parser.add_option("-v", "--vid", dest="vid", type=int,
                       help="specifies the Vendor ID. Default is 0xFFF1", metavar="VID", default=0xFFF1)
     parser.add_option("-p", "--pid", dest="pid", type=int,
                       help="specifies the Product ID. Default is 0x8000", metavar="PID", default=0x8000)
     parser.add_option("", "--rpc_console", help="Opens PW RPC Console",
-                      action="store_true", dest="doRPC_CONSOLE")
+                      action="store_true", dest="do_rpc_console")
     parser.add_option("-y", "--tty", help="Enumerated USB tty/serial interface enumerated for your physical device. E.g.: /dev/ACM0",
                       dest="tty", metavar="TTY", default=None)
 
@@ -166,29 +166,29 @@ def main(argv):
     # Platform Folder
     #
 
-    print(f"Target is set to {options.sampleDeviceTypeName}")
+    print(f"Target is set to {options.sample_device_type_name}")
     global gen_dir
     gen_dir = (
-        f"{_CHEF_SCRIPT_PATH}/out/{options.sampleDeviceTypeName}/zap-generated/")
+        f"{_CHEF_SCRIPT_PATH}/out/{options.sample_device_type_name}/zap-generated/")
 
     print("Setting up environment...")
-    if options.buildTarget == "esp32":
+    if options.build_target == "esp32":
         if config['esp32']['IDF_PATH'] is None:
             print('Path for esp32 SDK was not found. Make sure esp32.IDF_PATH is set on your config.yaml file')
             exit(1)
         plat_folder = os.path.normpath(f"{_CHEF_SCRIPT_PATH}/esp32")
         shell.run_cmd(f'source {config["esp32"]["IDF_PATH"]}/export.sh')
-    elif options.buildTarget == "nrfconnect":
+    elif options.build_target == "nrfconnect":
         if config['nrfconnect']['ZEPHYR_BASE'] is None:
             print('Path for nrfconnect SDK was not found. Make sure nrfconnect.ZEPHYR_BASE is set on your config.yaml file')
             exit(1)
         plat_folder = os.path.normpath(f"{_CHEF_SCRIPT_PATH}/nrfconnect")
         shell.run_cmd(f'source {config["nrfconnect"]["ZEPHYR_BASE"]}/zephyr-env.sh')
         shell.run_cmd("export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb")
-    elif options.buildTarget == "linux":
+    elif options.build_target == "linux":
         pass
     else:
-        print(f"Target {options.buildTarget} not supported")
+        print(f"Target {options.build_target} not supported")
 
     shell.run_cmd(f"source {_REPO_BASE_PATH}/scripts/activate.sh")
 
@@ -196,21 +196,21 @@ def main(argv):
     # Toolchain update
     #
 
-    if options.doUpdateToolchain:
-        if options.buildTarget == "esp32":
+    if options.do_update_toolchain:
+        if options.build_target == "esp32":
             print("ESP32 toolchain update not supported. Skipping")
-        elif options.buildTarget == "nrfconnect":
+        elif options.build_target == "nrfconnect":
             print("Updating toolchain")
             shell.run_cmd(
                 f"cd {_REPO_BASE_PATH} && python3 scripts/setup/nrfconnect/update_ncs.py --update")
-        elif options.buildTarget == "linux":
+        elif options.build_target == "linux":
             print("Linux toolchain update not supported. Skipping")
 
     #
     # ZAP bootstrapping
     #
 
-    if options.doBootstrapZap:
+    if options.do_bootstrap_zap:
         if sys.platform == "linux" or sys.platform == "linux2":
             print("Installing ZAP OS package dependencies")
             shell.run_cmd(
@@ -229,18 +229,18 @@ def main(argv):
     # Cluster customization
     #
 
-    if options.doRunGui:
+    if options.do_run_gui:
         print("Starting ZAP GUI editor")
         shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}/devices")
         shell.run_cmd(
-            f"{_REPO_BASE_PATH}/scripts/tools/zap/run_zaptool.sh {options.sampleDeviceTypeName}.zap")
+            f"{_REPO_BASE_PATH}/scripts/tools/zap/run_zaptool.sh {options.sample_device_type_name}.zap")
 
-    if options.doRunZap:
+    if options.do_run_zap:
         print("Running ZAP script to generate artifacts")
         shell.run_cmd(f"mkdir -p {gen_dir}/")
         shell.run_cmd(f"rm {gen_dir}/*")
         shell.run_cmd(
-            f"{_REPO_BASE_PATH}/scripts/tools/zap/generate.py {_CHEF_SCRIPT_PATH}/devices/{options.sampleDeviceTypeName}.zap -o {gen_dir}")
+            f"{_REPO_BASE_PATH}/scripts/tools/zap/generate.py {_CHEF_SCRIPT_PATH}/devices/{options.sample_device_type_name}.zap -o {gen_dir}")
         # af-gen-event.h is not generated
         shell.run_cmd(f"touch {gen_dir}/af-gen-event.h")
 
@@ -248,23 +248,23 @@ def main(argv):
     # Menuconfig
     #
 
-    if options.doMenuconfig:
-        if options.buildTarget == "esp32":
+    if options.do_menuconfig:
+        if options.build_target == "esp32":
             shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}/esp32")
             shell.run_cmd("idf.py menuconfig")
-        elif options.buildTarget == "nrfconnect":
+        elif options.build_target == "nrfconnect":
             shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}/nrfconnect")
             shell.run_cmd("west build -t menuconfig")
-        elif options.buildTarget == "linux":
+        elif options.build_target == "linux":
             print("Menuconfig not available on Linux target. Skipping")
 
     #
     # Build
     #
 
-    if options.doBuild:
+    if options.do_build:
         print("Building...")
-        if options.doRPC:
+        if options.do_rpc:
             print("RPC PW enabled")
             shell.run_cmd(
                 f"export SDKCONFIG_DEFAULTS={_CHEF_SCRIPT_PATH}/esp32/sdkconfig_rpc.defaults")
@@ -276,30 +276,30 @@ def main(argv):
             f"Product ID 0x{options.pid:02X} / Vendor ID 0x{options.vid:02X}")
         shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}")
 
-        if (options.buildTarget == "esp32") or (options.buildTarget == "nrfconnect"):
+        if (options.build_target == "esp32") or (options.build_target == "nrfconnect"):
             with open("project_include.cmake", "w") as f:
                 f.write(textwrap.dedent(f"""\
                         set(CONFIG_DEVICE_VENDOR_ID {options.vid})
                         set(CONFIG_DEVICE_PRODUCT_ID {options.pid})
-                        set(CONFIG_ENABLE_PW_RPC {"1" if options.doRPC else "0"})
-                        set(SAMPLE_NAME {options.sampleDeviceTypeName})"""))
+                        set(CONFIG_ENABLE_PW_RPC {"1" if options.do_rpc else "0"})
+                        set(SAMPLE_NAME {options.sample_device_type_name})"""))
 
-        if options.buildTarget == "esp32":
+        if options.build_target == "esp32":
             shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}/esp32")
-            if options.doClean:
+            if options.do_clean:
                 shell.run_cmd(f"rm {_CHEF_SCRIPT_PATH}/esp32/sdkconfig")
                 shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}/esp32")
                 shell.run_cmd(f"rm -rf {_CHEF_SCRIPT_PATH}/esp32/build")
                 shell.run_cmd("idf.py fullclean")
             shell.run_cmd("idf.py build")
-        elif options.buildTarget == "nrfconnect":
+        elif options.build_target == "nrfconnect":
             shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}/nrfconnect")
-            if options.doClean:
+            if options.do_clean:
                 # shell.run_cmd(f"rm -rf {paths['rootSampleFolder']}/nrfconnect/build")
                 shell.run_cmd("west build -b nrf52840dk_nrf52840")
             else:
                 shell.run_cmd("west build -b nrf52840dk_nrf52840")
-        elif options.buildTarget == "linux":
+        elif options.build_target == "linux":
             shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}/linux")
             with open(f"{_CHEF_SCRIPT_PATH}/linux/args.gni", "w") as f:
                 f.write(textwrap.dedent(f"""\
@@ -310,10 +310,10 @@ def main(argv):
                         """))
             with open(f"{_CHEF_SCRIPT_PATH}/linux/sample.gni", "w") as f:
                 f.write(textwrap.dedent(f"""\
-                        sample_zap_file = "{options.sampleDeviceTypeName}.zap"
-                        sample_name = "{options.sampleDeviceTypeName}"
+                        sample_zap_file = "{options.sample_device_type_name}.zap"
+                        sample_name = "{options.sample_device_type_name}"
                         """))
-            if options.doClean:
+            if options.do_clean:
                 shell.run_cmd(f"rm -rf out")
             shell.run_cmd("gn gen out")
             shell.run_cmd("ninja -C out")
@@ -326,20 +326,20 @@ def main(argv):
     # Flash
     #
 
-    if options.doFlash:
+    if options.do_flash:
         print("Flashing target")
-        if options.buildTarget == "esp32":
+        if options.build_target == "esp32":
             if config['esp32']['TTY'] is None:
                 print('The path for the serial enumeration for esp32 is not set. Make sure esp32.TTY is set on your config.yaml file')
                 exit(1)
             shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}/esp32")
-            if options.doErase:
+            if options.do_erase:
                 shell.run_cmd(
                     f"idf.py -p {config['esp32']['TTY']} erase-flash")
             shell.run_cmd(f"idf.py -p {config['esp32']['TTY']} flash")
-        elif options.buildTarget == "nrfconnect":
+        elif options.build_target == "nrfconnect":
             shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}/nrfconnect")
-            if options.doErase:
+            if options.do_erase:
                 shell.run_cmd("rm -rf build")
             else:
                 shell.run_cmd("west flash")
@@ -348,30 +348,30 @@ def main(argv):
     # Terminal interaction
     #
 
-    if options.doInteract:
+    if options.do_interact:
         print("Starting terminal...")
-        if options.buildTarget == "esp32":
+        if options.build_target == "esp32":
             if config['esp32']['TTY'] is None:
                 print('The path for the serial enumeration for esp32 is not set. Make sure esp32.TTY is set on your config.yaml file')
                 exit(1)
             shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}/esp32")
             shell.run_cmd(f"idf.py -p {config['esp32']['TTY']} monitor")
-        elif options.buildTarget == "nrfconnect":
+        elif options.build_target == "nrfconnect":
             if config['nrfconnect']['TTY'] is None:
                 print('The path for the serial enumeration for nordic is not set. Make sure nrfconnect.TTY is set on your config.yaml file')
                 exit(1)
             shell.run_cmd("killall screen")
             shell.run_cmd(f"screen {config['nrfconnect']['TTY']} 115200")
-        elif options.buildTarget == "linux":
+        elif options.build_target == "linux":
             print(
-                f"{_CHEF_SCRIPT_PATH}/linux/out/{options.sampleDeviceTypeName}")
+                f"{_CHEF_SCRIPT_PATH}/linux/out/{options.sample_device_type_name}")
             shell.run_cmd(
-                f"{_CHEF_SCRIPT_PATH}/linux/out/{options.sampleDeviceTypeName}")
+                f"{_CHEF_SCRIPT_PATH}/linux/out/{options.sample_device_type_name}")
 
     #
     # RPC Console
     #
-    if options.doRPC_CONSOLE:
+    if options.do_rpc_console:
         shell.run_cmd(
             f"python3 -m chip_rpc.console --device {config['esp32']['TTY']}")
 

--- a/examples/chef/constants.py
+++ b/examples/chef/constants.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class TermColors:
+    STRBOLD = '\033[1m'
+    STRRESET = '\033[0m'
+    STRCYAN = '\033[1;36m'
+    STRYELLOW = '\033[1;33m'

--- a/examples/chef/stateful_shell.py
+++ b/examples/chef/stateful_shell.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+from typing import Dict
+
+import constants
+
+
+TermColors = constants.TermColors
+
+
+class StatefulShell:
+    """A Shell that tracks state changes of the environment."""
+
+    def __init__(self) -> None:
+        if sys.platform == "linux" or sys.platform == "linux2":
+            self.shell_app = '/bin/bash'
+        elif sys.platform == "darwin":
+            self.shell_app = '/bin/zsh'
+        elif sys.platform == "win32":
+            print('Windows is currently not supported. Use Linux or MacOS platforms')
+            exit(1)
+
+        self.env: Dict[str, str] = os.environ.copy()
+        self.cwd: str = self.env["PWD"]
+
+        # This file holds the env after running a command. This is a better approach
+        # than writing to stdout because commands could redirect the stdout.
+        self.envfile_path: str = os.path.join(tempfile.gettempdir(), "envfile")
+
+    def print_env(self) -> None:
+        """Print environment variables in commandline friendly format for export.
+
+        The purpose of this function is to output the env variables in such a way
+        that a user can copy the env variables and paste them in their terminal to
+        quickly recreate the environment state.
+        """
+        for env_var in self.env:
+            quoted_value = shlex.quote(self.env[env_var])
+            if env_var:
+                print(f"export {env_var}={quoted_value}")
+
+    def run_cmd(self, cmd: str, *, raise_on_returncode=False) -> None:
+        """Runs a command and updates environment.
+
+        Args:
+          cmd: Command to execute.
+          raise_on_returncode: Whether to raise an error if the return code is nonzero.
+
+        Raises:
+          RuntimeError: If raise_on_returncode is set and nonzero return code is given.
+        """
+        env_dict = {}
+
+        # Set OLDPWD at beginning because opening the shell clears this. This handles 'cd -'.
+        # env -0 prints the env variables separated by null characters for easy parsing.
+        command_with_state = f"OLDPWD={self.env.get('OLDPWD', '')}; {cmd}; env -0 > {self.envfile_path}"
+        with subprocess.Popen(
+            [command_with_state],
+            env=self.env, cwd=self.cwd,
+            shell=True, executable=self.shell_app
+        ) as proc:
+            returncode = proc.wait()
+
+        # Load env state from envfile.
+        with open(self.envfile_path) as f:
+            # Split on null char because we use env -0.
+            env_entries = f.read().split("\0")
+            for entry in env_entries:
+                parts = entry.split("=")
+                # Handle case where an env variable contains text with '='.
+                env_dict[parts[0]] = "=".join(parts[1:])
+            self.env = env_dict
+            self.cwd = self.env["PWD"]
+
+        if raise_on_returncode and returncode != 0:
+            raise RuntimeError(
+                f"Error. Return code is not 0. It is: {returncode}")


### PR DESCRIPTION
#### Problem
* Chef tool is being refactored to be a little bit more maintainable. Some aesthetic changes are applied which come from the Google Python style guide.
* Before this PR, Chef tool will concatenate all commands into a single string to run. This was needed because the environment variables don't persist across calls to `subprocess`. This PR adds a class `StatefulShell` which will track the environment variable changes. This will make it easier to coordinate printing/logging with commands.

#### Change overview
* Addition of StatefulShell which tracks environment variables between calls to `subprocess`.
* Lint fixes - PEP8
* Remove unused statements
* Print splash text - this was not printed before
* Type hinting is added

#### Testing
Confirmed building using the following commands:
`./chef.py -zcbfe -d lighting-app -t esp32`
