### PR TITLE
Include full path to examples/all-clusters-app/esp32/

### DIFF
--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -97,7 +97,7 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
         $ cd ${HOME}/tools/esp-idf
         $ ./install.sh
         $ . ./export.sh
-        $ cd {path-to-connectedhomeip}
+        $ cd {path-to-connectedhomeip}/examples/all-clusters-app/esp32/
         ```
 
     To download and install packages.

--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -97,7 +97,7 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
         $ cd ${HOME}/tools/esp-idf
         $ ./install.sh
         $ . ./export.sh
-        $ cd {path-to-connectedhomeip}/examples/all-clusters-app/esp32/
+        $ cd {path-to-connectedhomeip}
         ```
 
     To download and install packages.
@@ -115,7 +115,13 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
 
 -   Target Set
 
-To set IDF target, run set-target with one of the commands.
+To set IDF target, first:
+
+        ```
+        $ cd {path-to-connectedhomeip}/examples/all-clusters-app/esp32/
+        ```
+
+Then run set-target with one of the commands.
 
         ```
         $ idf.py set-target esp32


### PR DESCRIPTION
Not `cd`ing to the full esp32 path results in `doesn't seem to be a CMake build directory`

#### Problem
* Fix documentation to work with latest revision