### PR TITLE
Implement rules for SetRegulatoryConfig command

### DIFF
--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -259,9 +259,8 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(app::CommandH
     MATTER_TRACE_EVENT_SCOPE("SetRegulatoryConfig", "GeneralCommissioning");
     DeviceControlServer * server = &DeviceLayer::DeviceControlServer::DeviceControlSvr();
     Commands::SetRegulatoryConfigResponse::Type response;
-    uint8_t location = to_underlying(commandData.newRegulatoryConfig);
 
-    if (location > to_underlying(RegulatoryLocationType::kIndoorOutdoor))
+    if (commandData.newRegulatoryConfig > RegulatoryLocationType::kIndoorOutdoor)
     {
         response.errorCode = CommissioningError::kValueOutsideRange;
         response.debugText = commandData.countryCode;
@@ -269,14 +268,13 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(app::CommandH
     else
     {
         uint8_t locationCapability;
+        uint8_t location = to_underlying(commandData.newRegulatoryConfig);
 
         CheckSuccess(ConfigurationMgr().GetLocationCapability(locationCapability), Failure);
 
         // If the LocationCapability attribute is not Indoor/Outdoor and the NewRegulatoryConfig value received does not match
         // either the Indoor or Outdoor fixed value in LocationCapability.
-        if ((locationCapability !=
-             to_underlying(chip::app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoorOutdoor)) &&
-            (location != locationCapability))
+        if ((locationCapability != to_underlying(RegulatoryLocationType::kIndoorOutdoor)) && (location != locationCapability))
         {
             response.errorCode = CommissioningError::kValueOutsideRange;
             response.debugText = commandData.countryCode;

--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -261,7 +261,7 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(app::CommandH
     Commands::SetRegulatoryConfigResponse::Type response;
     uint8_t location = to_underlying(commandData.newRegulatoryConfig);
 
-    if (location > to_underlying(chip::app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoorOutdoor))
+    if (location > to_underlying(RegulatoryLocationType::kIndoorOutdoor))
     {
         response.errorCode = CommissioningError::kValueOutsideRange;
         response.debugText = commandData.countryCode;

--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -258,12 +258,37 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(app::CommandH
 {
     MATTER_TRACE_EVENT_SCOPE("SetRegulatoryConfig", "GeneralCommissioning");
     DeviceControlServer * server = &DeviceLayer::DeviceControlServer::DeviceControlSvr();
-
-    CheckSuccess(server->SetRegulatoryConfig(to_underlying(commandData.newRegulatoryConfig), commandData.countryCode), Failure);
-    Breadcrumb::Set(commandPath.mEndpointId, commandData.breadcrumb);
-
     Commands::SetRegulatoryConfigResponse::Type response;
-    response.errorCode = CommissioningError::kOk;
+    uint8_t location = to_underlying(commandData.newRegulatoryConfig);
+
+    if (location > to_underlying(chip::app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoorOutdoor))
+    {
+        response.errorCode = CommissioningError::kValueOutsideRange;
+        response.debugText = commandData.countryCode;
+    }
+    else
+    {
+        uint8_t locationCapability;
+
+        CheckSuccess(ConfigurationMgr().GetLocationCapability(locationCapability), Failure);
+
+        // If the LocationCapability attribute is not Indoor/Outdoor and the NewRegulatoryConfig value received does not match
+        // either the Indoor or Outdoor fixed value in LocationCapability.
+        if ((locationCapability !=
+             to_underlying(chip::app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoorOutdoor)) &&
+            (location != locationCapability))
+        {
+            response.errorCode = CommissioningError::kValueOutsideRange;
+            response.debugText = commandData.countryCode;
+        }
+        else
+        {
+            CheckSuccess(server->SetRegulatoryConfig(location, commandData.countryCode), Failure);
+            Breadcrumb::Set(commandPath.mEndpointId, commandData.breadcrumb);
+            response.errorCode = CommissioningError::kOk;
+        }
+    }
+
     commandObj->AddResponse(commandPath, response);
 
     return true;

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -113,7 +113,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
     if (!PosixConfig::ConfigValueExists(PosixConfig::kConfigKey_LocationCapability))
     {
-        uint32_t location = to_underlying(chip::app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoor);
+        uint32_t location = to_underlying(chip::app::Clusters::GeneralCommissioning::RegulatoryLocationType::kIndoorOutdoor);
         err               = WriteConfigValue(PosixConfig::kConfigKey_LocationCapability, location);
         SuccessOrExit(err);
     }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* As per Test-Plan, test-step 9 expect that " SetRegulatoryConfigResponse command response from DUT to TH1 with field ErrorCode as 'Error - ValueOutsideRange' and DebugText as a 'string' value" when TH1 sends SetRegulatoryConfig command to the DUT with NewRegulatoryConfig data value as '3', Breadcrumb as 0 and CountryCode is of type 'string'. But we are getting response as success with the value 0

* Fixes #17319

#### Change overview
Implement rules for SetRegulatoryConfig command

#### Testing
How was this tested? (at least one bullet point required)
```
yufengwang@yufengwang:~/connectedhomeip/out/debug/standalone$ ./chip-tool generalcommissioning set-regulatory-config 3 te9 0 12344321 0
....
[1651708380.414967][3374629:3374634] CHIP:DMG: InvokeResponseMessage =
[1651708380.414981][3374629:3374634] CHIP:DMG: {
[1651708380.414994][3374629:3374634] CHIP:DMG: 	suppressResponse = false, 
[1651708380.415006][3374629:3374634] CHIP:DMG: 	InvokeResponseIBs =
[1651708380.415025][3374629:3374634] CHIP:DMG: 	[
[1651708380.415037][3374629:3374634] CHIP:DMG: 		InvokeResponseIB =
[1651708380.415056][3374629:3374634] CHIP:DMG: 		{
[1651708380.415071][3374629:3374634] CHIP:DMG: 			CommandDataIB =
[1651708380.415086][3374629:3374634] CHIP:DMG: 			{
[1651708380.415098][3374629:3374634] CHIP:DMG: 				CommandPathIB =
[1651708380.415112][3374629:3374634] CHIP:DMG: 				{
[1651708380.415127][3374629:3374634] CHIP:DMG: 					EndpointId = 0x0,
[1651708380.415142][3374629:3374634] CHIP:DMG: 					ClusterId = 0x30,
[1651708380.415156][3374629:3374634] CHIP:DMG: 					CommandId = 0x3,
[1651708380.415169][3374629:3374634] CHIP:DMG: 				},
[1651708380.415184][3374629:3374634] CHIP:DMG: 				
[1651708380.415197][3374629:3374634] CHIP:DMG: 				CommandData = 
[1651708380.415211][3374629:3374634] CHIP:DMG: 				{
[1651708380.415225][3374629:3374634] CHIP:DMG: 					0x0 = 1, 
[1651708380.415241][3374629:3374634] CHIP:DMG: 					0x1 = "te9", 
[1651708380.415256][3374629:3374634] CHIP:DMG: 				},
[1651708380.415268][3374629:3374634] CHIP:DMG: 			},
[1651708380.415285][3374629:3374634] CHIP:DMG: 			
[1651708380.415297][3374629:3374634] CHIP:DMG: 		},
[1651708380.415314][3374629:3374634] CHIP:DMG: 		
[1651708380.415326][3374629:3374634] CHIP:DMG: 	],
[1651708380.415343][3374629:3374634] CHIP:DMG: 	
[1651708380.415355][3374629:3374634] CHIP:DMG: 	InteractionModelRevision = 1
[1651708380.415367][3374629:3374634] CHIP:DMG: },
[1651708380.415415][3374629:3374634] CHIP:DMG: Received Command Response Data, Endpoint=0 Cluster=0x0000_0030 Command=0x0000_0003
[1651708380.415441][3374629:3374634] CHIP:TOO: Endpoint: 0 Cluster: 0x0000_0030 Command 0x0000_0003
[1651708380.415471][3374629:3374634] CHIP:TOO:   SetRegulatoryConfigResponse: {
[1651708380.415491][3374629:3374634] CHIP:TOO:     errorCode: 1
[1651708380.415505][3374629:3374634] CHIP:TOO:     debugText: te9
[1651708380.415517][3374629:3374634] CHIP:TOO:    }
```

