### PR TITLE
Fix persistant counter read start value size check

### DIFF
--- a/src/lib/support/PersistedCounter.h
+++ b/src/lib/support/PersistedCounter.h
@@ -197,7 +197,7 @@ private:
             ReturnErrorOnFailure(err);
         }
 
-        if (size != sizeof(valueLE))
+        if (size > sizeof(valueLE))
         {
             // TODO: Again, figure out whether this could lead to bootloops.
             return CHIP_ERROR_INCORRECT_STATE;


### PR DESCRIPTION
#### Problem
Size check returns an error if the real read size is smaller than the size allocated.
Platform implementation uses the smallest amount of memory possible to save data which can result in the read size being smaller than the allocated size.

Issue was introduced in #17883 

#### Change overview
Only return an error if the read size is superior to allocated size

#### Testing
Manual test on efr32 MG12 to validate fix
