### PR TITLE
Add event subscription and any cluster commands to chip-tool-darwin

### DIFF
--- a/examples/chip-tool-darwin/BUILD.gn
+++ b/examples/chip-tool-darwin/BUILD.gn
@@ -38,7 +38,10 @@ config("config") {
 executable("chip-tool-darwin") {
   sources = [
     "${chip_root}/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp",
+    "commands/clusters/ClusterCommandBridge.h",
     "commands/clusters/ModelCommandBridge.mm",
+    "commands/clusters/ReportCommandBridge.h",
+    "commands/clusters/WriteAttributeCommandBridge.h",
     "commands/common/CHIPCommandBridge.mm",
     "commands/common/CHIPCommandStorageDelegate.mm",
     "commands/common/CHIPToolKeypair.mm",

--- a/examples/chip-tool-darwin/commands/clusters/ClusterCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/clusters/ClusterCommandBridge.h
@@ -1,0 +1,133 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#import <CHIP/CHIP.h>
+#import <CHIP/CHIPDevice_Internal.h>
+#include <lib/support/UnitTestUtils.h>
+
+#include "ModelCommandBridge.h"
+
+class ClusterCommand : public ModelCommand {
+public:
+    ClusterCommand()
+        : ModelCommand("command-by-id")
+    {
+        AddArgument("cluster-id", 0, UINT32_MAX, &mClusterId);
+        AddArgument("command-id", 0, UINT32_MAX, &mCommandId);
+        AddArgument("payload", &mPayload);
+        AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
+        AddArgument("repeat-count", 1, UINT16_MAX, &mRepeatCount);
+        AddArgument("repeat-delay-ms", 0, UINT16_MAX, &mRepeatDelayInMs);
+        ModelCommand::AddArguments();
+    }
+
+    ClusterCommand(chip::ClusterId clusterId)
+        : ModelCommand("command-by-id")
+        , mClusterId(clusterId)
+    {
+        AddArgument("command-id", 0, UINT32_MAX, &mCommandId);
+        AddArgument("payload", &mPayload);
+        AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
+        AddArgument("repeat-count", 1, UINT16_MAX, &mRepeatCount);
+        AddArgument("repeat-delay-ms", 0, UINT16_MAX, &mRepeatDelayInMs);
+        ModelCommand::AddArguments();
+    }
+
+    ClusterCommand(const char * _Nonnull commandName)
+        : ModelCommand(commandName)
+    {
+        AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
+        AddArgument("repeat-count", 1, UINT16_MAX, &mRepeatCount);
+        AddArgument("repeat-delay-ms", 0, UINT16_MAX, &mRepeatDelayInMs);
+    }
+
+    ~ClusterCommand() {}
+
+    CHIP_ERROR SendCommand(CHIPDevice * _Nonnull device, chip::EndpointId endpointId) override
+    {
+        chip::TLV::TLVWriter writer;
+        chip::TLV::TLVReader reader;
+
+        mData = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(sizeof(uint8_t), mDataMaxLen));
+        VerifyOrReturnError(mData != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        writer.Init(mData, mDataMaxLen);
+
+        ReturnErrorOnFailure(mPayload.Encode(writer, chip::TLV::AnonymousTag()));
+        reader.Init(mData, writer.GetLengthWritten());
+        ReturnErrorOnFailure(reader.Next());
+
+        id commandFields = NSObjectFromCHIPTLV(&reader);
+        if (commandFields == nil) {
+            return CHIP_ERROR_INTERNAL;
+        }
+        return ClusterCommand::SendCommand(device, endpointId, mClusterId, mCommandId, commandFields);
+    }
+
+    CHIP_ERROR SendCommand(CHIPDevice * _Nonnull device, chip::EndpointId endpointId, chip::ClusterId clusterId,
+        chip::CommandId commandId, id _Nonnull commandFields)
+    {
+        uint16_t repeatCount = mRepeatCount.ValueOr(1);
+        uint16_t __block responsesNeeded = repeatCount;
+        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
+
+        while (repeatCount--) {
+            [device invokeCommandWithEndpointId:[NSNumber numberWithUnsignedShort:endpointId]
+                                      clusterId:[NSNumber numberWithUnsignedInteger:clusterId]
+                                      commandId:[NSNumber numberWithUnsignedInteger:commandId]
+                                  commandFields:commandFields
+                             timedInvokeTimeout:mTimedInteractionTimeoutMs.HasValue()
+                                 ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()]
+                                 : nil
+                                    clientQueue:callbackQueue
+                                     completion:^(
+                                         NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                                         CHIP_ERROR err = [CHIPError errorToCHIPErrorCode:error];
+                                         responsesNeeded--;
+                                         if (err != CHIP_NO_ERROR) {
+                                             mError = err;
+                                             ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(err));
+                                         }
+                                         if (responsesNeeded == 0) {
+                                             SetCommandExitStatus(mError);
+                                         }
+                                     }];
+
+            if (mRepeatDelayInMs.HasValue()) {
+                chip::test_utils::SleepMillis(mRepeatDelayInMs.Value());
+            }
+        }
+        return CHIP_NO_ERROR;
+    }
+
+protected:
+    chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
+    chip::Optional<uint16_t> mRepeatCount;
+    chip::Optional<uint16_t> mRepeatDelayInMs;
+    CHIP_ERROR mError = CHIP_NO_ERROR;
+
+private:
+    chip::ClusterId mClusterId;
+    chip::CommandId mCommandId;
+
+    CustomArgument mPayload;
+    static constexpr uint32_t mDataMaxLen = 4096;
+    uint8_t * _Nullable mData = nullptr;
+};

--- a/examples/chip-tool-darwin/commands/clusters/ModelCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/clusters/ModelCommandBridge.h
@@ -38,7 +38,7 @@ public:
     CHIP_ERROR RunCommand() override;
     chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(10); }
 
