### PR TITLE
[build] Fix #18008 - Only build Android when ANDROID_HOME set.

### DIFF
--- a/gn_build.sh
+++ b/gn_build.sh
@@ -113,13 +113,13 @@ for arg; do
     user_args+=" $arg"
 done
 
-# Android prebuilt JAR setup
-python3 third_party/android_deps/set_up_android_deps.py
-
 # Android SDK setup
 android_sdk_args=""
 
 if [[ -d "${ANDROID_NDK_HOME}/toolchains" && -d "${ANDROID_HOME}/platforms" ]]; then
+    # Android prebuilt JAR setup
+    python3 third_party/android_deps/set_up_android_deps.py
+
     android_sdk_args+="android_sdk_root=\"$ANDROID_HOME\" android_ndk_root=\"$ANDROID_NDK_HOME\""
     extra_args+=" $android_sdk_args enable_android_builds=true"
 else


### PR DESCRIPTION
#### Problem
Fix #18008
./gn_build fails on Android build when ANDROID_HOME is not defined.
The script is supposed to skip Android build in this case.