### PR TITLE
Fix inet Android build

### DIFF
--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -543,8 +543,7 @@ static struct if_nameindex * backport_if_nameindex(void)
         lastIntfName = addrIter->ifa_name;
     }
 
-    tmpval =
-        (struct if_nameindex *) Platform::MemoryAlloc((numIntf + 1) * sizeof(struct if_nameindex));
+    tmpval = (struct if_nameindex *) Platform::MemoryAlloc((numIntf + 1) * sizeof(struct if_nameindex));
     VerifyOrExit(tmpval != NULL, );
     memset(tmpval, 0, (numIntf + 1) * sizeof(struct if_nameindex));
 
@@ -576,8 +575,7 @@ static struct if_nameindex * backport_if_nameindex(void)
         }
     }
 
-    retval = (struct if_nameindex *) Platform::MemoryAlloc(
-        (maxIntfNum + 1) * sizeof(struct if_nameindex));
+    retval = (struct if_nameindex *) Platform::MemoryAlloc((maxIntfNum + 1) * sizeof(struct if_nameindex));
     VerifyOrExit(retval != NULL, );
     memset(retval, 0, (maxIntfNum + 1) * sizeof(struct if_nameindex));
 

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -507,11 +507,11 @@ static void backport_if_freenameindex(struct if_nameindex * inArray)
     {
         if (inArray[i].if_name != NULL)
         {
-            MemoryFree(inArray[i].if_name);
+            Platform::MemoryFree(inArray[i].if_name);
         }
     }
 
-    MemoryFree(inArray);
+    Platform::MemoryFree(inArray);
 }
 
 static struct if_nameindex * backport_if_nameindex(void)
@@ -543,7 +543,8 @@ static struct if_nameindex * backport_if_nameindex(void)
         lastIntfName = addrIter->ifa_name;
     }
 
-    tmpval = (struct if_nameindex *) MemoryAlloc((numIntf + 1) * sizeof(struct if_nameindex));
+    tmpval =
+        (struct if_nameindex *) Platform::MemoryAlloc((numIntf + 1) * sizeof(struct if_nameindex));
     VerifyOrExit(tmpval != NULL, );
     memset(tmpval, 0, (numIntf + 1) * sizeof(struct if_nameindex));
 
@@ -575,7 +576,8 @@ static struct if_nameindex * backport_if_nameindex(void)
         }
     }
 
-    retval = (struct if_nameindex *) MemoryAlloc((maxIntfNum + 1) * sizeof(struct if_nameindex));
+    retval = (struct if_nameindex *) Platform::MemoryAlloc(
+        (maxIntfNum + 1) * sizeof(struct if_nameindex));
     VerifyOrExit(retval != NULL, );
     memset(retval, 0, (maxIntfNum + 1) * sizeof(struct if_nameindex));
 
@@ -615,7 +617,7 @@ static struct if_nameindex * backport_if_nameindex(void)
 exit:
     if (tmpval != NULL)
     {
-        MemoryFree(tmpval);
+        Platform::MemoryFree(tmpval);
     }
 
     if (addrList != NULL)


### PR DESCRIPTION
MemoryFree and MemoryAlloc are in the ::chip::Platform namespace, while
the call sites are in the ::chip::Inet namespace.
