### PR TITLE
Implement cluster-specific status APIs on WriteHandler.

### DIFF
--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -302,8 +302,7 @@ private:
      */
     CHIP_ERROR ProcessGroupCommandDataIB(CommandDataIB::Parser & aCommandElement);
     CHIP_ERROR SendCommandResponse();
-    CHIP_ERROR AddStatusInternal(const ConcreteCommandPath & aCommandPath, const Protocols::InteractionModel::Status aStatus,
-                                 const Optional<ClusterStatus> & aClusterStatus);
+    CHIP_ERROR AddStatusInternal(const ConcreteCommandPath & aCommandPath, const StatusIB & aStatus);
 
     /**
      * If this function fails, it may leave our TLV buffer in an inconsistent state.  Callers should snapshot as needed before

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -639,6 +639,18 @@ CHIP_ERROR WriteHandler::AddStatus(const ConcreteDataAttributePath & aPath, cons
     return AddStatus(aPath, StatusIB(aStatus));
 }
 
+CHIP_ERROR WriteHandler::AddClusterSpecificSuccess(const ConcreteDataAttributePath & aPath, ClusterStatus aClusterStatus)
+{
+    using Protocols::InteractionModel::Status;
+    return AddStatus(aPath, StatusIB(Status::Success, aClusterStatus));
+}
+
+CHIP_ERROR WriteHandler::AddClusterSpecificFailure(const ConcreteDataAttributePath & aPath, ClusterStatus aClusterStatus)
+{
+    using Protocols::InteractionModel::Status;
+    return AddStatus(aPath, StatusIB(Status::Failure, aClusterStatus));
+}
+
 CHIP_ERROR WriteHandler::AddStatus(const ConcreteDataAttributePath & aPath, const StatusIB & aStatus)
 {
     AttributeStatusIBs::Builder & writeResponses   = mWriteResponseBuilder.GetWriteResponses();

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -82,17 +82,10 @@ public:
     CHIP_ERROR ProcessGroupAttributeDataIBs(TLV::TLVReader & aAttributeDataIBsReader);
 
     CHIP_ERROR AddStatus(const ConcreteDataAttributePath & aPath, const Protocols::InteractionModel::Status aStatus);
-    CHIP_ERROR AddStatus(const ConcreteDataAttributePath & aPath, const StatusIB & aStatus);
 
-    CHIP_ERROR AddClusterSpecificSuccess(const AttributePathParams & aAttributePathParams, uint8_t aClusterStatus)
-    {
-        return CHIP_ERROR_NOT_IMPLEMENTED;
-    }
+    CHIP_ERROR AddClusterSpecificSuccess(const ConcreteDataAttributePath & aAttributePathParams, uint8_t aClusterStatus);
 
-    CHIP_ERROR AddClusterSpecificFailure(const AttributePathParams & aAttributePathParams, uint8_t aClusterStatus)
-    {
-        return CHIP_ERROR_NOT_IMPLEMENTED;
-    }
+    CHIP_ERROR AddClusterSpecificFailure(const ConcreteDataAttributePath & aAttributePathParams, uint8_t aClusterStatus);
 
     FabricIndex GetAccessingFabricIndex() const;
 
@@ -156,6 +149,8 @@ private:
     // process the group write request (usually due to malformed messages). This function should only be called by
     // ProcessGroupAttributeDataIBs.
     CHIP_ERROR DeliverFinalListWriteEndForGroupWrite(bool writeWasSuccessful);
+
+    CHIP_ERROR AddStatus(const ConcreteDataAttributePath & aPath, const StatusIB & aStatus);
 
 private:
     // ExchangeDelegate


### PR DESCRIPTION
Also cleans up the implementation of the equivalent CommandHandler
APIs a bit.

Fixes https://github.com/project-chip/connectedhomeip/issues/9908

#### Problem
See above.

#### Change overview
See above.

#### Testing
No behavior changes; just fixing the API surface for now.