-    virtual CHIP_ERROR SendCommand(CHIPDevice * _Nullable device, chip::EndpointId endPointId) = 0;
+    virtual CHIP_ERROR SendCommand(CHIPDevice * _Nonnull device, chip::EndpointId endPointId) = 0;
 
 private:
     chip::NodeId mNodeId;

--- a/examples/chip-tool-darwin/commands/clusters/ModelCommandBridge.mm
+++ b/examples/chip-tool-darwin/commands/clusters/ModelCommandBridge.mm
@@ -35,6 +35,8 @@ CHIP_ERROR ModelCommand::RunCommand()
                                 CHIP_ERROR err = CHIP_NO_ERROR;
                                 if (error) {
                                     err = [CHIPError errorToCHIPErrorCode:error];
+                                } else if (device == nil) {
+                                    err = CHIP_ERROR_INTERNAL;
                                 } else {
                                     err = SendCommand(device, mEndPointId);
                                 }

--- a/examples/chip-tool-darwin/commands/clusters/ReportCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/clusters/ReportCommandBridge.h
@@ -1,0 +1,231 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "ModelCommandBridge.h"
+
+class ReadAttribute : public ModelCommand {
+public:
+    ReadAttribute()
+        : ModelCommand("read-by-id")
+    {
+        AddArgument("cluster-id", 0, UINT32_MAX, &mClusterId);
+        AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
+        ModelCommand::AddArguments();
+    }
+
+    ReadAttribute(chip::ClusterId clusterId)
+        : ModelCommand("read-by-id")
+        , mClusterId(clusterId)
+    {
+        AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
+        ModelCommand::AddArguments();
+    }
+
+    ReadAttribute(const char * _Nonnull attributeName)
+        : ModelCommand("read")
+    {
+        AddArgument("attr-name", attributeName);
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
+        ModelCommand::AddArguments();
+    }
+
+    ~ReadAttribute() {}
+
+    CHIP_ERROR SendCommand(CHIPDevice * _Nonnull device, chip::EndpointId endpointId) override
+    {
+        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
+        CHIPReadParams * params = [[CHIPReadParams alloc] init];
+        params.fabricFiltered = mFabricFiltered.HasValue() ? [NSNumber numberWithBool:mFabricFiltered.Value()] : nil;
+        [device
+            readAttributeWithEndpointId:[NSNumber numberWithUnsignedShort:endpointId]
+                              clusterId:[NSNumber numberWithUnsignedInteger:mClusterId]
+                            attributeId:[NSNumber numberWithUnsignedInteger:mAttributeId]
+                                 params:params
+                            clientQueue:callbackQueue
+                             completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                                 CHIP_ERROR err = [CHIPError errorToCHIPErrorCode:error];
+                                 if (values) {
+                                     for (id item in values) {
+                                         NSLog(@"Response Item: %@", [item description]);
+                                     }
+                                 }
+                                 if (err != CHIP_NO_ERROR) {
+                                     ChipLogError(chipTool, "Error: %s", chip::ErrorStr(err));
+                                 }
+                                 SetCommandExitStatus(err);
+                             }];
+        return CHIP_NO_ERROR;
+    }
+
+protected:
+    chip::Optional<bool> mFabricFiltered;
+
+private:
+    chip::ClusterId mClusterId;
+    chip::AttributeId mAttributeId;
+};
+
+class SubscribeAttribute : public ModelCommand {
+public:
+    SubscribeAttribute()
+        : ModelCommand("subscribe-by-id")
+    {
+        AddArgument("cluster-id", 0, UINT32_MAX, &mClusterId);
+        AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
+        AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions);
+        AddArgument("wait", 0, 1, &mWait);
+        ModelCommand::AddArguments();
+    }
+
+    SubscribeAttribute(chip::ClusterId clusterId)
+        : ModelCommand("subscribe-by-id")
+        , mClusterId(clusterId)
+    {
+        AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
+        AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions);
+        AddArgument("wait", 0, 1, &mWait);
+        ModelCommand::AddArguments();
+    }
+
+    SubscribeAttribute(const char * _Nonnull attributeName)
+        : ModelCommand("subscribe")
+    {
+        AddArgument("attr-name", attributeName);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
+        AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions);
+        AddArgument("wait", 0, 1, &mWait);
+        ModelCommand::AddArguments();
+    }
+
+    ~SubscribeAttribute() {}
+
+    CHIP_ERROR SendCommand(CHIPDevice * _Nonnull device, chip::EndpointId endpointId) override
+    {
+        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
+        CHIPSubscribeParams * params = [[CHIPSubscribeParams alloc] init];
+        params.keepPreviousSubscriptions
+            = mKeepSubscriptions.HasValue() ? [NSNumber numberWithBool:mKeepSubscriptions.Value()] : nil;
+        [device subscribeAttributeWithEndpointId:[NSNumber numberWithUnsignedShort:endpointId]
+                                       clusterId:[NSNumber numberWithUnsignedInteger:mClusterId]
+                                     attributeId:[NSNumber numberWithUnsignedInteger:mAttributeId]
+                                     minInterval:[NSNumber numberWithUnsignedInteger:mMinInterval]
+                                     maxInterval:[NSNumber numberWithUnsignedInteger:mMaxInterval]
+                                          params:params
+                                     clientQueue:callbackQueue
+                                   reportHandler:^(
+                                       NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                                       if (values) {
+                                           for (id item in values) {
+                                               NSLog(@"Response Item: %@", [item description]);
+                                           }
+                                       }
+                                       if (error || !mWait) {
+                                           SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                                       }
+                                   }
+                         subscriptionEstablished:nil];
+
+        return CHIP_NO_ERROR;
+    }
+
+protected:
+    chip::Optional<bool> mKeepSubscriptions;
+    chip::Optional<bool> mFabricFiltered;
+    uint16_t mMinInterval;
+    uint16_t mMaxInterval;
+    bool mWait;
+
+private:
+    chip::ClusterId mClusterId;
+    chip::AttributeId mAttributeId;
+};
+
+class SubscribeEvent : public ModelCommand {
+public:
+    SubscribeEvent()
+        : ModelCommand("subscribe-all-events")
+    {
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
+        AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions);
+        AddArgument("wait", 0, 1, &mWait);
+        ModelCommand::AddArguments();
+    }
+
+    ~SubscribeEvent() {}
+
+    CHIP_ERROR SendCommand(CHIPDevice * _Nonnull device, chip::EndpointId endpointId) override
+    {
+        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
+
+        CHIPSubscribeParams * params = [[CHIPSubscribeParams alloc] init];
+        params.keepPreviousSubscriptions
+            = mKeepSubscriptions.HasValue() ? [NSNumber numberWithBool:mKeepSubscriptions.Value()] : nil;
+        [device subscribeWithQueue:callbackQueue
+            minInterval:mMinInterval
+            maxInterval:mMaxInterval
+            params:params
+            cacheContainer:nil
+            attributeReportHandler:^(NSArray * value) {
+                if (!mWait) {
+                    SetCommandExitStatus(CHIP_NO_ERROR);
+                }
+            }
+            eventReportHandler:^(NSArray * value) {
+                for (id item in value) {
+                    NSLog(@"Response Item: %@", [item description]);
+                }
+                if (!mWait) {
+                    SetCommandExitStatus(CHIP_NO_ERROR);
+                }
+            }
+            errorHandler:^(NSError * error) {
+                if (error && !mWait) {
+                    SetCommandExitStatus([CHIPError errorToCHIPErrorCode:error]);
+                }
+            }
+            subscriptionEstablished:^() {
+            }];
+
+        return CHIP_NO_ERROR;
+    }
+
+    chip::System::Clock::Timeout GetWaitDuration() const override
+    {
+        return chip::System::Clock::Seconds16(mWait ? UINT16_MAX : 10);
+    }
+
+protected:
+    chip::Optional<bool> mKeepSubscriptions;
+    chip::Optional<chip::EventNumber> mEventNumber;
+    uint16_t mMinInterval;
+    uint16_t mMaxInterval;
+    bool mWait;
+};

