### PR TITLE
Resolving android tv-casting-app build issues

### DIFF
--- a/examples/tv-casting-app/android/BUILD.gn
+++ b/examples/tv-casting-app/android/BUILD.gn
@@ -79,7 +79,6 @@ group("default") {
     ":java",
     ":jni",
     "${chip_root}/src/app/server/java",
-    "${chip_root}/src/controller/java",
     "${chip_root}/src/platform/android:java",
   ]
 }

--- a/examples/tv-casting-app/linux/CastingUtils.cpp
+++ b/examples/tv-casting-app/linux/CastingUtils.cpp
@@ -18,6 +18,11 @@
 
 #include "CastingUtils.h"
 
+using namespace chip;
+using namespace chip::System;
+using namespace chip::DeviceLayer;
+using namespace chip::Dnssd;
+
 CHIP_ERROR DiscoverCommissioners()
 {
     // Send discover commissioners request

--- a/examples/tv-casting-app/linux/CastingUtils.h
+++ b/examples/tv-casting-app/linux/CastingUtils.h
@@ -34,12 +34,12 @@ CHIP_ERROR DiscoverCommissioners();
 
 CHIP_ERROR RequestCommissioning(int index);
 
-void PrepareForCommissioning(const Dnssd::DiscoveredNodeData * selectedCommissioner = nullptr);
+void PrepareForCommissioning(const chip::Dnssd::DiscoveredNodeData * selectedCommissioner = nullptr);
 
 void InitCommissioningFlow(intptr_t commandArg);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
-void HandleUDCSendExpiration(System::Layer * aSystemLayer, void * context);
+void HandleUDCSendExpiration(chip::System::Layer * aSystemLayer, void * context);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 
 void PrintFabrics();

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -117,6 +117,8 @@ int main(int argc, char * argv[])
 #endif
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+    DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init(CHIP_CONFIG_KVS_PATH);
+
     // Init the commissionable data provider based on command line options
     // to handle custom verifiers, discriminators, etc.
     err = InitCommissionableDataProvider(gCommissionableDataProvider, LinuxDeviceOptions::GetInstance());
@@ -124,7 +126,7 @@ int main(int argc, char * argv[])
     DeviceLayer::SetCommissionableDataProvider(&gCommissionableDataProvider);
 
     // Initialize device attestation config
-    SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    SetDeviceAttestationCredentialsProvider(chip::Credentials::Examples::GetExampleDACProvider());
 
     // Initialize device attestation verifier from a constant version
     {

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -51,13 +51,11 @@ chip_data_model("tv-casting-common") {
     "src/TargetVideoPlayerInfo.cpp",
   ]
 
-  deps = [
-    "${chip_root}/examples/platform/linux:app-main",
-    "${chip_root}/src/credentials:default_attestation_verifier",
-    "${chip_root}/src/lib",
-    "${chip_root}/third_party/inipp",
-    "${chip_root}/third_party/jsoncpp",
-  ]
+  deps = [ "${chip_root}/third_party/jsoncpp" ]
+
+  if (chip_enable_transport_trace) {
+    public_deps = [ "${chip_root}/examples/common/tracing:trace_handlers" ]
+  }
 
   public_configs = [ ":config" ]
 

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -25,13 +25,8 @@
 #include "TargetEndpointInfo.h"
 #include "TargetVideoPlayerInfo.h"
 
-using namespace chip;
-using namespace chip::Controller;
-using namespace chip::Credentials;
-using namespace chip::app::Clusters::ContentLauncher::Commands;
-
-constexpr System::Clock::Seconds16 kCommissioningWindowTimeout = System::Clock::Seconds16(3 * 60);
-constexpr EndpointId kTvEndpoint                               = 1;
+constexpr chip::System::Clock::Seconds16 kCommissioningWindowTimeout = chip::System::Clock::Seconds16(3 * 60);
+constexpr chip::EndpointId kTvEndpoint                               = 1;
 
 /**
  * @brief Represents a TV Casting server that can get the casting app commissioned
@@ -48,7 +43,7 @@ public:
     void InitServer();
 
     CHIP_ERROR DiscoverCommissioners();
-    const Dnssd::DiscoveredNodeData * GetDiscoveredCommissioner(int index);
+    const chip::Dnssd::DiscoveredNodeData * GetDiscoveredCommissioner(int index);
     CHIP_ERROR OpenBasicCommissioningWindow();
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     CHIP_ERROR SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress commissioner);
@@ -57,19 +52,21 @@ public:
     CHIP_ERROR InitBindingHandlers();
     TargetVideoPlayerInfo * GetTargetVideoPlayerInfo() { return &mTargetVideoPlayerInfo; }
     CHIP_ERROR TargetVideoPlayerInfoInit(chip::NodeId nodeId, chip::FabricIndex fabricIndex);
-    void ReadServerClusters(EndpointId endpointId);
+    void ReadServerClusters(chip::EndpointId endpointId);
     void ReadServerClustersForNode(chip::NodeId nodeId);
-    static void OnDescriptorReadSuccessResponse(void * context, const app::DataModel::DecodableList<ClusterId> & responseList);
+    static void OnDescriptorReadSuccessResponse(void * context,
+                                                const chip::app::DataModel::DecodableList<chip::ClusterId> & responseList);
     static void OnDescriptorReadFailureResponse(void * context, CHIP_ERROR error);
     CHIP_ERROR ContentLauncherLaunchURL(const char * contentUrl, const char * contentDisplayStr);
-    static void OnContentLauncherSuccessResponse(void * context, const LaunchResponse::DecodableType & response);
+    static void OnContentLauncherSuccessResponse(
+        void * context, const chip::app::Clusters::ContentLauncher::Commands::LaunchResponse::DecodableType & response);
     static void OnContentLauncherFailureResponse(void * context, CHIP_ERROR error);
-    static void DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
+    static void DeviceEventCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
 
-    NodeId GetVideoPlayerNodeForFabricIndex(FabricIndex fabricIndex);
-    FabricIndex GetVideoPlayerFabricIndexForNode(NodeId nodeId);
+    chip::NodeId GetVideoPlayerNodeForFabricIndex(chip::FabricIndex fabricIndex);
+    chip::FabricIndex GetVideoPlayerFabricIndexForNode(chip::NodeId nodeId);
     void PrintBindings();
-    FabricIndex CurrentFabricIndex() { return mTargetVideoPlayerInfo.GetFabricIndex(); }
+    chip::FabricIndex CurrentFabricIndex() { return mTargetVideoPlayerInfo.GetFabricIndex(); }
     void SetDefaultFabricIndex();
 
 private:
@@ -78,5 +75,5 @@ private:
 
     bool mInited = false;
     TargetVideoPlayerInfo mTargetVideoPlayerInfo;
-    CommissionableNodeController mCommissionableNodeController;
+    chip::Controller::CommissionableNodeController mCommissionableNodeController;
 };

--- a/examples/tv-casting-app/tv-casting-common/include/TargetEndpointInfo.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetEndpointInfo.h
@@ -20,23 +20,21 @@
 
 #include <platform/CHIPDeviceLayer.h>
 
-using namespace chip;
-
 class TargetEndpointInfo
 {
 public:
-    void Initialize(EndpointId endpointId);
+    void Initialize(chip::EndpointId endpointId);
     void Reset() { mInitialized = false; }
     bool IsInitialized() { return mInitialized; }
-    EndpointId GetEndpointId() const { return mEndpointId; }
+    chip::EndpointId GetEndpointId() const { return mEndpointId; }
 
-    bool HasCluster(ClusterId clusterId);
-    bool AddCluster(ClusterId clusterId);
+    bool HasCluster(chip::ClusterId clusterId);
+    bool AddCluster(chip::ClusterId clusterId);
     void PrintInfo();
 
 private:
-    static constexpr size_t kMaxNumberOfClustersPerEndpoint = 10;
-    ClusterId mClusters[kMaxNumberOfClustersPerEndpoint]    = {};
-    EndpointId mEndpointId;
+    static constexpr size_t kMaxNumberOfClustersPerEndpoint    = 10;
+    chip::ClusterId mClusters[kMaxNumberOfClustersPerEndpoint] = {};
+    chip::EndpointId mEndpointId;
     bool mInitialized = false;
 };

--- a/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
@@ -22,8 +22,6 @@
 #include "app/clusters/bindings/BindingManager.h"
 #include <platform/CHIPDeviceLayer.h>
 
-using namespace chip;
-
 class TargetVideoPlayerInfo
 {
 public:
@@ -32,18 +30,18 @@ public:
     {}
 
     bool IsInitialized() { return mInitialized; }
-    NodeId GetNodeId() const { return mNodeId; }
-    FabricIndex GetFabricIndex() const { return mFabricIndex; }
-    OperationalDeviceProxy * GetOperationalDeviceProxy() const { return mOperationalDeviceProxy; }
+    chip::NodeId GetNodeId() const { return mNodeId; }
+    chip::FabricIndex GetFabricIndex() const { return mFabricIndex; }
+    chip::OperationalDeviceProxy * GetOperationalDeviceProxy() const { return mOperationalDeviceProxy; }
 
-    CHIP_ERROR Initialize(NodeId nodeId, FabricIndex fabricIndex);
-    TargetEndpointInfo * GetOrAddEndpoint(EndpointId endpointId);
-    TargetEndpointInfo * GetEndpoint(EndpointId endpointId);
-    bool HasEndpoint(EndpointId endpointId);
+    CHIP_ERROR Initialize(chip::NodeId nodeId, chip::FabricIndex fabricIndex);
+    TargetEndpointInfo * GetOrAddEndpoint(chip::EndpointId endpointId);
+    TargetEndpointInfo * GetEndpoint(chip::EndpointId endpointId);
+    bool HasEndpoint(chip::EndpointId endpointId);
     void PrintInfo();
 
 private:
-    static void HandleDeviceConnected(void * context, OperationalDeviceProxy * device)
+    static void HandleDeviceConnected(void * context, chip::OperationalDeviceProxy * device)
     {
         TargetVideoPlayerInfo * _this  = static_cast<TargetVideoPlayerInfo *>(context);
         _this->mOperationalDeviceProxy = device;
@@ -51,7 +49,7 @@ private:
         ChipLogProgress(AppServer, "HandleDeviceConnected created an instance of OperationalDeviceProxy");
     }
 
-    static void HandleDeviceConnectionFailure(void * context, PeerId peerId, CHIP_ERROR error)
+    static void HandleDeviceConnectionFailure(void * context, chip::PeerId peerId, CHIP_ERROR error)
     {
         TargetVideoPlayerInfo * _this  = static_cast<TargetVideoPlayerInfo *>(context);
         _this->mOperationalDeviceProxy = nullptr;
@@ -59,12 +57,12 @@ private:
 
     static constexpr size_t kMaxNumberOfEndpoints = 5;
     TargetEndpointInfo mEndpoints[kMaxNumberOfEndpoints];
-    NodeId mNodeId;
-    FabricIndex mFabricIndex;
-    OperationalDeviceProxy * mOperationalDeviceProxy;
+    chip::NodeId mNodeId;
+    chip::FabricIndex mFabricIndex;
+    chip::OperationalDeviceProxy * mOperationalDeviceProxy;
 
-    Callback::Callback<OnDeviceConnected> mOnConnectedCallback;
-    Callback::Callback<OnDeviceConnectionFailure> mOnConnectionFailureCallback;
+    chip::Callback::Callback<chip::OnDeviceConnected> mOnConnectedCallback;
+    chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnConnectionFailureCallback;
 
     bool mInitialized = false;
 };

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -18,6 +18,11 @@
 
 #include "CastingServer.h"
 
+using namespace chip;
+using namespace chip::Controller;
+using namespace chip::Credentials;
+using namespace chip::app::Clusters::ContentLauncher::Commands;
+
 CastingServer * CastingServer::castingServer_ = nullptr;
 
 // TODO: Accept these values over CLI
@@ -39,7 +44,6 @@ void CastingServer::InitServer()
     {
         return;
     }
-    DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init(CHIP_CONFIG_KVS_PATH);
 
     // Enter commissioning mode, open commissioning window
     static chip::CommonCaseDeviceServerInitParams initParams;

--- a/examples/tv-casting-app/tv-casting-common/src/TargetEndpointInfo.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/TargetEndpointInfo.cpp
@@ -17,6 +17,8 @@
  */
 #include "TargetEndpointInfo.h"
 
+using namespace chip;
+
 void TargetEndpointInfo::Initialize(EndpointId endpointId)
 {
     mEndpointId = endpointId;

--- a/examples/tv-casting-app/tv-casting-common/src/TargetVideoPlayerInfo.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/TargetVideoPlayerInfo.cpp
@@ -17,6 +17,8 @@
  */
 #include "TargetVideoPlayerInfo.h"
 
+using namespace chip;
+
 CASEClientPool<CHIP_CONFIG_DEVICE_MAX_ACTIVE_CASE_CLIENTS> gCASEClientPool;
 
 CHIP_ERROR TargetVideoPlayerInfo::Initialize(NodeId nodeId, FabricIndex fabricIndex)

--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -189,8 +189,7 @@ class AndroidBuilder(Builder):
                       title='Prepare Native libs ' + self.identifier)
 
         if self.app.ExampleName() == 'tv-casting-app':
-            libs = ['libCHIPController.so',
-                    'libc++_shared.so', 'libTvCastingApp.so']
+            libs = ['libc++_shared.so', 'libTvCastingApp.so']
         else:
             libs = ['libSetupPayloadParser.so',
                     'libc++_shared.so', 'libTvApp.so']
@@ -202,7 +201,6 @@ class AndroidBuilder(Builder):
             jars = {
                 'AndroidPlatform.jar': 'third_party/connectedhomeip/src/platform/android/AndroidPlatform.jar',
                 'CHIPAppServer.jar': 'third_party/connectedhomeip/src/app/server/java/CHIPAppServer.jar',
-                'CHIPController.jar': 'third_party/connectedhomeip/src/controller/java/CHIPController.jar',
                 'TvCastingApp.jar': 'TvCastingApp.jar',
             }
         else:

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -1021,8 +1021,6 @@ ninja -C {out}/android-arm-chip-tv-casting-app
 # Prepare Native libs android-arm-chip-tv-casting-app
 mkdir -p {root}/examples/tv-casting-app/android/App/app/libs/jniLibs/armeabi-v7a
 
-cp {out}/android-arm-chip-tv-casting-app/lib/jni/armeabi-v7a/libCHIPController.so {root}/examples/tv-casting-app/android/App/app/libs/jniLibs/armeabi-v7a/libCHIPController.so
-
 cp {out}/android-arm-chip-tv-casting-app/lib/jni/armeabi-v7a/libc++_shared.so {root}/examples/tv-casting-app/android/App/app/libs/jniLibs/armeabi-v7a/libc++_shared.so
 
 cp {out}/android-arm-chip-tv-casting-app/lib/jni/armeabi-v7a/libTvCastingApp.so {root}/examples/tv-casting-app/android/App/app/libs/jniLibs/armeabi-v7a/libTvCastingApp.so
@@ -1030,8 +1028,6 @@ cp {out}/android-arm-chip-tv-casting-app/lib/jni/armeabi-v7a/libTvCastingApp.so 
 cp {out}/android-arm-chip-tv-casting-app/lib/third_party/connectedhomeip/src/platform/android/AndroidPlatform.jar {root}/examples/tv-casting-app/android/App/app/libs/AndroidPlatform.jar
 
 cp {out}/android-arm-chip-tv-casting-app/lib/third_party/connectedhomeip/src/app/server/java/CHIPAppServer.jar {root}/examples/tv-casting-app/android/App/app/libs/CHIPAppServer.jar
-
-cp {out}/android-arm-chip-tv-casting-app/lib/third_party/connectedhomeip/src/controller/java/CHIPController.jar {root}/examples/tv-casting-app/android/App/app/libs/CHIPController.jar
 
 cp {out}/android-arm-chip-tv-casting-app/lib/TvCastingApp.jar {root}/examples/tv-casting-app/android/App/app/libs/TvCastingApp.jar
 
@@ -1112,8 +1108,6 @@ ninja -C {out}/android-arm64-chip-tv-casting-app
 # Prepare Native libs android-arm64-chip-tv-casting-app
 mkdir -p {root}/examples/tv-casting-app/android/App/app/libs/jniLibs/arm64-v8a
 
-cp {out}/android-arm64-chip-tv-casting-app/lib/jni/arm64-v8a/libCHIPController.so {root}/examples/tv-casting-app/android/App/app/libs/jniLibs/arm64-v8a/libCHIPController.so
-
 cp {out}/android-arm64-chip-tv-casting-app/lib/jni/arm64-v8a/libc++_shared.so {root}/examples/tv-casting-app/android/App/app/libs/jniLibs/arm64-v8a/libc++_shared.so
 
 cp {out}/android-arm64-chip-tv-casting-app/lib/jni/arm64-v8a/libTvCastingApp.so {root}/examples/tv-casting-app/android/App/app/libs/jniLibs/arm64-v8a/libTvCastingApp.so
@@ -1121,8 +1115,6 @@ cp {out}/android-arm64-chip-tv-casting-app/lib/jni/arm64-v8a/libTvCastingApp.so 
 cp {out}/android-arm64-chip-tv-casting-app/lib/third_party/connectedhomeip/src/platform/android/AndroidPlatform.jar {root}/examples/tv-casting-app/android/App/app/libs/AndroidPlatform.jar
 
 cp {out}/android-arm64-chip-tv-casting-app/lib/third_party/connectedhomeip/src/app/server/java/CHIPAppServer.jar {root}/examples/tv-casting-app/android/App/app/libs/CHIPAppServer.jar
-
-cp {out}/android-arm64-chip-tv-casting-app/lib/third_party/connectedhomeip/src/controller/java/CHIPController.jar {root}/examples/tv-casting-app/android/App/app/libs/CHIPController.jar
 
 cp {out}/android-arm64-chip-tv-casting-app/lib/TvCastingApp.jar {root}/examples/tv-casting-app/android/App/app/libs/TvCastingApp.jar
 


### PR DESCRIPTION
#### Problem
Android tv-casting-app build was failing due to compilation issues with tv-casting-common, related to namespace usage and dependency libraries

#### Change overview
1. Moved `using namepace *` declarations to .cpp instead of .h files as per C++ best practices.
2. Moved  call to `DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init(CHIP_CONFIG_KVS_PATH)` out of tv-casting-common to tv-casting-app/linux as `KeyValueStoreMgrImpl` only has platform specific implementations. Calling `Init()` from `KeyValueStoreMgrImpl` from tv-casting-common leads to a function not found compilation error.
3. Reduced dependency lib list for tv-casting-common (examples/platform/linux:app-main, src/credentials:default_attestation_verifier, src/lib, third_party/inipp were not needed).
4. Removed dependency of android tv-casting-app from libCHIPController as that was not needed.

#### Testing
* Built both Linux as well as Android tv-casting-app and ran them successfully.