### PR TITLE
Define required_submodules in environment_no_cipd.json

### DIFF
--- a/scripts/environment_no_cipd.json
+++ b/scripts/environment_no_cipd.json
@@ -3,5 +3,6 @@
         "gn_root": ".",
         "gn_targets": [":python_packages.install"]
     },
+    "required_submodules": ["third_party/pigweed/repo"],
     "gni_file": "build_overrides/pigweed_environment.gni"
 }


### PR DESCRIPTION

#### Problem
Currently no required_submodules are defined, which makes
scripts/no_cipd_bootstrap.sh complain with:

```
Not all submodules are initialized. Please run the following commands.

    git submodule update --init third_party/mbed-mcu-boot/repo/boot/espressif/hal/esp-idf
...
```

#### Change overview
It restricts submodules initialized in `scripts/environment_no_cipd.json` like `scripts/environment.json` is doing.

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
* If unit tests existed, how were they fixed/modified to prevent this in future?
* If new unit tests are not added, why not?
* If integration tests were added, how do they verify this change?
* If new integration tests are not added, why not?
* If manually tested, what platforms controller and device platforms were manually tested, and how? Tested using `source scripts/no_cipd_bootstrap.sh`.
* If no testing is required, why not?