--- a/examples/chip-tool-darwin/commands/clusters/WriteAttributeCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/clusters/WriteAttributeCommandBridge.h
@@ -1,0 +1,115 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include <app/WriteClient.h>
+
+#include "ModelCommandBridge.h"
+
+class WriteAttribute : public ModelCommand {
+public:
+    WriteAttribute()
+        : ModelCommand("write-by-id")
+    {
+        AddArgument("cluster-id", 0, UINT32_MAX, &mClusterId);
+        AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
+        AddArgument("attribute-value", &mAttributeValue);
+        AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
+        ModelCommand::AddArguments();
+    }
+
+    WriteAttribute(chip::ClusterId clusterId)
+        : ModelCommand("write-by-id")
+        , mClusterId(clusterId)
+    {
+        AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
+        AddArgument("attribute-value", &mAttributeValue);
+        AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
+        ModelCommand::AddArguments();
+    }
+
+    WriteAttribute(const char * _Nonnull attributeName)
+        : ModelCommand("write")
+    {
+        AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
+    }
+
+    ~WriteAttribute() {}
+
+    CHIP_ERROR SendCommand(CHIPDevice * _Nonnull device, chip::EndpointId endpointId) override
+    {
+        chip::TLV::TLVWriter writer;
+        chip::TLV::TLVReader reader;
+
+        mData = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(sizeof(uint8_t), mDataMaxLen));
+        VerifyOrReturnError(mData != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        writer.Init(mData, mDataMaxLen);
+
+        ReturnErrorOnFailure(mAttributeValue.Encode(writer, chip::TLV::AnonymousTag()));
+        reader.Init(mData, writer.GetLengthWritten());
+        ReturnErrorOnFailure(reader.Next());
+
+        id value = NSObjectFromCHIPTLV(&reader);
+        if (value == nil) {
+            return CHIP_ERROR_INTERNAL;
+        }
+
+        return WriteAttribute::SendCommand(device, endpointId, mClusterId, mAttributeId, value);
+    }
+
+    CHIP_ERROR SendCommand(CHIPDevice * _Nonnull device, chip::EndpointId endpointId, chip::ClusterId clusterId,
+        chip::AttributeId attributeId, id _Nonnull value)
+    {
+        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
+        [device
+            writeAttributeWithEndpointId:[NSNumber numberWithUnsignedShort:endpointId]
+                               clusterId:[NSNumber numberWithUnsignedInteger:clusterId]
+                             attributeId:[NSNumber numberWithUnsignedInteger:attributeId]
+                                   value:value
+                       timedWriteTimeout:mTimedInteractionTimeoutMs.HasValue()
+                           ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()]
+                           : nil
+                             clientQueue:callbackQueue
+                              completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
+                                  CHIP_ERROR chipError = [CHIPError errorToCHIPErrorCode:error];
+                                  if (chipError != CHIP_NO_ERROR) {
+                                      ChipLogError(chipTool, "Error: %s", chip::ErrorStr(chipError));
+                                  }
+                                  if (values) {
+                                      for (id item in values) {
+                                          NSLog(@"Response Item: %@", [item description]);
+                                      }
+                                  }
+                                  SetCommandExitStatus(chipError);
+                              }];
+        return CHIP_NO_ERROR;
+    }
+
+protected:
+    chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
+
+private:
+    chip::ClusterId mClusterId;
+    chip::AttributeId mAttributeId;
+    CHIP_ERROR mError = CHIP_NO_ERROR;
+    CustomArgument mAttributeValue;
+    static constexpr uint32_t mDataMaxLen = 4096;
+    uint8_t * _Nullable mData = nullptr;
+};

