### PR TITLE
Pull latest zap

### DIFF
--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -29,7 +29,7 @@ jobs:
 
         runs-on: ubuntu-20.04
         container:
-            image: connectedhomeip/chip-build-zap:0.5.64
+            image: connectedhomeip/chip-build-zap:0.5.70
         defaults:
             run:
                 shell: sh


### PR DESCRIPTION
#### Problem
Update zap to latest

#### Change overview
RAN:

```
cd third_party/zap/repo/
git fetch https://github.com/project-chip/zap.git master
git checkout FETCH_HEAD
```

Also updated the zap template workflow to use a newer image of the zap dockerfile (moved to 0.5.70)

#### Testing
CI will validate that no file generation differences will occur.