### PR TITLE
Fix some buffer handling issues in BtpEngine.

### DIFF
--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -144,6 +144,7 @@ SequenceNumber_t BtpEngine::GetAndRecordRxAckSeqNum()
     return ret;
 }
 
+#if CHIP_ENABLE_CHIPOBLE_TEST
 bool BtpEngine::IsCommandPacket(const PacketBufferHandle & p)
 {
     if (p.IsNull())
@@ -160,6 +161,7 @@ bool BtpEngine::IsCommandPacket(const PacketBufferHandle & p)
     }
     return rx_flags.Has(HeaderFlags::kCommandMessage);
 }
+#endif // CHIP_ENABLE_CHIPOBLE_TEST
 
 bool BtpEngine::HasUnackedData() const
 {

--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -144,6 +144,23 @@ SequenceNumber_t BtpEngine::GetAndRecordRxAckSeqNum()
     return ret;
 }
 
+bool BtpEngine::IsCommandPacket(const PacketBufferHandle & p)
+{
+    if (p.IsNull())
+    {
+        return false;
+    }
+
+    BitFlags<HeaderFlags> rx_flags;
+    Encoding::LittleEndian::Reader reader(data->Start(), data->DataLength());
+    CHIP_ERROR err = reader.Read8(rx_flags.RawStorage()).StatusCode();
+    if (err != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+    return rx_flags.Has(HeaderFlags::kCommandMessage);
+}
+
 bool BtpEngine::HasUnackedData() const
 {
     return (mRxOldestUnackedSeqNum != mRxNextSeqNum);
@@ -240,62 +257,65 @@ CHIP_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle &&
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     BitFlags<HeaderFlags> rx_flags;
-    // BLE data uses little-endian byte order.
-    Encoding::LittleEndian::Reader reader(data->Start(), data->DataLength());
 
     VerifyOrExit(!data.IsNull(), err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    mRxCharCount++;
+    { // Scope for reader, so we can do the VerifyOrExit above.
+        // BLE data uses little-endian byte order.
+        Encoding::LittleEndian::Reader reader(data->Start(), data->DataLength());
 
-    // Get header flags, always in first byte.
-    err = reader.Read8(rx_flags.RawStorage()).StatusCode();
-    SuccessOrExit(err);
+        mRxCharCount++;
+
+        // Get header flags, always in first byte.
+        err = reader.Read8(rx_flags.RawStorage()).StatusCode();
+        SuccessOrExit(err);
 #if CHIP_ENABLE_CHIPOBLE_TEST
-    if (rx_flags.Has(HeaderFlags::kCommandMessage))
-        SetRxPacketType(kType_Control);
-    else
-        SetRxPacketType(kType_Data);
+        if (rx_flags.Has(HeaderFlags::kCommandMessage))
+            SetRxPacketType(kType_Control);
+        else
+            SetRxPacketType(kType_Data);
 #endif
 
-    didReceiveAck = rx_flags.Has(HeaderFlags::kFragmentAck);
+        didReceiveAck = rx_flags.Has(HeaderFlags::kFragmentAck);
 
-    // Get ack number, if any.
-    if (didReceiveAck)
-    {
-        err = reader.Read8(&receivedAck).StatusCode();
+        // Get ack number, if any.
+        if (didReceiveAck)
+        {
+            err = reader.Read8(&receivedAck).StatusCode();
+            SuccessOrExit(err);
+
+            err = HandleAckReceived(receivedAck);
+            SuccessOrExit(err);
+        }
+
+        // Get sequence number.
+        err = reader.Read8(&mRxNewestUnackedSeqNum).StatusCode();
         SuccessOrExit(err);
 
-        err = HandleAckReceived(receivedAck);
-        SuccessOrExit(err);
+        // Verify that received sequence number is the next one we'd expect.
+        VerifyOrExit(mRxNewestUnackedSeqNum == mRxNextSeqNum, err = BLE_ERROR_INVALID_BTP_SEQUENCE_NUMBER);
+
+        // Increment next expected rx sequence number.
+        IncSeqNum(mRxNextSeqNum);
+
+        // If fragment was stand-alone ack, we're done here; no payload for message reassembler.
+        if (!DidReceiveData(rx_flags))
+        {
+            ExitNow();
+        }
+
+        // Truncate the incoming fragment length by the mRxFragmentSize as the negotiated
+        // mRxFragnentSize may be smaller than the characteristic size.  Make sure
+        // we're not truncating to a data length smaller than what we have already consumed.
+        VerifyOrExit(reader.OctetsRead() <= mRxFragmentSize, err = BLE_ERROR_REASSEMBLER_INCORRECT_STATE);
+        data->SetDataLength(chip::min(data->DataLength(), mRxFragmentSize));
+
+        // Now mark the bytes we consumed as consumed.
+        data->ConsumeHead(static_cast<uint16_t>(reader.OctetsRead()));
+
+        ChipLogDebugBtpEngine(Ble, ">>> BTP reassembler received data:");
+        PrintBufDebug(data);
     }
-
-    // Get sequence number.
-    err = reader.Read8(&mRxNewestUnackedSeqNum).StatusCode();
-    SuccessOrExit(err);
-
-    // Verify that received sequence number is the next one we'd expect.
-    VerifyOrExit(mRxNewestUnackedSeqNum == mRxNextSeqNum, err = BLE_ERROR_INVALID_BTP_SEQUENCE_NUMBER);
-
-    // Increment next expected rx sequence number.
-    IncSeqNum(mRxNextSeqNum);
-
-    // If fragment was stand-alone ack, we're done here; no payload for message reassembler.
-    if (!DidReceiveData(rx_flags))
-    {
-        ExitNow();
-    }
-
-    // Truncate the incoming fragment length by the mRxFragmentSize as the negotiated
-    // mRxFragnentSize may be smaller than the characteristic size.  Make sure
-    // we're not truncating to a data length smaller than what we have already consumed.
-    VerifyOrExit(reader.OctetsRead() <= mRxFragmentSize, err = BLE_ERROR_REASSEMBLER_INCORRECT_STATE);
-    data->SetDataLength(chip::min(data->DataLength(), mRxFragmentSize));
-
-    // Now mark the bytes we consumed as consumed.
-    data->ConsumeHead(static_cast<uint16_t>(reader.OctetsRead()));
-
-    ChipLogDebugBtpEngine(Ble, ">>> BTP reassembler received data:");
-    PrintBufDebug(data);
 
     if (mRxState == kState_Idle)
     {

--- a/src/ble/BtpEngine.h
+++ b/src/ble/BtpEngine.h
@@ -130,7 +130,7 @@ public:
     inline SequenceNumber_t SetRxPacketSeq(SequenceNumber_t seq) { return (mRxPacketSeq = seq); }
     inline SequenceNumber_t TxPacketSeq() { return mTxPacketSeq; }
     inline SequenceNumber_t RxPacketSeq() { return mRxPacketSeq; }
-    bool IsCommandPacket(const PacketBufferHandle & p);
+    static bool IsCommandPacket(const PacketBufferHandle & p);
     inline void PushPacketTag(const PacketBufferHandle & p, PacketType_t type)
     {
         p->SetStart(p->Start() - sizeof(type));

--- a/src/ble/BtpEngine.h
+++ b/src/ble/BtpEngine.h
@@ -130,10 +130,7 @@ public:
     inline SequenceNumber_t SetRxPacketSeq(SequenceNumber_t seq) { return (mRxPacketSeq = seq); }
     inline SequenceNumber_t TxPacketSeq() { return mTxPacketSeq; }
     inline SequenceNumber_t RxPacketSeq() { return mRxPacketSeq; }
-    inline bool IsCommandPacket(const PacketBufferHandle & p)
-    {
-        return BitFlags<HeaderFlags>(*(p->Start())).Has(HeaderFlags::kCommandMessage);
-    }
+    bool IsCommandPacket(const PacketBufferHandle & p);
     inline void PushPacketTag(const PacketBufferHandle & p, PacketType_t type)
     {
         p->SetStart(p->Start() - sizeof(type));


### PR DESCRIPTION
Two problems:

1. BtpEngine::HandleCharacteristicReceived null-checked the incoming
   buffer _after_ it had already dereferenced it, which is pretty
   pointless.

2. BtpEngine::IsCommandPacket read one byte from the buffer even if
   the buffer was zero-length.

Fixes https://github.com/project-chip/connectedhomeip/issues/3922

#### Problem
See above.

#### Change overview
Make sure we check for null before dereferencing and don't directly poke at Start() without checking length.

#### Testing
Not sure how to exercise the error cases here in our CI.