--- a/examples/chip-tool-darwin/templates/commands.zapt
+++ b/examples/chip-tool-darwin/templates/commands.zapt
@@ -11,7 +11,10 @@
 
 #include <commands/clusters/ComplexArgument.h>
 #include <app/data-model/DecodableList.h>
-#include <commands/clusters/ModelCommandBridge.h>
+#include <commands/clusters/ClusterCommandBridge.h>
+#include <commands/clusters/ReportCommandBridge.h>
+#include <commands/clusters/WriteAttributeCommandBridge.h>
+#include <app-common/zap-generated/cluster-objects.h>
 
 {{> clusters_header}}
 
@@ -22,10 +25,10 @@
 /*
  * Command {{asUpperCamelCase name}}
  */
-class {{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}: public ModelCommand
+class {{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}: public ClusterCommand
 {
 public:
-    {{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}(): ModelCommand("{{asDelimitedCommand name}}"){{#zcl_command_arguments}}{{#if_chip_complex}}, mComplex_{{asUpperCamelCase label}}(&mRequest.{{asLowerCamelCase label}}){{/if_chip_complex}}{{/zcl_command_arguments}}
+    {{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}(): ClusterCommand("{{asDelimitedCommand name}}"){{#zcl_command_arguments}}{{#if_chip_complex}}, mComplex_{{asUpperCamelCase label}}(&mRequest.{{asLowerCamelCase label}}){{/if_chip_complex}}{{/zcl_command_arguments}}
     {
         {{#chip_cluster_command_arguments}}
         {{#if_chip_complex}}
@@ -36,8 +39,7 @@ public:
         AddArgument("{{asUpperCamelCase label}}", {{asTypeMinValue type}}, {{asTypeMaxValue type}}, &m{{asUpperCamelCase label}});
         {{/if_chip_complex}}
         {{/chip_cluster_command_arguments}}
-        AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
-        ModelCommand::AddArguments();
+        ClusterCommand::AddArguments();
     }
 
     CHIP_ERROR SendCommand(CHIPDevice * device, chip::EndpointId endpointId) override
@@ -60,24 +62,32 @@ public:
         params.{{asStructPropertyName label}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:m{{asUpperCamelCase label}}];
         {{/if_chip_complex}}
         {{/chip_cluster_command_arguments}}
-        [cluster {{asLowerCamelCase name}}With{{#if (hasArguments)}}Params:params completionHandler:{{else}}CompletionHandler:{{/if}}
-        {{#if hasSpecificResponse}}
-            ^(CHIP{{asUpperCamelCase clusterName}}Cluster{{asUpperCamelCase responseName}}Params * _Nullable values, NSError * _Nullable error) {
-                 NSLog(@"Values: %@", values);
-        {{else}}
-            ^(NSError * _Nullable error) {
-        {{/if}}
-            chipError = [CHIPError errorToCHIPErrorCode:error];
-            if (error != nil) {
-              ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(chipError));
-            }
-            SetCommandExitStatus(chipError);
-            }];
+        uint16_t repeatCount = mRepeatCount.ValueOr(1);
+        uint16_t __block responsesNeeded = repeatCount;
+        while (repeatCount--)
+        {
+            [cluster {{asLowerCamelCase name}}With{{#if (hasArguments)}}Params:params completionHandler:{{else}}CompletionHandler:{{/if}}
+            {{#if hasSpecificResponse}}
+                ^(CHIP{{asUpperCamelCase clusterName}}Cluster{{asUpperCamelCase responseName}}Params * _Nullable values, NSError * _Nullable error) {
+                    NSLog(@"Values: %@", values);
+            {{else}}
+                ^(NSError * _Nullable error) {
+            {{/if}}
+                    chipError = [CHIPError errorToCHIPErrorCode:error];
+                    responsesNeeded--;
+                    if (chipError != CHIP_NO_ERROR) {
+                        mError = chipError;
+                        ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(chipError));
+                    }
+                    if (responsesNeeded == 0) {
+                        SetCommandExitStatus(mError);
+                    }
+                }];
+        }
         return chipError;
     }
 
 private:
-    chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
     {{#chip_cluster_command_arguments}}
     {{#if_chip_complex}}
     chip::app::Clusters::{{asUpperCamelCase parent.clusterName}}::Commands::{{asUpperCamelCase parent.name}}::Type mRequest;
@@ -100,14 +110,11 @@ private:
 /*
  * Attribute {{asUpperCamelCase name}}
  */
-class Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public ModelCommand
+class Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public ReadAttribute
 {
 public:
-    Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): ModelCommand("read")
+    Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): ReadAttribute("{{asDelimitedCommand (asUpperCamelCase name)}}")
     {
-        AddArgument("attr-name", "{{asDelimitedCommand (asUpperCamelCase name)}}");
-        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
-        ModelCommand::AddArguments();
     }
 
     ~Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}()
@@ -142,18 +149,16 @@ public:
          }];
         return err;
     }
-private:
-    chip::Optional<bool> mFabricFiltered;
 
 };
 
 {{#if isWritableAttribute}}
 {{! No list support for writing yet.  Need to figure out how to represent the
     values. }}
-class Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public ModelCommand
+class Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public WriteAttribute
 {
 public:
-    Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): ModelCommand("write"){{#if_chip_complex}}, mComplex(&mValue){{/if_chip_complex}}
+    Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): WriteAttribute("{{asDelimitedCommand (asUpperCamelCase name)}}"){{#if_chip_complex}}, mComplex(&mValue){{/if_chip_complex}}
     {
         AddArgument("attr-name", "{{asDelimitedCommand (asUpperCamelCase name)}}");
         {{#if_chip_complex}}
@@ -163,8 +168,7 @@ public:
         {{else}}
         AddArgument("attr-value", {{asTypeMinValue type}}, {{asTypeMaxValue type}}, &mValue);
         {{/if_chip_complex}}
-        AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
-        ModelCommand::AddArguments();
+        WriteAttribute::AddArguments();
     }
 
     ~Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}()
@@ -201,7 +205,6 @@ public:
     }
 
 private:
-    chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
     {{#if_chip_complex}}
     {{zapTypeToEncodableClusterObjectType type ns=parent.name forceNotOptional=true}} mValue;
     TypedComplexArgument<{{zapTypeToEncodableClusterObjectType type ns=parent.name forceNotOptional=true}}> mComplex;
@@ -216,17 +219,11 @@ private:
 
 {{/if}}
 {{#if isReportableAttribute}}
-class SubscribeAttribute{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public ModelCommand
+class SubscribeAttribute{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public SubscribeAttribute
 {
 public:
-    SubscribeAttribute{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): ModelCommand("subscribe")
+    SubscribeAttribute{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): SubscribeAttribute("{{asDelimitedCommand (asUpperCamelCase name)}}")
     {
-        AddArgument("attr-name", "{{asDelimitedCommand (asUpperCamelCase name)}}");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
-        AddArgument("wait", 0, 1, &mWait);
-        ModelCommand::AddArguments();
     }
 
     ~SubscribeAttribute{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}()
@@ -239,6 +236,7 @@ public:
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
         CHIP{{asUpperCamelCase parent.name}} * cluster = [[CHIP{{asUpperCamelCase parent.name}} alloc] initWithDevice:device endpoint:endpointId queue:callbackQueue];
         CHIPSubscribeParams * params = [[CHIPSubscribeParams alloc] init];
+        params.keepPreviousSubscriptions = mKeepSubscriptions.HasValue() ? [NSNumber numberWithBool:mKeepSubscriptions.Value()] : nil;
         params.fabricFiltered = mFabricFiltered.HasValue() ? [NSNumber numberWithBool:mFabricFiltered.Value()] : nil;
         [cluster subscribe{{>attribute}}WithMinInterval:[NSNumber numberWithUnsignedInt:mMinInterval] 
                                             maxInterval:[NSNumber numberWithUnsignedInt:mMaxInterval] 
@@ -258,11 +256,6 @@ public:
         return chip::System::Clock::Seconds16(mWait ? UINT16_MAX : 10);
     }
 
-private:
-    chip::Optional<bool> mFabricFiltered;
-    uint16_t mMinInterval;
-    uint16_t mMaxInterval;
-    bool mWait;
 };
 
 {{/if}}
@@ -275,18 +268,29 @@ private:
 {{#chip_client_clusters}}
 void registerCluster{{asUpperCamelCase name}}(Commands & commands)
 {
+    using namespace chip::app::Clusters::{{asUpperCamelCase name}};
+    
     const char * clusterName = "{{asUpperCamelCase name}}";
 
     commands_list clusterCommands = {
+        make_unique<ClusterCommand>(Id), //
         {{#chip_cluster_commands}}
         make_unique<{{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}>(), //
         {{/chip_cluster_commands}}
         {{#chip_server_cluster_attributes}}
-        {{! TODO: Various types (floats, structs) not supported here. }}
+        {{#first}}
+         make_unique<ReadAttribute>(Id), //
+        {{/first}}
         make_unique<Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}>(), //
+        {{#first}}
+        make_unique<WriteAttribute>(Id), //
+        {{/first}}
         {{#if isWritableAttribute}}
         make_unique<Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}>(), //
         {{/if}}
+        {{#first}}
+        make_unique<SubscribeAttribute>(Id), //
+        {{/first}}
         {{#if isReportableAttribute}}
         make_unique<SubscribeAttribute{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}>(), //
         {{/if}}
@@ -297,8 +301,24 @@ void registerCluster{{asUpperCamelCase name}}(Commands & commands)
 }
 {{/chip_client_clusters}}
 
+void registerClusterAny(Commands & commands)
+{
+    const char * clusterName = "Any";
+
+    commands_list clusterCommands = {
+        make_unique<ClusterCommand>(),  //
+        make_unique<ReadAttribute>(),   //
+        make_unique<WriteAttribute>(),  //
+        make_unique<SubscribeAttribute>(), //
+        make_unique<SubscribeEvent>(),     //
+    };
+
+    commands.Register(clusterName, clusterCommands);
+}
+
 void registerClusters(Commands & commands)
 {
+    registerClusterAny(commands);
 {{#chip_client_clusters}}
     registerCluster{{asUpperCamelCase name}}(commands);
 {{/chip_client_clusters}}


### PR DESCRIPTION
#### Problem
chip-tool-darwin is missing capability to target wild card attributes and clusters. chip-tool-darwin is also missing ability to subscribe to events. 

* Fixes #16143

#### Change overview
- Updates class definition outside of code gen to reduce code.
- Adds Any Cluster commands
- Adds ability to subscribe to all events.
- Adds `chip-tool-darwin [CLUSTER_NAME] command-by-id` `chip-tool-darwin [CLUSTER_NAME] read-by-id`  `chip-tool-darwin [CLUSTER_NAME] write-by-id`  `chip-tool-darwin [CLUSTER_NAME] subscribe-by-id`

#### Testing
- Generated code
- Compiled code
- Ran added chip-tool-commands