### PR TITLE
Give default for mandatory attributes when not present in cluster

### DIFF
--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -516,6 +516,43 @@ Protocols::InteractionModel::Status UnsupportedAttributeStatus(const ConcreteAtt
 
 } // anonymous namespace
 
+template <typename T>
+CHIP_ERROR EncodeDefaultForUnfoundManditoryAttribute(const ConcreteReadAttributePath & aPath, AttributeReportIBs::Builder & aAttributeReports, T value)
+{
+    ChipLogDetail(DataManagement, "Couldn't find global attribute using basic default");
+    TLV::TLVWriter backup;
+    aAttributeReports.Checkpoint(backup);
+
+    AttributeReportIB::Builder & attributeReport = aAttributeReports.CreateAttributeReport();
+    ReturnErrorOnFailure(aAttributeReports.GetError());
+
+    AttributeDataIB::Builder & attributeDataIBBuilder = attributeReport.CreateAttributeData();
+    ReturnErrorOnFailure(attributeDataIBBuilder.GetError());
+
+    DataVersion version = 0;
+    ReturnErrorOnFailure(ReadClusterDataVersion(aPath, version));
+    attributeDataIBBuilder.DataVersion(version);
+    ReturnErrorOnFailure(attributeDataIBBuilder.GetError());
+
+    AttributePathIB::Builder & attributePathIBBuilder = attributeDataIBBuilder.CreatePath();
+    ReturnErrorOnFailure(attributeDataIBBuilder.GetError());
+
+    attributePathIBBuilder.Endpoint(aPath.mEndpointId)
+        .Cluster(aPath.mClusterId)
+        .Attribute(aPath.mAttributeId)
+        .EndOfAttributePathIB();
+    ReturnErrorOnFailure(attributePathIBBuilder.GetError());
+
+    TLV::TLVWriter * writer            = attributeDataIBBuilder.GetWriter();
+
+    bool isNullable = false;
+    TLV::Tag tag = TLV::ContextTag(to_underlying(AttributeDataIB::Tag::kData));
+    VerifyOrReturnError(NumericAttributeTraits<T>::CanRepresentValue(isNullable, value), CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnErrorOnFailure(NumericAttributeTraits<T>::Encode(*writer, tag, value));
+    return SendSuccessStatus(attributeReport, attributeDataIBBuilder);
+}
+
+
 CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, bool aIsFabricFiltered,
                                  const ConcreteReadAttributePath & aPath, AttributeReportIBs::Builder & aAttributeReports,
                                  AttributeValueEncoder::AttributeEncodeState * apEncoderState)
@@ -545,6 +582,22 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, b
 
     if (attributeCluster == nullptr && attributeMetadata == nullptr)
     {
+        switch (aPath.mAttributeId)
+        {
+        case Clusters::Globals::Attributes::FeatureMap::Id:
+            {
+                uint32_t defaultValue = 0;
+                return EncodeDefaultForUnfoundManditoryAttribute(aPath, aAttributeReports, defaultValue);
+            }
+            break;
+        case Clusters::Globals::Attributes::ClusterRevision::Id:
+            {
+                uint16_t defaultValue = 1;
+                return EncodeDefaultForUnfoundManditoryAttribute(aPath, aAttributeReports, defaultValue);
+            }
+        default:
+            break;
+        }
         return SendFailureStatus(aPath, aAttributeReports, UnsupportedAttributeStatus(aPath), nullptr);
     }
 

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -517,7 +517,8 @@ Protocols::InteractionModel::Status UnsupportedAttributeStatus(const ConcreteAtt
 } // anonymous namespace
 
 template <typename T>
-CHIP_ERROR EncodeDefaultForUnfoundManditoryAttribute(const ConcreteReadAttributePath & aPath, AttributeReportIBs::Builder & aAttributeReports, T value)
+CHIP_ERROR EncodeDefaultForUnfoundManditoryAttribute(const ConcreteReadAttributePath & aPath,
+                                                     AttributeReportIBs::Builder & aAttributeReports, T value)
 {
     ChipLogDetail(DataManagement, "Couldn't find global attribute using basic default");
     TLV::TLVWriter backup;
@@ -543,15 +544,14 @@ CHIP_ERROR EncodeDefaultForUnfoundManditoryAttribute(const ConcreteReadAttribute
         .EndOfAttributePathIB();
     ReturnErrorOnFailure(attributePathIBBuilder.GetError());
 
-    TLV::TLVWriter * writer            = attributeDataIBBuilder.GetWriter();
+    TLV::TLVWriter * writer = attributeDataIBBuilder.GetWriter();
 
     bool isNullable = false;
-    TLV::Tag tag = TLV::ContextTag(to_underlying(AttributeDataIB::Tag::kData));
+    TLV::Tag tag    = TLV::ContextTag(to_underlying(AttributeDataIB::Tag::kData));
     VerifyOrReturnError(NumericAttributeTraits<T>::CanRepresentValue(isNullable, value), CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorOnFailure(NumericAttributeTraits<T>::Encode(*writer, tag, value));
     return SendSuccessStatus(attributeReport, attributeDataIBBuilder);
 }
-
 
 CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, bool aIsFabricFiltered,
                                  const ConcreteReadAttributePath & aPath, AttributeReportIBs::Builder & aAttributeReports,
@@ -603,17 +603,15 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, b
     {
         switch (aPath.mAttributeId)
         {
-        case Clusters::Globals::Attributes::FeatureMap::Id:
-            {
-                uint32_t defaultValue = 0;
-                return EncodeDefaultForUnfoundManditoryAttribute(aPath, aAttributeReports, defaultValue);
-            }
-            break;
-        case Clusters::Globals::Attributes::ClusterRevision::Id:
-            {
-                uint16_t defaultValue = 1;
-                return EncodeDefaultForUnfoundManditoryAttribute(aPath, aAttributeReports, defaultValue);
-            }
+        case Clusters::Globals::Attributes::FeatureMap::Id: {
+            uint32_t defaultValue = 0;
+            return EncodeDefaultForUnfoundManditoryAttribute(aPath, aAttributeReports, defaultValue);
+        }
+        break;
+        case Clusters::Globals::Attributes::ClusterRevision::Id: {
+            uint16_t defaultValue = 1;
+            return EncodeDefaultForUnfoundManditoryAttribute(aPath, aAttributeReports, defaultValue);
+        }
         default:
             break;
         }


### PR DESCRIPTION
#### Problem
* Fixes #17275
* Many cluster instances are giving 0x86(unsupported attribute) for mandatory attributes.

#### Change overview
Certain attributes like ClusterRevision and FeatureMap are mandatory for every cluster instance, but there are many instances where these mandatory fields are missing. We will give default safe values when attributes are missing from cluster instance and we 

#### Testing
How was this tested? (at least one bullet point required)
* Manual - Using examples/lighting-app which doesn't have ClusterRevision in DiagnosticLogs Cluster, confirmed I am getting the default value of 1. FeatureMap give default value of 0
