### PR TITLE
[Tizen] Explicitly set chmod for Docker copied file

### DIFF
--- a/integrations/docker/images/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/chip-build-nrf-platform/Dockerfile
@@ -7,7 +7,7 @@ ARG NCS_REVISION=5ea8f7fa91d7315fcc6cd9eb3aa74f9640d0abac
 RUN set -x \
     && apt-get update \
     && apt-get install --no-install-recommends -fy \
-    curl=7.68.0-1ubuntu2.7 \
+    curl=7.68.0-1ubuntu2.10 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line

--- a/integrations/docker/images/chip-build-tizen/Dockerfile
+++ b/integrations/docker/images/chip-build-tizen/Dockerfile
@@ -88,11 +88,13 @@ RUN set -x \
     # Base packages
     && wget --progress=dot:mega -r -nd --no-parent \
     http://download.tizen.org/releases/milestone/tizen/base/latest/repos/standard/packages/armv7l/ \
+    -A 'iniparser-*.armv7l.rpm' \
     -A 'libblkid-devel-*.armv7l.rpm' \
     -A 'libcap-*.armv7l.rpm' \
     -A 'libffi-devel-*.armv7l.rpm' \
     -A 'liblzma-*.armv7l.rpm' \
     -A 'libmount-devel-*.armv7l.rpm' \
+    -A 'libuuid-*.armv7l.rpm' \
     -A 'pcre-devel-*.armv7l.rpm' \
     -A 'xdgmime-*.armv7l.rpm' \
     # Unified packages
@@ -100,17 +102,24 @@ RUN set -x \
     http://download.tizen.org/releases/milestone/tizen/unified/latest/repos/standard/packages/armv7l/ \
     -A 'aul-0*.armv7l.rpm' \
     -A 'aul-devel-*.armv7l.rpm' \
+    -A 'bundle-0*.armv7l.rpm' \
+    -A 'bundle-devel-*.armv7l.rpm' \
     -A 'buxton2-*.armv7l.rpm' \
     -A 'cynara-devel-*.armv7l.rpm' \
     -A 'dbus-1*.armv7l.rpm' \
     -A 'dbus-devel-*.armv7l.rpm' \
     -A 'dbus-libs-1*.armv7l.rpm' \
     -A 'glib2-devel-2*.armv7l.rpm' \
-    -A 'libtzplatform-config-*.armv7l.rpm' \
+    -A 'json-glib-devel-*.armv7l.rpm' \
     -A 'libcynara-client-*.armv7l.rpm' \
     -A 'libcynara-commons-*.armv7l.rpm' \
     -A 'libdns_sd-*.armv7l.rpm' \
+    -A 'libjson-glib-*.armv7l.rpm' \
     -A 'libsystemd-*.armv7l.rpm' \
+    -A 'libtzplatform-config-*.armv7l.rpm' \
+    -A 'parcel-0*.armv7l.rpm' \
+    -A 'parcel-devel-*.armv7l.rpm' \
+    -A 'pkgmgr-info-*.armv7l.rpm' \
     -A 'vconf-compat-*.armv7l.rpm' \
     -A 'vconf-internal-keys-devel-*.armv7l.rpm' \
     # Unified packages (snapshots)

--- a/integrations/docker/images/chip-build-tizen/Dockerfile
+++ b/integrations/docker/images/chip-build-tizen/Dockerfile
@@ -55,6 +55,7 @@ RUN set -x \
     && : # last line
 
 COPY secret-tool.py $TIZEN_SDK_ROOT/tools/certificate-encryptor/secret-tool
+RUN chmod 0755 $TIZEN_SDK_ROOT/tools/certificate-encryptor/secret-tool
 ENV PATH="$TIZEN_SDK_ROOT/tools/ide/bin:$PATH"
 
 # ------------------------------------------------------------------------------
@@ -100,8 +101,6 @@ RUN set -x \
     -A 'aul-0*.armv7l.rpm' \
     -A 'aul-devel-*.armv7l.rpm' \
     -A 'buxton2-*.armv7l.rpm' \
-    -A 'capi-network-nsd-*.armv7l.rpm' \
-    -A 'capi-network-thread-*.armv7l.rpm' \
     -A 'cynara-devel-*.armv7l.rpm' \
     -A 'dbus-1*.armv7l.rpm' \
     -A 'dbus-devel-*.armv7l.rpm' \
@@ -111,10 +110,15 @@ RUN set -x \
     -A 'libcynara-client-*.armv7l.rpm' \
     -A 'libcynara-commons-*.armv7l.rpm' \
     -A 'libdns_sd-*.armv7l.rpm' \
-    -A 'libnsd-dns-sd-*.armv7l.rpm' \
     -A 'libsystemd-*.armv7l.rpm' \
     -A 'vconf-compat-*.armv7l.rpm' \
     -A 'vconf-internal-keys-devel-*.armv7l.rpm' \
+    # Unified packages (snapshots)
+    && wget --progress=dot:mega -r -nd --no-parent \
+    http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/armv7l/ \
+    -A 'capi-network-nsd-*.armv7l.rpm' \
+    -A 'capi-network-thread-*.armv7l.rpm' \
+    -A 'libnsd-dns-sd-*.armv7l.rpm' \
     # Install base sysroot
     && unzip -o '*.zip' \
     && cp -rf data/* $TIZEN_SDK_ROOT \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.70 Version bump reason: push git to 2.25.1-1ubuntu3.4 (from 3.3)
+0.5.71 Version bump reason: [Tizen] Fix permission bits for secret-tool


### PR DESCRIPTION
#### Problem

Without the explicit chmod the secret-tool might inherit incorrect permission bits from the build context - it might not be executable or might be inaccessible by non-root users (the latest image https://hub.docker.com/r/connectedhomeip/chip-build-tizen/tags has incorrect mode for this file - inaccessible by other users).

#### Change overview

- explicit `chmod` in Dockerfile after COPY
- fix RPM snapshots download (bug introduced in bfb4af115ae10da6f141144f967367a038d8c06e)

#### Testing

Tested locally if modifications of chmod in git (build context) will not affect Docker image.